### PR TITLE
Dx: Add check for node version before yarn start

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -626,6 +626,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/cli/ @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
+/scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
 /scripts/helpers/ @grafana/grafana-developer-enablement-squad
 /scripts/import_many_dashboards.sh @torkelo
 /scripts/mixin-check.sh @bergquist

--- a/package.json
+++ b/package.json
@@ -460,7 +460,7 @@
     ]
   },
   "engines": {
-    "node": "22.16.0"
+    "node": ">= 22 <23"
   },
   "packageManager": "yarn@4.9.2",
   "dependenciesMeta": {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "12.1.0-pre",
   "repository": "github:grafana/grafana",
   "scripts": {
+    "predev": "./scripts/check-frontend-dev.sh",
     "build": "NODE_ENV=production nx exec --verbose -- webpack --config scripts/webpack/webpack.prod.js",
     "build:nominify": "yarn run build -- --env noMinify=1",
     "build:stats": "NODE_ENV=production webpack --progress --config scripts/webpack/webpack.stats.js",
@@ -46,7 +47,7 @@
     "prettier:check": "prettier --check --ignore-path .prettierignore --list-different=false --log-level=warn \"**/*.{ts,tsx,scss,md,mdx,json,js,cjs}\"",
     "prettier:checkDocs": "prettier --check --list-different=false --log-level=warn \"docs/**/*.md\" \"*.md\" \"packages/**/*.{ts,tsx,scss,md,mdx,json,js,cjs}\"",
     "prettier:write": "prettier --ignore-path .prettierignore --list-different \"**/*.{js,ts,tsx,scss,md,mdx,json,cjs}\" --write",
-    "start": "NODE_ENV=dev nx exec -- webpack --config scripts/webpack/webpack.dev.js --watch",
+    "start": "yarn predev && NODE_ENV=dev nx exec -- webpack --config scripts/webpack/webpack.dev.js --watch",
     "start:liveReload": "yarn start -- --env liveReload=1",
     "start:noTsCheck": "yarn start -- --env noTsCheck=1",
     "start:noLint": "yarn start -- --env noTsCheck=1 --env noLint=1",
@@ -459,7 +460,7 @@
     ]
   },
   "engines": {
-    "node": ">= 22 <23"
+    "node": "22.16.0"
   },
   "packageManager": "yarn@4.9.2",
   "dependenciesMeta": {

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+
+# Exit early if running in CI environment
+if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
+  exit 0
+fi
+
+
+# Colors for prettier output
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+BOLD='\033[1m'
+
+
+REQUIRED_VERSION=$(cat .nvmrc | sed 's/v//')
+CURRENT_VERSION=$(node --version | sed 's/v//')
+
+if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then
+    echo ""
+    echo "${RED}⚠️  WARNING  ⚠️${NC}"
+    echo "${YELLOW}${BOLD}Node.js version mismatch!${NC}"
+    echo ""
+    echo "${BOLD}${CYAN}Recommended:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
+    echo "${BOLD}${CYAN}Current:${NC}     ${RED}$CURRENT_VERSION${NC}"
+    echo ""
+    echo "${BOLD}${YELLOW}⚠️  We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
+    echo "    Using a different version may lead to unexpected build issues or runtime errors."
+    echo ""
+    echo "${BOLD}💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:${NC}"
+    echo "   • ${BLUE}nvm${NC} - Node Version Manager"
+    echo "   • ${BLUE}fnm${NC} - Fast Node Manager"
+    echo ""
+    echo "${BLUE}${BOLD}If you experience issues building Grafana, first switch to the recommended version of Node.js.${NC}"
+    echo ""
+fi
+
+

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -5,7 +5,6 @@ if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ] || [ -n "$IGNORE_NODE_VERSION_CHECK"
   exit 0
 fi
 
-
 # Colors for prettier output
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
@@ -15,6 +14,14 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 BOLD='\033[1m'
 
+# Check if .nvmrc file exists
+if [ ! -f ".nvmrc" ]; then
+    printf "%b\n" ""
+    printf "%b\n" "${RED}⚠️  ERROR  ⚠️${NC}"
+    printf "%b\n" "${YELLOW}${BOLD}.nvmrc file not found!${NC} Run '${BLUE}git checkout main -- .nvmrc${NC}' to fix."
+    printf "%b\n" ""
+    exit 1
+fi
 
 REQUIRED_VERSION=$(cat .nvmrc | sed 's/v//')
 CURRENT_VERSION=$(node --version | sed 's/v//')
@@ -27,8 +34,8 @@ if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then
     printf "%b\n" "${BOLD}${CYAN}Recommended:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
     printf "%b\n" "${BOLD}${CYAN}Current:${NC}     ${RED}$CURRENT_VERSION${NC}"
     printf "%b\n" ""
-    printf "%b\n" "${BOLD}${YELLOW}⚠️  We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
-    printf "%b\n" "    Using a different version may lead to unexpected build issues or runtime errors."
+    printf "%b\n" "${BOLD}${YELLOW}⚠️ We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
+    printf "%b\n" "   Using a different version may lead to unexpected build issues or runtime errors."
     printf "%b\n" ""
     printf "%b\n" "${BOLD}💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:${NC}"
     printf "%b\n" "   • ${BLUE}nvm${NC} - Node Version Manager"

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -23,7 +23,7 @@ if [ ! -f ".nvmrc" ]; then
     exit 1
 fi
 
-REQUIRED_VERSION=$(cat .nvmrc | sed 's/v//')
+REQUIRED_VERSION=$(sed 's/v//' .nvmrc)
 CURRENT_VERSION=$(node --version | sed 's/v//')
 
 if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 
 # Exit early if running in CI environment
-if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ]; then
+if [ -n "$CI" ] || [ -n "$GITHUB_ACTIONS" ] || [ -n "$IGNORE_NODE_VERSION_CHECK" ]; then
   exit 0
 fi
 

--- a/scripts/check-frontend-dev.sh
+++ b/scripts/check-frontend-dev.sh
@@ -20,22 +20,22 @@ REQUIRED_VERSION=$(cat .nvmrc | sed 's/v//')
 CURRENT_VERSION=$(node --version | sed 's/v//')
 
 if [ "$CURRENT_VERSION" != "$REQUIRED_VERSION" ]; then
-    echo ""
-    echo "${RED}⚠️  WARNING  ⚠️${NC}"
-    echo "${YELLOW}${BOLD}Node.js version mismatch!${NC}"
-    echo ""
-    echo "${BOLD}${CYAN}Recommended:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
-    echo "${BOLD}${CYAN}Current:${NC}     ${RED}$CURRENT_VERSION${NC}"
-    echo ""
-    echo "${BOLD}${YELLOW}⚠️  We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
-    echo "    Using a different version may lead to unexpected build issues or runtime errors."
-    echo ""
-    echo "${BOLD}💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:${NC}"
-    echo "   • ${BLUE}nvm${NC} - Node Version Manager"
-    echo "   • ${BLUE}fnm${NC} - Fast Node Manager"
-    echo ""
-    echo "${BLUE}${BOLD}If you experience issues building Grafana, first switch to the recommended version of Node.js.${NC}"
-    echo ""
+    printf "%b\n" ""
+    printf "%b\n" "${RED}⚠️  WARNING  ⚠️${NC}"
+    printf "%b\n" "${YELLOW}${BOLD}Node.js version mismatch!${NC}"
+    printf "%b\n" ""
+    printf "%b\n" "${BOLD}${CYAN}Recommended:${NC} ${GREEN}$REQUIRED_VERSION${NC} (from .nvmrc)"
+    printf "%b\n" "${BOLD}${CYAN}Current:${NC}     ${RED}$CURRENT_VERSION${NC}"
+    printf "%b\n" ""
+    printf "%b\n" "${BOLD}${YELLOW}⚠️  We only test and support developing Grafana with the specific LTS Node.js release.${NC}"
+    printf "%b\n" "    Using a different version may lead to unexpected build issues or runtime errors."
+    printf "%b\n" ""
+    printf "%b\n" "${BOLD}💡 Consider using a node version manager and configuring it to auto-switch to the recommended version:${NC}"
+    printf "%b\n" "   • ${BLUE}nvm${NC} - Node Version Manager"
+    printf "%b\n" "   • ${BLUE}fnm${NC} - Fast Node Manager"
+    printf "%b\n" ""
+    printf "%b\n" "${BLUE}${BOLD}If you experience issues building Grafana, first switch to the recommended version of Node.js.${NC}"
+    printf "%b\n" ""
 fi
 
 


### PR DESCRIPTION
Often people run into issues building Grafana due to small differences in Node.js versions. This has recently happened more frequently due to Node's improved TypeScript and ESM support which we're now relying on more.

This PR adds a `yarn predev` script which runs before `yarn start` to check the correct Node.js version is installed. If there's a mismatch, a _warning_ will be printed to the console, but developers will be able to continue (against our advice!)

<img width="972" height="541" alt="image" src="https://github.com/user-attachments/assets/de5400f6-c2d2-4163-9bdd-681054c4d173" />
