### PR TITLE
fix(cli): set plugin ownership to match pluginDir

### DIFF
--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -176,17 +176,10 @@ func doInstallPlugin(ctx context.Context, pluginID, version string, o pluginInst
 	if err != nil {
 		return err
 	}
-	if os.Geteuid() == 0 {
-	pluginPath := filepath.Join(o.pluginDir, pluginID)
-	parentInfo, err := os.Stat(o.pluginDir)
-	if err == nil {
-		if stat, ok := parentInfo.Sys().(*syscall.Stat_t); ok {
-			if chownErr := os.Chown(pluginPath, int(stat.Uid), int(stat.Gid)); chownErr != nil {
-				services.Logger.Warnf("Failed to chown plugin directory %s: %v", pluginPath, chownErr)
-			}
-		}
-	}
+if os.Geteuid() == 0 {
+  chownPluginDirRecursively(o.pluginDir, pluginID)
 }
+
 
 	for _, dep := range extractedArchive.Dependencies {
 		services.Logger.Infof("Fetching %s dependency %s...", pluginID, dep.ID)

--- a/pkg/cmd/grafana-cli/commands/install_command.go
+++ b/pkg/cmd/grafana-cli/commands/install_command.go
@@ -176,6 +176,17 @@ func doInstallPlugin(ctx context.Context, pluginID, version string, o pluginInst
 	if err != nil {
 		return err
 	}
+	if os.Geteuid() == 0 {
+	pluginPath := filepath.Join(o.pluginDir, pluginID)
+	parentInfo, err := os.Stat(o.pluginDir)
+	if err == nil {
+		if stat, ok := parentInfo.Sys().(*syscall.Stat_t); ok {
+			if chownErr := os.Chown(pluginPath, int(stat.Uid), int(stat.Gid)); chownErr != nil {
+				services.Logger.Warnf("Failed to chown plugin directory %s: %v", pluginPath, chownErr)
+			}
+		}
+	}
+}
 
 	for _, dep := range extractedArchive.Dependencies {
 		services.Logger.Infof("Fetching %s dependency %s...", pluginID, dep.ID)

--- a/pkg/cmd/grafana-cli/commands/install_command_default.go
+++ b/pkg/cmd/grafana-cli/commands/install_command_default.go
@@ -1,0 +1,5 @@
+// +build !linux,!darwin
+
+package commands
+
+func chownPluginDirRecursively(pluginDir, pluginID string) {}

--- a/pkg/cmd/grafana-cli/commands/install_command_unix.go
+++ b/pkg/cmd/grafana-cli/commands/install_command_unix.go
@@ -1,0 +1,22 @@
+// +build linux darwin
+
+package commands
+
+import (
+  "os"
+  "path/filepath"
+  "syscall"
+)
+
+func chownPluginDirRecursively(pluginDir, pluginID string) {
+  pluginPath := filepath.Join(pluginDir, pluginID)
+  filepath.Walk(pluginPath, func(path string, info os.FileInfo, err error) error {
+    if err != nil {
+      return nil  
+    }
+    if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+      os.Chown(path, int(stat.Uid), int(stat.Gid)) 
+    }
+    return nil
+  })
+}


### PR DESCRIPTION
**CLI: Ensure installed plugin ownership matches pluginDir parent**

**What is this feature?**  
Fixes a bug in `grafana-cli` where plugins installed with `sudo` would be owned by root, causing permission issues later. The ownership of installed plugins now matches the parent directory of `pluginDir`.

**Why do we need this feature?**  
Currently, using `sudo grafana-cli plugins install` installs plugin files as root, even when the rest of the Grafana installation is owned by another user (e.g., `grafana`). This breaks plugin updates and sandboxing behavior.

**Who is this feature for?**  
System administrators and users who install plugins via CLI in environments where Grafana is not running as root.

**Which issue(s) does this PR fix?**  
Fixes #107678

**Special notes for your reviewer:**  
- This fix uses `os.Chown` to assign the same UID/GID to the installed plugin directory as its parent (`pluginDir`).
- Please verify the behavior under different permission contexts (`sudo`, systemd service user, etc.).
