### PR TITLE
Plugins: add info logging for successfully installed plugins

### DIFF
--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -66,18 +66,28 @@ export async function importPluginModule({
     return importPluginModuleInSandbox({ pluginId });
   }
 
-  return SystemJS.import(modulePath).catch((e) => {
-    let error = new Error('Could not load plugin: ' + e);
-    console.error(error);
-    pluginsLogger.logError(error, {
-      path,
-      pluginId,
-      pluginVersion: version ?? '',
-      expectedHash: moduleHash ?? '',
-      loadingStrategy: loadingStrategy.toString(),
-      sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
-      newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
+  return SystemJS.import(modulePath)
+    .then((module) => {
+      pluginsLogger.logInfo('Plugin loaded successfully: ', {
+        path,
+        pluginId,
+        pluginVersion: version ?? '',
+        loadingStrategy: loadingStrategy.toString(),
+      });
+      return module;
+    })
+    .catch((e) => {
+      let error = new Error('Could not load plugin: ' + e);
+      console.error(error);
+      pluginsLogger.logError(error, {
+        path,
+        pluginId,
+        pluginVersion: version ?? '',
+        expectedHash: moduleHash ?? '',
+        loadingStrategy: loadingStrategy.toString(),
+        sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
+        newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
+      });
+      throw error;
     });
-    throw error;
-  });
 }


### PR DESCRIPTION
**What is this feature?**

The Logs Drilldown plugin is trying to create an SLO based on `plugin_error_rate = plugin_loading_errors_total / plugin_loaded_events_total` Right now we are counting plugin_loading_errors_total based off of the log line `Could not load plugin:` In order to calculate success or plugin_loaded_events_total, the log line `'Plugin loaded successfully:` has been added. Example for `Could not load plugin:` in [deployment tools](https://github.com/grafana/deployment_tools/pull/306419)

If there is a better way to achieve this or another way for plugins to do SLOs, please let me know!

**Why do we need this feature?**
This is necessary to make SLO calculations.

**Who is this feature for?**
Logs Drilldown, but potentially any plugin making an SLO.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
