### PR TITLE
Feature/unified storage search dual reader

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1037,6 +1037,7 @@ export interface FeatureToggles {
   */
   foldersAppPlatformAPI?: boolean;
   /**
+<<<<<<< HEAD
   * Set this to true to use the new PluginImporter functionality
   * @default false
   */
@@ -1055,4 +1056,9 @@ export interface FeatureToggles {
   * @default false
   */
   pluginAssetProvider?: boolean;
+  /**
+  * Enable dual reader for unified storage search
+  * @default false
+  */
+  unifiedStorageSearchDualReaderEnabled?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1057,7 +1057,6 @@ export interface FeatureToggles {
   pluginAssetProvider?: boolean;
   /**
   * Enable dual reader for unified storage search
-  * @default false
   */
   unifiedStorageSearchDualReaderEnabled?: boolean;
 }

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1037,7 +1037,6 @@ export interface FeatureToggles {
   */
   foldersAppPlatformAPI?: boolean;
   /**
-<<<<<<< HEAD
   * Set this to true to use the new PluginImporter functionality
   * @default false
   */

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -122,7 +122,7 @@ func RegisterAPIService(
 	dbp := legacysql.NewDatabaseProvider(sql)
 	namespacer := request.GetNamespaceMapper(cfg)
 	legacyDashboardSearcher := legacysearcher.NewDashboardSearchClient(dashStore, sorter)
-	folderClient := client.NewK8sHandler(dual, request.GetNamespaceMapper(cfg), folders.FolderResourceInfo.GroupVersionResource(), restConfigProvider.GetRestConfig, dashStore, userService, unified, sorter)
+	folderClient := client.NewK8sHandler(dual, request.GetNamespaceMapper(cfg), folders.FolderResourceInfo.GroupVersionResource(), restConfigProvider.GetRestConfig, dashStore, userService, unified, sorter, features)
 	builder := &DashboardsAPIBuilder{
 		log: log.New("grafana-apiserver.dashboards"),
 

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -43,7 +43,7 @@ type SearchHandler struct {
 }
 
 func NewSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyDashboardSearcher resourcepb.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles) *SearchHandler {
-	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), dashboardv0alpha1.DashboardResourceInfo.GroupResource(), resourceClient, legacyDashboardSearcher)
+	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), dashboardv0alpha1.DashboardResourceInfo.GroupResource(), resourceClient, legacyDashboardSearcher, features)
 	return &SearchHandler{
 		client:   searchClient,
 		log:      log.New("grafana-apiserver.dashboards.search"),

--- a/pkg/services/apiserver/client/client.go
+++ b/pkg/services/apiserver/client/client.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/dashboard/legacysearcher"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
@@ -46,9 +47,9 @@ type k8sHandler struct {
 }
 
 func NewK8sHandler(dual dualwrite.Service, namespacer request.NamespaceMapper, gvr schema.GroupVersionResource,
-	restConfig func(context.Context) (*rest.Config, error), dashStore dashboards.Store, userSvc user.Service, resourceClient resource.ResourceClient, sorter sort.Service) K8sHandler {
+	restConfig func(context.Context) (*rest.Config, error), dashStore dashboards.Store, userSvc user.Service, resourceClient resource.ResourceClient, sorter sort.Service, features featuremgmt.FeatureToggles) K8sHandler {
 	legacySearcher := legacysearcher.NewDashboardSearchClient(dashStore, sorter)
-	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), gvr.GroupResource(), resourceClient, legacySearcher)
+	searchClient := resource.NewSearchClient(dualwrite.NewSearchAdapter(dual), gvr.GroupResource(), resourceClient, legacySearcher, features)
 
 	return &k8sHandler{
 		namespacer:  namespacer,

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -387,7 +387,7 @@ func ProvideDashboardServiceImpl(
 	serverLockService *serverlock.ServerLockService,
 	kvstore kvstore.KVStore,
 ) (*DashboardServiceImpl, error) {
-	k8sclient := dashboardclient.NewK8sClientWithFallback(cfg, restConfigProvider, dashboardStore, userService, resourceClient, sorter, dual, r)
+	k8sclient := dashboardclient.NewK8sClientWithFallback(cfg, restConfigProvider, dashboardStore, userService, resourceClient, sorter, dual, r, features)
 	dashSvc := &DashboardServiceImpl{
 		cfg:                       cfg,
 		log:                       log.New("dashboard-service"),

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -61,6 +61,7 @@ func ProvideService(cfg *setting.Cfg, db db.DB, dashboardService dashboards.Dash
 			userService,
 			unified,
 			sorter,
+			features,
 		),
 		dashSvc: dashboardService,
 		log:     log.New("dashboard-version"),

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1819,6 +1819,14 @@ var (
 			Expression:        "false",
 			RequiresRestart:   true,
 		},
+		{
+			Name:              "unifiedStorageSearchDualReaderEnabled",
+			Description:       "Enable dual reader for unified storage search",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaSearchAndStorageSquad,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -235,3 +235,4 @@ enablePluginImporter,experimental,@grafana/plugins-platform-backend,false,false,
 otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
 alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 pluginAssetProvider,experimental,@grafana/plugins-platform-backend,false,true,false
+unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -950,4 +950,8 @@ const (
 	// FlagPluginAssetProvider
 	// Allows decoupled core plugins to load from the Grafana CDN
 	FlagPluginAssetProvider = "pluginAssetProvider"
+
+	// FlagUnifiedStorageSearchDualReaderEnabled
+	// Enable dual reader for unified storage search
+	FlagUnifiedStorageSearchDualReaderEnabled = "unifiedStorageSearchDualReaderEnabled"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3352,6 +3352,20 @@
     },
     {
       "metadata": {
+        "name": "unifiedStorageSearchDualReaderEnabled",
+        "resourceVersion": "1752500336818",
+        "creationTimestamp": "2025-07-14T13:38:56Z"
+      },
+      "spec": {
+        "description": "Enable dual reader for unified storage search",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "unifiedStorageSearchPermissionFiltering",
         "resourceVersion": "1750434297879",
         "creationTimestamp": "2025-01-22T11:38:37Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2452,6 +2452,22 @@
     },
     {
       "metadata": {
+        "name": "pluginAssetProvider",
+        "resourceVersion": "1752486584712",
+        "creationTimestamp": "2025-07-14T09:49:44Z"
+      },
+      "spec": {
+        "description": "Allows decoupled core plugins to load from the Grafana CDN",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "requiresRestart": true,
+        "hideFromAdminPage": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "pluginLoadingRefactor",
         "resourceVersion": "1752218524617",
         "creationTimestamp": "2025-07-11T07:22:04Z",
@@ -2462,22 +2478,6 @@
         "stage": "experimental",
         "codeowner": "@grafana/plugins-platform-backend",
         "frontend": true,
-        "hideFromAdminPage": true,
-        "hideFromDocs": true,
-        "expression": "false"
-      }
-    },
-    {
-      "metadata": {
-        "name": "pluginAssetProvider",
-        "resourceVersion": "1752486584712",
-        "creationTimestamp": "2025-07-14T09:49:44Z"
-      },
-      "spec": {
-        "description": "Allows decoupled core plugins to load from the Grafana CDN",
-        "stage": "experimental",
-        "codeowner": "@grafana/plugins-platform-backend",
-        "requiresRestart": true,
         "hideFromAdminPage": true,
         "hideFromDocs": true,
         "expression": "false"

--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -122,6 +122,7 @@ func ProvideService(
 			userService,
 			resourceClient,
 			sorter,
+			features,
 		)
 
 		unifiedStore := ProvideUnifiedStore(k8sHandler, userService, tracer)
@@ -140,6 +141,7 @@ func ProvideService(
 			userService,
 			resourceClient,
 			sorter,
+			features,
 		)
 		srv.dashboardK8sClient = dashHandler
 	}

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -199,7 +199,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 
 	tracer := noop.NewTracerProvider().Tracer("TestIntegrationFolderServiceViaUnifiedStorage")
 	dashboardStore := dashboards.NewFakeDashboardStore(t)
-	k8sCli := client.NewK8sHandler(dualwrite.ProvideTestService(), request.GetNamespaceMapper(cfg), folderv1.FolderResourceInfo.GroupVersionResource(), restCfgProvider.GetRestConfig, dashboardStore, userService, nil, sort.ProvideService())
+	k8sCli := client.NewK8sHandler(dualwrite.ProvideTestService(), request.GetNamespaceMapper(cfg), folderv1.FolderResourceInfo.GroupVersionResource(), restCfgProvider.GetRestConfig, dashboardStore, userService, nil, sort.ProvideService(), nil)
 	unifiedStore := ProvideUnifiedStore(k8sCli, userService, tracer)
 
 	ctx := context.Background()

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -6,6 +6,8 @@ import (
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -15,13 +17,15 @@ type DualWriter interface {
 }
 
 func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient resourcepb.ResourceIndexClient,
-	legacyClient resourcepb.ResourceIndexClient) resourcepb.ResourceIndexClient {
+	legacyClient resourcepb.ResourceIndexClient, features featuremgmt.FeatureToggles) resourcepb.ResourceIndexClient {
 	if dual.IsEnabled(gr) {
 		return &searchWrapper{
 			dual:          dual,
 			groupResource: gr,
 			unifiedClient: unifiedClient,
 			legacyClient:  legacyClient,
+			features:      features,
+			logger:        log.New("unified-storage.search-client"),
 		}
 	}
 	//nolint:errcheck
@@ -37,6 +41,8 @@ type searchWrapper struct {
 
 	unifiedClient resourcepb.ResourceIndexClient
 	legacyClient  resourcepb.ResourceIndexClient
+	features      featuremgmt.FeatureToggles
+	logger        log.Logger
 }
 
 func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest,
@@ -49,6 +55,27 @@ func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceSta
 	if unified {
 		client = s.unifiedClient
 	}
+
+	// If dual reader feature flag is enabled, make a background call to the other client
+	if s.features != nil && s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) {
+		var backgroundClient resourcepb.ResourceIndexClient
+		if unified {
+			backgroundClient = s.legacyClient
+		} else {
+			backgroundClient = s.unifiedClient
+		}
+
+		// Make background call without blocking the main request
+		go func() {
+			_, bgErr := backgroundClient.GetStats(context.Background(), in, opts...)
+			if bgErr != nil {
+				s.logger.Error("Background GetStats call failed", "unified", !unified, "error", bgErr)
+			} else {
+				s.logger.Debug("Background GetStats call succeeded", "unified", !unified)
+			}
+		}()
+	}
+
 	return client.GetStats(ctx, in, opts...)
 }
 
@@ -62,5 +89,26 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 	if unified {
 		client = s.unifiedClient
 	}
+
+	// If dual reader feature flag is enabled, make a background call to the other client
+	if s.features != nil && s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) {
+		var backgroundClient resourcepb.ResourceIndexClient
+		if unified {
+			backgroundClient = s.legacyClient
+		} else {
+			backgroundClient = s.unifiedClient
+		}
+
+		// Make background call without blocking the main request
+		go func() {
+			_, bgErr := backgroundClient.Search(context.Background(), in, opts...)
+			if bgErr != nil {
+				s.logger.Error("Background Search call failed", "unified", !unified, "error", bgErr)
+			} else {
+				s.logger.Debug("Background Search call succeeded", "unified", !unified)
+			}
+		}()
+	}
+
 	return client.Search(ctx, in, opts...)
 }

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -1,0 +1,299 @@
+package resource
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// Mock DualWriter
+type MockDualWriter struct {
+	mock.Mock
+}
+
+func (m *MockDualWriter) IsEnabled(gr schema.GroupResource) bool {
+	args := m.Called(gr)
+	return args.Bool(0)
+}
+
+func (m *MockDualWriter) ReadFromUnified(ctx context.Context, gr schema.GroupResource) (bool, error) {
+	args := m.Called(ctx, gr)
+	return args.Bool(0), args.Error(1)
+}
+
+// Mock ResourceIndexClient
+type MockResourceIndexClient struct {
+	mock.Mock
+	searchCalled chan struct{}
+	statsCalled  chan struct{}
+}
+
+func NewMockResourceIndexClient() *MockResourceIndexClient {
+	return &MockResourceIndexClient{
+		searchCalled: make(chan struct{}, 1),
+		statsCalled:  make(chan struct{}, 1),
+	}
+}
+
+func (m *MockResourceIndexClient) Search(ctx context.Context, in *resourcepb.ResourceSearchRequest, opts ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	args := m.Called(ctx, in, opts)
+
+	// Signal that Search was called
+	select {
+	case m.searchCalled <- struct{}{}:
+	default:
+	}
+
+	return args.Get(0).(*resourcepb.ResourceSearchResponse), args.Error(1)
+}
+
+func (m *MockResourceIndexClient) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest, opts ...grpc.CallOption) (*resourcepb.ResourceStatsResponse, error) {
+	args := m.Called(ctx, in, opts)
+
+	// Signal that GetStats was called
+	select {
+	case m.statsCalled <- struct{}{}:
+	default:
+	}
+
+	return args.Get(0).(*resourcepb.ResourceStatsResponse), args.Error(1)
+}
+
+func setupTestSearchClient(t *testing.T) (schema.GroupResource, *MockResourceIndexClient, *MockResourceIndexClient, featuremgmt.FeatureToggles) {
+	t.Helper()
+	gr := schema.GroupResource{Group: "test", Resource: "items"}
+	unifiedClient := NewMockResourceIndexClient()
+	legacyClient := NewMockResourceIndexClient()
+	features := featuremgmt.WithFeatures()
+	return gr, unifiedClient, legacyClient, features
+}
+
+func setupTestSearchWrapper(t *testing.T, dual *MockDualWriter, unifiedClient, legacyClient *MockResourceIndexClient, features featuremgmt.FeatureToggles, gr schema.GroupResource) *searchWrapper {
+	t.Helper()
+	return &searchWrapper{
+		dual:          dual,
+		groupResource: gr,
+		unifiedClient: unifiedClient,
+		legacyClient:  legacyClient,
+		features:      features,
+		logger:        log.NewNopLogger(),
+	}
+}
+
+func TestSearchClient_NewSearchClient(t *testing.T) {
+	gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+
+	t.Run("returns wrapper when dual writer is enabled", func(t *testing.T) {
+		dual := &MockDualWriter{} // Create fresh mock for this test
+		dual.On("IsEnabled", gr).Return(true)
+
+		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
+
+		wrapper, ok := client.(*searchWrapper)
+		require.True(t, ok)
+		assert.Equal(t, dual, wrapper.dual)
+		assert.Equal(t, gr, wrapper.groupResource)
+		assert.Equal(t, unifiedClient, wrapper.unifiedClient)
+		assert.Equal(t, legacyClient, wrapper.legacyClient)
+
+		dual.AssertExpectations(t)
+	})
+
+	t.Run("returns unified client when dual writer disabled but read from unified", func(t *testing.T) {
+		dual := &MockDualWriter{} // Create fresh mock for this test
+		dual.On("IsEnabled", gr).Return(false)
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(true, nil)
+
+		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
+
+		assert.Equal(t, unifiedClient, client)
+		dual.AssertExpectations(t)
+	})
+
+	t.Run("returns legacy client when dual writer disabled and not reading from unified", func(t *testing.T) {
+		dual := &MockDualWriter{} // Create fresh mock for this test
+		dual.On("IsEnabled", gr).Return(false)
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
+
+		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
+
+		assert.Equal(t, legacyClient, client)
+		dual.AssertExpectations(t)
+	})
+}
+
+func TestSearchWrapper_Search(t *testing.T) {
+	gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+	req := &resourcepb.ResourceSearchRequest{Query: "test"}
+	expectedResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}
+
+	t.Run("uses unified client when reading from unified", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(true, nil)
+		unifiedClient.On("Search", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+
+		resp, err := wrapper.Search(ctx, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		dual.AssertExpectations(t)
+		unifiedClient.AssertExpectations(t)
+		legacyClient.AssertNotCalled(t, "Search")
+	})
+
+	t.Run("uses legacy client when not reading from unified", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
+		legacyClient.On("Search", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+
+		resp, err := wrapper.Search(ctx, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		dual.AssertExpectations(t)
+		legacyClient.AssertExpectations(t)
+		unifiedClient.AssertNotCalled(t, "Search")
+	})
+
+	t.Run("makes background call to unified when feature flag enabled and using legacy", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
+		legacyClient.On("Search", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		// Expect background call to unified client
+		unifiedBgResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}
+		unifiedClient.On("Search", mock.Anything, req, mock.Anything).Return(unifiedBgResponse, nil)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+
+		resp, err := wrapper.Search(ctx, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		// Wait for background goroutine to complete
+		select {
+		case <-unifiedClient.searchCalled:
+			// Background call was made
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Background unified client call was not made within timeout")
+		}
+
+		dual.AssertExpectations(t)
+		legacyClient.AssertExpectations(t)
+		unifiedClient.AssertExpectations(t)
+	})
+
+	t.Run("handles background call error gracefully", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
+		legacyClient.On("Search", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		// Background call returns error - should be handled gracefully
+		unifiedClient.On("Search", mock.Anything, req, mock.Anything).Return((*resourcepb.ResourceSearchResponse)(nil), assert.AnError)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+
+		resp, err := wrapper.Search(ctx, req)
+
+		// Main request should still succeed despite background error
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		// Wait for background goroutine to complete
+		select {
+		case <-unifiedClient.searchCalled:
+			// Background call was made (even though it failed)
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Background unified client call was not made within timeout")
+		}
+
+		dual.AssertExpectations(t)
+		legacyClient.AssertExpectations(t)
+		unifiedClient.AssertExpectations(t)
+	})
+}
+
+func TestSearchWrapper_GetStats(t *testing.T) {
+	gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
+	req := &resourcepb.ResourceStatsRequest{Namespace: "test"}
+	expectedResponse := &resourcepb.ResourceStatsResponse{Stats: []*resourcepb.ResourceStatsResponse_Stats{{Count: 100}}}
+
+	t.Run("uses unified client when reading from unified", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(true, nil)
+		unifiedClient.On("GetStats", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, features, gr)
+
+		resp, err := wrapper.GetStats(ctx, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		dual.AssertExpectations(t)
+		unifiedClient.AssertExpectations(t)
+		legacyClient.AssertNotCalled(t, "GetStats")
+	})
+
+	t.Run("makes background call to unified when feature flag enabled and using legacy", func(t *testing.T) {
+		ctx := testutil.NewDefaultTestContext(t)
+		dual := &MockDualWriter{}
+		featuresWithFlag := featuremgmt.WithFeatures(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled)
+
+		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
+		legacyClient.On("GetStats", mock.Anything, req, mock.Anything).Return(expectedResponse, nil)
+
+		// Expect background call to unified client
+		unifiedBgResponse := &resourcepb.ResourceStatsResponse{Stats: []*resourcepb.ResourceStatsResponse_Stats{{Count: 50}}}
+		unifiedClient.On("GetStats", mock.Anything, req, mock.Anything).Return(unifiedBgResponse, nil)
+
+		wrapper := setupTestSearchWrapper(t, dual, unifiedClient, legacyClient, featuresWithFlag, gr)
+
+		resp, err := wrapper.GetStats(ctx, req)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedResponse, resp)
+
+		// Wait for background goroutine to complete
+		select {
+		case <-unifiedClient.statsCalled:
+			// Background call was made
+		case <-time.After(100 * time.Millisecond):
+			t.Fatal("Background unified client GetStats call was not made within timeout")
+		}
+
+		dual.AssertExpectations(t)
+		legacyClient.AssertExpectations(t)
+		unifiedClient.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

Introduces a feature toggle that enables Search to send shadow traffic to unified storage when Legacy is the main storage.

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/9102

**Why do we need this feature?**

we want to be able to see how Search traffic will impact unified storage

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to https://github.com/grafana/search-and-storage-team/issues/379

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
