### PR TITLE
Secrets: Add authz checks for the single-tenant SecureValue client

### DIFF
--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -23,7 +23,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/secret/service"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/secret/database"
@@ -70,7 +70,7 @@ func Setup(t *testing.T, opts ...func(*SetupConfig)) Sut {
 	require.NoError(t, err)
 
 	// Initialize access client + access control
-	accessControl := &actest.FakeAccessControl{ExpectedEvaluate: true}
+	accessControl := acimpl.ProvideAccessControl(nil)
 	accessClient := accesscontrol.NewLegacyAccessClient(accessControl, accesscontrol.ResourceAuthorizerOptions{
 		Resource: "securevalues",
 		Attr:     "uid",
@@ -132,6 +132,7 @@ func Setup(t *testing.T, opts ...func(*SetupConfig)) Sut {
 		EncryptedValueStorage:      encryptedValueStorage,
 		SQLKeeper:                  sqlKeeper,
 		Database:                   database,
+		AccessClient:               accessClient,
 	}
 }
 
@@ -143,6 +144,7 @@ type Sut struct {
 	EncryptedValueStorage      contracts.EncryptedValueStorage
 	SQLKeeper                  *sqlkeeper.SQLKeeper
 	Database                   *database.Database
+	AccessClient               types.AccessClient
 }
 
 type CreateSvConfig struct {

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -777,7 +777,7 @@ func Initialize(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*Ser
 	}
 	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService)
 	secureValueValidator := validator3.ProvideSecureValueValidator()
-	secureValueClientProvider := secret.ProvideSecureValueClientProvider(secureValueService, secureValueValidator)
+	secureValueClientProvider := secret.ProvideSecureValueClientProvider(secureValueService, secureValueValidator, accessClient)
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer)
 	decryptStorage, err := metadata.ProvideDecryptStorage(tracer, ossKeeperService, keeperMetadataStorage, secureValueMetadataStorage, decryptAuthorizer, registerer)
 	if err != nil {
@@ -1330,7 +1330,7 @@ func InitializeForTest(t sqlutil.ITestDB, testingT interface {
 	}
 	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService)
 	secureValueValidator := validator3.ProvideSecureValueValidator()
-	secureValueClientProvider := secret.ProvideSecureValueClientProvider(secureValueService, secureValueValidator)
+	secureValueClientProvider := secret.ProvideSecureValueClientProvider(secureValueService, secureValueValidator, accessClient)
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer)
 	decryptStorage, err := metadata.ProvideDecryptStorage(tracer, ossKeeperService, keeperMetadataStorage, secureValueMetadataStorage, decryptAuthorizer, registerer)
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

Adds authorization checks on the client with the access client.

**Why do we need this feature?**

Making sure the request in context has the right permissions in single-tenant mode.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1481

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
