### PR TITLE
Provisioning: Fix ImportAllPanelsFromLocalRepository test

### DIFF
--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -528,6 +528,12 @@ spec:
 }
 
 func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T) {
+	t.Skip(
+		"Flaky Test",
+		"https://github.com/grafana/grafana-enterprise/actions/runs/16441629279/job/46463665864?pr=9136",
+		"https://github.com/grafana/grafana-enterprise/actions/runs/16441629279/job/46463665904?pr=9136",
+	)
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -554,7 +554,7 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	require.NoError(t, err)
 
 	// Now, we import it, such that it may exist
-	// The sync may not be necesary as the sync may have happened automatically at this point
+	// The sync may not be necessary as the sync may have happened automatically at this point
 	helper.SyncAndWait(t, repo, nil)
 
 	// Make sure the repo can read and validate the file

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -528,12 +528,6 @@ spec:
 }
 
 func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T) {
-	t.Skip(
-		"Flaky Test",
-		"https://github.com/grafana/grafana-enterprise/actions/runs/16441629279/job/46463665864?pr=9136",
-		"https://github.com/grafana/grafana-enterprise/actions/runs/16441629279/job/46463665904?pr=9136",
-	)
-
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -541,16 +535,27 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	helper := runGrafana(t)
 	ctx := context.Background()
 
+	// The dashboard shouldn't exist yet
+	const allPanels = "n1jR8vnnz"
+	_, err := helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
+	require.Error(t, err, "no all-panels dashboard should exist")
+	require.True(t, apierrors.IsNotFound(err))
+
 	const repo = "local-tmp"
 	// Set up the repository and the file to import.
 	helper.CopyToProvisioningPath(t, "testdata/all-panels.json", "all-panels.json")
-
 	localTmp := helper.RenderObject(t, "testdata/local-write.json.tmpl", map[string]any{
 		"Name":        repo,
 		"SyncEnabled": true,
 	})
-	_, err := helper.Repositories.Resource.Create(ctx, localTmp, metav1.CreateOptions{})
+
+	// We create the repository
+	_, err = helper.Repositories.Resource.Create(ctx, localTmp, metav1.CreateOptions{})
 	require.NoError(t, err)
+
+	// Now, we import it, such that it may exist
+	// The sync may not be necesary as the sync may have happened automatically at this point
+	helper.SyncAndWait(t, repo, nil)
 
 	// Make sure the repo can read and validate the file
 	obj, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "all-panels.json")
@@ -558,21 +563,14 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 
 	resource, _, err := unstructured.NestedMap(obj.Object, "resource")
 	require.NoError(t, err, "missing resource")
-	action, _, err := unstructured.NestedString(resource, "action")
 	require.NoError(t, err, "invalid action")
-
 	require.NotNil(t, resource["file"], "the raw file")
 	require.NotNil(t, resource["dryRun"], "dryRun result")
-	require.Equal(t, "create", action)
 
-	// But the dashboard shouldn't exist yet
-	const allPanels = "n1jR8vnnz"
-	_, err = helper.DashboardsV1.Resource.Get(ctx, allPanels, metav1.GetOptions{})
-	require.Error(t, err, "no all-panels dashboard should exist")
-	require.True(t, apierrors.IsNotFound(err))
-
-	// Now, we import it, such that it may exist
-	helper.SyncAndWait(t, repo, nil)
+	action, _, err := unstructured.NestedString(resource, "action")
+	require.NoError(t, err, "invalid action")
+	// FIXME: there is no point in in returning action for a read / get request.
+	require.Equal(t, "update", action)
 
 	_, err = helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
 	require.NoError(t, err, "can list values")


### PR DESCRIPTION
Examples:
```
 --- FAIL: TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository (2.06s)
    helper_test.go:230: Grafana is listening on 127.0.0.1:36871
    provisioning_test.go:600: 
        	Error Trace:	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/pkg/tests/apis/provisioning/provisioning_test.go:600
        	Error:      	Not equal: 
        	            	expected: "create"
        	            	actual  : "update"
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1 +1 @@
        	            	-create
        	            	+update
        	Test:       	TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository
FAIL
FAIL	github.com/grafana/grafana/pkg/tests/apis/provisioning	26.018s
FAIL
```

.
```
 --- FAIL: TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository (1.55s)
    helper_test.go:230: Grafana is listening on 127.0.0.1:43541
    provisioning_test.go:605: 
        	Error Trace:	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/pkg/tests/apis/provisioning/provisioning_test.go:605
        	Error:      	An error is expected but got nil.
        	Test:       	TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository
        	Messages:   	no all-panels dashboard should exist
FAIL
FAIL	github.com/grafana/grafana/pkg/tests/apis/provisioning	21.370s
FAIL
```