### PR TITLE
Chore: Fix console warning for Canvas

### DIFF
--- a/public/app/features/canvas/runtime/root.tsx
+++ b/public/app/features/canvas/runtime/root.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from 'react';
+
 import { CanvasFrameOptions } from '../frame';
 
 import { FrameState } from './frame';
@@ -49,7 +51,9 @@ export class RootElement extends FrameState {
         ref={this.setRootRef}
         style={{ ...this.sizeStyle, ...this.dataStyle }}
       >
-        {this.elements.map((v) => v.render())}
+        {this.elements.map((v) => (
+          <Fragment key={v.UID}>{v.render()}</Fragment>
+        ))}
       </div>
     );
   }


### PR DESCRIPTION
Tiny fix for this warning:
<img width="3352" height="512" alt="Screenshot 2025-07-18 at 3 50 05 PM" src="https://github.com/user-attachments/assets/c572c3cd-c514-4de9-b7c4-030ae77ce966" />



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
