### PR TITLE
Context: Clean up contexthandler.Middleware spans

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/open-feature/go-sdk/openfeature"
 
 	authnClients "github.com/grafana/grafana/pkg/services/authn/clients"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -152,6 +153,16 @@ func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context 
 	if h.cfg.IDResponseHeaderEnabled && reqContext.SignedInUser != nil {
 		reqContext.Resp.Before(h.addIDHeaderEndOfRequestFunc(reqContext.SignedInUser))
 	}
+
+	// Set open feature evaluation context with namespace
+	ns := "default"
+	if id != nil {
+		ns = id.Namespace
+	}
+	evalCtx := openfeature.NewEvaluationContext(ns, map[string]any{
+		"namespace": ns,
+	})
+	ctx = openfeature.MergeTransactionContext(ctx, evalCtx)
 
 	return ctx
 }

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -100,7 +100,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 }
 
 func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context {
-	ctx, span := tracing.Start(ctx, "ContextHandler.Middleware")
+	ctx, span := tracing.Start(ctx, "ContextHandler.setRequestContext")
 	defer span.End()
 
 	reqContext := &contextmodel.ReqContext{

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -88,16 +88,17 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		// Preserve the original span so the auth middleware span doesn't get propagated as a parent of the rest of the request
 		span := trace.SpanFromContext(ctx)
-		ctx = h.doAuthStuff(ctx)
+		ctx = h.setRequestContext(ctx)
+
+		// Preserve the original span so the auth middleware span doesn't get propagated as a parent of the rest of the request
 		ctx = trace.ContextWithSpan(ctx, span)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
 
-func (h *ContextHandler) doAuthStuff(ctx context.Context) context.Context {
+func (h *ContextHandler) setRequestContext(ctx context.Context) context.Context {
 	ctx, span := tracing.Start(ctx, "ContextHandler.Middleware")
 	defer span.End()
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -92,7 +92,7 @@ func (h *ContextHandler) Middleware(next http.Handler) http.Handler {
 		span := trace.SpanFromContext(ctx)
 		ctx = h.setRequestContext(ctx)
 
-		// Preserve the original span so the auth middleware span doesn't get propagated as a parent of the rest of the request
+		// Preserve the original span so the setRequestContext span doesn't get propagated as a parent of the rest of the request
 		ctx = trace.ContextWithSpan(ctx, span)
 
 		next.ServeHTTP(w, r.WithContext(ctx))


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/pull/107956, we spotted some improvements that could be made to how the ContextHandler.Middleware creates it's tracing spans.

Previously, the middleware would end its span before calling the next HTTP handler, but still included the span on the context passed through. This lead to weird traces where the rest of the request was a child of the "Auth - Middleware" span, but it did not take up duration of it.

<img width="960" height="136" alt="image" src="https://github.com/user-attachments/assets/a7da6b35-e5cf-47ec-af11-b7549d4f50c0" />

This PR improves the traces by:
 - moving the body of the middleware into a seperate function so it can call `tracing.Start(); defer span.End()` easily
 - renaming the span to `ContextHandler.Middleware`
 - Preserve the original span before the middleware and put it back onto the context before invoking `next.ServeHTTP`

The net result of this is that the `ContextHandler.Middleware` span is a _sibling_ to the next HTTP request, not a parent of it.

Before:

<img width="1149" height="422" alt="10307_2025-07-17-18-42_firefox" src="https://github.com/user-attachments/assets/4f949e58-2fa2-427f-b490-89de5ecded07" />

After:

<img width="1154" height="431" alt="10305_2025-07-17-18-31_firefox" src="https://github.com/user-attachments/assets/43fb4ec1-072f-466e-887e-6b983b9a8e3c" />