### PR TITLE
Canvas: Fix infinite-viewer connections viewport values

### DIFF
--- a/public/app/features/canvas/runtime/scene.tsx
+++ b/public/app/features/canvas/runtime/scene.tsx
@@ -238,8 +238,10 @@ export class Scene {
 
     if (svgConnections) {
       const scale = this.infiniteViewer!.getZoom();
-      const left = this.infiniteViewer!.getScrollLeft();
-      const top = this.infiniteViewer!.getScrollTop();
+      // NOTE: sometimes getScrollLeft and getScrollTop return NaN,
+      // so we use || 0 to ensure we have a valid number
+      const left = this.infiniteViewer!.getScrollLeft() || 0;
+      const top = this.infiniteViewer!.getScrollTop() || 0;
       const width = this.width;
       const height = this.height;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In some cases, `getScrollLeft()` and `getScrollTop()` return `NaN` values, even when the InfiniteViewer instance appears to be fully initialized and rendered. While I haven’t been able to consistently reproduce the issue, these NaN values can cause errors when updating the SVG viewport, resulting in console warnings or rendering issues.

This PR adds a defensive check to ensure these values are valid numbers before using them, helping to avoid unnecessary errors in the browser console.