### PR TITLE
Analytics: Fix depth calculation when reporting new folder creation

### DIFF
--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -41,7 +41,7 @@ export default function CreateNewButton({ parentFolder, canCreateDashboard, canC
         parentUid: parentFolder?.uid,
       });
 
-      const depth = parentFolder?.parents ? parentFolder.parents.length + 1 : 0;
+      const depth = parentFolder ? (parentFolder.parents?.length || 0) + 1 : 0;
       reportInteraction('grafana_manage_dashboards_folder_created', {
         is_subfolder: Boolean(parentFolder?.uid),
         folder_depth: depth,


### PR DESCRIPTION
Fix issue with depth attribute which reported 0 for both root level folders and their subfolder, ie folders which should have depth = 1 | 0 all were reported as depth = 0.