### PR TITLE
Chore: add `minimumReleaseAge` to renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,7 +32,7 @@
       matchCurrentVersion: "!/^0/",
       matchUpdateTypes: ["patch"],
       matchPackageNames: ["!/^@?storybook/", "!/^@locker/", "!/^@grafana/"],
-      minimumReleaseAge: "7 days"
+      minimumReleaseAge: "7 days",
     },
     {
       automerge: true,
@@ -45,22 +45,27 @@
       groupName: "Storybook updates",
       matchPackageNames: ["/^@?storybook/"],
       rangeStrategy: "bump",
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "React Aria",
       matchPackageNames: ["@react-aria/{/,}**", "@react-stately/{/,}**"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "Moveable",
       matchPackageNames: ["moveable", "react-moveable"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "Slate",
       matchPackageNames: ["@types/slate", "@types/slate-react", "slate", "slate-react"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "d3",
       matchPackageNames: ["d3{/,}**", "@types/d3{/,}**"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "scenes",
@@ -73,21 +78,25 @@
     {
       groupName: "visx",
       matchPackageNames: ["@visx/{/,}**"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "uLibraries",
       matchPackageNames: ["@leeoniya/**", "uplot"],
       reviewers: ["leeoniya"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "locker",
       reviewers: ["team:grafana/plugins-platform-frontend"],
       matchPackageNames: ["@locker/{/,}**"],
+      minimumReleaseAge: "7 days",
     },
     {
       groupName: "augurs",
       matchPackageNames: ["@bsull/augurs"],
       reviewers: ["sd2k"],
+      minimumReleaseAge: "7 days",
     },
     {
       "matchDepTypes": ["devDependencies"],

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,9 +28,17 @@
   postUpdateOptions: ["yarnDedupeHighest"],
   packageRules: [
     {
+      automerge: true,
       matchCurrentVersion: "!/^0/",
       matchUpdateTypes: ["patch"],
-      matchPackageNames: ["!/^@?storybook/", "!/^@locker/"],
+      matchPackageNames: ["!/^@?storybook/", "!/^@locker/", "!/^@grafana/"],
+      minimumReleaseAge: "7 days"
+    },
+    {
+      automerge: true,
+      matchCurrentVersion: "!/^0/",
+      matchUpdateTypes: ["patch"],
+      matchPackageNames: ["/^@grafana/"],
     },
     {
       extends: ["schedule:monthly"],


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- reenables automerging in renovate
- adds a minimum release age of 7 days for non-grafana packages

**Why do we need this feature?**

- keep deps up to date

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
