### PR TITLE
Chore: Fix releaseFinder script perf

### DIFF
--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -73,13 +73,13 @@ declare -a release_branches=()
 declare -a direct_tags=()
 declare -a included_tags=()
 
-# Use git branch --contains for much better performance
+# Use git branch --contains
 echo "Checking release branches..."
 for branch in $(git branch -r --contains "$COMMIT_HASH" 2>/dev/null | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/^\s*origin\///'); do
     release_branches+=("$branch")
 done
 
-# Use git tag --contains for much better performance
+# Use git tag --contains
 echo "Checking tags..."
 for tag in $(git tag --contains "$COMMIT_HASH" 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sort -V); do
     # If this is the first tag containing the commit, it's the initial release tag

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -46,83 +46,64 @@ fi
 echo "Fetching latest remote information..."
 git fetch --all --tags --prune 2>/dev/null
 
-echo "Finding release branches and tags containing the commit..."
-echo
-
-echo "Results for commit: $COMMIT_HASH"
+echo "Finding releases containing commit: $COMMIT_HASH"
 echo "============================================="
 echo
 
-# Get commit details
-echo "Commit details:"
-echo "  Author: $(git log -1 --format="%an <%ae>" "$COMMIT_HASH")"
-echo "  Date: $(git log -1 --format="%ad" --date=iso "$COMMIT_HASH")"
+# Get all commit details in one call for better performance
+commit_info=$(git log -1 --format="%an <%ae>%n%ad%n%B" --date=iso "$COMMIT_HASH")
+author=$(echo "$commit_info" | sed -n '1p')
+date=$(echo "$commit_info" | sed -n '2p')
+commit_message=$(echo "$commit_info" | sed -n '3,$p')
 
-# Extract original PR number and create link
-PR_NUMBER=$(git log -1 --pretty=format:"%B" "$COMMIT_HASH" | grep -o '#[0-9]\+' | head -n1 | tr -d '#')
+echo "Commit details:"
+echo "  Author: $author"
+echo "  Date: $date"
+
+# Extract PR number and title
+PR_NUMBER=$(echo "$commit_message" | grep -o '#[0-9]\+' | head -n1 | tr -d '#')
 if [ -n "$PR_NUMBER" ]; then
-    # Extract PR title (first line of commit message)
-    PR_TITLE=$(git log -1 --pretty=format:"%s" "$COMMIT_HASH")
+    PR_TITLE=$(echo "$commit_message" | head -n1)
     echo "  PR: #$PR_NUMBER - $PR_TITLE"
     echo "  Link: https://github.com/grafana/grafana/pull/$PR_NUMBER"
 fi
 echo
 
-# Arrays to store results
-declare -a release_branches=()
-declare -a direct_tags=()
-declare -a included_tags=()
+# Find release branches and tags containing the commit
+release_branches=$(git branch -r --contains "$COMMIT_HASH" 2>/dev/null | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/.*origin\///')
+release_tags=$(git tag --contains "$COMMIT_HASH" 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sort -V)
 
-# Use git branch --contains
-echo "Checking release branches..."
-for branch in $(git branch -r --contains "$COMMIT_HASH" 2>/dev/null | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/.*origin\///'); do
-    release_branches+=("$branch")
-done
+# Get all existing tags for upcoming release filtering
+all_tags=$(git tag 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$')
 
-# Use git tag --contains
-echo "Checking tags..."
-for tag in $(git tag --contains "$COMMIT_HASH" 2>/dev/null | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sort -V); do
-    # If this is the first tag containing the commit, it's the initial release tag
-    if [ ${#direct_tags[@]} -eq 0 ]; then
-        direct_tags+=("$tag")
-    else
-        included_tags+=("$tag")
-    fi
-done
-
-# Print previous releases if they exist
-if [ ${#direct_tags[@]} -gt 0 ] || [ ${#included_tags[@]} -gt 0 ]; then
+# Display previous releases
+if [ -n "$release_tags" ]; then
     echo "This commit has been included in these PREVIOUS on-prem releases:"
-    # Get all tags sorted
-    readarray -t all_tags < <(printf "%s\n" "${direct_tags[@]}" "${included_tags[@]}" | sort -V)
-    # Get the first release
-    first_release="${all_tags[0]}"
-    # Print all tags with annotation for the first release
-    for tag in "${all_tags[@]}"; do
+    first_release=$(echo "$release_tags" | head -1)
+    while read -r tag; do
         if [ "$tag" = "$first_release" ]; then
             echo "  - $tag (first release)"
         else
             echo "  - $tag"
         fi
-    done
+    done <<< "$release_tags"
     echo
     echo "Note: This code may have been backported to previous release branches. Please check the original PR for backport information."
     echo
 fi
 
-# Print upcoming releases
-if [ ${#release_branches[@]} -eq 0 ]; then
-    echo "  This commit is not yet included in any release branches."
-    echo "  The corresponding release branch has likely not been created yet."
-else
+# Display upcoming releases
+if [ -n "$release_branches" ]; then
     echo "This commit will be included in these UPCOMING on-prem releases:"
-    for branch in "${release_branches[@]}"; do
-        # Convert branch name to tag format (e.g., release-11.5.0 -> v11.5.0)
+    while read -r branch; do
         tag_version="v${branch#release-}"
         # Only show branches that don't have a corresponding tag yet
-        if ! git tag | grep -q "^$tag_version$"; then
+        if ! echo "$all_tags" | grep -q "^$tag_version$"; then
             echo "  - $tag_version"
         fi
-    done | sort -V
+    done <<< "$release_branches" | sort -V
+else
+    echo "This commit is not yet included in any release branches."
+    echo "The corresponding release branch has likely not been created yet."
 fi
 echo

--- a/scripts/releasefinder.sh
+++ b/scripts/releasefinder.sh
@@ -75,7 +75,7 @@ declare -a included_tags=()
 
 # Use git branch --contains
 echo "Checking release branches..."
-for branch in $(git branch -r --contains "$COMMIT_HASH" 2>/dev/null | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/^\s*origin\///'); do
+for branch in $(git branch -r --contains "$COMMIT_HASH" 2>/dev/null | grep -E 'origin/release-[0-9]+\.[0-9]+\.[0-9]+(\+security-[0-9]{2})?$' | sed 's/.*origin\///'); do
     release_branches+=("$branch")
 done
 


### PR DESCRIPTION
Fix performance issue in releasefinder.sh script

The script was hanging on large repositories due to my previously written inefficient git operations. Replaced individual `git merge-base --is-ancestor` calls with `git branch --contains` and `git tag --contains` for better performance.