### PR TITLE
Chore: use `satisfies` and remove a load of `any`s

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3605,19 +3605,6 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"]
     ],
-    "public/app/plugins/datasource/tempo/traceql/traceql.test.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "2"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "4"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "5"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "6"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "7"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "8"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "9"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "10"]
-    ],
     "public/app/plugins/datasource/zipkin/QueryField.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/public/app/plugins/datasource/tempo/traceql/traceql.test.ts
+++ b/public/app/plugins/datasource/tempo/traceql/traceql.test.ts
@@ -74,7 +74,7 @@ describe('TraceQL grammar', () => {
 
   describe('TraceQL patterns', () => {
     it('should match span-set patterns', () => {
-      const spanSetRule = (traceqlGrammar as any)['span-set'];
+      const spanSetRule = traceqlGrammar['span-set'];
       expect(spanSetRule).toBeDefined();
       expect(spanSetRule.pattern).toBeDefined();
       const spanSetPattern = spanSetRule.pattern as RegExp;
@@ -84,7 +84,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should match with-clause patterns', () => {
-      const withClauseRule = (traceqlGrammar as any)['with-clause'];
+      const withClauseRule = traceqlGrammar['with-clause'];
       expect(withClauseRule).toBeDefined();
       expect(withClauseRule.pattern).toBeDefined();
       const withClausePattern = withClauseRule.pattern as RegExp;
@@ -95,7 +95,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should match comment patterns', () => {
-      const commentRule = (traceqlGrammar as any).comment;
+      const commentRule = traceqlGrammar.comment;
       expect(commentRule).toBeDefined();
       expect(commentRule.pattern).toBeDefined();
       const commentPattern = commentRule.pattern as RegExp;
@@ -104,7 +104,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should match number patterns', () => {
-      const numberRule = (traceqlGrammar as any).number;
+      const numberRule = traceqlGrammar.number;
       expect(numberRule).toBeDefined();
       const numberPattern = numberRule as RegExp;
       expect(numberPattern.test('123')).toBe(true);
@@ -114,7 +114,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should match operator patterns', () => {
-      const operatorRule = (traceqlGrammar as any).operator;
+      const operatorRule = traceqlGrammar.operator;
       expect(operatorRule).toBeDefined();
       const operatorPattern = operatorRule as RegExp;
       expect(operatorPattern.test('=')).toBe(true);
@@ -345,7 +345,7 @@ describe('TraceQL grammar', () => {
 
     testCases.forEach(({ name, query, shouldMatch }) => {
       it(`should ${shouldMatch ? 'match' : 'not match'} ${name}`, () => {
-        const grammar = traceqlGrammar as any;
+        const grammar = traceqlGrammar;
         const spanSetPattern = grammar['span-set']?.pattern as RegExp;
         const withClausePattern = grammar['with-clause']?.pattern as RegExp;
         const commentPattern = grammar.comment?.pattern as RegExp;
@@ -367,7 +367,7 @@ describe('TraceQL grammar', () => {
 
   describe('With clause validation', () => {
     it('should validate with clause parameter names', () => {
-      const grammar = traceqlGrammar as any;
+      const grammar = traceqlGrammar;
       const withClause = grammar['with-clause'];
       expect(withClause).toBeDefined();
       expect(withClause.inside).toBeDefined();
@@ -382,7 +382,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should validate with clause parameter values', () => {
-      const grammar = traceqlGrammar as any;
+      const grammar = traceqlGrammar;
       const withClause = grammar['with-clause'];
       expect(withClause).toBeDefined();
       expect(withClause.inside).toBeDefined();
@@ -400,7 +400,7 @@ describe('TraceQL grammar', () => {
     });
 
     it('should validate with clause keyword', () => {
-      const grammar = traceqlGrammar as any;
+      const grammar = traceqlGrammar;
       const withClause = grammar['with-clause'];
       expect(withClause).toBeDefined();
       expect(withClause.inside).toBeDefined();
@@ -418,7 +418,7 @@ describe('TraceQL grammar', () => {
   describe('Edge cases', () => {
     it('should handle multiple with clauses (invalid but should not crash)', () => {
       const query = '{span.name="test"} with (most_recent=true) with (other=false)';
-      const grammar = traceqlGrammar as any;
+      const grammar = traceqlGrammar;
       const withClausePattern = grammar['with-clause']?.pattern as RegExp;
 
       if (withClausePattern) {
@@ -432,7 +432,7 @@ describe('TraceQL grammar', () => {
 
     it('should handle with clause without parameters', () => {
       const query = '{span.name="test"} with ()';
-      const grammar = traceqlGrammar as any;
+      const grammar = traceqlGrammar;
       const withClausePattern = grammar['with-clause']?.pattern as RegExp;
 
       if (withClausePattern) {

--- a/public/app/plugins/datasource/tempo/traceql/traceql.ts
+++ b/public/app/plugins/datasource/tempo/traceql/traceql.ts
@@ -229,7 +229,7 @@ export const languageDefinition = {
 };
 
 // For "Search" tab (query builder)
-export const traceqlGrammar: Grammar = {
+export const traceqlGrammar = {
   comment: {
     pattern: /\/\/.*/,
   },
@@ -277,4 +277,4 @@ export const traceqlGrammar: Grammar = {
   number: /\b-?\d+((\.\d*)?([eE][+-]?\d+)?)?\b/,
   operator: new RegExp(`/[-+*/=%^~]|&&?|\\|?\\||!=?|<(?:=>?|<|>)?|>[>=]?|`, 'i'),
   punctuation: /[{};()`,.]/,
-};
+} satisfies Grammar;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- follow up to https://github.com/grafana/grafana/pull/107000
- uses `satisfies`
- removes a load of `any`s

**Why do we need this feature?**

- so we don't have `any`s all over the codebase 

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
