### PR TITLE
Plugins: adds plugin version to mutation logs

### DIFF
--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -382,7 +382,7 @@ describe('usePluginComponent()', () => {
 
     // Should log an error in dev mode
     expect(log.error).toHaveBeenCalledWith(
-      'Attempted to mutate object property "c" from extension with id myorg-extensions-app',
+      'Attempted to mutate object property "c" from extension with id myorg-extensions-app and version unknown',
       {
         stack: expect.any(String),
       }
@@ -438,7 +438,7 @@ describe('usePluginComponent()', () => {
 
     // Should log a warning
     expect(log.warning).toHaveBeenCalledWith(
-      'Attempted to mutate object property "c" from extension with id myorg-extensions-app',
+      'Attempted to mutate object property "c" from extension with id myorg-extensions-app and version unknown',
       {
         stack: expect.any(String),
       }

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -267,7 +267,7 @@ describe('usePluginComponents()', () => {
     // Should also render the component if it wants to change the props
     expect(() => render(<Component foo={originalFoo} override />)).not.toThrow();
     expect(log.error).toHaveBeenCalledWith(
-      `Attempted to mutate object property "foo4" from extension with id myorg-extensions-app`,
+      `Attempted to mutate object property "foo4" from extension with id myorg-extensions-app and version unknown`,
       {
         stack: expect.any(String),
       }
@@ -331,7 +331,7 @@ describe('usePluginComponents()', () => {
     // Should also render the component if it wants to change the props
     expect(() => render(<Component foo={originalFoo} override />)).not.toThrow();
     expect(log.warning).toHaveBeenCalledWith(
-      `Attempted to mutate object property "foo4" from extension with id myorg-extensions-app`,
+      `Attempted to mutate object property "foo4" from extension with id myorg-extensions-app and version unknown`,
       {
         stack: expect.any(String),
       }

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -399,14 +399,17 @@ describe('Plugin Extensions / Utils', () => {
       });
 
       it('should be possible to modify values in proxied object, but logs an error', () => {
-        const proxy = getMutationObserverProxy({ a: 'a' }, { pluginId: 'myorg-cool-datasource', source: 'datasource' });
+        const proxy = getMutationObserverProxy(
+          { a: 'a' },
+          { pluginId: 'myorg-cool-datasource', source: 'datasource', pluginVersion: '1.2.3' }
+        );
 
         expect(() => {
           proxy.a = 'b';
         }).not.toThrow();
 
         expect(log.error).toHaveBeenCalledWith(
-          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
+          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version 1.2.3`,
           {
             stack: expect.any(String),
           }
@@ -548,7 +551,11 @@ describe('Plugin Extensions / Utils', () => {
       config.buildInfo.env = 'development';
 
       const obj = { a: 'a' };
-      const copy = writableProxy(obj, { source: 'datasource', pluginId: 'myorg-cool-datasource' });
+      const copy = writableProxy(obj, {
+        source: 'datasource',
+        pluginId: 'myorg-cool-datasource',
+        pluginVersion: '1.2.3',
+      });
 
       expect(copy).not.toBe(obj);
       expect(copy.a).toBe('a');
@@ -558,7 +565,7 @@ describe('Plugin Extensions / Utils', () => {
       }).not.toThrow();
 
       expect(log.error).toHaveBeenCalledWith(
-        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
+        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version 1.2.3`,
         {
           stack: expect.any(String),
         }

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -406,7 +406,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.error).toHaveBeenCalledWith(
-          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource`,
+          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -427,7 +427,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.debug).toHaveBeenCalledWith(
-          `Attempted to define object property "b" from extension with id myorg-cool-extension`,
+          `Attempted to define object property "b" from extension with id myorg-cool-extension and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -450,7 +450,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.error).toHaveBeenCalledWith(
-          `Attempted to delete object property "c" from extension with id unknown`,
+          `Attempted to delete object property "c" from extension with id unknown and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -473,7 +473,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.warning).toHaveBeenCalledWith(
-          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource`,
+          `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -494,7 +494,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.debug).toHaveBeenCalledWith(
-          `Attempted to define object property "b" from extension with id myorg-cool-extension`,
+          `Attempted to define object property "b" from extension with id myorg-cool-extension and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -517,7 +517,7 @@ describe('Plugin Extensions / Utils', () => {
         }).not.toThrow();
 
         expect(log.warning).toHaveBeenCalledWith(
-          `Attempted to delete object property "c" from extension with id unknown`,
+          `Attempted to delete object property "c" from extension with id unknown and version unknown`,
           {
             stack: expect.any(String),
           }
@@ -558,7 +558,7 @@ describe('Plugin Extensions / Utils', () => {
       }).not.toThrow();
 
       expect(log.error).toHaveBeenCalledWith(
-        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource`,
+        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
         {
           stack: expect.any(String),
         }
@@ -581,7 +581,7 @@ describe('Plugin Extensions / Utils', () => {
       }).not.toThrow();
 
       expect(log.warning).toHaveBeenCalledWith(
-        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource`,
+        `Attempted to mutate object property "a" from datasource with id myorg-cool-datasource and version unknown`,
         {
           stack: expect.any(String),
         }
@@ -605,9 +605,12 @@ describe('Plugin Extensions / Utils', () => {
       expect(Object.isFrozen(copy.b)).toBe(true);
       expect(copy.b).toEqual({ c: 'c' });
 
-      expect(log.debug).toHaveBeenCalledWith(`Attempted to define object property "a" from extension with id unknown`, {
-        stack: expect.any(String),
-      });
+      expect(log.debug).toHaveBeenCalledWith(
+        `Attempted to define object property "a" from extension with id unknown and version unknown`,
+        {
+          stack: expect.any(String),
+        }
+      );
     });
   });
 
@@ -893,7 +896,7 @@ describe('Plugin Extensions / Utils', () => {
       // Logs a warning
       expect(log.error).toHaveBeenCalledTimes(1);
       expect(log.error).toHaveBeenCalledWith(
-        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel`,
+        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version unknown`,
         {
           stack: expect.any(String),
         }
@@ -921,7 +924,7 @@ describe('Plugin Extensions / Utils', () => {
       // Logs a warning
       expect(log.warning).toHaveBeenCalledTimes(1);
       expect(log.warning).toHaveBeenCalledWith(
-        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel`,
+        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version unknown`,
         {
           stack: expect.any(String),
         }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -329,7 +329,7 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
 
       if (isObject(value) || isArray(value)) {
         if (!cache.has(value)) {
-          cache.set(value, getMutationObserverProxy(value, { log, source, pluginId }));
+          cache.set(value, getMutationObserverProxy(value, { log, source, pluginId, pluginVersion }));
         }
         return cache.get(value);
       }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -251,6 +251,7 @@ interface ProxyOptions {
   log?: ExtensionsLog;
   source?: MutationSource;
   pluginId?: string;
+  pluginVersion?: string;
 }
 
 /**
@@ -261,6 +262,7 @@ interface ProxyOptions {
  * @param options.log The logger to use
  * @param options.source The source of the mutation
  * @param options.pluginId The id of the plugin that is mutating the object
+ * @param options.pluginVersion The version of the plugin that is mutating the object
  * @returns A new proxy object that logs any attempted mutation to the original object
  */
 export function getMutationObserverProxy<T extends object>(obj: T, options?: ProxyOptions): T {
@@ -268,31 +270,40 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
     return obj;
   }
 
-  const { log = baseLog, source = 'extension', pluginId = 'unknown' } = options ?? {};
+  const { log = baseLog, source = 'extension', pluginId = 'unknown', pluginVersion = 'unknown' } = options ?? {};
   const cache = new WeakMap();
   const logFunction = isGrafanaDevMode() ? log.error.bind(log) : log.warning.bind(log); // should show error during local development
 
   return new Proxy(obj, {
     deleteProperty(target, prop) {
-      logFunction(`Attempted to delete object property "${String(prop)}" from ${source} with id ${pluginId}`, {
-        stack: new Error().stack ?? '',
-      });
+      logFunction(
+        `Attempted to delete object property "${String(prop)}" from ${source} with id ${pluginId} and version ${pluginVersion}`,
+        {
+          stack: new Error().stack ?? '',
+        }
+      );
       Reflect.deleteProperty(target, prop);
       return true;
     },
     defineProperty(target, prop, descriptor) {
       // because immer (used by RTK) calls Object.isFrozen and Object.freeze we know that defineProperty will be called
       // behind the scenes as well so we only log message with debug level to minimize the noise and false positives
-      log.debug(`Attempted to define object property "${String(prop)}" from ${source} with id ${pluginId}`, {
-        stack: new Error().stack ?? '',
-      });
+      log.debug(
+        `Attempted to define object property "${String(prop)}" from ${source} with id ${pluginId} and version ${pluginVersion}`,
+        {
+          stack: new Error().stack ?? '',
+        }
+      );
       Reflect.defineProperty(target, prop, descriptor);
       return true;
     },
     set(target, prop, newValue) {
-      logFunction(`Attempted to mutate object property "${String(prop)}" from ${source} with id ${pluginId}`, {
-        stack: new Error().stack ?? '',
-      });
+      logFunction(
+        `Attempted to mutate object property "${String(prop)}" from ${source} with id ${pluginId} and version ${pluginVersion}`,
+        {
+          stack: new Error().stack ?? '',
+        }
+      );
       Reflect.set(target, prop, newValue);
       return true;
     },
@@ -336,6 +347,7 @@ export function getMutationObserverProxy<T extends object>(obj: T, options?: Pro
  * @param options.log The logger to use
  * @param options.source The source of the mutation
  * @param options.pluginId The id of the plugin that is mutating the object
+ * @param options.pluginVersion The version of the plugin that is mutating the object
  * @returns A new proxy object that logs any attempted mutation to the original object
  */
 export function writableProxy<T>(value: T, options?: ProxyOptions): T {
@@ -344,10 +356,10 @@ export function writableProxy<T>(value: T, options?: ProxyOptions): T {
     return value;
   }
 
-  const { log = baseLog, source = 'extension', pluginId = 'unknown' } = options ?? {};
+  const { log = baseLog, source = 'extension', pluginId = 'unknown', pluginVersion = 'unknown' } = options ?? {};
 
   // Default: we return a proxy of a deep-cloned version of the original object, which logs warnings when mutation is attempted
-  return getMutationObserverProxy(cloneDeep(value), { log, pluginId, source });
+  return getMutationObserverProxy(cloneDeep(value), { log, pluginId, pluginVersion, source });
 }
 
 function isRecord(value: unknown): value is Record<string | number | symbol, unknown> {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This pull request enhances logging for plugin-related operations by including the plugin version in log messages and updates the relevant utility functions and tests to support this change. The most significant updates involve modifying the `ProxyOptions` interface, the `getMutationObserverProxy` and `writableProxy` functions, and their associated test cases.

### Updates to Utilities

* **Added `pluginVersion` to `ProxyOptions` interface**: Introduced a new optional field, `pluginVersion`, to include the plugin version in logging. Defaulted to `'unknown'` if not provided. (`public/app/features/plugins/extensions/utils.tsx`, [[1]](diffhunk://#diff-3f90fac5341aff369739dfaf25c08dd6813e3f020a62efb5d859e3cf9f5f7450R254) [[2]](diffhunk://#diff-3f90fac5341aff369739dfaf25c08dd6813e3f020a62efb5d859e3cf9f5f7450R265-R306)
* **Enhanced `getMutationObserverProxy` and `writableProxy` functions**: Updated these functions to utilize the new `pluginVersion` field in log messages, ensuring detailed context for mutation operations. (`public/app/features/plugins/extensions/utils.tsx`, [[1]](diffhunk://#diff-3f90fac5341aff369739dfaf25c08dd6813e3f020a62efb5d859e3cf9f5f7450R265-R306) [[2]](diffhunk://#diff-3f90fac5341aff369739dfaf25c08dd6813e3f020a62efb5d859e3cf9f5f7450L321-R332) [[3]](diffhunk://#diff-3f90fac5341aff369739dfaf25c08dd6813e3f020a62efb5d859e3cf9f5f7450L347-R362)

### Updates to Test Cases

* **Modified test cases to reflect new logging format**: Updated log expectations in test cases to include the plugin version in messages. (`public/app/features/plugins/extensions/utils.test.tsx`, [[1]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L402-R412) [[2]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L430-R433) [[3]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L453-R456) [[4]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L476-R479) [[5]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L608-R620)
* **Added `pluginVersion` to test data**: Adjusted test setups to include the `pluginVersion` field where applicable. (`public/app/features/plugins/extensions/utils.test.tsx`, [[1]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L551-R558) [[2]](diffhunk://#diff-55aa3882c35810b02fe0d82a81b629da412c91c8eaa3fec9c937696dd2123915L561-R568)

### Updates to Plugin Component Tests

* **Updated log messages in `usePluginComponent` and `usePluginComponents` tests**: Adjusted test cases to verify the inclusion of the `pluginVersion` field in log outputs. (`public/app/features/plugins/extensions/usePluginComponent.test.tsx`, [[1]](diffhunk://#diff-c5d14e2d83eb42d9c834f2e35523a1943cb578826bf29fd98ca2533b7129027fL385-R385) [[2]](diffhunk://#diff-c5d14e2d83eb42d9c834f2e35523a1943cb578826bf29fd98ca2533b7129027fL441-R441); `public/app/features/plugins/extensions/usePluginComponents.test.tsx`, [[3]](diffhunk://#diff-fa6bda42c7f06c27aec19a44a4fa3578c206c69e4641dd39b89d47beec868ae4L270-R270) [[4]](diffhunk://#diff-fa6bda42c7f06c27aec19a44a4fa3578c206c69e4641dd39b89d47beec868ae4L334-R334)

**Why do we need this feature?**

So we can identify mutations more easily

**Who is this feature for?**

Plugins platform maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
