### PR TITLE
New logs Panel: Log details improvements + default details value update

### DIFF
--- a/public/app/features/logs/components/LogDetailsRow.tsx
+++ b/public/app/features/logs/components/LogDetailsRow.tsx
@@ -83,6 +83,7 @@ const getStyles = memoizeOne((theme: GrafanaTheme2) => {
     }),
     copyButton: css({
       '& > button': {
+        gap: 0,
         color: theme.colors.text.secondary,
         padding: 0,
         justifyContent: 'center',

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -490,5 +490,29 @@ describe('LogLineDetails', () => {
 
       expect(onClickHideField).toHaveBeenCalledWith('key1');
     });
+
+    test('Exposes buttons to reorder displayed fields', async () => {
+      const setDisplayedFields = jest.fn();
+      const onClickHideField = jest.fn();
+      setup(
+        undefined,
+        { labels: { key1: 'label1', key2: 'label2' } },
+        { displayedFields: ['key1', 'key2', 'key3'], setDisplayedFields, onClickHideField }
+      );
+
+      await userEvent.click(screen.getByText('Organize displayed fields'));
+
+      expect(screen.getAllByLabelText('Remove field')).toHaveLength(3);
+      expect(screen.getAllByLabelText('Move down')).toHaveLength(3);
+      expect(screen.getAllByLabelText('Move up')).toHaveLength(3);
+
+      await userEvent.click(screen.getAllByLabelText('Move down')[0]);
+
+      expect(setDisplayedFields).toHaveBeenCalledWith(['key2', 'key1', 'key3']);
+
+      await userEvent.click(screen.getAllByLabelText('Move up')[2]);
+
+      expect(setDisplayedFields).toHaveBeenCalledWith(['key1', 'key3', 'key2']);
+    });
   });
 });

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Resizable } from 're-resizable';
-import { useCallback, useEffect, useRef } from 'react';
+import { memo, useCallback, useEffect, useRef } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { getDragStyles, useStyles2 } from '@grafana/ui';
@@ -67,7 +67,7 @@ export interface InlineLogLineDetailsProps {
   logs: LogListModel[];
 }
 
-export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
+export const InlineLogLineDetails = memo(({ logs }: InlineLogLineDetailsProps) => {
   const { showDetails } = useLogListContext();
   const styles = useStyles2(getStyles, 'inline');
 
@@ -84,7 +84,8 @@ export const InlineLogLineDetails = ({ logs }: InlineLogLineDetailsProps) => {
       </div>
     </div>
   );
-};
+});
+InlineLogLineDetails.displayName = 'InlineLogLineDetails';
 
 export const LOG_LINE_DETAILS_HEIGHT = 35;
 

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { getDragStyles, useStyles2 } from '@grafana/ui';
 
 import { LogLineDetailsComponent } from './LogLineDetailsComponent';
-import { useLogListContext } from './LogListContext';
+import { getDetailsScrollPosition, saveDetailsScrollPosition, useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 import { LOG_LIST_MIN_WIDTH } from './virtualization';
 
@@ -70,6 +70,18 @@ export interface InlineLogLineDetailsProps {
 export const InlineLogLineDetails = memo(({ logs }: InlineLogLineDetailsProps) => {
   const { showDetails } = useLogListContext();
   const styles = useStyles2(getStyles, 'inline');
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+
+  const saveScroll = useCallback(() => {
+    saveDetailsScrollPosition(showDetails[0], scrollRef.current?.scrollTop ?? 0);
+  }, [showDetails]);
+
+  useEffect(() => {
+    if (!scrollRef.current) {
+      return;
+    }
+    scrollRef.current.scrollTop = getDetailsScrollPosition(showDetails[0]);
+  }, [showDetails]);
 
   if (!showDetails.length) {
     return null;
@@ -78,7 +90,7 @@ export const InlineLogLineDetails = memo(({ logs }: InlineLogLineDetailsProps) =
   return (
     <div className={`${styles.inlineWrapper} log-line-inline-details`}>
       <div className={styles.container}>
-        <div className={styles.scrollContainer}>
+        <div className={styles.scrollContainer} ref={scrollRef} onScroll={saveScroll}>
           <LogLineDetailsComponent log={showDetails[0]} logs={logs} />
         </div>
       </div>

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { camelCase, groupBy } from 'lodash';
-import { startTransition, useCallback, useMemo, useRef, useState } from 'react';
+import { memo, startTransition, useCallback, useMemo, useRef, useState } from 'react';
 
 import { DataFrameType, GrafanaTheme2, store } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
@@ -22,7 +22,7 @@ interface LogLineDetailsComponentProps {
   logs: LogListModel[];
 }
 
-export const LogLineDetailsComponent = ({ log, logs }: LogLineDetailsComponentProps) => {
+export const LogLineDetailsComponent = memo(({ log, logs }: LogLineDetailsComponentProps) => {
   const { displayedFields, logOptionsStorageKey, setDisplayedFields } = useLogListContext();
   const [search, setSearch] = useState('');
   const inputRef = useRef('');
@@ -175,7 +175,8 @@ export const LogLineDetailsComponent = ({ log, logs }: LogLineDetailsComponentPr
       </div>
     </>
   );
-};
+});
+LogLineDetailsComponent.displayName = 'LogLineDetailsComponent';
 
 function groupOptionName(group: string) {
   return `${camelCase(group)}Open`;

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -123,7 +123,7 @@ export const LogLineDetailsComponent = memo(({ log, logs }: LogLineDetailsCompon
             isOpen={linksOpen}
             onToggle={(isOpen: boolean) => handleToggle('linksOpen', isOpen)}
           >
-            <LogLineDetailsFields log={log} logs={logs} fields={fieldsWithLinks.links} search={search} />
+            <LogLineDetailsFields disableActions log={log} logs={logs} fields={fieldsWithLinks.links} search={search} />
             <LogLineDetailsFields
               disableActions
               log={log}

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -8,8 +8,8 @@ import { Card, IconButton, useStyles2 } from '@grafana/ui';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
-import { useLogListContext } from './LogListContext';
 import { LogLineDetailsMode } from './LogLineDetails';
+import { useLogListContext } from './LogListContext';
 
 export const LogLineDetailsDisplayedFields = () => {
   const { displayedFields, setDisplayedFields } = useLogListContext();
@@ -115,7 +115,6 @@ const DraggableDisplayedField = ({ field, index, moveField }: DraggableDisplayed
 
 const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
   fieldCard: css({
-    cursor: 'move',
     display: 'block',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),
@@ -124,6 +123,7 @@ const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
     wordBreak: 'break-word',
   }),
   fieldWrapper: css({
+    cursor: 'move',
     display: 'flex',
     gap: theme.spacing(0.5),
     justifyContent: 'space-evenly',

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
+import { DragDropContext, Draggable, DraggableProvided, Droppable, DropResult } from '@hello-pangea/dnd';
 import { useCallback } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -32,7 +32,7 @@ export const LogLineDetailsDisplayedFields = () => {
       if (result.destination == null) {
         return;
       }
-      reorganizeDisplayedFields(result.source.index, result.source.index);
+      reorganizeDisplayedFields(result.source.index, result.destination.index);
     },
     [reorganizeDisplayedFields]
   );
@@ -40,22 +40,20 @@ export const LogLineDetailsDisplayedFields = () => {
   return (
     <div>
       <DragDropContext onDragEnd={onDragEnd}>
-        <Droppable ignoreContainerClipping={true} droppableId="displayed-fields" direction="vertical">
+        <Droppable droppableId="displayed-fields" direction="vertical">
           {(provided) => {
             return (
-              <>
-                <div ref={provided.innerRef} {...provided.droppableProps}>
-                  {displayedFields.map((field, index) => (
-                    <DraggableDisplayedField
-                      key={field}
-                      field={field}
-                      index={index}
-                      moveField={reorganizeDisplayedFields}
-                    />
-                  ))}
-                </div>
+              <div ref={provided.innerRef} {...provided.droppableProps}>
+                {displayedFields.map((field, index) => (
+                  <DraggableDisplayedField
+                    key={field}
+                    field={field}
+                    index={index}
+                    moveField={reorganizeDisplayedFields}
+                  />
+                ))}
                 {provided.placeholder}
-              </>
+              </div>
             );
           }}
         </Droppable>
@@ -71,45 +69,56 @@ interface DraggableDisplayedFieldProps {
 }
 
 const DraggableDisplayedField = ({ field, index, moveField }: DraggableDisplayedFieldProps) => {
+  return (
+    <Draggable draggableId={field} index={index}>
+      {(provided) => (
+        <DisplayedField key={field} field={field} index={index} moveField={moveField} provided={provided} />
+      )}
+    </Draggable>
+  );
+};
+
+const DisplayedField = ({
+  field,
+  index,
+  moveField,
+  provided,
+}: DraggableDisplayedFieldProps & { provided: DraggableProvided }) => {
   const { detailsMode, displayedFields, onClickHideField } = useLogListContext();
   const styles = useStyles2(getStyles, detailsMode);
   const nextIndex = index === displayedFields.length - 1 ? 0 : index + 1;
   const prevIndex = index === 0 ? displayedFields.length - 1 : index - 1;
   return (
-    <Draggable draggableId={field} index={index}>
-      {(provided) => (
-        <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
-          <Card noMargin className={styles.fieldCard}>
-            <div className={styles.fieldWrapper}>
-              <div className={styles.field}>
-                {field === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-line-details.log-line-field', 'Log line') : field}
-              </div>
-              {displayedFields.length > 1 && (
-                <>
-                  <IconButton
-                    name="arrow-down"
-                    onClick={() => moveField(index, nextIndex)}
-                    tooltip={t('logs.log-line-details.move-displayed-field-down', 'Move down')}
-                  />
-                  <IconButton
-                    name="arrow-up"
-                    onClick={() => moveField(index, prevIndex)}
-                    tooltip={t('logs.log-line-details.move-displayed-field-up', 'Move up')}
-                  />
-                </>
-              )}
-              {onClickHideField && (
-                <IconButton
-                  name="times"
-                  onClick={() => onClickHideField(field)}
-                  tooltip={t('logs.log-line-details.remove-displayed-field', 'Remove field')}
-                />
-              )}
-            </div>
-          </Card>
+    <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
+      <Card noMargin className={styles.fieldCard}>
+        <div className={styles.fieldWrapper}>
+          <div className={styles.field}>
+            {field === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-line-details.log-line-field', 'Log line') : field}
+          </div>
+          {displayedFields.length > 1 && (
+            <>
+              <IconButton
+                name="arrow-down"
+                onClick={() => moveField(index, nextIndex)}
+                tooltip={t('logs.log-line-details.move-displayed-field-down', 'Move down')}
+              />
+              <IconButton
+                name="arrow-up"
+                onClick={() => moveField(index, prevIndex)}
+                tooltip={t('logs.log-line-details.move-displayed-field-up', 'Move up')}
+              />
+            </>
+          )}
+          {onClickHideField && (
+            <IconButton
+              name="times"
+              onClick={() => onClickHideField(field)}
+              tooltip={t('logs.log-line-details.remove-displayed-field', 'Remove field')}
+            />
+          )}
         </div>
-      )}
-    </Draggable>
+      </Card>
+    </div>
   );
 };
 

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -127,8 +127,9 @@ const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
     display: 'block',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),
-    maxWidth: detailsMode === 'inline' ? 'max-content' : undefined,
-    minWidth: detailsMode === 'inline' ? '20%' : undefined,
+    width: detailsMode === 'inline' ? '30vw' : undefined,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
     wordBreak: 'break-word',
   }),
   fieldWrapper: css({

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -9,24 +9,32 @@ import { Card, IconButton, useStyles2 } from '@grafana/ui';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 
 import { useLogListContext } from './LogListContext';
+import { LogLineDetailsMode } from './LogLineDetails';
 
 export const LogLineDetailsDisplayedFields = () => {
   const { displayedFields, setDisplayedFields } = useLogListContext();
+
+  const reorganizeDisplayedFields = useCallback(
+    (srcIndex: number, destIndex: number) => {
+      const newDisplayedFields = [...displayedFields];
+      const element = displayedFields[srcIndex];
+
+      newDisplayedFields.splice(srcIndex, 1);
+      newDisplayedFields.splice(destIndex, 0, element);
+
+      setDisplayedFields?.(newDisplayedFields);
+    },
+    [displayedFields, setDisplayedFields]
+  );
 
   const onDragEnd = useCallback(
     (result: DropResult) => {
       if (result.destination == null) {
         return;
       }
-
-      const newDisplayedFields = [...displayedFields];
-      const element = displayedFields[result.source.index];
-      newDisplayedFields.splice(result.source.index, 1);
-      newDisplayedFields.splice(result.destination.index, 0, element);
-
-      setDisplayedFields?.(newDisplayedFields);
+      reorganizeDisplayedFields(result.source.index, result.source.index);
     },
-    [displayedFields, setDisplayedFields]
+    [reorganizeDisplayedFields]
   );
 
   return (
@@ -38,7 +46,12 @@ export const LogLineDetailsDisplayedFields = () => {
               <>
                 <div ref={provided.innerRef} {...provided.droppableProps}>
                   {displayedFields.map((field, index) => (
-                    <DraggableDisplayedField key={field} field={field} index={index} />
+                    <DraggableDisplayedField
+                      key={field}
+                      field={field}
+                      index={index}
+                      moveField={reorganizeDisplayedFields}
+                    />
                   ))}
                 </div>
                 {provided.placeholder}
@@ -54,26 +67,45 @@ export const LogLineDetailsDisplayedFields = () => {
 interface DraggableDisplayedFieldProps {
   field: string;
   index: number;
+  moveField: (srcIndex: number, destIndex: number) => void;
 }
 
-const DraggableDisplayedField = ({ field, index }: DraggableDisplayedFieldProps) => {
-  const { onClickHideField } = useLogListContext();
-  const styles = useStyles2(getStyles);
+const DraggableDisplayedField = ({ field, index, moveField }: DraggableDisplayedFieldProps) => {
+  const { detailsMode, displayedFields, onClickHideField } = useLogListContext();
+  const styles = useStyles2(getStyles, detailsMode);
+  const nextIndex = index === displayedFields.length - 1 ? 0 : index + 1;
+  const prevIndex = index === 0 ? displayedFields.length - 1 : index - 1;
   return (
     <Draggable draggableId={field} index={index}>
       {(provided) => (
         <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
           <Card noMargin className={styles.fieldCard}>
-            <div>
-              {field === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-line-details.log-line-field', 'Log line') : field}
+            <div className={styles.fieldWrapper}>
+              <div className={styles.field}>
+                {field === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-line-details.log-line-field', 'Log line') : field}
+              </div>
+              {displayedFields.length > 1 && (
+                <>
+                  <IconButton
+                    name="arrow-down"
+                    onClick={() => moveField(index, nextIndex)}
+                    tooltip={t('logs.log-line-details.move-displayed-field-down', 'Move down')}
+                  />
+                  <IconButton
+                    name="arrow-up"
+                    onClick={() => moveField(index, prevIndex)}
+                    tooltip={t('logs.log-line-details.move-displayed-field-up', 'Move up')}
+                  />
+                </>
+              )}
+              {onClickHideField && (
+                <IconButton
+                  name="times"
+                  onClick={() => onClickHideField(field)}
+                  tooltip={t('logs.log-line-details.remove-displayed-field', 'Remove field')}
+                />
+              )}
             </div>
-            {onClickHideField && (
-              <IconButton
-                name="times"
-                onClick={() => onClickHideField(field)}
-                tooltip={t('logs.log-line-details.remove-displayed-field', 'Remove field')}
-              />
-            )}
           </Card>
         </div>
       )}
@@ -81,11 +113,22 @@ const DraggableDisplayedField = ({ field, index }: DraggableDisplayedFieldProps)
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
+const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
   fieldCard: css({
     cursor: 'move',
+    display: 'block',
     padding: theme.spacing(1),
     marginBottom: theme.spacing(1),
+    maxWidth: detailsMode === 'inline' ? 'max-content' : undefined,
+    minWidth: detailsMode === 'inline' ? '20%' : undefined,
     wordBreak: 'break-word',
+  }),
+  fieldWrapper: css({
+    display: 'flex',
+    gap: theme.spacing(0.5),
+    justifyContent: 'space-evenly',
+  }),
+  field: css({
+    flex: 1,
   }),
 });

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -1,8 +1,7 @@
 import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
 import { parse, stringify } from 'lossless-json';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import * as React from 'react';
+import { memo, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { CoreApp, Field, fuzzySearch, GrafanaTheme2, IconName, LinkModel, LogLabelStatsModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -25,7 +24,7 @@ interface LogLineDetailsFieldsProps {
   search?: string;
 }
 
-export const LogLineDetailsFields = ({ disableActions, fields, log, logs, search }: LogLineDetailsFieldsProps) => {
+export const LogLineDetailsFields = memo(({ disableActions, fields, log, logs, search }: LogLineDetailsFieldsProps) => {
   if (!fields.length) {
     return null;
   }
@@ -53,7 +52,8 @@ export const LogLineDetailsFields = ({ disableActions, fields, log, logs, search
       ))}
     </div>
   );
-};
+});
+LogLineDetailsFields.displayName = 'LogLineDetailsFields';
 
 interface LinkModelWithIcon extends LinkModel<Field> {
   icon?: IconName;

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -310,7 +310,6 @@ export const LogLineDetailsField = ({
         )}
         <div className={styles.label}>
           {singleKey ? keys[0] : <MultipleValue values={keys} />}
-          {singleKey ? keys[0] : <MultipleValue values={keys} />}
         </div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import { isEqual } from 'lodash';
+import { parse, stringify } from 'lossless-json';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 
@@ -148,6 +149,7 @@ export const LogLineDetailsField = ({
     onClickHideField,
     onPinLine,
     pinLineButtonTooltipTitle,
+    syntaxHighlighting,
   } = useLogListContext();
 
   const styles = useStyles2(getFieldStyles);
@@ -309,8 +311,11 @@ export const LogLineDetailsField = ({
         <div className={styles.label}>{singleKey ? keys[0] : <MultipleValue values={keys} />}</div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>
-            {singleValue ? values[0] : <MultipleValue showCopy={true} values={values} />}
-            {singleValue && <ClipboardButtonWrapper value={values[0]} />}
+            {singleValue ? (
+              <SingleValue value={values[0]} syntaxHighlighting={syntaxHighlighting} />
+            ) : (
+              <MultipleValue showCopy={true} values={values} />
+            )}
           </div>
         </div>
       </div>
@@ -406,10 +411,11 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
   }),
   valueContainer: css({
     display: 'flex',
-    alignItems: 'center',
     lineHeight: theme.typography.body.lineHeight,
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-all',
+    maxHeight: '50vh',
+    overflow: 'auto',
   }),
 });
 
@@ -469,6 +475,28 @@ const MultipleValue = ({ showCopy, values = [] }: { showCopy?: boolean; values: 
         })}
       </tbody>
     </table>
+  );
+};
+
+const SingleValue = ({ value: originalValue, syntaxHighlighting }: { value: string; syntaxHighlighting?: boolean }) => {
+  const value = useMemo(() => {
+    if (!syntaxHighlighting) {
+      return originalValue;
+    }
+    try {
+      const parsed = stringify(parse(originalValue), undefined, 2);
+      if (parsed) {
+        return parsed;
+      }
+    } catch (error) {}
+    return originalValue;
+  }, [originalValue, syntaxHighlighting]);
+
+  return (
+    <>
+      {value}
+      <ClipboardButtonWrapper value={value} />
+    </>
   );
 };
 

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -105,12 +105,12 @@ const getFieldsStyles = (theme: GrafanaTheme2) => ({
   fieldsTable: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `${theme.spacing(11.5)} minmax(15%, 30%) 1fr`,
+    gridTemplateColumns: `${theme.spacing(11.5)} minmax(min-content, 20vw) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `minmax(15%, 30%) 1fr`,
+    gridTemplateColumns: `minmax(min-content, 20vw) 1fr`,
   }),
 });
 
@@ -308,7 +308,10 @@ export const LogLineDetailsField = ({
             />
           </div>
         )}
-        <div className={styles.label}>{singleKey ? keys[0] : <MultipleValue values={keys} />}</div>
+        <div className={styles.label}>
+          {singleKey ? keys[0] : <MultipleValue values={keys} />}
+          {singleKey ? keys[0] : <MultipleValue values={keys} />}
+        </div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>
             {singleValue ? (

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -308,9 +308,7 @@ export const LogLineDetailsField = ({
             />
           </div>
         )}
-        <div className={styles.label}>
-          {singleKey ? keys[0] : <MultipleValue values={keys} />}
-        </div>
+        <div className={styles.label}>{singleKey ? keys[0] : <MultipleValue values={keys} />}</div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>
             {singleValue ? (

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -105,12 +105,12 @@ const getFieldsStyles = (theme: GrafanaTheme2) => ({
   fieldsTable: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `${theme.spacing(11.5)} minmax(min-content, 20vw) 1fr`,
+    gridTemplateColumns: `${theme.spacing(11.5)} auto 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `minmax(min-content, 20vw) 1fr`,
+    gridTemplateColumns: `auto 1fr`,
   }),
 });
 

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -439,6 +439,7 @@ const getClipboardButtonStyles = (theme: GrafanaTheme2) => ({
   button: css({
     '& > button': {
       color: theme.colors.text.secondary,
+      gap: 0,
       padding: 0,
       justifyContent: 'center',
       borderRadius: theme.shape.radius.circle,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -442,8 +442,11 @@ export const LogListContextProvider = ({
   );
 
   const closeDetails = useCallback(() => {
+    if (showDetails.length) {
+      removeDetailsScrollPosition(showDetails[0]);
+    }
     setShowDetails([]);
-  }, []);
+  }, [showDetails]);
 
   const toggleDetails = useCallback(
     (log: LogListModel) => {
@@ -584,4 +587,18 @@ function getDetailsWidth(
     return currentWidth ?? defaultWidth;
   }
   return detailsWidth;
+}
+
+const detailsScrollMap = new Map<string, number>();
+
+export function saveDetailsScrollPosition(log: LogListModel, position: number) {
+  detailsScrollMap.set(log.uid, position);
+}
+
+export function getDetailsScrollPosition(log: LogListModel) {
+  return detailsScrollMap.get(log.uid) ?? 0;
+}
+
+export function removeDetailsScrollPosition(log: LogListModel) {
+  detailsScrollMap.delete(log.uid);
 }

--- a/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/__mocks__/LogListContext.tsx
@@ -191,3 +191,9 @@ export const LogListContextProvider = ({
     </LogListContext.Provider>
   );
 };
+
+export const saveDetailsScrollPosition = jest.fn();
+
+export const getDetailsScrollPosition = jest.fn();
+
+export const removeDetailsScrollPosition = jest.fn();

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -110,7 +110,7 @@ export class LogListModel implements LogRowModel {
   get body(): string {
     if (this._body === undefined) {
       try {
-        const parsed = stringify(parse(this.raw), undefined, 2);
+        const parsed = stringify(parse(this.raw), undefined, this._wrapLogMessage ? 2 : 1);
         if (parsed) {
           this.raw = parsed;
         }

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -159,7 +159,7 @@ export const LogsPanel = ({
     onNewLogsReceived,
     fontSize,
     syntaxHighlighting,
-    detailsMode,
+    detailsModeProp,
     ...options
   },
   id,
@@ -517,6 +517,9 @@ export const LogsPanel = ({
 
   const onClickShowField = isOnClickShowField(options.onClickShowField) ? options.onClickShowField : showField;
   const onClickHideField = isOnClickHideField(options.onClickHideField) ? options.onClickHideField : hideField;
+
+  // In Dashboards, default to inline. Otherwise, let apps control or have automatic behavior.
+  const detailsMode = detailsModeProp ? detailsModeProp : app === CoreApp.Dashboard ? 'inline' : undefined;
 
   return (
     <>

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -159,7 +159,7 @@ export const LogsPanel = ({
     onNewLogsReceived,
     fontSize,
     syntaxHighlighting,
-    detailsModeProp,
+    detailsMode: detailsModeProp,
     ...options
   },
   id,

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -123,7 +123,6 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
               },
             ],
           },
-          defaultValue: 'inline',
         });
     }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8805,6 +8805,8 @@
       "links-section": "Links",
       "log-line-field": "Log line",
       "log-line-section": "Log line",
+      "move-displayed-field-down": "Move down",
+      "move-displayed-field-up": "Move up",
       "no-details": "No fields to display.",
       "pin-line": "Pin log",
       "remove-displayed-field": "Remove field",


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

Changes in this PR:

- Removed default value for `detailsMode`. When in a dashboard, inline is passed, otherwise the passed prop or the stored value is used.
- Prettify JSON field values, controlled by syntax highlighting state:


https://github.com/user-attachments/assets/11291a70-81a0-448f-bcaa-7b4db13d60e6

- Improved column size for log details keys.
- Memoized details components
- Organize displayed fields in Log Details: added to organize icons as a fallback.

https://github.com/user-attachments/assets/829f99c3-09e2-42e9-b6f6-dcfddcea0bc0

- Improvements for inline details in general