### PR TITLE
TraceView: Grafana Assistant hook to analyze trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@grafana/alerting": "workspace:*",
+    "@grafana/assistant": "^0.0.7",
     "@grafana/aws-sdk": "0.7.1",
     "@grafana/azure-sdk": "0.0.7",
     "@grafana/data": "workspace:*",

--- a/public/app/features/explore/TraceView/TraceView.test.tsx
+++ b/public/app/features/explore/TraceView/TraceView.test.tsx
@@ -12,6 +12,10 @@ import { TraceView } from './TraceView';
 import { TraceData, TraceSpanData } from './components/types/trace';
 import { transformDataFrames } from './utils/transform';
 
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: jest.fn(() => [false, null]), // [isAvailable, openAssistant]
+}));
+
 function getTraceView(frames: DataFrame[]) {
   const store = configureStore();
   const topOfViewRef = createRef<HTMLDivElement>();

--- a/public/app/features/explore/TraceView/TraceView.tsx
+++ b/public/app/features/explore/TraceView/TraceView.tsx
@@ -167,6 +167,7 @@ export function TraceView(props: Props) {
   const timeZone = useSelector((state) => getTimeZone(state.user));
   const datasourceType = datasource ? datasource?.type : 'unknown';
   const datasourceUid = datasource ? datasource?.uid : '';
+  const datasourceName = datasource ? datasource?.name : '';
   const scrollElement = props.scrollElement
     ? props.scrollElement
     : document.getElementsByClassName(props.scrollElementClass ?? '')[0];
@@ -188,6 +189,8 @@ export function TraceView(props: Props) {
             setFocusedSpanIdForSearch={setFocusedSpanIdForSearch}
             spanFilterMatches={spanFilterMatches}
             datasourceType={datasourceType}
+            datasourceName={datasourceName}
+            datasourceUid={datasourceUid}
             setHeaderHeight={setHeaderHeight}
             app={exploreId ? CoreApp.Explore : CoreApp.Unknown}
           />

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -7,7 +7,6 @@ import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Icon, useTheme2 } from '@grafana/ui';
 
-
 import { config } from '../../../../../../core/config';
 import { downloadTraceAsJson } from '../../../../../inspector/utils/download';
 
@@ -100,10 +99,12 @@ export default function TracePageActions(props: TracePageActionsProps) {
 
     return (
       <ActionButton
-        onClick={() => openAssistant?.({ 
-          prompt: `Summarize this trace view.`,
-          context,
-        })}
+        onClick={() =>
+          openAssistant?.({
+            prompt: `Summarize this trace view.`,
+            context,
+          })
+        }
         ariaLabel={t('explore.trace-page-actions.ariaLabel-analyze-trace', 'Analyze Trace')}
         label={t('explore.trace-page-actions.label-analyze-trace', 'Analyze Trace')}
         icon={'ai-sparkle'}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -73,7 +73,7 @@ export default function TracePageActions(props: TracePageActionsProps) {
   function AssistantButton() {
     const [isAvailable, openAssistant] = useAssistant();
 
-    if (!isAvailable) {
+    if (!isAvailable || !openAssistant) {
       return null;
     }
 

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -79,30 +79,32 @@ export default function TracePageActions(props: TracePageActionsProps) {
     }
 
     return (
-      <button onClick={() => openAssistant?.({ 
-        prompt: `Help me summarize this trace view`,
-        context: [
-          createContext(ItemDataType.Datasource, {
-            datasourceName: datasourceName || 'unknown',
-            datasourceUid: datasourceUid || 'unknown',
-            datasourceType: datasourceType || 'unknown',
-          }),
-          createContext(ItemDataType.Structured, {
-            title: t('explore.trace-page-actions.trace-view-query', 'Trace View Query'),
-            data: {
-              query: traceId,
-            },
-          }),
-        ],
-      })}>
-        <Trans i18nKey="explore.trace-page-actions.open-assistant">Analyze trace</Trans>
-      </button>
+      <ActionButton
+        onClick={() => openAssistant?.({ 
+          prompt: `Help me summarize this trace view`,
+          context: [
+            createContext(ItemDataType.Datasource, {
+              datasourceName: datasourceName || 'unknown',
+              datasourceUid: datasourceUid || 'unknown',
+              datasourceType: datasourceType || 'unknown',
+            }),
+            createContext(ItemDataType.Structured, {
+              title: t('explore.trace-page-actions.trace-view-query', 'Trace View Query'),
+              data: {
+                query: traceId,
+              },
+            }),
+          ],
+        })}
+        ariaLabel={t('explore.trace-page-actions.ariaLabel-analyze-trace', 'Analyze Trace')}
+        label={t('explore.trace-page-actions.label-analyze-trace', 'Analyze Trace')}
+        icon={'ai-sparkle'}
+      />
     );
   }
 
   return (
     <div className={styles.TracePageActions}>
-      <AssistantButton />
       {config.feedbackLinksEnabled && (
         <div className={styles.feedbackContainer}>
           <Icon name="comment-alt-message" />
@@ -121,6 +123,7 @@ export default function TracePageActions(props: TracePageActionsProps) {
         </div>
       )}
 
+      <AssistantButton />
       <ActionButton
         onClick={copyTraceId}
         ariaLabel={t('explore.trace-page-actions.ariaLabel-copy-trace-id', 'Copy Trace ID')}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
+import { useAssistant } from '@grafana/assistant';
 import { GrafanaTheme2, CoreApp, DataFrame } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Icon, useTheme2 } from '@grafana/ui';
+
 
 import { config } from '../../../../../../core/config';
 import { downloadTraceAsJson } from '../../../../../inspector/utils/download';
@@ -66,8 +68,23 @@ export default function TracePageActions(props: TracePageActionsProps) {
     });
   };
 
+  function AssistantButton() {
+    const [isAvailable, openAssistant, closeAssistant] = useAssistant();
+
+    if (!isAvailable) {
+      return <div><Trans i18nKey="explore.trace-page-actions.assistant-not-available">Assistant not available</Trans></div>;
+    }
+
+    return (
+      <button onClick={() => openAssistant?.({ prompt: `Help me summarize this trace with id: ${traceId}` })}>
+        <Trans i18nKey="explore.trace-page-actions.open-assistant">Open Assistant</Trans>
+      </button>
+    );
+  }
+
   return (
     <div className={styles.TracePageActions}>
+      <AssistantButton />
       {config.feedbackLinksEnabled && (
         <div className={styles.feedbackContainer}>
           <Icon name="comment-alt-message" />

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -78,23 +78,31 @@ export default function TracePageActions(props: TracePageActionsProps) {
       return null;
     }
 
+    const context = [
+      createContext(ItemDataType.Structured, {
+        title: t('explore.trace-page-actions.trace-view-query', 'Trace View Query'),
+        data: {
+          query: traceId,
+        },
+      }),
+    ];
+
+    // Only add datasource context if datasource information exists
+    if (datasourceName && datasourceUid && datasourceType) {
+      context.unshift(
+        createContext(ItemDataType.Datasource, {
+          datasourceName,
+          datasourceUid,
+          datasourceType,
+        })
+      );
+    }
+
     return (
       <ActionButton
         onClick={() => openAssistant?.({ 
-          prompt: `Help me summarize this trace view`,
-          context: [
-            createContext(ItemDataType.Datasource, {
-              datasourceName: datasourceName || 'unknown',
-              datasourceUid: datasourceUid || 'unknown',
-              datasourceType: datasourceType || 'unknown',
-            }),
-            createContext(ItemDataType.Structured, {
-              title: t('explore.trace-page-actions.trace-view-query', 'Trace View Query'),
-              data: {
-                query: traceId,
-              },
-            }),
-          ],
+          prompt: `Summarize this trace view.`,
+          context,
         })}
         ariaLabel={t('explore.trace-page-actions.ariaLabel-analyze-trace', 'Analyze Trace')}
         label={t('explore.trace-page-actions.label-analyze-trace', 'Analyze Trace')}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -105,7 +105,7 @@ export default function TracePageActions(props: TracePageActionsProps) {
             context,
           })
         }
-        ariaLabel={t('explore.trace-page-actions.ariaLabel-analyze-trace', 'Analyze Trace')}
+        ariaLabel={t('explore.trace-page-actions.label-analyze-trace', 'Analyze Trace')}
         label={t('explore.trace-page-actions.label-analyze-trace', 'Analyze Trace')}
         icon={'ai-sparkle'}
       />

--- a/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/Actions/TracePageActions.tsx
@@ -95,7 +95,7 @@ export default function TracePageActions(props: TracePageActionsProps) {
           }),
         ],
       })}>
-        <Trans i18nKey="explore.trace-page-actions.open-assistant">Open Assistant</Trans>
+        <Trans i18nKey="explore.trace-page-actions.open-assistant">Analyze trace</Trans>
       </button>
     );
   }

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -21,6 +21,10 @@ import { defaultFilters } from '../../useSearch';
 import { TracePageHeader } from './TracePageHeader';
 import { trace } from './mocks';
 
+jest.mock('@grafana/assistant', () => ({
+  useAssistant: jest.fn(() => [false, null]), // [isAvailable, openAssistant]
+}));
+
 const setup = () => {
   const defaultProps = {
     trace,

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -45,6 +45,8 @@ export type TracePageHeaderProps = {
   setFocusedSpanIdForSearch: React.Dispatch<React.SetStateAction<string>>;
   spanFilterMatches: Set<string> | undefined;
   datasourceType: string;
+  datasourceName?: string;
+  datasourceUid?: string;
   setHeaderHeight: (height: number) => void;
 };
 
@@ -61,6 +63,8 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
     setFocusedSpanIdForSearch,
     spanFilterMatches,
     datasourceType,
+    datasourceName,
+    datasourceUid,
     setHeaderHeight,
   } = props;
   const styles = useStyles2(getNewStyles);
@@ -136,7 +140,14 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
       <div className={styles.titleRow}>
         {links && links.length > 0 && <ExternalLinks links={links} className={styles.TracePageHeaderBack} />}
         {title}
-        <TracePageActions traceId={trace.traceID} data={data} app={app} />
+        <TracePageActions 
+          traceId={trace.traceID} 
+          data={data} 
+          app={app} 
+          datasourceType={datasourceType}
+          datasourceName={datasourceName}
+          datasourceUid={datasourceUid}
+        />
       </div>
 
       <div className={styles.subtitle}>

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -140,10 +140,10 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
       <div className={styles.titleRow}>
         {links && links.length > 0 && <ExternalLinks links={links} className={styles.TracePageHeaderBack} />}
         {title}
-        <TracePageActions 
-          traceId={trace.traceID} 
-          data={data} 
-          app={app} 
+        <TracePageActions
+          traceId={trace.traceID}
+          data={data}
+          app={app}
           datasourceType={datasourceType}
           datasourceName={datasourceName}
           datasourceUid={datasourceUid}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7191,10 +7191,12 @@
       "ariaLabel-copy-trace-id": "Copy Trace ID",
       "ariaLabel-export-trace": "Export Trace",
       "give-feedback": "Give feedback",
+      "label-analyze-trace": "Analyze Trace",
       "label-copied": "Copied!",
       "label-export": "Export",
       "label-trace-id": "Trace ID",
-      "title-share-thoughts-about-tracing-grafana": "Share your thoughts about tracing in Grafana."
+      "title-share-thoughts-about-tracing-grafana": "Share your thoughts about tracing in Grafana.",
+      "trace-view-query": "Trace View Query"
     },
     "trace-page-header": {
       "text-partial-trace": "Partial trace",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,6 +3033,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@grafana/assistant@npm:^0.0.7":
+  version: 0.0.7
+  resolution: "@grafana/assistant@npm:0.0.7"
+  peerDependencies:
+    "@grafana/data": ">=12.0.0"
+    "@grafana/runtime": ">=12.0.0"
+    "@grafana/scenes": ">=5.41.0"
+    "@grafana/ui": ">=12.0.0"
+    react: ">=18.0.0"
+    rxjs: ">=7.0.0"
+  checksum: 10/c83523a032cb748867f683e87ad5b00a04bb4918ae5c7aafe5587b418b73b769a92de948335f0d9055d06036004e7a9794722f627cab3111b076eb27423d4344
+  languageName: node
+  linkType: hard
+
 "@grafana/async-query-data@npm:0.4.1":
   version: 0.4.1
   resolution: "@grafana/async-query-data@npm:0.4.1"
@@ -18139,6 +18153,7 @@ __metadata:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
     "@glideapps/glide-data-grid": "npm:^6.0.0"
     "@grafana/alerting": "workspace:*"
+    "@grafana/assistant": "npm:^0.0.7"
     "@grafana/aws-sdk": "npm:0.7.1"
     "@grafana/azure-sdk": "npm:0.0.7"
     "@grafana/data": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

Grafana Assistant hook to analyze trace. Adds an `Analyze Trace` button in the trace view which sends a query and context on to the Grafana Assistant.

**Why do we need this feature?**

Adds a hook into the Grafana Assistant so we can query a trace and analyze it.

**Who is this feature for?**

Trace view and assistant users!

**Special notes for your reviewer:**

<img width="672" height="294" alt="Screenshot 2025-07-22 at 16 30 34" src="https://github.com/user-attachments/assets/ed214dfa-c068-4619-b7f2-2fbd9c05a9f7" />
