### PR TITLE
fix: handle dashboards without version entries in unified storage migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -230,7 +230,7 @@ require (
 require (
 	github.com/grafana/grafana/apps/advisor v0.0.0-20250627191313-2f1a6ae1712b // @grafana/plugins-platform-backend
 	github.com/grafana/grafana/apps/alerting/notifications v0.0.0-20250627191313-2f1a6ae1712b // @grafana/alerting-backend
-	github.com/grafana/grafana/apps/dashboard v0.0.0-20250716154214-974103c6fa20 // @grafana/grafana-app-platform-squad @grafana/dashboards-squad
+	github.com/grafana/grafana/apps/dashboard v0.0.0-20250716132114-6fd75ebc5441 // @grafana/grafana-app-platform-squad @grafana/dashboards-squad
 	github.com/grafana/grafana/apps/folder v0.0.0-20250627191313-2f1a6ae1712b // @grafana/grafana-search-and-storage
 	github.com/grafana/grafana/apps/iam v0.0.0-20250627191313-2f1a6ae1712b // @grafana/identity-access-team
 	github.com/grafana/grafana/apps/investigations v0.0.0-20250627191313-2f1a6ae1712b // @fcjack @matryer

--- a/go.sum
+++ b/go.sum
@@ -1613,8 +1613,8 @@ github.com/grafana/grafana/apps/advisor v0.0.0-20250627191313-2f1a6ae1712b h1:8o
 github.com/grafana/grafana/apps/advisor v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:q+h3HbmqU/PposW6lq8cMle1v8vuyX1LCMrGzbabHxc=
 github.com/grafana/grafana/apps/alerting/notifications v0.0.0-20250627191313-2f1a6ae1712b h1:jr+C3epmjhd5Yyob4P1Z/dPaW4LRTkU5UJLXsI4eaeM=
 github.com/grafana/grafana/apps/alerting/notifications v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:WpI7TCck4P2wKTO2WJLBRcfOWvUGvTdxYu3QqS3z7jM=
-github.com/grafana/grafana/apps/dashboard v0.0.0-20250716154214-974103c6fa20 h1:2aeZOXOdJID5BbrUtBWG+yGUU4wDXkqwsq9drSalrDE=
-github.com/grafana/grafana/apps/dashboard v0.0.0-20250716154214-974103c6fa20/go.mod h1:1XWiRSVuDQiayapHhQiDc4S4e9GzEZgg/3GeNCuDgn4=
+github.com/grafana/grafana/apps/dashboard v0.0.0-20250716132114-6fd75ebc5441 h1:+TSbaxCXBZrKkdROWBzdWna8uStE1f9LYd7GiqjVfz8=
+github.com/grafana/grafana/apps/dashboard v0.0.0-20250716132114-6fd75ebc5441/go.mod h1:1XWiRSVuDQiayapHhQiDc4S4e9GzEZgg/3GeNCuDgn4=
 github.com/grafana/grafana/apps/folder v0.0.0-20250627191313-2f1a6ae1712b h1:31MwoIKKT9Ay0ZjbT4lkfcPijiWogUWzXs2EjrCgodI=
 github.com/grafana/grafana/apps/folder v0.0.0-20250627191313-2f1a6ae1712b/go.mod h1:dLtYBp1pza5HYalezNvzlP8JDeKrZ5BKTonDgEOE0NY=
 github.com/grafana/grafana/apps/iam v0.0.0-20250627191313-2f1a6ae1712b h1:NV8v9xdM/pzjjy+1cLqUseia3bYcvQGh88vZdMW/jA0=

--- a/pkg/registry/apis/dashboard/legacy/migrate.go
+++ b/pkg/registry/apis/dashboard/legacy/migrate.go
@@ -211,10 +211,11 @@ func (a *dashboardSqlAccess) countValues(ctx context.Context, opts MigrateOption
 
 func (a *dashboardSqlAccess) migrateDashboards(ctx context.Context, orgId int64, opts MigrateOptions, stream resourcepb.BulkStore_BulkProcessClient) (*BlobStoreInfo, error) {
 	query := &DashboardQuery{
-		OrgID:      orgId,
-		Limit:      100000000,
-		GetHistory: opts.WithHistory, // include history
-		Order:      "ASC",            // oldest first
+		OrgID:         orgId,
+		Limit:         100000000,
+		GetHistory:    opts.WithHistory, // include history
+		AllowFallback: true,             // allow fallback to dashboard table during migration
+		Order:         "ASC",            // oldest first
 	}
 
 	blobs := &BlobStoreInfo{}

--- a/pkg/registry/apis/dashboard/legacy/migrate_test.go
+++ b/pkg/registry/apis/dashboard/legacy/migrate_test.go
@@ -115,9 +115,8 @@ func TestDashboardMigrationQuery(t *testing.T) {
 		require.Contains(t, sql, "dashboard_version.data",
 			"Regular history SQL should use direct dashboard_version.data")
 
-		// Verify it has the strict filter that requires version entries to exist
-		require.Contains(t, sql, "dashboard_version.id IS NOT NULL",
-			"Regular history SQL should exclude dashboards without version entries")
+		// NOTE: We intentionally do NOT add dashboard_version.id IS NOT NULL filter
+		// to allow for cases where dashboard_version entries might be missing
 
 		// Should not contain COALESCE functions
 		require.NotContains(t, sql, "COALESCE(dashboard_version.created, dashboard.updated)",

--- a/pkg/registry/apis/dashboard/legacy/migrate_test.go
+++ b/pkg/registry/apis/dashboard/legacy/migrate_test.go
@@ -1,0 +1,155 @@
+package legacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate/mocks"
+)
+
+func TestDashboardMigrationQuery(t *testing.T) {
+	// Test that migration queries use AllowFallback flag correctly
+	nodb := &legacysql.LegacyDatabaseHelper{
+		Table: func(n string) string {
+			return "grafana." + n
+		},
+	}
+
+	t.Run("Migration query should enable AllowFallback flag", func(t *testing.T) {
+		// Create a migration query as would be used in actual migration
+		migrationQuery := &DashboardQuery{
+			OrgID:         1,
+			GetHistory:    true,  // Migration includes history
+			AllowFallback: true,  // This is the key flag for migration
+			Order:         "ASC", // Migration uses ascending order
+		}
+
+		// Verify UseHistoryTable returns true (requirement for COALESCE logic)
+		require.True(t, migrationQuery.UseHistoryTable(), "Migration query should use history table")
+
+		// Verify the flag is set correctly
+		require.True(t, migrationQuery.AllowFallback, "Migration query should allow fallback")
+		require.True(t, migrationQuery.GetHistory, "Migration query should get history")
+		require.Equal(t, "ASC", migrationQuery.Order, "Migration should use ascending order")
+	})
+
+	t.Run("Regular history query should not use AllowFallback", func(t *testing.T) {
+		// Regular history query without migration
+		historyQuery := &DashboardQuery{
+			OrgID:      1,
+			GetHistory: true,
+			Order:      "DESC",
+		}
+
+		require.True(t, historyQuery.UseHistoryTable(), "History query should use history table")
+		require.False(t, historyQuery.AllowFallback, "Regular history query should not allow fallback")
+		require.True(t, historyQuery.GetHistory, "History query should get history")
+	})
+
+	t.Run("Migration query template produces COALESCE SQL", func(t *testing.T) {
+		// Test that the SQL template produces COALESCE logic for migration queries
+		migrationQuery := &DashboardQuery{
+			OrgID:         1,
+			GetHistory:    true,
+			AllowFallback: true,
+			Order:         "ASC",
+		}
+
+		req := newQueryReq(nodb, migrationQuery)
+		req.SQLTemplate = mocks.NewTestingSQLTemplate()
+
+		// Execute the template to get the generated SQL
+		rawQuery, err := sqltemplate.Execute(sqlQueryDashboards, &req)
+		require.NoError(t, err)
+
+		sql := rawQuery
+
+		// Verify that COALESCE functions are present in the generated SQL
+		// These should be used when GetHistory=true AND AllowFallback=true
+		require.Contains(t, sql, "COALESCE(dashboard_version.created, dashboard.updated)",
+			"Migration SQL should contain COALESCE for updated timestamp")
+		require.Contains(t, sql, "COALESCE(dashboard_version.version, dashboard.version)",
+			"Migration SQL should contain COALESCE for version")
+		require.Contains(t, sql, "COALESCE(dashboard_version.data, dashboard.data)",
+			"Migration SQL should contain COALESCE for data")
+		require.Contains(t, sql, "COALESCE(dashboard_version.api_version, dashboard.api_version)",
+			"Migration SQL should contain COALESCE for api_version")
+		require.Contains(t, sql, "COALESCE(dashboard_version.message, '')",
+			"Migration SQL should contain COALESCE for message with empty string fallback")
+
+		// Verify ORDER BY uses COALESCE as well
+		require.Contains(t, sql, "COALESCE(dashboard_version.created, dashboard.updated) ASC",
+			"Migration SQL should ORDER BY COALESCED created timestamp")
+		require.Contains(t, sql, "COALESCE(dashboard_version.version, dashboard.version) ASC",
+			"Migration SQL should ORDER BY COALESCED version")
+
+		// Verify it doesn't have the strict history table filter that would exclude NULL version entries
+		require.NotContains(t, sql, "dashboard_version.id IS NOT NULL",
+			"Migration SQL should not exclude dashboards without version entries")
+	})
+
+	t.Run("Regular history query produces strict SQL", func(t *testing.T) {
+		// Test that regular history queries still use strict dashboard_version fields
+		historyQuery := &DashboardQuery{
+			OrgID:      1,
+			GetHistory: true,
+			Order:      "DESC",
+		}
+
+		req := newQueryReq(nodb, historyQuery)
+		req.SQLTemplate = mocks.NewTestingSQLTemplate()
+
+		rawQuery, err := sqltemplate.Execute(sqlQueryDashboards, &req)
+		require.NoError(t, err)
+
+		sql := rawQuery
+
+		// Verify that direct dashboard_version fields are used (no COALESCE)
+		require.Contains(t, sql, "dashboard_version.created as updated",
+			"Regular history SQL should use direct dashboard_version.created")
+		require.Contains(t, sql, "dashboard_version.version",
+			"Regular history SQL should use direct dashboard_version.version")
+		require.Contains(t, sql, "dashboard_version.data",
+			"Regular history SQL should use direct dashboard_version.data")
+
+		// Verify it has the strict filter that requires version entries to exist
+		require.Contains(t, sql, "dashboard_version.id IS NOT NULL",
+			"Regular history SQL should exclude dashboards without version entries")
+
+		// Should not contain COALESCE functions
+		require.NotContains(t, sql, "COALESCE(dashboard_version.created, dashboard.updated)",
+			"Regular history SQL should not contain COALESCE for updated")
+	})
+}
+
+func TestMigrateDashboardsConfiguration(t *testing.T) {
+	// Test the actual migration function configuration
+
+	t.Run("Migration options should configure query correctly", func(t *testing.T) {
+		// Test the migration configuration as used in real migration
+		opts := MigrateOptions{
+			WithHistory: true, // Migration includes history
+		}
+
+		// This simulates what happens in migrateDashboards function
+		expectedQuery := &DashboardQuery{
+			OrgID:         1,
+			Limit:         100000000,
+			GetHistory:    opts.WithHistory, // Should be true
+			AllowFallback: true,             // Should be true for migration
+			Order:         "ASC",            // Should be ASC for migration
+		}
+
+		// Verify the configuration matches what migration sets up
+		require.True(t, expectedQuery.GetHistory, "Migration should enable GetHistory")
+		require.True(t, expectedQuery.AllowFallback, "Migration should enable AllowFallback")
+		require.Equal(t, "ASC", expectedQuery.Order, "Migration should use ascending order")
+		require.Equal(t, 100000000, expectedQuery.Limit, "Migration should use large limit")
+
+		// Verify UseHistoryTable logic
+		require.True(t, expectedQuery.UseHistoryTable(), "Migration query should use history table")
+	})
+}

--- a/pkg/registry/apis/dashboard/legacy/queries_test.go
+++ b/pkg/registry/apis/dashboard/legacy/queries_test.go
@@ -85,6 +85,15 @@ func TestDashboardQueries(t *testing.T) {
 						Order:      "ASC",
 					}),
 				},
+				{
+					Name: "migration_with_fallback",
+					Data: getQuery(&DashboardQuery{
+						OrgID:         1,
+						GetHistory:    true,
+						AllowFallback: true,
+						Order:         "ASC",
+					}),
+				},
 			},
 			sqlQueryPanels: {
 				{

--- a/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
+++ b/pkg/registry/apis/dashboard/legacy/query_dashboards.sql
@@ -61,9 +61,6 @@ WHERE dashboard.is_folder = {{ .Arg .Query.GetFolders }}
   AND COALESCE(dashboard_version.version, dashboard.version) < {{ .Arg .Query.LastID }}
   {{ end }}
   {{ end }}
-  {{ if and .Query.GetHistory (not .Query.AllowFallback) }}
-  AND dashboard_version.id IS NOT NULL
-  {{ end }}
   ORDER BY
     {{ if and .Query.GetHistory (not .Query.AllowFallback) }}
     dashboard_version.created {{ .Query.Order }},

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -263,6 +263,7 @@ func (a *dashboardSqlAccess) scanRow(rows *sql.Rows, history bool) (*dashboardRo
 		&updated, &updatedBy, &updatedByID,
 		&version, &message, &data, &apiVersion,
 	)
+
 	switch apiVersion.String {
 	case "":
 		apiVersion.String = dashboardV0.VERSION // default value

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
@@ -12,9 +12,9 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  dashboard_version.created as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
+  dashboard_version.created_by as updated_by_id,
   dashboard_version.version,
   dashboard_version.message,
   dashboard_version.data,
@@ -26,6 +26,7 @@ LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
+  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-export_with_history.sql
@@ -26,7 +26,6 @@ LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
-  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
@@ -23,7 +23,7 @@ FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
-LEFT OUTER JOIN `grafana`.`user` as updated_user ON dashboard_version.created_by = updated_user.id
+LEFT OUTER JOIN `grafana`.`user` as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
   AND dashboard.uid = 'UUU'

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-history_uid_at_version.sql
@@ -12,13 +12,13 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  COALESCE(dashboard_version.created, dashboard.updated) as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
-  dashboard_version.version,
-  dashboard_version.message,
-  dashboard_version.data,
-  dashboard_version.api_version
+  COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
+  COALESCE(dashboard_version.version, dashboard.version) as version,
+  COALESCE(dashboard_version.message, '') as message,
+  COALESCE(dashboard_version.data, dashboard.data) as data,
+  COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM `grafana`.`dashboard` as dashboard
 LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
@@ -29,6 +29,6 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
   ORDER BY
-    dashboard_version.created DESC,
-    dashboard_version.version DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) DESC,
+    COALESCE(dashboard_version.version, dashboard.version) DESC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/mysql--query_dashboards-migration_with_fallback.sql
@@ -19,16 +19,14 @@ SELECT
   COALESCE(dashboard_version.message, '') as message,
   COALESCE(dashboard_version.data, dashboard.data) as data,
   COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
-FROM "grafana"."dashboard" as dashboard
-LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
-LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
-LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
-LEFT OUTER JOIN "grafana"."user" as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
+FROM `grafana`.`dashboard` as dashboard
+LEFT OUTER JOIN `grafana`.`dashboard_version` as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
+LEFT OUTER JOIN `grafana`.`dashboard_provisioning` as provisioning ON dashboard.id = provisioning.dashboard_id
+LEFT OUTER JOIN `grafana`.`user` as created_user ON dashboard.created_by = created_user.id
+LEFT OUTER JOIN `grafana`.`user` as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
 WHERE dashboard.is_folder = FALSE
-  AND dashboard.org_id = 2
-  AND dashboard.uid = 'UUU'
-  AND dashboard_version.version = 3
+  AND dashboard.org_id = 1
   ORDER BY
-    COALESCE(dashboard_version.created, dashboard.updated) DESC,
-    COALESCE(dashboard_version.version, dashboard.version) DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) ASC,
+    COALESCE(dashboard_version.version, dashboard.version) ASC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
@@ -26,7 +26,6 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
-  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-export_with_history.sql
@@ -12,9 +12,9 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  dashboard_version.created as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
+  dashboard_version.created_by as updated_by_id,
   dashboard_version.version,
   dashboard_version.message,
   dashboard_version.data,
@@ -26,6 +26,7 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
+  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-history_uid_at_version.sql
@@ -12,13 +12,13 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  COALESCE(dashboard_version.created, dashboard.updated) as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
-  dashboard_version.version,
-  dashboard_version.message,
-  dashboard_version.data,
-  dashboard_version.api_version
+  COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
+  COALESCE(dashboard_version.version, dashboard.version) as version,
+  COALESCE(dashboard_version.message, '') as message,
+  COALESCE(dashboard_version.data, dashboard.data) as data,
+  COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
@@ -29,6 +29,6 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
   ORDER BY
-    dashboard_version.created DESC,
-    dashboard_version.version DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) DESC,
+    COALESCE(dashboard_version.version, dashboard.version) DESC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/postgres--query_dashboards-migration_with_fallback.sql
@@ -25,10 +25,8 @@ LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
 WHERE dashboard.is_folder = FALSE
-  AND dashboard.org_id = 2
-  AND dashboard.uid = 'UUU'
-  AND dashboard_version.version = 3
+  AND dashboard.org_id = 1
   ORDER BY
-    COALESCE(dashboard_version.created, dashboard.updated) DESC,
-    COALESCE(dashboard_version.version, dashboard.version) DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) ASC,
+    COALESCE(dashboard_version.version, dashboard.version) ASC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
@@ -26,7 +26,6 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
-  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-export_with_history.sql
@@ -12,9 +12,9 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  dashboard_version.created as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
+  dashboard_version.created_by as updated_by_id,
   dashboard_version.version,
   dashboard_version.message,
   dashboard_version.data,
@@ -26,6 +26,7 @@ LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = creat
 LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard_version.created_by = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 1
+  AND dashboard_version.id IS NOT NULL
   ORDER BY
     dashboard_version.created ASC,
     dashboard_version.version ASC,

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
@@ -23,7 +23,7 @@ FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
-LEFT OUTER JOIN "grafana"."user" as updated_user ON dashboard_version.created_by = updated_user.id
+LEFT OUTER JOIN "grafana"."user" as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
 WHERE dashboard.is_folder = FALSE
   AND dashboard.org_id = 2
   AND dashboard.uid = 'UUU'

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-history_uid_at_version.sql
@@ -12,13 +12,13 @@ SELECT
   dashboard.created,
   created_user.uid         as created_by,
   dashboard.created_by     as created_by_id,
-  dashboard_version.created,
+  COALESCE(dashboard_version.created, dashboard.updated) as updated,
   updated_user.uid       as updated_by,
-  updated_user.id        as created_by_id,
-  dashboard_version.version,
-  dashboard_version.message,
-  dashboard_version.data,
-  dashboard_version.api_version
+  COALESCE(dashboard_version.created_by, dashboard.updated_by) as updated_by_id,
+  COALESCE(dashboard_version.version, dashboard.version) as version,
+  COALESCE(dashboard_version.message, '') as message,
+  COALESCE(dashboard_version.data, dashboard.data) as data,
+  COALESCE(dashboard_version.api_version, dashboard.api_version) as api_version
 FROM "grafana"."dashboard" as dashboard
 LEFT OUTER JOIN "grafana"."dashboard_version" as dashboard_version ON dashboard.id = dashboard_version.dashboard_id
 LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.id = provisioning.dashboard_id
@@ -29,6 +29,6 @@ WHERE dashboard.is_folder = FALSE
   AND dashboard.uid = 'UUU'
   AND dashboard_version.version = 3
   ORDER BY
-    dashboard_version.created DESC,
-    dashboard_version.version DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) DESC,
+    COALESCE(dashboard_version.version, dashboard.version) DESC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-migration_with_fallback.sql
+++ b/pkg/registry/apis/dashboard/legacy/testdata/sqlite--query_dashboards-migration_with_fallback.sql
@@ -25,10 +25,8 @@ LEFT OUTER JOIN "grafana"."dashboard_provisioning" as provisioning ON dashboard.
 LEFT OUTER JOIN "grafana"."user" as created_user ON dashboard.created_by = created_user.id
 LEFT OUTER JOIN "grafana"."user" as updated_user ON COALESCE(dashboard_version.created_by, dashboard.updated_by) = updated_user.id
 WHERE dashboard.is_folder = FALSE
-  AND dashboard.org_id = 2
-  AND dashboard.uid = 'UUU'
-  AND dashboard_version.version = 3
+  AND dashboard.org_id = 1
   ORDER BY
-    COALESCE(dashboard_version.created, dashboard.updated) DESC,
-    COALESCE(dashboard_version.version, dashboard.version) DESC,
+    COALESCE(dashboard_version.created, dashboard.updated) ASC,
+    COALESCE(dashboard_version.version, dashboard.version) ASC,
     dashboard.uid ASC

--- a/pkg/registry/apis/dashboard/legacy/types.go
+++ b/pkg/registry/apis/dashboard/legacy/types.go
@@ -27,6 +27,10 @@ type DashboardQuery struct {
 	GetHistory bool
 	Version    int64
 
+	// Allow fallback to dashboard table when version data is missing
+	// Used during migration to handle dashboards without version entries
+	AllowFallback bool
+
 	// Only folders
 	GetFolders bool
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Some dashboards exist in the `dashboard` table but have no corresponding entries in the `dashboard_version` table. When using history table queries for migration, `NULL` values from the `LEFT JOIN` cause failures.

This change implements conditional `COALESCE` logic in the SQL query:

- For history queries (`GetHistory=true`): Use direct `dashboard_version` fields to preserve correct behavior (return 0 when no versions exist)
- For migration queries (`UseHistoryTable=true`, `GetHistory=false`): Use `COALESCE` to fall back to dashboard table values when version entries are missing
- For regular queries: No changes (`dashboard` table only)

This ensures successful migration of all dashboards while preserving the semantic meaning of history queries.

**Who is this feature for?**

Migration of Dashboard to Unified Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes grafana/search-and-storage-team#364

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
