### PR TITLE
chore: remove unused GrafanaAppInit postMessage

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -126,8 +126,6 @@ export class GrafanaApp {
   async init() {
     try {
       await preInitTasks();
-      // Let iframe container know grafana has started loading
-      window.parent.postMessage('GrafanaAppInit', '*');
       const regionalFormat = config.featureToggles.localeFormatPreference
         ? config.regionalFormat
         : config.bootData.user.language;


### PR DESCRIPTION
**What is this feature?**

This PR removes the sending of the `GrafanaAppInit` message since the single event handler was removed in the cdb49887d80.
