### PR TITLE
Alerting: Improve new list view performance

### DIFF
--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -124,29 +124,7 @@ export function usePopulateGrafanaPrometheusApiCache() {
         prometheusApi.util.upsertQueryEntries(
           groups.map((group) => ({
             endpointName: 'getGrafanaGroups',
-            arg: { folderUid: group.folderUid, groupName: group.name },
-            value: { data: { groups: [group] }, status: 'success' },
-          }))
-        )
-      );
-    },
-    [dispatch]
-  );
-
-  return { populateGroupsResponseCache };
-}
-
-export function usePopulatePrometheusApiCache() {
-  const dispatch = useDispatch();
-
-  const populateGroupsResponseCache = useCallback(
-    (ruleSourceUid: string, groups: Array<PromRuleGroupDTO<PromRuleDTO>>) => {
-      // ⚠️ make sure to use `upsertQueryEntries` to batch insert, as otherwise it will have to run through the entire async thunk lifecycle for each group
-      dispatch(
-        prometheusApi.util.upsertQueryEntries(
-          groups.map((group) => ({
-            endpointName: 'getGroups',
-            arg: { ruleSource: { uid: ruleSourceUid }, namespace: group.file, groupName: group.name },
+            arg: { folderUid: group.folderUid, groupName: group.name, limitAlerts: 0 },
             value: { data: { groups: [group] }, status: 'success' },
           }))
         )

--- a/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
@@ -51,9 +51,7 @@ function PaginatedGroupsLoader({ rulesSourceIdentifier, application, groupFilter
   const hasFilters = Boolean(groupFilter || namespaceFilter);
 
   const { uid, name } = rulesSourceIdentifier;
-  const prometheusGroupsGenerator = usePrometheusGroupsGenerator({
-    populateCache: hasFilters ? false : true,
-  });
+  const prometheusGroupsGenerator = usePrometheusGroupsGenerator();
 
   // If there are no filters we can match one frontend page to one API page.
   // However, if there are filters, we need to fetch more groups from the API to populate one frontend page

--- a/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
@@ -3,12 +3,7 @@ import { useCallback } from 'react';
 import { DataSourceRulesSourceIdentifier, RuleHealth } from 'app/types/unified-alerting';
 import { PromAlertingRuleState, PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
-import {
-  PromRulesResponse,
-  prometheusApi,
-  usePopulateGrafanaPrometheusApiCache,
-  usePopulatePrometheusApiCache,
-} from '../../api/prometheusApi';
+import { PromRulesResponse, prometheusApi, usePopulateGrafanaPrometheusApiCache } from '../../api/prometheusApi';
 
 const { useLazyGetGroupsQuery, useLazyGetGrafanaGroupsQuery } = prometheusApi;
 
@@ -26,8 +21,7 @@ interface FetchGroupsOptions {
   groupNextToken?: string;
 }
 
-export function usePrometheusGroupsGenerator(hookOptions: UseGeneratorHookOptions = {}) {
-  const { populateGroupsResponseCache } = usePopulatePrometheusApiCache();
+export function usePrometheusGroupsGenerator() {
   const [getGroups] = useLazyGetGroupsQuery();
 
   return useCallback(
@@ -39,16 +33,12 @@ export function usePrometheusGroupsGenerator(hookOptions: UseGeneratorHookOption
           ...fetchOptions,
         }).unwrap();
 
-        if (hookOptions.populateCache) {
-          populateGroupsResponseCache(ruleSource.uid, response.data.groups);
-        }
-
         return response;
       };
 
       yield* genericGroupsGenerator(getRuleSourceGroupsWithCache, groupLimit);
     },
-    [getGroups, hookOptions.populateCache, populateGroupsResponseCache]
+    [getGroups]
   );
 }
 
@@ -74,8 +64,6 @@ export function useGrafanaGroupsGenerator(hookOptions: UseGeneratorHookOptions =
         ...fetchOptions.filter,
       }).unwrap();
 
-      // This is not mandatory to preload ruler rules, but it improves the UX
-      // Because the user waits a bit longer for the initial load but doesn't need to wait for each group to be loaded
       if (hookOptions.populateCache) {
         populateGroupsResponseCache(response.data.groups);
       }

--- a/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 
-import { useDispatch } from 'app/types/store';
 import { DataSourceRulesSourceIdentifier, RuleHealth } from 'app/types/unified-alerting';
 import { PromAlertingRuleState, PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
@@ -1,6 +1,6 @@
 import { AsyncIterableX, empty, from } from 'ix/asynciterable';
 import { merge } from 'ix/asynciterable/merge';
-import { catchError, concatMap, tap, withAbort } from 'ix/asynciterable/operators';
+import { catchError, concatMap, withAbort } from 'ix/asynciterable/operators';
 import { isEmpty } from 'lodash';
 
 import {
@@ -15,7 +15,6 @@ import {
   PromRuleGroupDTO,
 } from 'app/types/unified-alerting-dto';
 
-import { usePopulateGrafanaPrometheusApiCache } from '../../api/prometheusApi';
 import { RulesFilter } from '../../search/rulesSearchParser';
 import {
   getDataSourceByUid,
@@ -52,7 +51,6 @@ interface GetIteratorResult {
 }
 
 export function useFilteredRulesIteratorProvider() {
-  const { populateGroupsResponseCache } = usePopulateGrafanaPrometheusApiCache();
   const allExternalRulesSources = getExternalRulesSources();
 
   const prometheusGroupsGenerator = usePrometheusGroupsGenerator();
@@ -73,7 +71,6 @@ export function useFilteredRulesIteratorProvider() {
       })
     ).pipe(
       withAbort(abortController.signal),
-      tap(populateGroupsResponseCache),
       concatMap((groups) =>
         groups
           .filter((group) => groupFilter(group, normalizedFilterState))


### PR DESCRIPTION
This PR uses `upsertQueryEntries` for batch inserts of rule groups into the RTKQ cache, calling `dispatch(upsertQueryData())` for each rule group has to run through the entire async thunk life-cycle for each rule group and is quite slow when a user has thousands of rule groups.

<img width="1863" height="1105" alt="466467605-9a090dc2-650c-4811-8b1a-4f5927c866fe" src="https://github.com/user-attachments/assets/87a4294b-f89a-43f4-a1e6-3d88c4064edf" />

**Special notes for your reviewer:**

I've removed caching for data source managed  rules as it does not offer many benefits and keeping the cache logic in sync with the RTKQ endpoint definition for fetching groups is not worth the marginal improvement.

`upsertQueryEntries` does not automatically call `transformResponse()`
for entries, which could introduce odd cache bugs.

Rules iteration for the search view was also inserting into the cache prior to this PR, but we don't actually call into `getGroups` or `getGrafanaGroups` from there :)