### PR TITLE
Provisioning: Add user token to git and bitbucket repository specs

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/types.go
+++ b/pkg/apis/provisioning/v0alpha1/types.go
@@ -64,6 +64,8 @@ type GitRepositoryConfig struct {
 	URL string `json:"url,omitempty"`
 	// The branch to use in the repository.
 	Branch string `json:"branch"`
+	// TokenUser is the user that will be used to access the repository if it's a personal access token.
+	TokenUser string `json:"tokenUser,omitempty"`
 	// Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.
 	Token string `json:"token,omitempty"`
 	// Token for accessing the repository, but encrypted. This is not possible to read back to a user decrypted.
@@ -82,6 +84,8 @@ type BitbucketRepositoryConfig struct {
 	URL string `json:"url,omitempty"`
 	// The branch to use in the repository.
 	Branch string `json:"branch"`
+	// TokenUser is the user that will be used to access the repository if it's a personal access token.
+	TokenUser string `json:"tokenUser,omitempty"`
 	// Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.
 	Token string `json:"token,omitempty"`
 	// Token for accessing the repository, but encrypted. This is not possible to read back to a user decrypted.

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -115,6 +115,13 @@ func schema_pkg_apis_provisioning_v0alpha1_BitbucketRepositoryConfig(ref common.
 							Format:      "",
 						},
 					},
+					"tokenUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TokenUser is the user that will be used to access the repository if it's a personal access token.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"token": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.",
@@ -443,6 +450,13 @@ func schema_pkg_apis_provisioning_v0alpha1_GitRepositoryConfig(ref common.Refere
 						SchemaProps: spec.SchemaProps{
 							Description: "The branch to use in the repository.",
 							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"tokenUser": {
+						SchemaProps: spec.SchemaProps{
+							Description: "TokenUser is the user that will be used to access the repository if it's a personal access token.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/bitbucketrepositoryconfig.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/bitbucketrepositoryconfig.go
@@ -9,6 +9,7 @@ package v0alpha1
 type BitbucketRepositoryConfigApplyConfiguration struct {
 	URL            *string `json:"url,omitempty"`
 	Branch         *string `json:"branch,omitempty"`
+	TokenUser      *string `json:"tokenUser,omitempty"`
 	Token          *string `json:"token,omitempty"`
 	EncryptedToken []byte  `json:"encryptedToken,omitempty"`
 	Path           *string `json:"path,omitempty"`
@@ -33,6 +34,14 @@ func (b *BitbucketRepositoryConfigApplyConfiguration) WithURL(value string) *Bit
 // If called multiple times, the Branch field is set to the value of the last call.
 func (b *BitbucketRepositoryConfigApplyConfiguration) WithBranch(value string) *BitbucketRepositoryConfigApplyConfiguration {
 	b.Branch = &value
+	return b
+}
+
+// WithTokenUser sets the TokenUser field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TokenUser field is set to the value of the last call.
+func (b *BitbucketRepositoryConfigApplyConfiguration) WithTokenUser(value string) *BitbucketRepositoryConfigApplyConfiguration {
+	b.TokenUser = &value
 	return b
 }
 

--- a/pkg/generated/applyconfiguration/provisioning/v0alpha1/gitrepositoryconfig.go
+++ b/pkg/generated/applyconfiguration/provisioning/v0alpha1/gitrepositoryconfig.go
@@ -9,6 +9,7 @@ package v0alpha1
 type GitRepositoryConfigApplyConfiguration struct {
 	URL            *string `json:"url,omitempty"`
 	Branch         *string `json:"branch,omitempty"`
+	TokenUser      *string `json:"tokenUser,omitempty"`
 	Token          *string `json:"token,omitempty"`
 	EncryptedToken []byte  `json:"encryptedToken,omitempty"`
 	Path           *string `json:"path,omitempty"`
@@ -33,6 +34,14 @@ func (b *GitRepositoryConfigApplyConfiguration) WithURL(value string) *GitReposi
 // If called multiple times, the Branch field is set to the value of the last call.
 func (b *GitRepositoryConfigApplyConfiguration) WithBranch(value string) *GitRepositoryConfigApplyConfiguration {
 	b.Branch = &value
+	return b
+}
+
+// WithTokenUser sets the TokenUser field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the TokenUser field is set to the value of the last call.
+func (b *GitRepositoryConfigApplyConfiguration) WithTokenUser(value string) *GitRepositoryConfigApplyConfiguration {
+	b.TokenUser = &value
 	return b
 }
 

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1196,6 +1196,7 @@ func (b *APIBuilder) AsRepository(ctx context.Context, r *provisioning.Repositor
 			URL:            r.Spec.Git.URL,
 			Branch:         r.Spec.Git.Branch,
 			Path:           r.Spec.Git.Path,
+			TokenUser:      r.Spec.Git.TokenUser,
 			Token:          token,
 			EncryptedToken: r.Spec.Git.EncryptedToken,
 		}

--- a/pkg/registry/apis/provisioning/repository/git/repository.go
+++ b/pkg/registry/apis/provisioning/repository/git/repository.go
@@ -33,6 +33,7 @@ const gitTokenSecretSuffix = "-git-token"
 type RepositoryConfig struct {
 	URL            string
 	Branch         string
+	TokenUser      string
 	Token          string
 	EncryptedToken []byte
 	Path           string
@@ -54,7 +55,12 @@ func NewGitRepository(
 ) (GitRepository, error) {
 	var opts []options.Option
 	if len(gitConfig.Token) > 0 {
-		opts = append(opts, options.WithBasicAuth("git", gitConfig.Token))
+		tokenUser := gitConfig.TokenUser
+		if tokenUser == "" {
+			tokenUser = "git"
+		}
+
+		opts = append(opts, options.WithBasicAuth(tokenUser, gitConfig.Token))
 	}
 
 	client, err := nanogit.NewHTTPClient(gitConfig.URL, opts...)

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -2597,6 +2597,10 @@
             "description": "Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.",
             "type": "string"
           },
+          "tokenUser": {
+            "description": "TokenUser is the user that will be used to access the repository if it's a personal access token.",
+            "type": "string"
+          },
           "url": {
             "description": "The repository URL (e.g. `https://bitbucket.org/example/test`).",
             "type": "string"
@@ -2780,6 +2784,10 @@
           },
           "token": {
             "description": "Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again.",
+            "type": "string"
+          },
+          "tokenUser": {
+            "description": "TokenUser is the user that will be used to access the repository if it's a personal access token.",
             "type": "string"
           },
           "url": {

--- a/public/app/api/clients/provisioning/v0alpha1/endpoints.gen.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/endpoints.gen.ts
@@ -862,6 +862,8 @@ export type BitbucketRepositoryConfig = {
   path?: string;
   /** Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again. */
   token?: string;
+  /** TokenUser is the user that will be used to access the repository if it's a personal access token. */
+  tokenUser?: string;
   /** The repository URL (e.g. `https://bitbucket.org/example/test`). */
   url?: string;
 };
@@ -876,6 +878,8 @@ export type GitRepositoryConfig = {
   path?: string;
   /** Token for accessing the repository. If set, it will be encrypted into encryptedToken, then set to an empty string again. */
   token?: string;
+  /** TokenUser is the user that will be used to access the repository if it's a personal access token. */
+  tokenUser?: string;
   /** The repository URL (e.g. `https://github.com/example/test.git`). */
   url?: string;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Add token user to git and bitbucket specs
- Use token user if available in git type

**Why do we need this feature?**

Github and GitLab use the hardcoded `git` user but not Bitbucket. This change allows the use of a token user for Bitbucket and Git, which is useful for authentication and access control.

**Who is this feature for?**

Users of Git Sync

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/346>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
