### PR TITLE
CI: Change prerelease bucket path from {VERSION} to {VERSION}_{BUILD_ID}

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -186,5 +186,5 @@ jobs:
       bucket: grafana-prerelease
       pattern: artifacts-*
       run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ needs.setup.outputs.build_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -186,5 +186,5 @@ jobs:
       bucket: grafana-prerelease
       pattern: artifacts-*
       run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ needs.setup.outputs.build_id }}
       environment: prod


### PR DESCRIPTION
Because we plan on using this mechanism in our CI builds to upload artifacts for release- branches as well, we want to make sure we distinguish repeated uploads of the same version in the prerelease bucket.

To avoid a new commit on `release-11.5.6` from overwriting a previous `11.5.6` build at `gs://grafana-prerelease/11.5.6/`, the new path will be `gs://grafana-prerelease/11.5.6_901877/`.