### PR TITLE
I18n: Use locale-aware date formatting in grafana-data

### DIFF
--- a/packages/grafana-data/src/datetime/formatter.test.ts
+++ b/packages/grafana-data/src/datetime/formatter.test.ts
@@ -1,4 +1,89 @@
+import { initRegionalFormatForTests } from '@grafana/i18n';
+
+import * as featureToggles from '../utils/featureToggles';
+
 import { dateTimeFormat, dateTimeFormatTimeAgo, dateTimeFormatWithAbbrevation, timeZoneAbbrevation } from './formatter';
+
+// Default time zone ("browser") is set to Pacific/Easter in jest.config.js
+const referenceDate = '2020-04-17T12:36:15.779Z';
+
+describe('dateTimeFormat (regionalFormatPreference)', () => {
+  let mockGetFeatureToggle: jest.SpyInstance;
+
+  beforeAll(() => {
+    initRegionalFormatForTests('en-AU');
+    mockGetFeatureToggle = jest.spyOn(featureToggles, 'getFeatureToggle').mockImplementation((featureName) => {
+      return featureName === 'localeFormatPreference';
+    });
+  });
+
+  afterAll(() => {
+    mockGetFeatureToggle.mockRestore();
+  });
+
+  it('formats dates in the browsers timezone by default', () => {
+    expect(dateTimeFormat(referenceDate)).toBe('17/04/2020, 6:36:15 am');
+  });
+
+  it('formats dates in the browsers timezone by default when invalid time zone is set', () => {
+    const options = { timeZone: 'asdf123' };
+    expect(dateTimeFormat(referenceDate, options)).toBe('17/04/2020, 6:36:15 am');
+  });
+
+  it.each([
+    ['UTC', '17/04/2020, 12:36:15 pm'],
+    ['Europe/Stockholm', '17/04/2020, 2:36:15 pm'],
+    ['Australia/Perth', '17/04/2020, 8:36:15 pm'],
+    ['Asia/Yakutsk', '17/04/2020, 9:36:15 pm'],
+    ['America/Panama', '17/04/2020, 7:36:15 am'],
+    ['America/Los_Angeles', '17/04/2020, 5:36:15 am'],
+    ['Africa/Djibouti', '17/04/2020, 3:36:15 pm'],
+    ['Europe/London', '17/04/2020, 1:36:15 pm'],
+    ['Europe/Berlin', '17/04/2020, 2:36:15 pm'],
+    ['Europe/Moscow', '17/04/2020, 3:36:15 pm'],
+    ['Europe/Madrid', '17/04/2020, 2:36:15 pm'],
+    ['America/New_York', '17/04/2020, 8:36:15 am'],
+    ['America/Chicago', '17/04/2020, 7:36:15 am'],
+    ['America/Denver', '17/04/2020, 6:36:15 am'],
+  ])('formats with the supplied time zone %s', (timeZone, expected) => {
+    expect(dateTimeFormat(referenceDate, { timeZone })).toBe(expected);
+  });
+
+  it('does not include seconds in the output if the time does not', () => {
+    expect(dateTimeFormat('2020-04-17T12:36:00.000Z')).toBe('17/04/2020, 6:36 am');
+  });
+
+  it("includes milliseconds in the output when 'defaultWithMS' is set to true", () => {
+    expect(dateTimeFormat('2020-04-17T12:36:15.123Z', { defaultWithMS: true })).toBe('17/04/2020, 6:36:15.123 am');
+  });
+
+  it.each([
+    ['en-GB', '17/04/2020, 06:36:15'],
+    ['en-US', '4/17/2020, 6:36:15 AM'],
+    ['fr-FR', '17/04/2020 06:36:15'],
+    ['es-ES', '17/4/2020, 6:36:15'],
+    ['de-DE', '17.4.2020, 06:36:15'],
+    ['pt-BR', '17/04/2020, 06:36:15'],
+    ['zh-Hans', '2020/4/17 06:36:15'],
+    ['it-IT', '17/04/2020, 06:36:15'],
+    ['ja-JP', '2020/4/17 6:36:15'],
+    ['id-ID', '17/4/2020, 06.36.15'],
+    ['ko-KR', '2020. 4. 17. 오전 6:36:15'],
+    ['ru-RU', '17.04.2020, 06:36:15'],
+    ['cs-CZ', '17. 4. 2020 6:36:15'],
+    ['nl-NL', '17-4-2020, 06:36:15'],
+    ['hu-HU', '2020. 04. 17. 6:36:15'],
+    ['pt-PT', '17/04/2020, 06:36:15'],
+    ['pl-PL', '17.04.2020, 06:36:15'],
+    ['sv-SE', '2020-04-17 06:36:15'],
+    ['tr-TR', '17.04.2020 06:36:15'],
+    ['zh-Hant', '2020/4/17 上午6:36:15'],
+  ])('with locale %s', (locale, expected) => {
+    initRegionalFormatForTests(locale);
+
+    expect(dateTimeFormat(referenceDate)).toBe(expected);
+  });
+});
 
 describe('dateTimeFormat', () => {
   describe('when no time zone have been set', () => {
@@ -81,7 +166,7 @@ describe('dateTimeFormat', () => {
     });
   });
 
-  describe('DateTimeFormatISO', () => {
+  describe('with custom ISO format', () => {
     it('should format according to ISO standard', () => {
       const options = { timeZone: 'Europe/Stockholm', format: 'YYYY-MM-DDTHH:mm:ss.SSSZ' };
       expect(dateTimeFormat(1587126975779, options)).toBe('2020-04-17T14:36:15.779+02:00');
@@ -95,39 +180,41 @@ describe('dateTimeFormat', () => {
       expect(dateTimeFormat(1587126975779, options)).toBe('2020-04-17T14:36:15.779+02:00');
     });
   });
+});
 
-  describe('dateTimeFormatTimeAgo', () => {
-    it('should return the correct format for years ago', () => {
-      const options = { timeZone: 'Europe/Stockholm' };
-      expect(dateTimeFormatTimeAgo(1587126975779, options)).toContain('years ago');
-    });
+describe('dateTimeFormatTimeAgo', () => {
+  it('should return the correct format for years ago', () => {
+    const options = { timeZone: 'Europe/Stockholm' };
+    expect(dateTimeFormatTimeAgo(1587126975779, options)).toContain('years ago');
   });
-  describe('dateTimeFormatWithAbbreviation', () => {
-    it('should return the correct format with zone abbreviation', () => {
-      const options = { timeZone: 'Europe/Stockholm' };
-      expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 14:36:15 CEST');
-    });
-    it('should return the correct format with zone abbreviation', () => {
-      const options = { timeZone: 'America/New_York' };
-      expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 08:36:15 EDT');
-    });
-    it('should return the correct format with zone abbreviation', () => {
-      const options = { timeZone: 'Europe/Bucharest' };
-      expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 15:36:15 EEST');
-    });
+});
+
+describe('dateTimeFormatWithAbbreviation', () => {
+  it('should return the correct format with zone abbreviation', () => {
+    const options = { timeZone: 'Europe/Stockholm' };
+    expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 14:36:15 CEST');
   });
-  describe('timeZoneAbbrevation', () => {
-    it('should return the correct abbreviation', () => {
-      const options = { timeZone: 'Europe/Stockholm' };
-      expect(timeZoneAbbrevation(1587126975779, options)).toBe('CEST');
-    });
-    it('should return the correct abbreviation', () => {
-      const options = { timeZone: 'America/New_York' };
-      expect(timeZoneAbbrevation(1587126975779, options)).toBe('EDT');
-    });
-    it('should return the correct abbreviation', () => {
-      const options = { timeZone: 'Europe/Bucharest' };
-      expect(timeZoneAbbrevation(1587126975779, options)).toBe('EEST');
-    });
+  it('should return the correct format with zone abbreviation', () => {
+    const options = { timeZone: 'America/New_York' };
+    expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 08:36:15 EDT');
+  });
+  it('should return the correct format with zone abbreviation', () => {
+    const options = { timeZone: 'Europe/Bucharest' };
+    expect(dateTimeFormatWithAbbrevation(1587126975779, options)).toBe('2020-04-17 15:36:15 EEST');
+  });
+});
+
+describe('timeZoneAbbrevation', () => {
+  it('should return the correct abbreviation', () => {
+    const options = { timeZone: 'Europe/Stockholm' };
+    expect(timeZoneAbbrevation(1587126975779, options)).toBe('CEST');
+  });
+  it('should return the correct abbreviation', () => {
+    const options = { timeZone: 'America/New_York' };
+    expect(timeZoneAbbrevation(1587126975779, options)).toBe('EDT');
+  });
+  it('should return the correct abbreviation', () => {
+    const options = { timeZone: 'Europe/Bucharest' };
+    expect(timeZoneAbbrevation(1587126975779, options)).toBe('EEST');
   });
 });

--- a/packages/grafana-data/src/datetime/formatter.test.ts
+++ b/packages/grafana-data/src/datetime/formatter.test.ts
@@ -11,7 +11,6 @@ describe('dateTimeFormat (regionalFormatPreference)', () => {
   let mockGetFeatureToggle: jest.SpyInstance;
 
   beforeAll(() => {
-    initRegionalFormatForTests('en-AU');
     mockGetFeatureToggle = jest.spyOn(featureToggles, 'getFeatureToggle').mockImplementation((featureName) => {
       return featureName === 'localeFormatPreference';
     });

--- a/packages/grafana-data/src/datetime/formatter.test.ts
+++ b/packages/grafana-data/src/datetime/formatter.test.ts
@@ -11,6 +11,7 @@ describe('dateTimeFormat (regionalFormatPreference)', () => {
   let mockGetFeatureToggle: jest.SpyInstance;
 
   beforeAll(() => {
+    initRegionalFormatForTests('en-AU');
     mockGetFeatureToggle = jest.spyOn(featureToggles, 'getFeatureToggle').mockImplementation((featureName) => {
       return featureName === 'localeFormatPreference';
     });

--- a/packages/grafana-data/src/datetime/formatter.ts
+++ b/packages/grafana-data/src/datetime/formatter.ts
@@ -1,11 +1,76 @@
 /* eslint-disable id-blacklist, no-restricted-imports */
 import moment, { Moment } from 'moment-timezone';
 
+import { formatDate } from '@grafana/i18n';
+
 import { TimeZone } from '../types/time';
+import { getFeatureToggle } from '../utils/featureToggles';
 
 import { DateTimeOptions, getTimeZone } from './common';
 import { systemDateFormats } from './formats';
 import { DateTimeInput, toUtc, dateTimeAsMoment } from './moment_wrapper';
+
+/**
+ * Converts a Grafana DateTimeInput to a plain Javascript Date object.
+ */
+function toDate(dateInUtc: DateTimeInput): Date {
+  if (dateInUtc instanceof Date) {
+    return dateInUtc;
+  }
+
+  if (typeof dateInUtc === 'string' || typeof dateInUtc === 'number') {
+    return new Date(dateInUtc);
+  }
+
+  return dateTimeAsMoment(dateInUtc).toDate();
+}
+
+/**
+ * Converts a Grafana timezone string to an IANA timezone string.
+ */
+function toIANATimezone(grafanaTimezone: string) {
+  // Intl APIs will use the browser's timezone by default (if tz is undefined)
+  if (grafanaTimezone === 'browser') {
+    return undefined;
+  }
+
+  const zone = moment.tz.zone(grafanaTimezone);
+  if (!zone) {
+    // If the timezone is invalid, we default to the browser's timezone
+    return undefined;
+  }
+
+  return grafanaTimezone;
+}
+
+function getIntlOptions(
+  date: Date,
+  options?: DateTimeOptionsWithFormat
+): Intl.DateTimeFormatOptions & { timeZone?: string } {
+  const timeZone = getTimeZone(options);
+
+  const intlOptions: Intl.DateTimeFormatOptions = {
+    year: 'numeric', // ↔ dateStyle: 'short'
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric', // ↔ timeStyle: 'short'
+    minute: 'numeric',
+    timeZone: toIANATimezone(timeZone),
+  };
+
+  // If the time has seconds, ensure they're included in the format
+  const hasSeconds = date.getSeconds() !== 0;
+  if (hasSeconds) {
+    intlOptions.second = 'numeric';
+  }
+
+  if (options?.defaultWithMS) {
+    intlOptions.second = 'numeric';
+    intlOptions.fractionalSecondDigits = 3; // Include milliseconds
+  }
+
+  return intlOptions;
+}
 
 /**
  * The type describing the options that can be passed to the {@link dateTimeFormat}
@@ -23,17 +88,30 @@ export interface DateTimeOptionsWithFormat extends DateTimeOptions {
 
 type DateTimeFormatter<T extends DateTimeOptions = DateTimeOptions> = (dateInUtc: DateTimeInput, options?: T) => string;
 
+// NOTE:
+// These date formatting functions now just wrap the @grafana/i18n formatting functions
+// (which themselves wrap the browserIntl APIs). In the future we may deprecate these
+// in favor of using @grafana/i18n directly.
+
 /**
- * Helper function to format date and time according to the specified options. If no options
- * are supplied, then default values are used. For more details, see {@link DateTimeOptionsWithFormat}.
+ * Helper function to format date and time according to the specified options.
+ * If no options are supplied, then the date is formatting according to the user's locale preference.
  *
  * @param dateInUtc - date in UTC format, e.g. string formatted with UTC offset, UNIX epoch in seconds etc.
  * @param options
  *
  * @public
  */
-export const dateTimeFormat: DateTimeFormatter<DateTimeOptionsWithFormat> = (dateInUtc, options?) =>
-  toTz(dateInUtc, getTimeZone(options)).format(getFormat(options));
+export const dateTimeFormat: DateTimeFormatter<DateTimeOptionsWithFormat> = (dateInUtc, options?) => {
+  // If a custom format is provided (or the toggle isn't enabled), use the previous implementation
+  if (!getFeatureToggle('localeFormatPreference') || options?.format) {
+    return toTz(dateInUtc, getTimeZone(options)).format(getFormat(options));
+  }
+
+  const dateAsDate = toDate(dateInUtc);
+  const intlOptions = getIntlOptions(dateAsDate, options); // TODO - if invalid timezone, use browser timezone
+  return formatDate(dateAsDate, intlOptions);
+};
 
 /**
  * Helper function to format date and time according to the standard ISO format e.g. 2013-02-04T22:44:30.652Z.
@@ -70,8 +148,18 @@ export const dateTimeFormatTimeAgo: DateTimeFormatter = (dateInUtc, options?) =>
  *
  * @public
  */
-export const dateTimeFormatWithAbbrevation: DateTimeFormatter = (dateInUtc, options?) =>
-  toTz(dateInUtc, getTimeZone(options)).format(`${systemDateFormats.fullDate} z`);
+export const dateTimeFormatWithAbbrevation: DateTimeFormatter = (dateInUtc, options?) => {
+  // If a custom format is provided (or the toggle isn't enabled), use the previous implementation
+  if (!getFeatureToggle('localeFormatPreference') || options?.format) {
+    return toTz(dateInUtc, getTimeZone(options)).format(`${systemDateFormats.fullDate} z`);
+  }
+
+  const dateAsDate = toDate(dateInUtc);
+  const intlOptions = getIntlOptions(dateAsDate, options);
+  intlOptions.timeZoneName = 'short';
+
+  return formatDate(dateAsDate, intlOptions);
+};
 
 /**
  * Helper function to return only the time zone abbreviation for a given date and time value. If no options

--- a/packages/grafana-data/src/datetime/formatter.ts
+++ b/packages/grafana-data/src/datetime/formatter.ts
@@ -28,7 +28,7 @@ function toDate(dateInUtc: DateTimeInput): Date {
 /**
  * Converts a Grafana timezone string to an IANA timezone string.
  */
-function toIANATimezone(grafanaTimezone: string) {
+export function toIANATimezone(grafanaTimezone: string) {
   // Intl APIs will use the browser's timezone by default (if tz is undefined)
   if (grafanaTimezone === 'browser') {
     return undefined;

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -1,3 +1,5 @@
+import { initRegionalFormatForTests } from '@grafana/i18n';
+
 import { RawTimeRange, TimeRange } from '../types/time';
 import * as featureToggles from '../utils/featureToggles';
 
@@ -395,11 +397,10 @@ describe('Range Utils', () => {
   });
 
   describe('describeTimeRange - localeFormatPreference enabled', () => {
-    // Tests default to en-AU
-
     let mockGetFeatureToggle: jest.SpyInstance;
 
     beforeAll(() => {
+      initRegionalFormatForTests('en-AU');
       mockGetFeatureToggle = jest.spyOn(featureToggles, 'getFeatureToggle').mockImplementation((featureName) => {
         return featureName === 'localeFormatPreference';
       });

--- a/packages/grafana-data/src/datetime/rangeutil.test.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.test.ts
@@ -1,9 +1,11 @@
 import { RawTimeRange, TimeRange } from '../types/time';
+import * as featureToggles from '../utils/featureToggles';
 
 import { dateTime } from './moment_wrapper';
 import {
   convertRawToRange,
   describeInterval,
+  describeTimeRange,
   isRelativeTimeRange,
   relativeToTimeRange,
   roundInterval,
@@ -308,6 +310,183 @@ describe('Range Utils', () => {
 
       expect(relativeTimeRange.from).toEqual(1209600);
       expect(relativeTimeRange.to).toEqual(604800);
+    });
+  });
+
+  describe('describeTimeRange', () => {
+    it.each([
+      ['now-5m', 'now', 'Last 5 minutes'],
+      ['now-15m', 'now', 'Last 15 minutes'],
+      ['now-1h', 'now', 'Last 1 hour'],
+      ['now-24h', 'now', 'Last 24 hours'],
+      ['now-7d', 'now', 'Last 7 days'],
+      ['now-30d', 'now', 'Last 30 days'],
+      ['now/d', 'now/d', 'Today'],
+      ['now/d', 'now', 'Today so far'],
+      ['now/w', 'now/w', 'This week'],
+      ['now/M', 'now/M', 'This month'],
+      ['now/y', 'now/y', 'This year'],
+      ['now-1d/d', 'now-1d/d', 'Yesterday'],
+      ['now-1w/w', 'now-1w/w', 'Previous week'],
+      ['now-1M/M', 'now-1M/M', 'Previous month'],
+      ['now-1y/y', 'now-1y/y', 'Previous year'],
+      ['now/fQ', 'now/fQ', 'This fiscal quarter'],
+      ['now/fy', 'now/fy', 'This fiscal year'],
+      ['now-1Q/fQ', 'now-1Q/fQ', 'Previous fiscal quarter'],
+      ['now-1y/fy', 'now-1y/fy', 'Previous fiscal year'],
+    ])('should return display name "%s" for range from "%s" to "%s"', (from, to, expected) => {
+      expect(describeTimeRange({ from, to })).toBe(expected);
+    });
+
+    it('should prioritize custom quick ranges over standard ranges', () => {
+      const customRanges = [{ from: 'now-5m', to: 'now', display: 'Lightning round!' }];
+
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, customRanges)).toBe('Lightning round!');
+    });
+
+    it('should format with the default timezone', () => {
+      // Tests default to Pacific/Easter
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('2023-01-15 05:30:00 to 2023-01-15 09:45:00');
+    });
+
+    it('should respect timezone in datetime formatting', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to }, 'Australia/Sydney');
+      expect(result).toBe('2023-01-15 21:30:00 to 2023-01-16 01:45:00');
+    });
+
+    it('should handle absolute from, relative to', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = 'now';
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('2023-01-15 05:30:00 to a few seconds ago');
+    });
+
+    it('should handle relative from, absolute to', () => {
+      const from = 'now-1h';
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('an hour ago to 2023-01-15 09:45:00');
+    });
+
+    it('should handle invalid relative expressions', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = 'invalid-expression';
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toContain('Invalid date');
+    });
+
+    it('should handle empty custom ranges array', () => {
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, [])).toBe('Last 5 minutes');
+    });
+
+    it('should handle null custom ranges', () => {
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, undefined)).toBe('Last 5 minutes');
+    });
+  });
+
+  describe('describeTimeRange - localeFormatPreference enabled', () => {
+    // Tests default to en-AU
+
+    let mockGetFeatureToggle: jest.SpyInstance;
+
+    beforeAll(() => {
+      mockGetFeatureToggle = jest.spyOn(featureToggles, 'getFeatureToggle').mockImplementation((featureName) => {
+        return featureName === 'localeFormatPreference';
+      });
+    });
+
+    afterAll(() => {
+      mockGetFeatureToggle.mockRestore();
+    });
+
+    it.each([
+      ['now-5m', 'now', 'Last 5 minutes'],
+      ['now-15m', 'now', 'Last 15 minutes'],
+      ['now-1h', 'now', 'Last 1 hour'],
+      ['now-7d', 'now', 'Last 7 days'],
+      ['now/d', 'now/d', 'Today'],
+      ['now/d', 'now', 'Today so far'],
+      ['now/w', 'now/w', 'This week'],
+      ['now-1d/d', 'now-1d/d', 'Yesterday'],
+      ['now-1w/w', 'now-1w/w', 'Previous week'],
+      ['now-1y/y', 'now-1y/y', 'Previous year'],
+      ['now/fQ', 'now/fQ', 'This fiscal quarter'],
+      ['now-1Q/fQ', 'now-1Q/fQ', 'Previous fiscal quarter'],
+    ])('should return display name "%s" for range from "%s" to "%s"', (from, to, expected) => {
+      expect(describeTimeRange({ from, to })).toBe(expected);
+    });
+
+    it('should prioritize custom quick ranges over standard ranges', () => {
+      const customRanges = [{ from: 'now-5m', to: 'now', display: 'Lightning round!' }];
+
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, customRanges)).toBe('Lightning round!');
+    });
+
+    it('should format with the default timezone', () => {
+      // Tests default to Pacific/Easter
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('15/1/23, 5:30 – 9:45 am');
+    });
+
+    it('should respect timezone in datetime formatting', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to }, 'Australia/Sydney');
+      expect(result).toBe('15/1/23, 9:30 pm – 16/1/23, 1:45 am');
+    });
+
+    it('should include seconds in the output if the time has seconds', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = dateTime('2023-01-15T14:45:12Z');
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('15/1/23, 5:30:00 am – 9:45:12 am');
+    });
+
+    it('should handle absolute from, relative to', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = 'now';
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('15/01/2023, 5:30 am to a few seconds ago');
+    });
+
+    it('should handle relative from, absolute to', () => {
+      const from = 'now-1h';
+      const to = dateTime('2023-01-15T14:45:00Z');
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toBe('an hour ago to 15/01/2023, 9:45 am');
+    });
+
+    it('should handle invalid relative expressions', () => {
+      const from = dateTime('2023-01-15T10:30:00Z');
+      const to = 'invalid-expression';
+
+      const result = describeTimeRange({ from, to });
+      expect(result).toContain('Invalid date');
+    });
+
+    it('should handle empty custom ranges array', () => {
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, [])).toBe('Last 5 minutes');
+    });
+
+    it('should handle null custom ranges', () => {
+      expect(describeTimeRange({ from: 'now-5m', to: 'now' }, undefined, undefined)).toBe('Last 5 minutes');
     });
   });
 });

--- a/packages/grafana-data/src/utils/featureToggles.ts
+++ b/packages/grafana-data/src/utils/featureToggles.ts
@@ -1,0 +1,13 @@
+import { FeatureToggles } from '../types/featureToggles.gen';
+
+type FeatureToggleName = keyof FeatureToggles;
+
+/**
+ * Check a featureToggle
+ * @param featureName featureToggle name
+ * @param def default value if featureToggles aren't defined, false if not provided
+ * @returns featureToggle value or def.
+ */
+export function getFeatureToggle(featureName: FeatureToggleName, def = false) {
+  return window.grafanaBootData?.settings.featureToggles[featureName] ?? def;
+}

--- a/packages/grafana-i18n/src/dates.ts
+++ b/packages/grafana-i18n/src/dates.ts
@@ -1,7 +1,12 @@
 import deepEqual from 'fast-deep-equal';
-import memoize from 'micro-memoize';
+import memoize, { AnyFn, Memoized } from 'micro-memoize';
 
 const deepMemoize: typeof memoize = (fn) => memoize(fn, { isEqual: deepEqual });
+
+function clearMemoizedCache(fn: Memoized<AnyFn>) {
+  fn.cache.keys.length = 0;
+  fn.cache.values.length = 0;
+}
 
 let regionalFormat: string | undefined;
 
@@ -41,5 +46,8 @@ export const formatDateRange = (
 };
 
 export const initRegionalFormat = (regionalFormatArg: string) => {
+  clearMemoizedCache(formatDate);
+  clearMemoizedCache(formatDuration);
+
   regionalFormat = regionalFormatArg;
 };

--- a/packages/grafana-i18n/src/dates.ts
+++ b/packages/grafana-i18n/src/dates.ts
@@ -46,6 +46,8 @@ export const formatDateRange = (
 };
 
 export const initRegionalFormat = (regionalFormatArg: string) => {
+  // We don't expect this to be called with a different locale during the lifetime of the app,
+  // so this is mostly here so we can change it during tests and clear out previously memoized values.
   clearMemoizedCache(formatDate);
   clearMemoizedCache(formatDuration);
 

--- a/packages/grafana-i18n/src/index.ts
+++ b/packages/grafana-i18n/src/index.ts
@@ -24,4 +24,4 @@ export {
 } from './constants';
 export { initPluginTranslations, t, Trans } from './i18n';
 export type { ResourceLoader, Resources, TFunction, TransProps } from './types';
-export { formatDate, formatDuration, formatDateRange } from './dates';
+export { formatDate, formatDuration, formatDateRange, initRegionalFormat as initRegionalFormatForTests } from './dates';

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/mapper.ts
@@ -7,6 +7,7 @@ export const mapOptionToTimeRange = (option: TimeOption, timeZone?: TimeZone): T
   return rangeUtil.convertRawToRange({ from: option.from, to: option.to }, timeZone, undefined, commonFormat);
 };
 
+// TODO: Should we keep these format presets somewhere common?
 const rangeFormatShort: Intl.DateTimeFormatOptions = {
   dateStyle: 'short',
   timeStyle: 'short',

--- a/public/test/jest-setup.ts
+++ b/public/test/jest-setup.ts
@@ -13,6 +13,7 @@ jest.isolateModulesAsync(async () => {
     appEvents: testAppEvents,
   }));
 });
+import { initRegionalFormatForTests } from '@grafana/i18n';
 import { GrafanaBootConfig } from '@grafana/runtime';
 
 import 'blob-polyfill';
@@ -23,6 +24,9 @@ import '../vendor/flot/jquery.flot';
 import '../vendor/flot/jquery.flot.time';
 
 const global = window as any;
+
+const regionalFormatPreference = 'en-AU';
+initRegionalFormatForTests(regionalFormatPreference);
 
 // mock the default window.grafanaBootData settings
 const settings: Partial<GrafanaBootConfig> = {

--- a/public/test/jest-setup.ts
+++ b/public/test/jest-setup.ts
@@ -13,7 +13,6 @@ jest.isolateModulesAsync(async () => {
     appEvents: testAppEvents,
   }));
 });
-import { initRegionalFormatForTests } from '@grafana/i18n';
 import { GrafanaBootConfig } from '@grafana/runtime';
 
 import 'blob-polyfill';
@@ -24,9 +23,6 @@ import '../vendor/flot/jquery.flot';
 import '../vendor/flot/jquery.flot.time';
 
 const global = window as any;
-
-const regionalFormatPreference = 'en-AU';
-initRegionalFormatForTests(regionalFormatPreference);
 
 // mock the default window.grafanaBootData settings
 const settings: Partial<GrafanaBootConfig> = {


### PR DESCRIPTION
This PR changes the date time formatting functions in `@grafana/data` to use the new `@grafana/i18n` functions which format according to the user's regional formatting preference. Methods changed are:
 - `dateTimeFormat()`
   - Changed to use `@grafana/i18n`'s `formatDate()`
 - `dateTimeFormatWithAbbrevation()`
    - Confusingly named, this function is identical to `dateTimeFormat()` but includes time zone
    - Changed to use `@grafana/i18n`'s `formatDate()`
 - `describeTimeRange()`
   - Changed to use  `@grafana/i18n`'s `formatDateRange()` when both `from` and `to` are absolute times
   - Otherwise, it falls back to using the above `dateTimeFormat()` method (which uses the `@grafana/i18n` methods) for the absolute time components, and manually concatenates them into a string
   - This isn't ideal for i18n, but it's what we'll do initially to reduce the scope of this PR
 - plus any other functions that use these

The new locale-aware formatting is used when the `regionalFormatPreference` toggle is enabled.

The advantages of these new methods is that they respect the user's regional format preference and use the native browser Intl APIs. I've found it makes the ranges especially much easier to read.

This makes them "more correct" (at least, Grafana gets to worry less about how to correctly format a date), and hopefully should make it easier for us to remove date/time formatting dependencies such as moment.js. The browser `formatRange` method is particularly nice as it will shorten ranges if the occur on the same day!

**Before:**

<img width="501" height="48" alt="image" src="https://github.com/user-attachments/assets/7eb55e8b-e31a-46c0-90ec-15fff679fde1" />

**After (en-AU):**

<img width="434" height="48" alt="image" src="https://github.com/user-attachments/assets/fdbe17bd-8a11-4dc0-bb3f-0f311566f665" />

**After (de-DE):**

<img width="409" height="48" alt="image" src="https://github.com/user-attachments/assets/aa4a5be4-d45b-4941-aebb-a826f9728c9b" />

**After (en-AU, same day):**

<img width="372" height="48" alt="image" src="https://github.com/user-attachments/assets/b796a653-09d8-4b79-bbbe-fc75fd2aa316" />

**Before (to now):**

<img width="482" height="48" alt="image" src="https://github.com/user-attachments/assets/d1c629fc-0629-4ab3-b869-a2029f8fc643" />


**After (en-AU, to now):**

<img width="476" height="48" alt="image" src="https://github.com/user-attachments/assets/3699a9fd-2d7b-4782-86f0-733689c313d2" />


Fixes https://github.com/grafana/grafana/issues/105386  
Closes https://github.com/grafana/grafana/issues/101312