### PR TITLE
fix(alerting): use alerting-admin as navId for settings

### DIFF
--- a/public/app/features/alerting/unified/settings/navigation.test.ts
+++ b/public/app/features/alerting/unified/settings/navigation.test.ts
@@ -28,7 +28,7 @@ describe('useSettingsPageNav', () => {
 
     const { result } = renderHook(() => useSettingsPageNav(), { wrapper });
 
-    expect(result.current.navId).toBe('alerting');
+    expect(result.current.navId).toBe('alerting-admin');
 
     // Check the structure
     // eslint-disable-next-line testing-library/no-node-access
@@ -75,7 +75,7 @@ describe('useSettingsPageNav', () => {
 
     const { result } = renderHook(() => useSettingsPageNav(), { wrapper });
 
-    expect(result.current.navId).toBe('alerting');
+    expect(result.current.navId).toBe('alerting-admin');
 
     // Should have 3 children: alertmanager + 2 extensions
     // eslint-disable-next-line testing-library/no-node-access

--- a/public/app/features/alerting/unified/settings/navigation.ts
+++ b/public/app/features/alerting/unified/settings/navigation.ts
@@ -34,7 +34,7 @@ export function useSettingsPageNav() {
   };
 
   return {
-    navId: 'alerting',
+    navId: 'alerting-admin',
     pageNav,
   };
 }


### PR DESCRIPTION
This PR fixes an issue where the alerting settings page was not correctly highlighting the "Settings" navigation item. This was because the `navId` was set to `alerting` instead of `alerting-admin`. This PR changes the `navId` to `alerting-admin` to fix this issue.