### PR TITLE
Use v2alpha2 by default

### DIFF
--- a/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2alpha1/dashboard_spec.cue
@@ -111,8 +111,6 @@ DashboardLink: {
 	keepTime: bool | *false
 }
 
-// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
-// This type is widely used in the codebase and changing it will have a big impact
 DataSourceRef: {
 	// The plugin type-id
 	type?: string
@@ -387,14 +385,15 @@ VizConfigKind: {
 }
 
 AnnotationQuerySpec: {
-	query:      DataQueryKind
+	datasource?: DataSourceRef
+	query?:      DataQueryKind
 	enable:      bool
 	hide:        bool
 	iconColor:   string
 	name:        string
 	builtIn?:    bool | *false
 	filter?:     AnnotationPanelFilter
-	legacyOptions?:     [string]: _ // Catch-all field for datasource-specific properties. Should not be available in as code tooling.
+	legacyOptions?:     [string]: _ //Catch-all field for datasource-specific properties
 }
 
 AnnotationQueryKind: {
@@ -413,19 +412,15 @@ QueryOptionsSpec: {
 }
 
 DataQueryKind: {
-	kind: "DataQuery"
-	group: string
-	version: string | *"v0"
-	// New type for datasource reference
-	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
-	datasource?: {
-		name?: string
-	}
+	// The kind of a DataQueryKind is the datasource type
+	kind: string
 	spec: [string]: _
 }
 
 PanelQuerySpec: {
 	query:       DataQueryKind
+	datasource?: DataSourceRef
+
 	refId:  string
 	hidden: bool
 }
@@ -728,6 +723,7 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
+	datasource?:  DataSourceRef
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort

--- a/apps/dashboard/kinds/v2alpha2/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2alpha2/dashboard_spec.cue
@@ -111,6 +111,8 @@ DashboardLink: {
 	keepTime: bool | *false
 }
 
+// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
+// This type is widely used in the codebase and changing it will have a big impact
 DataSourceRef: {
 	// The plugin type-id
 	type?: string
@@ -385,15 +387,14 @@ VizConfigKind: {
 }
 
 AnnotationQuerySpec: {
-	datasource?: DataSourceRef
-	query?:      DataQueryKind
+	query:      DataQueryKind
 	enable:      bool
 	hide:        bool
 	iconColor:   string
 	name:        string
 	builtIn?:    bool | *false
 	filter?:     AnnotationPanelFilter
-	legacyOptions?:     [string]: _ //Catch-all field for datasource-specific properties
+	legacyOptions?:     [string]: _ // Catch-all field for datasource-specific properties. Should not be available in as code tooling.
 }
 
 AnnotationQueryKind: {
@@ -412,15 +413,19 @@ QueryOptionsSpec: {
 }
 
 DataQueryKind: {
-	// The kind of a DataQueryKind is the datasource type
-	kind: string
+	kind: "DataQuery"
+	group: string
+	version: string | *"v0"
+	// New type for datasource reference
+	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
+	datasource?: {
+		name?: string
+	}
 	spec: [string]: _
 }
 
 PanelQuerySpec: {
 	query:       DataQueryKind
-	datasource?: DataSourceRef
-
 	refId:  string
 	hidden: bool
 }
@@ -723,7 +728,6 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
-	datasource?:  DataSourceRef
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec.cue
@@ -115,8 +115,6 @@ DashboardLink: {
 	keepTime: bool | *false
 }
 
-// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
-// This type is widely used in the codebase and changing it will have a big impact
 DataSourceRef: {
 	// The plugin type-id
 	type?: string
@@ -391,14 +389,15 @@ VizConfigKind: {
 }
 
 AnnotationQuerySpec: {
-	query:      DataQueryKind
+	datasource?: DataSourceRef
+	query?:      DataQueryKind
 	enable:      bool
 	hide:        bool
 	iconColor:   string
 	name:        string
 	builtIn?:    bool | *false
 	filter?:     AnnotationPanelFilter
-	legacyOptions?:     [string]: _ // Catch-all field for datasource-specific properties. Should not be available in as code tooling.
+	legacyOptions?:     [string]: _ //Catch-all field for datasource-specific properties
 }
 
 AnnotationQueryKind: {
@@ -417,19 +416,15 @@ QueryOptionsSpec: {
 }
 
 DataQueryKind: {
-	kind: "DataQuery"
-	group: string
-	version: string | *"v0"
-	// New type for datasource reference
-	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
-	datasource?: {
-		name?: string
-	}
+	// The kind of a DataQueryKind is the datasource type
+	kind: string
 	spec: [string]: _
 }
 
 PanelQuerySpec: {
 	query:       DataQueryKind
+	datasource?: DataSourceRef
+
 	refId:  string
 	hidden: bool
 }
@@ -732,6 +727,7 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
+	datasource?:  DataSourceRef
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/dashboard_spec_gen.go
@@ -23,42 +23,49 @@ func NewDashboardAnnotationQueryKind() *DashboardAnnotationQueryKind {
 
 // +k8s:openapi-gen=true
 type DashboardAnnotationQuerySpec struct {
-	Query     DashboardDataQueryKind          `json:"query"`
-	Enable    bool                            `json:"enable"`
-	Hide      bool                            `json:"hide"`
-	IconColor string                          `json:"iconColor"`
-	Name      string                          `json:"name"`
-	BuiltIn   *bool                           `json:"builtIn,omitempty"`
-	Filter    *DashboardAnnotationPanelFilter `json:"filter,omitempty"`
-	// Catch-all field for datasource-specific properties. Should not be available in as code tooling.
+	Datasource *DashboardDataSourceRef         `json:"datasource,omitempty"`
+	Query      *DashboardDataQueryKind         `json:"query,omitempty"`
+	Enable     bool                            `json:"enable"`
+	Hide       bool                            `json:"hide"`
+	IconColor  string                          `json:"iconColor"`
+	Name       string                          `json:"name"`
+	BuiltIn    *bool                           `json:"builtIn,omitempty"`
+	Filter     *DashboardAnnotationPanelFilter `json:"filter,omitempty"`
+	// Catch-all field for datasource-specific properties
 	LegacyOptions map[string]interface{} `json:"legacyOptions,omitempty"`
 }
 
 // NewDashboardAnnotationQuerySpec creates a new DashboardAnnotationQuerySpec object.
 func NewDashboardAnnotationQuerySpec() *DashboardAnnotationQuerySpec {
 	return &DashboardAnnotationQuerySpec{
-		Query:   *NewDashboardDataQueryKind(),
 		BuiltIn: (func(input bool) *bool { return &input })(false),
 	}
 }
 
 // +k8s:openapi-gen=true
+type DashboardDataSourceRef struct {
+	// The plugin type-id
+	Type *string `json:"type,omitempty"`
+	// Specific datasource instance
+	Uid *string `json:"uid,omitempty"`
+}
+
+// NewDashboardDataSourceRef creates a new DashboardDataSourceRef object.
+func NewDashboardDataSourceRef() *DashboardDataSourceRef {
+	return &DashboardDataSourceRef{}
+}
+
+// +k8s:openapi-gen=true
 type DashboardDataQueryKind struct {
-	Kind    string `json:"kind"`
-	Group   string `json:"group"`
-	Version string `json:"version"`
-	// New type for datasource reference
-	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
-	Datasource *DashboardV2alpha1DataQueryKindDatasource `json:"datasource,omitempty"`
-	Spec       map[string]interface{}                    `json:"spec"`
+	// The kind of a DataQueryKind is the datasource type
+	Kind string                 `json:"kind"`
+	Spec map[string]interface{} `json:"spec"`
 }
 
 // NewDashboardDataQueryKind creates a new DashboardDataQueryKind object.
 func NewDashboardDataQueryKind() *DashboardDataQueryKind {
 	return &DashboardDataQueryKind{
-		Kind:    "DataQuery",
-		Version: "v0",
-		Spec:    map[string]interface{}{},
+		Spec: map[string]interface{}{},
 	}
 }
 
@@ -192,9 +199,10 @@ func NewDashboardPanelQueryKind() *DashboardPanelQueryKind {
 
 // +k8s:openapi-gen=true
 type DashboardPanelQuerySpec struct {
-	Query  DashboardDataQueryKind `json:"query"`
-	RefId  string                 `json:"refId"`
-	Hidden bool                   `json:"hidden"`
+	Query      DashboardDataQueryKind  `json:"query"`
+	Datasource *DashboardDataSourceRef `json:"datasource,omitempty"`
+	RefId      string                  `json:"refId"`
+	Hidden     bool                    `json:"hidden"`
 }
 
 // NewDashboardPanelQuerySpec creates a new DashboardPanelQuerySpec object.
@@ -1221,6 +1229,7 @@ type DashboardQueryVariableSpec struct {
 	Refresh            DashboardVariableRefresh                      `json:"refresh"`
 	SkipUrlSync        bool                                          `json:"skipUrlSync"`
 	Description        *string                                       `json:"description,omitempty"`
+	Datasource         *DashboardDataSourceRef                       `json:"datasource,omitempty"`
 	Query              DashboardDataQueryKind                        `json:"query"`
 	Regex              string                                        `json:"regex"`
 	Sort               DashboardVariableSort                         `json:"sort"`
@@ -1628,21 +1637,6 @@ func NewDashboardGroupByVariableSpec() *DashboardGroupByVariableSpec {
 	}
 }
 
-// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
-// This type is widely used in the codebase and changing it will have a big impact
-// +k8s:openapi-gen=true
-type DashboardDataSourceRef struct {
-	// The plugin type-id
-	Type *string `json:"type,omitempty"`
-	// Specific datasource instance
-	Uid *string `json:"uid,omitempty"`
-}
-
-// NewDashboardDataSourceRef creates a new DashboardDataSourceRef object.
-func NewDashboardDataSourceRef() *DashboardDataSourceRef {
-	return &DashboardDataSourceRef{}
-}
-
 // Adhoc variable kind
 // +k8s:openapi-gen=true
 type DashboardAdhocVariableKind struct {
@@ -1774,16 +1768,6 @@ func NewDashboardSpec() *DashboardSpec {
 		TimeSettings: *NewDashboardTimeSettingsSpec(),
 		Variables:    []DashboardVariableKind{},
 	}
-}
-
-// +k8s:openapi-gen=true
-type DashboardV2alpha1DataQueryKindDatasource struct {
-	Name *string `json:"name,omitempty"`
-}
-
-// NewDashboardV2alpha1DataQueryKindDatasource creates a new DashboardV2alpha1DataQueryKindDatasource object.
-func NewDashboardV2alpha1DataQueryKindDatasource() *DashboardV2alpha1DataQueryKindDatasource {
-	return &DashboardV2alpha1DataQueryKindDatasource{}
 }
 
 // +k8s:openapi-gen=true

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/zz_generated.openapi.go
@@ -109,7 +109,6 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardTimeRangeOption":                                                                                                                                                     schema_pkg_apis_dashboard_v2alpha1_DashboardTimeRangeOption(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardTimeSettingsSpec":                                                                                                                                                    schema_pkg_apis_dashboard_v2alpha1_DashboardTimeSettingsSpec(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardTransformationKind":                                                                                                                                                  schema_pkg_apis_dashboard_v2alpha1_DashboardTransformationKind(ref),
-		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1DataQueryKindDatasource":                                                                                                                                     schema_pkg_apis_dashboard_v2alpha1_DashboardV2alpha1DataQueryKindDatasource(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1FieldConfigSourceOverrides":                                                                                                                                  schema_pkg_apis_dashboard_v2alpha1_DashboardV2alpha1FieldConfigSourceOverrides(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1RangeMapOptions":                                                                                                                                             schema_pkg_apis_dashboard_v2alpha1_DashboardV2alpha1RangeMapOptions(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1RegexMapOptions":                                                                                                                                             schema_pkg_apis_dashboard_v2alpha1_DashboardV2alpha1RegexMapOptions(ref),
@@ -596,10 +595,14 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardAnnotationQuerySpec(ref common.
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"datasource": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef"),
+						},
+					},
 					"query": {
 						SchemaProps: spec.SchemaProps{
-							Default: map[string]interface{}{},
-							Ref:     ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind"),
+							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind"),
 						},
 					},
 					"enable": {
@@ -643,7 +646,7 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardAnnotationQuerySpec(ref common.
 					},
 					"legacyOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Catch-all field for datasource-specific properties. Should not be available in as code tooling.",
+							Description: "Catch-all field for datasource-specific properties",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -657,11 +660,11 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardAnnotationQuerySpec(ref common.
 						},
 					},
 				},
-				Required: []string{"query", "enable", "hide", "iconColor", "name"},
+				Required: []string{"enable", "hide", "iconColor", "name"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardAnnotationPanelFilter", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardAnnotationPanelFilter", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef"},
 	}
 }
 
@@ -1502,29 +1505,10 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardDataQueryKind(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-					"group": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-					"version": {
-						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
-						},
-					},
-					"datasource": {
-						SchemaProps: spec.SchemaProps{
-							Description: "New type for datasource reference Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.",
-							Ref:         ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1DataQueryKindDatasource"),
+							Description: "The kind of a DataQueryKind is the datasource type",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"spec": {
@@ -1542,11 +1526,9 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardDataQueryKind(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"kind", "group", "version", "spec"},
+				Required: []string{"kind", "spec"},
 			},
 		},
-		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardV2alpha1DataQueryKindDatasource"},
 	}
 }
 
@@ -1554,8 +1536,7 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardDataSourceRef(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec This type is widely used in the codebase and changing it will have a big impact",
-				Type:        []string{"object"},
+				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -2909,6 +2890,11 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardPanelQuerySpec(ref common.Refer
 							Ref:     ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind"),
 						},
 					},
+					"datasource": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef"),
+						},
+					},
 					"refId": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -2928,7 +2914,7 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardPanelQuerySpec(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef"},
 	}
 }
 
@@ -3264,6 +3250,11 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardQueryVariableSpec(ref common.Re
 							Format: "",
 						},
 					},
+					"datasource": {
+						SchemaProps: spec.SchemaProps{
+							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef"),
+						},
+					},
 					"query": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -3360,7 +3351,7 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardQueryVariableSpec(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardVariableOption"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataSourceRef", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardVariableOption"},
 	}
 }
 
@@ -4345,24 +4336,6 @@ func schema_pkg_apis_dashboard_v2alpha1_DashboardTransformationKind(ref common.R
 		},
 		Dependencies: []string{
 			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1.DashboardDataTransformerConfig"},
-	}
-}
-
-func schema_pkg_apis_dashboard_v2alpha1_DashboardV2alpha1DataQueryKindDatasource(ref common.ReferenceCallback) common.OpenAPIDefinition {
-	return common.OpenAPIDefinition{
-		Schema: spec.Schema{
-			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
-				Properties: map[string]spec.Schema{
-					"name": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-				},
-			},
-		},
 	}
 }
 

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha2/dashboard_spec.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha2/dashboard_spec.cue
@@ -115,6 +115,8 @@ DashboardLink: {
 	keepTime: bool | *false
 }
 
+// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
+// This type is widely used in the codebase and changing it will have a big impact
 DataSourceRef: {
 	// The plugin type-id
 	type?: string
@@ -389,15 +391,14 @@ VizConfigKind: {
 }
 
 AnnotationQuerySpec: {
-	datasource?: DataSourceRef
-	query?:      DataQueryKind
+	query:      DataQueryKind
 	enable:      bool
 	hide:        bool
 	iconColor:   string
 	name:        string
 	builtIn?:    bool | *false
 	filter?:     AnnotationPanelFilter
-	legacyOptions?:     [string]: _ //Catch-all field for datasource-specific properties
+	legacyOptions?:     [string]: _ // Catch-all field for datasource-specific properties. Should not be available in as code tooling.
 }
 
 AnnotationQueryKind: {
@@ -416,15 +417,19 @@ QueryOptionsSpec: {
 }
 
 DataQueryKind: {
-	// The kind of a DataQueryKind is the datasource type
-	kind: string
+	kind: "DataQuery"
+	group: string
+	version: string | *"v0"
+	// New type for datasource reference
+	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
+	datasource?: {
+		name?: string
+	}
 	spec: [string]: _
 }
 
 PanelQuerySpec: {
 	query:       DataQueryKind
-	datasource?: DataSourceRef
-
 	refId:  string
 	hidden: bool
 }
@@ -727,7 +732,6 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
-	datasource?:  DataSourceRef
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha2/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha2/dashboard_spec_gen.go
@@ -23,49 +23,42 @@ func NewDashboardAnnotationQueryKind() *DashboardAnnotationQueryKind {
 
 // +k8s:openapi-gen=true
 type DashboardAnnotationQuerySpec struct {
-	Datasource *DashboardDataSourceRef         `json:"datasource,omitempty"`
-	Query      *DashboardDataQueryKind         `json:"query,omitempty"`
-	Enable     bool                            `json:"enable"`
-	Hide       bool                            `json:"hide"`
-	IconColor  string                          `json:"iconColor"`
-	Name       string                          `json:"name"`
-	BuiltIn    *bool                           `json:"builtIn,omitempty"`
-	Filter     *DashboardAnnotationPanelFilter `json:"filter,omitempty"`
-	// Catch-all field for datasource-specific properties
+	Query     DashboardDataQueryKind          `json:"query"`
+	Enable    bool                            `json:"enable"`
+	Hide      bool                            `json:"hide"`
+	IconColor string                          `json:"iconColor"`
+	Name      string                          `json:"name"`
+	BuiltIn   *bool                           `json:"builtIn,omitempty"`
+	Filter    *DashboardAnnotationPanelFilter `json:"filter,omitempty"`
+	// Catch-all field for datasource-specific properties. Should not be available in as code tooling.
 	LegacyOptions map[string]interface{} `json:"legacyOptions,omitempty"`
 }
 
 // NewDashboardAnnotationQuerySpec creates a new DashboardAnnotationQuerySpec object.
 func NewDashboardAnnotationQuerySpec() *DashboardAnnotationQuerySpec {
 	return &DashboardAnnotationQuerySpec{
+		Query:   *NewDashboardDataQueryKind(),
 		BuiltIn: (func(input bool) *bool { return &input })(false),
 	}
 }
 
 // +k8s:openapi-gen=true
-type DashboardDataSourceRef struct {
-	// The plugin type-id
-	Type *string `json:"type,omitempty"`
-	// Specific datasource instance
-	Uid *string `json:"uid,omitempty"`
-}
-
-// NewDashboardDataSourceRef creates a new DashboardDataSourceRef object.
-func NewDashboardDataSourceRef() *DashboardDataSourceRef {
-	return &DashboardDataSourceRef{}
-}
-
-// +k8s:openapi-gen=true
 type DashboardDataQueryKind struct {
-	// The kind of a DataQueryKind is the datasource type
-	Kind string                 `json:"kind"`
-	Spec map[string]interface{} `json:"spec"`
+	Kind    string `json:"kind"`
+	Group   string `json:"group"`
+	Version string `json:"version"`
+	// New type for datasource reference
+	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
+	Datasource *DashboardV2alpha2DataQueryKindDatasource `json:"datasource,omitempty"`
+	Spec       map[string]interface{}                    `json:"spec"`
 }
 
 // NewDashboardDataQueryKind creates a new DashboardDataQueryKind object.
 func NewDashboardDataQueryKind() *DashboardDataQueryKind {
 	return &DashboardDataQueryKind{
-		Spec: map[string]interface{}{},
+		Kind:    "DataQuery",
+		Version: "v0",
+		Spec:    map[string]interface{}{},
 	}
 }
 
@@ -199,10 +192,9 @@ func NewDashboardPanelQueryKind() *DashboardPanelQueryKind {
 
 // +k8s:openapi-gen=true
 type DashboardPanelQuerySpec struct {
-	Query      DashboardDataQueryKind  `json:"query"`
-	Datasource *DashboardDataSourceRef `json:"datasource,omitempty"`
-	RefId      string                  `json:"refId"`
-	Hidden     bool                    `json:"hidden"`
+	Query  DashboardDataQueryKind `json:"query"`
+	RefId  string                 `json:"refId"`
+	Hidden bool                   `json:"hidden"`
 }
 
 // NewDashboardPanelQuerySpec creates a new DashboardPanelQuerySpec object.
@@ -1229,7 +1221,6 @@ type DashboardQueryVariableSpec struct {
 	Refresh            DashboardVariableRefresh                      `json:"refresh"`
 	SkipUrlSync        bool                                          `json:"skipUrlSync"`
 	Description        *string                                       `json:"description,omitempty"`
-	Datasource         *DashboardDataSourceRef                       `json:"datasource,omitempty"`
 	Query              DashboardDataQueryKind                        `json:"query"`
 	Regex              string                                        `json:"regex"`
 	Sort               DashboardVariableSort                         `json:"sort"`
@@ -1637,6 +1628,21 @@ func NewDashboardGroupByVariableSpec() *DashboardGroupByVariableSpec {
 	}
 }
 
+// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
+// This type is widely used in the codebase and changing it will have a big impact
+// +k8s:openapi-gen=true
+type DashboardDataSourceRef struct {
+	// The plugin type-id
+	Type *string `json:"type,omitempty"`
+	// Specific datasource instance
+	Uid *string `json:"uid,omitempty"`
+}
+
+// NewDashboardDataSourceRef creates a new DashboardDataSourceRef object.
+func NewDashboardDataSourceRef() *DashboardDataSourceRef {
+	return &DashboardDataSourceRef{}
+}
+
 // Adhoc variable kind
 // +k8s:openapi-gen=true
 type DashboardAdhocVariableKind struct {
@@ -1768,6 +1774,16 @@ func NewDashboardSpec() *DashboardSpec {
 		TimeSettings: *NewDashboardTimeSettingsSpec(),
 		Variables:    []DashboardVariableKind{},
 	}
+}
+
+// +k8s:openapi-gen=true
+type DashboardV2alpha2DataQueryKindDatasource struct {
+	Name *string `json:"name,omitempty"`
+}
+
+// NewDashboardV2alpha2DataQueryKindDatasource creates a new DashboardV2alpha2DataQueryKindDatasource object.
+func NewDashboardV2alpha2DataQueryKindDatasource() *DashboardV2alpha2DataQueryKindDatasource {
+	return &DashboardV2alpha2DataQueryKindDatasource{}
 }
 
 // +k8s:openapi-gen=true

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha2/zz_generated.openapi.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha2/zz_generated.openapi.go
@@ -109,6 +109,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardTimeRangeOption":                                                                                                                                                     schema_pkg_apis_dashboard_v2alpha2_DashboardTimeRangeOption(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardTimeSettingsSpec":                                                                                                                                                    schema_pkg_apis_dashboard_v2alpha2_DashboardTimeSettingsSpec(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardTransformationKind":                                                                                                                                                  schema_pkg_apis_dashboard_v2alpha2_DashboardTransformationKind(ref),
+		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2DataQueryKindDatasource":                                                                                                                                     schema_pkg_apis_dashboard_v2alpha2_DashboardV2alpha2DataQueryKindDatasource(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2FieldConfigSourceOverrides":                                                                                                                                  schema_pkg_apis_dashboard_v2alpha2_DashboardV2alpha2FieldConfigSourceOverrides(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2RangeMapOptions":                                                                                                                                             schema_pkg_apis_dashboard_v2alpha2_DashboardV2alpha2RangeMapOptions(ref),
 		"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2RegexMapOptions":                                                                                                                                             schema_pkg_apis_dashboard_v2alpha2_DashboardV2alpha2RegexMapOptions(ref),
@@ -595,14 +596,10 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardAnnotationQuerySpec(ref common.
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
-					"datasource": {
-						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef"),
-						},
-					},
 					"query": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind"),
+							Default: map[string]interface{}{},
+							Ref:     ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind"),
 						},
 					},
 					"enable": {
@@ -646,7 +643,7 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardAnnotationQuerySpec(ref common.
 					},
 					"legacyOptions": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Catch-all field for datasource-specific properties",
+							Description: "Catch-all field for datasource-specific properties. Should not be available in as code tooling.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,
@@ -660,11 +657,11 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardAnnotationQuerySpec(ref common.
 						},
 					},
 				},
-				Required: []string{"enable", "hide", "iconColor", "name"},
+				Required: []string{"query", "enable", "hide", "iconColor", "name"},
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardAnnotationPanelFilter", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardAnnotationPanelFilter", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind"},
 	}
 }
 
@@ -1505,10 +1502,29 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardDataQueryKind(ref common.Refere
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The kind of a DataQueryKind is the datasource type",
-							Default:     "",
-							Type:        []string{"string"},
-							Format:      "",
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"group": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Default: "",
+							Type:    []string{"string"},
+							Format:  "",
+						},
+					},
+					"datasource": {
+						SchemaProps: spec.SchemaProps{
+							Description: "New type for datasource reference Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.",
+							Ref:         ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2DataQueryKindDatasource"),
 						},
 					},
 					"spec": {
@@ -1526,9 +1542,11 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardDataQueryKind(ref common.Refere
 						},
 					},
 				},
-				Required: []string{"kind", "spec"},
+				Required: []string{"kind", "group", "version", "spec"},
 			},
 		},
+		Dependencies: []string{
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardV2alpha2DataQueryKindDatasource"},
 	}
 }
 
@@ -1536,7 +1554,8 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardDataSourceRef(ref common.Refere
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec This type is widely used in the codebase and changing it will have a big impact",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
@@ -2890,11 +2909,6 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardPanelQuerySpec(ref common.Refer
 							Ref:     ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind"),
 						},
 					},
-					"datasource": {
-						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef"),
-						},
-					},
 					"refId": {
 						SchemaProps: spec.SchemaProps{
 							Default: "",
@@ -2914,7 +2928,7 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardPanelQuerySpec(ref common.Refer
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind"},
 	}
 }
 
@@ -3250,11 +3264,6 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardQueryVariableSpec(ref common.Re
 							Format: "",
 						},
 					},
-					"datasource": {
-						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef"),
-						},
-					},
 					"query": {
 						SchemaProps: spec.SchemaProps{
 							Default: map[string]interface{}{},
@@ -3351,7 +3360,7 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardQueryVariableSpec(ref common.Re
 			},
 		},
 		Dependencies: []string{
-			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataSourceRef", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardVariableOption"},
+			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataQueryKind", "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardVariableOption"},
 	}
 }
 
@@ -4336,6 +4345,24 @@ func schema_pkg_apis_dashboard_v2alpha2_DashboardTransformationKind(ref common.R
 		},
 		Dependencies: []string{
 			"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha2.DashboardDataTransformerConfig"},
+	}
+}
+
+func schema_pkg_apis_dashboard_v2alpha2_DashboardV2alpha2DataQueryKindDatasource(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Type: []string{"object"},
+				Properties: map[string]spec.Schema{
+					"name": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/packages/grafana-schema/src/schema/dashboard/v2.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2.ts
@@ -1,3 +1,3 @@
-export * from './v2alpha1/types.spec.gen';
+export * from './v2alpha2/types.spec.gen';
 export * from './v2alpha2/types.status.gen';
 export * from './v2alpha2/types.metadata.gen';

--- a/packages/grafana-schema/src/schema/dashboard/v2.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2.ts
@@ -1,0 +1,3 @@
+export * from './v2alpha1/types.spec.gen';
+export * from './v2alpha2/types.status.gen';
+export * from './v2alpha2/types.metadata.gen';

--- a/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
@@ -1,4 +1,4 @@
-import { defaultDataQueryKind, Spec } from './v2alpha1/types.spec.gen';
+import { defaultDataQueryKind, Spec } from './v2alpha2/types.spec.gen';
 
 export const handyTestingSchema: Spec = {
   title: 'Default Dashboard',

--- a/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
@@ -1,4 +1,4 @@
-import { defaultDataQueryKind, Spec } from './v2alpha2/types.spec.gen';
+import { defaultDataQueryKind, Spec } from './v2';
 
 export const handyTestingSchema: Spec = {
   title: 'Default Dashboard',

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha1/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha1/types.spec.gen.ts
@@ -11,19 +11,19 @@ export const defaultAnnotationQueryKind = (): AnnotationQueryKind => ({
 });
 
 export interface AnnotationQuerySpec {
-	query: DataQueryKind;
+	datasource?: DataSourceRef;
+	query?: DataQueryKind;
 	enable: boolean;
 	hide: boolean;
 	iconColor: string;
 	name: string;
 	builtIn?: boolean;
 	filter?: AnnotationPanelFilter;
-	// Catch-all field for datasource-specific properties. Should not be available in as code tooling.
+	// Catch-all field for datasource-specific properties
 	legacyOptions?: Record<string, any>;
 }
 
 export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
-	query: defaultDataQueryKind(),
 	enable: false,
 	hide: false,
 	iconColor: "",
@@ -31,22 +31,24 @@ export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
 	builtIn: false,
 });
 
+export interface DataSourceRef {
+	// The plugin type-id
+	type?: string;
+	// Specific datasource instance
+	uid?: string;
+}
+
+export const defaultDataSourceRef = (): DataSourceRef => ({
+});
+
 export interface DataQueryKind {
-	kind: "DataQuery";
-	group: string;
-	version: string;
-	// New type for datasource reference
-	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
-	datasource?: {
-		name?: string;
-	};
+	// The kind of a DataQueryKind is the datasource type
+	kind: string;
 	spec: Record<string, any>;
 }
 
 export const defaultDataQueryKind = (): DataQueryKind => ({
-	kind: "DataQuery",
-	group: "",
-	version: "v0",
+	kind: "",
 	spec: {},
 });
 
@@ -149,6 +151,7 @@ export const defaultPanelQueryKind = (): PanelQueryKind => ({
 
 export interface PanelQuerySpec {
 	query: DataQueryKind;
+	datasource?: DataSourceRef;
 	refId: string;
 	hidden: boolean;
 }
@@ -991,6 +994,7 @@ export interface QueryVariableSpec {
 	refresh: VariableRefresh;
 	skipUrlSync: boolean;
 	description?: string;
+	datasource?: DataSourceRef;
 	query: DataQueryKind;
 	regex: string;
 	sort: VariableSort;
@@ -1279,18 +1283,6 @@ export const defaultGroupByVariableSpec = (): GroupByVariableSpec => ({
 	multi: false,
 	hide: "dontHide",
 	skipUrlSync: false,
-});
-
-// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
-// This type is widely used in the codebase and changing it will have a big impact
-export interface DataSourceRef {
-	// The plugin type-id
-	type?: string;
-	// Specific datasource instance
-	uid?: string;
-}
-
-export const defaultDataSourceRef = (): DataSourceRef => ({
 });
 
 // Adhoc variable kind

--- a/packages/grafana-schema/src/schema/dashboard/v2alpha2/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2alpha2/types.spec.gen.ts
@@ -11,19 +11,19 @@ export const defaultAnnotationQueryKind = (): AnnotationQueryKind => ({
 });
 
 export interface AnnotationQuerySpec {
-	datasource?: DataSourceRef;
-	query?: DataQueryKind;
+	query: DataQueryKind;
 	enable: boolean;
 	hide: boolean;
 	iconColor: string;
 	name: string;
 	builtIn?: boolean;
 	filter?: AnnotationPanelFilter;
-	// Catch-all field for datasource-specific properties
+	// Catch-all field for datasource-specific properties. Should not be available in as code tooling.
 	legacyOptions?: Record<string, any>;
 }
 
 export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
+	query: defaultDataQueryKind(),
 	enable: false,
 	hide: false,
 	iconColor: "",
@@ -31,24 +31,22 @@ export const defaultAnnotationQuerySpec = (): AnnotationQuerySpec => ({
 	builtIn: false,
 });
 
-export interface DataSourceRef {
-	// The plugin type-id
-	type?: string;
-	// Specific datasource instance
-	uid?: string;
-}
-
-export const defaultDataSourceRef = (): DataSourceRef => ({
-});
-
 export interface DataQueryKind {
-	// The kind of a DataQueryKind is the datasource type
-	kind: string;
+	kind: "DataQuery";
+	group: string;
+	version: string;
+	// New type for datasource reference
+	// Not creating a new type until we figure out how to handle DS refs for group by, adhoc, and every place that uses DataSourceRef in TS.
+	datasource?: {
+		name?: string;
+	};
 	spec: Record<string, any>;
 }
 
 export const defaultDataQueryKind = (): DataQueryKind => ({
-	kind: "",
+	kind: "DataQuery",
+	group: "",
+	version: "v0",
 	spec: {},
 });
 
@@ -151,7 +149,6 @@ export const defaultPanelQueryKind = (): PanelQueryKind => ({
 
 export interface PanelQuerySpec {
 	query: DataQueryKind;
-	datasource?: DataSourceRef;
 	refId: string;
 	hidden: boolean;
 }
@@ -994,7 +991,6 @@ export interface QueryVariableSpec {
 	refresh: VariableRefresh;
 	skipUrlSync: boolean;
 	description?: string;
-	datasource?: DataSourceRef;
 	query: DataQueryKind;
 	regex: string;
 	sort: VariableSort;
@@ -1283,6 +1279,18 @@ export const defaultGroupByVariableSpec = (): GroupByVariableSpec => ({
 	multi: false,
 	hide: "dontHide",
 	skipUrlSync: false,
+});
+
+// Keeping this for backwards compatibility for GroupByVariableSpec and AdhocVariableSpec
+// This type is widely used in the codebase and changing it will have a big impact
+export interface DataSourceRef {
+	// The plugin type-id
+	type?: string;
+	// Specific datasource instance
+	uid?: string;
+}
+
+export const defaultDataSourceRef = (): DataSourceRef => ({
 });
 
 // Adhoc variable kind

--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -6,7 +6,7 @@ import { defaultDashboard as defaultDashboardData } from '@grafana/schema';
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { DashboardSearchItemType } from 'app/features/search/types';

--- a/public/app/core/components/Select/DashboardPicker.test.tsx
+++ b/public/app/core/components/Select/DashboardPicker.test.tsx
@@ -6,7 +6,7 @@ import { defaultDashboard as defaultDashboardData } from '@grafana/schema';
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { DashboardSearchItemType } from 'app/features/search/types';
@@ -80,7 +80,7 @@ const mockDashboard: DashboardDTO = {
 };
 
 const mockDashboardV2: DashboardWithAccessInfo<DashboardV2Spec> = {
-  apiVersion: 'v2alpha1',
+  apiVersion: 'v2alpha2',
   kind: 'DashboardWithAccessInfo',
   spec: {
     ...defaultDashboardV2Spec(),

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -4,7 +4,7 @@ import { AppEvents, isTruthy, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { folderAPIv1beta1 as folderAPI } from 'app/api/clients/folder/v1beta1';
 import { createBaseQuery, handleRequestError } from 'app/api/createBaseQuery';
 import appEvents from 'app/core/app_events';

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -4,7 +4,7 @@ import { AppEvents, isTruthy, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { folderAPIv1beta1 as folderAPI } from 'app/api/clients/folder/v1beta1';
 import { createBaseQuery, handleRequestError } from 'app/api/createBaseQuery';
 import appEvents from 'app/core/app_events';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRendering.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRendering.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { ConditionalRenderingChangedEvent } from '../edit-pane/shared';
 

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRendering.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRendering.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObject, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { ConditionalRenderingChangedEvent } from '../edit-pane/shared';
 

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingData.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingData.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { PanelData } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingDataKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { ConditionalRenderingDataKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Combobox, ComboboxOption } from '@grafana/ui';
 
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingData.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingData.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { PanelData } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingDataKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { ConditionalRenderingDataKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Combobox, ComboboxOption } from '@grafana/ui';
 
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroup.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroup.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Stack } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroup.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroup.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Stack } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingTimeRangeSize.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingTimeRangeSize.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { rangeUtil, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Field, Select, useStyles2 } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingTimeRangeSize.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingTimeRangeSize.tsx
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { rangeUtil, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
-import { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Field, Select, useStyles2 } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingVariable.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, VariableDependencyConfig } from '@grafana/scenes';
-import { ConditionalRenderingVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { ConditionalRenderingVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Box, Combobox, ComboboxOption, Input, Stack } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingVariable.tsx
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, VariableDependencyConfig } from '@grafana/scenes';
-import { ConditionalRenderingVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { ConditionalRenderingVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Box, Combobox, ComboboxOption, Input, Stack } from '@grafana/ui';
 
 import { ConditionalRenderingBase, ConditionalRenderingBaseState } from './ConditionalRenderingBase';

--- a/public/app/features/dashboard-scene/conditional-rendering/types.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/types.ts
@@ -4,7 +4,7 @@ import {
   ConditionalRenderingGroupKind,
   ConditionalRenderingTimeRangeSizeKind,
   ConditionalRenderingVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { ConditionalRenderingData } from './ConditionalRenderingData';
 import { ConditionalRenderingGroup } from './ConditionalRenderingGroup';

--- a/public/app/features/dashboard-scene/conditional-rendering/types.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/types.ts
@@ -4,7 +4,7 @@ import {
   ConditionalRenderingGroupKind,
   ConditionalRenderingTimeRangeSizeKind,
   ConditionalRenderingVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { ConditionalRenderingData } from './ConditionalRenderingData';
 import { ConditionalRenderingGroup } from './ConditionalRenderingGroup';

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -4,7 +4,7 @@ import { BackendSrv, config, locationService, setBackendSrv } from '@grafana/run
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import store from 'app/core/store';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardVersionError, DashboardWithAccessInfo } from 'app/features/dashboard/api/types';

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.test.ts
@@ -4,7 +4,7 @@ import { BackendSrv, config, locationService, setBackendSrv } from '@grafana/run
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import store from 'app/core/store';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardVersionError, DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
@@ -97,7 +97,7 @@ const setupDashboardAPI = (
 const setupV1FailureV2Success = (
   v2Response: DashboardWithAccessInfo<DashboardV2Spec> = {
     access: {},
-    apiVersion: 'v2alpha1',
+    apiVersion: 'v2alpha2',
     kind: 'DashboardWithAccessInfo',
     metadata: {
       name: 'fake-dash',
@@ -108,7 +108,7 @@ const setupV1FailureV2Success = (
   }
 ) => {
   const getDashSpy = jest.fn();
-  setupLoadDashboardMockReject(new DashboardVersionError('v2alpha1'));
+  setupLoadDashboardMockReject(new DashboardVersionError('v2alpha2'));
   setupDashboardAPI(v2Response, getDashSpy);
   return getDashSpy;
 };
@@ -364,7 +364,7 @@ describe('DashboardScenePageStateManager v2', () => {
       setupDashboardAPI(
         {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash',
@@ -411,7 +411,7 @@ describe('DashboardScenePageStateManager v2', () => {
       setupDashboardAPI(
         {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash',
@@ -431,7 +431,7 @@ describe('DashboardScenePageStateManager v2', () => {
       setupDashboardAPI(
         {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash2',
@@ -454,7 +454,7 @@ describe('DashboardScenePageStateManager v2', () => {
       setupDashboardAPI(
         {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash',
@@ -479,7 +479,7 @@ describe('DashboardScenePageStateManager v2', () => {
       setupDashboardAPI(
         {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash',
@@ -576,7 +576,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -610,7 +610,7 @@ describe('DashboardScenePageStateManager v2', () => {
 
         loader.setDashboardCache('fake-dash', {
           access: {},
-          apiVersion: 'v2alpha1',
+          apiVersion: 'v2alpha2',
           kind: 'DashboardWithAccessInfo',
           metadata: {
             name: 'fake-dash',
@@ -633,7 +633,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -659,7 +659,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -694,7 +694,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -717,7 +717,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -742,7 +742,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -773,7 +773,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -794,7 +794,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -824,7 +824,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -858,7 +858,7 @@ describe('DashboardScenePageStateManager v2', () => {
         setupDashboardAPI(
           {
             access: {},
-            apiVersion: 'v2alpha1',
+            apiVersion: 'v2alpha2',
             kind: 'DashboardWithAccessInfo',
             metadata: {
               name: 'fake-dash',
@@ -875,7 +875,7 @@ describe('DashboardScenePageStateManager v2', () => {
         await loader.loadDashboard({ uid: 'fake-dash', route: DashboardRoutes.Normal });
 
         const mockLoader = {
-          loadDashboard: jest.fn().mockRejectedValue(new DashboardVersionError('v2alpha1')),
+          loadDashboard: jest.fn().mockRejectedValue(new DashboardVersionError('v2alpha2')),
         };
 
         loader['dashboardLoader'] = mockLoader as unknown as DashboardLoaderSrvV2;
@@ -948,7 +948,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       const originalFetchDashboard = v2Manager.fetchDashboard;
       v2Manager.fetchDashboard = jest.fn().mockResolvedValue({
         access: {},
-        apiVersion: 'v2alpha1',
+        apiVersion: 'v2alpha2',
         kind: 'DashboardWithAccessInfo',
         metadata: {
           name: 'fake-dash',
@@ -984,7 +984,7 @@ describe('UnifiedDashboardScenePageStateManager', () => {
       // V2 dashboard response
       const v2Response: DashboardWithAccessInfo<DashboardV2Spec> = {
         access: {},
-        apiVersion: 'v2alpha1',
+        apiVersion: 'v2alpha2',
         kind: 'DashboardWithAccessInfo',
         metadata: {
           name: 'v2-dash',
@@ -1590,7 +1590,7 @@ const v2ProvisionedDashboardResource = {
   resource: {
     type: {
       group: 'dashboard.grafana.app',
-      version: 'v2alpha1',
+      version: 'v2alpha2',
       kind: 'Dashboard',
       resource: 'dashboards',
     },
@@ -1598,7 +1598,7 @@ const v2ProvisionedDashboardResource = {
     existing: {},
     action: 'update',
     dryRun: {
-      apiVersion: 'dashboard.grafana.app/v2alpha1',
+      apiVersion: 'dashboard.grafana.app/v2alpha2',
       kind: 'Dashboard',
       metadata: {
         annotations: {

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -2,7 +2,7 @@ import { locationUtil, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { BASE_URL } from 'app/api/clients/provisioning/v0alpha1/baseAPI';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { getMessageFromError, getMessageIdFromError, getStatusFromError } from 'app/core/utils/errors';

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -2,7 +2,7 @@ import { locationUtil, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { BASE_URL } from 'app/api/clients/provisioning/v0alpha1/baseAPI';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { getMessageFromError, getMessageIdFromError, getStatusFromError } from 'app/core/utils/errors';
@@ -15,7 +15,7 @@ import {
 } from 'app/features/apiserver/types';
 import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardVersionError, DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
-import { isDashboardV2Resource, isDashboardV2Spec } from 'app/features/dashboard/api/utils';
+import { isDashboardV2Resource, isDashboardV2Spec, isV2StoredVersion } from 'app/features/dashboard/api/utils';
 import { dashboardLoaderSrv, DashboardLoaderSrvV2 } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { emitDashboardViewEvent } from 'app/features/dashboard/state/analyticsProcessor';
@@ -204,7 +204,7 @@ abstract class DashboardScenePageStateManagerBase<T>
     dryRun: any,
     provisioningPreview: ProvisioningPreview
   ) {
-    if (dryRun.apiVersion.split('/')[1] === 'v2alpha1') {
+    if (dryRun.apiVersion.split('/')[1] === 'v2alpha2') {
       return {
         ...dryRun,
         kind: 'DashboardWithAccessInfo',
@@ -751,7 +751,7 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       return await operation(this.activeManager);
     } catch (error) {
       if (error instanceof DashboardVersionError) {
-        const manager = error.data.storedVersion === 'v2alpha1' ? this.v2Manager : this.v1Manager;
+        const manager = isV2StoredVersion(error.data.storedVersion) ? this.v2Manager : this.v1Manager;
         this.activeManager = manager;
         return await operation(manager);
       } else {
@@ -797,7 +797,7 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
     try {
       return await this.v1Manager.loadSnapshotScene(slug);
     } catch (error) {
-      if (error instanceof DashboardVersionError && error.data.storedVersion === 'v2alpha1') {
+      if (error instanceof DashboardVersionError && isV2StoredVersion(error.data.storedVersion)) {
         return await this.v2Manager.loadSnapshotScene(slug);
       }
       throw new Error('Snapshot not found');

--- a/public/app/features/dashboard-scene/saving/DetectChangesWorker.ts
+++ b/public/app/features/dashboard-scene/saving/DetectChangesWorker.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { jsonDiff } from '../settings/version-history/utils';
 

--- a/public/app/features/dashboard-scene/saving/DetectChangesWorker.ts
+++ b/public/app/features/dashboard-scene/saving/DetectChangesWorker.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { jsonDiff } from '../settings/version-history/utils';
 

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -7,7 +7,7 @@ import {
   AdhocVariableSpec,
   Spec as DashboardV2Spec,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -7,7 +7,7 @@ import {
   AdhocVariableSpec,
   Spec as DashboardV2Spec,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard-scene/saving/shared.tsx
+++ b/public/app/features/dashboard-scene/saving/shared.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, isFetchError } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Alert, Box, Button, Stack } from '@grafana/ui';
 import { WorkflowOption } from 'app/features/provisioning/types';
 

--- a/public/app/features/dashboard-scene/saving/shared.tsx
+++ b/public/app/features/dashboard-scene/saving/shared.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, isFetchError } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Alert, Box, Button, Stack } from '@grafana/ui';
 import { WorkflowOption } from 'app/features/provisioning/types';
 

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -4,7 +4,7 @@ import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import appEvents from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -4,7 +4,7 @@ import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import appEvents from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -16,7 +16,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { Dashboard, DashboardLink, LibraryPanel } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import appEvents from 'app/core/app_events';
 import { ScrollRefElement } from 'app/core/components/NativeScrollbar';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
@@ -757,7 +757,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     const { meta } = this.state;
     const spec = this.getSaveAsModel(options);
 
-    const apiVersion = this.serializer instanceof V2DashboardSerializer ? 'v2alpha1' : 'v1beta1'; // get from the dashboard?
+    const apiVersion = this.serializer instanceof V2DashboardSerializer ? 'v2alpha2' : 'v1beta1'; // get from the dashboard?
     return {
       apiVersion: `dashboard.grafana.app/${apiVersion}`,
       kind: 'Dashboard',

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -16,7 +16,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { Dashboard, DashboardLink, LibraryPanel } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import appEvents from 'app/core/app_events';
 import { ScrollRefElement } from 'app/core/components/NativeScrollbar';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -2,8 +2,8 @@ import { find } from 'lodash';
 
 import { DataSourceInstanceSettings, DataSourceRef, PanelPluginMeta, TypedVariableModel } from '@grafana/data';
 import { Dashboard, DashboardCursorSync, ThresholdsMode } from '@grafana/schema';
-import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import { DatasourceVariableKind, QueryVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { createAdHocVariableAdapter } from 'app/features/variables/adhoc/adapter';

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -6,7 +6,7 @@ import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2
 import {
   DatasourceVariableKind,
   QueryVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { createAdHocVariableAdapter } from 'app/features/variables/adhoc/adapter';

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -3,10 +3,7 @@ import { find } from 'lodash';
 import { DataSourceInstanceSettings, DataSourceRef, PanelPluginMeta, TypedVariableModel } from '@grafana/data';
 import { Dashboard, DashboardCursorSync, ThresholdsMode } from '@grafana/schema';
 import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
-import {
-  DatasourceVariableKind,
-  QueryVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { DatasourceVariableKind, QueryVariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { createAdHocVariableAdapter } from 'app/features/variables/adhoc/adapter';

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -9,7 +9,7 @@ import {
   AnnotationQueryKind,
   QueryVariableKind,
   LibraryPanelRef,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel, GridPos } from 'app/features/dashboard/state/PanelModel';

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -9,7 +9,7 @@ import {
   AnnotationQueryKind,
   QueryVariableKind,
   LibraryPanelRef,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import config from 'app/core/config';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel, GridPos } from 'app/features/dashboard/state/PanelModel';

--- a/public/app/features/dashboard-scene/scene/export/utils.ts
+++ b/public/app/features/dashboard-scene/scene/export/utils.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 /**
  * Removes a panel reference from a layout.

--- a/public/app/features/dashboard-scene/scene/export/utils.ts
+++ b/public/app/features/dashboard-scene/scene/export/utils.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 /**
  * Removes a panel reference from a layout.

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,6 +1,6 @@
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -17,7 +17,7 @@ import {
   SceneGridLayoutDragStartEvent,
   SceneObject,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { useStyles2 } from '@grafana/ui';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -17,7 +17,7 @@ import {
   SceneGridLayoutDragStartEvent,
   SceneObject,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { useStyles2 } from '@grafana/ui';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -9,7 +9,7 @@ import {
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
-import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import appEvents from 'app/core/app_events';
 import { LS_ROW_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -9,7 +9,7 @@ import {
   VariableDependencyConfig,
   VizPanel,
 } from '@grafana/scenes';
-import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import appEvents from 'app/core/app_events';
 import { LS_ROW_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -8,7 +8,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeRowsLayout } from '../../serialization/layoutSerializers/RowsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -8,7 +8,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeRowsLayout } from '../../serialization/layoutSerializers/RowsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -9,7 +9,7 @@ import {
   SceneObject,
   VizPanel,
 } from '@grafana/scenes';
-import { TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { LS_TAB_COPY_KEY } from 'app/core/constants';
 import { appEvents } from 'app/core/core';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -9,7 +9,7 @@ import {
   SceneObject,
   VizPanel,
 } from '@grafana/scenes';
-import { TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { LS_TAB_COPY_KEY } from 'app/core/constants';
 import { appEvents } from 'app/core/core';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -7,7 +7,7 @@ import {
   SceneObjectUrlValues,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeTabsLayout } from '../../serialization/layoutSerializers/TabsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -7,7 +7,7 @@ import {
   SceneObjectUrlValues,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeTabsLayout } from '../../serialization/layoutSerializers/TabsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -4,7 +4,7 @@ import {
   GridLayoutItemKind,
   RowsLayoutRowKind,
   TabsLayoutTabKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { LS_PANEL_COPY_KEY, LS_ROW_COPY_KEY, LS_TAB_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';
 

--- a/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/paste.ts
@@ -4,7 +4,7 @@ import {
   GridLayoutItemKind,
   RowsLayoutRowKind,
   TabsLayoutTabKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { LS_PANEL_COPY_KEY, LS_ROW_COPY_KEY, LS_TAB_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';
 

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -1,5 +1,5 @@
 import { SceneObject, VizPanel } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { LayoutRegistryItem } from './LayoutRegistryItem';

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -1,5 +1,5 @@
 import { SceneObject, VizPanel } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { LayoutRegistryItem } from './LayoutRegistryItem';

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -17,7 +17,7 @@ import {
   PanelKind,
   PanelSpec,
   QueryVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { AnnoKeyDashboardSnapshotOriginalUrl } from 'app/features/apiserver/types';
 import { SaveDashboardAsOptions } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -17,7 +17,7 @@ import {
   PanelKind,
   PanelSpec,
   QueryVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import { AnnoKeyDashboardSnapshotOriginalUrl } from 'app/features/apiserver/types';
 import { SaveDashboardAsOptions } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { AnnoKeyDashboardSnapshotOriginalUrl, ObjectMeta } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { AnnoKeyDashboardSnapshotOriginalUrl, ObjectMeta } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';

--- a/public/app/features/dashboard-scene/serialization/annotations.test.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.test.ts
@@ -1,5 +1,5 @@
 import { AnnotationQuery } from '@grafana/data';
-import { AnnotationQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { AnnotationQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { transformV1ToV2AnnotationQuery, transformV2ToV1AnnotationQuery } from './annotations';
 

--- a/public/app/features/dashboard-scene/serialization/annotations.test.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.test.ts
@@ -1,5 +1,5 @@
 import { AnnotationQuery } from '@grafana/data';
-import { AnnotationQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { AnnotationQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { transformV1ToV2AnnotationQuery, transformV2ToV1AnnotationQuery } from './annotations';
 

--- a/public/app/features/dashboard-scene/serialization/annotations.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.ts
@@ -2,7 +2,7 @@ import { AnnotationQuery } from '@grafana/data';
 import {
   AnnotationQueryKind,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { getRuntimePanelDataSource } from './layoutSerializers/utils';
 

--- a/public/app/features/dashboard-scene/serialization/annotations.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.ts
@@ -1,8 +1,5 @@
 import { AnnotationQuery } from '@grafana/data';
-import {
-  AnnotationQueryKind,
-  defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { AnnotationQueryKind, defaultDataQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { getRuntimePanelDataSource } from './layoutSerializers/utils';
 

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -9,7 +9,7 @@ import {
   defaultTimeSettingsSpec,
   GroupByVariableKind,
   Spec as DashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';
@@ -109,7 +109,7 @@ export async function buildNewDashboardSaveModelV2(
   }
 
   const data: DashboardWithAccessInfo<DashboardV2Spec> = {
-    apiVersion: 'v2alpha1',
+    apiVersion: 'v2alpha2',
     kind: 'DashboardWithAccessInfo',
     spec: {
       ...defaultDashboardV2Spec(),

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -9,7 +9,7 @@ import {
   defaultTimeSettingsSpec,
   GroupByVariableKind,
   Spec as DashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
@@ -2,7 +2,7 @@ import {
   Spec as DashboardV2Spec,
   defaultAutoGridLayoutSpec,
   AutoGridLayoutItemKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
@@ -2,7 +2,7 @@ import {
   Spec as DashboardV2Spec,
   defaultAutoGridLayoutSpec,
   AutoGridLayoutItemKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -8,7 +8,7 @@ import {
   GridLayoutItemSpec,
   PanelKind,
   LibraryPanelKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { contextSrv } from 'app/core/core';
 
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -8,7 +8,7 @@ import {
   GridLayoutItemSpec,
   PanelKind,
   LibraryPanelKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { contextSrv } from 'app/core/core';
 
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
@@ -1,5 +1,5 @@
 import { SceneGridLayout } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.test.ts
@@ -1,5 +1,5 @@
 import { SceneGridLayout } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -1,7 +1,4 @@
-import {
-  Spec as DashboardV2Spec,
-  RowsLayoutRowKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec, RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   RowsLayoutRowKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.test.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -1,7 +1,4 @@
-import {
-  Spec as DashboardV2Spec,
-  TabsLayoutTabKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec, TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabItemRepeaterBehavior } from '../../scene/layout-tabs/TabItemRepeaterBehavior';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   TabsLayoutTabKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabItemRepeaterBehavior } from '../../scene/layout-tabs/TabItemRepeaterBehavior';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -1,5 +1,5 @@
 import { Registry, RegistryItem } from '@grafana/data';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -1,5 +1,5 @@
 import { Registry, RegistryItem } from '@grafana/data';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -1,7 +1,7 @@
 import {
   defaultDataQueryKind,
   PanelQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { getRuntimePanelDataSource } from './utils';
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  defaultDataQueryKind,
-  PanelQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { defaultDataQueryKind, PanelQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { getRuntimePanelDataSource } from './utils';
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -20,7 +20,7 @@ import {
   QueryVariableKind,
   TabsLayoutTabKind,
   DataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { ConditionalRendering } from '../../conditional-rendering/ConditionalRendering';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -20,7 +20,7 @@ import {
   QueryVariableKind,
   TabsLayoutTabKind,
   DataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { ConditionalRendering } from '../../conditional-rendering/ConditionalRendering';

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -26,7 +26,7 @@ import {
   VariableOption,
   defaultDataQueryKind,
   AdHocFilterWithLabels,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { getIntervalsQueryFromNewIntervalModel } from '../utils/utils';
 

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -26,7 +26,7 @@ import {
   VariableOption,
   defaultDataQueryKind,
   AdHocFilterWithLabels,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { getIntervalsQueryFromNewIntervalModel } from '../utils/utils';
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -29,7 +29,7 @@ import {
   IntervalVariableKind,
   QueryVariableKind,
   TextVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { AnnoKeyDashboardIsSnapshot } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -15,7 +15,6 @@ import {
   SceneDataTransformer,
   SceneGridItem,
 } from '@grafana/scenes';
-import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import {
   AdhocVariableKind,
   ConstantVariableKind,
@@ -30,6 +29,7 @@ import {
   QueryVariableKind,
   TextVariableKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import { AnnoKeyDashboardIsSnapshot } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -29,7 +29,7 @@ import {
   IntervalVariableKind,
   QueryVariableKind,
   TextVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { AnnoKeyDashboardIsSnapshot } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
@@ -678,7 +678,7 @@ describe('transformSaveModelSchemaV2ToScene', () => {
       // Create a dashboard with an annotation that has options
       const dashboardWithAnnotationOptions: DashboardWithAccessInfo<DashboardV2Spec> = {
         kind: 'DashboardWithAccessInfo',
-        apiVersion: 'v2alpha1',
+        apiVersion: 'v2alpha2',
         metadata: {
           name: 'test-dashboard',
           namespace: 'default',

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -40,7 +40,7 @@ import {
   PanelKind,
   QueryVariableKind,
   TextVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import {
   AnnoKeyCreatedBy,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -40,7 +40,7 @@ import {
   PanelKind,
   QueryVariableKind,
   TextVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import {
   AnnoKeyCreatedBy,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -31,7 +31,7 @@ import {
   AutoGridLayoutSpec,
   RowsLayoutSpec,
   TabsLayoutSpec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.test.ts
@@ -31,7 +31,7 @@ import {
   AutoGridLayoutSpec,
   RowsLayoutSpec,
   TabsLayoutSpec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { DashboardAnnotationsDataLayer } from '../scene/DashboardAnnotationsDataLayer';

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -44,7 +44,7 @@ import {
   FieldConfig,
   FieldColor,
   defaultDataQueryKind,
-} from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha1/types.spec.gen';
+} from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha2/types.spec.gen';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
 import { PanelTimeRange } from '../scene/PanelTimeRange';

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -44,7 +44,7 @@ import {
   FieldConfig,
   FieldColor,
   defaultDataQueryKind,
-} from '../../../../../packages/grafana-schema/src/schema/dashboard/v2alpha2/types.spec.gen';
+} from '../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
 import { PanelTimeRange } from '../scene/PanelTimeRange';

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -16,7 +16,7 @@ import {
   FieldConfigSource,
   SpecialValueMatch,
   ThresholdsMode,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -16,7 +16,7 @@ import {
   FieldConfigSource,
   SpecialValueMatch,
   ThresholdsMode,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
@@ -3,7 +3,7 @@ import {
   defaultVariableSort,
   defaultVariableRefresh,
   defaultDashboardCursorSync,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import {
   transformCursorSynctoEnum,

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
@@ -3,7 +3,7 @@ import {
   defaultVariableSort,
   defaultVariableRefresh,
   defaultDashboardCursorSync,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import {
   transformCursorSynctoEnum,

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -17,7 +17,7 @@ import {
   VariableRefresh,
   VariableSort,
   FieldColorModeId as FieldColorModeIdV2,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 // used for QueryVariableKind's query prop - in schema V2 we've deprecated string type and support only DataQuery
 export const LEGACY_STRING_VALUE_KEY = '__legacyStringValue';

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -17,7 +17,7 @@ import {
   VariableRefresh,
   VariableSort,
   FieldColorModeId as FieldColorModeIdV2,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 // used for QueryVariableKind's query prop - in schema V2 we've deprecated string type and support only DataQuery
 export const LEGACY_STRING_VALUE_KEY = '__legacyStringValue';

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, sceneUtils } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Alert, Box, Button, CodeEditor, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, sceneUtils } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Alert, Box, Button, CodeEditor, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -3,7 +3,7 @@ import { AsyncState } from 'react-use/lib/useAsync';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Alert, Label, RadioButtonGroup, Stack, Switch, TextLink } from '@grafana/ui';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -3,7 +3,7 @@ import { AsyncState } from 'react-use/lib/useAsync';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Alert, Label, RadioButtonGroup, Stack, Switch, TextLink } from '@grafana/ui';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,7 +1,7 @@
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import * as ResponseTransformers from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
 import { DashboardDataDTO } from 'app/types/dashboard';
@@ -175,7 +175,7 @@ describe('ShareExportTab', () => {
 
       // Should use V2 API version
       expect(result.json).toMatchObject({
-        apiVersion: 'dashboard.grafana.app/v2alpha1',
+        apiVersion: 'dashboard.grafana.app/v2alpha2',
         kind: 'Dashboard',
         status: {},
       });
@@ -325,7 +325,7 @@ describe('ShareExportTab', () => {
 
     scene.serializer.getSaveModel = jest.fn(() => mockV2Dashboard);
     scene.serializer.makeExportableExternally = jest.fn(() => Promise.resolve(mockV2Dashboard));
-    scene.serializer.apiVersion = 'dashboard.grafana.app/v2alpha1';
+    scene.serializer.apiVersion = 'dashboard.grafana.app/v2alpha2';
     scene.getInitialSaveModel = jest.fn(() => mockV2Dashboard);
 
     return tab;

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,7 +1,7 @@
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import * as ResponseTransformers from 'app/features/dashboard/api/ResponseTransformers';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
 import { DashboardDataDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -8,7 +8,7 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Stack, Switch } from '@grafana/ui';
 import { ObjectMeta } from 'app/features/apiserver/types';
 import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -8,7 +8,7 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Stack, Switch } from '@grafana/ui';
 import { ObjectMeta } from 'app/features/apiserver/types';
 import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
@@ -4,7 +4,7 @@ import { Controller, FieldErrors, UseFormReturn } from 'react-hook-form';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Button, Field, FormFieldErrors, FormsOnSubmit, Stack, Input } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
@@ -4,7 +4,7 @@ import { Controller, FieldErrors, UseFormReturn } from 'react-hook-form';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Button, Field, FormFieldErrors, FormsOnSubmit, Stack, Input } from '@grafana/ui';
 import { FolderPicker } from 'app/core/components/Select/FolderPicker';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -6,7 +6,7 @@ import {
   AnnotationQueryKind,
   Spec as DashboardV2Spec,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Form } from 'app/core/components/Form/Form';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -6,7 +6,7 @@ import {
   AnnotationQueryKind,
   Spec as DashboardV2Spec,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { Form } from 'app/core/components/Form/Form';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/v2schema/test-helpers.ts
+++ b/public/app/features/dashboard-scene/v2schema/test-helpers.ts
@@ -10,7 +10,7 @@ import {
   SceneVariableState,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';

--- a/public/app/features/dashboard-scene/v2schema/test-helpers.ts
+++ b/public/app/features/dashboard-scene/v2schema/test-helpers.ts
@@ -10,7 +10,7 @@ import {
   SceneVariableState,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { DashboardScene } from '../scene/DashboardScene';
 import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';

--- a/public/app/features/dashboard-scene/v2schema/transformers.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/transformers.test.ts
@@ -1,8 +1,8 @@
 import { config } from '@grafana/runtime';
 import { CustomVariable, GroupByVariable } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
-import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import * as libpanels from 'app/features/library-panels/state/api';
 

--- a/public/app/features/dashboard-scene/v2schema/transformers.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/transformers.test.ts
@@ -2,7 +2,7 @@ import { config } from '@grafana/runtime';
 import { CustomVariable, GroupByVariable } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
 import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import * as libpanels from 'app/features/library-panels/state/api';
 

--- a/public/app/features/dashboard-scene/v2schema/transformers.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/transformers.test.ts
@@ -2,7 +2,7 @@ import { config } from '@grafana/runtime';
 import { CustomVariable, GroupByVariable } from '@grafana/scenes';
 import { LibraryPanel } from '@grafana/schema';
 import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import * as libpanels from 'app/features/library-panels/state/api';
 

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -1,5 +1,4 @@
 import { AnnotationQuery, DataQuery, VariableModel, VariableRefresh, Panel } from '@grafana/schema';
-import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import {
   Spec as DashboardV2Spec,
   defaultDataQueryKind,
@@ -10,6 +9,7 @@ import {
   RowsLayoutRowKind,
   VariableKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { handyTestingSchema } from '@grafana/schema/dist/esm/schema/dashboard/v2_examples';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyDashboardGnetId,

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -9,7 +9,7 @@ import {
   RowsLayoutKind,
   RowsLayoutRowKind,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyDashboardGnetId,

--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -9,7 +9,7 @@ import {
   RowsLayoutKind,
   RowsLayoutRowKind,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyDashboardGnetId,
@@ -394,7 +394,7 @@ describe('ResponseTransformers', () => {
       const transformed = ResponseTransformers.ensureV2Response(dto);
 
       // Metadata
-      expect(transformed.apiVersion).toBe('v2alpha1');
+      expect(transformed.apiVersion).toBe('v2alpha2');
       expect(transformed.kind).toBe('DashboardWithAccessInfo');
       expect(transformed.metadata.annotations?.[AnnoKeyCreatedBy]).toEqual('user1');
       expect(transformed.metadata.annotations?.[AnnoKeyUpdatedBy]).toEqual('user2');
@@ -798,7 +798,7 @@ describe('ResponseTransformers', () => {
 
     it('should transform DashboardWithAccessInfo<DashboardV2Spec> to DashboardDTO', () => {
       const dashboardV2: DashboardWithAccessInfo<DashboardV2Spec> = {
-        apiVersion: 'v2alpha1',
+        apiVersion: 'v2alpha2',
         kind: 'DashboardWithAccessInfo',
         metadata: {
           creationTimestamp: '2023-01-01T00:00:00Z',

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -41,7 +41,7 @@ import {
   defaultDataQueryKind,
   RowsLayoutRowKind,
   GridLayoutKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardLink, DataTransformerConfig } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
 import { isWeekStart, WeekStart } from '@grafana/ui';
 import {

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -41,7 +41,7 @@ import {
   defaultDataQueryKind,
   RowsLayoutRowKind,
   GridLayoutKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DashboardLink, DataTransformerConfig } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
 import { isWeekStart, WeekStart } from '@grafana/ui';
 import {
@@ -183,7 +183,7 @@ export function ensureV2Response(
   };
 
   return {
-    apiVersion: 'v2alpha1',
+    apiVersion: 'v2alpha2',
     kind: 'DashboardWithAccessInfo',
     metadata: {
       creationTimestamp: creationTimestamp || '', // TODO verify this empty string is valid

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
@@ -2,7 +2,7 @@ import { Dashboard } from '@grafana/schema';
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
@@ -64,7 +64,7 @@ describe('UnifiedDashboardAPI', () => {
 
     it('should fallback to v2 if v1 throws DashboardVersionError', async () => {
       const mockV2Response = { spec: { title: 'test' } };
-      v1Client.getDashboardDTO.mockRejectedValue(new DashboardVersionError('v2alpha1', 'Dashboard is V1 format'));
+      v1Client.getDashboardDTO.mockRejectedValue(new DashboardVersionError('v2alpha2', 'Dashboard is V1 format'));
       v2Client.getDashboardDTO.mockResolvedValue(mockV2Response as DashboardWithAccessInfo<DashboardV2Spec>);
 
       const result = await api.getDashboardDTO('123');
@@ -88,7 +88,7 @@ describe('UnifiedDashboardAPI', () => {
         },
       };
 
-      v1Client.getDashboardDTO.mockRejectedValue(new DashboardVersionError('v2alpha1', 'Dashboard is V1 format'));
+      v1Client.getDashboardDTO.mockRejectedValue(new DashboardVersionError('v2alpha2', 'Dashboard is V1 format'));
       v2Client.getDashboardDTO.mockImplementation((params) => {
         const actualClient = jest.requireActual('./v2').K8sDashboardV2API;
         const client = new actualClient();
@@ -152,7 +152,7 @@ describe('UnifiedDashboardAPI', () => {
 
   describe('deleteDashboard', () => {
     it('should not try other version if fails', async () => {
-      v1Client.deleteDashboard.mockRejectedValue(new DashboardVersionError('v2alpha1', 'Dashboard is V1 format'));
+      v1Client.deleteDashboard.mockRejectedValue(new DashboardVersionError('v2alpha2', 'Dashboard is V1 format'));
 
       try {
         await api.deleteDashboard('123', true);
@@ -188,7 +188,7 @@ describe('UnifiedDashboardAPI', () => {
           {
             metadata: { name: 'v2-dash', resourceVersion: '123', creationTimestamp: '2023-01-01T00:00:00Z' },
             spec: null,
-            status: { conversion: { failed: true, storedVersion: 'v2alpha1', error: 'conversion failed' } },
+            status: { conversion: { failed: true, storedVersion: 'v2alpha2', error: 'conversion failed' } },
           },
           {
             kind: 'Dashboard',
@@ -200,13 +200,13 @@ describe('UnifiedDashboardAPI', () => {
         ],
       };
       const mockV2Response = {
-        apiVersion: 'dashboard.grafana.app/v2alpha1',
+        apiVersion: 'dashboard.grafana.app/v2alpha2',
         kind: 'DashboardList',
         metadata: { resourceVersion: '456' },
         items: [
           {
             kind: 'Dashboard',
-            apiVersion: 'dashboard.grafana.app/v2alpha1',
+            apiVersion: 'dashboard.grafana.app/v2alpha2',
             metadata: { name: 'v2-dash', resourceVersion: '456', creationTimestamp: '2023-01-01T00:00:00Z' },
             spec: { title: 'v2', elements: {} },
             status: {},
@@ -273,7 +273,7 @@ describe('UnifiedDashboardAPI', () => {
 
     it('should use v2 client for v2 dashboard resource', async () => {
       const mockV2Dashboard = {
-        apiVersion: 'dashboard.grafana.app/v2alpha1',
+        apiVersion: 'dashboard.grafana.app/v2alpha2',
         kind: 'Dashboard',
         metadata: {
           name: 'dash-1',

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.test.ts
@@ -2,7 +2,7 @@ import { Dashboard } from '@grafana/schema';
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { isResource } from 'app/features/apiserver/guards';
 import { Resource, ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
@@ -7,7 +7,13 @@ import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
 import { DashboardAPI, DashboardVersionError, DashboardWithAccessInfo, ListDeletedDashboardsOptions } from './types';
-import { isDashboardV2Spec, isV1DashboardCommand, isV2DashboardCommand, failedFromVersion } from './utils';
+import {
+  isDashboardV2Spec,
+  isV1DashboardCommand,
+  isV2DashboardCommand,
+  failedFromVersion,
+  isV2StoredVersion,
+} from './utils';
 import { K8sDashboardAPI } from './v1';
 import { K8sDashboardV2API } from './v2';
 
@@ -27,7 +33,7 @@ export class UnifiedDashboardAPI
     try {
       return await this.v1Client.getDashboardDTO(uid);
     } catch (error) {
-      if (error instanceof DashboardVersionError && error.data.storedVersion === 'v2alpha1') {
+      if (error instanceof DashboardVersionError && isV2StoredVersion(error.data.storedVersion)) {
         return await this.v2Client.getDashboardDTO(uid);
       }
       throw error;

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { isResource } from 'app/features/apiserver/guards';
 import { Resource, ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardDTO } from 'app/types/dashboard';
 
 import { UnifiedDashboardAPI } from './UnifiedDashboardAPI';

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DashboardDTO } from 'app/types/dashboard';
 
 import { UnifiedDashboardAPI } from './UnifiedDashboardAPI';

--- a/public/app/features/dashboard/api/types.ts
+++ b/public/app/features/dashboard/api/types.ts
@@ -1,5 +1,5 @@
 import { UrlQueryMap } from '@grafana/data';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha1/types.status.gen';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { ListOptions, Resource, ResourceList } from 'app/features/apiserver/types';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
 import { AnnotationsPermissions, SaveDashboardResponseDTO } from 'app/types/dashboard';
@@ -40,7 +40,7 @@ export interface DashboardVersionError extends Error {
   status: number;
   data: {
     // The version which was stored when the dashboard was created / updated.
-    // Currently known versions are: 'v2alpha1' | 'v1beta1' | 'v0alpha1'
+    // Currently known versions are: 'v2alpha2' | 'v1beta1' | 'v0alpha1'
     storedVersion: string;
     message: string;
   };

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,13 +1,17 @@
 import { config, locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha1/types.status.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { Resource } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
 import { DashboardWithAccessInfo } from './types';
+
+export function isV2StoredVersion(version: string): boolean {
+  return version === 'v2alpha1' || version === 'v2alpha2';
+}
 
 export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
   const isDashboardSceneEnabled = config.featureToggles.dashboardScene;

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,6 +1,6 @@
 import { config, locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { Resource } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -281,14 +281,14 @@ describe('v1 dashboard API', () => {
   });
 
   describe('version error handling', () => {
-    it('should throw DashboardVersionError for v2alpha1 conversion error', async () => {
+    it('should throw DashboardVersionError for v2alpha2 conversion error', async () => {
       const mockDashboardWithError = {
         ...mockDashboardDto,
         status: {
           conversion: {
             failed: true,
             error: 'backend conversion not yet implemented',
-            storedVersion: 'v2alpha1',
+            storedVersion: 'v2alpha2',
           },
         },
       };

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -1,7 +1,7 @@
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Dashboard } from '@grafana/schema';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha1/types.status.gen';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';
 import kbn from 'app/core/utils/kbn';
@@ -26,6 +26,7 @@ import { DashboardDataDTO, DashboardDTO, SaveDashboardResponseDTO } from 'app/ty
 import { SaveDashboardCommand } from '../components/SaveDashboard/types';
 
 import { DashboardAPI, DashboardVersionError, DashboardWithAccessInfo, ListDeletedDashboardsOptions } from './types';
+import { isV2StoredVersion } from './utils';
 
 export const K8S_V1_DASHBOARD_API_CONFIG = {
   group: 'dashboard.grafana.app',
@@ -116,7 +117,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       const dash = await this.client.subresource<DashboardWithAccessInfo<DashboardDataDTO>>(uid, 'dto');
 
       // This could come as conversion error from v0 or v2 to V1.
-      if (dash.status?.conversion?.failed && dash.status.conversion.storedVersion === 'v2alpha1') {
+      if (dash.status?.conversion?.failed && isV2StoredVersion(dash.status.conversion.storedVersion)) {
         throw new DashboardVersionError(dash.status.conversion.storedVersion, dash.status.conversion.error);
       }
 

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
   AnnoKeyFolder,
@@ -37,7 +37,7 @@ const mockGet = jest.fn().mockResolvedValue(mockDashboardDto);
 
 const mockPut = jest.fn().mockImplementation((url, data) => {
   return {
-    apiVersion: 'dashboard.grafana.app/v2alpha1',
+    apiVersion: 'dashboard.grafana.app/v2alpha2',
     kind: 'Dashboard',
     metadata: {
       name: data.metadata?.name,
@@ -53,7 +53,7 @@ const mockPut = jest.fn().mockImplementation((url, data) => {
 
 const mockPost = jest.fn().mockImplementation((url, data) => {
   return {
-    apiVersion: 'dashboard.grafana.app/v2alpha1',
+    apiVersion: 'dashboard.grafana.app/v2alpha2',
     kind: 'Dashboard',
     metadata: {
       name: data.metadata?.name || 'restored-dash',
@@ -220,7 +220,7 @@ describe('v2 dashboard API', () => {
       });
       expect(mockPut).toHaveBeenCalledTimes(1);
       expect(mockPut).toHaveBeenCalledWith(
-        '/apis/dashboard.grafana.app/v2alpha1/namespaces/default/dashboards/existing-dash',
+        '/apis/dashboard.grafana.app/v2alpha2/namespaces/default/dashboards/existing-dash',
         {
           metadata: {
             name: 'existing-dash',
@@ -329,7 +329,7 @@ describe('v2 dashboard API', () => {
           conversion: {
             failed: true,
             error: 'other-error',
-            storedVersion: 'v2alpha1',
+            storedVersion: 'v2alpha2',
           },
         },
       };
@@ -381,7 +381,7 @@ describe('v2 dashboard API', () => {
 
       expect(dashboardToRestore.metadata.resourceVersion).toBe('');
       expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v2alpha1/'),
+        expect.stringContaining('/apis/dashboard.grafana.app/v2alpha2/'),
         expect.objectContaining({
           metadata: expect.objectContaining({
             resourceVersion: '',

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
   AnnoKeyFolder,

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -220,7 +220,7 @@ describe('v2 dashboard API', () => {
       });
       expect(mockPut).toHaveBeenCalledTimes(1);
       expect(mockPut).toHaveBeenCalledWith(
-        '/apis/dashboard.grafana.app/v2alpha2/namespaces/default/dashboards/existing-dash',
+        '/apis/dashboard.grafana.app/v2alpha1/namespaces/default/dashboards/existing-dash',
         {
           metadata: {
             name: 'existing-dash',
@@ -329,7 +329,7 @@ describe('v2 dashboard API', () => {
           conversion: {
             failed: true,
             error: 'other-error',
-            storedVersion: 'v2alpha2',
+            storedVersion: 'v2alpha1',
           },
         },
       };
@@ -381,7 +381,7 @@ describe('v2 dashboard API', () => {
 
       expect(dashboardToRestore.metadata.resourceVersion).toBe('');
       expect(mockPost).toHaveBeenCalledWith(
-        expect.stringContaining('/apis/dashboard.grafana.app/v2alpha2/'),
+        expect.stringContaining('/apis/dashboard.grafana.app/v2alpha1/'),
         expect.objectContaining({
           metadata: expect.objectContaining({
             resourceVersion: '',

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -1,7 +1,7 @@
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha1/types.status.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';
 import kbn from 'app/core/utils/kbn';
@@ -28,7 +28,7 @@ import { isDashboardV2Spec } from './utils';
 
 export const K8S_V2_DASHBOARD_API_CONFIG = {
   group: 'dashboard.grafana.app',
-  version: 'v2alpha1',
+  version: 'v2alpha2',
   resource: 'dashboards',
 };
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -28,7 +28,7 @@ import { isDashboardV2Spec } from './utils';
 
 export const K8S_V2_DASHBOARD_API_CONFIG = {
   group: 'dashboard.grafana.app',
-  version: 'v2alpha2',
+  version: 'v2alpha1',
   resource: 'dashboards',
 };
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -1,6 +1,6 @@
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Status } from '@grafana/schema/src/schema/dashboard/v2alpha2/types.status.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -4,7 +4,7 @@ import moment from 'moment'; // eslint-disable-line no-restricted-imports
 
 import { AppEvents, dateMath, UrlQueryMap, UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
 import kbn from 'app/core/utils/kbn';

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -4,7 +4,7 @@ import moment from 'moment'; // eslint-disable-line no-restricted-imports
 
 import { AppEvents, dateMath, UrlQueryMap, UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
 import kbn from 'app/core/utils/kbn';

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -1,5 +1,5 @@
 import { VariableModel } from '@grafana/schema/dist/esm/index';
-import { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+import { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -1,5 +1,5 @@
 import { VariableModel } from '@grafana/schema/dist/esm/index';
-import { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+import { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 

--- a/public/app/features/manage-dashboards/state/actions.test.ts
+++ b/public/app/features/manage-dashboards/state/actions.test.ts
@@ -8,7 +8,7 @@ import {
   defaultPanelSpec,
   defaultQueryVariableSpec,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 

--- a/public/app/features/manage-dashboards/state/actions.test.ts
+++ b/public/app/features/manage-dashboards/state/actions.test.ts
@@ -8,7 +8,7 @@ import {
   defaultPanelSpec,
   defaultQueryVariableSpec,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { browseDashboardsAPI } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -5,7 +5,7 @@ import {
   QueryVariableKind,
   PanelQueryKind,
   AnnotationQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { browseDashboardsAPI, ImportInputs } from 'app/features/browse-dashboards/api/browseDashboardsAPI';

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -5,7 +5,7 @@ import {
   QueryVariableKind,
   PanelQueryKind,
   AnnotationQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { browseDashboardsAPI, ImportInputs } from 'app/features/browse-dashboards/api/browseDashboardsAPI';

--- a/public/app/features/manage-dashboards/utils/validation.test.ts
+++ b/public/app/features/manage-dashboards/utils/validation.test.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
 import { AnnoKeyFolder, AnnoKeyFolderTitle } from 'app/features/apiserver/types';
 import { setDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
@@ -23,7 +23,7 @@ const legacyDashboard: DashboardDTO = {
 
 const v2Dashboard: DashboardWithAccessInfo<DashboardV2Spec> = {
   kind: 'DashboardWithAccessInfo',
-  apiVersion: 'v2alpha1',
+  apiVersion: 'v2alpha2',
   metadata: {
     creationTimestamp: '2021-09-29T14:00:00Z',
     name: 'dashboard-uid',

--- a/public/app/features/manage-dashboards/utils/validation.test.ts
+++ b/public/app/features/manage-dashboards/utils/validation.test.ts
@@ -1,7 +1,7 @@
 import {
   Spec as DashboardV2Spec,
   defaultSpec as defaultDashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2alpha2/types.spec.gen';
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { AnnoKeyFolder, AnnoKeyFolderTitle } from 'app/features/apiserver/types';
 import { setDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';


### PR DESCRIPTION
- Add DS breaking changes on v2alpha2 only
- Use v2alpha2 by default as type 
- Keep using v2alpha1 as the endpoint to the API until we have the conversions in place
