### PR TITLE
Playwright: Increase timeout when waiting for app pages

### DIFF
--- a/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
+++ b/e2e-playwright/various-suite/frontend-sandbox-app.spec.ts
@@ -31,7 +31,7 @@ test.describe(
           await expect(sandboxDiv).toBeHidden();
 
           const appPage = page.getByTestId('sandbox-app-test-page-one');
-          await expect(appPage).toBeVisible();
+          await expect(appPage).toBeVisible({ timeout: 10000 });
         });
 
         test('Loads the app configuration without the sandbox div wrapper', async ({ page }) => {
@@ -41,7 +41,7 @@ test.describe(
           await expect(sandboxDiv).toBeHidden();
 
           const configPage = page.getByTestId('sandbox-app-test-config-page');
-          await expect(configPage).toBeVisible();
+          await expect(configPage).toBeVisible({ timeout: 10000 });
         });
       });
 
@@ -59,7 +59,7 @@ test.describe(
           await expect(sandboxDiv).toBeVisible();
 
           const appPage = page.getByTestId('sandbox-app-test-page-one');
-          await expect(appPage).toBeVisible();
+          await expect(appPage).toBeVisible({ timeout: 10000 });
         });
 
         test('Loads the app configuration with the sandbox div wrapper', async ({ page }) => {
@@ -69,7 +69,7 @@ test.describe(
           await expect(sandboxDiv).toBeVisible();
 
           const configPage = page.getByTestId('sandbox-app-test-config-page');
-          await expect(configPage).toBeVisible();
+          await expect(configPage).toBeVisible({ timeout: 10000 });
         });
       });
     });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- increases the timeout waiting for visibility in this test

**Why do we need this feature?**

- have seen this test fail in CI, see e.g. https://github.com/grafana/grafana/actions/runs/16351197879/job/46198903624?pr=108263
- stable e2e tests

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
