### PR TITLE
Secrets: Bump API version to v1beta1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.4 // @grafana/alerting-backend
 	github.com/microsoft/go-mssqldb v1.8.0 // @grafana/partner-datasources
 	github.com/migueleliasweb/go-github-mock v1.1.0 // @grafana/grafana-app-platform-squad
+	github.com/mitchellh/copystructure v1.2.0 // @grafana/grafana-operator-experience-squad
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c //@grafana/identity-access-team
 	github.com/mocktools/go-smtp-mock/v2 v2.3.1 // @grafana/grafana-backend-group
 	github.com/modern-go/reflect2 v1.0.2 // @grafana/alerting-backend
@@ -233,8 +234,9 @@ require (
 	github.com/grafana/grafana/apps/iam v0.0.0-20250627191313-2f1a6ae1712b // @grafana/identity-access-team
 	github.com/grafana/grafana/apps/investigations v0.0.0-20250627191313-2f1a6ae1712b // @fcjack @matryer
 	github.com/grafana/grafana/apps/playlist v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-app-platform-squad
+	github.com/grafana/grafana/apps/secret v0.0.0-20250711114246-c9b2126c4ad5 // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana/pkg/aggregator v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-app-platform-squad
-	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-app-platform-squad
+	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250711114246-c9b2126c4ad5 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-operator-experience-squad
 	github.com/grafana/grafana/pkg/apiserver v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-app-platform-squad
 
@@ -455,7 +457,6 @@ require (
 	github.com/miekg/dns v1.1.63 // indirect
 	github.com/minio/asm2plan9s v0.0.0-20200509001527-cdd76441f9d8 // indirect
 	github.com/minio/c2goasm v0.0.0-20190812172519-36a3d3bbc4f3 // indirect
-	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1621,10 +1621,12 @@ github.com/grafana/grafana/apps/investigations v0.0.0-20250627191313-2f1a6ae1712
 github.com/grafana/grafana/apps/investigations v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:8RlQ4U9lccPEBD/QxV4zyIMh9+lzjS/7xGpiqn3cHLY=
 github.com/grafana/grafana/apps/playlist v0.0.0-20250627191313-2f1a6ae1712b h1:elfpvk06igCjE0yL+/urc69UDOt1B/sPfdNg9X9kUMc=
 github.com/grafana/grafana/apps/playlist v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:fPtx6dwGm0PweQRVbgtthMapJMvXobBcORbndb7Dgd4=
+github.com/grafana/grafana/apps/secret v0.0.0-20250711114246-c9b2126c4ad5 h1:+fMhUoqwGdY8ntH0GL2icJa3uk+bTiIMicawDG2r9Uc=
+github.com/grafana/grafana/apps/secret v0.0.0-20250711114246-c9b2126c4ad5/go.mod h1:TIrKvhgo2j6lvVeOZ3TUmXbI4I48d6v7QcadL/f6SKQ=
 github.com/grafana/grafana/pkg/aggregator v0.0.0-20250627191313-2f1a6ae1712b h1:ei01IFqmnXkOrrVvsT3CYe+i5xYra3SCX7Wsu3PMsDU=
 github.com/grafana/grafana/pkg/aggregator v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:+H4Va9jDJlGQJjAN+OFD/hLx2I/yEzDRMQLaKecvgAc=
-github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250627191313-2f1a6ae1712b h1:e0dG1tPpuv4NHCAPP235Gip/MBQB8fQ2XW2bwHqoWh4=
-github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:u0+k7KLCvGi6zHWsc2B7r+tmGcYjN/qR+gn51pl104E=
+github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250711114246-c9b2126c4ad5 h1:f4fopIH6eQRoZ/E7bstn69UtDAHleIdQ6DrdzEs++Ug=
+github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250711114246-c9b2126c4ad5/go.mod h1:eAlOam2uWhrsEZlOoAr7XZ9hbBP7SyYGYn31/aQAPs8=
 github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250627191313-2f1a6ae1712b h1:rkQO7exsDLdr4KGA7kgEnkQnbJGePbDIP1SUQptLRs8=
 github.com/grafana/grafana/pkg/apis/secret v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:9YjiHZzii2DZfocRDJbqSeC8M3GWenU5yexeHHxsZ4Y=
 github.com/grafana/grafana/pkg/apiserver v0.0.0-20250627191313-2f1a6ae1712b h1:QyJLJn3xwFTIXu9KPZujsrIUN0X8DdiR9b2h75L0AfI=

--- a/go.work.sum
+++ b/go.work.sum
@@ -718,7 +718,7 @@ github.com/grafana/grafana/apps/dashboard v0.0.0-20250616145019-8d27f12428cb/go.
 github.com/grafana/grafana/apps/investigation v0.0.0-20250121113133-e747350fee2d/go.mod h1:HQprw3MmiYj5OUV9CZnkwA1FKDZBmYACuAB3oDvUOmI=
 github.com/grafana/grafana/apps/playlist v0.0.0-20250121113133-e747350fee2d/go.mod h1:DjJe5osrW/BKrzN9hAAOSElNWutj1bcriExa7iDP7kA=
 github.com/grafana/grafana/pkg/aggregator v0.0.0-20250121113133-e747350fee2d/go.mod h1:1sq0guad+G4SUTlBgx7SXfhnzy7D86K/LcVOtiQCiMA=
-github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250710134100-1f3dc0533caf/go.mod h1:eAlOam2uWhrsEZlOoAr7XZ9hbBP7SyYGYn31/aQAPs8=
+github.com/grafana/grafana/pkg/apimachinery v0.0.0-20250711114246-c9b2126c4ad5/go.mod h1:eAlOam2uWhrsEZlOoAr7XZ9hbBP7SyYGYn31/aQAPs8=
 github.com/grafana/grafana/pkg/semconv v0.0.0-20250121113133-e747350fee2d/go.mod h1:tfLnBpPYgwrBMRz4EXqPCZJyCjEG4Ev37FSlXnocJ2c=
 github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250121113133-e747350fee2d/go.mod h1:CXpwZ3Mkw6xVlGKc0SqUxqXCP3Uv182q6qAQnLaLxRg=
 github.com/grafana/grafana/pkg/storage/unified/apistore v0.0.0-20250514132646-acbc7b54ed9e/go.mod h1:xrKQcxQxz+IUF90ybtfENFeEXtlj9nAsX/3Fw0KEIeQ=
@@ -1424,7 +1424,6 @@ k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7 h1:2OX19X59HxDprNCVrWi6jb7LW1
 k8s.io/gengo/v2 v2.0.0-20250207200755-1244d31929d7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=
 k8s.io/klog v1.0.0 h1:Pt+yjF5aB1xDSVbau4VsWe+dQNzA0qv1LlXdC2dF6Q8=
 k8s.io/klog v1.0.0/go.mod h1:4Bi6QPql/J/LkTDqv7R/cd3hPo4k2DG6Ptcz060Ez5I=
-k8s.io/kms v0.33.2/go.mod h1:C1I8mjFFBNzfUZXYt9FZVJ8MJl7ynFbGgZFbBzkBJ3E=
 lukechampine.com/uint128 v1.2.0 h1:mBi/5l91vocEN8otkC5bDLhi2KdCticRiwbdB0O+rjI=
 modernc.org/cc/v3 v3.36.3 h1:uISP3F66UlixxWEcKuIWERa4TwrZENHSL8tWxZz8bHg=
 modernc.org/ccgo/v3 v3.16.9 h1:AXquSwg7GuMk11pIdw7fmO1Y/ybgazVkMhsZWCV0mHM=

--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
@@ -16,7 +16,7 @@ var (
 
 // DecryptStorage is the interface for wiring and dependency injection.
 type DecryptStorage interface {
-	Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error)
+	Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv1beta1.ExposedSecureValue, error)
 }
 
 // DecryptAuthorizer is the interface for authorizing decryption requests.

--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
@@ -15,12 +15,12 @@ var (
 
 // KeeperMetadataStorage is the interface for wiring and dependency injection.
 type KeeperMetadataStorage interface {
-	Create(ctx context.Context, keeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error)
-	Read(ctx context.Context, namespace xkube.Namespace, name string, opts ReadOpts) (*secretv0alpha1.Keeper, error)
-	Update(ctx context.Context, keeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error)
+	Create(ctx context.Context, keeper *secretv1beta1.Keeper, actorUID string) (*secretv1beta1.Keeper, error)
+	Read(ctx context.Context, namespace xkube.Namespace, name string, opts ReadOpts) (*secretv1beta1.Keeper, error)
+	Update(ctx context.Context, keeper *secretv1beta1.Keeper, actorUID string) (*secretv1beta1.Keeper, error)
 	Delete(ctx context.Context, namespace xkube.Namespace, name string) error
-	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.Keeper, error)
-	GetKeeperConfig(ctx context.Context, namespace string, name *string, opts ReadOpts) (secretv0alpha1.KeeperConfig, error)
+	List(ctx context.Context, namespace xkube.Namespace) ([]secretv1beta1.Keeper, error)
+	GetKeeperConfig(ctx context.Context, namespace string, name *string, opts ReadOpts) (secretv1beta1.KeeperConfig, error)
 }
 
 // ErrKeeperInvalidSecureValues is returned when a Keeper references SecureValues that do not exist.
@@ -95,14 +95,14 @@ func (s ExternalID) String() string {
 
 // Keeper is the interface for secret keepers.
 type Keeper interface {
-	Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (ExternalID, error)
-	Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID, exposedValueOrRef string) error
-	Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID) (secretv0alpha1.ExposedSecureValue, error)
-	Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID ExternalID) error
+	Store(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, exposedValueOrRef string) (ExternalID, error)
+	Update(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID ExternalID, exposedValueOrRef string) error
+	Expose(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID ExternalID) (secretv1beta1.ExposedSecureValue, error)
+	Delete(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID ExternalID) error
 }
 
 // Service is the interface for secret keeper services.
 // This exists because OSS and Enterprise have different amounts of keepers available.
 type KeeperService interface {
-	KeeperForConfig(secretv0alpha1.KeeperConfig) (Keeper, error)
+	KeeperForConfig(secretv1beta1.KeeperConfig) (Keeper, error)
 }

--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"errors"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 )
 
@@ -30,9 +30,9 @@ type ReadOpts struct {
 
 // SecureValueMetadataStorage is the interface for wiring and dependency injection.
 type SecureValueMetadataStorage interface {
-	Create(ctx context.Context, sv *secretv0alpha1.SecureValue, actorUID string) (*secretv0alpha1.SecureValue, error)
-	Read(ctx context.Context, namespace xkube.Namespace, name string, opts ReadOpts) (*secretv0alpha1.SecureValue, error)
-	List(ctx context.Context, namespace xkube.Namespace) ([]secretv0alpha1.SecureValue, error)
+	Create(ctx context.Context, sv *secretv1beta1.SecureValue, actorUID string) (*secretv1beta1.SecureValue, error)
+	Read(ctx context.Context, namespace xkube.Namespace, name string, opts ReadOpts) (*secretv1beta1.SecureValue, error)
+	List(ctx context.Context, namespace xkube.Namespace) ([]secretv1beta1.SecureValue, error)
 	SetVersionToActive(ctx context.Context, namespace xkube.Namespace, name string, version int64) error
 	SetVersionToInactive(ctx context.Context, namespace xkube.Namespace, name string, version int64) error
 	SetExternalID(ctx context.Context, namespace xkube.Namespace, name string, version int64, externalID ExternalID) error

--- a/pkg/registry/apis/secret/decrypt/authorizer.go
+++ b/pkg/registry/apis/secret/decrypt/authorizer.go
@@ -9,7 +9,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 )
 
@@ -88,8 +88,8 @@ func (a *decryptAuthorizer) Authorize(ctx context.Context, secureValueName strin
 // Changes: 1) we don't support `*` for verbs; 2) we support specific names in the permission.
 func hasPermissionInToken(tokenPermissions []string, name string) bool {
 	var (
-		group    = secretv0alpha1.GROUP
-		resource = secretv0alpha1.SecureValuesResourceInfo.GetName()
+		group    = secretv1beta1.APIGroup
+		resource = secretv1beta1.SecureValuesResourceInfo.GetName()
 		verb     = "decrypt"
 	)
 

--- a/pkg/registry/apis/secret/decrypt/service_test.go
+++ b/pkg/registry/apis/secret/decrypt/service_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/service"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/stretchr/testify/mock"
@@ -22,7 +22,7 @@ func TestDecryptService(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		mockStorage := &MockDecryptStorage{}
-		mockStorage.On("Decrypt", mock.Anything, mock.Anything, mock.Anything).Return(secretv0alpha1.ExposedSecureValue(""), mockErr)
+		mockStorage.On("Decrypt", mock.Anything, mock.Anything, mock.Anything).Return(secretv1beta1.ExposedSecureValue(""), mockErr)
 		decryptedValuesResp := map[string]service.DecryptResult{
 			"secure-value-1": service.NewDecryptResultErr(mockErr),
 		}
@@ -42,8 +42,8 @@ func TestDecryptService(t *testing.T) {
 
 		mockStorage := &MockDecryptStorage{}
 		// Set up the mock to return a different value for each name in the test
-		exposedSecureValue1 := secretv0alpha1.NewExposedSecureValue("value1")
-		exposedSecureValue2 := secretv0alpha1.NewExposedSecureValue("value2")
+		exposedSecureValue1 := secretv1beta1.NewExposedSecureValue("value1")
+		exposedSecureValue2 := secretv1beta1.NewExposedSecureValue("value2")
 		mockStorage.On("Decrypt", mock.Anything, xkube.Namespace("default"), "secure-value-1").
 			Return(exposedSecureValue1, nil)
 		mockStorage.On("Decrypt", mock.Anything, xkube.Namespace("default"), "secure-value-2").
@@ -69,11 +69,11 @@ func TestDecryptService(t *testing.T) {
 
 		mockErr := errors.New("mock error")
 		mockStorage := &MockDecryptStorage{}
-		exposedSecureValue := secretv0alpha1.NewExposedSecureValue("value")
+		exposedSecureValue := secretv1beta1.NewExposedSecureValue("value")
 		mockStorage.On("Decrypt", mock.Anything, xkube.Namespace("default"), "secure-value-1").
 			Return(exposedSecureValue, nil)
 		mockStorage.On("Decrypt", mock.Anything, xkube.Namespace("default"), "secure-value-2").
-			Return(secretv0alpha1.ExposedSecureValue(""), mockErr)
+			Return(secretv1beta1.ExposedSecureValue(""), mockErr)
 
 		decryptedValuesResp := map[string]service.DecryptResult{
 			"secure-value-1": service.NewDecryptResultValue(&exposedSecureValue),
@@ -95,7 +95,7 @@ type MockDecryptStorage struct {
 	mock.Mock
 }
 
-func (m *MockDecryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv0alpha1.ExposedSecureValue, error) {
+func (m *MockDecryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (secretv1beta1.ExposedSecureValue, error) {
 	args := m.Called(ctx, namespace, name)
-	return args.Get(0).(secretv0alpha1.ExposedSecureValue), args.Error(1)
+	return args.Get(0).(secretv1beta1.ExposedSecureValue), args.Error(1)
 }

--- a/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/fakes/fake_keeper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 )
 
@@ -24,7 +24,7 @@ func NewFakeKeeper() *FakeKeeper {
 	}
 }
 
-func (s *FakeKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {
+func (s *FakeKeeper) Store(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {
 	ns, ok := s.values[namespace]
 	if !ok {
 		ns = make(map[string]string)
@@ -36,7 +36,7 @@ func (s *FakeKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 	return contracts.ExternalID(uid), nil
 }
 
-func (s *FakeKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *FakeKeeper) Expose(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID) (secretv1beta1.ExposedSecureValue, error) {
 	ns, ok := s.values[namespace]
 	if !ok {
 		return "", ErrSecretNotFound
@@ -46,14 +46,14 @@ func (s *FakeKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig
 		return "", ErrSecretNotFound
 	}
 
-	return secretv0alpha1.NewExposedSecureValue(exposedVal), nil
+	return secretv1beta1.NewExposedSecureValue(exposedVal), nil
 }
 
-func (s *FakeKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) error {
+func (s *FakeKeeper) Delete(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID) error {
 	return nil
 }
 
-func (s *FakeKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID, exposedValueOrRef string) error {
+func (s *FakeKeeper) Update(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID, exposedValueOrRef string) error {
 	ns, ok := s.values[namespace]
 	if !ok {
 		return ErrSecretNotFound

--- a/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/secretkeeper.go
@@ -3,7 +3,7 @@ package secretkeeper
 import (
 	"go.opentelemetry.io/otel/trace"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper/sqlkeeper"
 	"github.com/prometheus/client_golang/prometheus"
@@ -30,6 +30,6 @@ func ProvideService(
 
 // Ignore the config, but we could use it to get the keeper type and then return the correct keeper.
 // Instantiation only happens on ProvideService ONCE.
-func (k *OSSKeeperService) KeeperForConfig(secretv0alpha1.KeeperConfig) (contracts.Keeper, error) {
+func (k *OSSKeeperService) KeeperForConfig(secretv1beta1.KeeperConfig) (contracts.Keeper, error) {
 	return k.systemKeeper, nil
 }

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/secretkeeper/metrics"
 	"github.com/prometheus/client_golang/prometheus"
@@ -36,7 +36,7 @@ func NewSQLKeeper(
 	}
 }
 
-func (s *SQLKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {
+func (s *SQLKeeper) Store(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, exposedValueOrRef string) (contracts.ExternalID, error) {
 	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Store", trace.WithAttributes(attribute.String("namespace", namespace)))
 	defer span.End()
 
@@ -58,7 +58,7 @@ func (s *SQLKeeper) Store(ctx context.Context, cfg secretv0alpha1.KeeperConfig, 
 	return externalID, nil
 }
 
-func (s *SQLKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) (secretv0alpha1.ExposedSecureValue, error) {
+func (s *SQLKeeper) Expose(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID) (secretv1beta1.ExposedSecureValue, error) {
 	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Expose", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("externalID", externalID.String()),
@@ -76,13 +76,13 @@ func (s *SQLKeeper) Expose(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 		return "", fmt.Errorf("unable to decrypt value: %w", err)
 	}
 
-	exposedValue := secretv0alpha1.NewExposedSecureValue(string(exposedBytes))
+	exposedValue := secretv1beta1.NewExposedSecureValue(string(exposedBytes))
 	s.metrics.ExposeDuration.WithLabelValues(string(cfg.Type())).Observe(time.Since(start).Seconds())
 
 	return exposedValue, nil
 }
 
-func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID) error {
+func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID) error {
 	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Delete", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("externalID", externalID.String()),
@@ -100,7 +100,7 @@ func (s *SQLKeeper) Delete(ctx context.Context, cfg secretv0alpha1.KeeperConfig,
 	return nil
 }
 
-func (s *SQLKeeper) Update(ctx context.Context, cfg secretv0alpha1.KeeperConfig, namespace string, externalID contracts.ExternalID, exposedValueOrRef string) error {
+func (s *SQLKeeper) Update(ctx context.Context, cfg secretv1beta1.KeeperConfig, namespace string, externalID contracts.ExternalID, exposedValueOrRef string) error {
 	ctx, span := s.tracer.Start(ctx, "SQLKeeper.Update", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.String("externalID", externalID.String()),

--- a/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
+++ b/pkg/registry/apis/secret/secretkeeper/sqlkeeper/keeper_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	encryptionmanager "github.com/grafana/grafana/pkg/registry/apis/secret/encryption/manager"
@@ -44,7 +44,7 @@ func Test_SQLKeeperSetup(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sqlKeeper)
 
-	keeperCfg := &secretv0alpha1.SystemKeeperConfig{}
+	keeperCfg := &secretv1beta1.SystemKeeperConfig{}
 
 	t.Run("storing an encrypted value returns no error", func(t *testing.T) {
 		externalId1, err := sqlKeeper.Store(ctx, keeperCfg, namespace1, plaintext1)

--- a/pkg/registry/apis/secret/service/decrypt.go
+++ b/pkg/registry/apis/secret/service/decrypt.go
@@ -3,14 +3,14 @@ package service
 import (
 	"context"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 )
 
 // DecryptResult is the (union) result of a decryption operation.
 // It contains the decrypted `value` when the decryption succeeds, and the `err` when it fails.
 // It is not possible to construct a `DecryptResult` where both `value` and `err` are set from another package.
 type DecryptResult struct {
-	value *secretv0alpha1.ExposedSecureValue
+	value *secretv1beta1.ExposedSecureValue
 	err   error
 }
 
@@ -18,7 +18,7 @@ func (d DecryptResult) Error() error {
 	return d.err
 }
 
-func (d DecryptResult) Value() *secretv0alpha1.ExposedSecureValue {
+func (d DecryptResult) Value() *secretv1beta1.ExposedSecureValue {
 	return d.value
 }
 
@@ -26,7 +26,7 @@ func NewDecryptResultErr(err error) DecryptResult {
 	return DecryptResult{err: err}
 }
 
-func NewDecryptResultValue(value *secretv0alpha1.ExposedSecureValue) DecryptResult {
+func NewDecryptResultValue(value *secretv1beta1.ExposedSecureValue) DecryptResult {
 	return DecryptResult{value: value}
 }
 

--- a/pkg/registry/apis/secret/service/secure_value_test.go
+++ b/pkg/registry/apis/secret/service/secure_value_test.go
@@ -3,11 +3,12 @@ package service_test
 import (
 	"testing"
 
-	"github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/testutils"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 )
 
 func TestCrud(t *testing.T) {
@@ -23,7 +24,7 @@ func TestCrud(t *testing.T) {
 		// Create the same secure value twice
 		input := sv1.DeepCopy()
 		input.Spec.Description = "d2"
-		input.Spec.Value = v0alpha1.NewExposedSecureValue("v2")
+		input.Spec.Value = ptr.To(secretv1beta1.NewExposedSecureValue("v2"))
 
 		sv2, err := sut.CreateSv(t.Context(), testutils.CreateSvWithSv(input))
 		require.NoError(t, err)
@@ -55,6 +56,7 @@ func TestCrud(t *testing.T) {
 		// Update the secure value
 		input := sv1.DeepCopy()
 		input.Spec.Description = "d2"
+		input.Spec.Value = ptr.To(secretv1beta1.NewExposedSecureValue("v3"))
 		sv2, err := sut.UpdateSv(t.Context(), input)
 		require.NoError(t, err)
 

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -6,11 +6,12 @@ import (
 
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	encryptionstorage "github.com/grafana/grafana/pkg/storage/secret/encryption"
 	"go.opentelemetry.io/otel/trace/noop"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	"github.com/grafana/grafana/pkg/infra/usagestats"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
@@ -138,28 +139,28 @@ type Sut struct {
 }
 
 type CreateSvConfig struct {
-	Sv *secretv0alpha1.SecureValue
+	Sv *secretv1beta1.SecureValue
 }
 
-func CreateSvWithSv(sv *secretv0alpha1.SecureValue) func(*CreateSvConfig) {
+func CreateSvWithSv(sv *secretv1beta1.SecureValue) func(*CreateSvConfig) {
 	return func(cfg *CreateSvConfig) {
 		cfg.Sv = sv
 	}
 }
 
-func (s *Sut) CreateSv(ctx context.Context, opts ...func(*CreateSvConfig)) (*secretv0alpha1.SecureValue, error) {
+func (s *Sut) CreateSv(ctx context.Context, opts ...func(*CreateSvConfig)) (*secretv1beta1.SecureValue, error) {
 	cfg := CreateSvConfig{
-		Sv: &secretv0alpha1.SecureValue{
+		Sv: &secretv1beta1.SecureValue{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "sv1",
 				Namespace: "ns1",
 			},
-			Spec: secretv0alpha1.SecureValueSpec{
+			Spec: secretv1beta1.SecureValueSpec{
 				Description: "desc1",
-				Value:       secretv0alpha1.NewExposedSecureValue("v1"),
+				Value:       ptr.To(secretv1beta1.NewExposedSecureValue("v1")),
 				Decrypters:  []string{"decrypter1"},
 			},
-			Status: secretv0alpha1.SecureValueStatus{},
+			Status: secretv1beta1.SecureValueStatus{},
 		},
 	}
 	for _, opt := range opts {
@@ -173,12 +174,12 @@ func (s *Sut) CreateSv(ctx context.Context, opts ...func(*CreateSvConfig)) (*sec
 	return createdSv, nil
 }
 
-func (s *Sut) UpdateSv(ctx context.Context, sv *secretv0alpha1.SecureValue) (*secretv0alpha1.SecureValue, error) {
+func (s *Sut) UpdateSv(ctx context.Context, sv *secretv1beta1.SecureValue) (*secretv1beta1.SecureValue, error) {
 	newSv, _, err := s.SecureValueService.Update(ctx, sv, "actor-uid")
 	return newSv, err
 }
 
-func (s *Sut) DeleteSv(ctx context.Context, namespace, name string) (*secretv0alpha1.SecureValue, error) {
+func (s *Sut) DeleteSv(ctx context.Context, namespace, name string) (*secretv1beta1.SecureValue, error) {
 	sv, err := s.SecureValueService.Delete(ctx, xkube.Namespace(namespace), name)
 	return sv, err
 }
@@ -191,7 +192,7 @@ func newKeeperServiceWrapper(keeper contracts.Keeper) *keeperServiceWrapper {
 	return &keeperServiceWrapper{keeper: keeper}
 }
 
-func (wrapper *keeperServiceWrapper) KeeperForConfig(cfg secretv0alpha1.KeeperConfig) (contracts.Keeper, error) {
+func (wrapper *keeperServiceWrapper) KeeperForConfig(cfg secretv1beta1.KeeperConfig) (contracts.Keeper, error) {
 	return wrapper.keeper, nil
 }
 

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -13,7 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana-app-sdk/logging"
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -60,7 +60,7 @@ type decryptStorage struct {
 }
 
 // Decrypt decrypts a secure value from the keeper.
-func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv0alpha1.ExposedSecureValue, decryptErr error) {
+func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace, name string) (_ secretv1beta1.ExposedSecureValue, decryptErr error) {
 	ctx, span := s.tracer.Start(ctx, "DecryptStorage.Decrypt", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
 		attribute.String("name", name),

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -7,9 +7,10 @@ import (
 	"github.com/grafana/authlib/authn"
 	"github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/testutils"
 )
@@ -73,12 +74,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		}))
 
 		// Create a secure value that is not in the allowlist
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = svName
 		sv.Namespace = "default"
 
@@ -110,12 +111,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		}))
 
 		// Create a secure value that is in the allowlist
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = "sv-test"
 		sv.Namespace = "default"
 
@@ -149,12 +150,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		}))
 
 		// Create a secure value that is in the allowlist
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = svName
 		sv.Namespace = "default"
 
@@ -181,12 +182,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		sut := testutils.Setup(t)
 
 		// Create a secure value
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = "sv-test"
 		sv.Namespace = "default"
 
@@ -214,12 +215,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		sut := testutils.Setup(t)
 
 		// Create a secure value
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = svName
 		sv.Namespace = "default"
 
@@ -246,12 +247,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		sut := testutils.Setup(t)
 
 		// Create a secure value
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = "sv-test"
 		sv.Namespace = "default"
 
@@ -279,12 +280,12 @@ func TestIntegrationDecrypt(t *testing.T) {
 		sut := testutils.Setup(t)
 
 		// Create a secure value
-		spec := secretv0alpha1.SecureValueSpec{
+		spec := secretv1beta1.SecureValueSpec{
 			Description: "description",
 			Decrypters:  []string{svcIdentity},
-			Value:       secretv0alpha1.NewExposedSecureValue("value"),
+			Value:       ptr.To(secretv1beta1.NewExposedSecureValue("value")),
 		}
-		sv := &secretv0alpha1.SecureValue{Spec: spec}
+		sv := &secretv1beta1.SecureValue{Spec: spec}
 		sv.Name = svName
 		sv.Namespace = "default"
 

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -46,7 +46,7 @@ func ProvideKeeperMetadataStorage(
 	}, nil
 }
 
-func (s *keeperMetadataStorage) Create(ctx context.Context, keeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error) {
+func (s *keeperMetadataStorage) Create(ctx context.Context, keeper *secretv1beta1.Keeper, actorUID string) (*secretv1beta1.Keeper, error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.Create", trace.WithAttributes(
 		attribute.String("name", keeper.GetName()),
@@ -111,7 +111,7 @@ func (s *keeperMetadataStorage) Create(ctx context.Context, keeper *secretv0alph
 	return createdKeeper, nil
 }
 
-func (s *keeperMetadataStorage) Read(ctx context.Context, namespace xkube.Namespace, name string, opts contracts.ReadOpts) (*secretv0alpha1.Keeper, error) {
+func (s *keeperMetadataStorage) Read(ctx context.Context, namespace xkube.Namespace, name string, opts contracts.ReadOpts) (*secretv1beta1.Keeper, error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.Read", trace.WithAttributes(
 		attribute.String("name", name),
@@ -174,7 +174,7 @@ func (s *keeperMetadataStorage) read(ctx context.Context, namespace, name string
 	return &keeper, nil
 }
 
-func (s *keeperMetadataStorage) Update(ctx context.Context, newKeeper *secretv0alpha1.Keeper, actorUID string) (*secretv0alpha1.Keeper, error) {
+func (s *keeperMetadataStorage) Update(ctx context.Context, newKeeper *secretv1beta1.Keeper, actorUID string) (*secretv1beta1.Keeper, error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.Update", trace.WithAttributes(
 		attribute.String("name", newKeeper.GetName()),
@@ -291,7 +291,7 @@ func (s *keeperMetadataStorage) Delete(ctx context.Context, namespace xkube.Name
 	return nil
 }
 
-func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (keeperList []secretv0alpha1.Keeper, err error) {
+func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (keeperList []secretv1beta1.Keeper, err error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.List", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
@@ -318,7 +318,7 @@ func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namesp
 	}
 	defer func() { _ = rows.Close() }()
 
-	keepers := make([]secretv0alpha1.Keeper, 0)
+	keepers := make([]secretv1beta1.Keeper, 0)
 
 	for rows.Next() {
 		var row keeperDB
@@ -350,7 +350,7 @@ func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namesp
 
 // validateSecureValueReferences checks that all secure values referenced by the keeper exist and are not referenced by other third-party keepers.
 // It is used by other methods inside a transaction.
-func (s *keeperMetadataStorage) validateSecureValueReferences(ctx context.Context, keeper *secretv0alpha1.Keeper) (err error) {
+func (s *keeperMetadataStorage) validateSecureValueReferences(ctx context.Context, keeper *secretv1beta1.Keeper) (err error) {
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.ValidateSecureValueReferences", trace.WithAttributes(
 		attribute.String("name", keeper.GetName()),
 		attribute.String("namespace", keeper.GetNamespace()),
@@ -497,7 +497,7 @@ func (s *keeperMetadataStorage) validateSecureValueReferences(ctx context.Contex
 	return nil
 }
 
-func (s *keeperMetadataStorage) GetKeeperConfig(ctx context.Context, namespace string, name *string, opts contracts.ReadOpts) (secretv0alpha1.KeeperConfig, error) {
+func (s *keeperMetadataStorage) GetKeeperConfig(ctx context.Context, namespace string, name *string, opts contracts.ReadOpts) (secretv1beta1.KeeperConfig, error) {
 	ctx, span := s.tracer.Start(ctx, "KeeperMetadataStorage.GetKeeperConfig", trace.WithAttributes(
 		attribute.String("namespace", namespace),
 		attribute.Bool("isForUpdate", opts.ForUpdate),
@@ -506,7 +506,7 @@ func (s *keeperMetadataStorage) GetKeeperConfig(ctx context.Context, namespace s
 
 	// Check if keeper is the systemwide one.
 	if name == nil {
-		return &secretv0alpha1.SystemKeeperConfig{}, nil
+		return &secretv1beta1.SystemKeeperConfig{}, nil
 	}
 
 	start := time.Now()
@@ -518,7 +518,7 @@ func (s *keeperMetadataStorage) GetKeeperConfig(ctx context.Context, namespace s
 		return nil, err
 	}
 
-	keeperConfig := toProvider(secretv0alpha1.KeeperType(kp.Type), kp.Payload)
+	keeperConfig := toProvider(secretv1beta1.KeeperType(kp.Type), kp.Payload)
 
 	s.metrics.KeeperMetadataGetKeeperConfigDuration.Observe(time.Since(start).Seconds())
 

--- a/pkg/storage/secret/metadata/keeper_store_test.go
+++ b/pkg/storage/secret/metadata/keeper_store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/utils/ptr"
 )
 
 func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
@@ -22,10 +23,10 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 	defaultKeeperName := "kp-test"
 	defaultKeeperNS := "default"
 
-	testKeeper := &secretv0alpha1.Keeper{
-		Spec: secretv0alpha1.KeeperSpec{
+	testKeeper := &secretv1beta1.Keeper{
+		Spec: secretv1beta1.KeeperSpec{
 			Description: "description",
-			AWS:         &secretv0alpha1.AWSKeeperConfig{},
+			Aws:         &secretv1beta1.KeeperAWSConfig{},
 		},
 	}
 
@@ -41,7 +42,7 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		// get system keeper config
 		keeperConfig, err := keeperMetadataStorage.GetKeeperConfig(ctx, defaultKeeperNS, nil, contracts.ReadOpts{})
 		require.NoError(t, err)
-		require.IsType(t, &secretv0alpha1.SystemKeeperConfig{}, keeperConfig)
+		require.IsType(t, &secretv1beta1.SystemKeeperConfig{}, keeperConfig)
 	})
 
 	t.Run("get test keeper config", func(t *testing.T) {
@@ -90,10 +91,10 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		keeperTest := "kp-test2"
 		keeperNamespaceTest := "ns"
 
-		testKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		testKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "another description",
-				AWS:         &secretv0alpha1.AWSKeeperConfig{},
+				Aws:         &secretv1beta1.KeeperAWSConfig{},
 			},
 		}
 		testKeeper.Name = keeperTest
@@ -128,10 +129,10 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		keeperNamespaceTest := "ns"
 
 		// Create initial keeper
-		initialKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		initialKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "initial description",
-				AWS:         &secretv0alpha1.AWSKeeperConfig{},
+				Aws:         &secretv1beta1.KeeperAWSConfig{},
 			},
 		}
 		initialKeeper.Name = keeperTest
@@ -147,10 +148,10 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		require.Equal(t, "initial description", keeper.Spec.Description)
 
 		// Update the keeper with new values
-		updatedKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		updatedKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "updated description",
-				AWS:         &secretv0alpha1.AWSKeeperConfig{},
+				Aws:         &secretv1beta1.KeeperAWSConfig{},
 			},
 		}
 		updatedKeeper.Name = keeperTest
@@ -182,19 +183,17 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		keeperNamespaceTest := "ns"
 
 		// Create initial keeper with first AWS config
-		initialKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		initialKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "initial description",
-				AWS: &secretv0alpha1.AWSKeeperConfig{
-					AWSCredentials: secretv0alpha1.AWSCredentials{
-						AccessKeyID: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_ACCESS_KEY_ID_1",
-						},
-						SecretAccessKey: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_SECRET_ACCESS_KEY_1",
-						},
-						KMSKeyID: "kms-key-id-1",
+				Aws: &secretv1beta1.KeeperAWSConfig{
+					AccessKeyID: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_ACCESS_KEY_ID_1",
 					},
+					SecretAccessKey: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_SECRET_ACCESS_KEY_1",
+					},
+					KmsKeyID: ptr.To("kms-key-id-1"),
 				},
 			},
 		}
@@ -208,24 +207,22 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		// Verify initial AWS config
 		keeper, err := keeperMetadataStorage.Read(ctx, xkube.Namespace(keeperNamespaceTest), keeperTest, contracts.ReadOpts{})
 		require.NoError(t, err)
-		require.Equal(t, "AWS_ACCESS_KEY_ID_1", keeper.Spec.AWS.AccessKeyID.ValueFromEnv)
-		require.Equal(t, "AWS_SECRET_ACCESS_KEY_1", keeper.Spec.AWS.SecretAccessKey.ValueFromEnv)
-		require.Equal(t, "kms-key-id-1", keeper.Spec.AWS.KMSKeyID)
+		require.Equal(t, "AWS_ACCESS_KEY_ID_1", keeper.Spec.Aws.AccessKeyID.ValueFromEnv)
+		require.Equal(t, "AWS_SECRET_ACCESS_KEY_1", keeper.Spec.Aws.SecretAccessKey.ValueFromEnv)
+		require.Equal(t, "kms-key-id-1", *keeper.Spec.Aws.KmsKeyID)
 
 		// Update with new AWS config
-		updatedKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		updatedKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "updated description",
-				AWS: &secretv0alpha1.AWSKeeperConfig{
-					AWSCredentials: secretv0alpha1.AWSCredentials{
-						AccessKeyID: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_ACCESS_KEY_ID_2",
-						},
-						SecretAccessKey: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_SECRET_ACCESS_KEY_2",
-						},
-						KMSKeyID: "kms-key-id-2",
+				Aws: &secretv1beta1.KeeperAWSConfig{
+					AccessKeyID: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_ACCESS_KEY_ID_2",
 					},
+					SecretAccessKey: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_SECRET_ACCESS_KEY_2",
+					},
+					KmsKeyID: ptr.To("kms-key-id-2"),
 				},
 			},
 		}
@@ -239,9 +236,9 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		// Verify updated AWS config
 		updatedKeeper, err = keeperMetadataStorage.Read(ctx, xkube.Namespace(keeperNamespaceTest), keeperTest, contracts.ReadOpts{})
 		require.NoError(t, err)
-		require.Equal(t, "AWS_ACCESS_KEY_ID_2", updatedKeeper.Spec.AWS.AccessKeyID.ValueFromEnv)
-		require.Equal(t, "AWS_SECRET_ACCESS_KEY_2", updatedKeeper.Spec.AWS.SecretAccessKey.ValueFromEnv)
-		require.Equal(t, "kms-key-id-2", updatedKeeper.Spec.AWS.KMSKeyID)
+		require.Equal(t, "AWS_ACCESS_KEY_ID_2", updatedKeeper.Spec.Aws.AccessKeyID.ValueFromEnv)
+		require.Equal(t, "AWS_SECRET_ACCESS_KEY_2", updatedKeeper.Spec.Aws.SecretAccessKey.ValueFromEnv)
+		require.Equal(t, "kms-key-id-2", *updatedKeeper.Spec.Aws.KmsKeyID)
 	})
 
 	t.Run("list keepers in empty namespace", func(t *testing.T) {
@@ -276,17 +273,15 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		keeperNamespaceTest := "ns1"
 
 		// Create initial keeper
-		initialKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		initialKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "initial description",
-				AWS: &secretv0alpha1.AWSKeeperConfig{
-					AWSCredentials: secretv0alpha1.AWSCredentials{
-						AccessKeyID: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_ACCESS_KEY_ID",
-						},
-						SecretAccessKey: secretv0alpha1.CredentialValue{
-							ValueFromEnv: "AWS_SECRET_ACCESS_KEY",
-						},
+				Aws: &secretv1beta1.KeeperAWSConfig{
+					AccessKeyID: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_ACCESS_KEY_ID",
+					},
+					SecretAccessKey: secretv1beta1.KeeperCredentialValue{
+						ValueFromEnv: "AWS_SECRET_ACCESS_KEY",
 					},
 				},
 			},
@@ -320,10 +315,10 @@ func Test_KeeperMetadataStorage_GetKeeperConfig(t *testing.T) {
 		ctx := context.Background()
 		keeperMetadataStorage := initStorage(t)
 
-		nonExistentKeeper := &secretv0alpha1.Keeper{
-			Spec: secretv0alpha1.KeeperSpec{
+		nonExistentKeeper := &secretv1beta1.Keeper{
+			Spec: secretv1beta1.KeeperSpec{
 				Description: "some description",
-				AWS:         &secretv0alpha1.AWSKeeperConfig{},
+				Aws:         &secretv1beta1.KeeperAWSConfig{},
 			},
 		}
 		nonExistentKeeper.Name = "non-existent"

--- a/pkg/storage/secret/metadata/secure_value_model.go
+++ b/pkg/storage/secret/metadata/secure_value_model.go
@@ -7,8 +7,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
@@ -45,7 +45,7 @@ func (*secureValueDB) TableName() string {
 }
 
 // toKubernetes maps a DB row into a Kubernetes resource (metadata + spec).
-func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
+func (sv *secureValueDB) toKubernetes() (*secretv1beta1.SecureValue, error) {
 	annotations := make(map[string]string, 0)
 	if sv.Annotations != "" {
 		if err := json.Unmarshal([]byte(sv.Annotations), &annotations); err != nil {
@@ -68,12 +68,12 @@ func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
 		}
 	}
 
-	resource := &secretv0alpha1.SecureValue{
-		Spec: secretv0alpha1.SecureValueSpec{
+	resource := &secretv1beta1.SecureValue{
+		Spec: secretv1beta1.SecureValueSpec{
 			Description: sv.Description,
 			Decrypters:  decrypters,
 		},
-		Status: secretv0alpha1.SecureValueStatus{
+		Status: secretv1beta1.SecureValueStatus{
 			ExternalID: sv.ExternalID,
 			Version:    sv.Version,
 		},
@@ -111,7 +111,7 @@ func (sv *secureValueDB) toKubernetes() (*secretv0alpha1.SecureValue, error) {
 }
 
 // toCreateRow maps a Kubernetes resource into a DB row for new resources being created/inserted.
-func toCreateRow(sv *secretv0alpha1.SecureValue, actorUID string) (*secureValueDB, error) {
+func toCreateRow(sv *secretv1beta1.SecureValue, actorUID string) (*secureValueDB, error) {
 	row, err := toRow(sv, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert SecureValue to secureValueDB: %w", err)
@@ -129,7 +129,7 @@ func toCreateRow(sv *secretv0alpha1.SecureValue, actorUID string) (*secureValueD
 }
 
 // toRow maps a Kubernetes resource into a DB row.
-func toRow(sv *secretv0alpha1.SecureValue, externalID string) (*secureValueDB, error) {
+func toRow(sv *secretv1beta1.SecureValue, externalID string) (*secureValueDB, error) {
 	var annotations string
 	if len(sv.Annotations) > 0 {
 		cleanedAnnotations := xkube.CleanAnnotations(sv.Annotations)

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -46,7 +46,7 @@ type secureValueMetadataStorage struct {
 	tracer  trace.Tracer
 }
 
-func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv0alpha1.SecureValue, actorUID string) (*secretv0alpha1.SecureValue, error) {
+func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1beta1.SecureValue, actorUID string) (*secretv1beta1.SecureValue, error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.Create", trace.WithAttributes(
 		attribute.String("name", sv.GetName()),
@@ -289,7 +289,7 @@ func (s *secureValueMetadataStorage) readActiveVersion(ctx context.Context, name
 	return secureValue, nil
 }
 
-func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.Namespace, name string, opts contracts.ReadOpts) (*secretv0alpha1.SecureValue, error) {
+func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.Namespace, name string, opts contracts.ReadOpts) (*secretv1beta1.SecureValue, error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.Read", trace.WithAttributes(
 		attribute.String("name", name),
@@ -314,7 +314,7 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 	return secureValueKub, nil
 }
 
-func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (svList []secretv0alpha1.SecureValue, error error) {
+func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (svList []secretv1beta1.SecureValue, error error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.List", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
@@ -341,7 +341,7 @@ func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.N
 	}
 	defer func() { _ = rows.Close() }()
 
-	secureValues := make([]secretv0alpha1.SecureValue, 0)
+	secureValues := make([]secretv1beta1.SecureValue, 0)
 	for rows.Next() {
 		row := secureValueDB{}
 

--- a/pkg/storage/secret/metadata/secure_value_store_test.go
+++ b/pkg/storage/secret/metadata/secure_value_store_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	secretv0alpha1 "github.com/grafana/grafana/pkg/apis/secret/v0alpha1"
+	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -14,15 +14,16 @@ import (
 	"github.com/grafana/grafana/pkg/storage/secret/migrator"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
+	"k8s.io/utils/ptr"
 )
 
 func createTestKeeper(t *testing.T, ctx context.Context, keeperStorage contracts.KeeperMetadataStorage, name, namespace string) string {
 	t.Helper()
 
-	testKeeper := &secretv0alpha1.Keeper{
-		Spec: secretv0alpha1.KeeperSpec{
+	testKeeper := &secretv1beta1.Keeper{
+		Spec: secretv1beta1.KeeperSpec{
 			Description: "test keeper description",
-			AWS:         &secretv0alpha1.AWSKeeperConfig{},
+			Aws:         &secretv1beta1.KeeperAWSConfig{},
 		},
 	}
 	testKeeper.Name = name
@@ -56,10 +57,10 @@ func Test_SecureValueMetadataStorage_CreateAndRead(t *testing.T) {
 		keeperName := createTestKeeper(t, ctx, keeperStorage, "test-keeper", "default")
 
 		// Create a test secure value
-		testSecureValue := &secretv0alpha1.SecureValue{
-			Spec: secretv0alpha1.SecureValueSpec{
+		testSecureValue := &secretv1beta1.SecureValue{
+			Spec: secretv1beta1.SecureValueSpec{
 				Description: "test description",
-				Value:       "test-value",
+				Value:       ptr.To(secretv1beta1.NewExposedSecureValue("test-value")),
 				Keeper:      &keeperName,
 			},
 		}
@@ -110,10 +111,10 @@ func Test_SecureValueMetadataStorage_CreateAndRead(t *testing.T) {
 		keeperName := createTestKeeper(t, ctx, keeperStorage, "test-keeper-2", "default")
 
 		// Create a test secure value
-		testSecureValue := &secretv0alpha1.SecureValue{
-			Spec: secretv0alpha1.SecureValueSpec{
+		testSecureValue := &secretv1beta1.SecureValue{
+			Spec: secretv1beta1.SecureValueSpec{
 				Description: "test description 2",
-				Value:       "test-value-2",
+				Value:       ptr.To(secretv1beta1.NewExposedSecureValue("test-value-2")),
 				Keeper:      &keeperName,
 			},
 		}


### PR DESCRIPTION
**What is this feature?**

Updates code to use v1beta1 API version for Secrets.

There were minor changes in the spec in terms of camelCase and some types which became a pointer, but other than that no functional changes, just search and replace mostly.

**Why do we need this feature?**

Evolve API.

**Who is this feature for?**

Developers 

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1474

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
