### PR TITLE
add data transformations learning journey to transform data docs

### DIFF
--- a/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/transform-data/index.md
@@ -88,6 +88,8 @@ Transformations are a powerful way to manipulate data returned by a query before
 - Perform mathematical operations across queries
 - Use the output of one transformation as the input to another transformation
 
+{{< docs/learning-journeys title="Transform data in a Grafana Cloud dashboard" url="https://grafana.com/docs/learning-journeys/data-transformation/" >}}
+
 For users that rely on multiple views of the same dataset, transformations offer an efficient method of creating and maintaining numerous dashboards.
 
 You can also use the output of one transformation as the input to another transformation, which results in a performance gain.
@@ -645,7 +647,7 @@ After choosing which field you want to group your data by, you can add various c
 | server 2  | 88.6                   |
 | server 3  | 59.6                   |
 
-If you had added the count stat to the group by, there would be an extra column showing that the count of each server from above was 3.
+If you had added the count stat to the group by transformation, there would be an extra column showing that the count of each server from above was 3.
 
 | Server ID | CPU Temperature (mean) | Server ID (count) |
 | --------- | ---------------------- | ----------------- |

--- a/scripts/docs/generate-transformations.ts
+++ b/scripts/docs/generate-transformations.ts
@@ -102,6 +102,8 @@ Transformations are a powerful way to manipulate data returned by a query before
 - Perform mathematical operations across queries
 - Use the output of one transformation as the input to another transformation
 
+{{< docs/learning-journeys title="Transform data in a Grafana Cloud dashboard" url="https://grafana.com/docs/learning-journeys/data-transformation/" >}}
+
 For users that rely on multiple views of the same dataset, transformations offer an efficient method of creating and maintaining numerous dashboards.
 
 You can also use the output of one transformation as the input to another transformation, which results in a performance gain.


### PR DESCRIPTION
**What is this feature?**

This PR adds the [data transformations learning journey](https://grafana.com/docs/learning-journeys/data-transformation/) to the transform data docs.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
