### PR TITLE
fix: Makes created and updated by nullable strings for library panel migration

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -489,10 +489,10 @@ type panel struct {
 	FolderUID sql.NullString
 
 	Created   time.Time
-	CreatedBy string
+	CreatedBy sql.NullString
 
 	Updated   time.Time
-	UpdatedBy string
+	UpdatedBy sql.NullString
 
 	Version int64
 
@@ -633,13 +633,13 @@ func parseLibraryPanelRow(p panel) (dashboardV0.LibraryPanel, error) {
 	if p.FolderUID.Valid {
 		meta.SetFolder(p.FolderUID.String)
 	}
-	meta.SetCreatedBy(p.CreatedBy)
+	meta.SetCreatedBy(getUserID(p.CreatedBy, sql.NullInt64{}))
 	meta.SetGeneration(p.Version)
 	meta.SetDeprecatedInternalID(p.ID) //nolint:staticcheck
 
 	// Only set updated metadata if it is different
-	if p.UpdatedBy != p.CreatedBy || p.Updated.Sub(p.Created) > time.Second {
-		meta.SetUpdatedBy(p.UpdatedBy)
+	if p.UpdatedBy.Valid && p.Updated.Sub(p.Created) > time.Second {
+		meta.SetUpdatedBy(getUserID(p.UpdatedBy, sql.NullInt64{}))
 		meta.SetUpdatedTimestamp(&p.Updated)
 	}
 

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards_test.go
@@ -230,9 +230,9 @@ func TestParseLibraryPanelRow(t *testing.T) {
 		UID:         "panel-uid",
 		FolderUID:   sql.NullString{String: "folder-uid", Valid: true},
 		Created:     time.Now(),
-		CreatedBy:   "creator",
+		CreatedBy:   sql.NullString{String: "creator", Valid: true},
 		Updated:     time.Now(),
-		UpdatedBy:   "updator",
+		UpdatedBy:   sql.NullString{String: "updator", Valid: true},
 		Version:     2,
 		Type:        "graph",
 		Description: "desc from db",
@@ -261,6 +261,8 @@ func TestParseLibraryPanelRow(t *testing.T) {
 	t.Run("metadata is set correctly", func(t *testing.T) {
 		p := basePanel
 		p.Name = "Test Panel"
+		// Ensure there's a time difference greater than 1 second to trigger updated metadata
+		p.Updated = p.Created.Add(2 * time.Second)
 		model := map[string]interface{}{
 			"title":       "Test Panel",
 			"type":        "graph",
@@ -278,8 +280,8 @@ func TestParseLibraryPanelRow(t *testing.T) {
 		require.Equal(t, p.ID, meta.GetDeprecatedInternalID()) // nolint:staticcheck
 		require.Equal(t, p.Version, meta.GetGeneration())
 		require.Equal(t, p.FolderUID.String, meta.GetFolder())
-		require.Equal(t, p.CreatedBy, meta.GetCreatedBy())
-		require.Equal(t, p.UpdatedBy, meta.GetUpdatedBy())
+		require.Equal(t, "user:creator", meta.GetCreatedBy())
+		require.Equal(t, "user:updator", meta.GetUpdatedBy())
 	})
 
 	t.Run("panel title in dashboard vs library panel title is set correctly", func(t *testing.T) {
@@ -299,5 +301,67 @@ func TestParseLibraryPanelRow(t *testing.T) {
 
 		require.Equal(t, "Model Title", item.Spec.PanelTitle)
 		require.Equal(t, "Database Name", item.Spec.Title)
+	})
+
+	t.Run("handles NULL created_by and updated_by fields", func(t *testing.T) {
+		p := basePanel
+		p.Name = "Test Panel"
+		// Set CreatedBy and UpdatedBy to NULL (Invalid)
+		p.CreatedBy = sql.NullString{String: "", Valid: false}
+		p.UpdatedBy = sql.NullString{String: "", Valid: false}
+		model := map[string]interface{}{
+			"title":       "Test Panel",
+			"type":        "graph",
+			"description": "desc from db",
+		}
+		modelBytes, err := json.Marshal(model)
+		require.NoError(t, err)
+		p.Model = modelBytes
+
+		item, err := parseLibraryPanelRow(p)
+		require.NoError(t, err)
+
+		meta, err := utils.MetaAccessor(&item)
+		require.NoError(t, err)
+
+		// When CreatedBy is NULL, it should be set to empty string
+		require.Equal(t, "", meta.GetCreatedBy())
+
+		// When UpdatedBy is NULL and not valid, updated metadata should not be set
+		require.Equal(t, "", meta.GetUpdatedBy())
+		// The updated timestamp should not be set when UpdatedBy is invalid
+		updatedTimestamp, err := meta.GetUpdatedTimestamp()
+		require.NoError(t, err)
+		require.Nil(t, updatedTimestamp)
+	})
+
+	t.Run("handles valid created_by but NULL updated_by", func(t *testing.T) {
+		p := basePanel
+		p.Name = "Test Panel"
+		p.CreatedBy = sql.NullString{String: "creator", Valid: true}
+		p.UpdatedBy = sql.NullString{String: "", Valid: false}
+		// Make sure there's a time difference to trigger the update logic
+		p.Updated = p.Created.Add(10 * time.Second)
+		model := map[string]interface{}{
+			"title":       "Test Panel",
+			"type":        "graph",
+			"description": "desc from db",
+		}
+		modelBytes, err := json.Marshal(model)
+		require.NoError(t, err)
+		p.Model = modelBytes
+
+		item, err := parseLibraryPanelRow(p)
+		require.NoError(t, err)
+
+		meta, err := utils.MetaAccessor(&item)
+		require.NoError(t, err)
+
+		require.Equal(t, "user:creator", meta.GetCreatedBy())
+		// Even with time difference, if UpdatedBy is not valid, updated metadata should not be set
+		require.Equal(t, "", meta.GetUpdatedBy())
+		updatedTimestamp, err := meta.GetUpdatedTimestamp()
+		require.NoError(t, err)
+		require.Nil(t, updatedTimestamp)
 	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes library panel migrations to Unified Storage when the `created_by` and `updated_by` fields are NULL. This uses the same strategy as can be seen for dashboards in the same file.

**Why do we need this feature?**

To properly be able migrate library panels to Unified Storage

**Who is this feature for?**

Data migrations from legacy storage to Unified Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/360

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
