### PR TITLE
SCIM: add non ga banner

### DIFF
--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -4,11 +4,9 @@ import { connect, ConnectedProps } from 'react-redux';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
+import { Alert, Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { config } from 'app/core/config';
-import { appEvents } from 'app/core/core';
-import { PageBannerDisplayEvent, PageBannerSeverity } from 'app/extensions/banners/types';
 import { StoreState } from 'app/types/store';
 
 import AuthDrawer from './AuthDrawer';
@@ -47,30 +45,14 @@ export const AuthConfigPageUnconnected = ({
     loadSettings();
   }, [loadSettings]);
 
-  useEffect(() => {
-    const isSCIMEnabled = config.featureToggles.enableSCIM;
-
-    if (isSCIMEnabled) {
-      const SCIMBannerBody = () => (
-        <div>
-          <Trans i18nKey="auth-config.scim-banner.message">
-            SCIM is currently in development and not recommended for production use. Please use with caution and expect
-            potential changes.
-          </Trans>
-        </div>
-      );
-
-      appEvents.publish(
-        new PageBannerDisplayEvent({
-          severity: PageBannerSeverity.warning,
-          body: SCIMBannerBody,
-          onClose: () => {},
-        })
-      );
-    }
-  }, []);
-
   const [showDrawer, setShowDrawer] = useState(false);
+  const [showSCIMBanner, setShowSCIMBanner] = useState(false);
+
+  // Check if SCIM banner should be shown
+  useEffect(() => {
+    const isSCIMEnabled = config.featureToggles.enableSCIM || false;
+    setShowSCIMBanner(isSCIMEnabled);
+  }, []);
 
   const authProviders = getRegisteredAuthProviders();
   const availableProviders = authProviders.filter((p) => !providerStatuses[p.id]?.hide);
@@ -127,6 +109,14 @@ export const AuthConfigPageUnconnected = ({
       }
     >
       <Page.Contents isLoading={isLoading}>
+        {showSCIMBanner && (
+          <Alert severity="warning" title="" onRemove={() => setShowSCIMBanner(false)} style={{ marginBottom: 16 }}>
+            <Trans i18nKey="auth-config.scim-banner.message">
+              SCIM is currently in development and not recommended for production use. Please use with caution and
+              expect potential changes.
+            </Trans>
+          </Alert>
+        )}
         {!providerList.length ? (
           <ConfigureAuthCTA />
         ) : (

--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -7,12 +7,14 @@ import { reportInteraction } from '@grafana/runtime';
 import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { config } from 'app/core/config';
+import { appEvents } from 'app/core/core';
 import { StoreState } from 'app/types/store';
 
 import AuthDrawer from './AuthDrawer';
 import ConfigureAuthCTA from './components/ConfigureAuthCTA';
 import { ProviderCard, ProviderSAMLCard, ProviderSCIMCard } from './components/ProviderCard';
 import { loadSettings } from './state/actions';
+import { PageBannerDisplayEvent, PageBannerSeverity } from 'app/extensions/banners/types';
 
 import { getRegisteredAuthProviders } from './index';
 
@@ -44,6 +46,29 @@ export const AuthConfigPageUnconnected = ({
   useEffect(() => {
     loadSettings();
   }, [loadSettings]);
+
+  useEffect(() => {
+    const isSCIMEnabled = config.featureToggles.enableSCIM;
+
+    if (isSCIMEnabled) {
+      const SCIMBannerBody = () => (
+        <div>
+          <Trans i18nKey="auth-config.scim-banner.message">
+            SCIM is currently in development and not recommended for production use. Please use with caution and expect
+            potential changes.
+          </Trans>
+        </div>
+      );
+
+      appEvents.publish(
+        new PageBannerDisplayEvent({
+          severity: PageBannerSeverity.warning,
+          body: SCIMBannerBody,
+          onClose: () => {},
+        })
+      );
+    }
+  }, []);
 
   const [showDrawer, setShowDrawer] = useState(false);
 

--- a/public/app/features/auth-config/AuthProvidersListPage.tsx
+++ b/public/app/features/auth-config/AuthProvidersListPage.tsx
@@ -8,13 +8,13 @@ import { Grid, TextLink, ToolbarButton } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { config } from 'app/core/config';
 import { appEvents } from 'app/core/core';
+import { PageBannerDisplayEvent, PageBannerSeverity } from 'app/extensions/banners/types';
 import { StoreState } from 'app/types/store';
 
 import AuthDrawer from './AuthDrawer';
 import ConfigureAuthCTA from './components/ConfigureAuthCTA';
 import { ProviderCard, ProviderSAMLCard, ProviderSCIMCard } from './components/ProviderCard';
 import { loadSettings } from './state/actions';
-import { PageBannerDisplayEvent, PageBannerSeverity } from 'app/extensions/banners/types';
 
 import { getRegisteredAuthProviders } from './index';
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3359,6 +3359,9 @@
       "text-badge-enabled": "Enabled",
       "text-badge-not-enabled": "Not enabled"
     },
+    "scim-banner": {
+      "message": "SCIM is currently in development and not recommended for production use. Please use with caution and expect potential changes."
+    },
     "server-discovery-modal": {
       "label-the-wellknownopenidconfiguration-endpoint-for-your-id-p": "The .well-known/openid-configuration endpoint for your IdP",
       "title-open-id-connect-discovery-url": "OpenID Connect Discovery URL"


### PR DESCRIPTION

**What is this feature?**

Adds a warning to the Authentications List Page that SCIM is not in GA.

**Why do we need this feature?**

A small warning to let people know that this feature might change.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/1526

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
