### PR TITLE
OTel: Add experimental formatting for OTel identified log lines

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1026,4 +1026,8 @@ export interface FeatureToggles {
   * @default false
   */
   enablePluginImporter?: boolean;
+  /**
+  * Applies OTel formatting templates to displayed logs
+  */
+  otelLogsFormatting?: boolean;
 }

--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -36,6 +36,7 @@ export interface Options {
   onLogOptionsChange?: unknown;
   onNewLogsReceived?: unknown;
   prettifyLogMessage: boolean;
+  setDisplayedFields?: unknown;
   showCommonLabels: boolean;
   showControls?: boolean;
   showLabels: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1765,6 +1765,13 @@ var (
 			FrontendOnly:      true,
 			Expression:        "false",
 		},
+		{
+			Name:         "otelLogsFormatting",
+			Description:  "Applies OTel formatting templates to displayed logs",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaObservabilityLogsSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -229,3 +229,4 @@ newInfluxDSConfigPageDesign,privatePreview,@grafana/partner-datasources,false,fa
 enableAppChromeExtensions,experimental,@grafana/plugins-platform-backend,false,false,true
 foldersAppPlatformAPI,experimental,@grafana/grafana-search-navigate-organise,false,false,true
 enablePluginImporter,experimental,@grafana/plugins-platform-backend,false,false,true
+otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -926,4 +926,8 @@ const (
 	// FlagEnablePluginImporter
 	// Set this to true to use the new PluginImporter functionality
 	FlagEnablePluginImporter = "enablePluginImporter"
+
+	// FlagOtelLogsFormatting
+	// Applies OTel formatting templates to displayed logs
+	FlagOtelLogsFormatting = "otelLogsFormatting"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2227,6 +2227,19 @@
     },
     {
       "metadata": {
+        "name": "otelLogsFormatting",
+        "resourceVersion": "1750152612973",
+        "creationTimestamp": "2025-06-17T09:30:12Z"
+      },
+      "spec": {
+        "description": "Applies OTel formatting templates to displayed logs",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "panelFilterVariable",
         "resourceVersion": "1750434297879",
         "creationTimestamp": "2023-11-03T12:15:54Z"

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -1,0 +1,49 @@
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { createLogLine } from '../mocks/logRow';
+
+import { getDisplayedFieldsForLogs, getOtelFormattedBody } from './formats';
+
+describe('getDisplayedFieldsForLogs', () => {
+  test('Does not return displayed fields if not an OTel log line', () => {
+    const log = createLogLine({ labels: { place: 'luna' }, entry: `place="luna" 1ms 3 KB` });
+
+    expect(getDisplayedFieldsForLogs([log])).toEqual([]);
+  });
+
+  test('Does not return displayed fields if telemetry_sdk_language is empty', () => {
+    const log = createLogLine({ labels: { severity_number: '1' }, entry: `place="luna" 1ms 3 KB` });
+
+    expect(getDisplayedFieldsForLogs([log])).toEqual([]);
+  });
+
+  test('Does not return displayed fields if telemetry_sdk_language is empty', () => {
+    const log = createLogLine({
+      labels: { severity_number: '1', telemetry_sdk_language: 'php', scope_name: 'scope' },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
+  });
+});
+
+describe('getOtelFormattedBody', () => {
+  test('Does not modify non OTel logs', () => {
+    const log = createLogLine({ labels: { place: 'luna' }, entry: `place="luna" 1ms 3 KB` });
+    expect(getOtelFormattedBody(log)).toEqual(`place="luna" 1ms 3 KB`);
+  });
+
+  test('Returns an OTel augmented log line body', () => {
+    const log = createLogLine({
+      labels: {
+        severity_number: '1',
+        telemetry_sdk_language: 'php',
+        scope_name: 'scope',
+        aws_ignore: 'ignored',
+        key: 'value',
+        otel: 'otel',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+    expect(getOtelFormattedBody(log)).toEqual(`place="luna" 1ms 3 KB key=value otel=otel`);
+  });
+});

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -47,8 +47,11 @@ export function getDisplayFormatForLanguage(language: string) {
 }
 
 export function getDefaultOTelDisplayFormat() {
-  return ['severity_text', 'scope_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME];
+  return ['scope_name', 'thread_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME];
 }
+
+const OTEL_RESOURCE_ATTRS_REGEX = /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_)/;
+const OTEL_LOG_FIELDS_REGEX = /^(flags|observed_timestamp|scope_name|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 
 export function getOtelFormattedBody(log: LogListModel) {
   if (!log.otelLanguage) {

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -8,7 +8,7 @@ import { LogListModel } from '../panel/processing';
  */
 const OTEL_PROBE_FIELD = 'severity_number';
 export function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
-	const languages = logs
+  const languages = logs
     .filter((log) => log.labels[OTEL_PROBE_FIELD] !== undefined)
     .filter((log) => log.labels.telemetry_sdk_language !== undefined)
     .map((log) => log.labels.telemetry_sdk_language);
@@ -31,9 +31,6 @@ export function getDisplayedFieldsForLanguages(languages: string[]) {
 }
 
 export function getDisplayedFieldsForLogs(logs: LogListModel[] | LogRowModel[]): string[] {
-  console.log(identifyOTelLanguages(logs));
-  console.log(getDisplayedFieldsForLanguages(identifyOTelLanguages(logs)));
-
   return getDisplayedFieldsForLanguages(identifyOTelLanguages(logs));
 }
 

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -50,14 +50,18 @@ export function getDefaultOTelDisplayFormat() {
   return ['scope_name', 'thread_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME];
 }
 
-const OTEL_RESOURCE_ATTRS_REGEX = /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_)/;
-const OTEL_LOG_FIELDS_REGEX = /^(flags|observed_timestamp|scope_name|severity_number|severity_text|span_id|trace_id|detected_level)$/;
+const OTEL_RESOURCE_ATTRS_REGEX =
+  /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_)/;
+const OTEL_LOG_FIELDS_REGEX =
+  /^(flags|observed_timestamp|scope_name|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 
 export function getOtelFormattedBody(log: LogListModel) {
   if (!log.otelLanguage) {
     return log.raw;
   }
-  const additionalFields = ['timestamp', 'detected_level', 'flags', 'trace_id', 'span_id'];
+  const additionalFields = Object.keys(log.labels).filter(
+    (label) => !OTEL_RESOURCE_ATTRS_REGEX.test(label) && !OTEL_LOG_FIELDS_REGEX.test(label)
+  );
   return (
     log.raw +
     ' ' +

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -54,7 +54,7 @@ export function getOtelFormattedBody(log: LogListModel) {
   if (!log.otelLanguage) {
     return log.raw;
   }
-  const additionalFields = ['timestamp', 'detected_level', 'flags', 'scope_name', 'trace_id', 'span_id'];
+  const additionalFields = ['timestamp', 'detected_level', 'flags', 'trace_id', 'span_id'];
   return (
     log.raw +
     ' ' +

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -1,0 +1,46 @@
+import { LogRowModel } from '@grafana/data';
+
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { LogListModel } from '../panel/processing';
+
+/**
+ * The presence of this field along log fields determines OTel origin.
+ */
+const OTEL_PROBE_FIELD = 'severity_number';
+export function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
+	const languages = logs
+    .filter((log) => log.labels[OTEL_PROBE_FIELD] !== undefined)
+    .filter((log) => log.labels.telemetry_sdk_language !== undefined)
+    .map((log) => log.labels.telemetry_sdk_language);
+  return [...new Set(languages)];
+}
+
+export function getDisplayedFieldsForLanguages(languages: string[]) {
+  const displayedFields: string[] = [];
+
+  languages.forEach((language) => {
+    const format = getDisplayFormatForLanguage(language) ?? getDefaultOTelDisplayFormat();
+    format.forEach((field) => {
+      if (!displayedFields.includes(field)) {
+        displayedFields.push(field);
+      }
+    });
+  });
+
+  return displayedFields;
+}
+
+export function getDisplayedFieldsForLogs(logs: LogListModel[] | LogRowModel[]): string[] {
+  console.log(identifyOTelLanguages(logs));
+  console.log(getDisplayedFieldsForLanguages(identifyOTelLanguages(logs)));
+
+  return getDisplayedFieldsForLanguages(identifyOTelLanguages(logs));
+}
+
+export function getDisplayFormatForLanguage(language: string) {
+  return undefined;
+}
+
+export function getDefaultOTelDisplayFormat() {
+  return ['severity_text', 'scope_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME];
+}

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -8,8 +8,14 @@ import { LogListModel } from '../panel/processing';
  */
 const OTEL_PROBE_FIELD = 'severity_number';
 export function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
-  const languages = logs.map((log) => identifyOTelLanguage(log)).filter((language) => language !== undefined);
-  return [...new Set(languages)];
+  const languagesSet = new Set<string>();
+  logs.forEach((log) => {
+    const lang = identifyOTelLanguage(log);
+    if (lang !== undefined) {
+      languagesSet.add(lang);
+    }
+  });
+  return [...languagesSet];
 }
 
 export function identifyOTelLanguage(log: LogListModel | LogRowModel): string | undefined {

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -42,6 +42,7 @@ export function getDisplayedFieldsForLogs(logs: LogListModel[] | LogRowModel[]):
   return getDisplayedFieldsForLanguages(logs, identifyOTelLanguages(logs));
 }
 
+// Languages not implemented.
 export function getDisplayFormatForLanguage(language: string) {
   return undefined;
 }

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -25,6 +25,7 @@ import {
 import { PopoverContent } from '@grafana/ui';
 
 import { DownloadFormat, checkLogsError, checkLogsSampled, downloadLogs as download } from '../../utils';
+import { getDisplayedFieldsForLogs } from '../otel/formats';
 
 import { LogLineDetailsMode } from './LogLineDetails';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
@@ -184,7 +185,7 @@ export const LogListContextProvider = ({
   enableLogDetails,
   detailsMode: detailsModeProp,
   dedupStrategy,
-  displayedFields,
+  displayedFields: displayedFieldsProp,
   filterLevels,
   fontSize,
   forceEscape = false,
@@ -238,6 +239,7 @@ export const LogListContextProvider = ({
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
   const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>(detailsModeProp ?? 'sidebar');
+  const displayedFields = useMemo(() => displayedFieldsProp.length > 0 ? displayedFieldsProp : getDisplayedFieldsForLogs(logs), [displayedFieldsProp, logs]);
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -22,6 +22,7 @@ import {
   shallowCompare,
   store,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { PopoverContent } from '@grafana/ui';
 
 import { DownloadFormat, checkLogsError, checkLogsSampled, downloadLogs as download } from '../../utils';
@@ -32,7 +33,6 @@ import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
 import { LogListFontSize } from './LogList';
 import { LogListModel } from './processing';
 import { LOG_LIST_MIN_WIDTH } from './virtualization';
-import { config } from '@grafana/runtime';
 
 export interface LogListContextData extends Omit<Props, 'containerElement' | 'logs' | 'logsMeta' | 'showControls'> {
   closeDetails: () => void;

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -186,7 +186,7 @@ export const LogListContextProvider = ({
   enableLogDetails,
   detailsMode: detailsModeProp,
   dedupStrategy,
-  displayedFields: displayedFieldsProp,
+  displayedFields,
   filterLevels,
   fontSize,
   forceEscape = false,
@@ -240,13 +240,16 @@ export const LogListContextProvider = ({
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
   const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>(detailsModeProp ?? 'sidebar');
-  const displayedFields = useMemo(
-    () =>
-      displayedFieldsProp.length > 0 || !config.featureToggles.otelLogsFormatting
-        ? displayedFieldsProp
-        : getDisplayedFieldsForLogs(logs),
-    [displayedFieldsProp, logs]
-  );
+
+  useEffect(() => {
+    if (displayedFields.length > 0 || !config.featureToggles.otelLogsFormatting || !setDisplayedFields) {
+      return;
+    }
+    const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
+    if (otelDisplayedFields.length) {
+      setDisplayedFields(otelDisplayedFields);
+    }
+  }, [displayedFields.length, logs, setDisplayedFields]);
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -32,6 +32,7 @@ import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
 import { LogListFontSize } from './LogList';
 import { LogListModel } from './processing';
 import { LOG_LIST_MIN_WIDTH } from './virtualization';
+import { config } from '@grafana/runtime';
 
 export interface LogListContextData extends Omit<Props, 'containerElement' | 'logs' | 'logsMeta' | 'showControls'> {
   closeDetails: () => void;
@@ -239,7 +240,13 @@ export const LogListContextProvider = ({
   const [showDetails, setShowDetails] = useState<LogListModel[]>([]);
   const [detailsWidth, setDetailsWidthState] = useState(getDetailsWidth(containerElement, logOptionsStorageKey));
   const [detailsMode, setDetailsMode] = useState<LogLineDetailsMode>(detailsModeProp ?? 'sidebar');
-  const displayedFields = useMemo(() => displayedFieldsProp.length > 0 ? displayedFieldsProp : getDisplayedFieldsForLogs(logs), [displayedFieldsProp, logs]);
+  const displayedFields = useMemo(
+    () =>
+      displayedFieldsProp.length > 0 || !config.featureToggles.otelLogsFormatting
+        ? displayedFieldsProp
+        : getDisplayedFieldsForLogs(logs),
+    [displayedFieldsProp, logs]
+  );
 
   useEffect(() => {
     // Props are updated in the context only of the panel is being externally controlled.

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -6,6 +6,7 @@ import { createLogLine, createLogRow } from '../mocks/logRow';
 import { LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
 import { LogLineVirtualization } from './virtualization';
+import { config } from '@grafana/runtime';
 
 describe('preProcessLogs', () => {
   let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;
@@ -345,5 +346,45 @@ describe('preProcessLogs', () => {
       expect(longLog.collapsed).toBe(false);
       expect(longLog.body).toBe(entry);
     });
+  });
+});
+
+describe('OTel logs', () => {
+  let originalOtelLogsFormatting = config.featureToggles.otelLogsFormatting;
+  afterAll(() => {
+    config.featureToggles.otelLogsFormatting = originalOtelLogsFormatting;
+  });
+
+  test('Requires a feature flag', () => {
+    const log = createLogLine({
+      labels: {
+        severity_number: '1',
+        telemetry_sdk_language: 'php',
+        scope_name: 'scope',
+        aws_ignore: 'ignored',
+        key: 'value',
+        otel: 'otel',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+    expect(log.otelLanguage).toBeDefined();
+    expect(log.body).toEqual(`place="luna" 1ms 3 KB`);
+  });
+
+  test('Augments OTel log lines', () => {
+    config.featureToggles.otelLogsFormatting = true;
+    const log = createLogLine({
+      labels: {
+        severity_number: '1',
+        telemetry_sdk_language: 'php',
+        scope_name: 'scope',
+        aws_ignore: 'ignored',
+        key: 'value',
+        otel: 'otel',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+    expect(log.otelLanguage).toBeDefined();
+    expect(log.body).toEqual(`place="luna" 1ms 3 KB key=value otel=otel`);
   });
 });

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -1,4 +1,5 @@
 import { createTheme, Field, FieldType, LogLevel, LogRowModel, LogsSortOrder, toDataFrame } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine, createLogRow } from '../mocks/logRow';
@@ -6,7 +7,6 @@ import { createLogLine, createLogRow } from '../mocks/logRow';
 import { LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
 import { LogLineVirtualization } from './virtualization';
-import { config } from '@grafana/runtime';
 
 describe('preProcessLogs', () => {
   let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -91,7 +91,7 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
    * onClickHideField?: (key: string) => void;
-   * 
+   *
    * Called from the new Log Details Panel when fields are reordered. If ommited, a default implementation is used.
    * setDisplayedFields?: (key: string) => void;
    *

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -60,6 +60,7 @@ import {
   isOnLogOptionsChange,
   isOnNewLogsReceivedType,
   isReactNodeArray,
+  isSetDisplayedFields,
   onNewLogsReceivedType,
   Options,
 } from './types';
@@ -90,6 +91,9 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * Called from the "eye" icon in Log Details to request hiding the displayed field. If ommited, a default implementation is used.
    * onClickHideField?: (key: string) => void;
+   * 
+   * Called from the new Log Details Panel when fields are reordered. If ommited, a default implementation is used.
+   * setDisplayedFields?: (key: string) => void;
    *
    * Passed to the LogRowMenuCell component to be rendered before the default actions in the menu.
    * logRowMenuIconsBefore?: ReactNode[];
@@ -517,6 +521,9 @@ export const LogsPanel = ({
 
   const onClickShowField = isOnClickShowField(options.onClickShowField) ? options.onClickShowField : showField;
   const onClickHideField = isOnClickHideField(options.onClickHideField) ? options.onClickHideField : hideField;
+  const setDisplayedFieldsFn = isSetDisplayedFields(options.setDisplayedFields)
+    ? options.setDisplayedFields
+    : setDisplayedFields;
 
   // In Dashboards, default to inline. Otherwise, let apps control or have automatic behavior.
   const detailsMode = detailsModeProp ? detailsModeProp : app === CoreApp.Dashboard ? 'inline' : undefined;
@@ -576,7 +583,7 @@ export const LogsPanel = ({
               onOpenContext={onOpenContext}
               onPermalinkClick={showPermaLink() ? onPermalinkClick : undefined}
               permalinkedLogId={getLogsPanelState()?.logs?.id ?? undefined}
-              setDisplayedFields={setDisplayedFields}
+              setDisplayedFields={setDisplayedFieldsFn}
               showControls={Boolean(showControls)}
               showTime={showTime}
               sortOrder={sortOrder}

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -55,6 +55,7 @@ composableKinds: PanelCfg: {
 					logLineMenuCustomItems?: _
 					onNewLogsReceived?:      _
 					displayedFields?: [...string]
+					setDisplayedFields?:     _
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -34,6 +34,7 @@ export interface Options {
   onLogOptionsChange?: unknown;
   onNewLogsReceived?: unknown;
   prettifyLogMessage: boolean;
+  setDisplayedFields?: unknown;
   showCommonLabels: boolean;
   showControls?: boolean;
   showLabels: boolean;

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -10,11 +10,12 @@ type onClickFilterLabelType = (key: string, value: string, frame?: DataFrame) =>
 type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterValueType = (value: string, refId?: string) => void;
 type onClickFilterOutStringType = (value: string, refId?: string) => void;
-type isFilterLabelActiveType = (key: string, value: string, refId?: string) => Promise<boolean>;
-type isOnClickShowFieldType = (value: string) => void;
-type isOnClickHideFieldType = (value: string) => void;
+type filterLabelActiveType = (key: string, value: string, refId?: string) => Promise<boolean>;
+type onClickShowFieldType = (value: string) => void;
+type onClickHideFieldType = (value: string) => void;
 export type onNewLogsReceivedType = (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
 type onLogOptionsChangeType = (option: keyof LogListControlOptions, value: string | boolean | string[]) => void;
+type setDisplayedFieldsType = (fields: string[]) => void;
 
 export type GetFieldLinksFn = (
   field: Field,
@@ -39,15 +40,19 @@ export function isOnClickFilterOutString(callback: unknown): callback is onClick
   return typeof callback === 'function';
 }
 
-export function isIsFilterLabelActive(callback: unknown): callback is isFilterLabelActiveType {
+export function isIsFilterLabelActive(callback: unknown): callback is filterLabelActiveType {
   return typeof callback === 'function';
 }
 
-export function isOnClickShowField(callback: unknown): callback is isOnClickShowFieldType {
+export function isOnClickShowField(callback: unknown): callback is onClickShowFieldType {
   return typeof callback === 'function';
 }
 
-export function isOnClickHideField(callback: unknown): callback is isOnClickHideFieldType {
+export function isOnClickHideField(callback: unknown): callback is onClickHideFieldType {
+  return typeof callback === 'function';
+}
+
+export function isSetDisplayedFields(callback: unknown): callback is setDisplayedFieldsType {
   return typeof callback === 'function';
 }
 


### PR DESCRIPTION
This PR introduces experimental OTel formatting to the new logs panel. This works by looking for the presence of a label with the name `severity_number` and another `telemetry_sdk_language` with a non-empty value. When this label is present, the line is interpreted as an OTel log line, and formatting is applied. 

The format consist of:
- Displayed fields. If some of these fields are present, they will be added as displayed fields: 'scope_name', 'thread_name', 'exception_type', and 'exception_message'
- Augmented log line. From the list of labels, those that don't match the regular expressions OTEL_RESOURCE_ATTRS_REGEX and OTEL_LOG_FIELDS_REGEX are appended to the original log line as logfmt.

Example.

Original log line:

<img width="801" height="41" alt="imagen" src="https://github.com/user-attachments/assets/008800f7-1524-4745-9dbb-4567c18e6cde" />

OTel log line:

<img width="1475" height="71" alt="imagen" src="https://github.com/user-attachments/assets/a130fb58-c2af-479e-b319-b794888b8766" />


Requires `otelLogsFormatting` enabled.
Requires `newLogsPanel` enabled.

Drilldown requires https://github.com/grafana/logs-drilldown/pull/1421
Part of https://github.com/grafana/grafana/issues/101083