### PR TITLE
`Authorizer`: rename and enforce only once for `NewGrafanaAuthorizer`

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -18,7 +18,7 @@ type GrafanaAuthorizer struct {
 	auth authorizer.Authorizer
 }
 
-// NewGrafanaAuthorizer returns an authorizer configured for a grafana instance.
+// NewGrafanaAuthorizerBuiltInST returns an authorizer configured for a grafana instance.
 // This authorizer is a chain of smaller authorizers that together form the decision if
 // access should be granted.
 //  1. We deny all impersonate request.
@@ -28,7 +28,7 @@ type GrafanaAuthorizer struct {
 //  4. We check authorizer that is configured speficially for an api.
 //  5. As a last fallback we check Role, this will only happen if an api have not configured
 //     an authorizer or return authorizer.DecisionNoOpinion
-func NewGrafanaAuthorizer(cfg *setting.Cfg) *GrafanaAuthorizer {
+func NewGrafanaAuthorizerBuiltInST(cfg *setting.Cfg) *GrafanaAuthorizer {
 	authorizers := []authorizer.Authorizer{
 		newImpersonationAuthorizer(),
 		authorizerfactory.NewPrivilegedGroups(k8suser.SystemPrivilegedGroup),

--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -2,6 +2,8 @@ package authorizer
 
 import (
 	"context"
+	"runtime"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/setting"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -18,7 +20,8 @@ type GrafanaAuthorizer struct {
 	auth authorizer.Authorizer
 }
 
-// NewGrafanaAuthorizerBuiltInST returns an authorizer configured for a grafana instance.
+// NewGrafanaBuiltInSTAuthorizer returns an authorizer configured for a grafana instance.
+// should not be used anywhere except the ST builtin
 // This authorizer is a chain of smaller authorizers that together form the decision if
 // access should be granted.
 //  1. We deny all impersonate request.
@@ -28,7 +31,18 @@ type GrafanaAuthorizer struct {
 //  4. We check authorizer that is configured speficially for an api.
 //  5. As a last fallback we check Role, this will only happen if an api have not configured
 //     an authorizer or return authorizer.DecisionNoOpinion
-func NewGrafanaAuthorizerBuiltInST(cfg *setting.Cfg) *GrafanaAuthorizer {
+func NewGrafanaBuiltInSTAuthorizer(cfg *setting.Cfg) *GrafanaAuthorizer {
+	// Runtime check: ensure this function is only called from the apiserver package
+	if pc, _, _, ok := runtime.Caller(1); ok {
+		if fn := runtime.FuncForPC(pc); fn != nil {
+			callerName := fn.Name()
+			// Allow calls only from the apiserver package
+			if !strings.Contains(callerName, "/services/apiserver.") {
+				panic("NewGrafanaBuiltInSTAuthorizer can only be used from the apiserver package for ST builtin mode")
+			}
+		}
+	}
+
 	authorizers := []authorizer.Authorizer{
 		newImpersonationAuthorizer(),
 		authorizerfactory.NewPrivilegedGroups(k8suser.SystemPrivilegedGroup),

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -138,7 +138,7 @@ func ProvideService(
 		rr:                                rr,
 		stopCh:                            make(chan struct{}),
 		builders:                          []builder.APIGroupBuilder{},
-		authorizer:                        authorizer.NewGrafanaAuthorizerBuiltInST(cfg),
+		authorizer:                        authorizer.NewGrafanaBuiltInSTAuthorizer(cfg),
 		tracing:                           tracing,
 		db:                                db, // For Unified storage
 		metrics:                           reg,

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -138,7 +138,7 @@ func ProvideService(
 		rr:                                rr,
 		stopCh:                            make(chan struct{}),
 		builders:                          []builder.APIGroupBuilder{},
-		authorizer:                        authorizer.NewGrafanaAuthorizer(cfg),
+		authorizer:                        authorizer.NewGrafanaAuthorizerBuiltInST(cfg),
 		tracing:                           tracing,
 		db:                                db, // For Unified storage
 		metrics:                           reg,


### PR DESCRIPTION
The question of when should I use [authsvc.NewGrafanaAuthorizer](https://github.com/grafana/grafana/blob/main/pkg/services/apiserver/auth/authorizer/authorizer.go#L31) vs [authsvc.NewResourceAuthorizer](https://github.com/grafana/grafana/blob/main/pkg/services/apiserver/auth/authorizer/resource.go#L12)

**naming** is really hard, `NewGrafanaAuthorizer(cfg)` should most likely not be used anywhere except the builtin single-tenant grafana apiserver.  `NewResourceAuthorizer` is relevant for each resource; it essentially maps the k8s authorizer to our RBAC client https://github.com/grafana/authlib/blob/main/types/access.go#L19

This is an attempt at renaming, commenting.

Ideally, we would make this method private, but that would require at least to make, the functions (newImpersonationAuthorizer, newNamespaceAuthorizer, newRoleAuthorizer) public in the authorizer package.





disgarded to check [enforce only once by runtime](https://github.com/grafana/grafana/pull/108294/commits/44a92af9879e47f13c7319d3b305d4099c9fb321), and disgarded linting rules (basically adding file matching inside of https://github.com/grafana/grafana/blob/main/pkg/ruleguard.rules.go