### PR TITLE
Plugins: externalise jsx-runtime

### DIFF
--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -100,6 +100,7 @@ export const sharedDependenciesMap = {
   moment: () => import('moment').then((module) => ({ ...module, __useDefault: true })),
   prismjs: () => import('prismjs'),
   react: () => import('react'),
+  'react/jsx-runtime': () => import('react/jsx-runtime'),
   'react-dom': () => import('react-dom'),
   // bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
   'react-inlinesvg': () => import('react-inlinesvg'),

--- a/public/app/features/plugins/loader/sharedDependencies.ts
+++ b/public/app/features/plugins/loader/sharedDependencies.ts
@@ -100,7 +100,10 @@ export const sharedDependenciesMap = {
   moment: () => import('moment').then((module) => ({ ...module, __useDefault: true })),
   prismjs: () => import('prismjs'),
   react: () => import('react'),
+  // Externalise react/jsx-runtime to align with runtime version of react.
+  // This should make major react update easier to manage in the future.
   'react/jsx-runtime': () => import('react/jsx-runtime'),
+  'react/jsx-dev-runtime': () => import('react/jsx-dev-runtime'),
   'react-dom': () => import('react-dom'),
   // bundling grafana-ui in plugins requires sharing react-inlinesvg for the icon cache
   'react-inlinesvg': () => import('react-inlinesvg'),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR shares the `react/jsx-runtime` and `react/jsx-dev-runtime` modules from Grafana with plugins at runtime.

**Why do we need this feature?**

React 19 contains breaking changes to its internals which have been identified as a blocker for Grafana to upgrade it's version of React because a small number of plugins bundle the `react/jsx-runtime`. This is problematic due to the version of React Grafana is using being different to the version the plugins bundled `react/jsx-runtime` expects and things go 💥 .

By sharing the dependency with plugins and then externalising it in plugins webpack configs we create an upgrade path for the existing plugins that bundle `react/jsx-runtime`, open up the door for future plugins to use Reacts automatic jsx feature (which relies on this dependency), and hopefully unblock future react updates.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related grafana/grafana-community-team/issues/553

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
