### PR TITLE
New Log Details: Support multiple log details displayed

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -323,6 +323,9 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
   const { matchingUids, search } = useLogListSearchContext();
 
   const highlight = useMemo(() => {
+    if (!syntaxHighlighting) {
+      return undefined;
+    }
     const searchWords = log.searchWords && log.searchWords[0] ? log.searchWords.slice() : [];
     if (search && matchingUids?.includes(log.uid)) {
       searchWords.push(search);
@@ -331,7 +334,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
       return undefined;
     }
     return { searchWords, highlightClassName: styles.matchHighLight };
-  }, [log.searchWords, log.uid, matchingUids, search, styles.matchHighLight]);
+  }, [log.searchWords, log.uid, matchingUids, search, styles.matchHighLight, syntaxHighlighting]);
 
   if (log.hasAnsi) {
     return (

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -376,7 +376,7 @@ export const getStyles = (theme: GrafanaTheme2, virtualization?: LogLineVirtuali
     parsedField: theme.colors.text.primary,
   };
 
-  const hoverColor = tinycolor(theme.colors.background.canvas).darken(4).toRgbString();
+  const hoverColor = tinycolor(theme.colors.background.canvas).darken(5).toRgbString();
 
   return {
     logLine: css({
@@ -450,7 +450,7 @@ export const getStyles = (theme: GrafanaTheme2, virtualization?: LogLineVirtuali
       lineHeight: theme.typography.bodySmall.lineHeight,
     }),
     detailsDisplayed: css({
-      background: hoverColor,
+      background: tinycolor(theme.colors.background.canvas).darken(2).toRgbString(),
     }),
     pinnedLogLine: css({
       backgroundColor: tinycolor(theme.colors.info.transparent).setAlpha(0.25).toString(),

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -241,7 +241,7 @@ const LogLineComponent = memo(
             </Button>
           </div>
         )}
-        {detailsMode === 'inline' && detailsShown && <InlineLogLineDetails logs={logs} />}
+        {detailsMode === 'inline' && detailsShown && <InlineLogLineDetails logs={logs} log={log} />}
       </>
     );
   }

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -323,10 +323,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
   const { matchingUids, search } = useLogListSearchContext();
 
   const highlight = useMemo(() => {
-    if (!syntaxHighlighting) {
-      return undefined;
-    }
-    const searchWords = log.searchWords && log.searchWords[0] ? log.searchWords.slice() : [];
+    const searchWords = syntaxHighlighting && log.searchWords && log.searchWords[0] ? log.searchWords.slice() : [];
     if (search && matchingUids?.includes(log.uid)) {
       searchWords.push(search);
     }

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -541,5 +541,62 @@ describe('LogLineDetails', () => {
       expect(screen.getAllByText('First log')).toHaveLength(2);
       expect(screen.getAllByText('Second log')).toHaveLength(1);
     });
+
+    test('Changes details focus when logs are added and removed', async () => {
+      const logs = [
+        createLogLine({ uid: '1', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'First log' }),
+        createLogLine({ uid: '2', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'Second log' }),
+      ];
+
+      const props: Props = {
+        containerElement: document.createElement('div'),
+        focusLogLine: jest.fn(),
+        logs: [logs[0]],
+        onResize: jest.fn(),
+      };
+
+      const contextData: LogListContextData = {
+        ...defaultValue,
+        showDetails: [logs[0]],
+      };
+
+      const { rerender } = render(
+        <LogListContext.Provider value={contextData}>
+          <LogLineDetails {...props} />
+        </LogListContext.Provider>
+      );
+
+      expect(screen.queryAllByRole('tab')).toHaveLength(0);
+
+      await userEvent.click(screen.getByText('Log line'));
+      // Tab not displayed, only line body
+      expect(screen.getAllByText('First log')).toHaveLength(1);
+
+      contextData.showDetails = logs;
+      props.logs = logs;
+
+      rerender(
+        <LogListContext.Provider value={contextData}>
+          <LogLineDetails {...props} />
+        </LogListContext.Provider>
+      );
+
+      expect(screen.queryAllByRole('tab')).toHaveLength(2);
+      // Tab and log line body
+      expect(screen.getAllByText('Second log')).toHaveLength(2);
+
+      contextData.showDetails = [logs[1]];
+      props.logs = [logs[1]];
+
+      rerender(
+        <LogListContext.Provider value={contextData}>
+          <LogLineDetails {...props} />
+        </LogListContext.Provider>
+      );
+
+      expect(screen.queryAllByRole('tab')).toHaveLength(0);
+      // Tab not displayed, only line body
+      expect(screen.getAllByText('Second log')).toHaveLength(1);
+    });
   });
 });

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -515,4 +515,31 @@ describe('LogLineDetails', () => {
       expect(setDisplayedFields).toHaveBeenCalledWith(['key1', 'key3', 'key2']);
     });
   });
+
+  describe('Multiple log details', () => {
+    test('Does not render tabs when displaying a single log', () => {
+      setup(undefined, { labels: { key1: 'label1', key2: 'label2' } });
+      expect(screen.queryAllByRole('tab')).toHaveLength(0);
+    });
+
+    test('Renders multiple log details', async () => {
+      const logs = [
+        createLogLine({ uid: '1', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'First log' }),
+        createLogLine({ uid: '2', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'Second log' }),
+      ];
+      setup({ logs }, undefined, { showDetails: logs });
+
+      expect(screen.queryAllByRole('tab')).toHaveLength(2);
+
+      await userEvent.click(screen.getByText('Log line'));
+
+      expect(screen.getAllByText('First log')).toHaveLength(1);
+      expect(screen.getAllByText('Second log')).toHaveLength(2);
+
+      await userEvent.click(screen.queryAllByRole('tab')[0]);
+
+      expect(screen.getAllByText('First log')).toHaveLength(2);
+      expect(screen.getAllByText('Second log')).toHaveLength(1);
+    });
+  });
 });

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -19,11 +19,12 @@ import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
 interface LogLineDetailsComponentProps {
+  focusLogLine?: (log: LogListModel) => void;
   log: LogListModel;
   logs: LogListModel[];
 }
 
-export const LogLineDetailsComponent = memo(({ log, logs }: LogLineDetailsComponentProps) => {
+export const LogLineDetailsComponent = memo(({ focusLogLine, log, logs }: LogLineDetailsComponentProps) => {
   const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields } = useLogListContext();
   const [search, setSearch] = useState('');
   const inputRef = useRef('');
@@ -101,7 +102,7 @@ export const LogLineDetailsComponent = memo(({ log, logs }: LogLineDetailsCompon
 
   return (
     <>
-      <LogLineDetailsHeader log={log} search={search} onSearch={handleSearch} />
+      <LogLineDetailsHeader focusLogLine={focusLogLine} log={log} search={search} onSearch={handleSearch} />
       <div className={styles.componentWrapper}>
         <ControlledCollapse
           className={styles.collapsable}

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -14,12 +14,13 @@ import { useLogIsPinned, useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
 interface Props {
+  focusLogLine?: (log: LogListModel) => void;
   log: LogListModel;
   search: string;
   onSearch(newSearch: string): void;
 }
 
-export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
+export const LogLineDetailsHeader = ({ focusLogLine, log, search, onSearch }: Props) => {
   const {
     closeDetails,
     detailsMode,
@@ -52,6 +53,10 @@ export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
     },
     [noInteractions]
   );
+
+  const scrollToLogLine = useCallback(() => {
+    focusLogLine?.(log);
+  }, [focusLogLine, log]);
 
   const copyLogLine = useCallback(() => {
     copyText(log.entry, containerRef);
@@ -143,22 +148,32 @@ export const LogLineDetailsHeader = ({ log, search, onSearch }: Props) => {
         ref={inputRef}
         suffix={search !== '' ? clearSearch : undefined}
       />
-      {showLogLineToggle && (
-        <IconButton
-          tooltip={
-            logLineDisplayed
-              ? t('logs.log-line-details.hide-log-line', 'Hide log line')
-              : t('logs.log-line-details.show-log-line', 'Show log line')
-          }
-          tooltipPlacement="top"
-          size="md"
-          name="eye"
-          onClick={toggleLogLine}
-          tabIndex={0}
-          variant={logLineDisplayed ? 'primary' : undefined}
-        />
-      )}
       <div className={styles.icons}>
+        {focusLogLine && (
+          <IconButton
+            tooltip={t('logs.log-line-details.scroll-to-logline', 'Scroll to log line')}
+            tooltipPlacement="top"
+            size="md"
+            name="arrows-v"
+            onClick={scrollToLogLine}
+            tabIndex={0}
+          />
+        )}
+        {showLogLineToggle && (
+          <IconButton
+            tooltip={
+              logLineDisplayed
+                ? t('logs.log-line-details.hide-log-line', 'Hide log line')
+                : t('logs.log-line-details.show-log-line', 'Show log line')
+            }
+            tooltipPlacement="top"
+            size="md"
+            name="eye"
+            onClick={toggleLogLine}
+            tabIndex={0}
+            variant={logLineDisplayed ? 'primary' : undefined}
+          />
+        )}
         <IconButton
           tooltip={t('logs.log-line-details.copy-to-clipboard', 'Copy to clipboard')}
           tooltipPlacement="top"

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -466,9 +466,7 @@ export const LogListContextProvider = ({
   );
 
   const closeDetails = useCallback(() => {
-    if (showDetails.length) {
-      removeDetailsScrollPosition(showDetails[0]);
-    }
+    showDetails.forEach((log) => removeDetailsScrollPosition(log));
     setShowDetails([]);
   }, [showDetails]);
 
@@ -477,8 +475,9 @@ export const LogListContextProvider = ({
       if (!enableLogDetails) {
         return;
       }
-      const found = showDetails.findIndex((stateLog) => stateLog === log || stateLog.uid === log.uid);
-      if (found >= 0) {
+      const found = showDetails.find((stateLog) => stateLog === log || stateLog.uid === log.uid);
+      if (found) {
+        removeDetailsScrollPosition(found);
         setShowDetails(showDetails.filter((stateLog) => stateLog !== log && stateLog.uid !== log.uid));
       } else {
         // Supporting one displayed details for now

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -482,7 +482,7 @@ export const LogListContextProvider = ({
         setShowDetails(showDetails.filter((stateLog) => stateLog !== log && stateLog.uid !== log.uid));
       } else {
         // Supporting one displayed details for now
-        setShowDetails([log]);
+        setShowDetails([...showDetails, log]);
       }
     },
     [enableLogDetails, showDetails]

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8912,6 +8912,7 @@
       "no-details": "No fields to display.",
       "pin-line": "Pin log",
       "remove-displayed-field": "Remove field",
+      "remove-log": "Remove log",
       "search": {
         "no-results": "No results to display."
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8913,6 +8913,7 @@
       "pin-line": "Pin log",
       "remove-displayed-field": "Remove field",
       "remove-log": "Remove log",
+      "scroll-to-logline": "Scroll to log line",
       "search": {
         "no-results": "No results to display."
       },


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075, this PR adds support for multiple displayed fields. For the Sidebar, it displays them as tabs. For inline, they are individually toggled.

Additional change: the `syntax highlighting` option controls the highlight of search words when string filters are used. Closes https://github.com/grafana/grafana/issues/68572

Demo:

https://github.com/user-attachments/assets/ee6e148c-4dff-4319-806b-7bff2e78e242

