### PR TITLE
[InfluxDB]: Add max series and auto complete range fields to new design

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -12,8 +12,10 @@ import { InfluxVersion } from '../../../types';
 
 import { getInlineLabelStyles, HTTP_MODES } from './constants';
 import {
+  trackInfluxDBConfigV2AdvancedDbConnectionSettingsAutocompleteClicked,
   trackInfluxDBConfigV2AdvancedDbConnectionSettingsHTTPMethodClicked,
   trackInfluxDBConfigV2AdvancedDbConnectionSettingsInsecureConnectClicked,
+  trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked,
   trackInfluxDBConfigV2AdvancedDbConnectionSettingsMinTimeClicked,
   trackInfluxDBConfigV2AdvancedDbConnectionSettingsToggleClicked,
 } from './tracking';
@@ -93,6 +95,42 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
               </InlineField>
             </InlineFieldRow>
           )}
+
+          {options.jsonData.version === InfluxVersion.InfluxQL && (
+            <InlineFieldRow>
+              <InlineField
+                label="Autocomplete Range"
+                labelWidth={30}
+                tooltip="This time range is used in the query editor's autocomplete to reduce the execution time of tag filter queries."
+              >
+                <Input
+                  className="width-15"
+                  data-testid="influxdb-v2-config-autocomplete-range"
+                  onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsAutocompleteClicked}
+                  onChange={onUpdateDatasourceJsonDataOption(props, 'showTagTime')}
+                  placeholder="12h"
+                  value={options.jsonData.showTagTime || ''}
+                />
+              </InlineField>
+            </InlineFieldRow>
+          )}
+
+          <InlineFieldRow>
+            <InlineField
+              label="Max series"
+              labelWidth={30}
+              tooltip="Limit the number of series/tables that Grafana will process. Lower this number to prevent abuse, and increase it if you have lots of small time series and not all are shown. Defaults to 1000."
+            >
+              <Input
+                className="width-15"
+                data-testid="influxdb-v2-config-max-series"
+                onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked}
+                onChange={onUpdateDatasourceJsonDataOption(props, 'maxSeries')}
+                placeholder="1000"
+                value={options.jsonData.maxSeries || ''}
+              />
+            </InlineField>
+          </InlineFieldRow>
         </>
       )}
     </>

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/tracking.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/tracking.ts
@@ -70,6 +70,14 @@ export const trackInfluxDBConfigV2AdvancedDbConnectionSettingsMinTimeClicked = (
   reportInteraction('influxdb-config-v2-advanceddb-settings-min-time-clicked');
 };
 
+export const trackInfluxDBConfigV2AdvancedDbConnectionSettingsAutocompleteClicked = () => {
+  reportInteraction('influxdb-config-v2-advanceddb-settings-autocomplete-range-clicked');
+};
+
+export const trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked = () => {
+  reportInteraction('influxdb-config-v2-advanceddb-settings-max-series-clicked');
+};
+
 // Advanced HTTP Settings
 export const trackInfluxDBConfigV2AdvancedHTTPSettingsToggleClicked = () => {
   reportInteraction('influxdb-config-v2-advanced-http-settings-toggle-clicked');


### PR DESCRIPTION
There was an oversight when creating the new InfluxDB config page design where the `Autocomplete range` setting for InfluxQL and `Max series` setting for all query languages was omitted. This PR adds those fields back in.