### PR TITLE
TableNG: Improve header height calc for wrapped headers

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -184,7 +184,6 @@ export function TableNG(props: TableNGProps) {
     fields: visibleFields,
     hasNestedFrames,
     defaultHeight: defaultRowHeight,
-    headerHeight,
     expandedRows,
     typographyCtx,
   });

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -498,8 +498,6 @@ describe('TableNG hooks', () => {
         });
       });
 
-      expect(countFn).toHaveBeenCalledWith('Longer name that needs wrapping', 87);
-
       renderHook(() => {
         const typographyCtx = useTypographyCtx();
         return useHeaderHeight({
@@ -528,8 +526,6 @@ describe('TableNG hooks', () => {
           showTypeIcons: true,
         });
       });
-
-      expect(countFn).toHaveBeenCalledWith('Longer name that needs wrapping', 27);
     });
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1037,7 +1037,7 @@ describe('TableNG utils', () => {
       expect(result).toEqual({
         text: 'asdfasdf asdfasdf asdfasdf',
         idx: 1,
-        numLines: 2.6,
+        numLines: 3,
       });
     });
 
@@ -1073,7 +1073,7 @@ describe('TableNG utils', () => {
       // "the longest text in this field" has 31 characters, so it should wrap to 4 lines
       expect(result).toEqual({
         idx: 0,
-        numLines: 1.7,
+        numLines: 2,
         text: 'a bit longer text',
       });
     });
@@ -1108,7 +1108,7 @@ describe('TableNG utils', () => {
 
       // With a 50px width and 5px per character, we can fit 10 characters per line
       // "the longest text in this field" has 31 characters, so it should wrap to 4 lines
-      expect(result).toEqual({ idx: 0, numLines: 2.7, text: 'Field with a very long name' });
+      expect(result).toEqual({ idx: 0, numLines: 3, text: 'Field with a very long name' });
     });
 
     it.todo('should ignore columns which are not wrapped');

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1073,7 +1073,7 @@ describe('TableNG utils', () => {
       // "the longest text in this field" has 31 characters, so it should wrap to 4 lines
       expect(result).toEqual({
         idx: 0,
-        numLines: 2,
+        numLines: 3,
         text: 'a bit longer text',
       });
     });
@@ -1108,7 +1108,7 @@ describe('TableNG utils', () => {
 
       // With a 50px width and 5px per character, we can fit 10 characters per line
       // "the longest text in this field" has 31 characters, so it should wrap to 4 lines
-      expect(result).toEqual({ idx: 0, numLines: 3, text: 'Field with a very long name' });
+      expect(result).toEqual({ idx: 0, numLines: 4, text: 'Field with a very long name' });
     });
 
     it.todo('should ignore columns which are not wrapped');

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -69,8 +69,8 @@ export function shouldTextWrap(field: Field): boolean {
   return Boolean(cellOptions?.wrapText);
 }
 
-// matches characters which CSS
-const spaceRegex = /[\s-]/;
+const spaceRegex = /[\s-]/; // matches characters which CSS breaks on in `word-break: break-word` mode
+const CHAR_WIDTH_PESSIMISM_FACTOR = 1.1; // account for variance in character widths
 
 export interface GetMaxWrapCellOptions {
   colWidths: number[];
@@ -107,8 +107,8 @@ export function getMaxWrapCell(
         const cellText = String(cellTextRaw);
 
         if (spaceRegex.test(cellText)) {
-          const charsPerLine = colWidths[i] / avgCharWidth;
-          const approxLines = cellText.length / charsPerLine;
+          const charsPerLine = colWidths[i] / (avgCharWidth * CHAR_WIDTH_PESSIMISM_FACTOR);
+          const approxLines = Math.ceil(cellText.length / charsPerLine); // ceil to round up to next line.
 
           if (approxLines > maxLines) {
             maxLines = approxLines;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

After a bit of dogfooding, the wrap header text feature introduced in #107338 has some issues doing the math in some marginal cases. This PR was created using some known problematic strings and has better results when calculating the desired number of lines for a given string.

**Who is this feature for?**

Anyone using text wrap or header text wrap.

#### Before

https://github.com/user-attachments/assets/e5705086-4203-4116-b6d5-e1664944d36a

#### After

https://github.com/user-attachments/assets/619849f6-61db-40fc-97a5-0576b659acc4

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
