### PR TITLE
Alerting: Fix Jira HCL export with fields & add export snapshots test

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -1,7 +1,9 @@
 package api
 
 import (
+	"bytes"
 	"context"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -12,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	alertingNotify "github.com/grafana/alerting/notify"
 	prometheus "github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
@@ -56,6 +59,9 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
+
+//go:embed test-data/receiver-exports/*
+var receiverExportResponses embed.FS
 
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
@@ -1893,6 +1899,112 @@ func TestIntegrationProvisioningApiContactPointExport(t *testing.T) {
 				require.Equal(t, expectedResponse, string(response.Body()))
 			})
 		})
+	})
+}
+
+func TestApiContactPointExportSnapshot(t *testing.T) {
+	// This test should fail whenever the export of a contact point changes. If the change is expected, update
+	// the corresponding test response file(s) in test-data/receiver-exports/*
+	type testcase struct {
+		name       string
+		receiver   models.Receiver
+		redacted   bool
+		exportType string
+	}
+	runTestCase := func(t *testing.T, tc testcase) {
+		postableReceiver, err := legacy_storage.ReceiverToPostableApiReceiver(&tc.receiver)
+		require.NoError(t, err)
+		postable := definitions.PostableUserConfig{
+			AlertmanagerConfig: definitions.PostableApiAlertingConfig{
+				Config: definitions.Config{
+					Route: &definitions.Route{
+						Receiver: postableReceiver.Name,
+					},
+				},
+				Receivers: []*definitions.PostableApiReceiver{postableReceiver},
+			},
+		}
+
+		amConfig, err := json.Marshal(postable)
+		require.NoError(t, err)
+
+		env := createTestEnv(t, string(amConfig))
+		env.ac.Callback = func(user *user.SignedInUser, evaluator accesscontrol.Evaluator) (bool, error) {
+			return true, nil
+		}
+		sut := createProvisioningSrvSutFromEnv(t, &env)
+		rc := createTestRequestCtx()
+
+		switch tc.exportType {
+		case "yaml":
+			rc.Req.Header.Add("Accept", "application/yaml")
+		case "json":
+			rc.Req.Header.Add("Accept", "application/json")
+		case "hcl":
+			rc.Req.Form.Add("format", "hcl")
+		default:
+			t.Fatalf("unknown export type %q", tc.exportType)
+		}
+
+		if tc.redacted {
+			rc.Req.Form.Set("decrypt", "false")
+		} else {
+			rc.Req.Form.Set("decrypt", "true")
+		}
+
+		response := sut.RouteGetContactPointsExport(&rc)
+		require.Equalf(t, 200, response.Status(), "expected 200, got %d, body: %q", response.Status(), response.Body())
+
+		actualBody := response.Body()
+		if tc.exportType == "json" {
+			// Indent the JSON for easier comparison.
+			// This isn't strictly necessary, but it makes the test output more readable.
+			out := new(bytes.Buffer)
+			err = json.Indent(out, actualBody, "", " ")
+			require.NoError(t, err)
+			actualBody = out.Bytes()
+		}
+
+		p := path.Join("test-data", "receiver-exports", "redacted")
+		if !tc.redacted {
+			p = path.Join("test-data", "receiver-exports", "unredacted")
+		}
+		p = path.Join(p, fmt.Sprintf("%s.%s", tc.name, tc.exportType))
+
+		// To update these files: os.WriteFile(path.Join(p), actualBody, 0644)
+
+		exportRaw, err := receiverExportResponses.ReadFile(p)
+		require.NoError(t, err)
+		require.Equal(t, string(exportRaw), string(actualBody))
+	}
+
+	t.Run("contact point export for all known configs", func(t *testing.T) {
+		allIntegrationsName := "all-integrations"
+		for _, exportType := range []string{"yaml", "json", "hcl"} {
+			t.Run(fmt.Sprintf("exportType=%s", exportType), func(t *testing.T) {
+				for _, redacted := range []bool{true, false} {
+					t.Run(fmt.Sprintf("redacted=%t", redacted), func(t *testing.T) {
+						allIntegrations := make([]models.Integration, 0, len(alertingNotify.AllKnownConfigsForTesting))
+						for integrationType := range alertingNotify.AllKnownConfigsForTesting {
+							integration := models.IntegrationGen(
+								models.IntegrationMuts.WithName(allIntegrationsName),
+								models.IntegrationMuts.WithUID(fmt.Sprintf("%s-uid", integrationType)),
+								models.IntegrationMuts.WithValidConfig(integrationType),
+							)()
+							integration.DisableResolveMessage = redacted
+							allIntegrations = append(allIntegrations, integration)
+						}
+						receiver := models.ReceiverGen(models.ReceiverMuts.WithName(allIntegrationsName), models.ReceiverMuts.WithIntegrations(allIntegrations...))()
+						runTestCase(t, testcase{
+							name:       allIntegrationsName,
+							receiver:   receiver,
+							redacted:   redacted,
+							exportType: exportType,
+						})
+					})
+				}
+			})
+		}
 	})
 }
 

--- a/pkg/services/ngalert/api/compat_contact_points_test.go
+++ b/pkg/services/ngalert/api/compat_contact_points_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // Test that conversion notify.APIReceiver -> definitions.ContactPoint -> notify.APIReceiver does not lose data
@@ -210,5 +211,88 @@ func TestContactPointFromContactPointExports(t *testing.T) {
 		require.Equal(t, int64(112), *result.Mqtt[0].QoS)
 		require.Nil(t, result.Mqtt[1].QoS)
 		require.Nil(t, result.Mqtt[2].QoS)
+	})
+
+	t.Run("jira with various fields values as string", func(t *testing.T) {
+		testcases := []struct {
+			name        string
+			input       definitions.RawMessage
+			expected    *string
+			expectedErr bool
+		}{
+			{
+				name:     "standard map[string]string",
+				input:    definitions.RawMessage(`{ "fields" : {"test-data" : "test-value"} }`),
+				expected: util.Pointer(`{"test-data":"test-value"}`),
+			},
+			{
+				name:     "map[string]int",
+				input:    definitions.RawMessage(`{ "fields" : {"test-data" : 42} }`),
+				expected: util.Pointer(`{"test-data":42}`),
+			},
+			{
+				name:     "map[string]interface{} with null value",
+				input:    definitions.RawMessage(`{ "fields" : {"test-data" : null} }`),
+				expected: util.Pointer(`{"test-data":null}`),
+			},
+			{
+				name:     "null fields",
+				input:    definitions.RawMessage(`{ "fields" : null }`),
+				expected: nil,
+			},
+			{
+				name:     "empty map",
+				input:    definitions.RawMessage(`{ "fields" : {} }`),
+				expected: util.Pointer(`{}`),
+			},
+			{
+				name:     "nested map",
+				input:    definitions.RawMessage(`{ "fields" : {"test-data" : {"test-data-nested" : "test-value-nested"}} }`),
+				expected: util.Pointer(`{"test-data":{"test-data-nested":"test-value-nested"}}`),
+			},
+			{
+				name:     "nested slice",
+				input:    definitions.RawMessage(`{ "fields" : {"test-data" : ["slice1", "slice2"]} }`),
+				expected: util.Pointer(`{"test-data":["slice1","slice2"]}`),
+			},
+			{
+				name:        "string value",
+				input:       definitions.RawMessage(`{ "fields" : "some string" }`),
+				expectedErr: true,
+			},
+			{
+				name:        "slice",
+				input:       definitions.RawMessage(`{ "fields" : ["slice1", "slice2"} }`),
+				expectedErr: true,
+			},
+		}
+		for _, tc := range testcases {
+			t.Run(tc.name, func(t *testing.T) {
+				export := definitions.ContactPointExport{
+					Name: "test",
+					Receivers: []definitions.ReceiverExport{
+						{
+							Type:     "jira",
+							Settings: tc.input,
+						},
+					},
+				}
+
+				result, err := ContactPointFromContactPointExport(export)
+				if tc.expectedErr {
+					require.Error(t, err, "Expected error for input: %s", tc.input)
+					return
+				} else {
+					require.NoError(t, err, "Unexpected error for input: %s", tc.input)
+				}
+				require.Len(t, result.Jira, 1)
+
+				if tc.expected == nil {
+					require.Nil(t, result.Jira[0].Fields)
+				} else {
+					require.Equal(t, *tc.expected, *result.Jira[0].Fields)
+				}
+			})
+		}
 	})
 }

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
@@ -1,0 +1,329 @@
+resource "grafana_contact_point" "contact_point_2b661702215368fe" {
+  name = "all-integrations"
+
+  alertmanager {
+    disable_resolve_message = true
+    url                     = "https://alertmanager-01.com"
+    basic_auth_user         = "grafana"
+    basic_auth_password     = "[REDACTED]"
+  }
+
+  dingding {
+    disable_resolve_message = true
+    url                     = "[REDACTED]"
+    message_type            = "actionCard"
+    title                   = "Alerts firing: {{ len .Alerts.Firing }}"
+    message                 = "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
+  }
+
+  discord {
+    disable_resolve_message = true
+    url                     = "[REDACTED]"
+    title                   = "test-title"
+    message                 = "test-message"
+    avatar_url              = "http://avatar"
+    use_discord_username    = true
+  }
+
+  email {
+    disable_resolve_message = true
+    addresses               = ["test@grafana.com"]
+    single_email            = true
+    message                 = "test-message"
+    subject                 = "test-subject"
+  }
+
+  googlechat {
+    disable_resolve_message = true
+    url                     = "[REDACTED]"
+    title                   = "test-title"
+    message                 = "test-message"
+  }
+
+  jira {
+    disable_resolve_message = true
+    api_url                 = "http://localhost"
+    project                 = "Test Project"
+    issue_type              = "Test Issue Type"
+    summary                 = "Test Summary"
+    description             = "Test Description"
+    labels                  = ["Test Label", "Test Label 2"]
+    priority                = "Test Priority"
+    reopen_transition       = "Test Reopen Transition"
+    resolve_transition      = "Test Resolve Transition"
+    wont_fix_resolution     = "Test Won't Fix Resolution"
+    reopen_duration         = "1m"
+    dedup_key_field         = "10000"
+    fields = {
+      test-field = "test-value"
+    }
+    user     = "[REDACTED]"
+    password = "[REDACTED]"
+  }
+
+  kafka {
+    disable_resolve_message = true
+    rest_proxy_url          = "http://localhost/"
+    topic                   = "test-topic"
+    description             = "test-description"
+    details                 = "test-details"
+    username                = "test-user"
+    password                = "[REDACTED]"
+    api_version             = "v2"
+    cluster_id              = "12345"
+  }
+
+  line {
+    disable_resolve_message = true
+    token                   = "[REDACTED]"
+    title                   = "test-title"
+    description             = "test-description"
+  }
+
+  mqtt {
+    disable_resolve_message = true
+    broker_url              = "tcp://localhost:1883"
+    client_id               = "grafana-test-client-id"
+    topic                   = "grafana/alerts"
+    message_format          = "json"
+    username                = "test-username"
+    password                = "[REDACTED]"
+    qos                     = 0
+    retain                  = false
+
+    tls_config {
+      insecure_skip_verify = false
+      ca_certificate       = "[REDACTED]"
+      client_certificate   = "[REDACTED]"
+      client_key           = "[REDACTED]"
+    }
+  }
+
+  opsgenie {
+    disable_resolve_message = true
+    api_key                 = "[REDACTED]"
+    url                     = "http://localhost"
+    message                 = "test-message"
+    description             = "test-description"
+    auto_close              = false
+    override_priority       = false
+    send_tags_as            = "both"
+
+    responders {
+      id   = "test-id"
+      type = "team"
+    }
+    responders {
+      username = "test-user"
+      type     = "user"
+    }
+    responders {
+      name = "test-schedule"
+      type = "schedule"
+    }
+  }
+
+  pagerduty {
+    disable_resolve_message = true
+    integration_key         = "[REDACTED]"
+    severity                = "test-severity"
+    class                   = "test-class"
+    component               = "test-component"
+    group                   = "test-group"
+    summary                 = "test-summary"
+    source                  = "test-source"
+    client                  = "test-client"
+    client_url              = "http://localhost/test-client-url"
+    url                     = "http://localhost/test-api-url"
+  }
+
+  oncall {
+    disable_resolve_message = true
+    url                     = "http://localhost"
+    http_method             = "PUT"
+    max_alerts              = 2
+    authorization_scheme    = "basic"
+    basic_auth_user         = "test-user"
+    basic_auth_password     = "[REDACTED]"
+    title                   = "test-title"
+    message                 = "test-message"
+  }
+
+  pushover {
+    disable_resolve_message = true
+    user_key                = "[REDACTED]"
+    api_token               = "[REDACTED]"
+    priority                = 1
+    ok_priority             = 2
+    retry                   = 555
+    expire                  = 333
+    device                  = "test-device"
+    sound                   = "test-sound"
+    ok_sound                = "test-ok-sound"
+    title                   = "test-title"
+    message                 = "test-message"
+    upload_image            = false
+  }
+
+  sensugo {
+    disable_resolve_message = true
+    url                     = "http://localhost"
+    api_key                 = "[REDACTED]"
+    entity                  = "test-entity"
+    check                   = "test-check"
+    namespace               = "test-namespace"
+    handler                 = "test-handler"
+    message                 = "test-message"
+  }
+
+  slack {
+    disable_resolve_message = true
+    endpoint_url            = "http://localhost/endpoint_url"
+    url                     = "[REDACTED]"
+    token                   = "[REDACTED]"
+    recipient               = "test-recipient"
+    text                    = "test-text"
+    title                   = "test-title"
+    username                = "test-username"
+    icon_emoji              = "test-icon"
+    icon_url                = "http://localhost/icon_url"
+    mention_channel         = "channel"
+    mention_users           = "test-mentionUsers"
+    mention_groups          = "test-mentionGroups"
+    color                   = "test-color"
+  }
+
+  sns {
+    disable_resolve_message = true
+    api_url                 = "https://sns.us-east-1.amazonaws.com"
+
+    sigv4 {
+      region     = "us-east-1"
+      access_key = "[REDACTED]"
+      secret_key = "[REDACTED]"
+      profile    = "default"
+      role_arn   = "arn:aws:iam:us-east-1:0123456789:role/my-role"
+    }
+
+    topic_arn    = "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+    phone_number = "123-456-7890"
+    target_arn   = "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+    subject      = "subject"
+    message      = "message"
+    attributes = {
+      attr1 = "val1"
+    }
+  }
+
+  teams {
+    disable_resolve_message = true
+    url                     = "http://localhost"
+    message                 = "test-message"
+    title                   = "test-title"
+    section_title           = "test-second-title"
+  }
+
+  telegram {
+    disable_resolve_message  = true
+    token                    = "[REDACTED]"
+    chat_id                  = "12345678"
+    message_thread_id        = "13579"
+    message                  = "test-message"
+    parse_mode               = "html"
+    disable_web_page_preview = true
+    protect_content          = true
+    disable_notifications    = true
+  }
+
+  threema {
+    disable_resolve_message = true
+    gateway_id              = "*1234567"
+    recipient_id            = "*1234567"
+    api_secret              = "[REDACTED]"
+    title                   = "test-title"
+    description             = "test-description"
+  }
+
+  victorops {
+    disable_resolve_message = true
+    url                     = "[REDACTED]"
+    message_type            = "test-messagetype"
+    title                   = "test-title"
+    description             = "test-description"
+  }
+
+  webhook {
+    disable_resolve_message = true
+    url                     = "http://localhost"
+    http_method             = "PUT"
+    max_alerts              = 2
+    authorization_scheme    = "basic"
+    basic_auth_user         = "test-user"
+    basic_auth_password     = "[REDACTED]"
+    title                   = "test-title"
+    message                 = "test-message"
+
+    tlsConfig {
+      insecure_skip_verify = false
+      ca_certificate       = "[REDACTED]"
+      client_certificate   = "[REDACTED]"
+      client_key           = "[REDACTED]"
+    }
+
+    hmacConfig {
+      secret           = "[REDACTED]"
+      header           = "X-Grafana-Alerting-Signature"
+      timestamp_header = "X-Grafana-Alerting-Timestamp"
+    }
+
+    http_config {
+
+      oauth2 {
+        client_id     = "test-client-id"
+        client_secret = "[REDACTED]"
+        token_url     = "https://localhost/auth/token"
+        scopes        = ["scope1", "scope2"]
+        endpoint_params = {
+          param1 = "value1"
+          param2 = "value2"
+        }
+
+        tls_config {
+          insecure_skip_verify = false
+          ca_certificate       = "[REDACTED]"
+          client_certificate   = "[REDACTED]"
+          client_key           = "[REDACTED]"
+        }
+
+        proxy_config {
+          proxy_url              = "http://localproxy:8080"
+          no_proxy               = "localhost"
+          proxy_from_environment = false
+          proxy_connect_header = {
+            X-Proxy-Header = "proxy-value"
+          }
+        }
+      }
+    }
+  }
+
+  wecom {
+    disable_resolve_message = true
+    url                     = "[REDACTED]"
+    secret                  = "[REDACTED]"
+    agent_id                = "test-agent_id"
+    corp_id                 = "test-corp_id"
+    message                 = "test-message"
+    title                   = "test-title"
+    msg_type                = "markdown"
+    to_user                 = "test-touser"
+  }
+
+  webex {
+    disable_resolve_message = true
+    token                   = "[REDACTED]"
+    api_url                 = "http://localhost"
+    message                 = "test-message"
+    room_id                 = "test-room-id"
+  }
+}

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
@@ -54,11 +54,9 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     wont_fix_resolution     = "Test Won't Fix Resolution"
     reopen_duration         = "1m"
     dedup_key_field         = "10000"
-    fields = {
-      test-field = "test-value"
-    }
-    user     = "[REDACTED]"
-    password = "[REDACTED]"
+    fields                  = "{\"test-field\":\"test-value\"}"
+    user                    = "[REDACTED]"
+    password                = "[REDACTED]"
   }
 
   kafka {

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.json
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.json
@@ -1,0 +1,405 @@
+{
+ "apiVersion": 1,
+ "contactPoints": [
+  {
+   "orgId": 1,
+   "name": "all-integrations",
+   "receivers": [
+    {
+     "uid": "dingding-uid",
+     "type": "dingding",
+     "settings": {
+      "message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+      "msgType": "actionCard",
+      "title": "Alerts firing: {{ len .Alerts.Firing }}",
+      "url": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "discord-uid",
+     "type": "discord",
+     "settings": {
+      "avatar_url": "http://avatar",
+      "message": "test-message",
+      "title": "test-title",
+      "url": "[REDACTED]",
+      "use_discord_username": true
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "email-uid",
+     "type": "email",
+     "settings": {
+      "addresses": "test@grafana.com",
+      "message": "test-message",
+      "singleEmail": true,
+      "subject": "test-subject"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "googlechat-uid",
+     "type": "googlechat",
+     "settings": {
+      "message": "test-message",
+      "title": "test-title",
+      "url": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "jira-uid",
+     "type": "jira",
+     "settings": {
+      "api_url": "http://localhost",
+      "dedup_key_field": "10000",
+      "description": "Test Description",
+      "fields": {
+       "test-field": "test-value"
+      },
+      "issue_type": "Test Issue Type",
+      "labels": [
+       "Test Label",
+       "Test Label 2"
+      ],
+      "password": "[REDACTED]",
+      "priority": "Test Priority",
+      "project": "Test Project",
+      "reopen_duration": "1m",
+      "reopen_transition": "Test Reopen Transition",
+      "resolve_transition": "Test Resolve Transition",
+      "summary": "Test Summary",
+      "user": "[REDACTED]",
+      "wont_fix_resolution": "Test Won't Fix Resolution"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "kafka-uid",
+     "type": "kafka",
+     "settings": {
+      "apiVersion": "v2",
+      "description": "test-description",
+      "details": "test-details",
+      "kafkaClusterId": "12345",
+      "kafkaRestProxy": "http://localhost/",
+      "kafkaTopic": "test-topic",
+      "password": "[REDACTED]",
+      "username": "test-user"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "line-uid",
+     "type": "LINE",
+     "settings": {
+      "description": "test-description",
+      "title": "test-title",
+      "token": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "mqtt-uid",
+     "type": "mqtt",
+     "settings": {
+      "brokerUrl": "tcp://localhost:1883",
+      "clientId": "grafana-test-client-id",
+      "messageFormat": "json",
+      "password": "[REDACTED]",
+      "qos": "0",
+      "retain": false,
+      "tlsConfig": {
+       "caCertificate": "[REDACTED]",
+       "clientCertificate": "[REDACTED]",
+       "clientKey": "[REDACTED]",
+       "insecureSkipVerify": false
+      },
+      "topic": "grafana/alerts",
+      "username": "test-username"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "oncall-uid",
+     "type": "oncall",
+     "settings": {
+      "authorization_scheme": "basic",
+      "httpMethod": "PUT",
+      "maxAlerts": "2",
+      "message": "test-message",
+      "password": "[REDACTED]",
+      "title": "test-title",
+      "url": "http://localhost",
+      "username": "test-user"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "opsgenie-uid",
+     "type": "opsgenie",
+     "settings": {
+      "apiKey": "[REDACTED]",
+      "apiUrl": "http://localhost",
+      "autoClose": false,
+      "description": "test-description",
+      "message": "test-message",
+      "overridePriority": false,
+      "responders": [
+       {
+        "id": "test-id",
+        "type": "team"
+       },
+       {
+        "type": "user",
+        "username": "test-user"
+       },
+       {
+        "name": "test-schedule",
+        "type": "schedule"
+       }
+      ],
+      "sendTagsAs": "both"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "pagerduty-uid",
+     "type": "pagerduty",
+     "settings": {
+      "class": "test-class",
+      "client": "test-client",
+      "client_url": "http://localhost/test-client-url",
+      "component": "test-component",
+      "group": "test-group",
+      "integrationKey": "[REDACTED]",
+      "severity": "test-severity",
+      "source": "test-source",
+      "summary": "test-summary",
+      "url": "http://localhost/test-api-url"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "prometheus-alertmanager-uid",
+     "type": "prometheus-alertmanager",
+     "settings": {
+      "basicAuthPassword": "[REDACTED]",
+      "basicAuthUser": "grafana",
+      "url": "https://alertmanager-01.com"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "pushover-uid",
+     "type": "pushover",
+     "settings": {
+      "apiToken": "[REDACTED]",
+      "device": "test-device",
+      "expire": 333,
+      "message": "test-message",
+      "okPriority": 2,
+      "okSound": "test-ok-sound",
+      "priority": 1,
+      "retry": 555,
+      "sound": "test-sound",
+      "title": "test-title",
+      "uploadImage": false,
+      "userKey": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "sensugo-uid",
+     "type": "sensugo",
+     "settings": {
+      "apikey": "[REDACTED]",
+      "check": "test-check",
+      "entity": "test-entity",
+      "handler": "test-handler",
+      "message": "test-message",
+      "namespace": "test-namespace",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "slack-uid",
+     "type": "slack",
+     "settings": {
+      "color": "test-color",
+      "endpointUrl": "http://localhost/endpoint_url",
+      "icon_emoji": "test-icon",
+      "icon_url": "http://localhost/icon_url",
+      "mentionChannel": "channel",
+      "mentionGroups": "test-mentionGroups",
+      "mentionUsers": "test-mentionUsers",
+      "recipient": "test-recipient",
+      "text": "test-text",
+      "title": "test-title",
+      "token": "[REDACTED]",
+      "url": "[REDACTED]",
+      "username": "test-username"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "sns-uid",
+     "type": "sns",
+     "settings": {
+      "api_url": "https://sns.us-east-1.amazonaws.com",
+      "attributes": {
+       "attr1": "val1"
+      },
+      "message": "message",
+      "phone_number": "123-456-7890",
+      "sigv4": {
+       "access_key": "[REDACTED]",
+       "profile": "default",
+       "region": "us-east-1",
+       "role_arn": "arn:aws:iam:us-east-1:0123456789:role/my-role",
+       "secret_key": "[REDACTED]"
+      },
+      "subject": "subject",
+      "target_arn": "arn:aws:sns:us-east-1:0123456789:SNSTopicName",
+      "topic_arn": "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "teams-uid",
+     "type": "teams",
+     "settings": {
+      "message": "test-message",
+      "sectiontitle": "test-second-title",
+      "title": "test-title",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "telegram-uid",
+     "type": "telegram",
+     "settings": {
+      "bottoken": "[REDACTED]",
+      "chatid": "12345678",
+      "disable_notifications": true,
+      "disable_web_page_preview": true,
+      "message": "test-message",
+      "message_thread_id": "13579",
+      "parse_mode": "html",
+      "protect_content": true
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "threema-uid",
+     "type": "threema",
+     "settings": {
+      "api_secret": "[REDACTED]",
+      "description": "test-description",
+      "gateway_id": "*1234567",
+      "recipient_id": "*1234567",
+      "title": "test-title"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "victorops-uid",
+     "type": "victorops",
+     "settings": {
+      "description": "test-description",
+      "messageType": "test-messagetype",
+      "title": "test-title",
+      "url": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "webex-uid",
+     "type": "webex",
+     "settings": {
+      "api_url": "http://localhost",
+      "bot_token": "[REDACTED]",
+      "message": "test-message",
+      "room_id": "test-room-id"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "webhook-uid",
+     "type": "webhook",
+     "settings": {
+      "authorization_scheme": "basic",
+      "hmacConfig": {
+       "header": "X-Grafana-Alerting-Signature",
+       "secret": "[REDACTED]",
+       "timestampHeader": "X-Grafana-Alerting-Timestamp"
+      },
+      "httpMethod": "PUT",
+      "http_config": {
+       "oauth2": {
+        "client_id": "test-client-id",
+        "client_secret": "[REDACTED]",
+        "endpoint_params": {
+         "param1": "value1",
+         "param2": "value2"
+        },
+        "proxy_config": {
+         "no_proxy": "localhost",
+         "proxy_connect_header": {
+          "X-Proxy-Header": "proxy-value"
+         },
+         "proxy_from_environment": false,
+         "proxy_url": "http://localproxy:8080"
+        },
+        "scopes": [
+         "scope1",
+         "scope2"
+        ],
+        "tls_config": {
+         "caCertificate": "[REDACTED]",
+         "clientCertificate": "[REDACTED]",
+         "clientKey": "[REDACTED]",
+         "insecureSkipVerify": false
+        },
+        "token_url": "https://localhost/auth/token"
+       }
+      },
+      "maxAlerts": "2",
+      "message": "test-message",
+      "password": "[REDACTED]",
+      "title": "test-title",
+      "tlsConfig": {
+       "caCertificate": "[REDACTED]",
+       "clientCertificate": "[REDACTED]",
+       "clientKey": "[REDACTED]",
+       "insecureSkipVerify": false
+      },
+      "url": "http://localhost",
+      "username": "test-user"
+     },
+     "disableResolveMessage": true
+    },
+    {
+     "uid": "wecom-uid",
+     "type": "wecom",
+     "settings": {
+      "agent_id": "test-agent_id",
+      "corp_id": "test-corp_id",
+      "endpointUrl": "http://localhost/test-endpointUrl",
+      "message": "test-message",
+      "msgtype": "markdown",
+      "secret": "[REDACTED]",
+      "title": "test-title",
+      "touser": "test-touser",
+      "url": "[REDACTED]"
+     },
+     "disableResolveMessage": true
+    }
+   ]
+  }
+ ]
+}

--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.yaml
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.yaml
@@ -1,0 +1,309 @@
+apiVersion: 1
+contactPoints:
+    - orgId: 1
+      name: all-integrations
+      receivers:
+        - uid: dingding-uid
+          type: dingding
+          settings:
+            message: '{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved'
+            msgType: actionCard
+            title: 'Alerts firing: {{ len .Alerts.Firing }}'
+            url: '[REDACTED]'
+          disableResolveMessage: true
+        - uid: discord-uid
+          type: discord
+          settings:
+            avatar_url: http://avatar
+            message: test-message
+            title: test-title
+            url: '[REDACTED]'
+            use_discord_username: true
+          disableResolveMessage: true
+        - uid: email-uid
+          type: email
+          settings:
+            addresses: test@grafana.com
+            message: test-message
+            singleEmail: true
+            subject: test-subject
+          disableResolveMessage: true
+        - uid: googlechat-uid
+          type: googlechat
+          settings:
+            message: test-message
+            title: test-title
+            url: '[REDACTED]'
+          disableResolveMessage: true
+        - uid: jira-uid
+          type: jira
+          settings:
+            api_url: http://localhost
+            dedup_key_field: "10000"
+            description: Test Description
+            fields:
+                test-field: test-value
+            issue_type: Test Issue Type
+            labels:
+                - Test Label
+                - Test Label 2
+            password: '[REDACTED]'
+            priority: Test Priority
+            project: Test Project
+            reopen_duration: 1m
+            reopen_transition: Test Reopen Transition
+            resolve_transition: Test Resolve Transition
+            summary: Test Summary
+            user: '[REDACTED]'
+            wont_fix_resolution: Test Won't Fix Resolution
+          disableResolveMessage: true
+        - uid: kafka-uid
+          type: kafka
+          settings:
+            apiVersion: v2
+            description: test-description
+            details: test-details
+            kafkaClusterId: "12345"
+            kafkaRestProxy: http://localhost/
+            kafkaTopic: test-topic
+            password: '[REDACTED]'
+            username: test-user
+          disableResolveMessage: true
+        - uid: line-uid
+          type: LINE
+          settings:
+            description: test-description
+            title: test-title
+            token: '[REDACTED]'
+          disableResolveMessage: true
+        - uid: mqtt-uid
+          type: mqtt
+          settings:
+            brokerUrl: tcp://localhost:1883
+            clientId: grafana-test-client-id
+            messageFormat: json
+            password: '[REDACTED]'
+            qos: "0"
+            retain: false
+            tlsConfig:
+                caCertificate: '[REDACTED]'
+                clientCertificate: '[REDACTED]'
+                clientKey: '[REDACTED]'
+                insecureSkipVerify: false
+            topic: grafana/alerts
+            username: test-username
+          disableResolveMessage: true
+        - uid: oncall-uid
+          type: oncall
+          settings:
+            authorization_scheme: basic
+            httpMethod: PUT
+            maxAlerts: "2"
+            message: test-message
+            password: '[REDACTED]'
+            title: test-title
+            url: http://localhost
+            username: test-user
+          disableResolveMessage: true
+        - uid: opsgenie-uid
+          type: opsgenie
+          settings:
+            apiKey: '[REDACTED]'
+            apiUrl: http://localhost
+            autoClose: false
+            description: test-description
+            message: test-message
+            overridePriority: false
+            responders:
+                - id: test-id
+                  type: team
+                - type: user
+                  username: test-user
+                - name: test-schedule
+                  type: schedule
+            sendTagsAs: both
+          disableResolveMessage: true
+        - uid: pagerduty-uid
+          type: pagerduty
+          settings:
+            class: test-class
+            client: test-client
+            client_url: http://localhost/test-client-url
+            component: test-component
+            group: test-group
+            integrationKey: '[REDACTED]'
+            severity: test-severity
+            source: test-source
+            summary: test-summary
+            url: http://localhost/test-api-url
+          disableResolveMessage: true
+        - uid: prometheus-alertmanager-uid
+          type: prometheus-alertmanager
+          settings:
+            basicAuthPassword: '[REDACTED]'
+            basicAuthUser: grafana
+            url: https://alertmanager-01.com
+          disableResolveMessage: true
+        - uid: pushover-uid
+          type: pushover
+          settings:
+            apiToken: '[REDACTED]'
+            device: test-device
+            expire: 333
+            message: test-message
+            okPriority: 2
+            okSound: test-ok-sound
+            priority: 1
+            retry: 555
+            sound: test-sound
+            title: test-title
+            uploadImage: false
+            userKey: '[REDACTED]'
+          disableResolveMessage: true
+        - uid: sensugo-uid
+          type: sensugo
+          settings:
+            apikey: '[REDACTED]'
+            check: test-check
+            entity: test-entity
+            handler: test-handler
+            message: test-message
+            namespace: test-namespace
+            url: http://localhost
+          disableResolveMessage: true
+        - uid: slack-uid
+          type: slack
+          settings:
+            color: test-color
+            endpointUrl: http://localhost/endpoint_url
+            icon_emoji: test-icon
+            icon_url: http://localhost/icon_url
+            mentionChannel: channel
+            mentionGroups: test-mentionGroups
+            mentionUsers: test-mentionUsers
+            recipient: test-recipient
+            text: test-text
+            title: test-title
+            token: '[REDACTED]'
+            url: '[REDACTED]'
+            username: test-username
+          disableResolveMessage: true
+        - uid: sns-uid
+          type: sns
+          settings:
+            api_url: https://sns.us-east-1.amazonaws.com
+            attributes:
+                attr1: val1
+            message: message
+            phone_number: 123-456-7890
+            sigv4:
+                access_key: '[REDACTED]'
+                profile: default
+                region: us-east-1
+                role_arn: arn:aws:iam:us-east-1:0123456789:role/my-role
+                secret_key: '[REDACTED]'
+            subject: subject
+            target_arn: arn:aws:sns:us-east-1:0123456789:SNSTopicName
+            topic_arn: arn:aws:sns:us-east-1:0123456789:SNSTopicName
+          disableResolveMessage: true
+        - uid: teams-uid
+          type: teams
+          settings:
+            message: test-message
+            sectiontitle: test-second-title
+            title: test-title
+            url: http://localhost
+          disableResolveMessage: true
+        - uid: telegram-uid
+          type: telegram
+          settings:
+            bottoken: '[REDACTED]'
+            chatid: "12345678"
+            disable_notifications: true
+            disable_web_page_preview: true
+            message: test-message
+            message_thread_id: "13579"
+            parse_mode: html
+            protect_content: true
+          disableResolveMessage: true
+        - uid: threema-uid
+          type: threema
+          settings:
+            api_secret: '[REDACTED]'
+            description: test-description
+            gateway_id: '*1234567'
+            recipient_id: '*1234567'
+            title: test-title
+          disableResolveMessage: true
+        - uid: victorops-uid
+          type: victorops
+          settings:
+            description: test-description
+            messageType: test-messagetype
+            title: test-title
+            url: '[REDACTED]'
+          disableResolveMessage: true
+        - uid: webex-uid
+          type: webex
+          settings:
+            api_url: http://localhost
+            bot_token: '[REDACTED]'
+            message: test-message
+            room_id: test-room-id
+          disableResolveMessage: true
+        - uid: webhook-uid
+          type: webhook
+          settings:
+            authorization_scheme: basic
+            hmacConfig:
+                header: X-Grafana-Alerting-Signature
+                secret: '[REDACTED]'
+                timestampHeader: X-Grafana-Alerting-Timestamp
+            http_config:
+                oauth2:
+                    client_id: test-client-id
+                    client_secret: '[REDACTED]'
+                    endpoint_params:
+                        param1: value1
+                        param2: value2
+                    proxy_config:
+                        no_proxy: localhost
+                        proxy_connect_header:
+                            X-Proxy-Header: proxy-value
+                        proxy_from_environment: false
+                        proxy_url: http://localproxy:8080
+                    scopes:
+                        - scope1
+                        - scope2
+                    tls_config:
+                        caCertificate: '[REDACTED]'
+                        clientCertificate: '[REDACTED]'
+                        clientKey: '[REDACTED]'
+                        insecureSkipVerify: false
+                    token_url: https://localhost/auth/token
+            httpMethod: PUT
+            maxAlerts: "2"
+            message: test-message
+            password: '[REDACTED]'
+            title: test-title
+            tlsConfig:
+                caCertificate: '[REDACTED]'
+                clientCertificate: '[REDACTED]'
+                clientKey: '[REDACTED]'
+                insecureSkipVerify: false
+            url: http://localhost
+            username: test-user
+          disableResolveMessage: true
+        - uid: wecom-uid
+          type: wecom
+          settings:
+            agent_id: test-agent_id
+            corp_id: test-corp_id
+            endpointUrl: http://localhost/test-endpointUrl
+            message: test-message
+            msgtype: markdown
+            secret: '[REDACTED]'
+            title: test-title
+            touser: test-touser
+            url: '[REDACTED]'
+          disableResolveMessage: true

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
@@ -1,0 +1,306 @@
+resource "grafana_contact_point" "contact_point_2b661702215368fe" {
+  name = "all-integrations"
+
+  alertmanager {
+    url                 = "https://alertmanager-01.com"
+    basic_auth_user     = "grafana"
+    basic_auth_password = "admin"
+  }
+
+  dingding {
+    url          = "http://localhost"
+    message_type = "actionCard"
+    title        = "Alerts firing: {{ len .Alerts.Firing }}"
+    message      = "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved"
+  }
+
+  discord {
+    url                  = "http://localhost"
+    title                = "test-title"
+    message              = "test-message"
+    avatar_url           = "http://avatar"
+    use_discord_username = true
+  }
+
+  email {
+    addresses    = ["test@grafana.com"]
+    single_email = true
+    message      = "test-message"
+    subject      = "test-subject"
+  }
+
+  googlechat {
+    url     = "http://localhost"
+    title   = "test-title"
+    message = "test-message"
+  }
+
+  jira {
+    api_url             = "http://localhost"
+    project             = "Test Project"
+    issue_type          = "Test Issue Type"
+    summary             = "Test Summary"
+    description         = "Test Description"
+    labels              = ["Test Label", "Test Label 2"]
+    priority            = "Test Priority"
+    reopen_transition   = "Test Reopen Transition"
+    resolve_transition  = "Test Resolve Transition"
+    wont_fix_resolution = "Test Won't Fix Resolution"
+    reopen_duration     = "1m"
+    dedup_key_field     = "10000"
+    fields = {
+      test-field = "test-value"
+    }
+    user     = "user"
+    password = "password"
+  }
+
+  kafka {
+    rest_proxy_url = "http://localhost/"
+    topic          = "test-topic"
+    description    = "test-description"
+    details        = "test-details"
+    username       = "test-user"
+    password       = "password"
+    api_version    = "v2"
+    cluster_id     = "12345"
+  }
+
+  line {
+    token       = "test"
+    title       = "test-title"
+    description = "test-description"
+  }
+
+  mqtt {
+    broker_url     = "tcp://localhost:1883"
+    client_id      = "grafana-test-client-id"
+    topic          = "grafana/alerts"
+    message_format = "json"
+    username       = "test-username"
+    password       = "test-password"
+    qos            = 0
+    retain         = false
+
+    tls_config {
+      insecure_skip_verify = false
+      ca_certificate       = "test-tls-ca-certificate"
+      client_certificate   = "test-tls-client-certificate"
+      client_key           = "test-tls-client-key"
+    }
+  }
+
+  opsgenie {
+    api_key           = "test-api-key"
+    url               = "http://localhost"
+    message           = "test-message"
+    description       = "test-description"
+    auto_close        = false
+    override_priority = false
+    send_tags_as      = "both"
+
+    responders {
+      id   = "test-id"
+      type = "team"
+    }
+    responders {
+      username = "test-user"
+      type     = "user"
+    }
+    responders {
+      name = "test-schedule"
+      type = "schedule"
+    }
+  }
+
+  pagerduty {
+    integration_key = "test-api-key"
+    severity        = "test-severity"
+    class           = "test-class"
+    component       = "test-component"
+    group           = "test-group"
+    summary         = "test-summary"
+    source          = "test-source"
+    client          = "test-client"
+    client_url      = "http://localhost/test-client-url"
+    url             = "http://localhost/test-api-url"
+  }
+
+  oncall {
+    url                  = "http://localhost"
+    http_method          = "PUT"
+    max_alerts           = 2
+    authorization_scheme = "basic"
+    basic_auth_user      = "test-user"
+    basic_auth_password  = "test-pass"
+    title                = "test-title"
+    message              = "test-message"
+  }
+
+  pushover {
+    user_key     = "test-user-key"
+    api_token    = "test-api-token"
+    priority     = 1
+    ok_priority  = 2
+    retry        = 555
+    expire       = 333
+    device       = "test-device"
+    sound        = "test-sound"
+    ok_sound     = "test-ok-sound"
+    title        = "test-title"
+    message      = "test-message"
+    upload_image = false
+  }
+
+  sensugo {
+    url       = "http://localhost"
+    api_key   = "test-api-key"
+    entity    = "test-entity"
+    check     = "test-check"
+    namespace = "test-namespace"
+    handler   = "test-handler"
+    message   = "test-message"
+  }
+
+  slack {
+    endpoint_url    = "http://localhost/endpoint_url"
+    url             = "http://localhost/url"
+    token           = "test-token"
+    recipient       = "test-recipient"
+    text            = "test-text"
+    title           = "test-title"
+    username        = "test-username"
+    icon_emoji      = "test-icon"
+    icon_url        = "http://localhost/icon_url"
+    mention_channel = "channel"
+    mention_users   = "test-mentionUsers"
+    mention_groups  = "test-mentionGroups"
+    color           = "test-color"
+  }
+
+  sns {
+    api_url = "https://sns.us-east-1.amazonaws.com"
+
+    sigv4 {
+      region     = "us-east-1"
+      access_key = "access-key"
+      secret_key = "secret-key"
+      profile    = "default"
+      role_arn   = "arn:aws:iam:us-east-1:0123456789:role/my-role"
+    }
+
+    topic_arn    = "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+    phone_number = "123-456-7890"
+    target_arn   = "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+    subject      = "subject"
+    message      = "message"
+    attributes = {
+      attr1 = "val1"
+    }
+  }
+
+  teams {
+    url           = "http://localhost"
+    message       = "test-message"
+    title         = "test-title"
+    section_title = "test-second-title"
+  }
+
+  telegram {
+    token                    = "test-token"
+    chat_id                  = "12345678"
+    message_thread_id        = "13579"
+    message                  = "test-message"
+    parse_mode               = "html"
+    disable_web_page_preview = true
+    protect_content          = true
+    disable_notifications    = true
+  }
+
+  threema {
+    gateway_id   = "*1234567"
+    recipient_id = "*1234567"
+    api_secret   = "test-secret"
+    title        = "test-title"
+    description  = "test-description"
+  }
+
+  victorops {
+    url          = "http://localhost"
+    message_type = "test-messagetype"
+    title        = "test-title"
+    description  = "test-description"
+  }
+
+  webhook {
+    url                  = "http://localhost"
+    http_method          = "PUT"
+    max_alerts           = 2
+    authorization_scheme = "basic"
+    basic_auth_user      = "test-user"
+    basic_auth_password  = "test-pass"
+    title                = "test-title"
+    message              = "test-message"
+
+    tlsConfig {
+      insecure_skip_verify = false
+      ca_certificate       = "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx\nMDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60\n2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3\nWMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML\n-----END CERTIFICATE-----"
+      client_certificate   = "-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow\nEjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d\n7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B\n5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr\nBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1\nNDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l\nWf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc\n6MF9+Yw1Yy0t\n-----END CERTIFICATE-----"
+      client_key           = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49\nAwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q\nEKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==\n-----END EC PRIVATE KEY-----"
+    }
+
+    hmacConfig {
+      secret           = "test-hmac-secret"
+      header           = "X-Grafana-Alerting-Signature"
+      timestamp_header = "X-Grafana-Alerting-Timestamp"
+    }
+
+    http_config {
+
+      oauth2 {
+        client_id     = "test-client-id"
+        client_secret = "test-client-secret"
+        token_url     = "https://localhost/auth/token"
+        scopes        = ["scope1", "scope2"]
+        endpoint_params = {
+          param1 = "value1"
+          param2 = "value2"
+        }
+
+        tls_config {
+          insecure_skip_verify = false
+          ca_certificate       = "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx\nMDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60\n2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3\nWMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML\n-----END CERTIFICATE-----"
+          client_certificate   = "-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow\nEjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d\n7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B\n5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr\nBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1\nNDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l\nWf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc\n6MF9+Yw1Yy0t\n-----END CERTIFICATE-----"
+          client_key           = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49\nAwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q\nEKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==\n-----END EC PRIVATE KEY-----"
+        }
+
+        proxy_config {
+          proxy_url              = "http://localproxy:8080"
+          no_proxy               = "localhost"
+          proxy_from_environment = false
+          proxy_connect_header = {
+            X-Proxy-Header = "proxy-value"
+          }
+        }
+      }
+    }
+  }
+
+  wecom {
+    url      = "test-url"
+    secret   = "test-secret"
+    agent_id = "test-agent_id"
+    corp_id  = "test-corp_id"
+    message  = "test-message"
+    title    = "test-title"
+    msg_type = "markdown"
+    to_user  = "test-touser"
+  }
+
+  webex {
+    token   = "12345"
+    api_url = "http://localhost"
+    message = "test-message"
+    room_id = "test-room-id"
+  }
+}

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
@@ -48,11 +48,9 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     wont_fix_resolution = "Test Won't Fix Resolution"
     reopen_duration     = "1m"
     dedup_key_field     = "10000"
-    fields = {
-      test-field = "test-value"
-    }
-    user     = "user"
-    password = "password"
+    fields              = "{\"test-field\":\"test-value\"}"
+    user                = "user"
+    password            = "password"
   }
 
   kafka {

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.json
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.json
@@ -1,0 +1,405 @@
+{
+ "apiVersion": 1,
+ "contactPoints": [
+  {
+   "orgId": 1,
+   "name": "all-integrations",
+   "receivers": [
+    {
+     "uid": "dingding-uid",
+     "type": "dingding",
+     "settings": {
+      "message": "{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved",
+      "msgType": "actionCard",
+      "title": "Alerts firing: {{ len .Alerts.Firing }}",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "discord-uid",
+     "type": "discord",
+     "settings": {
+      "avatar_url": "http://avatar",
+      "message": "test-message",
+      "title": "test-title",
+      "url": "http://localhost",
+      "use_discord_username": true
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "email-uid",
+     "type": "email",
+     "settings": {
+      "addresses": "test@grafana.com",
+      "message": "test-message",
+      "singleEmail": true,
+      "subject": "test-subject"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "googlechat-uid",
+     "type": "googlechat",
+     "settings": {
+      "message": "test-message",
+      "title": "test-title",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "jira-uid",
+     "type": "jira",
+     "settings": {
+      "api_url": "http://localhost",
+      "dedup_key_field": "10000",
+      "description": "Test Description",
+      "fields": {
+       "test-field": "test-value"
+      },
+      "issue_type": "Test Issue Type",
+      "labels": [
+       "Test Label",
+       "Test Label 2"
+      ],
+      "password": "password",
+      "priority": "Test Priority",
+      "project": "Test Project",
+      "reopen_duration": "1m",
+      "reopen_transition": "Test Reopen Transition",
+      "resolve_transition": "Test Resolve Transition",
+      "summary": "Test Summary",
+      "user": "user",
+      "wont_fix_resolution": "Test Won't Fix Resolution"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "kafka-uid",
+     "type": "kafka",
+     "settings": {
+      "apiVersion": "v2",
+      "description": "test-description",
+      "details": "test-details",
+      "kafkaClusterId": "12345",
+      "kafkaRestProxy": "http://localhost/",
+      "kafkaTopic": "test-topic",
+      "password": "password",
+      "username": "test-user"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "line-uid",
+     "type": "LINE",
+     "settings": {
+      "description": "test-description",
+      "title": "test-title",
+      "token": "test"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "mqtt-uid",
+     "type": "mqtt",
+     "settings": {
+      "brokerUrl": "tcp://localhost:1883",
+      "clientId": "grafana-test-client-id",
+      "messageFormat": "json",
+      "password": "test-password",
+      "qos": "0",
+      "retain": false,
+      "tlsConfig": {
+       "caCertificate": "test-tls-ca-certificate",
+       "clientCertificate": "test-tls-client-certificate",
+       "clientKey": "test-tls-client-key",
+       "insecureSkipVerify": false
+      },
+      "topic": "grafana/alerts",
+      "username": "test-username"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "oncall-uid",
+     "type": "oncall",
+     "settings": {
+      "authorization_scheme": "basic",
+      "httpMethod": "PUT",
+      "maxAlerts": "2",
+      "message": "test-message",
+      "password": "test-pass",
+      "title": "test-title",
+      "url": "http://localhost",
+      "username": "test-user"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "opsgenie-uid",
+     "type": "opsgenie",
+     "settings": {
+      "apiKey": "test-api-key",
+      "apiUrl": "http://localhost",
+      "autoClose": false,
+      "description": "test-description",
+      "message": "test-message",
+      "overridePriority": false,
+      "responders": [
+       {
+        "id": "test-id",
+        "type": "team"
+       },
+       {
+        "type": "user",
+        "username": "test-user"
+       },
+       {
+        "name": "test-schedule",
+        "type": "schedule"
+       }
+      ],
+      "sendTagsAs": "both"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "pagerduty-uid",
+     "type": "pagerduty",
+     "settings": {
+      "class": "test-class",
+      "client": "test-client",
+      "client_url": "http://localhost/test-client-url",
+      "component": "test-component",
+      "group": "test-group",
+      "integrationKey": "test-api-key",
+      "severity": "test-severity",
+      "source": "test-source",
+      "summary": "test-summary",
+      "url": "http://localhost/test-api-url"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "prometheus-alertmanager-uid",
+     "type": "prometheus-alertmanager",
+     "settings": {
+      "basicAuthPassword": "admin",
+      "basicAuthUser": "grafana",
+      "url": "https://alertmanager-01.com"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "pushover-uid",
+     "type": "pushover",
+     "settings": {
+      "apiToken": "test-api-token",
+      "device": "test-device",
+      "expire": 333,
+      "message": "test-message",
+      "okPriority": 2,
+      "okSound": "test-ok-sound",
+      "priority": 1,
+      "retry": 555,
+      "sound": "test-sound",
+      "title": "test-title",
+      "uploadImage": false,
+      "userKey": "test-user-key"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "sensugo-uid",
+     "type": "sensugo",
+     "settings": {
+      "apikey": "test-api-key",
+      "check": "test-check",
+      "entity": "test-entity",
+      "handler": "test-handler",
+      "message": "test-message",
+      "namespace": "test-namespace",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "slack-uid",
+     "type": "slack",
+     "settings": {
+      "color": "test-color",
+      "endpointUrl": "http://localhost/endpoint_url",
+      "icon_emoji": "test-icon",
+      "icon_url": "http://localhost/icon_url",
+      "mentionChannel": "channel",
+      "mentionGroups": "test-mentionGroups",
+      "mentionUsers": "test-mentionUsers",
+      "recipient": "test-recipient",
+      "text": "test-text",
+      "title": "test-title",
+      "token": "test-token",
+      "url": "http://localhost/url",
+      "username": "test-username"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "sns-uid",
+     "type": "sns",
+     "settings": {
+      "api_url": "https://sns.us-east-1.amazonaws.com",
+      "attributes": {
+       "attr1": "val1"
+      },
+      "message": "message",
+      "phone_number": "123-456-7890",
+      "sigv4": {
+       "access_key": "access-key",
+       "profile": "default",
+       "region": "us-east-1",
+       "role_arn": "arn:aws:iam:us-east-1:0123456789:role/my-role",
+       "secret_key": "secret-key"
+      },
+      "subject": "subject",
+      "target_arn": "arn:aws:sns:us-east-1:0123456789:SNSTopicName",
+      "topic_arn": "arn:aws:sns:us-east-1:0123456789:SNSTopicName"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "teams-uid",
+     "type": "teams",
+     "settings": {
+      "message": "test-message",
+      "sectiontitle": "test-second-title",
+      "title": "test-title",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "telegram-uid",
+     "type": "telegram",
+     "settings": {
+      "bottoken": "test-token",
+      "chatid": "12345678",
+      "disable_notifications": true,
+      "disable_web_page_preview": true,
+      "message": "test-message",
+      "message_thread_id": "13579",
+      "parse_mode": "html",
+      "protect_content": true
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "threema-uid",
+     "type": "threema",
+     "settings": {
+      "api_secret": "test-secret",
+      "description": "test-description",
+      "gateway_id": "*1234567",
+      "recipient_id": "*1234567",
+      "title": "test-title"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "victorops-uid",
+     "type": "victorops",
+     "settings": {
+      "description": "test-description",
+      "messageType": "test-messagetype",
+      "title": "test-title",
+      "url": "http://localhost"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "webex-uid",
+     "type": "webex",
+     "settings": {
+      "api_url": "http://localhost",
+      "bot_token": "12345",
+      "message": "test-message",
+      "room_id": "test-room-id"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "webhook-uid",
+     "type": "webhook",
+     "settings": {
+      "authorization_scheme": "basic",
+      "hmacConfig": {
+       "header": "X-Grafana-Alerting-Signature",
+       "secret": "test-hmac-secret",
+       "timestampHeader": "X-Grafana-Alerting-Timestamp"
+      },
+      "httpMethod": "PUT",
+      "http_config": {
+       "oauth2": {
+        "client_id": "test-client-id",
+        "client_secret": "test-client-secret",
+        "endpoint_params": {
+         "param1": "value1",
+         "param2": "value2"
+        },
+        "proxy_config": {
+         "no_proxy": "localhost",
+         "proxy_connect_header": {
+          "X-Proxy-Header": "proxy-value"
+         },
+         "proxy_from_environment": false,
+         "proxy_url": "http://localproxy:8080"
+        },
+        "scopes": [
+         "scope1",
+         "scope2"
+        ],
+        "tls_config": {
+         "caCertificate": "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx\nMDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60\n2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3\nWMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML\n-----END CERTIFICATE-----",
+         "clientCertificate": "-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow\nEjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d\n7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B\n5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr\nBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1\nNDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l\nWf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc\n6MF9+Yw1Yy0t\n-----END CERTIFICATE-----",
+         "clientKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49\nAwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q\nEKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==\n-----END EC PRIVATE KEY-----",
+         "insecureSkipVerify": false
+        },
+        "token_url": "https://localhost/auth/token"
+       }
+      },
+      "maxAlerts": "2",
+      "message": "test-message",
+      "password": "test-pass",
+      "title": "test-title",
+      "tlsConfig": {
+       "caCertificate": "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx\nMDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60\n2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3\nWMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML\n-----END CERTIFICATE-----",
+       "clientCertificate": "-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow\nEjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d\n7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B\n5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr\nBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1\nNDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l\nWf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc\n6MF9+Yw1Yy0t\n-----END CERTIFICATE-----",
+       "clientKey": "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49\nAwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q\nEKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==\n-----END EC PRIVATE KEY-----",
+       "insecureSkipVerify": false
+      },
+      "url": "http://localhost",
+      "username": "test-user"
+     },
+     "disableResolveMessage": false
+    },
+    {
+     "uid": "wecom-uid",
+     "type": "wecom",
+     "settings": {
+      "agent_id": "test-agent_id",
+      "corp_id": "test-corp_id",
+      "endpointUrl": "http://localhost/test-endpointUrl",
+      "message": "test-message",
+      "msgtype": "markdown",
+      "secret": "test-secret",
+      "title": "test-title",
+      "touser": "test-touser",
+      "url": "test-url"
+     },
+     "disableResolveMessage": false
+    }
+   ]
+  }
+ ]
+}

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.yaml
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.yaml
@@ -1,0 +1,353 @@
+apiVersion: 1
+contactPoints:
+    - orgId: 1
+      name: all-integrations
+      receivers:
+        - uid: dingding-uid
+          type: dingding
+          settings:
+            message: '{{ len .Alerts.Firing }} alerts are firing, {{ len .Alerts.Resolved }} are resolved'
+            msgType: actionCard
+            title: 'Alerts firing: {{ len .Alerts.Firing }}'
+            url: http://localhost
+          disableResolveMessage: false
+        - uid: discord-uid
+          type: discord
+          settings:
+            avatar_url: http://avatar
+            message: test-message
+            title: test-title
+            url: http://localhost
+            use_discord_username: true
+          disableResolveMessage: false
+        - uid: email-uid
+          type: email
+          settings:
+            addresses: test@grafana.com
+            message: test-message
+            singleEmail: true
+            subject: test-subject
+          disableResolveMessage: false
+        - uid: googlechat-uid
+          type: googlechat
+          settings:
+            message: test-message
+            title: test-title
+            url: http://localhost
+          disableResolveMessage: false
+        - uid: jira-uid
+          type: jira
+          settings:
+            api_url: http://localhost
+            dedup_key_field: "10000"
+            description: Test Description
+            fields:
+                test-field: test-value
+            issue_type: Test Issue Type
+            labels:
+                - Test Label
+                - Test Label 2
+            password: password
+            priority: Test Priority
+            project: Test Project
+            reopen_duration: 1m
+            reopen_transition: Test Reopen Transition
+            resolve_transition: Test Resolve Transition
+            summary: Test Summary
+            user: user
+            wont_fix_resolution: Test Won't Fix Resolution
+          disableResolveMessage: false
+        - uid: kafka-uid
+          type: kafka
+          settings:
+            apiVersion: v2
+            description: test-description
+            details: test-details
+            kafkaClusterId: "12345"
+            kafkaRestProxy: http://localhost/
+            kafkaTopic: test-topic
+            password: password
+            username: test-user
+          disableResolveMessage: false
+        - uid: line-uid
+          type: LINE
+          settings:
+            description: test-description
+            title: test-title
+            token: test
+          disableResolveMessage: false
+        - uid: mqtt-uid
+          type: mqtt
+          settings:
+            brokerUrl: tcp://localhost:1883
+            clientId: grafana-test-client-id
+            messageFormat: json
+            password: test-password
+            qos: "0"
+            retain: false
+            tlsConfig:
+                caCertificate: test-tls-ca-certificate
+                clientCertificate: test-tls-client-certificate
+                clientKey: test-tls-client-key
+                insecureSkipVerify: false
+            topic: grafana/alerts
+            username: test-username
+          disableResolveMessage: false
+        - uid: oncall-uid
+          type: oncall
+          settings:
+            authorization_scheme: basic
+            httpMethod: PUT
+            maxAlerts: "2"
+            message: test-message
+            password: test-pass
+            title: test-title
+            url: http://localhost
+            username: test-user
+          disableResolveMessage: false
+        - uid: opsgenie-uid
+          type: opsgenie
+          settings:
+            apiKey: test-api-key
+            apiUrl: http://localhost
+            autoClose: false
+            description: test-description
+            message: test-message
+            overridePriority: false
+            responders:
+                - id: test-id
+                  type: team
+                - type: user
+                  username: test-user
+                - name: test-schedule
+                  type: schedule
+            sendTagsAs: both
+          disableResolveMessage: false
+        - uid: pagerduty-uid
+          type: pagerduty
+          settings:
+            class: test-class
+            client: test-client
+            client_url: http://localhost/test-client-url
+            component: test-component
+            group: test-group
+            integrationKey: test-api-key
+            severity: test-severity
+            source: test-source
+            summary: test-summary
+            url: http://localhost/test-api-url
+          disableResolveMessage: false
+        - uid: prometheus-alertmanager-uid
+          type: prometheus-alertmanager
+          settings:
+            basicAuthPassword: admin
+            basicAuthUser: grafana
+            url: https://alertmanager-01.com
+          disableResolveMessage: false
+        - uid: pushover-uid
+          type: pushover
+          settings:
+            apiToken: test-api-token
+            device: test-device
+            expire: 333
+            message: test-message
+            okPriority: 2
+            okSound: test-ok-sound
+            priority: 1
+            retry: 555
+            sound: test-sound
+            title: test-title
+            uploadImage: false
+            userKey: test-user-key
+          disableResolveMessage: false
+        - uid: sensugo-uid
+          type: sensugo
+          settings:
+            apikey: test-api-key
+            check: test-check
+            entity: test-entity
+            handler: test-handler
+            message: test-message
+            namespace: test-namespace
+            url: http://localhost
+          disableResolveMessage: false
+        - uid: slack-uid
+          type: slack
+          settings:
+            color: test-color
+            endpointUrl: http://localhost/endpoint_url
+            icon_emoji: test-icon
+            icon_url: http://localhost/icon_url
+            mentionChannel: channel
+            mentionGroups: test-mentionGroups
+            mentionUsers: test-mentionUsers
+            recipient: test-recipient
+            text: test-text
+            title: test-title
+            token: test-token
+            url: http://localhost/url
+            username: test-username
+          disableResolveMessage: false
+        - uid: sns-uid
+          type: sns
+          settings:
+            api_url: https://sns.us-east-1.amazonaws.com
+            attributes:
+                attr1: val1
+            message: message
+            phone_number: 123-456-7890
+            sigv4:
+                access_key: access-key
+                profile: default
+                region: us-east-1
+                role_arn: arn:aws:iam:us-east-1:0123456789:role/my-role
+                secret_key: secret-key
+            subject: subject
+            target_arn: arn:aws:sns:us-east-1:0123456789:SNSTopicName
+            topic_arn: arn:aws:sns:us-east-1:0123456789:SNSTopicName
+          disableResolveMessage: false
+        - uid: teams-uid
+          type: teams
+          settings:
+            message: test-message
+            sectiontitle: test-second-title
+            title: test-title
+            url: http://localhost
+          disableResolveMessage: false
+        - uid: telegram-uid
+          type: telegram
+          settings:
+            bottoken: test-token
+            chatid: "12345678"
+            disable_notifications: true
+            disable_web_page_preview: true
+            message: test-message
+            message_thread_id: "13579"
+            parse_mode: html
+            protect_content: true
+          disableResolveMessage: false
+        - uid: threema-uid
+          type: threema
+          settings:
+            api_secret: test-secret
+            description: test-description
+            gateway_id: '*1234567'
+            recipient_id: '*1234567'
+            title: test-title
+          disableResolveMessage: false
+        - uid: victorops-uid
+          type: victorops
+          settings:
+            description: test-description
+            messageType: test-messagetype
+            title: test-title
+            url: http://localhost
+          disableResolveMessage: false
+        - uid: webex-uid
+          type: webex
+          settings:
+            api_url: http://localhost
+            bot_token: "12345"
+            message: test-message
+            room_id: test-room-id
+          disableResolveMessage: false
+        - uid: webhook-uid
+          type: webhook
+          settings:
+            authorization_scheme: basic
+            hmacConfig:
+                header: X-Grafana-Alerting-Signature
+                secret: test-hmac-secret
+                timestampHeader: X-Grafana-Alerting-Timestamp
+            http_config:
+                oauth2:
+                    client_id: test-client-id
+                    client_secret: test-client-secret
+                    endpoint_params:
+                        param1: value1
+                        param2: value2
+                    proxy_config:
+                        no_proxy: localhost
+                        proxy_connect_header:
+                            X-Proxy-Header: proxy-value
+                        proxy_from_environment: false
+                        proxy_url: http://localproxy:8080
+                    scopes:
+                        - scope1
+                        - scope2
+                    tls_config:
+                        caCertificate: |-
+                            -----BEGIN CERTIFICATE-----
+                            MIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx
+                            MDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60
+                            2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3
+                            WMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML
+                            -----END CERTIFICATE-----
+                        clientCertificate: |-
+                            -----BEGIN CERTIFICATE-----
+                            MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+                            DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+                            EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+                            7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+                            5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+                            BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+                            NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+                            Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+                            6MF9+Yw1Yy0t
+                            -----END CERTIFICATE-----
+                        clientKey: |-
+                            -----BEGIN EC PRIVATE KEY-----
+                            MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+                            AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+                            EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+                            -----END EC PRIVATE KEY-----
+                        insecureSkipVerify: false
+                    token_url: https://localhost/auth/token
+            httpMethod: PUT
+            maxAlerts: "2"
+            message: test-message
+            password: test-pass
+            title: test-title
+            tlsConfig:
+                caCertificate: |-
+                    -----BEGIN CERTIFICATE-----
+                    MIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx
+                    MDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60
+                    2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3
+                    WMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML
+                    -----END CERTIFICATE-----
+                clientCertificate: |-
+                    -----BEGIN CERTIFICATE-----
+                    MIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw
+                    DgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow
+                    EjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d
+                    7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B
+                    5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr
+                    BgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1
+                    NDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l
+                    Wf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc
+                    6MF9+Yw1Yy0t
+                    -----END CERTIFICATE-----
+                clientKey: |-
+                    -----BEGIN EC PRIVATE KEY-----
+                    MHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49
+                    AwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q
+                    EKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==
+                    -----END EC PRIVATE KEY-----
+                insecureSkipVerify: false
+            url: http://localhost
+            username: test-user
+          disableResolveMessage: false
+        - uid: wecom-uid
+          type: wecom
+          settings:
+            agent_id: test-agent_id
+            corp_id: test-corp_id
+            endpointUrl: http://localhost/test-endpointUrl
+            message: test-message
+            msgtype: markdown
+            secret: test-secret
+            title: test-title
+            touser: test-touser
+            url: test-url
+          disableResolveMessage: false

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -69,16 +69,16 @@ type JiraIntegration struct {
 	Project   string `yaml:"project,omitempty" json:"project,omitempty" hcl:"project"`
 	IssueType string `yaml:"issue_type,omitempty" json:"issue_type,omitempty" hcl:"issue_type"`
 
-	Summary           *string         `yaml:"summary,omitempty" json:"summary,omitempty" hcl:"summary"`
-	Description       *string         `yaml:"description,omitempty" json:"description,omitempty" hcl:"description"`
-	Labels            *[]string       `yaml:"labels,omitempty" json:"labels,omitempty" hcl:"labels"`
-	Priority          *string         `yaml:"priority,omitempty" json:"priority,omitempty" hcl:"priority"`
-	ReopenTransition  *string         `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty" hcl:"reopen_transition"`
-	ResolveTransition *string         `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty" hcl:"resolve_transition"`
-	WontFixResolution *string         `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty" hcl:"wont_fix_resolution"`
-	ReopenDuration    *string         `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty" hcl:"reopen_duration"`
-	DedupKeyFieldName *string         `yaml:"dedup_key_field,omitempty" json:"dedup_key_field,omitempty" hcl:"dedup_key_field"`
-	Fields            *map[string]any `yaml:"fields,omitempty" json:"fields,omitempty" hcl:"fields"`
+	Summary           *string            `yaml:"summary,omitempty" json:"summary,omitempty" hcl:"summary"`
+	Description       *string            `yaml:"description,omitempty" json:"description,omitempty" hcl:"description"`
+	Labels            *[]string          `yaml:"labels,omitempty" json:"labels,omitempty" hcl:"labels"`
+	Priority          *string            `yaml:"priority,omitempty" json:"priority,omitempty" hcl:"priority"`
+	ReopenTransition  *string            `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty" hcl:"reopen_transition"`
+	ResolveTransition *string            `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty" hcl:"resolve_transition"`
+	WontFixResolution *string            `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty" hcl:"wont_fix_resolution"`
+	ReopenDuration    *string            `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty" hcl:"reopen_duration"`
+	DedupKeyFieldName *string            `yaml:"dedup_key_field,omitempty" json:"dedup_key_field,omitempty" hcl:"dedup_key_field"`
+	Fields            *map[string]string `yaml:"fields,omitempty" json:"fields,omitempty" hcl:"fields"`
 
 	User     *Secret `yaml:"user,omitempty" json:"user,omitempty" hcl:"user"`
 	Password *Secret `yaml:"password,omitempty" json:"password,omitempty" hcl:"password"`

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -69,16 +69,19 @@ type JiraIntegration struct {
 	Project   string `yaml:"project,omitempty" json:"project,omitempty" hcl:"project"`
 	IssueType string `yaml:"issue_type,omitempty" json:"issue_type,omitempty" hcl:"issue_type"`
 
-	Summary           *string            `yaml:"summary,omitempty" json:"summary,omitempty" hcl:"summary"`
-	Description       *string            `yaml:"description,omitempty" json:"description,omitempty" hcl:"description"`
-	Labels            *[]string          `yaml:"labels,omitempty" json:"labels,omitempty" hcl:"labels"`
-	Priority          *string            `yaml:"priority,omitempty" json:"priority,omitempty" hcl:"priority"`
-	ReopenTransition  *string            `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty" hcl:"reopen_transition"`
-	ResolveTransition *string            `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty" hcl:"resolve_transition"`
-	WontFixResolution *string            `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty" hcl:"wont_fix_resolution"`
-	ReopenDuration    *string            `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty" hcl:"reopen_duration"`
-	DedupKeyFieldName *string            `yaml:"dedup_key_field,omitempty" json:"dedup_key_field,omitempty" hcl:"dedup_key_field"`
-	Fields            *map[string]string `yaml:"fields,omitempty" json:"fields,omitempty" hcl:"fields"`
+	Summary           *string   `yaml:"summary,omitempty" json:"summary,omitempty" hcl:"summary"`
+	Description       *string   `yaml:"description,omitempty" json:"description,omitempty" hcl:"description"`
+	Labels            *[]string `yaml:"labels,omitempty" json:"labels,omitempty" hcl:"labels"`
+	Priority          *string   `yaml:"priority,omitempty" json:"priority,omitempty" hcl:"priority"`
+	ReopenTransition  *string   `yaml:"reopen_transition,omitempty" json:"reopen_transition,omitempty" hcl:"reopen_transition"`
+	ResolveTransition *string   `yaml:"resolve_transition,omitempty" json:"resolve_transition,omitempty" hcl:"resolve_transition"`
+	WontFixResolution *string   `yaml:"wont_fix_resolution,omitempty" json:"wont_fix_resolution,omitempty" hcl:"wont_fix_resolution"`
+	ReopenDuration    *string   `yaml:"reopen_duration,omitempty" json:"reopen_duration,omitempty" hcl:"reopen_duration"`
+	DedupKeyFieldName *string   `yaml:"dedup_key_field,omitempty" json:"dedup_key_field,omitempty" hcl:"dedup_key_field"`
+
+	// This should be a map[string]any but gohcl does not support encoding that type. Instead, we force it to a string
+	// using a jsoniter extension `mapToJSONStringCodec` which will be handled in the TF provider.
+	Fields *string `yaml:"fields,omitempty" json:"fields,omitempty" hcl:"fields"`
 
 	User     *Secret `yaml:"user,omitempty" json:"user,omitempty" hcl:"user"`
 	Password *Secret `yaml:"password,omitempty" json:"password,omitempty" hcl:"password"`


### PR DESCRIPTION
**What is this feature?**

- Fixed Jira HCL export when Fields is populated.
- Adds a new test that snapshots and validates the contact point export output for all notifier types using their full configuration from `AllKnownConfigsForTesting`.

This improves upon existing tests, which either:
-  Don’t cover all notifier types, and/or
- Use only partial configurations.

This test should help:
- Track changes to the provisioning file and Terraform schema
- Ensure backwards compatibility
- Validate that new or modified fields are exported as expected
- Serve as a reference example for full contact point configurations

Updating the snapshots is straightforward: a single-line comment is included to write updated output back to the test data once validated.

NOTE: `Jira` hcl encoding was broken for non-nil fields, this is because gohcl doesn't support encoding `map[string]any`. Instead we convert `map[string]any` to `string` and leave it to the TF provider to correctly handle it.