### PR TITLE
Update _index.md

### DIFF
--- a/docs/sources/alerting/best-practices/_index.md
+++ b/docs/sources/alerting/best-practices/_index.md
@@ -8,7 +8,7 @@ labels:
     - cloud
     - enterprise
     - oss
-menuTitle: Best Practices
+menuTitle: Best practices
 title: Grafana Alerting best practices
 weight: 170
 ---


### PR DESCRIPTION
This PR makes a minor formatting correction to the documentation by changing the capitalization of "Best Practices" to "Best practices" in the menu title for the Grafana Alerting best practices documentation.

Updates menuTitle field to use lowercase "practices" for consistency with standard title formatting