### PR TITLE
[InfluxDb]: Fix DBRP mapping typo

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.tsx
@@ -121,8 +121,8 @@ export const UrlAndAuthenticationSection = (props: Props) => {
 
           {requiresDbrpMapping && (
             <Alert severity="warning" title="InfluxQL requires DBRP mapping">
-              InfluxDB OSS 1.x and 2.x users must configure a Database + Retention Policy (DBRP) mapping via the CLI or
-              API before data can be queried.{' '}
+              {`${options.jsonData.product} requires a Database + Retention Policy (DBRP) mapping via the CLI or
+              API before data can be queried.`}{' '}
               <TextLink href="https://docs.influxdata.com/influxdb/cloud/query-data/influxql/dbrp/" external>
                 Learn how to set this up
               </TextLink>


### PR DESCRIPTION
This PR fixes a typo that was describing the InfluxDB products that needed DBRP mapping were only OSS 1.x and OSS 2.x. This change renders the correct product.