### PR TITLE
iam: Fix incorrect LDAP login form alert about UI configuration

### DIFF
--- a/public/app/features/admin/ldap/LdapSettingsPage.tsx
+++ b/public/app/features/admin/ldap/LdapSettingsPage.tsx
@@ -278,7 +278,14 @@ export const LdapSettingsPage = () => {
     <Alert title={t('ldap-settings-page.login-form-alert.title', 'Basic login disabled')}>
       <Trans i18nKey="ldap-settings-page.login-form-alert.description">
         Your LDAP configuration is not working because the basic login form is currently disabled. Please enable the
-        login form to use LDAP authentication. You can enable it on the Authentication page under “Auth settings”.
+        login form to use LDAP authentication. See our{' '}
+        <TextLink
+          href="https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#disable_login_form"
+          external
+        >
+          <Trans i18nKey="ldap-settings-page.documentation">documentation</Trans>
+        </TextLink>{' '}
+        for details on how to enable it.
       </Trans>
     </Alert>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8546,7 +8546,7 @@
       "placeholder": "example: 127.0.0.1"
     },
     "login-form-alert": {
-      "description": "Your LDAP configuration is not working because the basic login form is currently disabled. Please enable the login form to use LDAP authentication. You can enable it on the Authentication page under “Auth settings”.",
+      "description": "Your LDAP configuration is not working because the basic login form is currently disabled. Please enable the login form to use LDAP authentication. See our <2><0>documentation</0></2> for details on how to enable it.",
       "title": "Basic login disabled"
     },
     "search_filter": {


### PR DESCRIPTION
**What is this feature?**

This PR updates the alert shown in the LDAP page when "basic auth login" id disabled. It previously referenced an option that is not available in the "Auth settings" drawer. Instead, we're updating the message to point to the docs on how to toggle the `disable_login_form` config.

**Which issue(s) does this PR fix?**:

Follow up to https://github.com/grafana/grafana/pull/93037.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
