### PR TITLE
fix: Always return searchWrapper to enable shadow traffic

### DIFF
--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -24,21 +24,14 @@ type DualWriter interface {
 
 func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient resourcepb.ResourceIndexClient,
 	legacyClient resourcepb.ResourceIndexClient, features featuremgmt.FeatureToggles) resourcepb.ResourceIndexClient {
-	if dual.IsEnabled(gr) {
-		return &searchWrapper{
-			dual:          dual,
-			groupResource: gr,
-			unifiedClient: unifiedClient,
-			legacyClient:  legacyClient,
-			features:      features,
-			logger:        log.New("unified-storage.search-client"),
-		}
+	return &searchWrapper{
+		dual:          dual,
+		groupResource: gr,
+		unifiedClient: unifiedClient,
+		legacyClient:  legacyClient,
+		features:      features,
+		logger:        log.New("unified-storage.search-client"),
 	}
-	//nolint:errcheck
-	if ok, _ := dual.ReadFromUnified(context.Background(), gr); ok {
-		return unifiedClient
-	}
-	return legacyClient
 }
 
 type searchWrapper struct {

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -130,9 +130,8 @@ func setupTestSearchWrapper(t *testing.T, dual *MockDualWriter, unifiedClient, l
 func TestSearchClient_NewSearchClient(t *testing.T) {
 	gr, unifiedClient, legacyClient, features := setupTestSearchClient(t)
 
-	t.Run("returns wrapper when dual writer is enabled", func(t *testing.T) {
+	t.Run("always returns wrapper", func(t *testing.T) {
 		dual := &MockDualWriter{} // Create fresh mock for this test
-		dual.On("IsEnabled", gr).Return(true)
 
 		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
 
@@ -142,30 +141,6 @@ func TestSearchClient_NewSearchClient(t *testing.T) {
 		assert.Equal(t, gr, wrapper.groupResource)
 		assert.Equal(t, unifiedClient, wrapper.unifiedClient)
 		assert.Equal(t, legacyClient, wrapper.legacyClient)
-
-		dual.AssertExpectations(t)
-	})
-
-	t.Run("returns unified client when dual writer disabled but read from unified", func(t *testing.T) {
-		dual := &MockDualWriter{} // Create fresh mock for this test
-		dual.On("IsEnabled", gr).Return(false)
-		dual.On("ReadFromUnified", mock.Anything, gr).Return(true, nil)
-
-		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
-
-		assert.Equal(t, unifiedClient, client)
-		dual.AssertExpectations(t)
-	})
-
-	t.Run("returns legacy client when dual writer disabled and not reading from unified", func(t *testing.T) {
-		dual := &MockDualWriter{} // Create fresh mock for this test
-		dual.On("IsEnabled", gr).Return(false)
-		dual.On("ReadFromUnified", mock.Anything, gr).Return(false, nil)
-
-		client := NewSearchClient(dual, gr, unifiedClient, legacyClient, features)
-
-		assert.Equal(t, legacyClient, client)
-		dual.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Remove conditional dual writer check in NewSearchClient that was preventing shadow traffic from working. The `IsEnabled()` check always returned false without the `managedDualWriter` flag, blocking the creation of `searchWrapper` needed for background requests.

Now always returns `searchWrapper` which correctly delegates to the appropriate client while enabling shadow traffic when the `unifiedStorageSearchDualReaderEnabled` feature flag is enabled.

**Why do we need this feature?**

To get shadow search traffic to work.

**Who is this feature for?**

Grafana Search & Storage team, who want to test search with live traffic

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/search-and-storage-team/issues/379

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
