### PR TITLE
ExtensionSidebar: Expose methods to open and close the extension sidebar

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -174,6 +174,12 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
    * @param props The props to be passed to the component.
    */
   openSidebar: (componentTitle: string, props?: Record<string, unknown>) => void;
+
+  /**
+   * @internal
+   * Closes the extension sidebar.
+   */
+  closeSidebar: () => void;
 };
 
 // Extension Points & Contexts

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -6,6 +6,7 @@ export * from './templateSrv';
 export * from './live';
 export * from './LocationService';
 export * from './appEvents';
+export * from './pluginExtensions/extensionSidebar';
 
 export {
   setPluginComponentHook,

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.test.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.test.ts
@@ -1,0 +1,127 @@
+import { EventBus } from '@grafana/data';
+
+import { getAppEvents } from '../appEvents';
+
+import {
+  closeExtensionSidebar,
+  CloseExtensionSidebarEvent,
+  openExtensionSidebar,
+  OpenExtensionSidebarEvent,
+} from './extensionSidebar';
+
+jest.mock('../appEvents', () => ({
+  getAppEvents: jest.fn(),
+}));
+
+describe('extensionSidebar', () => {
+  let mockEventBus: EventBus;
+  let mockPublish: jest.Mock;
+
+  beforeEach(() => {
+    mockPublish = jest.fn();
+    mockEventBus = {
+      publish: mockPublish,
+    } as unknown as EventBus;
+
+    jest.mocked(getAppEvents).mockReturnValue(mockEventBus);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('openExtensionSidebar', () => {
+    it('should publish OpenExtensionSidebarEvent with correct payload', () => {
+      const pluginId = 'test-plugin';
+      const componentTitle = 'Test Component';
+      const props = { foo: 'bar', count: 42 };
+
+      openExtensionSidebar(pluginId, componentTitle, props);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+
+      const publishedEvent = mockPublish.mock.calls[0][0];
+      expect(publishedEvent).toBeInstanceOf(OpenExtensionSidebarEvent);
+      expect(publishedEvent.payload).toEqual({
+        pluginId,
+        componentTitle,
+        props,
+      });
+    });
+
+    it('should publish OpenExtensionSidebarEvent without props when props are not provided', () => {
+      const pluginId = 'test-plugin';
+      const componentTitle = 'Test Component';
+
+      openExtensionSidebar(pluginId, componentTitle);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+
+      const publishedEvent = mockPublish.mock.calls[0][0];
+      expect(publishedEvent).toBeInstanceOf(OpenExtensionSidebarEvent);
+      expect(publishedEvent.payload).toEqual({
+        pluginId,
+        componentTitle,
+        props: undefined,
+      });
+    });
+
+    it('should handle empty props object', () => {
+      const pluginId = 'test-plugin';
+      const componentTitle = 'Test Component';
+      const props = {};
+
+      openExtensionSidebar(pluginId, componentTitle, props);
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+
+      const publishedEvent = mockPublish.mock.calls[0][0];
+      expect(publishedEvent).toBeInstanceOf(OpenExtensionSidebarEvent);
+      expect(publishedEvent.payload).toEqual({
+        pluginId,
+        componentTitle,
+        props,
+      });
+    });
+  });
+
+  describe('closeExtensionSidebar', () => {
+    it('should publish CloseExtensionSidebarEvent', () => {
+      closeExtensionSidebar();
+
+      expect(mockPublish).toHaveBeenCalledTimes(1);
+
+      const publishedEvent = mockPublish.mock.calls[0][0];
+      expect(publishedEvent).toBeInstanceOf(CloseExtensionSidebarEvent);
+    });
+  });
+
+  describe('Event Classes', () => {
+    it('OpenExtensionSidebarEvent should have correct type', () => {
+      expect(OpenExtensionSidebarEvent.type).toBe('open-extension-sidebar');
+    });
+
+    it('CloseExtensionSidebarEvent should have correct type', () => {
+      expect(CloseExtensionSidebarEvent.type).toBe('close-extension-sidebar');
+    });
+
+    it('OpenExtensionSidebarEvent should be instantiable with payload', () => {
+      const payload = {
+        pluginId: 'test-plugin',
+        componentTitle: 'Test Component',
+        props: { key: 'value' },
+      };
+
+      const event = new OpenExtensionSidebarEvent(payload);
+
+      expect(event.payload).toEqual(payload);
+      expect(event.type).toBe('open-extension-sidebar');
+    });
+
+    it('CloseExtensionSidebarEvent should be instantiable', () => {
+      const event = new CloseExtensionSidebarEvent();
+
+      expect(event.type).toBe('close-extension-sidebar');
+    });
+  });
+});

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
@@ -1,4 +1,4 @@
-import { BusEventWithPayload } from '@grafana/data';
+import { BusEventBase, BusEventWithPayload } from '@grafana/data';
 
 import { getAppEvents } from '../appEvents';
 
@@ -19,6 +19,13 @@ export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtension
 }
 
 /**
+ * @internal This is an internal API and should not be used outside of the Grafana Labs plugins.
+ */
+export class CloseExtensionSidebarEvent extends BusEventBase {
+  static type = 'close-extension-sidebar';
+}
+
+/**
  * Open the extension sidebar for a given plugin and component.
  *
  * @internal This is an internal API and should not be used outside of the Grafana Labs plugins.
@@ -32,5 +39,10 @@ export function openExtensionSidebar(pluginId: string, componentTitle: string, p
     componentTitle,
     props,
   });
+  getAppEvents().publish(event);
+}
+
+export function closeExtensionSidebar() {
+  const event = new CloseExtensionSidebarEvent();
   getAppEvents().publish(event);
 }

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
@@ -26,7 +26,7 @@ export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtension
  * @param componentTitle - The title of the component to open the sidebar for.
  * @param props - The props to pass to the component.
  */
-export function openExtensionSidebar(pluginId: string, componentTitle: string, props: Record<string, unknown>) {
+export function openExtensionSidebar(pluginId: string, componentTitle: string, props?: Record<string, unknown>) {
   const event = new OpenExtensionSidebarEvent({
     pluginId,
     componentTitle,

--- a/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
+++ b/packages/grafana-runtime/src/services/pluginExtensions/extensionSidebar.ts
@@ -1,0 +1,36 @@
+import { BusEventWithPayload } from '@grafana/data';
+
+import { getAppEvents } from '../appEvents';
+
+/**
+ * @internal This is an internal API and should not be used outside of the Grafana Labs plugins.
+ */
+export interface OpenExtensionSidebarPayload {
+  props?: Record<string, unknown>;
+  pluginId: string;
+  componentTitle: string;
+}
+
+/**
+ * @internal This is an internal API and should not be used outside of the Grafana Labs plugins.
+ */
+export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtensionSidebarPayload> {
+  static type = 'open-extension-sidebar';
+}
+
+/**
+ * Open the extension sidebar for a given plugin and component.
+ *
+ * @internal This is an internal API and should not be used outside of the Grafana Labs plugins.
+ * @param pluginId - The id of the plugin to open the sidebar for.
+ * @param componentTitle - The title of the component to open the sidebar for.
+ * @param props - The props to pass to the component.
+ */
+export function openExtensionSidebar(pluginId: string, componentTitle: string, props: Record<string, unknown>) {
+  const event = new OpenExtensionSidebarEvent({
+    pluginId,
+    componentTitle,
+    props,
+  });
+  getAppEvents().publish(event);
+}

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.test.tsx
@@ -1,9 +1,8 @@
 import { render, screen, act } from '@testing-library/react';
 
 import { store, EventBusSrv, EventBus } from '@grafana/data';
-import { config, getAppEvents, setAppEvents, locationService } from '@grafana/runtime';
+import { config, getAppEvents, setAppEvents, locationService, OpenExtensionSidebarEvent } from '@grafana/runtime';
 import { getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
-import { OpenExtensionSidebarEvent } from 'app/types/events';
 
 import {
   ExtensionSidebarContextProvider,

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -2,9 +2,15 @@ import { createContext, ReactNode, useCallback, useContext, useEffect, useState,
 import { useLocalStorage } from 'react-use';
 
 import { PluginExtensionPoints, store, type ExtensionInfo } from '@grafana/data';
-import { config, getAppEvents, reportInteraction, usePluginLinks, locationService } from '@grafana/runtime';
+import {
+  config,
+  getAppEvents,
+  reportInteraction,
+  usePluginLinks,
+  locationService,
+  OpenExtensionSidebarEvent,
+} from '@grafana/runtime';
 import { ExtensionPointPluginMeta, getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
-import { OpenExtensionSidebarEvent } from 'app/types/events';
 
 import { DEFAULT_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar';
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -9,6 +9,7 @@ import {
   usePluginLinks,
   locationService,
   OpenExtensionSidebarEvent,
+  CloseExtensionSidebarEvent,
 } from '@grafana/runtime';
 import { ExtensionPointPluginMeta, getExtensionPointPluginMeta } from 'app/features/plugins/extensions/utils';
 
@@ -191,9 +192,15 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
       }
     };
 
+    const closeSidebarHandler = (event: CloseExtensionSidebarEvent) => {
+      setDockedComponentId(undefined);
+    };
+
     const subscription = getAppEvents().subscribe(OpenExtensionSidebarEvent, openSidebarHandler);
+    const closeSubscription = getAppEvents().subscribe(CloseExtensionSidebarEvent, closeSidebarHandler);
     return () => {
       subscription.unsubscribe();
+      closeSubscription.unsubscribe();
     };
   }, [isEnabled, setDockedComponentWithProps, availableComponents]);
 

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -173,7 +173,10 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
       if (
         event.payload.pluginId &&
         event.payload.componentTitle &&
-        PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(event.payload.pluginId)
+        PERMITTED_EXTENSION_SIDEBAR_PLUGINS.includes(event.payload.pluginId) &&
+        availableComponents
+          .get(event.payload.pluginId)
+          ?.addedComponents.some((component) => component.title === event.payload.componentTitle)
       ) {
         setDockedComponentWithProps(
           JSON.stringify({ pluginId: event.payload.pluginId, componentTitle: event.payload.componentTitle }),
@@ -186,7 +189,7 @@ export const ExtensionSidebarContextProvider = ({ children }: ExtensionSidebarCo
     return () => {
       subscription.unsubscribe();
     };
-  }, [isEnabled, setDockedComponentWithProps]);
+  }, [isEnabled, setDockedComponentWithProps, availableComponents]);
 
   // update the stored docked component id when it changes
   useEffect(() => {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -16,11 +16,11 @@ import {
   PluginExtensionPoints,
   ExtensionInfo,
 } from '@grafana/data';
-import { reportInteraction, config, AppPluginConfig } from '@grafana/runtime';
+import { reportInteraction, config, AppPluginConfig, openExtensionSidebar } from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
-import { OpenExtensionSidebarEvent, ShowModalReactEvent } from 'app/types/events';
+import { ShowModalReactEvent } from 'app/types/events';
 
 import { ExtensionErrorBoundary } from './ExtensionErrorBoundary';
 import { ExtensionsLog, log as baseLog } from './logs/log';
@@ -533,13 +533,7 @@ export function getLinkExtensionOnClick(
         context,
         openModal: createOpenModalFunction(config),
         openSidebar: (componentTitle, context) => {
-          appEvents.publish(
-            new OpenExtensionSidebarEvent({
-              props: context,
-              pluginId,
-              componentTitle,
-            })
-          );
+          openExtensionSidebar(pluginId, componentTitle, context);
         },
       };
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -16,7 +16,13 @@ import {
   PluginExtensionPoints,
   ExtensionInfo,
 } from '@grafana/data';
-import { reportInteraction, config, AppPluginConfig, openExtensionSidebar } from '@grafana/runtime';
+import {
+  reportInteraction,
+  config,
+  AppPluginConfig,
+  openExtensionSidebar,
+  closeExtensionSidebar,
+} from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
@@ -534,6 +540,9 @@ export function getLinkExtensionOnClick(
         openModal: createOpenModalFunction(config),
         openSidebar: (componentTitle, context) => {
           openExtensionSidebar(pluginId, componentTitle, context);
+        },
+        closeSidebar: () => {
+          closeExtensionSidebar();
         },
       };
 

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -28,12 +28,6 @@ export interface ShowModalReactPayload {
   props?: any;
 }
 
-export interface OpenExtensionSidebarPayload {
-  props?: Record<string, unknown>;
-  pluginId: string;
-  componentTitle: string;
-}
-
 export interface ShowConfirmModalPayload {
   title?: string;
   text?: string;
@@ -188,10 +182,6 @@ export class ShowConfirmModalEvent extends BusEventWithPayload<ShowConfirmModalP
 
 export class ShowModalReactEvent extends BusEventWithPayload<ShowModalReactPayload> {
   static type = 'show-react-modal';
-}
-
-export class OpenExtensionSidebarEvent extends BusEventWithPayload<OpenExtensionSidebarPayload> {
-  static type = 'open-extension-sidebar';
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

For Grafana integrations and plugins opening and closing the extension sidebar is a crucial action in order to communicate with plugins rendering in the sidebar, e.g. Grafana Assistant.
Right now, Plugins can only open the sidebar using the `PluginExtensionEventHelpers`'s `openSidebar` method. This means, that this functionality is only available in extension points that are registered. I believe this functionality should be exposed on a higher level to also allow other components, e.g. an exposed component from the Assistant plugin, to use this functionality.

Additional to exposing the `openExtensionSidebar` method, this PR also exposes a `closeExtensionSidebar` method, which will close the sidebar.