### PR TITLE
Plugins: Stub logger method for backend plugin test mock

### DIFF
--- a/pkg/plugins/manager/fakes/fakes.go
+++ b/pkg/plugins/manager/fakes/fakes.go
@@ -661,3 +661,7 @@ func (p *FakeBackendPlugin) Kill() {
 func (p *FakeBackendPlugin) Target() backendplugin.Target {
 	return "test-target"
 }
+
+func (p *FakeBackendPlugin) Logger() log.Logger {
+	return log.NewTestLogger()
+}


### PR DESCRIPTION
**What is this feature?**

Adds a missing `Logger()` method to a mock that was not yet implemented.

**Why do we need this feature?**

Fixes a test in a PR in Enterprise: https://github.com/grafana/grafana-enterprise/pull/9083


