### PR TITLE
Monaco: Fix `hexdigits` in monaco langs

### DIFF
--- a/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
+++ b/packages/grafana-prometheus/src/components/monaco-query-field/promql.ts
@@ -162,7 +162,7 @@ export const language = {
   digits: /\d+(_+\d+)*/,
   octaldigits: /[0-7]+(_+[0-7]+)*/,
   binarydigits: /[0-1]+(_+[0-1]+)*/,
-  hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+  hexdigits: /[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
   integersuffix: /(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/,
   floatsuffix: /[fFlL]?/,
   // The main tokenizer for our languages

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/pyroscopeql/pyroscopeql.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/pyroscopeql/pyroscopeql.ts
@@ -31,7 +31,7 @@ export const language: languages.IMonarchLanguage = {
   digits: /\d+(_+\d+)*/,
   octaldigits: /[0-7]+(_+[0-7]+)*/,
   binarydigits: /[0-1]+(_+[0-1]+)*/,
-  hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+  hexdigits: /[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
   integersuffix: /(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/,
   floatsuffix: /[fFlL]?/,
 

--- a/public/app/plugins/datasource/parca/lang/lang.ts
+++ b/public/app/plugins/datasource/parca/lang/lang.ts
@@ -31,7 +31,7 @@ export const language: languages.IMonarchLanguage = {
   digits: /\d+(_+\d+)*/,
   octaldigits: /[0-7]+(_+[0-7]+)*/,
   binarydigits: /[0-1]+(_+[0-1]+)*/,
-  hexdigits: /[[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
+  hexdigits: /[0-9a-fA-F]+(_+[0-9a-fA-F]+)*/,
   integersuffix: /(ll|LL|u|U|l|L)?(ll|LL|u|U|l|L)?/,
   floatsuffix: /[fFlL]?/,
 


### PR DESCRIPTION


**What is this feature?**

The regex for `hexdigits` contained an extra `[` character. I do think `hexdigits` is not used at all, but I guess it's better to have a correct regex.