### PR TITLE
[--Dashboard-- data source] Implement AdHoc filtering

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1054,4 +1054,8 @@ export interface FeatureToggles {
   * Enable dual reader for unified storage search
   */
   unifiedStorageSearchDualReaderEnabled?: boolean;
+  /**
+  * Enables adhoc filtering support for the dashboard datasource
+  */
+  dashboardDsAdHocFiltering?: boolean;
 }

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -8,6 +8,7 @@ const (
 	grafanaAppPlatformSquad                     codeowner = "@grafana/grafana-app-platform-squad"
 	grafanaDashboardsSquad                      codeowner = "@grafana/dashboards-squad"
 	grafanaDatavizSquad                         codeowner = "@grafana/dataviz-squad"
+	grafanaDataProSquad                         codeowner = "@grafana/datapro"
 	grafanaFrontendPlatformSquad                codeowner = "@grafana/grafana-frontend-platform"
 	grafanaFrontendSearchNavOrganise            codeowner = "@grafana/grafana-search-navigate-organise"
 	grafanaBackendServicesSquad                 codeowner = "@grafana/grafana-backend-services-squad"

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1821,6 +1821,13 @@ var (
 			HideFromAdminPage: true,
 			HideFromDocs:      true,
 		},
+		{
+			Name:         "dashboardDsAdHocFiltering",
+			Description:  "Enables adhoc filtering support for the dashboard datasource",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDataProSquad,
+			FrontendOnly: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -235,3 +235,4 @@ otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
 alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 pluginAssetProvider,experimental,@grafana/plugins-platform-backend,false,true,false
 unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false
+dashboardDsAdHocFiltering,experimental,@grafana/datapro,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -950,4 +950,8 @@ const (
 	// FlagUnifiedStorageSearchDualReaderEnabled
 	// Enable dual reader for unified storage search
 	FlagUnifiedStorageSearchDualReaderEnabled = "unifiedStorageSearchDualReaderEnabled"
+
+	// FlagDashboardDsAdHocFiltering
+	// Enables adhoc filtering support for the dashboard datasource
+	FlagDashboardDsAdHocFiltering = "dashboardDsAdHocFiltering"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -798,6 +798,19 @@
     },
     {
       "metadata": {
+        "name": "dashboardDsAdHocFiltering",
+        "resourceVersion": "1752487974435",
+        "creationTimestamp": "2025-07-14T10:12:54Z"
+      },
+      "spec": {
+        "description": "Enables adhoc filtering support for the dashboard datasource",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardNewLayouts",
         "resourceVersion": "1750434297879",
         "creationTimestamp": "2024-10-23T08:55:45Z"

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -61,7 +61,14 @@ export function AdHocVariableForm({
           htmlFor="data-source-picker"
           tooltip={infoText}
         >
-          <DataSourcePicker current={datasource} onChange={onDataSourceChange} width={30} variables={true} noDefault />
+          <DataSourcePicker
+            current={datasource}
+            onChange={onDataSourceChange}
+            width={30}
+            variables={true}
+            dashboard={true}
+            noDefault
+          />
         </EditorField>
       </Box>
 

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -4,6 +4,7 @@ import { DataSourceInstanceSettings, MetricFindValue, readCSV } from '@grafana/d
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
+import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { Alert, CodeEditor, Field, Switch, Box } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
@@ -66,7 +67,7 @@ export function AdHocVariableForm({
             onChange={onDataSourceChange}
             width={30}
             variables={true}
-            dashboard={true}
+            dashboard={config.featureToggles.dashboardDsAdHocFiltering}
             noDefault
           />
         </EditorField>

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -8,6 +8,8 @@ import {
   LoadingState,
   standardTransformersRegistry,
   FieldType,
+  DataFrame,
+  AdHocVariableFilter,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
@@ -136,7 +138,18 @@ describe('DashboardDatasource', () => {
   describe('AdHoc Filtering', () => {
     const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
 
-    function createTestFrame(fields: any[]) {
+    // Type-safe interface for accessing private methods in tests
+    interface DashboardDatasourceWithPrivateMethods {
+      applyAdHocFilters: (frame: DataFrame, filters: AdHocVariableFilter[]) => DataFrame;
+    }
+
+    interface TestField {
+      name: string;
+      type: FieldType;
+      values: unknown[];
+    }
+
+    function createTestFrame(fields: TestField[]) {
       return {
         name: 'TestData',
         fields: fields.map((field) => ({
@@ -157,7 +170,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['John']);
       expect(result.fields[1].values).toEqual([25]);
@@ -170,7 +185,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '!=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '!=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
       expect(result.fields[1].values).toEqual([30, 35]);
@@ -183,7 +200,7 @@ describe('DashboardDatasource', () => {
         { name: 'status', type: FieldType.string, values: ['active', 'active', 'inactive'] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'name', operator: '!=', value: 'John' },
         { key: 'status', operator: '=', value: 'active' },
       ]);
@@ -199,7 +216,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '!=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '!=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual([null, 'Bob']);
       expect(result.fields[1].values).toEqual([30, 35]);
@@ -212,7 +231,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '=', value: '30' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '=', value: '30' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane']);
       expect(result.fields[1].values).toEqual([30]);
@@ -225,7 +246,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '30' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '!=', value: '30' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['John', 'Bob']);
       expect(result.fields[1].values).toEqual([25, 35]);
@@ -238,7 +261,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, null, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '25' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '!=', value: '25' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
       expect(result.fields[1].values).toEqual([null, 35]);
@@ -251,7 +276,7 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 25, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'name', operator: '!=', value: 'Bob' },
         { key: 'age', operator: '=', value: '25' },
       ]);
@@ -272,7 +297,9 @@ describe('DashboardDatasource', () => {
         { name: 'score', type: FieldType.number, values: [95.5, 87.25, 95.5, 92.0] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'score', operator: '=', value: '95.5' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'score', operator: '=', value: '95.5' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Alice', 'Charlie']);
       expect(result.fields[1].values).toEqual([95.5, 95.5]);
@@ -285,7 +312,9 @@ describe('DashboardDatasource', () => {
         { name: 'temperature', type: FieldType.number, values: [98.6, 99.1, 98.6] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'temperature', operator: '!=', value: '98.6' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'temperature', operator: '!=', value: '98.6' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Bob']);
       expect(result.fields[1].values).toEqual([99.1]);
@@ -299,7 +328,9 @@ describe('DashboardDatasource', () => {
       ]);
 
       // Note: 0.1 + 0.2 !== 0.3 in JavaScript due to floating point precision
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'value', operator: '=', value: '0.3' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'value', operator: '=', value: '0.3' },
+      ]);
 
       // Should only match the exact 0.3, not the computed 0.1 + 0.2
       expect(result.fields[0].values).toEqual(['Test2']);
@@ -313,7 +344,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual([]);
       expect(result.fields[1].values).toEqual([]);
@@ -334,7 +367,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'missing_field', operator: '=', value: 'test' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'missing_field', operator: '=', value: 'test' },
+      ]);
 
       // Should return empty result since field doesn't exist
       expect(result.fields[0].values).toEqual([]);
@@ -348,7 +383,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'missing_field', operator: '!=', value: 'test' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'missing_field', operator: '!=', value: 'test' },
+      ]);
 
       // Should return all rows since field doesn't exist (all rows are "not equal")
       expect(result.fields[0].values).toEqual(['John', 'Jane', 'Bob']);
@@ -363,7 +400,7 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35, 40] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'status', operator: '=', value: 'active' },
         { key: 'name', operator: '!=', value: 'Admin' },
         { key: 'missing_field', operator: '!=', value: 'ignored' }, // Should be ignored

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -12,13 +12,14 @@ import {
   AdHocVariableFilter,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
-import { setPluginImportUtils } from '@grafana/runtime';
+import { setPluginImportUtils, config } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,
   SceneDataNode,
   SceneDataTransformer,
   SceneFlexItem,
   SceneFlexLayout,
+  SceneObject,
   VizPanel,
 } from '@grafana/scenes';
 import { getVizPanelKeyForPanelId } from 'app/features/dashboard-scene/utils/utils';
@@ -136,13 +137,7 @@ describe('DashboardDatasource', () => {
   });
 
   describe('AdHoc Filtering', () => {
-    const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
-
-    // Type-safe interface for accessing private methods in tests
-    interface DashboardDatasourceWithPrivateMethods {
-      applyAdHocFilters: (frame: DataFrame, filters: AdHocVariableFilter[]) => DataFrame;
-    }
-
+    // Shared test utilities
     interface TestField {
       name: string;
       type: FieldType;
@@ -164,257 +159,415 @@ describe('DashboardDatasource', () => {
       };
     }
 
-    it('should apply equality filter correctly', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+    function createQueryRequest(filters: AdHocVariableFilter[], scene: SceneObject) {
+      return {
+        timezone: 'utc',
+        targets: [{ refId: 'A', panelId: 1 }],
+        requestId: '',
+        interval: '',
+        intervalMs: 0,
+        range: getDefaultTimeRange(),
+        scopedVars: {
+          __sceneObject: new SafeSerializableSceneObject(scene),
+        },
+        app: '',
+        startTime: 0,
+        filters: filters,
+      };
+    }
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '=', value: 'John' },
-      ]);
+    // Test AdHoc filtering via the Public API first, to ensure Integration
+    describe('Integration (Public API)', () => {
+      const originalToggleValue = config.featureToggles.dashboardDsAdHocFiltering;
 
-      expect(result.fields[0].values).toEqual(['John']);
-      expect(result.fields[1].values).toEqual([25]);
-      expect(result.length).toBe(1);
+      beforeEach(() => {
+        config.featureToggles.dashboardDsAdHocFiltering = true;
+      });
+
+      afterEach(() => {
+        config.featureToggles.dashboardDsAdHocFiltering = originalToggleValue;
+      });
+
+      it('should apply basic filtering end-to-end through public query method', async () => {
+        const testFrame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
+
+        const scene = new SceneFlexLayout({
+          children: [
+            new SceneFlexItem({
+              body: new VizPanel({
+                key: getVizPanelKeyForPanelId(1),
+                $data: new SceneDataNode({
+                  data: {
+                    series: [testFrame],
+                    state: LoadingState.Done,
+                    timeRange: getDefaultTimeRange(),
+                  },
+                }),
+              }),
+            }),
+          ],
+        });
+
+        const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
+        const filters: AdHocVariableFilter[] = [{ key: 'name', operator: '=', value: 'John' }];
+
+        const observable = ds.query(createQueryRequest(filters, scene));
+
+        let result: DataQueryResponse | undefined;
+        observable.subscribe({ next: (data) => (result = data) });
+
+        expect(result?.data[0].fields[0].values).toEqual(['John']);
+        expect(result?.data[0].fields[1].values).toEqual([25]);
+        expect(result?.data[0].length).toBe(1);
+      });
+
+      it('should respect feature toggle and not filter when disabled', async () => {
+        // Temporarily disable the feature toggle for this test
+        config.featureToggles.dashboardDsAdHocFiltering = false;
+
+        const testFrame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
+
+        const scene = new SceneFlexLayout({
+          children: [
+            new SceneFlexItem({
+              body: new VizPanel({
+                key: getVizPanelKeyForPanelId(1),
+                $data: new SceneDataNode({
+                  data: {
+                    series: [testFrame],
+                    state: LoadingState.Done,
+                    timeRange: getDefaultTimeRange(),
+                  },
+                }),
+              }),
+            }),
+          ],
+        });
+
+        const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
+        const filters: AdHocVariableFilter[] = [{ key: 'name', operator: '=', value: 'John' }];
+
+        const observable = ds.query(createQueryRequest(filters, scene));
+
+        let result: DataQueryResponse | undefined;
+        observable.subscribe({ next: (data) => (result = data) });
+
+        // Should return unfiltered data since feature toggle is disabled
+        expect(result?.data[0].fields[0].values).toEqual(['John', 'Jane', 'Bob']);
+        expect(result?.data[0].fields[1].values).toEqual([25, 30, 35]);
+        expect(result?.data[0].length).toBe(3);
+      });
+
+      it('should apply multiple filters with AND logic through public API', async () => {
+        const testFrame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'status', type: FieldType.string, values: ['active', 'active', 'inactive'] },
+        ]);
+
+        const scene = new SceneFlexLayout({
+          children: [
+            new SceneFlexItem({
+              body: new VizPanel({
+                key: getVizPanelKeyForPanelId(1),
+                $data: new SceneDataNode({
+                  data: {
+                    series: [testFrame],
+                    state: LoadingState.Done,
+                    timeRange: getDefaultTimeRange(),
+                  },
+                }),
+              }),
+            }),
+          ],
+        });
+
+        const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
+        const filters: AdHocVariableFilter[] = [
+          { key: 'name', operator: '!=', value: 'John' },
+          { key: 'status', operator: '=', value: 'active' },
+        ];
+
+        const observable = ds.query(createQueryRequest(filters, scene));
+
+        let result: DataQueryResponse | undefined;
+        observable.subscribe({ next: (data) => (result = data) });
+
+        expect(result?.data[0].fields[0].values).toEqual(['Jane']);
+        expect(result?.data[0].fields[1].values).toEqual(['active']);
+        expect(result?.data[0].length).toBe(1);
+      });
     });
 
-    it('should apply not-equal filter correctly', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+    // Now test AdHoc filtering with unit-tests to test all aspects of behaviour.
+    // Here we test a private method, which allows for smaller, simpler,
+    // faster tests.
+    // This is the bottom of the 'Test Pyramid'
+    describe('Algorithm (but by testing a Private Method)', () => {
+      const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '!=', value: 'John' },
-      ]);
+      // Type-safe interface for accessing private methods in tests
+      interface DashboardDatasourceWithPrivateMethods {
+        applyAdHocFilters: (frame: DataFrame, filters: AdHocVariableFilter[]) => DataFrame;
+      }
 
-      expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
-      expect(result.fields[1].values).toEqual([30, 35]);
-      expect(result.length).toBe(2);
-    });
+      it('should apply equality filter correctly', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should apply multiple filters with AND logic', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'status', type: FieldType.string, values: ['active', 'active', 'inactive'] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '=', value: 'John' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '!=', value: 'John' },
-        { key: 'status', operator: '=', value: 'active' },
-      ]);
+        expect(result.fields[0].values).toEqual(['John']);
+        expect(result.fields[1].values).toEqual([25]);
+        expect(result.length).toBe(1);
+      });
 
-      expect(result.fields[0].values).toEqual(['Jane']);
-      expect(result.fields[1].values).toEqual(['active']);
-      expect(result.length).toBe(1);
-    });
+      it('should apply not-equal filter correctly', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should handle null values correctly', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', null, 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '!=', value: 'John' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '!=', value: 'John' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
+        expect(result.fields[1].values).toEqual([30, 35]);
+        expect(result.length).toBe(2);
+      });
 
-      expect(result.fields[0].values).toEqual([null, 'Bob']);
-      expect(result.fields[1].values).toEqual([30, 35]);
-      expect(result.length).toBe(2);
-    });
+      it('should apply multiple filters with AND logic', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'status', type: FieldType.string, values: ['active', 'active', 'inactive'] },
+        ]);
 
-    it('should apply equality filter on numeric fields', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '!=', value: 'John' },
+          { key: 'status', operator: '=', value: 'active' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'age', operator: '=', value: '30' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Jane']);
+        expect(result.fields[1].values).toEqual(['active']);
+        expect(result.length).toBe(1);
+      });
 
-      expect(result.fields[0].values).toEqual(['Jane']);
-      expect(result.fields[1].values).toEqual([30]);
-      expect(result.length).toBe(1);
-    });
+      it('should handle null values correctly', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', null, 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should apply not-equal filter on numeric fields', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '!=', value: 'John' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'age', operator: '!=', value: '30' },
-      ]);
+        expect(result.fields[0].values).toEqual([null, 'Bob']);
+        expect(result.fields[1].values).toEqual([30, 35]);
+        expect(result.length).toBe(2);
+      });
 
-      expect(result.fields[0].values).toEqual(['John', 'Bob']);
-      expect(result.fields[1].values).toEqual([25, 35]);
-      expect(result.length).toBe(2);
-    });
+      it('should apply equality filter on numeric fields', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should handle numeric fields with null values', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, null, 35] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'age', operator: '=', value: '30' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'age', operator: '!=', value: '25' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Jane']);
+        expect(result.fields[1].values).toEqual([30]);
+        expect(result.length).toBe(1);
+      });
 
-      expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
-      expect(result.fields[1].values).toEqual([null, 35]);
-      expect(result.length).toBe(2);
-    });
+      it('should apply not-equal filter on numeric fields', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should handle mixed string and numeric filtering', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob', 'Alice'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 25, 35] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'age', operator: '!=', value: '30' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '!=', value: 'Bob' },
-        { key: 'age', operator: '=', value: '25' },
-      ]);
+        expect(result.fields[0].values).toEqual(['John', 'Bob']);
+        expect(result.fields[1].values).toEqual([25, 35]);
+        expect(result.length).toBe(2);
+      });
 
-      // Should match: name != 'Bob' AND age = 25
-      // John: !Bob + 25 ✓
-      // Jane: !Bob + 30 ✗
-      // Bob: Bob + 25 ✗
-      // Alice: !Bob + 35 ✗
-      expect(result.fields[0].values).toEqual(['John']);
-      expect(result.fields[1].values).toEqual([25]);
-      expect(result.length).toBe(1);
-    });
+      it('should handle numeric fields with null values', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, null, 35] },
+        ]);
 
-    it('should handle floating point numbers correctly', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['Alice', 'Bob', 'Charlie', 'Diana'] },
-        { name: 'score', type: FieldType.number, values: [95.5, 87.25, 95.5, 92.0] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'age', operator: '!=', value: '25' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'score', operator: '=', value: '95.5' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
+        expect(result.fields[1].values).toEqual([null, 35]);
+        expect(result.length).toBe(2);
+      });
 
-      expect(result.fields[0].values).toEqual(['Alice', 'Charlie']);
-      expect(result.fields[1].values).toEqual([95.5, 95.5]);
-      expect(result.length).toBe(2);
-    });
+      it('should handle mixed string and numeric filtering', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob', 'Alice'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 25, 35] },
+        ]);
 
-    it('should handle floating point numbers with != operator', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['Alice', 'Bob', 'Charlie'] },
-        { name: 'temperature', type: FieldType.number, values: [98.6, 99.1, 98.6] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '!=', value: 'Bob' },
+          { key: 'age', operator: '=', value: '25' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'temperature', operator: '!=', value: '98.6' },
-      ]);
+        // Should match: name != 'Bob' AND age = 25
+        // John: !Bob + 25 ✓
+        // Jane: !Bob + 30 ✗
+        // Bob: Bob + 25 ✗
+        // Alice: !Bob + 35 ✗
+        expect(result.fields[0].values).toEqual(['John']);
+        expect(result.fields[1].values).toEqual([25]);
+        expect(result.length).toBe(1);
+      });
 
-      expect(result.fields[0].values).toEqual(['Bob']);
-      expect(result.fields[1].values).toEqual([99.1]);
-      expect(result.length).toBe(1);
-    });
+      it('should handle floating point numbers correctly', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['Alice', 'Bob', 'Charlie', 'Diana'] },
+          { name: 'score', type: FieldType.number, values: [95.5, 87.25, 95.5, 92.0] },
+        ]);
 
-    it('should handle precision edge cases with floats', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['Test1', 'Test2', 'Test3'] },
-        { name: 'value', type: FieldType.number, values: [0.1 + 0.2, 0.3, 1.0000001] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'score', operator: '=', value: '95.5' },
+        ]);
 
-      // Note: 0.1 + 0.2 !== 0.3 in JavaScript due to floating point precision
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'value', operator: '=', value: '0.3' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Alice', 'Charlie']);
+        expect(result.fields[1].values).toEqual([95.5, 95.5]);
+        expect(result.length).toBe(2);
+      });
 
-      // Should only match the exact 0.3, not the computed 0.1 + 0.2
-      expect(result.fields[0].values).toEqual(['Test2']);
-      expect(result.fields[1].values).toEqual([0.3]);
-      expect(result.length).toBe(1);
-    });
+      it('should handle floating point numbers with != operator', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['Alice', 'Bob', 'Charlie'] },
+          { name: 'temperature', type: FieldType.number, values: [98.6, 99.1, 98.6] },
+        ]);
 
-    it('should handle empty data frames', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: [] },
-        { name: 'age', type: FieldType.number, values: [] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'temperature', operator: '!=', value: '98.6' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'name', operator: '=', value: 'John' },
-      ]);
+        expect(result.fields[0].values).toEqual(['Bob']);
+        expect(result.fields[1].values).toEqual([99.1]);
+        expect(result.length).toBe(1);
+      });
 
-      expect(result.fields[0].values).toEqual([]);
-      expect(result.fields[1].values).toEqual([]);
-      expect(result.length).toBe(0);
-    });
+      it('should handle precision edge cases with floats', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['Test1', 'Test2', 'Test3'] },
+          { name: 'value', type: FieldType.number, values: [0.1 + 0.2, 0.3, 1.0000001] },
+        ]);
 
-    it.skip('should handle remaining operators', () => {
-      // Not yet implemented, so we explicitly don't specify any behaviour for this
-    });
+        // Note: 0.1 + 0.2 !== 0.3 in JavaScript due to floating point precision
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'value', operator: '=', value: '0.3' },
+        ]);
 
-    it.skip('should handle remaining field types (eg. date)', () => {
-      // Not yet implemented, so we explicitly don't specify any behaviour for this
-    });
+        // Should only match the exact 0.3, not the computed 0.1 + 0.2
+        expect(result.fields[0].values).toEqual(['Test2']);
+        expect(result.fields[1].values).toEqual([0.3]);
+        expect(result.length).toBe(1);
+      });
 
-    it('should handle filters on missing fields with = operator', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+      it('should handle empty data frames', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: [] },
+          { name: 'age', type: FieldType.number, values: [] },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'missing_field', operator: '=', value: 'test' },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'name', operator: '=', value: 'John' },
+        ]);
 
-      // Should return empty result since field doesn't exist
-      expect(result.fields[0].values).toEqual([]);
-      expect(result.fields[1].values).toEqual([]);
-      expect(result.length).toBe(0);
-    });
+        expect(result.fields[0].values).toEqual([]);
+        expect(result.fields[1].values).toEqual([]);
+        expect(result.length).toBe(0);
+      });
 
-    it('should handle filters on missing fields with != operator', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-      ]);
+      it.skip('should handle remaining operators', () => {
+        // Not yet implemented, so we explicitly don't specify any behaviour for this
+      });
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'missing_field', operator: '!=', value: 'test' },
-      ]);
+      it.skip('should handle remaining field types (eg. date)', () => {
+        // Not yet implemented, so we explicitly don't specify any behaviour for this
+      });
 
-      // Should return all rows since field doesn't exist (all rows are "not equal")
-      expect(result.fields[0].values).toEqual(['John', 'Jane', 'Bob']);
-      expect(result.fields[1].values).toEqual([25, 30, 35]);
-      expect(result.length).toBe(3);
-    });
+      it('should handle filters on missing fields with = operator', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
 
-    it('should handle complex filtering scenario', () => {
-      const frame = createTestFrame([
-        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Admin', 'Bob'] },
-        { name: 'status', type: FieldType.string, values: ['active', 'inactive', 'active', 'active'] },
-        { name: 'age', type: FieldType.number, values: [25, 30, 35, 40] },
-      ]);
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'missing_field', operator: '=', value: 'test' },
+        ]);
 
-      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
-        { key: 'status', operator: '=', value: 'active' },
-        { key: 'name', operator: '!=', value: 'Admin' },
-        { key: 'missing_field', operator: '!=', value: 'ignored' }, // Should be ignored
-      ]);
+        // Should return empty result since field doesn't exist
+        expect(result.fields[0].values).toEqual([]);
+        expect(result.fields[1].values).toEqual([]);
+        expect(result.length).toBe(0);
+      });
 
-      // Should match: status=active AND name!=Admin
-      // John: active + !Admin ✓
-      // Jane: inactive + !Admin ✗
-      // Admin: active + Admin ✗
-      // Bob: active + !Admin ✓
-      expect(result.fields[0].values).toEqual(['John', 'Bob']);
-      expect(result.fields[1].values).toEqual(['active', 'active']);
-      expect(result.fields[2].values).toEqual([25, 40]);
-      expect(result.length).toBe(2);
+      it('should handle filters on missing fields with != operator', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+        ]);
+
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'missing_field', operator: '!=', value: 'test' },
+        ]);
+
+        // Should return all rows since field doesn't exist (all rows are "not equal")
+        expect(result.fields[0].values).toEqual(['John', 'Jane', 'Bob']);
+        expect(result.fields[1].values).toEqual([25, 30, 35]);
+        expect(result.length).toBe(3);
+      });
+
+      it('should handle complex filtering scenario', () => {
+        const frame = createTestFrame([
+          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Admin', 'Bob'] },
+          { name: 'status', type: FieldType.string, values: ['active', 'inactive', 'active', 'active'] },
+          { name: 'age', type: FieldType.number, values: [25, 30, 35, 40] },
+        ]);
+
+        const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+          { key: 'status', operator: '=', value: 'active' },
+          { key: 'name', operator: '!=', value: 'Admin' },
+          { key: 'missing_field', operator: '!=', value: 'ignored' }, // Should be ignored
+        ]);
+
+        // Should match: status=active AND name!=Admin
+        // John: active + !Admin ✓
+        // Jane: inactive + !Admin ✗
+        // Admin: active + Admin ✗
+        // Bob: active + !Admin ✓
+        expect(result.fields[0].values).toEqual(['John', 'Bob']);
+        expect(result.fields[1].values).toEqual(['active', 'active']);
+        expect(result.fields[2].values).toEqual([25, 40]);
+        expect(result.length).toBe(2);
+      });
     });
   });
 });
@@ -426,7 +579,6 @@ function setup(query: DashboardQuery, requestId?: string) {
         series: [arrayToDataFrame([1, 2, 3])],
         state: LoadingState.Done,
         timeRange: getDefaultTimeRange(),
-        structureRev: 11,
       },
     }),
     transformations: [{ id: 'reduce', options: {} }],

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -16,6 +16,7 @@ import {
   AdHocVariableFilter,
   MetricFindValue,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
   activateSceneObjectAndParentTree,
@@ -123,8 +124,10 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             ...field,
             config: {
               ...field.config,
-              // Enable AdHoc filtering for string and numeric fields
-              filterable: field.type === FieldType.string || field.type === FieldType.number,
+              // Enable AdHoc filtering for string and numeric fields only when feature toggle is enabled
+              filterable: config.featureToggles.dashboardDsAdHocFiltering
+                ? field.type === FieldType.string || field.type === FieldType.number
+                : field.config.filterable,
             },
             state: {
               ...field.state,
@@ -205,7 +208,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Evaluate a filter against a field value - unified method that dispatches based on field type
    */
-  private evaluateFilter(fieldValue: any, filter: AdHocVariableFilter, fieldType: FieldType): boolean {
+  private evaluateFilter(fieldValue: unknown, filter: AdHocVariableFilter, fieldType: FieldType): boolean {
     // Handle null/undefined values consistently across all types
     if (fieldValue == null) {
       return filter.operator === '!=' && filter.value !== '';
@@ -236,7 +239,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Compare string field values
    */
-  private compareStringValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
+  private compareStringValues = (fieldValue: unknown, filter: AdHocVariableFilter): boolean => {
     const filterValue = filter.value;
 
     switch (filter.operator) {
@@ -253,7 +256,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Compare numeric field values (integers and floats)
    */
-  private compareNumericValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
+  private compareNumericValues = (fieldValue: unknown, filter: AdHocVariableFilter): boolean => {
     // Parse filter value as a number
     const filterValue = parseFloat(filter.value);
 
@@ -263,7 +266,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     }
 
     // Ensure field value is a number
-    const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(fieldValue);
+    const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(String(fieldValue));
 
     // If field value is not a valid number, reject all rows
     if (isNaN(numericFieldValue)) {
@@ -289,7 +292,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Handle unsupported field types
    */
-  private compareUnsupportedValues = (_fieldValue: any, _filter: AdHocVariableFilter): boolean => {
+  private compareUnsupportedValues = (_fieldValue: unknown, _filter: AdHocVariableFilter): boolean => {
     // unknown field type, reject all rows
     return false;
   };

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -138,10 +138,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         };
       });
 
-      // Apply AdHoc filters to series data (copied and simplified from filterByValue.ts)
-      const filteredSeries =
-        filters.length > 0 ? series.map((frame) => this.applyAdHocFilters(frame, filters)) : series;
+      if (!config.featureToggles.dashboardDsAdHocFiltering || filters.length === 0) {
+        return [...series, ...annotations];
+      }
 
+      // Apply AdHoc filters to series data
+      const filteredSeries = series.map((frame) => this.applyAdHocFilters(frame, filters));
       return [...filteredSeries, ...annotations];
     }
   }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -12,6 +12,9 @@ import {
   DataFrame,
   LoadingState,
   Field,
+  FieldType,
+  AdHocVariableFilter,
+  MetricFindValue,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
@@ -71,6 +74,9 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       return of({ data: [] });
     }
 
+    // Extract AdHoc filters from the request
+    const adhocFilters = options.filters || [];
+
     return defer(() => {
       if (!sourceDataProvider!.isActive && sourceDataProvider?.setContainerWidth) {
         sourceDataProvider?.setContainerWidth(500);
@@ -82,7 +88,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         debounceTime(50),
         map((result) => {
           return {
-            data: this.getDataFramesForQueryTopic(result.data, query),
+            data: this.getDataFramesForQueryTopic(result.data, query, adhocFilters),
             state: result.data.state,
             errors: result.data.errors,
             error: result.data.error,
@@ -95,7 +101,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     });
   }
 
-  private getDataFramesForQueryTopic(data: PanelData, query: DashboardQuery): DataFrame[] {
+  private getDataFramesForQueryTopic(
+    data: PanelData,
+    query: DashboardQuery,
+    filters: AdHocVariableFilter[]
+  ): DataFrame[] {
     const annotations = data.annotations ?? [];
     if (query.topic === DataTopic.Annotations) {
       return annotations.map((frame) => ({
@@ -111,6 +121,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           ...s,
           fields: s.fields.map((field: Field) => ({
             ...field,
+            config: {
+              ...field.config,
+              // Enable AdHoc filtering for string fields (similar to Loki/Prometheus pattern)
+              filterable: field.type === FieldType.string,
+            },
             state: {
               ...field.state,
             },
@@ -118,8 +133,140 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         };
       });
 
-      return [...series, ...annotations];
+      // Apply AdHoc filters to series data (copied and simplified from filterByValue.ts)
+      const filteredSeries =
+        filters.length > 0 ? series.map((frame) => this.applyAdHocFilters(frame, filters)) : series;
+
+      return [...filteredSeries, ...annotations];
     }
+  }
+
+  /**
+   * Apply AdHoc filters to a DataFrame
+   * Optimized version with pre-computed field indices for better performance
+   */
+  private applyAdHocFilters(frame: DataFrame, filters: AdHocVariableFilter[]): DataFrame {
+    if (filters.length === 0 || frame.length === 0) {
+      return frame;
+    }
+
+    // Pre-compute field indices for better performance - O(m × f) instead of O(n × m × f)
+    const filterFieldIndices = filters
+      .map((filter) => {
+        const fieldIndex = frame.fields.findIndex((f) => f.name === filter.key);
+        return { filter, fieldIndex };
+      })
+      .filter(({ filter, fieldIndex }) => {
+        // If field is not present:
+        // - Keep filters with '=' operator (will always be false - reject rows)
+        // - Remove filters with '!=' operator (will always be true - no effect)
+        if (fieldIndex === -1) {
+          return filter.operator === '=';
+        }
+        return true;
+      });
+
+    // If no filters remain after optimization, return original frame
+    if (filterFieldIndices.length === 0) {
+      return frame;
+    }
+
+    // Short-circuit: if any filter has '=' operator with missing field, reject all rows
+    const hasImpossibleFilter = filterFieldIndices.some(({ fieldIndex }) => fieldIndex === -1);
+    if (hasImpossibleFilter) {
+      return this.reconstructDataFrame(frame, new Set<number>());
+    }
+
+    const matchingRows = new Set<number>();
+
+    // Check each row to see if it matches all filters (AND logic)
+    for (let rowIndex = 0; rowIndex < frame.length; rowIndex++) {
+      const rowMatches = filterFieldIndices.every(({ filter, fieldIndex }) => {
+        // Handle case where field doesn't exist (fieldIndex === -1)
+        if (fieldIndex === -1) {
+          return this.handleNonStringFieldFilter(filter);
+        }
+
+        const field = frame.fields[fieldIndex];
+
+        // Skip if field isn't a string field
+        if (field.type !== FieldType.string) {
+          return this.handleNonStringFieldFilter(filter);
+        }
+
+        const fieldValue = field.values[rowIndex];
+        return this.evaluateFilter(fieldValue, filter);
+      });
+
+      if (rowMatches) {
+        matchingRows.add(rowIndex);
+      }
+    }
+
+    return this.reconstructDataFrame(frame, matchingRows);
+  }
+
+  /**
+   * Handle filtering behavior for non-string fields
+   * Consistent with Prometheus DS behavior
+   */
+  private handleNonStringFieldFilter(filter: AdHocVariableFilter): boolean {
+    // Be consistent with Prometheus DS behavior:
+    // - reject when operator is '=' (field must exist and match)
+    // - allow when operator is '!=' (field doesn't exist, so it's "not equal")
+    switch (filter.operator) {
+      case '=':
+        return false; // Field doesn't exist or isn't string, so can't match
+      case '!=':
+        return true; // Field doesn't exist or isn't string, so it's "not equal"
+      default:
+        return true; // Unknown operator, skip this filter
+    }
+  }
+
+  /**
+   * Evaluate a filter against a field value
+   */
+  private evaluateFilter(fieldValue: any, filter: AdHocVariableFilter): boolean {
+    // Handle null/undefined values
+    if (fieldValue == null) {
+      return filter.operator === '!=' && filter.value !== '';
+    }
+
+    const filterValue = filter.value;
+
+    // Apply the filter based on operator
+    switch (filter.operator) {
+      case '=':
+        return fieldValue === filterValue;
+      case '!=':
+        return fieldValue !== filterValue;
+      default:
+        // Unknown operator, skip this filter
+        return true;
+    }
+  }
+
+  /**
+   * Reconstruct DataFrame with only matching rows
+   * Optimized to avoid repeated array operations
+   */
+  private reconstructDataFrame(frame: DataFrame, matchingRows: Set<number>): DataFrame {
+    const fields: Field[] = frame.fields.map((field) => {
+      const newValues = Array.from(matchingRows, (rowIndex) => field.values[rowIndex]);
+
+      return {
+        ...field,
+        values: newValues,
+        state: {}, // Clean the state as it's being recalculated
+      };
+    });
+
+    return {
+      ...frame,
+      fields: fields,
+      length: matchingRows.size,
+    };
   }
 
   private findSourcePanel(scene: SceneObject, panelId: number) {
@@ -168,5 +315,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
   testDatasource(): Promise<TestDataSourceResponse> {
     return Promise.resolve({ message: '', status: '' });
+  }
+
+  getTagKeys(): Promise<MetricFindValue[]> {
+    // Stub implementation to indicate AdHoc filter support
+    // Full implementation will be added in future PRs
+    return Promise.resolve([]);
   }
 }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -184,22 +184,14 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       const rowMatches = filterFieldIndices.every(({ filter, fieldIndex }) => {
         // Handle case where field doesn't exist (fieldIndex === -1)
         if (fieldIndex === -1) {
-          return this.handleNonStringFieldFilter(filter);
+          return this.compareUnsupportedValues(null, filter);
         }
 
         const field = frame.fields[fieldIndex];
+        const fieldValue = field.values[rowIndex];
 
-        // Handle string and numeric fields
-        if (field.type === FieldType.string) {
-          const fieldValue = field.values[rowIndex];
-          return this.evaluateStringFilter(fieldValue, filter);
-        } else if (field.type === FieldType.number) {
-          const fieldValue = field.values[rowIndex];
-          return this.evaluateNumericFilter(fieldValue, filter);
-        } else {
-          // Skip if field isn't a supported type
-          return this.handleNonStringFieldFilter(filter);
-        }
+        // Use unified evaluation method that dispatches based on field type
+        return this.evaluateFilter(fieldValue, filter, field.type);
       });
 
       if (rowMatches) {
@@ -211,82 +203,96 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   }
 
   /**
-   * Handle filtering behavior for non-string fields
-   * Consistent with Prometheus DS behavior
+   * Evaluate a filter against a field value - unified method that dispatches based on field type
    */
-  private handleNonStringFieldFilter(filter: AdHocVariableFilter): boolean {
-    // Be consistent with Prometheus DS behavior:
-    // - reject when operator is '=' (field must exist and match)
-    // - allow when operator is '!=' (field doesn't exist, so it's "not equal")
-    switch (filter.operator) {
-      case '=':
-        return false; // Field doesn't exist or isn't string, so can't match
-      case '!=':
-        return true; // Field doesn't exist or isn't string, so it's "not equal"
-      default:
-        return true; // Unknown operator, skip this filter
-    }
-  }
-
-  /**
-   * Evaluate a filter against a string field value
-   */
-  private evaluateStringFilter(fieldValue: any, filter: AdHocVariableFilter): boolean {
-    // Handle null/undefined values
+  private evaluateFilter(fieldValue: any, filter: AdHocVariableFilter, fieldType: FieldType): boolean {
+    // Handle null/undefined values consistently across all types
     if (fieldValue == null) {
       return filter.operator === '!=' && filter.value !== '';
     }
 
+    // Dispatch to type-specific comparison logic
+    const compareFn = this.getComparisonFunction(fieldType);
+    return compareFn(fieldValue, filter);
+  }
+
+  /**
+   * Get the appropriate comparison function based on field type
+   */
+  private getComparisonFunction(fieldType: FieldType) {
+    switch (fieldType) {
+      case FieldType.string:
+        return this.compareStringValues;
+      case FieldType.number:
+        return this.compareNumericValues;
+      // Easy to extend for future types:
+      // case FieldType.time:
+      //   return this.compareDateValues;
+      default:
+        return this.compareUnsupportedValues; // Skip unknown types
+    }
+  }
+
+  /**
+   * Compare string field values
+   */
+  private compareStringValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
     const filterValue = filter.value;
 
-    // Apply the filter based on operator
     switch (filter.operator) {
       case '=':
         return fieldValue === filterValue;
       case '!=':
         return fieldValue !== filterValue;
       default:
-        // Unknown operator, skip this filter
-        return true;
+        // Unknown operator, reject all rows
+        return false;
     }
-  }
+  };
 
   /**
-   * Evaluate a filter against a numeric field value
+   * Compare numeric field values (integers and floats)
    */
-  private evaluateNumericFilter(fieldValue: any, filter: AdHocVariableFilter): boolean {
-    // Handle null/undefined values
-    if (fieldValue == null) {
-      return filter.operator === '!=' && filter.value !== '';
-    }
-
+  private compareNumericValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
     // Parse filter value as a number
     const filterValue = parseFloat(filter.value);
 
-    // If filter value is not a valid number, skip this filter
+    // If filter value is not a valid number, reject all rows
     if (isNaN(filterValue)) {
-      return true;
+      return false;
     }
 
     // Ensure field value is a number
     const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(fieldValue);
 
-    // If field value is not a valid number, skip this filter
+    // If field value is not a valid number, reject all rows
     if (isNaN(numericFieldValue)) {
-      return true;
+      return false;
     }
 
-    // Apply the filter based on operator
     switch (filter.operator) {
       case '=':
         return numericFieldValue === filterValue;
       case '!=':
         return numericFieldValue !== filterValue;
+      // Easy to add more operators:
+      // case '>':
+      //   return numericFieldValue > filterValue;
+      // case '<':
+      //   return numericFieldValue < filterValue;
       default:
-        // Unknown operator, skip this filter
-        return true;
+        // Unknown operator, reject all rows
+        return false;
     }
-  }
+  };
+
+  /**
+   * Handle unsupported field types
+   */
+  private compareUnsupportedValues = (_fieldValue: any, _filter: AdHocVariableFilter): boolean => {
+    // unknown field type, reject all rows
+    return false;
+  };
 
   /**
    * Reconstruct DataFrame with only matching rows


### PR DESCRIPTION
## What is this feature?

Implementing AdHoc filtering for the `--Dashboard--` data source, behind an experimental feature toggle.

https://github.com/user-attachments/assets/c4c006e5-0b13-4819-b7f8-0f8a61a0a9d1

I've kept the scope purposefully small here in order to keep this PR small, and get it in front of our stakeholders as soon as possible. It includes support only for:
- String and numeric fields
- Operators `=` and `!=`

For cases other than these we simply reject all rows for now (to clearly indicate to the user that the newly added filter is not supported). We can extend support or add error-messages at a later date, as we find they are needed.

We also haven't implemented `getTagKeys` or `getTagValues`, again to keep scope small. We anticipate these filters being applied primarily by people clicking on data within panels, and not by hand-crafting the filter text in the filter input itself at the top of the dashboard (which is what `getTagKeys/Values` would enable).

## Why do we need this feature?

BI dashboarding tools such as Tableau and Looker allow for "Panel to Panel filtering", which is shown here in the video

https://github.com/user-attachments/assets/92ff03c2-aae6-47be-bf75-1e4d30338674

So users can click a value in a panel to immediately filter the whole dashboard (and all other panels) to the value they clicked. They can then continue clicking and filtering by clicking on other panels, and other values in those panels, to keep drilling and drilling down to the small set of data that they want to study.

AdHoc filters are a good fit for this because they scale well:
- They apply to all panels on a dashboard (which are powered by the single datasource they are scoped to), and
- They can contain multiple filter key-value pairs in a single filter, and
- They require zero per-panel configuration: They apply automatically.

BUT
Until now they've only been implemented for:
- Table cells (will be addressed in **another PR**), and
- A limited number of Observability datasources: Prom, Loki, Elastic, Tempo, Pyroscope, and a few others **(which we address in THIS PR)**

Our stakeholder wants Panel-to-Panel filtering to work with their BigQuery data from their data warehouse. But we can't implement AdHoc filtering in BigQuery itself because we can't rely on a column being present in another panel, even if it is powered by the same underlying table. If we try to filter to Customer BBC for example, by landing a `WHERE 'customer' = 'bbc'` clause into our panel query, we expect it to simply fail with a syntax error such as `customer column not found` for many of the panels on the dashboard, where for example the Customer column will not be present in the outermost query. It may have been aggregated away already, or never even queried, given there are a great many tables in many typical SQL databases encountered in the wild. 

The dashboards we anticipate in response to this are as follows:
> The designer configures a primary query or queries that will power the dashboard. These are unfiltered

^ This primary query will exist as a table panel that contains the full dataset. At this point **we know which columns are present in that dataset, and can rely on them always being present**. We won't ever get "column not found" errors. Then we can use the `--Dashboard--` datasource to power every other panel on the dashboard, and then (through this PR) enable Ad-hoc filtering on all of those panels.

## Who is this feature for?

BI users, building dashboards for other viewer-users, where the viewer-users need to filter and drill the dashboard quickly and easily on a variety of dimensions.

## Which issue(s) does this PR fix?:

None

## Special notes for your reviewer:

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] No docs, as this is experimental
