### PR TITLE
Trace view: Improved span details view

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.tsx
@@ -97,7 +97,7 @@ describe('AccordianKeyValues test', () => {
     setupAccordian({ isOpen: false } as AccordianKeyValuesProps);
 
     expect(
-      screen.getByRole('switch', { name: 'test accordian: span.kind = client omg = mos-def' })
+      screen.getByRole('switch', { name: 'test accordian: span.kind client omg mos-def' })
     ).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('cell')).toHaveLength(0);

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.test.tsx
@@ -96,9 +96,7 @@ describe('AccordianKeyValues test', () => {
   it('renders the summary instead of the table when it is not expanded', () => {
     setupAccordian({ isOpen: false } as AccordianKeyValuesProps);
 
-    expect(
-      screen.getByRole('switch', { name: 'test accordian: span.kind client omg mos-def' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'test accordian: span.kind client omg mos-def' })).toBeInTheDocument();
     expect(screen.queryByRole('table')).not.toBeInTheDocument();
     expect(screen.queryAllByRole('cell')).toHaveLength(0);
   });

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -68,7 +68,6 @@ export const getStyles = (theme: GrafanaTheme2) => {
       label: 'summaryItem',
       display: 'inline',
       paddingRight: '0.5rem',
-      borderRight: `1px solid ${autoColor(theme, '#ddd')}`,
       '&:last-child': {
         paddingRight: 0,
         borderRight: 'none',
@@ -77,11 +76,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     summaryLabel: css({
       label: 'summaryLabel',
       color: autoColor(theme, '#777'),
-    }),
-    summaryDelim: css({
-      label: 'summaryDelim',
-      color: autoColor(theme, '#bbb'),
-      padding: '0 0.2em',
+      paddingRight: '0.5rem',
     }),
   };
 };
@@ -116,7 +111,6 @@ export function KeyValuesSummary({ data = null }: KeyValuesSummaryProps) {
         // `i` is necessary in the key because item.key can repeat
         <li className={styles.summaryItem} key={`${item.key}-${i}`}>
           <span className={styles.summaryLabel}>{item.key}</span>
-          <span className={styles.summaryDelim}>=</span>
           {String(item.value)}
         </li>
       ))}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.test.tsx
@@ -106,9 +106,7 @@ describe('AccordianLogs tests', () => {
         name: '15μs (foo event name) : message oh the next log message more stuff',
       })
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole('switch', { name: '5μs: message oh the log message something else' })
-    ).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: '5μs: message oh the log message something else' })).toBeInTheDocument();
   });
 
   it('renders event name and duration when events list is open', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.test.tsx
@@ -56,7 +56,7 @@ describe('AccordianLogs tests', () => {
   it('shows the number of log entries', () => {
     setup();
 
-    expect(screen.getByRole('switch', { name: 'Events (2)' })).toBeInTheDocument();
+    expect(screen.getByRole('switch', { name: 'Events 2' })).toBeInTheDocument();
   });
 
   it('hides log entries when not expanded', () => {
@@ -103,11 +103,11 @@ describe('AccordianLogs tests', () => {
     setup({ isOpen: true, openedItems: new Set() } as AccordianLogsProps);
     expect(
       screen.getByRole('switch', {
-        name: '15μs (foo event name) : message = oh the next log message more = stuff',
+        name: '15μs (foo event name) : message oh the next log message more stuff',
       })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('switch', { name: '5μs: message = oh the log message something = else' })
+      screen.getByRole('switch', { name: '5μs: message oh the log message something else' })
     ).toBeInTheDocument();
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianLogs.tsx
@@ -18,7 +18,7 @@ import * as React from 'react';
 
 import { GrafanaTheme2, TraceLog } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Icon, useStyles2 } from '@grafana/ui';
+import { Counter, Icon, useStyles2 } from '@grafana/ui';
 
 import { autoColor } from '../../Theme';
 import { formatDuration } from '../utils';
@@ -31,24 +31,22 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     AccordianLogs: css({
       label: 'AccordianLogs',
-      border: `1px solid ${autoColor(theme, '#d8d8d8')}`,
       position: 'relative',
       marginBottom: '0.25rem',
     }),
     AccordianLogsHeader: css({
       label: 'AccordianLogsHeader',
-      background: autoColor(theme, '#e4e4e4'),
       color: 'inherit',
-      display: 'block',
-      padding: '0.25rem 0.5rem',
+      display: 'flex',
+      alignItems: 'center',
+      padding: '0.25rem 0.1em',
       '&:hover': {
-        background: autoColor(theme, '#dadada'),
+        background: autoColor(theme, '#e8e8e8'),
       },
     }),
     AccordianLogsContent: css({
       label: 'AccordianLogsContent',
       background: autoColor(theme, '#f0f0f0'),
-      borderTop: `1px solid ${autoColor(theme, '#d8d8d8')}`,
       padding: '0.5rem 0.5rem 0.25rem 0.5rem',
     }),
     AccordianLogsFooter: css({
@@ -90,7 +88,7 @@ export default function AccordianLogs({
     arrow = isOpen ? (
       <Icon name={'angle-down'} className={alignIcon} />
     ) : (
-      <Icon name={'angle-right'} className="u-align-icon" />
+      <Icon name={'angle-right'} className="u-align-icon" style={{ margin: '0 0.25rem 0 0' }} />
     );
     HeaderComponent = 'a';
     headerProps = {
@@ -108,7 +106,7 @@ export default function AccordianLogs({
         <strong>
           <Trans i18nKey="explore.accordian-logs.events">Events</Trans>
         </strong>{' '}
-        ({logs.length})
+        <Counter value={logs.length} variant="secondary" />
       </HeaderComponent>
       {isOpen && (
         <div className={styles.AccordianLogsContent}>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -190,19 +190,19 @@ describe('<SpanDetail>', () => {
 
   it('lists the service name, duration, start time and kind', () => {
     render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
-    expect(screen.getByText('Duration')).toBeInTheDocument();
-    expect(screen.getByText('Service')).toBeInTheDocument();
-    expect(screen.getByText('Start Time')).toBeInTheDocument();
-    expect(screen.getByText('Kind')).toBeInTheDocument();
+    expect(screen.getByText('Duration:')).toBeInTheDocument();
+    expect(screen.getByText('Service:')).toBeInTheDocument();
+    expect(screen.getByText('Start Time:')).toBeInTheDocument();
+    expect(screen.getByText('Kind:')).toBeInTheDocument();
     expect(screen.getByText('test-kind')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
-    expect(screen.getByText('Status Message')).toBeInTheDocument();
+    expect(screen.getByText('Status:')).toBeInTheDocument();
+    expect(screen.getByText('Status Message:')).toBeInTheDocument();
     expect(screen.getByText('test-message')).toBeInTheDocument();
-    expect(screen.getByText('Library Name')).toBeInTheDocument();
+    expect(screen.getByText('Library Name:')).toBeInTheDocument();
     expect(screen.getByText('test-name')).toBeInTheDocument();
-    expect(screen.getByText('Library Version')).toBeInTheDocument();
+    expect(screen.getByText('Library Version:')).toBeInTheDocument();
     expect(screen.getByText('test-version')).toBeInTheDocument();
-    expect(screen.getByText('Trace State')).toBeInTheDocument();
+    expect(screen.getByText('Trace State:')).toBeInTheDocument();
     expect(screen.getByText('test-state')).toBeInTheDocument();
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.test.tsx
@@ -190,19 +190,19 @@ describe('<SpanDetail>', () => {
 
   it('lists the service name, duration, start time and kind', () => {
     render(<SpanDetail {...(props as unknown as SpanDetailProps)} />);
-    expect(screen.getByText('Duration:')).toBeInTheDocument();
-    expect(screen.getByText('Service:')).toBeInTheDocument();
-    expect(screen.getByText('Start Time:')).toBeInTheDocument();
-    expect(screen.getByText('Kind:')).toBeInTheDocument();
+    expect(screen.getByText('Duration')).toBeInTheDocument();
+    expect(screen.getByText('Service')).toBeInTheDocument();
+    expect(screen.getByText('Start Time')).toBeInTheDocument();
+    expect(screen.getByText('Kind')).toBeInTheDocument();
     expect(screen.getByText('test-kind')).toBeInTheDocument();
-    expect(screen.getByText('Status:')).toBeInTheDocument();
-    expect(screen.getByText('Status Message:')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Status Message')).toBeInTheDocument();
     expect(screen.getByText('test-message')).toBeInTheDocument();
-    expect(screen.getByText('Library Name:')).toBeInTheDocument();
+    expect(screen.getByText('Library Name')).toBeInTheDocument();
     expect(screen.getByText('test-name')).toBeInTheDocument();
-    expect(screen.getByText('Library Version:')).toBeInTheDocument();
+    expect(screen.getByText('Library Version')).toBeInTheDocument();
     expect(screen.getByText('test-version')).toBeInTheDocument();
-    expect(screen.getByText('Trace State:')).toBeInTheDocument();
+    expect(screen.getByText('Trace State')).toBeInTheDocument();
     expect(screen.getByText('test-state')).toBeInTheDocument();
   });
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -28,12 +28,13 @@ import {
   TraceLog,
   PluginExtensionResourceAttributesContext,
   PluginExtensionPoints,
+  IconName,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { usePluginLinks } from '@grafana/runtime';
 import { TimeZone } from '@grafana/schema';
-import { Divider, Icon, TextArea, useStyles2 } from '@grafana/ui';
+import { Icon, TextArea, useStyles2 } from '@grafana/ui';
 
 import { pyroscopeProfileIdTagKey } from '../../../createSpanLink';
 import { autoColor } from '../../Theme';
@@ -159,9 +160,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'AccordianWarningsLabel',
       color: autoColor(theme, '#d36c08'),
     }),
-    AccordianKeyValuesItem: css({
-      marginBottom: theme.spacing(0.5),
-    }),
     Textarea: css({
       wordBreak: 'break-all',
       whiteSpace: 'pre',
@@ -173,6 +171,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexWrap: 'wrap',
       gap: '10px',
+      marginBottom: theme.spacing(2),
     }),
   };
 };
@@ -186,6 +185,7 @@ export type TraceFlameGraphs = {
 };
 
 export type SpanDetailProps = {
+  color: string;
   detailState: DetailState;
   logItemToggle: (spanID: string, log: TraceLog) => void;
   logsToggle: (spanID: string) => void;
@@ -215,6 +215,7 @@ export type SpanDetailProps = {
 
 export default function SpanDetail(props: SpanDetailProps) {
   const {
+    color,
     detailState,
     logItemToggle,
     logsToggle,
@@ -263,27 +264,32 @@ export default function SpanDetail(props: SpanDetailProps) {
   } = span;
 
   const { timeZone } = props;
+  const durationIcon: IconName = 'hourglass';
+  const startIcon: IconName = 'clock-nine';
+
   let overviewItems = [
     {
       key: 'svc',
-      label: t('explore.span-detail.overview-items.label.service', 'Service:'),
+      label: t('explore.span-detail.overview-items.label.service', 'Service'),
       value: process.serviceName,
     },
     {
       key: 'duration',
-      label: t('explore.span-detail.overview-items.label.duration', 'Duration:'),
+      label: t('explore.span-detail.overview-items.label.duration', 'Duration'),
       value: formatDuration(duration),
+      icon: durationIcon,
     },
     {
       key: 'start',
-      label: t('explore.span-detail.overview-items.label.start-time', 'Start Time:'),
+      label: t('explore.span-detail.overview-items.label.start-time', 'Start Time'),
       value: formatDuration(relativeStartTime) + getAbsoluteTime(startTime, timeZone),
+      icon: startIcon,
     },
     ...(span.childSpanCount > 0
       ? [
           {
             key: 'child_count',
-            label: t('explore.span-detail.overview-items.label.child-count', 'Child Count:'),
+            label: t('explore.span-detail.overview-items.label.child-count', 'Child Count'),
             value: span.childSpanCount,
           },
         ]
@@ -294,42 +300,42 @@ export default function SpanDetail(props: SpanDetailProps) {
   if (span.kind) {
     overviewItems.push({
       key: KIND,
-      label: t('explore.span-detail.label.kind', 'Kind:'),
+      label: t('explore.span-detail.label.kind', 'Kind'),
       value: span.kind,
     });
   }
   if (span.statusCode !== undefined) {
     overviewItems.push({
       key: STATUS,
-      label: t('explore.span-detail.label.status', 'Status:'),
+      label: t('explore.span-detail.label.status', 'Status'),
       value: SpanStatusCode[span.statusCode].toLowerCase(),
     });
   }
   if (span.statusMessage) {
     overviewItems.push({
       key: STATUS_MESSAGE,
-      label: t('explore.span-detail.label.status-message', 'Status Message:'),
+      label: t('explore.span-detail.label.status-message', 'Status Message'),
       value: span.statusMessage,
     });
   }
   if (span.instrumentationLibraryName) {
     overviewItems.push({
       key: LIBRARY_NAME,
-      label: t('explore.span-detail.label.library-name', 'Library Name:'),
+      label: t('explore.span-detail.label.library-name', 'Library Name'),
       value: span.instrumentationLibraryName,
     });
   }
   if (span.instrumentationLibraryVersion) {
     overviewItems.push({
       key: LIBRARY_VERSION,
-      label: t('explore.span-detail.label.library-version', 'Library Version:'),
+      label: t('explore.span-detail.label.library-version', 'Library Version'),
       value: span.instrumentationLibraryVersion,
     });
   }
   if (span.traceState) {
     overviewItems.push({
       key: TRACE_STATE,
-      label: t('explore.span-detail.label.trace-state', 'Trace State:'),
+      label: t('explore.span-detail.label.trace-state', 'Trace State'),
       value: span.traceState,
     });
   }
@@ -353,11 +359,10 @@ export default function SpanDetail(props: SpanDetailProps) {
           {operationName}
         </h2>
         <div className={styles.listWrapper}>
-          <LabeledList className={styles.list} divider={true} items={overviewItems} />
+          <LabeledList className={styles.list} divider={false} items={overviewItems} color={color} />
         </div>
       </div>
       <div className={styles.linkList}>{linksComponent}</div>
-      <Divider spacing={1} />
       <div>
         <div>
           <AccordianKeyValues
@@ -368,7 +373,6 @@ export default function SpanDetail(props: SpanDetailProps) {
           />
           {process.tags && (
             <AccordianKeyValues
-              className={styles.AccordianKeyValuesItem}
               data={process.tags}
               label={t('explore.span-detail.label-resource-attributes', 'Resource attributes')}
               linksGetter={resourceLinksGetter}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/index.tsx
@@ -270,18 +270,18 @@ export default function SpanDetail(props: SpanDetailProps) {
   let overviewItems = [
     {
       key: 'svc',
-      label: t('explore.span-detail.overview-items.label.service', 'Service'),
+      label: t('explore.span-detail.overview-items.label.service', 'Service:'),
       value: process.serviceName,
     },
     {
       key: 'duration',
-      label: t('explore.span-detail.overview-items.label.duration', 'Duration'),
+      label: t('explore.span-detail.overview-items.label.duration', 'Duration:'),
       value: formatDuration(duration),
       icon: durationIcon,
     },
     {
       key: 'start',
-      label: t('explore.span-detail.overview-items.label.start-time', 'Start Time'),
+      label: t('explore.span-detail.overview-items.label.start-time', 'Start Time:'),
       value: formatDuration(relativeStartTime) + getAbsoluteTime(startTime, timeZone),
       icon: startIcon,
     },
@@ -289,7 +289,7 @@ export default function SpanDetail(props: SpanDetailProps) {
       ? [
           {
             key: 'child_count',
-            label: t('explore.span-detail.overview-items.label.child-count', 'Child Count'),
+            label: t('explore.span-detail.overview-items.label.child-count', 'Child Count:'),
             value: span.childSpanCount,
           },
         ]
@@ -300,42 +300,42 @@ export default function SpanDetail(props: SpanDetailProps) {
   if (span.kind) {
     overviewItems.push({
       key: KIND,
-      label: t('explore.span-detail.label.kind', 'Kind'),
+      label: t('explore.span-detail.label.kind', 'Kind:'),
       value: span.kind,
     });
   }
   if (span.statusCode !== undefined) {
     overviewItems.push({
       key: STATUS,
-      label: t('explore.span-detail.label.status', 'Status'),
+      label: t('explore.span-detail.label.status', 'Status:'),
       value: SpanStatusCode[span.statusCode].toLowerCase(),
     });
   }
   if (span.statusMessage) {
     overviewItems.push({
       key: STATUS_MESSAGE,
-      label: t('explore.span-detail.label.status-message', 'Status Message'),
+      label: t('explore.span-detail.label.status-message', 'Status Message:'),
       value: span.statusMessage,
     });
   }
   if (span.instrumentationLibraryName) {
     overviewItems.push({
       key: LIBRARY_NAME,
-      label: t('explore.span-detail.label.library-name', 'Library Name'),
+      label: t('explore.span-detail.label.library-name', 'Library Name:'),
       value: span.instrumentationLibraryName,
     });
   }
   if (span.instrumentationLibraryVersion) {
     overviewItems.push({
       key: LIBRARY_VERSION,
-      label: t('explore.span-detail.label.library-version', 'Library Version'),
+      label: t('explore.span-detail.label.library-version', 'Library Version:'),
       value: span.instrumentationLibraryVersion,
     });
   }
   if (span.traceState) {
     overviewItems.push({
       key: TRACE_STATE,
-      label: t('explore.span-detail.label.trace-state', 'Trace State'),
+      label: t('explore.span-detail.label.trace-state', 'Trace State:'),
       value: span.traceState,
     });
   }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.test.tsx
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { createTheme } from '@grafana/data';
 import { setPluginLinksHook } from '@grafana/runtime';
@@ -69,22 +68,6 @@ describe('SpanDetailRow tests', () => {
 
   it('renders without exploding', () => {
     expect(() => setup()).not.toThrow();
-  });
-
-  it('calls toggle on click', async () => {
-    const mockToggle = jest.fn();
-    setup({ onDetailToggled: mockToggle } as unknown as SpanDetailRowProps);
-    expect(mockToggle).not.toHaveBeenCalled();
-
-    const detailRow = screen.getByTestId('detail-row-expanded-accent');
-    await userEvent.click(detailRow);
-    expect(mockToggle).toHaveBeenCalled();
-  });
-
-  it('renders the span tree offset', () => {
-    setup();
-
-    expect(screen.getByTestId('SpanTreeOffset--indentGuide')).toBeInTheDocument();
   });
 
   it('renders the SpanDetail', () => {

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -25,6 +25,7 @@ import { TraceSpan, TraceSpanReference } from '../types/trace';
 
 import SpanDetail, { TraceFlameGraphs } from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
+import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => {
@@ -62,6 +63,20 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
     infoWrapper: css({
       label: 'infoWrapper',
       padding: '0.75rem',
+    }),
+    cell: css({
+      label: 'cell',
+      display: 'flex !important',
+      width: '100% !important',
+    }),
+    indentSpacer: css({
+      label: 'indentSpacer',
+      flex: 'none',
+    }),
+    detailWrapper: css({
+      label: 'detailWrapper',
+      flex: '1',
+      minWidth: 0,
     }),
   };
 });
@@ -136,40 +151,56 @@ export class UnthemedSpanDetailRow extends PureComponent<SpanDetailRowProps> {
       setRedrawListView,
       timeRange,
       app,
+      hoverIndentGuideIds,
+      addHoverIndentGuideId,
+      removeHoverIndentGuideId,
+      visibleSpanIds,
     } = this.props;
     const styles = getStyles(theme);
     return (
       <TimelineRow>
-        <TimelineRow.Cell width={1}>
-          <div className={styles.infoWrapper} style={{ borderTopColor: color }}>
-            <SpanDetail
-              color={color}
-              detailState={detailState}
-              logItemToggle={logItemToggle}
-              logsToggle={logsToggle}
-              processToggle={processToggle}
-              referenceItemToggle={referenceItemToggle}
-              referencesToggle={referencesToggle}
-              warningsToggle={warningsToggle}
-              stackTracesToggle={stackTracesToggle}
+        <TimelineRow.Cell width={1} className={styles.cell}>
+          <div className={styles.indentSpacer}>
+            <SpanTreeOffset
               span={span}
-              traceToProfilesOptions={traceToProfilesOptions}
-              timeZone={timeZone}
-              tagsToggle={tagsToggle}
-              traceStartTime={traceStartTime}
-              traceDuration={traceDuration}
-              traceName={traceName}
-              createSpanLink={createSpanLink}
-              focusedSpanId={focusedSpanId}
-              createFocusSpanLink={createFocusSpanLink}
-              datasourceType={datasourceType}
-              datasourceUid={datasourceUid}
-              traceFlameGraphs={traceFlameGraphs}
-              setTraceFlameGraphs={setTraceFlameGraphs}
-              setRedrawListView={setRedrawListView}
-              timeRange={timeRange}
-              app={app}
+              showChildrenIcon={false}
+              hoverIndentGuideIds={hoverIndentGuideIds}
+              addHoverIndentGuideId={addHoverIndentGuideId}
+              removeHoverIndentGuideId={removeHoverIndentGuideId}
+              visibleSpanIds={visibleSpanIds}
             />
+          </div>
+          <div className={styles.detailWrapper}>
+            <div className={styles.infoWrapper} style={{ borderTopColor: color }}>
+              <SpanDetail
+                color={color}
+                detailState={detailState}
+                logItemToggle={logItemToggle}
+                logsToggle={logsToggle}
+                processToggle={processToggle}
+                referenceItemToggle={referenceItemToggle}
+                referencesToggle={referencesToggle}
+                warningsToggle={warningsToggle}
+                stackTracesToggle={stackTracesToggle}
+                span={span}
+                traceToProfilesOptions={traceToProfilesOptions}
+                timeZone={timeZone}
+                tagsToggle={tagsToggle}
+                traceStartTime={traceStartTime}
+                traceDuration={traceDuration}
+                traceName={traceName}
+                createSpanLink={createSpanLink}
+                focusedSpanId={focusedSpanId}
+                createFocusSpanLink={createFocusSpanLink}
+                datasourceType={datasourceType}
+                datasourceUid={datasourceUid}
+                traceFlameGraphs={traceFlameGraphs}
+                setTraceFlameGraphs={setTraceFlameGraphs}
+                setRedrawListView={setRedrawListView}
+                timeRange={timeRange}
+                app={app}
+              />
+            </div>
           </div>
         </TimelineRow.Cell>
       </TimelineRow>

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetailRow.tsx
@@ -13,21 +13,18 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import classNames from 'classnames';
 import { PureComponent } from 'react';
 
 import { CoreApp, GrafanaTheme2, LinkModel, TimeRange, TraceLog } from '@grafana/data';
 import { TraceToProfilesOptions } from '@grafana/o11y-ds-frontend';
 import { TimeZone } from '@grafana/schema';
-import { Button, clearButtonStyles, stylesFactory, withTheme2 } from '@grafana/ui';
+import { stylesFactory, withTheme2 } from '@grafana/ui';
 
-import { autoColor } from '../Theme';
 import { SpanLinkFunc } from '../types/links';
 import { TraceSpan, TraceSpanReference } from '../types/trace';
 
 import SpanDetail, { TraceFlameGraphs } from './SpanDetail';
 import DetailState from './SpanDetail/DetailState';
-import SpanTreeOffset from './SpanTreeOffset';
 import TimelineRow from './TimelineRow';
 
 const getStyles = stylesFactory((theme: GrafanaTheme2) => {
@@ -64,8 +61,6 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
     }),
     infoWrapper: css({
       label: 'infoWrapper',
-      border: `1px solid ${autoColor(theme, '#d3d3d3')}`,
-      borderTop: '3px solid',
       padding: '0.75rem',
     }),
   };
@@ -115,7 +110,6 @@ export class UnthemedSpanDetailRow extends PureComponent<SpanDetailRowProps> {
   render() {
     const {
       color,
-      columnDivision,
       detailState,
       logItemToggle,
       logsToggle,
@@ -131,16 +125,12 @@ export class UnthemedSpanDetailRow extends PureComponent<SpanDetailRowProps> {
       traceStartTime,
       traceDuration,
       traceName,
-      hoverIndentGuideIds,
-      addHoverIndentGuideId,
-      removeHoverIndentGuideId,
       theme,
       createSpanLink,
       focusedSpanId,
       createFocusSpanLink,
       datasourceType,
       datasourceUid,
-      visibleSpanIds,
       traceFlameGraphs,
       setTraceFlameGraphs,
       setRedrawListView,
@@ -150,26 +140,10 @@ export class UnthemedSpanDetailRow extends PureComponent<SpanDetailRowProps> {
     const styles = getStyles(theme);
     return (
       <TimelineRow>
-        <TimelineRow.Cell width={columnDivision} style={{ overflow: 'hidden' }}>
-          <SpanTreeOffset
-            span={span}
-            showChildrenIcon={false}
-            hoverIndentGuideIds={hoverIndentGuideIds}
-            addHoverIndentGuideId={addHoverIndentGuideId}
-            removeHoverIndentGuideId={removeHoverIndentGuideId}
-            visibleSpanIds={visibleSpanIds}
-          />
-          <Button
-            fill="text"
-            onClick={this._detailToggle}
-            className={classNames(styles.expandedAccent, clearButtonStyles(theme))}
-            style={{ borderColor: color }}
-            data-testid="detail-row-expanded-accent"
-          ></Button>
-        </TimelineRow.Cell>
-        <TimelineRow.Cell width={1 - columnDivision}>
+        <TimelineRow.Cell width={1}>
           <div className={styles.infoWrapper} style={{ borderTopColor: color }}>
             <SpanDetail
+              color={color}
               detailState={detailState}
               logItemToggle={logItemToggle}
               logsToggle={logsToggle}

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -25,7 +25,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flex: 'none',
     justifyContent: 'center',
     marginRight: '0.5rem',
-  }), 
+  }),
   buttonsContainer: css({
     display: 'flex',
     flexDirection: 'row',
@@ -95,7 +95,7 @@ export function TimelineCollapser(props: CollapserProps) {
             fill="solid"
             variant="secondary"
           />
-        </div>        
+        </div>
       </div>
     </div>
   );

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -14,16 +14,27 @@
 
 import { css } from '@emotion/css';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { IconButton, useStyles2 } from '@grafana/ui';
+import { Button, useStyles2 } from '@grafana/ui';
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   TimelineCollapser: css({
     alignItems: 'center',
     display: 'flex',
     flex: 'none',
     justifyContent: 'center',
     marginRight: '0.5rem',
+  }), 
+  buttonsContainer: css({
+    display: 'flex',
+    flexDirection: 'row',
+    gap: '0.5rem',
+    paddingRight: theme.spacing(1),
+  }),
+  buttonContainer: css({
+    display: 'flex',
+    alignItems: 'center',
   }),
 });
 
@@ -40,34 +51,48 @@ export function TimelineCollapser(props: CollapserProps) {
 
   return (
     <div className={styles.TimelineCollapser} data-testid="TimelineCollapser">
-      <IconButton
-        tooltip={t('explore.timeline-collapser.tooltip-expand', 'Expand +1')}
-        size="xl"
-        tooltipPlacement="top"
-        name="angle-down"
-        onClick={onExpandOne}
-      />
-      <IconButton
-        tooltip={t('explore.timeline-collapser.tooltip-collapse', 'Collapse +1')}
-        size="xl"
-        tooltipPlacement="top"
-        name="angle-right"
-        onClick={onCollapseOne}
-      />
-      <IconButton
-        tooltip={t('explore.timeline-collapser.tooltip-expand-all', 'Expand all')}
-        size="xl"
-        tooltipPlacement="top"
-        name="angle-double-down"
-        onClick={onExpandAll}
-      />
-      <IconButton
-        tooltip={t('explore.timeline-collapser.tooltip-collapse-all', 'Collapse all')}
-        size="xl"
-        tooltipPlacement="top"
-        name="angle-double-right"
-        onClick={onCollapseAll}
-      />
+      <div className={styles.buttonsContainer}>
+        <div className={styles.buttonContainer}>
+          <Button
+            tooltip={t('explore.timeline-collapser.tooltip-expand', 'Expand +1')}
+            size="sm"
+            tooltipPlacement="top"
+            icon="angle-down"
+            onClick={onExpandOne}
+            fill="solid"
+            variant="secondary"
+          />
+          <Button
+            tooltip={t('explore.timeline-collapser.tooltip-collapse', 'Collapse +1')}
+            size="sm"
+            tooltipPlacement="top"
+            icon="angle-up"
+            onClick={onCollapseOne}
+            fill="solid"
+            variant="secondary"
+          />
+        </div>
+        <div className={styles.buttonContainer}>
+          <Button
+            tooltip={t('explore.timeline-collapser.tooltip-expand-all', 'Expand all')}
+            size="sm"
+            tooltipPlacement="top"
+            icon="angle-double-down"
+            onClick={onExpandAll}
+            fill="solid"
+            variant="secondary"
+          />
+          <Button
+            tooltip={t('explore.timeline-collapser.tooltip-collapse-all', 'Collapse all')}
+            size="sm"
+            tooltipPlacement="top"
+            icon="angle-double-up"
+            onClick={onCollapseAll}
+            fill="solid"
+            variant="secondary"
+          />
+        </div>        
+      </div>
     </div>
   );
 }

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineCollapser.tsx
@@ -54,6 +54,7 @@ export function TimelineCollapser(props: CollapserProps) {
       <div className={styles.buttonsContainer}>
         <div className={styles.buttonContainer}>
           <Button
+            aria-label={t('explore.timeline-collapser.tooltip-expand', 'Expand +1')}
             tooltip={t('explore.timeline-collapser.tooltip-expand', 'Expand +1')}
             size="sm"
             tooltipPlacement="top"
@@ -63,6 +64,7 @@ export function TimelineCollapser(props: CollapserProps) {
             variant="secondary"
           />
           <Button
+            aria-label={t('explore.timeline-collapser.tooltip-collapse', 'Collapse +1')}
             tooltip={t('explore.timeline-collapser.tooltip-collapse', 'Collapse +1')}
             size="sm"
             tooltipPlacement="top"
@@ -74,6 +76,7 @@ export function TimelineCollapser(props: CollapserProps) {
         </div>
         <div className={styles.buttonContainer}>
           <Button
+            aria-label={t('explore.timeline-collapser.tooltip-expand-all', 'Expand all')}
             tooltip={t('explore.timeline-collapser.tooltip-expand-all', 'Expand all')}
             size="sm"
             tooltipPlacement="top"
@@ -83,6 +86,7 @@ export function TimelineCollapser(props: CollapserProps) {
             variant="secondary"
           />
           <Button
+            aria-label={t('explore.timeline-collapser.tooltip-collapse-all', 'Collapse all')}
             tooltip={t('explore.timeline-collapser.tooltip-collapse-all', 'Collapse all')}
             size="sm"
             tooltipPlacement="top"

--- a/public/app/features/explore/TraceView/components/common/LabeledList.tsx
+++ b/public/app/features/explore/TraceView/components/common/LabeledList.tsx
@@ -16,8 +16,8 @@ import { css } from '@emotion/css';
 import cx from 'classnames';
 import * as React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
-import { useStyles2 } from '@grafana/ui';
+import { GrafanaTheme2, IconName } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
 
 import { autoColor } from '../Theme';
 
@@ -45,7 +45,7 @@ const getStyles = (divider: boolean) => (theme: GrafanaTheme2) => {
             borderRight: `1px solid ${autoColor(theme, '#ddd')}`,
             padding: '0 8px',
           }
-        : {}),
+        : { padding: '0 4px' }),
     }),
     LabeledListLabel: css({
       label: 'LabeledListLabel',
@@ -56,24 +56,42 @@ const getStyles = (divider: boolean) => (theme: GrafanaTheme2) => {
       label: 'LabeledListValue',
       marginRight: divider ? undefined : '0.55rem',
     }),
+    LabeledListIcon: css({
+      label: 'LabeledListIcon',
+      marginRight: '0.25rem',
+      marginTop: '-0.1rem',
+    }),
+    LabeledListServiceLine: css({
+      label: 'LabeledListServiceLine',
+      display: 'inline-block',
+      width: '1.25rem',
+      height: '0.35rem',
+      marginRight: '0.5rem',
+      verticalAlign: 'middle',
+      borderRadius: theme.shape.radius.default,
+    }),
   };
 };
 
 type LabeledListProps = {
   className?: string;
   divider?: boolean;
-  items: Array<{ key: string; label: React.ReactNode; value: React.ReactNode }>;
+  items: Array<{ key: string; label: React.ReactNode; value: React.ReactNode, icon?: IconName }>;
+  color?: string;
 };
 
 export default function LabeledList(props: LabeledListProps) {
-  const { className, divider = false, items } = props;
+  const { className, divider = false, items, color } = props;
   const styles = useStyles2(getStyles(divider));
 
   return (
     <ul className={cx(styles.LabeledList, className)}>
-      {items.map(({ key, label, value }) => {
+      {items.map(({ key, label, value, icon }) => {
         return (
+          // If label is service, create small line on left with color
           <li className={styles.LabeledListItem} key={`${key}`}>
+            {label === 'Service:' && <div className={styles.LabeledListServiceLine} style={{ backgroundColor: color }} />}
+            {icon && <Icon name={icon} className={styles.LabeledListIcon} />}
             <span className={styles.LabeledListLabel}>{label}</span>
             <strong className={styles.LabeledListValue}>{value}</strong>
           </li>

--- a/public/app/features/explore/TraceView/components/common/LabeledList.tsx
+++ b/public/app/features/explore/TraceView/components/common/LabeledList.tsx
@@ -76,7 +76,7 @@ const getStyles = (divider: boolean) => (theme: GrafanaTheme2) => {
 type LabeledListProps = {
   className?: string;
   divider?: boolean;
-  items: Array<{ key: string; label: React.ReactNode; value: React.ReactNode, icon?: IconName }>;
+  items: Array<{ key: string; label: React.ReactNode; value: React.ReactNode; icon?: IconName }>;
   color?: string;
 };
 
@@ -90,7 +90,9 @@ export default function LabeledList(props: LabeledListProps) {
         return (
           // If label is service, create small line on left with color
           <li className={styles.LabeledListItem} key={`${key}`}>
-            {label === 'Service:' && <div className={styles.LabeledListServiceLine} style={{ backgroundColor: color }} />}
+            {label === 'Service:' && (
+              <div className={styles.LabeledListServiceLine} style={{ backgroundColor: color }} />
+            )}
             {icon && <Icon name={icon} className={styles.LabeledListIcon} />}
             <span className={styles.LabeledListLabel}>{label}</span>
             <strong className={styles.LabeledListValue}>{value}</strong>


### PR DESCRIPTION
**What is this feature?**

An improved design of the span details in the trace view.

**Why do we need this feature?**

Adds many improvements to the visual design of the span details view, such as
- removed all the extra blank space on the left which was taking up too much screen space,
- better shading, backgrounds and borders,
- better spacing,
- icons / service color in the LabeledList,
- expand / collapse all tweaks,
- and more!

**Who is this feature for?**

Trace view users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/82095

**Special notes for your reviewer:**

Before 

<img width="1346" height="388" alt="Screenshot 2025-07-15 at 08 44 58" src="https://github.com/user-attachments/assets/0fcc09a5-a203-4ba4-911c-6061d8143dc7" />


After

<img width="1338" height="415" alt="Screenshot 2025-07-15 at 08 45 09" src="https://github.com/user-attachments/assets/a896783b-1a71-44d0-8c10-bca28d2a857b" />
