### PR TITLE
Fix: Link path not recognised in CommandPalette link extensions 

### DIFF
--- a/public/app/features/commandPalette/KBarResults.tsx
+++ b/public/app/features/commandPalette/KBarResults.tsx
@@ -121,6 +121,10 @@ export const KBarResults = (props: KBarResultsProps) => {
       const url = (item as ActionImpl & { url?: string }).url;
 
       if (item.command) {
+        if (url) {
+          // If the item also has a url we should block navigation.
+          ev.preventDefault();
+        }
         item.command.perform(item);
         // TODO: ideally the perform method would return some marker or we would have something like preventDefault()
         if (!item.id.startsWith('scopes/') || item.id === 'scopes/apply') {

--- a/public/app/features/commandPalette/actions/useExtensionActions.ts
+++ b/public/app/features/commandPalette/actions/useExtensionActions.ts
@@ -22,8 +22,8 @@ export default function useExtensionActions(): CommandPaletteAction[] {
       priority: EXTENSIONS_PRIORITY,
       id: link.id,
       name: link.title,
-      target: link.path,
       perform: () => link.onClick && link.onClick(),
+      url: link.path,
     }));
   }, [links]);
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes a bug in the commandpalette extensions hook that was incorrectly assigning `link.path` to kbars `target` when it should be assigning it to `url`. Without this commandpalette extensions require an onClick for navigation.

Having corrected the original issue with `link.path` not being assigned to `url` I then noticed that kbar does no checks to prevent navigation via `url` if both `url` and `perform` are assigned. To resolve this I've added a `ev.preventDefault` to the KBarResults component so `perform` takes precedence in this scenario. Not sure if that's correct though as I've not looked at the command palette before.

**Why do we need this feature?**

So link extensions that don't have an onClick property navigate using the link extensions path property. e.g:

```
.addLink({
    targets: [PluginExtensionPoints.CommandPalette],
    title: 'AWS EC2 instances',
    description: 'Monitor your AWS EC2 instances',
    category: 'Pages',
    path: '/a/grafana-cmdpalette-app/three/ec2',
  });
```

_before_

https://github.com/user-attachments/assets/fb3a8670-3b21-4b16-ba01-21dbead773f0

_after_

https://github.com/user-attachments/assets/6b94894c-5da4-4e3f-93c1-25935a76f382


**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #108126

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
