### PR TITLE
[wip] : Skip subsequent cachechecks if we hit an error

### DIFF
--- a/pkg/services/authz/rbac/cache_test.go
+++ b/pkg/services/authz/rbac/cache_test.go
@@ -1,0 +1,148 @@
+package rbac
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/grafana/authlib/cache"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/tracing"
+)
+
+// mockCache implements cache.Cache for testing
+type mockCache struct {
+	shouldFail bool
+	getCount   int
+	setCount   int
+}
+
+func (m *mockCache) Get(ctx context.Context, key string) ([]byte, error) {
+	m.getCount++
+	if m.shouldFail {
+		return nil, errors.New("cache unavailable")
+	}
+	return nil, cache.ErrNotFound
+}
+
+func (m *mockCache) Set(ctx context.Context, key string, data []byte, ttl time.Duration) error {
+	m.setCount++
+	if m.shouldFail {
+		return errors.New("cache unavailable")
+	}
+	return nil
+}
+
+func (m *mockCache) Delete(ctx context.Context, key string) error {
+	if m.shouldFail {
+		return errors.New("cache unavailable")
+	}
+	return nil
+}
+
+func TestCacheCircuitBreaker(t *testing.T) {
+	mockBackend := &mockCache{shouldFail: true}
+	logger := log.NewNopLogger()
+	tracer := tracing.NewNoopTracerService()
+
+	// Create cache wrapper that will encounter errors
+	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
+
+	ctx := context.Background()
+
+	// First Get call should attempt cache
+	_, ok1 := wrapper.Get(ctx, "key1")
+	assert.False(t, ok1)
+	assert.Equal(t, 1, mockBackend.getCount, "First call should hit cache")
+
+	// Manually test the circuit breaker functionality
+	markCacheSkip(ctx)
+	assert.True(t, shouldSkipCache(ctx), "Context should be marked to skip cache")
+
+	// Second Get call should skip cache entirely due to marked context
+	_, ok2 := wrapper.Get(ctx, "key2")
+	assert.False(t, ok2)
+	assert.Equal(t, 1, mockBackend.getCount, "Second call should skip cache due to circuit breaker")
+
+	// Set call should also skip cache
+	wrapper.Set(ctx, "key3", "value")
+	assert.Equal(t, 0, mockBackend.setCount, "Set call should skip cache due to circuit breaker")
+}
+
+func TestCacheCircuitBreakerIntegration(t *testing.T) {
+	// Test that demonstrates how circuit breaker would work in practice
+	// where error handling is done at a higher level
+
+	mockBackend := &mockCache{shouldFail: false}
+	logger := log.NewNopLogger()
+	tracer := tracing.NewNoopTracerService()
+
+	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
+
+	// Simulate service-level circuit breaker logic
+	ctx := context.Background()
+
+	// First operation succeeds
+	_, ok := wrapper.Get(ctx, "key1")
+	assert.False(t, ok) // Cache miss, but no error
+	assert.Equal(t, 1, mockBackend.getCount)
+
+	// Simulate cache becoming unavailable
+	mockBackend.shouldFail = true
+
+	// Service detects cache error and marks context
+	_, ok = wrapper.Get(ctx, "key2")
+	assert.False(t, ok)
+	assert.Equal(t, 2, mockBackend.getCount)
+
+	// Service would detect the error and mark context for subsequent operations
+	markCacheSkip(ctx)
+
+	// Subsequent operations skip cache
+	_, ok = wrapper.Get(ctx, "key3")
+	assert.False(t, ok)
+	assert.Equal(t, 2, mockBackend.getCount, "Should skip due to circuit breaker")
+}
+
+func TestCacheCircuitBreakerRequestIsolation(t *testing.T) {
+	mockBackend := &mockCache{shouldFail: false}
+	logger := log.NewNopLogger()
+	tracer := tracing.NewNoopTracerService()
+
+	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
+
+	// First request context with circuit breaker active
+	ctx := context.Background()
+	markCacheSkip(ctx)
+	assert.True(t, shouldSkipCache(ctx), "First context should have circuit breaker active")
+
+	// Cache operation should be skipped
+	_, ok := wrapper.Get(ctx, "key1")
+	assert.False(t, ok)
+	assert.Equal(t, 0, mockBackend.getCount, "Should skip cache due to circuit breaker")
+
+	// Second request context - fresh start (no circuit breaker)
+	ctx2 := context.Background()
+	assert.False(t, shouldSkipCache(ctx2), "Fresh context should not have circuit breaker active")
+
+	// Cache operation should proceed normally
+	_, ok2 := wrapper.Get(ctx2, "key2")
+	assert.False(t, ok2) // Cache miss, but attempt was made
+	assert.Equal(t, 1, mockBackend.getCount, "Fresh request should allow cache operations")
+}
+
+func TestCachePerformance(t *testing.T) {
+	// Simulate context with cache skip marker
+	ctx := context.Background()
+	markCacheSkip(ctx)
+
+	// Multiple skip checks should be fast (atomic reads)
+	for i := 0; i < 1000; i++ {
+		skip := shouldSkipCache(ctx)
+		require.True(t, skip)
+	}
+}

--- a/pkg/services/authz/rbac/cache_test.go
+++ b/pkg/services/authz/rbac/cache_test.go
@@ -16,14 +16,14 @@ import (
 
 // mockCache implements cache.Cache for testing
 type mockCache struct {
-	shouldFail bool
-	getCount   int
-	setCount   int
+	cacheAvailable bool
+	getCount       int
+	setCount       int
 }
 
 func (m *mockCache) Get(ctx context.Context, key string) ([]byte, error) {
 	m.getCount++
-	if m.shouldFail {
+	if !m.cacheAvailable {
 		return nil, errors.New("cache unavailable")
 	}
 	return nil, cache.ErrNotFound
@@ -31,113 +31,105 @@ func (m *mockCache) Get(ctx context.Context, key string) ([]byte, error) {
 
 func (m *mockCache) Set(ctx context.Context, key string, data []byte, ttl time.Duration) error {
 	m.setCount++
-	if m.shouldFail {
+	if !m.cacheAvailable {
 		return errors.New("cache unavailable")
 	}
 	return nil
 }
 
 func (m *mockCache) Delete(ctx context.Context, key string) error {
-	if m.shouldFail {
+	if !m.cacheAvailable {
 		return errors.New("cache unavailable")
 	}
 	return nil
 }
 
-func TestCacheCircuitBreaker(t *testing.T) {
-	mockBackend := &mockCache{shouldFail: true}
-	logger := log.NewNopLogger()
-	tracer := tracing.NewNoopTracerService()
-
-	// Create cache wrapper that will encounter errors
-	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
-
-	ctx := context.Background()
-
-	// First Get call should attempt cache
-	_, ok1 := wrapper.Get(ctx, "key1")
-	assert.False(t, ok1)
-	assert.Equal(t, 1, mockBackend.getCount, "First call should hit cache")
-
-	// Manually test the circuit breaker functionality
-	markCacheSkip(ctx)
-	assert.True(t, shouldSkipCache(ctx), "Context should be marked to skip cache")
-
-	// Second Get call should skip cache entirely due to marked context
-	_, ok2 := wrapper.Get(ctx, "key2")
-	assert.False(t, ok2)
-	assert.Equal(t, 1, mockBackend.getCount, "Second call should skip cache due to circuit breaker")
-
-	// Set call should also skip cache
-	wrapper.Set(ctx, "key3", "value")
-	assert.Equal(t, 0, mockBackend.setCount, "Set call should skip cache due to circuit breaker")
+type mockCacheTestConfig struct {
+	CacheIsAvailable bool
 }
 
-func TestCacheCircuitBreakerIntegration(t *testing.T) {
-	// Test that demonstrates how circuit breaker would work in practice
-	// where error handling is done at a higher level
-
-	mockBackend := &mockCache{shouldFail: false}
+func newMockCache(cfg mockCacheTestConfig) (*mockCache, cacheWrap[string]) {
+	mockBackend := &mockCache{cacheAvailable: cfg.CacheIsAvailable}
 	logger := log.NewNopLogger()
 	tracer := tracing.NewNoopTracerService()
-
 	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
-
-	// Simulate service-level circuit breaker logic
-	ctx := context.Background()
-
-	// First operation succeeds
-	_, ok := wrapper.Get(ctx, "key1")
-	assert.False(t, ok) // Cache miss, but no error
-	assert.Equal(t, 1, mockBackend.getCount)
-
-	// Simulate cache becoming unavailable
-	mockBackend.shouldFail = true
-
-	// Service detects cache error and marks context
-	_, ok = wrapper.Get(ctx, "key2")
-	assert.False(t, ok)
-	assert.Equal(t, 2, mockBackend.getCount)
-
-	// Service would detect the error and mark context for subsequent operations
-	markCacheSkip(ctx)
-
-	// Subsequent operations skip cache
-	_, ok = wrapper.Get(ctx, "key3")
-	assert.False(t, ok)
-	assert.Equal(t, 2, mockBackend.getCount, "Should skip due to circuit breaker")
+	return mockBackend, wrapper
 }
 
-func TestCacheCircuitBreakerRequestIsolation(t *testing.T) {
-	mockBackend := &mockCache{shouldFail: false}
-	logger := log.NewNopLogger()
-	tracer := tracing.NewNoopTracerService()
+func TestCacheSkipBasicFunctionality(t *testing.T) {
+	t.Run("shouldSkipCache returns false for fresh context", func(t *testing.T) {
+		ctx := context.Background()
+		assert.False(t, shouldSkipCache(ctx))
+	})
 
-	wrapper := newCacheWrap[string](mockBackend, logger, tracer, 300)
+	t.Run("shouldSkipCache returns false for initialized but not marked context", func(t *testing.T) {
+		ctx := initMarkCacheSkipState(context.Background())
+		assert.False(t, shouldSkipCache(ctx))
+	})
 
-	// First request context with circuit breaker active
-	ctx := context.Background()
-	markCacheSkip(ctx)
-	assert.True(t, shouldSkipCache(ctx), "First context should have circuit breaker active")
+	t.Run("shouldSkipCache returns true after marking", func(t *testing.T) {
+		ctx := context.Background()
+		ctx = initMarkCacheSkipState(ctx)
+		markCacheSkip(ctx)
+		assert.True(t, shouldSkipCache(ctx))
+	})
 
-	// Cache operation should be skipped
-	_, ok := wrapper.Get(ctx, "key1")
-	assert.False(t, ok)
-	assert.Equal(t, 0, mockBackend.getCount, "Should skip cache due to circuit breaker")
+	t.Run("markCacheSkip logs warning when state not initialized", func(t *testing.T) {
+		// For this test, we'll just verify the behavior without capturing logs
+		// since the logging mechanism is working correctly based on the implementation
 
-	// Second request context - fresh start (no circuit breaker)
-	ctx2 := context.Background()
-	assert.False(t, shouldSkipCache(ctx2), "Fresh context should not have circuit breaker active")
+		ctx := context.Background() // Not initialized with initMarkCacheSkipState
 
-	// Cache operation should proceed normally
-	_, ok2 := wrapper.Get(ctx2, "key2")
-	assert.False(t, ok2) // Cache miss, but attempt was made
-	assert.Equal(t, 1, mockBackend.getCount, "Fresh request should allow cache operations")
+		// This should trigger a warning log since cache state is not initialized
+		// The warning will be logged but not captured in the test
+		markCacheSkip(ctx)
+
+		// shouldSkipCache should still return false since state wasn't initialized
+		assert.False(t, shouldSkipCache(ctx))
+
+		// Verify that the proper initialization works
+		ctxInitialized := initMarkCacheSkipState(context.Background())
+		markCacheSkip(ctxInitialized)
+		assert.True(t, shouldSkipCache(ctxInitialized))
+	})
 }
 
-func TestCachePerformance(t *testing.T) {
-	// Simulate context with cache skip marker
+func TestCacheErrorTriggersSkip(t *testing.T) {
+	t.Run("Get errors mark context to skip subsequent operations", func(t *testing.T) {
+		// initate mockedcache that is not available
+		mockBackend, wrapper := newMockCache(mockCacheTestConfig{CacheIsAvailable: false})
+		ctx := initMarkCacheSkipState(context.Background())
+
+		// First call hits cache and fails, triggering skip
+		_, ok1 := wrapper.Get(ctx, "key1")
+		assert.False(t, ok1)
+		assert.Equal(t, 1, mockBackend.getCount)
+		assert.True(t, shouldSkipCache(ctx), "Context should be marked to skip")
+
+		// Second call should skip cache
+		_, ok2 := wrapper.Get(ctx, "key2")
+		assert.False(t, ok2)
+		assert.Equal(t, 1, mockBackend.getCount, "Should skip due to previous error")
+	})
+
+	t.Run("Set errors mark context to skip subsequent operations", func(t *testing.T) {
+		mockBackend, wrapper := newMockCache(mockCacheTestConfig{CacheIsAvailable: false})
+		ctx := initMarkCacheSkipState(context.Background())
+
+		// First call hits cache and fails, triggering skip
+		wrapper.Set(ctx, "key1", "value1")
+		assert.Equal(t, 1, mockBackend.setCount)
+		assert.True(t, shouldSkipCache(ctx), "Context should be marked to skip")
+
+		// Second call should skip cache
+		wrapper.Set(ctx, "key2", "value2")
+		assert.Equal(t, 1, mockBackend.setCount, "Should skip due to previous error")
+	})
+}
+
+func TestCacheSkipPerformance(t *testing.T) {
 	ctx := context.Background()
+	ctx = initMarkCacheSkipState(ctx)
 	markCacheSkip(ctx)
 
 	// Multiple skip checks should be fast (atomic reads)

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -138,6 +138,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		attribute.String("folder", checkReq.ParentFolder),
 	)
 
+	// cache checks
 	permDenialKey := userPermDenialCacheKey(checkReq.Namespace.Value, checkReq.UserUID, checkReq.Action, checkReq.Name, checkReq.ParentFolder)
 	if _, ok := s.permDenialCache.Get(ctx, permDenialKey); ok {
 		s.metrics.permissionCacheUsage.WithLabelValues("true", checkReq.Action).Inc()
@@ -175,6 +176,7 @@ func (s *Service) Check(ctx context.Context, req *authzv1.CheckRequest) (*authzv
 		return deny, err
 	}
 
+	// Update cache denial if not allowed to access
 	if !allowed {
 		s.permDenialCache.Set(ctx, permDenialKey, true)
 	}


### PR DESCRIPTION
**What is this feature?**
skips cache checks if we hit and error

**Why do we need this feature?**
we hit multiple requests to cache

**Who is this feature for?**
consumers of 

**Which issue(s) does this PR fix?**:
https://github.com/grafana/identity-access-team/issues/1485