### PR TITLE
CloudWatch: Set accountId to undefined if not monitoring account

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import selectEvent from 'react-select-event';
 
 import { CustomVariableModel, DataSourceInstanceSettings } from '@grafana/data';
@@ -7,7 +7,12 @@ import * as ui from '@grafana/ui';
 import { CloudWatchDatasource } from '../../../datasource';
 import { setupMockedTemplateService } from '../../../mocks/CloudWatchDataSource';
 import { initialVariableModelState } from '../../../mocks/CloudWatchVariables';
-import { CloudWatchJsonData, MetricEditorMode, MetricQueryType } from '../../../types';
+import {
+  CloudWatchJsonData,
+  CloudWatchMetricsQuery,
+  MetricEditorMode,
+  MetricQueryType,
+} from '../../../types';
 
 import { MetricsQueryEditor, Props } from './MetricsQueryEditor';
 
@@ -18,7 +23,16 @@ jest.mock('@grafana/ui', () => ({
   },
 }));
 
-const setup = () => {
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual<typeof import('@grafana/runtime')>('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      cloudWatchCrossAccountQuerying: true,
+    },
+  },
+}));
+
+const setup = (customQuery?: Partial<CloudWatchMetricsQuery>, isMonitoringAccount?: boolean) => {
   const instanceSettings = {
     jsonData: { defaultRegion: 'us-east-1' },
   } as DataSourceInstanceSettings<CloudWatchJsonData>;
@@ -47,7 +61,7 @@ const setup = () => {
   datasource.resources.getMetrics = jest.fn().mockResolvedValue([]);
   datasource.resources.getRegions = jest.fn().mockResolvedValue([]);
   datasource.resources.getDimensionKeys = jest.fn().mockResolvedValue([]);
-  datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(false);
+  datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(isMonitoringAccount ?? false);
 
   const props: Props = {
     query: {
@@ -65,6 +79,7 @@ const setup = () => {
       matchExact: true,
       metricQueryType: MetricQueryType.Search,
       metricEditorMode: MetricEditorMode.Builder,
+      ...customQuery,
     },
     extraHeaderElementLeft: () => {},
     extraHeaderElementRight: () => {},
@@ -120,5 +135,32 @@ describe('QueryEditor', () => {
     expect(await screen.findByText('Label')).toBeInTheDocument();
     expect(screen.queryByText('Alias')).toBeNull();
     expect(screen.getByText("Period: ${PROP('Period')} InstanceId: ${PROP('Dim.InstanceId')}"));
+  });
+
+  it('should clear accountId field when datasource connects to a non-monitoring account', async () => {
+    const props = setup({ accountId: '123456789' });
+
+    render(<MetricsQueryEditor {...props} />);
+
+    expect(props.datasource.resources.isMonitoringAccount).toHaveBeenCalledWith('us-east-1');
+    await waitFor(async () => {
+      expect(props.onChange).toHaveBeenCalledWith({
+        ...props.query,
+        accountId: undefined,
+      });
+    });
+  });
+  it('should keep accountId field when datasource connects to a monitoring account', async () => {
+    const props = setup({ accountId: '123456789' }, true);
+
+    render(<MetricsQueryEditor {...props} />);
+
+    expect(props.datasource.resources.isMonitoringAccount).toHaveBeenCalledWith('us-east-1');
+    await waitFor(async () => {
+      expect(props.onChange).not.toHaveBeenCalledWith({
+        ...props.query,
+        accountId: undefined,
+      });
+    });
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -7,12 +7,7 @@ import * as ui from '@grafana/ui';
 import { CloudWatchDatasource } from '../../../datasource';
 import { setupMockedTemplateService } from '../../../mocks/CloudWatchDataSource';
 import { initialVariableModelState } from '../../../mocks/CloudWatchVariables';
-import {
-  CloudWatchJsonData,
-  CloudWatchMetricsQuery,
-  MetricEditorMode,
-  MetricQueryType,
-} from '../../../types';
+import { CloudWatchJsonData, CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../../../types';
 
 import { MetricsQueryEditor, Props } from './MetricsQueryEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { EditorField, EditorRow, InlineSelect } from '@grafana/plugin-ui';
+import { config } from '@grafana/runtime';
 import { ConfirmModal, Input, RadioButtonGroup, Space } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../../datasource';
@@ -58,6 +59,17 @@ export const MetricsQueryEditor = (props: Props) => {
     },
     [setShowConfirm, onChange, codeEditorIsDirty, query]
   );
+
+  const updateAccounIdOnMount = () => {
+    if (config.featureToggles.cloudWatchCrossAccountQuerying && query.accountId) {
+      datasource.resources.isMonitoringAccount(query.region).then((isMonitoring) => {
+        if (!isMonitoring && query.accountId) {
+          onChange({ ...query, accountId: undefined });
+        }
+      });
+    }
+  };
+  useEffect(updateAccounIdOnMount, [datasource, onChange, query]);
 
   useEffect(() => {
     extraHeaderElementLeft?.(


### PR DESCRIPTION
A bug was reported here, where accountId wasn't cleared when changing datasources in Explore, which makes the query run with the old accountId. This happens because Grafana migrates queries to the newly selected datasource automatically, if the datasource type is also "cloudwatch". Once it migrates the queries, it runs them automatically [here](https://github.com/grafana/grafana/blob/92d098fdfd8b8fc557a692aa993ce2449ccfd233/public/app/features/explore/state/datasource.ts#L75)

This cause the data to either be empty or an error to display, if the datasource doesn't have access to the selected account Id. 

This fix is not perfect. It updates the account id to be undefined if the account is not a monitoring account, because in that case the accountid is redundant. 
However, because of how Explore flow works, it will still run the query with the old accountId before the query model has a chance to update. This problem was described here: https://github.com/grafana/grafana/issues/70705
This will cause in some cases the error to be still present, before the user reruns the query: 
<img width="600" height="433" alt="Screenshot 2025-07-15 at 12 04 51" src="https://github.com/user-attachments/assets/4f5eaccc-de72-4b1b-b9d9-7ae2a1876086" />

I've tried adding a `onRunQuery()` after I update the `accountId` but that doesn't seem to do anything. 
Adding some kind of flag `isMonitoringAccount` to the query, then filtering it in `datasource.filterQuery` still wouldn't help, since the `accountId: undefined` update happens after the query is run. 

There is a ticket https://github.com/grafana/grafana/issues/62747 to implement query cancellation in Explore, but we probably shouldn't wait for it before we fix this bug. In any case this fix would be a part of utilizing query cancellation

Not sure if there's another way to do this, but from the tickets mentioned it seems like this is a known issue, and maybe this is better than nothing, since it at least fixes the query object to a valid state. 