### PR TITLE
DashboardMacro: Fail soft if `__dashboard` macro exists

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardMacro.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardMacro.ts
@@ -34,7 +34,12 @@ class DashboardMacro implements FormatVariable {
 }
 
 export function registerDashboardMacro() {
-  const unregister = sceneUtils.registerVariableMacro('__dashboard', DashboardMacro);
+  try {
+    const unregister = sceneUtils.registerVariableMacro('__dashboard', DashboardMacro);
 
-  return () => unregister();
+    return () => unregister();
+  } catch (e) {
+    console.error('Error registering dashboard macro', e);
+    return () => {};
+  }
 }


### PR DESCRIPTION
**What is this feature?**

<img width="3786" height="2534" alt="image" src="https://github.com/user-attachments/assets/e0c3271b-6ace-4179-afdc-e0ec49671493" />

We had a few reports about the above issue: https://raintank-corp.slack.com/archives/C08GW7KDCJ0/p1752344749071409

I am not 100% sure what needs to be happen to reproduce this, but this fix should at least prevent Grafana/Dashboards from rendering unavailable.