### PR TITLE
Tempo: Fix exemplar data links when streaming TraceQL metrics

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -782,6 +782,9 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         )
       )
     ).pipe(
+      map((response) => {
+        return enhanceTraceQlMetricsResponse(response, this.instanceSettings);
+      }),
       catchError((error) => {
         reportTempoQueryMetrics('grafana_traces_traceql_metrics_response', options, {
           success: false,

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -1,6 +1,7 @@
 import { SpanStatus } from '@opentelemetry/api';
 import { collectorTypes } from '@opentelemetry/exporter-collector';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
+import { isEqual } from 'lodash';
 
 import {
   createDataFrame,
@@ -474,9 +475,20 @@ export function enhanceTraceQlMetricsResponse(
       const traceIDField = frame.fields.find((field: Field) => field.name === 'traceId');
       if (traceIDField) {
         const links = getDataLinks(instanceSettings);
-        traceIDField.config.links = traceIDField.config.links?.length
-          ? [...traceIDField.config.links, ...links]
-          : links;
+        const existingLinks = traceIDField.config.links || [];
+
+        // Filter out links that already exist
+        const newLinks = links.filter(
+          (link) =>
+            !existingLinks.some(
+              (existing) =>
+                existing.title === link.title &&
+                existing.internal?.datasourceUid === link.internal?.datasourceUid &&
+                isEqual(existing.internal?.query, link.internal?.query)
+            )
+        );
+
+        traceIDField.config.links = existingLinks.length ? [...existingLinks, ...newLinks] : newLinks;
       }
       return frame;
     });

--- a/public/app/plugins/datasource/tempo/resultTransformer.ts
+++ b/public/app/plugins/datasource/tempo/resultTransformer.ts
@@ -481,7 +481,7 @@ export function enhanceTraceQlMetricsResponse(
         const newLinks = links.filter(
           (link) =>
             !existingLinks.some(
-              (existing) =>
+              (existing: DataLink) =>
                 existing.title === link.title &&
                 existing.internal?.datasourceUid === link.internal?.datasourceUid &&
                 isEqual(existing.internal?.query, link.internal?.query)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

There's currently a bug in TraceQL Metrics where exemplar data links aren't correctly rendered when streaming metrics is enabled, which means that the "View trace" button isn't visible. This PR fixes this issue and makes sure that there aren't duplicated links for each exemplar. 

**Who is this feature for?**

Users of the Tempo datasource.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
