### PR TITLE
shardQuerySplitting: group has pending requests or no shards to run

### DIFF
--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -88,7 +88,7 @@ function splitQueriesByStreamShard(
 
     const nextRequest = () => {
       const nextGroup =
-        groups[group + 1] && groupHasPendingRequests(groups[group + 1])
+        groups[group + 1] && (groups[group + 1].shards === undefined || groupHasPendingRequests(groups[group + 1]))
           ? groups[group + 1]
           : groups.find((shardGroup) => groupHasPendingRequests(shardGroup));
 

--- a/public/app/plugins/datasource/loki/shardQuerySplitting.ts
+++ b/public/app/plugins/datasource/loki/shardQuerySplitting.ts
@@ -87,6 +87,7 @@ function splitQueriesByStreamShard(
     }
 
     const nextRequest = () => {
+      // Find the next group to execute, which can be queries with pending shards to execute, or the next query with no shards.
       const nextGroup =
         groups[group + 1] && (groups[group + 1].shards === undefined || groupHasPendingRequests(groups[group + 1]))
           ? groups[group + 1]


### PR DESCRIPTION
When shard query splitting was executing multiple queries and the next one to run had no shards to execute, it was identified as not a pending query.

Now we check if it has pending shards o no shards, and execute.