### PR TITLE
I18n: Default regional format to Accept-Language header value

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -86,7 +86,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	}
 
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagLocaleFormatPreference) {
-		regionalFormat = "en" // default to "en", not "en-US", matching the regionalFormat code
+		regionalFormat = locale // Default to the Accept-Language header if no other preference is set
 		if urlPrefs.RegionalFormat != "" {
 			regionalFormat = urlPrefs.RegionalFormat
 		} else if prefs.JSONData.RegionalFormat != "" {

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -85,15 +85,27 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		locale = parts[0]
 	}
 
-	// We default the regional format (locale) to the Accept-Language header rather than the language preference
-	// mainly because we want to avoid defaulting to en-US for most users who have not set a preference, and we
-	// don't have more specific English language preferences yet.
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagLocaleFormatPreference) {
-		regionalFormat = locale
+		regionalFormat = "en"
+
+		// We default the regional format (locale) to the Accept-Language header rather than the language preference
+		// mainly because we want to avoid defaulting to en-US for most users who have not set a preference, and we
+		// don't have more specific English language preferences yet.
+
+		// Regional format preference order (from most-preferred to least):
+		// 1. URL parameter
+		// 2. regionalFormat User preference
+		// 3. Accept-Language header
+		// 4. Default to locale (Accept-Language header)
+		// 5. Language preference
 		if urlPrefs.RegionalFormat != "" {
 			regionalFormat = urlPrefs.RegionalFormat
 		} else if prefs.JSONData.RegionalFormat != "" {
 			regionalFormat = prefs.JSONData.RegionalFormat
+		} else if locale != "" {
+			regionalFormat = locale
+		} else if language != "" {
+			regionalFormat = language
 		}
 	}
 

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -69,8 +69,18 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	// Locale is used for some number and date/time formatting, whereas language is used just for
 	// translating words in the interface
 	acceptLangHeader := c.Req.Header.Get("Accept-Language")
+	acceptLangHeaderFirstValue := ""
+
+	if len(acceptLangHeader) > 0 {
+		parts := strings.Split(acceptLangHeader, ",")
+		acceptLangHeaderFirstValue = parts[0]
+	}
+
 	locale := "en-US" // default to en formatting, but use the accept-lang header or user's preference
-	var regionalFormat string
+	if acceptLangHeaderFirstValue != "" {
+		locale = acceptLangHeaderFirstValue
+	}
+
 	language := "" // frontend will set the default language
 	urlPrefs := getURLPrefs(c)
 
@@ -80,11 +90,7 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		language = prefs.JSONData.Language
 	}
 
-	if len(acceptLangHeader) > 0 {
-		parts := strings.Split(acceptLangHeader, ",")
-		locale = parts[0]
-	}
-
+	var regionalFormat string
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagLocaleFormatPreference) {
 		regionalFormat = "en"
 
@@ -96,14 +102,13 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		// 1. URL parameter
 		// 2. regionalFormat User preference
 		// 3. Accept-Language header
-		// 4. Default to locale (Accept-Language header)
-		// 5. Language preference
+		// 4. Language preference
 		if urlPrefs.RegionalFormat != "" {
 			regionalFormat = urlPrefs.RegionalFormat
 		} else if prefs.JSONData.RegionalFormat != "" {
 			regionalFormat = prefs.JSONData.RegionalFormat
-		} else if locale != "" {
-			regionalFormat = locale
+		} else if acceptLangHeaderFirstValue != "" {
+			regionalFormat = acceptLangHeaderFirstValue
 		} else if language != "" {
 			regionalFormat = language
 		}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -85,8 +85,11 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 		locale = parts[0]
 	}
 
+	// We default the regional format (locale) to the Accept-Language header rather than the language preference
+	// mainly because we want to avoid defaulting to en-US for most users who have not set a preference, and we
+	// don't have more specific English language preferences yet.
 	if hs.Features.IsEnabled(c.Req.Context(), featuremgmt.FlagLocaleFormatPreference) {
-		regionalFormat = locale // Default to the Accept-Language header if no other preference is set
+		regionalFormat = locale
 		if urlPrefs.RegionalFormat != "" {
 			regionalFormat = urlPrefs.RegionalFormat
 		} else if prefs.JSONData.RegionalFormat != "" {


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/108415, we will make the regional preference locale-aware formatting much more obvious in the dashboard time range picker. However, most users will not have regional format preference set, so it will initially default to `en-US`.

Defaulting the locale-aware formatting to `en-US` is problematic because we'll go from dates like `2025-20-07` to `7/20/2025`, which we don't want for Grafana's global audience. Instead, we'll look at the Accept-Language header as a stronger indicator for the user's default preference.

Part of https://github.com/grafana/grafana/issues/101312