### PR TITLE
OpenFeature: Fix bulk evaluation request postprocessing

### DIFF
--- a/pkg/services/featuremgmt/static_evaluator.go
+++ b/pkg/services/featuremgmt/static_evaluator.go
@@ -98,7 +98,7 @@ type OFREPBulkResponse struct {
 // OFREPFlag represents a single flag in the bulk response
 type OFREPFlag struct {
 	Key          string         `json:"key"`
-	Value        bool           `json:"value"`
+	Value        any            `json:"value"`
 	Reason       string         `json:"reason"`
 	Variant      string         `json:"variant,omitempty"`
 	Metadata     map[string]any `json:"metadata,omitempty"`

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -80,7 +80,7 @@ ABCD = true
 
 	openFeatureEnabledFlags := map[string]bool{}
 	for _, flag := range allFlags.Flags {
-		if flag.Value {
+		if v, ok := flag.Value.(bool); ok && v {
 			openFeatureEnabledFlags[flag.Key] = true
 		}
 	}


### PR DESCRIPTION
The initial implementation incorrectly attempted to write to `ResponseWriter` inside `ModifyResponse` which led to an empty response body. 
It's now fixed by properly replacing resp.Body and adjusting headers.