### PR TITLE
fix: re-order db initialization logic for resource server

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/db_engine_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db_engine_test.go
@@ -67,7 +67,7 @@ func TestNewResourceDbProvider(t *testing.T) {
 		engine, err := newResourceDBProvider(nil, cfg, nil)
 		require.Error(t, err)
 		require.Nil(t, engine)
-		require.Contains(t, err.Error(), "unknown")
+		require.Contains(t, err.Error(), "no database type specified")
 	})
 
 	t.Run("Unknown database type", func(t *testing.T) {

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -71,14 +71,15 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		tracer:      tracer,
 	}
 
-	dbCfg, err := sqlstore.NewDatabaseConfig(cfg, nil)
-	if err != nil {
-		return nil, err
-	}
+	dbType := cfg.SectionWithEnvOverrides("database").Key("type").String()
 
 	switch {
-	case dbCfg.Type != "":
-		logger.Info("Using database section", "db_type", dbCfg.Type)
+	case dbType != "":
+		logger.Info("Using database section", "db_type", dbType)
+		dbCfg, err := sqlstore.NewDatabaseConfig(cfg, nil)
+		if err != nil {
+			return nil, err
+		}
 		p.registerMetrics = true
 		p.engine, err = getEngine(dbCfg)
 		return p, err

--- a/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
+++ b/pkg/storage/unified/sql/db/dbimpl/dbimpl.go
@@ -70,17 +70,7 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		migrateFunc: migrations.MigrateResourceStore,
 		tracer:      tracer,
 	}
-	// Try to use the grafana db connection, should only happen in tests.
-	if grafanaDB != nil {
-		if newConfGetter(cfg.SectionWithEnvOverrides("database"), "").Bool(grafanaDBInstrumentQueriesKey) {
-			return nil, errGrafanaDBInstrumentedNotSupported
-		}
-		p.engine = grafanaDB.GetEngine()
-		p.logQueries = cfg.SectionWithEnvOverrides("database").Key("log_queries").MustBool(false)
-		return p, nil
-	}
 
-	// If we don't provide a DB, lets build it from the config.
 	dbCfg, err := sqlstore.NewDatabaseConfig(cfg, nil)
 	if err != nil {
 		return nil, err
@@ -92,6 +82,14 @@ func newResourceDBProvider(grafanaDB infraDB.DB, cfg *setting.Cfg, tracer trace.
 		p.registerMetrics = true
 		p.engine, err = getEngine(dbCfg)
 		return p, err
+	case grafanaDB != nil:
+		// Try to use the grafana db connection, should only happen in tests.
+		if newConfGetter(cfg.SectionWithEnvOverrides("database"), "").Bool(grafanaDBInstrumentQueriesKey) {
+			return nil, errGrafanaDBInstrumentedNotSupported
+		}
+		p.engine = grafanaDB.GetEngine()
+		p.logQueries = cfg.SectionWithEnvOverrides("database").Key("log_queries").MustBool(false)
+		return p, nil
 	default:
 		return nil, fmt.Errorf("no database type specified")
 	}


### PR DESCRIPTION
Re-order the db provider init logic so that we are backward compatible.