### PR TITLE
GHA: Add workspace check for wire changes

### DIFF
--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -45,3 +45,72 @@ jobs:
         fi
     - name: Ensure Dockerfile contains submodule COPY commands
       run: ./scripts/go-workspace/validate-dockerfile.sh
+
+  check-wire:
+    name: Check Wire Changes
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Set go version
+      uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639
+      with:
+        cache: false
+        go-version-file: go.mod
+
+    - name: Setup Enterprise
+      if: github.event.pull_request.head.repo.fork == false
+      uses: ./.github/actions/setup-enterprise
+
+    - name: Calculate generated wire checksums
+      id: pre_gen_oss
+      run: |
+        OSS_WIRE_CHECKSUM="$(sha256sum pkg/server/wire_gen.go | cut -d' ' -f1)"
+        echo "wire_checksum=$OSS_WIRE_CHECKSUM" >> "$GITHUB_OUTPUT"
+
+    - name: Calculate generated enterprise wire checksums
+      id: pre_gen_enterprise
+      if: github.event.pull_request.head.repo.fork == false
+      run: |
+        ENTERPRISE_WIRE_CHECKSUM="$(sha256sum pkg/server/enterprise_wire_gen.go | cut -d' ' -f1)"
+        echo "wire_checksum=$ENTERPRISE_WIRE_CHECKSUM" >> "$GITHUB_OUTPUT"
+
+    - name: Generate Go files
+      run: make gen-go
+
+    - name: Check for generated file changes
+      run: |
+        OSS_WIRE_CHANGED=false
+        CURRENT_OSS_WIRE_CHECKSUM=$(sha256sum pkg/server/wire_gen.go | cut -d' ' -f1)
+        if [ "$CURRENT_OSS_WIRE_CHECKSUM" != "${{ steps.pre_gen_oss.outputs.wire_checksum }}" ]; then
+          OSS_WIRE_CHANGED=true
+          echo "Uncomitted changes detected in pkg/server/wire_gen.go"
+        fi
+
+        ENTERPRISE_WIRE_CHANGED=false
+        if [ -f "pkg/server/enterprise_wire_gen.go" ]; then
+          CURRENT_ENTERPRISE_WIRE_CHECKSUM=$(sha256sum pkg/server/enterprise_wire_gen.go | cut -d' ' -f1)
+          if [ "$CURRENT_ENTERPRISE_WIRE_CHECKSUM" != "${{ steps.pre_gen_enterprise.outputs.wire_checksum }}" ]; then
+            ENTERPRISE_WIRE_CHANGED=true
+            echo "Uncomitted changes detected in pkg/server/enterprise_wire_gen.go"
+          fi
+        fi
+        
+        if [ "$OSS_WIRE_CHANGED" = "false" ] && [ "$ENTERPRISE_WIRE_CHANGED" = "false" ]; then
+          echo "No changes in generated Go files"
+        else
+          if [[ "${{ github.event.pull_request.head.repo.fork }}" == "false" ]]; then
+            echo "> !!! Please link Enterprise and run 'make gen-go', then commit the changes to both repositories."
+          else
+            echo "> !!! Please run 'make gen-go' and commit the changes."
+          fi
+          exit 1
+        fi


### PR DESCRIPTION
Adds a new check: if there are wire changes not properly committed in both OSS and Enterprise, exits with code 1.