### PR TITLE
sj/dashboard ds implements adhoc filtering NEW

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1054,4 +1054,8 @@ export interface FeatureToggles {
   * Enable dual reader for unified storage search
   */
   unifiedStorageSearchDualReaderEnabled?: boolean;
+  /**
+  * Enables adhoc filtering support for the dashboard datasource
+  */
+  dashboardDsAdHocFiltering?: boolean;
 }

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -40,7 +40,7 @@ export function CellActions({
   const onFilterFor = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (onCellFilterAdded) {
-        onCellFilterAdded({ key: field.name, operator: FILTER_FOR_OPERATOR, value: cell.value });
+        onCellFilterAdded({ key: field.name, operator: FILTER_FOR_OPERATOR, value: String(cell.value) });
       }
     },
     [cell, field, onCellFilterAdded]
@@ -48,7 +48,7 @@ export function CellActions({
   const onFilterOut = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (onCellFilterAdded) {
-        onCellFilterAdded({ key: field.name, operator: FILTER_OUT_OPERATOR, value: cell.value });
+        onCellFilterAdded({ key: field.name, operator: FILTER_OUT_OPERATOR, value: String(cell.value) });
       }
     },
     [cell, field, onCellFilterAdded]

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -40,7 +40,7 @@ export function CellActions({
   const onFilterFor = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (onCellFilterAdded) {
-        onCellFilterAdded({ key: field.name, operator: FILTER_FOR_OPERATOR, value: String(cell.value) });
+        onCellFilterAdded({ key: field.name, operator: FILTER_FOR_OPERATOR, value: cell.value });
       }
     },
     [cell, field, onCellFilterAdded]
@@ -48,7 +48,7 @@ export function CellActions({
   const onFilterOut = useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       if (onCellFilterAdded) {
-        onCellFilterAdded({ key: field.name, operator: FILTER_OUT_OPERATOR, value: String(cell.value) });
+        onCellFilterAdded({ key: field.name, operator: FILTER_OUT_OPERATOR, value: cell.value });
       }
     },
     [cell, field, onCellFilterAdded]

--- a/pkg/services/featuremgmt/codeowners.go
+++ b/pkg/services/featuremgmt/codeowners.go
@@ -8,6 +8,7 @@ const (
 	grafanaAppPlatformSquad                     codeowner = "@grafana/grafana-app-platform-squad"
 	grafanaDashboardsSquad                      codeowner = "@grafana/dashboards-squad"
 	grafanaDatavizSquad                         codeowner = "@grafana/dataviz-squad"
+	grafanaDataProSquad                         codeowner = "@grafana/datapro"
 	grafanaFrontendPlatformSquad                codeowner = "@grafana/grafana-frontend-platform"
 	grafanaFrontendSearchNavOrganise            codeowner = "@grafana/grafana-search-navigate-organise"
 	grafanaBackendServicesSquad                 codeowner = "@grafana/grafana-backend-services-squad"

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1821,6 +1821,13 @@ var (
 			HideFromAdminPage: true,
 			HideFromDocs:      true,
 		},
+		{
+			Name:         "dashboardDsAdHocFiltering",
+			Description:  "Enables adhoc filtering support for the dashboard datasource",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDataProSquad,
+			FrontendOnly: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -235,3 +235,4 @@ otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
 alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 pluginAssetProvider,experimental,@grafana/plugins-platform-backend,false,true,false
 unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false
+dashboardDsAdHocFiltering,experimental,@grafana/datapro,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -950,4 +950,8 @@ const (
 	// FlagUnifiedStorageSearchDualReaderEnabled
 	// Enable dual reader for unified storage search
 	FlagUnifiedStorageSearchDualReaderEnabled = "unifiedStorageSearchDualReaderEnabled"
+
+	// FlagDashboardDsAdHocFiltering
+	// Enables adhoc filtering support for the dashboard datasource
+	FlagDashboardDsAdHocFiltering = "dashboardDsAdHocFiltering"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -798,6 +798,19 @@
     },
     {
       "metadata": {
+        "name": "dashboardDsAdHocFiltering",
+        "resourceVersion": "1753174335493",
+        "creationTimestamp": "2025-07-22T08:52:15Z"
+      },
+      "spec": {
+        "description": "Enables adhoc filtering support for the dashboard datasource",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardNewLayouts",
         "resourceVersion": "1750434297879",
         "creationTimestamp": "2024-10-23T08:55:45Z"

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -61,7 +61,14 @@ export function AdHocVariableForm({
           htmlFor="data-source-picker"
           tooltip={infoText}
         >
-          <DataSourcePicker current={datasource} onChange={onDataSourceChange} width={30} variables={true} noDefault />
+          <DataSourcePicker
+            current={datasource}
+            onChange={onDataSourceChange}
+            width={30}
+            variables={true}
+            dashboard={true}
+            noDefault
+          />
         </EditorField>
       </Box>
 

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -4,6 +4,7 @@ import { DataSourceInstanceSettings, MetricFindValue, readCSV } from '@grafana/d
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
+import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
 import { Alert, CodeEditor, Field, Switch, Box } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
@@ -66,7 +67,7 @@ export function AdHocVariableForm({
             onChange={onDataSourceChange}
             width={30}
             variables={true}
-            dashboard={true}
+            dashboard={config.featureToggles.dashboardDsAdHocFiltering}
             noDefault
           />
         </EditorField>

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -206,18 +206,64 @@ describe('DashboardDatasource', () => {
       expect(result.length).toBe(2);
     });
 
-    it.skip('should ignore filters on non-string fields', () => {
+    it('should apply equality filter on numeric fields', () => {
       const frame = createTestFrame([
         { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '=', value: '25' }]);
+      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '=', value: '30' }]);
 
-      // Should return all rows since age field is not string
-      expect(result.fields[0].values).toEqual(['John', 'Jane', 'Bob']);
-      expect(result.fields[1].values).toEqual([25, 30, 35]);
-      expect(result.length).toBe(3);
+      expect(result.fields[0].values).toEqual(['Jane']);
+      expect(result.fields[1].values).toEqual([30]);
+      expect(result.length).toBe(1);
+    });
+
+    it('should apply not-equal filter on numeric fields', () => {
+      const frame = createTestFrame([
+        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+        { name: 'age', type: FieldType.number, values: [25, 30, 35] },
+      ]);
+
+      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '30' }]);
+
+      expect(result.fields[0].values).toEqual(['John', 'Bob']);
+      expect(result.fields[1].values).toEqual([25, 35]);
+      expect(result.length).toBe(2);
+    });
+
+    it('should handle numeric fields with null values', () => {
+      const frame = createTestFrame([
+        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
+        { name: 'age', type: FieldType.number, values: [25, null, 35] },
+      ]);
+
+      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '25' }]);
+
+      expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
+      expect(result.fields[1].values).toEqual([null, 35]);
+      expect(result.length).toBe(2);
+    });
+
+    it('should handle mixed string and numeric filtering', () => {
+      const frame = createTestFrame([
+        { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob', 'Alice'] },
+        { name: 'age', type: FieldType.number, values: [25, 30, 25, 35] },
+      ]);
+
+      const result = (ds as any).applyAdHocFilters(frame, [
+        { key: 'name', operator: '!=', value: 'Bob' },
+        { key: 'age', operator: '=', value: '25' },
+      ]);
+
+      // Should match: name != 'Bob' AND age = 25
+      // John: !Bob + 25 ✓
+      // Jane: !Bob + 30 ✗
+      // Bob: Bob + 25 ✗
+      // Alice: !Bob + 35 ✗
+      expect(result.fields[0].values).toEqual(['John']);
+      expect(result.fields[1].values).toEqual([25]);
+      expect(result.length).toBe(1);
     });
 
     it('should handle empty data frames', () => {
@@ -234,6 +280,10 @@ describe('DashboardDatasource', () => {
     });
 
     it.skip('should handle remaining operators', () => {
+      // Not yet implemented, so we explicitly don't specify any behaviour for this
+    });
+
+    it.skip('should handle remaining field types (eg. date)', () => {
       // Not yet implemented, so we explicitly don't specify any behaviour for this
     });
 

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -8,6 +8,8 @@ import {
   LoadingState,
   standardTransformersRegistry,
   FieldType,
+  DataFrame,
+  AdHocVariableFilter,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
@@ -136,7 +138,18 @@ describe('DashboardDatasource', () => {
   describe('AdHoc Filtering', () => {
     const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
 
-    function createTestFrame(fields: any[]) {
+    // Type-safe interface for accessing private methods in tests
+    interface DashboardDatasourceWithPrivateMethods {
+      applyAdHocFilters: (frame: DataFrame, filters: AdHocVariableFilter[]) => DataFrame;
+    }
+
+    interface TestField {
+      name: string;
+      type: FieldType;
+      values: unknown[];
+    }
+
+    function createTestFrame(fields: TestField[]) {
       return {
         name: 'TestData',
         fields: fields.map((field) => ({
@@ -157,7 +170,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['John']);
       expect(result.fields[1].values).toEqual([25]);
@@ -170,7 +185,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '!=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '!=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
       expect(result.fields[1].values).toEqual([30, 35]);
@@ -183,7 +200,7 @@ describe('DashboardDatasource', () => {
         { name: 'status', type: FieldType.string, values: ['active', 'active', 'inactive'] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'name', operator: '!=', value: 'John' },
         { key: 'status', operator: '=', value: 'active' },
       ]);
@@ -199,7 +216,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '!=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '!=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual([null, 'Bob']);
       expect(result.fields[1].values).toEqual([30, 35]);
@@ -212,7 +231,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '=', value: '30' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '=', value: '30' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane']);
       expect(result.fields[1].values).toEqual([30]);
@@ -225,7 +246,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '30' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '!=', value: '30' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['John', 'Bob']);
       expect(result.fields[1].values).toEqual([25, 35]);
@@ -238,7 +261,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, null, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'age', operator: '!=', value: '25' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'age', operator: '!=', value: '25' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Jane', 'Bob']);
       expect(result.fields[1].values).toEqual([null, 35]);
@@ -251,7 +276,7 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 25, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'name', operator: '!=', value: 'Bob' },
         { key: 'age', operator: '=', value: '25' },
       ]);
@@ -272,7 +297,9 @@ describe('DashboardDatasource', () => {
         { name: 'score', type: FieldType.number, values: [95.5, 87.25, 95.5, 92.0] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'score', operator: '=', value: '95.5' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'score', operator: '=', value: '95.5' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Alice', 'Charlie']);
       expect(result.fields[1].values).toEqual([95.5, 95.5]);
@@ -285,7 +312,9 @@ describe('DashboardDatasource', () => {
         { name: 'temperature', type: FieldType.number, values: [98.6, 99.1, 98.6] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'temperature', operator: '!=', value: '98.6' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'temperature', operator: '!=', value: '98.6' },
+      ]);
 
       expect(result.fields[0].values).toEqual(['Bob']);
       expect(result.fields[1].values).toEqual([99.1]);
@@ -299,7 +328,9 @@ describe('DashboardDatasource', () => {
       ]);
 
       // Note: 0.1 + 0.2 !== 0.3 in JavaScript due to floating point precision
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'value', operator: '=', value: '0.3' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'value', operator: '=', value: '0.3' },
+      ]);
 
       // Should only match the exact 0.3, not the computed 0.1 + 0.2
       expect(result.fields[0].values).toEqual(['Test2']);
@@ -313,7 +344,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'name', operator: '=', value: 'John' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'name', operator: '=', value: 'John' },
+      ]);
 
       expect(result.fields[0].values).toEqual([]);
       expect(result.fields[1].values).toEqual([]);
@@ -334,7 +367,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'missing_field', operator: '=', value: 'test' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'missing_field', operator: '=', value: 'test' },
+      ]);
 
       // Should return empty result since field doesn't exist
       expect(result.fields[0].values).toEqual([]);
@@ -348,7 +383,9 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [{ key: 'missing_field', operator: '!=', value: 'test' }]);
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
+        { key: 'missing_field', operator: '!=', value: 'test' },
+      ]);
 
       // Should return all rows since field doesn't exist (all rows are "not equal")
       expect(result.fields[0].values).toEqual(['John', 'Jane', 'Bob']);
@@ -363,7 +400,7 @@ describe('DashboardDatasource', () => {
         { name: 'age', type: FieldType.number, values: [25, 30, 35, 40] },
       ]);
 
-      const result = (ds as any).applyAdHocFilters(frame, [
+      const result = (ds as unknown as DashboardDatasourceWithPrivateMethods).applyAdHocFilters(frame, [
         { key: 'status', operator: '=', value: 'active' },
         { key: 'name', operator: '!=', value: 'Admin' },
         { key: 'missing_field', operator: '!=', value: 'ignored' }, // Should be ignored

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -16,6 +16,7 @@ import {
   AdHocVariableFilter,
   MetricFindValue,
 } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
   activateSceneObjectAndParentTree,
@@ -123,8 +124,10 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             ...field,
             config: {
               ...field.config,
-              // Enable AdHoc filtering for string and numeric fields
-              filterable: field.type === FieldType.string || field.type === FieldType.number,
+              // Enable AdHoc filtering for string and numeric fields only when feature toggle is enabled
+              filterable: config.featureToggles.dashboardDsAdHocFiltering
+                ? field.type === FieldType.string || field.type === FieldType.number
+                : field.config.filterable,
             },
             state: {
               ...field.state,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -289,7 +289,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Handle unsupported field types
    */
-  private compareUnsupportedValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
+  private compareUnsupportedValues = (_fieldValue: any, _filter: AdHocVariableFilter): boolean => {
     // unknown field type, skip this filter
     return true;
   };

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -12,6 +12,7 @@ import {
   DataFrame,
   LoadingState,
   Field,
+  FieldType,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
@@ -111,6 +112,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           ...s,
           fields: s.fields.map((field: Field) => ({
             ...field,
+            config: {
+              ...field.config,
+              // Enable AdHoc filtering for string fields (similar to Loki/Prometheus pattern)
+              filterable: field.type === FieldType.string,
+            },
             state: {
               ...field.state,
             },

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -208,7 +208,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Evaluate a filter against a field value - unified method that dispatches based on field type
    */
-  private evaluateFilter(fieldValue: any, filter: AdHocVariableFilter, fieldType: FieldType): boolean {
+  private evaluateFilter(fieldValue: unknown, filter: AdHocVariableFilter, fieldType: FieldType): boolean {
     // Handle null/undefined values consistently across all types
     if (fieldValue == null) {
       return filter.operator === '!=' && filter.value !== '';
@@ -239,7 +239,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Compare string field values
    */
-  private compareStringValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
+  private compareStringValues = (fieldValue: unknown, filter: AdHocVariableFilter): boolean => {
     const filterValue = filter.value;
 
     switch (filter.operator) {
@@ -256,7 +256,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Compare numeric field values (integers and floats)
    */
-  private compareNumericValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
+  private compareNumericValues = (fieldValue: unknown, filter: AdHocVariableFilter): boolean => {
     // Parse filter value as a number
     const filterValue = parseFloat(filter.value);
 
@@ -266,7 +266,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     }
 
     // Ensure field value is a number
-    const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(fieldValue);
+    const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(String(fieldValue));
 
     // If field value is not a valid number, reject all rows
     if (isNaN(numericFieldValue)) {
@@ -292,7 +292,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   /**
    * Handle unsupported field types
    */
-  private compareUnsupportedValues = (_fieldValue: any, _filter: AdHocVariableFilter): boolean => {
+  private compareUnsupportedValues = (_fieldValue: unknown, _filter: AdHocVariableFilter): boolean => {
     // unknown field type, reject all rows
     return false;
   };

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -290,15 +290,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
    * Handle unsupported field types
    */
   private compareUnsupportedValues = (fieldValue: any, filter: AdHocVariableFilter): boolean => {
-    // Use the same logic as handleNonStringFieldFilter for consistency
-    switch (filter.operator) {
-      case '=':
-        return false; // Field type not supported, so can't match
-      case '!=':
-        return true; // Field type not supported, so it's "not equal"
-      default:
-        return true; // Unknown operator, skip this filter
-    }
+    // unknown field type, skip this filter
+    return true;
   };
 
   /**

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -14,6 +14,7 @@ import {
   Field,
   FieldType,
   AdHocVariableFilter,
+  MetricFindValue,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
@@ -252,5 +253,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
   testDatasource(): Promise<TestDataSourceResponse> {
     return Promise.resolve({ message: '', status: '' });
+  }
+
+  getTagKeys(): Promise<MetricFindValue[]> {
+    // Stub implementation to indicate AdHoc filter support
+    // Full implementation will be added in future PRs
+    return Promise.resolve([]);
   }
 }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -245,8 +245,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       case '!=':
         return fieldValue !== filterValue;
       default:
-        // Unknown operator, skip this filter
-        return true;
+        // Unknown operator, reject all rows
+        return false;
     }
   };
 
@@ -257,17 +257,17 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     // Parse filter value as a number
     const filterValue = parseFloat(filter.value);
 
-    // If filter value is not a valid number, skip this filter
+    // If filter value is not a valid number, reject all rows
     if (isNaN(filterValue)) {
-      return true;
+      return false;
     }
 
     // Ensure field value is a number
     const numericFieldValue = typeof fieldValue === 'number' ? fieldValue : parseFloat(fieldValue);
 
-    // If field value is not a valid number, skip this filter
+    // If field value is not a valid number, reject all rows
     if (isNaN(numericFieldValue)) {
-      return true;
+      return false;
     }
 
     switch (filter.operator) {
@@ -281,8 +281,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       // case '<':
       //   return numericFieldValue < filterValue;
       default:
-        // Unknown operator, skip this filter
-        return true;
+        // Unknown operator, reject all rows
+        return false;
     }
   };
 
@@ -290,8 +290,8 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
    * Handle unsupported field types
    */
   private compareUnsupportedValues = (_fieldValue: any, _filter: AdHocVariableFilter): boolean => {
-    // unknown field type, skip this filter
-    return true;
+    // unknown field type, reject all rows
+    return false;
   };
 
   /**

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -267,7 +267,12 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
    */
   private reconstructDataFrame(frame: DataFrame, matchingRows: Set<number>): DataFrame {
     const fields: Field[] = frame.fields.map((field) => {
-      const newValues = Array.from(matchingRows, (rowIndex) => field.values[rowIndex]);
+      // Pre-allocate array and use direct assignment for better performance with large datasets
+      const newValues = new Array(matchingRows.size);
+      let i = 0;
+      for (const rowIndex of matchingRows) {
+        newValues[i++] = field.values[rowIndex];
+      }
 
       return {
         ...field,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -226,38 +226,27 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       }
     }
 
-    // Convert AdHoc filter to value matcher configuration
-    const matcherConfig = this.adHocFilterToMatcherConfig(filter);
-    if (!matcherConfig) {
-      return null;
+    // Map operator to matcher ID
+    let matcherId: ValueMatcherID;
+    switch (filter.operator) {
+      case '=':
+        matcherId = ValueMatcherID.equal;
+        break;
+      case '!=':
+        matcherId = ValueMatcherID.notEqual;
+        break;
+      default:
+        return null; // Unknown operator
     }
 
     try {
-      return getValueMatcher(matcherConfig);
+      return getValueMatcher({
+        id: matcherId,
+        options: { value: filter.value },
+      });
     } catch (error) {
       console.warn('Failed to create value matcher for filter:', filter, error);
       return null;
-    }
-  }
-
-  /**
-   * Convert AdHocVariableFilter to MatcherConfig for value matchers
-   */
-  private adHocFilterToMatcherConfig(filter: AdHocVariableFilter): MatcherConfig | null {
-    switch (filter.operator) {
-      case '=':
-        return {
-          id: ValueMatcherID.equal,
-          options: { value: filter.value },
-        };
-      case '!=':
-        return {
-          id: ValueMatcherID.notEqual,
-          options: { value: filter.value },
-        };
-      default:
-        // Unknown operator
-        return null;
     }
   }
 

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -192,7 +192,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         const field = frame.fields[fieldIndex];
 
         // Use Grafana's value matcher system
-        return matcher!(rowIndex, field, frame, [frame]);
+        return matcher?.(rowIndex, field, frame, [frame]) ?? false;
       });
 
       if (rowMatches) {

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -76,7 +76,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     }
 
     // Extract AdHoc filters from the request
-    const adhocFilters = options.filters || [];
+    const adHocFilters = options.filters || [];
 
     return defer(() => {
       if (!sourceDataProvider!.isActive && sourceDataProvider?.setContainerWidth) {
@@ -89,7 +89,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         debounceTime(50),
         map((result) => {
           return {
-            data: this.getDataFramesForQueryTopic(result.data, query, adhocFilters),
+            data: this.getDataFramesForQueryTopic(result.data, query, adHocFilters),
             state: result.data.state,
             errors: result.data.errors,
             error: result.data.error,

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -200,6 +200,11 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
       }
     }
 
+    // Early return if no filtering occurred
+    if (matchingRows.size === frame.length) {
+      return frame;
+    }
+
     return this.reconstructDataFrame(frame, matchingRows);
   }
 

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -17,7 +17,6 @@ import {
   MetricFindValue,
   getValueMatcher,
   ValueMatcherID,
-  MatcherConfig,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -189,11 +189,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
     // Check each row to see if it matches all filters (AND logic)
     for (let rowIndex = 0; rowIndex < frame.length; rowIndex++) {
       const rowMatches = filterFieldIndices.every(({ matcher, fieldIndex }) => {
-        // Handle case where field doesn't exist (fieldIndex === -1)
-        if (fieldIndex === -1) {
-          return false; // Impossible filter case
-        }
-
         const field = frame.fields[fieldIndex];
 
         // Use Grafana's value matcher system


### PR DESCRIPTION
- **Allow fields from --Dashboard-- ds to be filtered**
- **Add --Dashboard-- to AdHoc Data source picker**
- **Filter results from the --Dashboard-- datasource using the AdHoc filter**
- **Stub out `getTagKeys`**
- **Optimise the AdHoc filtering performance**
- **Add unit tests**
- **Add support for numeric fields**
- **Add floats to our spec (and our tests)**
- **Refactor, as per Cursor's recommendations:**
- **Also skip filters for unknown field types**
- **Fix linting errors**
- **Reject all rows when behaviour not yet implemented, instead of skipping filters**
- **Add feature toggle to toggles registry**
- **Wrap feature in the new feature-toggle**
- **Address Betterer linting issues**
- **Stringify cell values before we try to call `labelValue.replace`**
- **Rename `adhocFilters` to `adHocFilters`**
- **Revert "Stringify cell values before we try to call `labelValue.replace`"**
- **Refactor to use Grafana's existing value matcher architecture**
- **Remove redundant code**
- **Be defensive, allow for null values of `matcher`**
- **Optimise with a short-circuit (early return)**
- **Improve performance building new fields**
- **Inline AdHoc filter to matcher config logic**
- **Fix linting error**
