### PR TITLE
Alertmanager: Add MergeState method

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_mock/Alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager_mock/Alertmanager.go
@@ -13,6 +13,8 @@ import (
 
 	models "github.com/grafana/grafana/pkg/services/ngalert/models"
 
+	notifier "github.com/grafana/grafana/pkg/services/ngalert/notifier"
+
 	notify "github.com/grafana/alerting/notify"
 
 	v2models "github.com/prometheus/alertmanager/api/v2/models"
@@ -534,6 +536,52 @@ func (_c *AlertmanagerMock_ListSilences_Call) Return(_a0 v2models.GettableSilenc
 }
 
 func (_c *AlertmanagerMock_ListSilences_Call) RunAndReturn(run func(context.Context, []string) (v2models.GettableSilences, error)) *AlertmanagerMock_ListSilences_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// MergeState provides a mock function with given fields: _a0
+func (_m *AlertmanagerMock) MergeState(_a0 notifier.ExternalState) error {
+	ret := _m.Called(_a0)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MergeState")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(notifier.ExternalState) error); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// AlertmanagerMock_MergeState_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'MergeState'
+type AlertmanagerMock_MergeState_Call struct {
+	*mock.Call
+}
+
+// MergeState is a helper method to define mock.On call
+//   - _a0 notifier.ExternalState
+func (_e *AlertmanagerMock_Expecter) MergeState(_a0 interface{}) *AlertmanagerMock_MergeState_Call {
+	return &AlertmanagerMock_MergeState_Call{Call: _e.mock.On("MergeState", _a0)}
+}
+
+func (_c *AlertmanagerMock_MergeState_Call) Run(run func(_a0 notifier.ExternalState)) *AlertmanagerMock_MergeState_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(notifier.ExternalState))
+	})
+	return _c
+}
+
+func (_c *AlertmanagerMock_MergeState_Call) Return(_a0 error) *AlertmanagerMock_MergeState_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *AlertmanagerMock_MergeState_Call) RunAndReturn(run func(notifier.ExternalState) error) *AlertmanagerMock_MergeState_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/services/ngalert/notifier/alerts.go
+++ b/pkg/services/ngalert/notifier/alerts.go
@@ -13,7 +13,3 @@ func (am *alertmanager) GetAlerts(_ context.Context, active, silenced, inhibited
 func (am *alertmanager) GetAlertGroups(_ context.Context, active, silenced, inhibited bool, filter []string, receivers string) (alertingNotify.AlertGroups, error) {
 	return am.Base.GetAlertGroups(active, silenced, inhibited, filter, receivers)
 }
-
-func (am *alertmanager) MergeNflog(b []byte) error {
-	return am.Base.MergeNflog(b)
-}

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -72,15 +72,18 @@ type Alertmanager interface {
 	TestReceivers(ctx context.Context, c apimodels.TestReceiversConfigBodyParams) (*alertingNotify.TestReceiversResult, int, error)
 	TestTemplate(ctx context.Context, c apimodels.TestTemplatesConfigBodyParams) (*TestTemplatesResults, error)
 
+	// State
+	MergeState(ExternalState) error
+
 	// Lifecycle
 	StopAndWait()
 	Ready() bool
 }
 
-// StateMerger describes a type that is able to merge external state (nflog, silences) with its own.
-type StateMerger interface {
-	MergeNflog([]byte) error
-	MergeSilences([]byte) error
+// ExternalState holds nflog entries and silences from an external Alertmanager.
+type ExternalState struct {
+	Silences []byte
+	Nflog    []byte
 }
 
 type MultiOrgAlertmanager struct {

--- a/pkg/services/ngalert/notifier/silences.go
+++ b/pkg/services/ngalert/notifier/silences.go
@@ -21,7 +21,3 @@ func (am *alertmanager) CreateSilence(_ context.Context, ps *alertingNotify.Post
 func (am *alertmanager) DeleteSilence(_ context.Context, silenceID string) error {
 	return am.Base.DeleteSilence(silenceID)
 }
-
-func (am *alertmanager) MergeSilences(b []byte) error {
-	return am.Base.MergeSilences(b)
-}

--- a/pkg/services/ngalert/notifier/state.go
+++ b/pkg/services/ngalert/notifier/state.go
@@ -1,0 +1,9 @@
+package notifier
+
+// MergeState incorporates external nflog entries and silences to the Alertmanager's state.
+func (am *alertmanager) MergeState(state ExternalState) error {
+	if err := am.Base.MergeNflog(state.Nflog); err != nil {
+		return err
+	}
+	return am.Base.MergeSilences(state.Silences)
+}

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -789,3 +789,8 @@ func (am *Alertmanager) shouldSendConfig(ctx context.Context, hash [16]byte) boo
 	}
 	return md5.Sum(rawRemote) != hash
 }
+
+// MergeState should never be called on the remote Alertmanager implementation.
+func (am *Alertmanager) MergeState(notifier.ExternalState) error {
+	panic("Not implemented")
+}


### PR DESCRIPTION
This PR combines `MergeSilences` and `MergeNflog` into a single method, part of the `Alertmanager` interface.

Part of https://github.com/grafana/grafana/pull/107710