### PR TITLE
BrowseDashboards: Bulk move dashboards

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -15,6 +15,7 @@ import { useActionSelectionState } from '../../state/hooks';
 import { setAllSelection } from '../../state/slice';
 import { DashboardTreeSelection } from '../../types';
 
+import { BulkMoveProvisionedResourceDrawer } from './BulkMoveProvisionedResourcesDrawer';
 import { DeleteModal } from './DeleteModal';
 import { MoveModal } from './MoveModal';
 import { SelectedMixResourcesMsgModal } from './SelectedMixResourcesMsgModal';
@@ -26,6 +27,7 @@ export interface Props {
 
 export function BrowseActions({ folderDTO }: Props) {
   const [showBulkDeleteProvisionedResource, setShowBulkDeleteProvisionedResource] = useState(false);
+  const [showBulkMoveProvisionedResource, setShowBulkMoveProvisionedResource] = useState(false);
 
   const dispatch = useDispatch();
   const selectedItems = useActionSelectionState();
@@ -69,15 +71,29 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const showMoveModal = () => {
-    appEvents.publish(
-      new ShowModalReactEvent({
-        component: MoveModal,
-        props: {
-          selectedItems,
-          onConfirm: onMove,
-        },
-      })
-    );
+    if (hasProvisioned && hasNonProvisioned) {
+      // Mixed selection
+      appEvents.publish(
+        new ShowModalReactEvent({
+          component: SelectedMixResourcesMsgModal,
+          props: {},
+        })
+      );
+    } else if (hasProvisioned && provisioningEnabled) {
+      // Only provisioned items
+      setShowBulkMoveProvisionedResource(true);
+    } else {
+      // Only non-provisioned items
+      appEvents.publish(
+        new ShowModalReactEvent({
+          component: MoveModal,
+          props: {
+            selectedItems,
+            onConfirm: onMove,
+          },
+        })
+      );
+    }
   };
 
   const showDeleteModal = () => {
@@ -138,6 +154,13 @@ export function BrowseActions({ folderDTO }: Props) {
             Bulk delete for provisioned resources is not implemented yet.
           </Trans>
         </Drawer>
+      )}
+      {showBulkMoveProvisionedResource && (
+        <BulkMoveProvisionedResourceDrawer
+          selectedItems={selectedItems}
+          folderUid={folderDTO?.uid || ''}
+          onClose={() => setShowBulkMoveProvisionedResource(false)}
+        />
       )}
     </>
   );

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -158,7 +158,7 @@ export function BrowseActions({ folderDTO }: Props) {
       {showBulkMoveProvisionedResource && (
         <BulkMoveProvisionedResourceDrawer
           selectedItems={selectedItems}
-          folderUid={folderDTO?.uid || ''}
+          folderUid={folderDTO?.uid}
           onClose={() => setShowBulkMoveProvisionedResource(false)}
         />
       )}

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -71,7 +71,7 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const showMoveModal = () => {
-    if (hasProvisioned && hasNonProvisioned && provisioningEnabled) {
+    if (provisioningEnabled && hasProvisioned && hasNonProvisioned) {
       // Mixed selection
       appEvents.publish(
         new ShowModalReactEvent({
@@ -79,21 +79,26 @@ export function BrowseActions({ folderDTO }: Props) {
           props: {},
         })
       );
-    } else if (hasProvisioned && provisioningEnabled) {
+      return;
+    }
+
+    if (provisioningEnabled && hasProvisioned) {
       // Only provisioned items
       setShowBulkMoveProvisionedResource(true);
-    } else {
-      // Only non-provisioned items
-      appEvents.publish(
-        new ShowModalReactEvent({
-          component: MoveModal,
-          props: {
-            selectedItems,
-            onConfirm: onMove,
-          },
-        })
-      );
+      return;
     }
+
+    // Only non-provisioned items
+    appEvents.publish(
+      new ShowModalReactEvent({
+        component: MoveModal,
+        props: {
+          selectedItems,
+          onConfirm: onMove,
+        },
+      })
+    );
+    return;
   };
 
   const showDeleteModal = () => {
@@ -105,21 +110,25 @@ export function BrowseActions({ folderDTO }: Props) {
           props: {},
         })
       );
-    } else if (hasProvisioned && provisioningEnabled) {
+      return;
+    }
+
+    if (hasProvisioned && provisioningEnabled) {
       // Only provisioned items
       setShowBulkDeleteProvisionedResource(true);
-    } else {
-      // Only non-provisioned items
-      appEvents.publish(
-        new ShowModalReactEvent({
-          component: DeleteModal,
-          props: {
-            selectedItems,
-            onConfirm: onDelete,
-          },
-        })
-      );
+      return;
     }
+
+    // Only non-provisioned items
+    appEvents.publish(
+      new ShowModalReactEvent({
+        component: DeleteModal,
+        props: {
+          selectedItems,
+          onConfirm: onDelete,
+        },
+      })
+    );
   };
 
   const moveButton = (

--- a/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BrowseActions.tsx
@@ -71,7 +71,7 @@ export function BrowseActions({ folderDTO }: Props) {
   };
 
   const showMoveModal = () => {
-    if (hasProvisioned && hasNonProvisioned) {
+    if (hasProvisioned && hasNonProvisioned && provisioningEnabled) {
       // Mixed selection
       appEvents.publish(
         new ShowModalReactEvent({

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
@@ -9,6 +9,29 @@ export function BulkMoveFailedBanner({ result, onDismiss }: { result: BulkMoveRe
     return null;
   }
 
+  function getMessage(item: BulkMoveResult['failed'][0]) {
+    switch (item.failureType) {
+      case 'create':
+        return (
+          <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-create">
+            Failed to create resource in target location
+          </Trans>
+        );
+      case 'delete':
+        return (
+          <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-delete">
+            Resource was created at new location but could not be deleted from original location. Please manually remove
+            the old file.
+          </Trans>
+        );
+      case 'data-fetch':
+      default:
+        return (
+          <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-fetch">Failed to fetch resource data</Trans>
+        );
+    }
+  }
+
   return (
     <Alert
       severity="error"
@@ -18,21 +41,7 @@ export function BulkMoveFailedBanner({ result, onDismiss }: { result: BulkMoveRe
       <ul>
         {result.failed.map((item) => (
           <li key={item.uid}>
-            <strong>{item.title || item.uid}</strong> -{' '}
-            {item.failureType === 'create' ? (
-              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-create">
-                Failed to create resource in target location
-              </Trans>
-            ) : item.failureType === 'delete' ? (
-              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-delete">
-                Resource was created at new location but could not be deleted from original location. Please manually
-                remove the old file.
-              </Trans>
-            ) : (
-              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-fetch">
-                Failed to fetch resource data
-              </Trans>
-            )}
+            <strong>{item.title || item.uid}</strong> - {getMessage(item)}
             {item.error && `: ${item.error}`}
           </li>
         ))}

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
@@ -1,0 +1,42 @@
+import { Trans, t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+import { BulkMoveResult } from './utils';
+
+// TODO: Adjust this for bulk delete operation
+export function BulkMoveFailedBanner({ result, onDismiss }: { result: BulkMoveResult; onDismiss: () => void }) {
+  if (result.failed.length === 0) {
+    return null;
+  }
+
+  return (
+    <Alert
+      severity="error"
+      title={t('browse-dashboards.bulk-move-resources-form.failed-alert', 'Move Failed')}
+      onRemove={onDismiss}
+    >
+      <ul>
+        {result.failed.map((item) => (
+          <li key={item.uid}>
+            <strong>{item.title || item.uid}</strong> -{' '}
+            {item.failureType === 'create' ? (
+              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-create">
+                Failed to create resource in target location
+              </Trans>
+            ) : item.failureType === 'delete' ? (
+              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-delete">
+                Resource was created at new location but could not be deleted from original location. Please manually
+                remove the old file.
+              </Trans>
+            ) : (
+              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.failed-fetch">
+                Failed to fetch resource data
+              </Trans>
+            )}
+            {item.error && `: ${item.error}`}
+          </li>
+        ))}
+      </ul>
+    </Alert>
+  );
+}

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveFailedBanner.tsx
@@ -5,10 +5,6 @@ import { BulkMoveResult } from './utils';
 
 // TODO: Adjust this for bulk delete operation
 export function BulkMoveFailedBanner({ result, onDismiss }: { result: BulkMoveResult; onDismiss: () => void }) {
-  if (result.failed.length === 0) {
-    return null;
-  }
-
   function getMessage(item: BulkMoveResult['failed'][0]) {
     switch (item.failureType) {
       case 'create':

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProgress.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProgress.tsx
@@ -1,0 +1,28 @@
+import { t } from '@grafana/i18n';
+import { Box, Text } from '@grafana/ui';
+import ProgressBar from 'app/features/provisioning/Shared/ProgressBar';
+
+export interface ProgressState {
+  current: number;
+  total: number;
+  item: string;
+}
+
+export function BulkMoveProgress({ progress }: { progress: ProgressState }) {
+  const progressPercentage = Math.round((progress.current / progress.total) * 100);
+
+  return (
+    <Box>
+      <Text>
+        {t('browse-dashboards.bulk-move-resources-form.progress', 'Progress: {{current}} of {{total}}', {
+          current: progress.current,
+          total: progress.total,
+        })}
+      </Text>
+      <ProgressBar progress={progressPercentage} />
+      <Text variant="bodySmall" color="secondary">
+        {progress.item}
+      </Text>
+    </Box>
+  );
+}

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
@@ -1,0 +1,170 @@
+import { useState } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom-v5-compat';
+
+import { t, Trans } from '@grafana/i18n';
+import { Box, Button, Drawer, Field, Stack } from '@grafana/ui';
+import { useGetFolderQuery } from 'app/api/clients/folder/v1beta1';
+import {
+  RepositoryView,
+  useCreateRepositoryFilesWithPathMutation,
+  useDeleteRepositoryFilesWithPathMutation,
+} from 'app/api/clients/provisioning/v0alpha1';
+import { FolderPicker } from 'app/core/components/Select/FolderPicker';
+import { AnnoKeySourcePath } from 'app/features/apiserver/types';
+import { ResourceEditFormSharedFields } from 'app/features/dashboard-scene/components/Provisioned/ResourceEditFormSharedFields';
+import { getDefaultWorkflow, getWorkflowOptions } from 'app/features/dashboard-scene/saving/provisioned/defaults';
+import { generateTimestamp } from 'app/features/dashboard-scene/saving/provisioned/utils/timestamp';
+import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/shared';
+import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+
+import { DashboardTreeSelection } from '../../types';
+
+import { DescendantCount } from './DescendantCount';
+import { bulkMoveResources, notifyBulkMoveResult } from './utils';
+
+interface FormProps extends BulkMoveProvisionResourceProps {
+  initialValues: BaseProvisionedFormData;
+  repository: RepositoryView;
+  workflowOptions: Array<{ label: string; value: string }>;
+  isGitHub: boolean;
+}
+
+interface BulkMoveProvisionResourceProps {
+  folderUid?: string;
+  selectedItems: Omit<DashboardTreeSelection, 'panel' | '$all'>;
+  onClose: () => void;
+}
+
+export function FormContent({
+  selectedItems,
+  initialValues,
+  folderUid,
+  workflowOptions,
+  isGitHub,
+  repository,
+  onClose,
+}: FormProps) {
+  const [createFile] = useCreateRepositoryFilesWithPathMutation();
+  const [deleteFile] = useDeleteRepositoryFilesWithPathMutation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const [targetFolderUID, setTargetFolderUID] = useState<string>(folderUid || '');
+  const { data: targetFolder } = useGetFolderQuery({ name: targetFolderUID! }, { skip: !targetFolderUID });
+  const navigate = useNavigate();
+
+  const methods = useForm<BaseProvisionedFormData>({ defaultValues: initialValues });
+  const { handleSubmit, watch } = methods;
+  const [workflow] = watch(['workflow']);
+
+  const onFolderChange = (folderUid?: string) => {
+    setTargetFolderUID(folderUid || '');
+  };
+
+  const handleSubmitForm = async (formData: BaseProvisionedFormData) => {
+    if (!targetFolder || !repository) {
+      return;
+    }
+
+    setIsLoading(true);
+
+    const folderAnnotations = targetFolder?.metadata.annotations || {};
+
+    const results = await bulkMoveResources({
+      selectedItems,
+      targetFolderPath: folderAnnotations[AnnoKeySourcePath],
+      repository,
+      mutations: { createFile, deleteFile },
+      options: { ...formData },
+    });
+
+    notifyBulkMoveResult('move', results, () => onClose());
+
+    if (results.successful.length > 0 && results.failed.length === 0) {
+      navigate('/dashboards');
+    }
+
+    setIsLoading(false);
+  };
+
+  const canSubmit = targetFolderUID && !isLoading;
+
+  return (
+    <Drawer onClose={onClose} title={t('browse-dashboards.bulk-move-resources-form.title', 'Bulk Move Resources')}>
+      <FormProvider {...methods}>
+        <form onSubmit={handleSubmit(handleSubmitForm)}>
+          <Stack direction="column" gap={2}>
+            <Box paddingBottom={2}>
+              <Trans i18nKey="browse-dashboards.bulk-move-resources-form.move-warning">
+                This will move selected resources and their descendants. In total, this will affect:
+              </Trans>
+              <DescendantCount selectedItems={{ ...selectedItems, panel: {}, $all: false }} />
+            </Box>
+
+            {/* Target folder selection */}
+            <Field noMargin label={t('browse-dashboards.bulk-move-resources-form.target-folder', 'Target Folder')}>
+              <FolderPicker value={targetFolderUID} onChange={onFolderChange} />
+            </Field>
+
+            <ResourceEditFormSharedFields
+              resourceType="folder"
+              readOnly={isLoading}
+              workflow={workflow}
+              workflowOptions={workflowOptions}
+              isGitHub={isGitHub}
+            />
+
+            <Stack gap={2}>
+              <Button variant="primary" type="submit" disabled={!canSubmit}>
+                {isLoading
+                  ? t('browse-dashboards.bulk-move-resources-form.moving', 'Moving...')
+                  : t('browse-dashboards.bulk-move-resources-form.move-action', 'Move Resources')}
+              </Button>
+              <Button variant="secondary" onClick={onClose} fill="outline" disabled={isLoading}>
+                <Trans i18nKey="browse-dashboards.bulk-move-resources-form.cancel-action">Cancel</Trans>
+              </Button>
+            </Stack>
+          </Stack>
+        </form>
+      </FormProvider>
+    </Drawer>
+  );
+}
+
+export function BulkMoveProvisionedResourceDrawer({
+  folderUid,
+  selectedItems,
+  onClose,
+}: BulkMoveProvisionResourceProps) {
+  const { repository, folder } = useGetResourceRepositoryView({ folderName: folderUid });
+
+  const workflowOptions = getWorkflowOptions(repository);
+  const isGitHub = repository?.type === 'github';
+  const timestamp = generateTimestamp();
+  const path = folder?.metadata.annotations?.[AnnoKeySourcePath] || '';
+
+  const initialValues = {
+    repo: repository?.name || '',
+    title: '', // its ok to be empty, we don't use it
+    comment: '',
+    ref: `bulk-move/${timestamp}`,
+    workflow: getDefaultWorkflow(repository),
+    path: `${path}/`,
+  };
+
+  if (!repository) {
+    return null;
+  }
+
+  return (
+    <FormContent
+      repository={repository}
+      selectedItems={selectedItems}
+      initialValues={initialValues}
+      folderUid={folderUid}
+      workflowOptions={workflowOptions}
+      isGitHub={isGitHub}
+      onClose={onClose}
+    />
+  );
+}

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
@@ -63,7 +63,9 @@ export function FormContent({
   const [workflow] = watch(['workflow']);
 
   const onFolderChange = (folderUid?: string) => {
-    setTargetFolderUID(folderUid || '');
+    if (folderUid) {
+      setTargetFolderUID(folderUid);
+    }
   };
 
   const handleSubmitForm = async (formData: BaseProvisionedFormData) => {

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
@@ -39,7 +39,7 @@ interface BulkMoveProvisionResourceProps {
   onClose: () => void;
 }
 
-export function FormContent({
+function FormContent({
   selectedItems,
   initialValues,
   folderUid,
@@ -53,7 +53,7 @@ export function FormContent({
   const [isLoading, setIsLoading] = useState(false);
   const [results, setResults] = useState<BulkMoveResult | undefined>(); // This only gets set if there are any failed moves
 
-  const [targetFolderUID, setTargetFolderUID] = useState<string>(folderUid || '');
+  const [targetFolderUID, setTargetFolderUID] = useState<string | undefined>(undefined);
   const { data: targetFolder } = useGetFolderQuery({ name: targetFolderUID! }, { skip: !targetFolderUID });
   const navigate = useNavigate();
   const appEvents = getAppEvents();

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
@@ -91,7 +91,13 @@ function FormContent({
         type: AppEvents.alertSuccess.name,
         payload: [t('browse-dashboards.bulk-move-resources-form.success', 'Bulk move completed successfully')],
       });
-      navigate('/dashboards');
+      onClose();
+      // Navigate to the target folder
+      if (targetFolder?.metadata?.name) {
+        navigate(`/dashboards/f/${targetFolder.metadata.name}/`);
+      } else {
+        navigate('/dashboards'); // Fallback to root
+      }
     } else {
       setResults(results);
     }

--- a/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseActions/BulkMoveProvisionedResourcesDrawer.tsx
@@ -27,7 +27,7 @@ import { DescendantCount } from './DescendantCount';
 import { bulkMoveResources, BulkMoveResult } from './utils';
 
 interface FormProps extends BulkMoveProvisionResourceProps {
-  initialValues: BaseProvisionedFormData;
+  initialValues: Omit<BaseProvisionedFormData, 'title'>;
   repository: RepositoryView;
   workflowOptions: Array<{ label: string; value: string }>;
   isGitHub: boolean;
@@ -160,7 +160,6 @@ export function BulkMoveProvisionedResourceDrawer({
 
   const initialValues = {
     repo: repository?.name || '',
-    title: '', // its ok to be empty, we don't use it
     comment: '',
     ref: `bulk-move/${timestamp}`,
     workflow: getDefaultWorkflow(repository),

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -261,11 +261,11 @@ export async function moveResource({
         body: fileContent,
       })
       .unwrap();
-  } catch (createError) {
+  } catch (error) {
     return {
       success: false,
       failedToCreate: true,
-      error: createError instanceof Error ? createError.message : 'Create failed',
+      error: error instanceof Error ? error.message : 'Create failed',
     };
   }
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -153,7 +153,6 @@ export const bulkMoveResources = async ({
     fulfilledResources.map(async ({ uid, data, title }): Promise<MoveResultSuccess | MoveResultFailed> => {
       try {
         const fileName = formatFileName(data);
-        const newPath = formatFilePath(targetFolderPath, fileName);
         const body = data.resource.file;
 
         if (!body) {
@@ -162,8 +161,8 @@ export const bulkMoveResources = async ({
 
         const result = await moveResource({
           repositoryName: repository.name,
-          currentPath: formatFilePath(targetFolderPath, fileName),
-          targetPath: newPath,
+          currentPath: formatFilePath(options.path, fileName),
+          targetPath: formatFilePath(targetFolderPath, fileName),
           fileContent: body,
           commitMessage: options.comment || `Move dashboard: ${title || uid}`,
           ref: options.workflow === 'write' ? undefined : options.ref,
@@ -259,6 +258,7 @@ export async function moveResource({
         ref,
         message: commitMessage,
         body: fileContent,
+        skipDryRun: true, // We want to skip dry run, otherwise BE will check for UID and instead not create the file, but try to update it.
       })
       .unwrap();
   } catch (error) {

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -293,6 +293,9 @@ export async function moveResource({
 
 function formatFileName(data: ResourceWrapper) {
   const fileName = data.resource?.dryRun?.metadata?.annotations?.[AnnoKeySourcePath];
+  if (!fileName) {
+    throw new Error('Missing source path annotation');
+  }
   return fileName.split('/').pop();
 }
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -162,7 +162,7 @@ export const bulkMoveResources = async ({
 
         const result = await moveResource({
           repositoryName: repository.name,
-          currentPath: `${options.path}/${fileName}`,
+          currentPath: formatFilePath(targetFolderPath, fileName),
           targetPath: newPath,
           fileContent: body,
           commitMessage: options.comment || `Move dashboard: ${title || uid}`,

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -210,7 +210,7 @@ export const bulkMoveResources = async ({
 
       // Add delay between operations to prevent GitHub API rate limits and conflicts
       if (index < fulfilledResources.length - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 300)); // 300ms delay
+        await new Promise((resolve) => setTimeout(resolve, 20000)); // 20000 delay to prevent Git corruption
       }
     } catch (error) {
       console.error(`❌ Failed to move dashboard ${uid}:`, error);

--- a/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.test.tsx
@@ -29,6 +29,10 @@ jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   useDeleteRepositoryFilesWithPathMutation: jest.fn(),
 }));
 
+jest.mock('app/features/provisioning/utils/selectors', () => ({
+  selectAllRepos: jest.fn().mockReturnValue([]),
+}));
+
 jest.mock('app/api/clients/folder/v1beta1', () => ({
   useGetFolderQuery: jest.fn(),
 }));

--- a/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
@@ -60,7 +60,6 @@ export function MoveProvisionedDashboardForm({
   });
 
   const { data: targetFolder } = useGetFolderQuery({ name: targetFolderUID! }, { skip: !targetFolderUID });
-
   const [createFile, createRequest] = useCreateRepositoryFilesWithPathMutation();
   const [deleteFile, deleteRequest] = useDeleteRepositoryFilesWithPathMutation();
   const [targetPath, setTargetPath] = useState<string>('');

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
@@ -34,12 +34,14 @@ export function useProvisionedRequestHandler({
   workflow,
   handlers,
   isNew,
+  hideAlert = false,
 }: {
   dashboard: DashboardScene;
   request: ProvisionedRequest;
   workflow?: string;
   handlers: RequestHandlers;
   isNew?: boolean;
+  hideAlert?: boolean;
 }) {
   useEffect(() => {
     if (request.isError) {
@@ -57,11 +59,14 @@ export function useProvisionedRequestHandler({
         return;
       }
 
-      // Success message (could be configurable)
-      getAppEvents().publish({
-        type: AppEvents.alertSuccess.name,
-        payload: [t('dashboard-scene.edit-provisioned-dashboard-form.success', 'Dashboard changes saved successfully')],
-      });
+      if (!hideAlert) {
+        getAppEvents().publish({
+          type: AppEvents.alertSuccess.name,
+          payload: [
+            t('dashboard-scene.edit-provisioned-dashboard-form.success', 'Dashboard changes saved successfully'),
+          ],
+        });
+      }
 
       // New dashboard flow
       if (isNew && resource?.upsert && handlers.onNewDashboardSuccess) {
@@ -73,5 +78,5 @@ export function useProvisionedRequestHandler({
       // Write workflow
       handlers.onWriteSuccess?.();
     }
-  }, [request, workflow, handlers, isNew, dashboard]);
+  }, [request, workflow, handlers, isNew, dashboard, hideAlert]);
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3495,16 +3495,33 @@
     "browse-view": {
       "this-folder-is-empty": "This folder is empty"
     },
+    "bulk-move": {
+      "create-failed": "Create failed",
+      "delete-failed": "Delete failed",
+      "fetching-data": "Fetching dashboard data...",
+      "filename-required": "File name is required to format file path",
+      "missing-source-path": "Missing source path annotation",
+      "move-failed": "Move operation failed",
+      "moving-dashboard": "Moving \"{{title}}\"",
+      "no-file-content": "No file content found for dashboard {{uid}}",
+      "no-source-path": "No source path found for dashboard {{uid}}",
+      "unknown-error": "Unknown error"
+    },
     "bulk-move-resources-form": {
       "cancel-action": "Cancel",
+      "error": "Bulk move operation failed",
       "failed-alert": "Move Failed",
       "failed-create": "Failed to create resource in target location",
       "failed-delete": "Resource was created at new location but could not be deleted from original location. Please manually remove the old file.",
       "failed-fetch": "Failed to fetch resource data",
       "move-action": "Move Resources",
       "move-warning": "This will move selected resources and their descendants. In total, this will affect:",
-      "moving": "Moving...",
-      "success": "Bulk move completed successfully",
+      "moving": "Moving... ({{current}}/{{total}})",
+      "partial-success": "Moved {{successCount}} dashboard(s), {{failedCount}} failed",
+      "preparing": "Preparing...",
+      "progress": "Progress: {{current}} of {{total}}",
+      "success_one": "Successfully moved {{count}} dashboard(s)",
+      "success_other": "Successfully moved {{count}} dashboard(s)",
       "target-folder": "Target Folder",
       "title": "Bulk Move Resources"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3495,6 +3495,19 @@
     "browse-view": {
       "this-folder-is-empty": "This folder is empty"
     },
+    "bulk-move-resources-form": {
+      "cancel-action": "Cancel",
+      "failed-alert": "Move Failed",
+      "failed-create": "Failed to create resource in target location",
+      "failed-delete": "Resource was created at new location but could not be deleted from original location. Please manually remove the old file.",
+      "failed-fetch": "Failed to fetch resource data",
+      "move-action": "Move Resources",
+      "move-warning": "This will move selected resources and their descendants. In total, this will affect:",
+      "moving": "Moving...",
+      "success": "Bulk move completed successfully",
+      "target-folder": "Target Folder",
+      "title": "Bulk Move Resources"
+    },
     "counts": {
       "alertRule_one": "{{count}} alert rule",
       "alertRule_other": "{{count}} alert rule",
@@ -5742,7 +5755,6 @@
       "usage-count_other": "Used on {{count}} dashboards"
     },
     "move-provisioned-dashboard-form": {
-      "api-error": "Failed to move dashboard",
       "cancel-action": "Cancel",
       "current-file-not-found": "Current dashboard file could not be found",
       "drawer-title": "Move Provisioned Dashboard",
@@ -5751,7 +5763,6 @@
       "move-action": "Move dashboard",
       "move-read-only-message": "This dashboard cannot be moved directly from Grafana because the repository is read-only. To move this dashboard, please move the file in your Git repository.",
       "moving": "Moving...",
-      "partial-failure-warning": "Dashboard was created at new location but could not be deleted from original location. Please manually remove the old file.",
       "target-path-label": "Target path",
       "title-this-repository-is-read-only": "This repository is read only"
     },
@@ -9303,6 +9314,10 @@
       "link-title": "More questions? Talk to an expert",
       "title": "Why host with Grafana?"
     }
+  },
+  "move-operations": {
+    "error": "Failed to move {{resourceName}}",
+    "partial-success-warning": "{{resourceName}} was created at new location but could not be deleted from original location. Please manually remove the old file."
   },
   "multicombobox": {
     "all": {


### PR DESCRIPTION
**What is this feature?**

In browse dashboards page, implement bulk move action. 

**Happy flow:**   
To be added

**Failed to fetch resource data flow:**  

https://github.com/user-attachments/assets/efd1cdba-5896-4a06-9bc9-2f9784360794



**Why do we need this feature?**

Allow user bulk manage resources

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/git-ui-sync-project/issues/341

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
