### PR TITLE
I18n: Prepare locale format for preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -107,6 +107,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `elasticsearchCrossClusterSearch` | Enables cross cluster search in the Elasticsearch datasource                                           |
 | `alertRuleRestore`                | Enables the alert rule restore feature                                                                 |
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                        |
+| `localeFormatPreference`          | Specifies the locale so the correct format for numbers and dates can be shown                          |
 | `logsPanelControls`               | Enables a control component for the logs panel in Explore                                              |
 
 ## Development feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1564,7 +1564,7 @@ var (
 		{
 			Name:        "localeFormatPreference",
 			Description: "Specifies the locale so the correct format for numbers and dates can be shown",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaFrontendPlatformSquad,
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -203,7 +203,7 @@ alertingMigrationUI,GA,@grafana/alerting-squad,false,false,true
 alertingImportYAMLUI,GA,@grafana/alerting-squad,false,false,true
 unifiedStorageHistoryPruner,GA,@grafana/search-and-storage,false,false,false
 azureMonitorLogsBuilderEditor,preview,@grafana/partner-datasources,false,false,false
-localeFormatPreference,experimental,@grafana/grafana-frontend-platform,false,false,false
+localeFormatPreference,preview,@grafana/grafana-frontend-platform,false,false,false
 unifiedStorageGrpcConnectionPool,experimental,@grafana/search-and-storage,false,false,false
 extensionSidebar,experimental,@grafana/observability-logs,false,false,true
 alertingRulePermanentlyDelete,GA,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1854,12 +1854,15 @@
     {
       "metadata": {
         "name": "localeFormatPreference",
-        "resourceVersion": "1750434297879",
-        "creationTimestamp": "2025-03-31T13:59:07Z"
+        "resourceVersion": "1753261256848",
+        "creationTimestamp": "2025-03-31T13:59:07Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-07-23 09:00:56.848352786 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Specifies the locale so the correct format for numbers and dates can be shown",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-platform"
       }
     },

--- a/public/app/core/components/SharedPreferences/SharedPreferences.tsx
+++ b/public/app/core/components/SharedPreferences/SharedPreferences.tsx
@@ -342,7 +342,7 @@ export class SharedPreferences extends PureComponent<Props, State> {
                   <span className={styles.labelText}>
                     <Trans i18nKey="shared-preferences.fields.locale-preference-label">Region format</Trans>
                   </span>
-                  <FeatureBadge featureState={FeatureState.experimental} />
+                  <FeatureBadge featureState={FeatureState.preview} />
                 </Label>
               }
               description={t(

--- a/public/app/core/internationalization/locales.ts
+++ b/public/app/core/internationalization/locales.ts
@@ -4,280 +4,418 @@ interface Locale {
   code: string;
 }
 
-// TODO re-check translations
+// Grafana does not support right-to-left languages in the UI, so to avoid confusion
+// and a poor experience, we've commented out the right-to-left languages so they don't
+// appear as options.
 export const LOCALES: Locale[] = [
   // Afrikaans - Standard
   { name: 'Afrikaans', code: 'af' },
-  // Arabic - Standard
-  { name: 'العربية', code: 'ar' },
-  // Arabic - Algeria
-  { name: 'العربية (الجزائر)', code: 'ar-DZ' },
-  // Arabic - Kuwait
-  { name: 'العربية (الكويت)', code: 'ar-KW' },
-  // Arabic - Libya
-  { name: 'العربية (ليبيا)', code: 'ar-LY' },
-  // Arabic - Morocco
-  { name: 'العربية (المغرب)', code: 'ar-MA' },
-  // Arabic - Palestine
-  { name: 'العربية (فلسطين)', code: 'ar-PS' },
-  // Arabic - Saudi Arabia
-  { name: 'العربية (السعودية)', code: 'ar-SA' },
-  // Arabic - Tunisia
-  { name: 'العربية (تونس)', code: 'ar-TN' },
+
+  // // Arabic - Standard
+  // { name: 'العربية', code: 'ar' }, // Disabled because RTL
+
+  // // Arabic - Algeria
+  // { name: 'العربية (الجزائر)', code: 'ar-DZ' }, // Disabled because RTL
+
+  // // Arabic - Kuwait
+  // { name: 'العربية (الكويت)', code: 'ar-KW' }, // Disabled because RTL
+
+  // // Arabic - Libya
+  // { name: 'العربية (ليبيا)', code: 'ar-LY' }, // Disabled because RTL
+
+  // // Arabic - Morocco
+  // { name: 'العربية (المغرب)', code: 'ar-MA' }, // Disabled because RTL
+
+  // // Arabic - Palestine
+  // { name: 'العربية (فلسطين)', code: 'ar-PS' }, // Disabled because RTL
+
+  // // Arabic - Saudi Arabia
+  // { name: 'العربية (السعودية)', code: 'ar-SA' }, // Disabled because RTL
+
+  // // Arabic - Tunisia
+  // { name: 'العربية (تونس)', code: 'ar-TN' }, // Disabled because RTL
+
   // Azerbaijani - Azerbaijan
   { name: 'Azərbaycan dili', code: 'az' },
+
   // Belarusian - Belarus
   { name: 'Беларуская мова', code: 'be-BY' },
+
   // Bulgarian - Bulgaria
   { name: 'Български език', code: 'bg-BG' },
+
   // Bambara - Mali
   { name: 'Bamanankan', code: 'bm' },
+
   // Bengali - Standard
   { name: 'বাংলা', code: 'bn' },
+
   // Bengali - Bangladesh
   { name: 'বাংলা', code: 'bn-BD' },
+
   // Tibetan - Tibet (China) and Bhutan
   { name: 'བོད་ཡིག', code: 'bo' },
+
   // Breton - Brittany (France)
   { name: 'Brezhoneg', code: 'br' },
+
   // Bosnian - Bosnia and Herzegovina
   { name: 'Bosanski jezik', code: 'bs' },
+
   // Catalan - Catalonia (Spain)
   { name: 'Català', code: 'ca-ES' },
+
   // Czech - Czech Republic
   { name: 'Čeština', code: 'cs-CZ' },
+
   // Welsh - Wales (United Kingdom)
   { name: 'Cymraeg', code: 'cy-GB' },
+
   // Chuvash - Chuvashia (Russia)
   { name: 'Чӑвашла', code: 'cv-RU' },
+
   // Danish - Denmark
   { name: 'Dansk', code: 'da-DK' },
+
   // German - Germany
   { name: 'Deutsch', code: 'de-DE' },
+
   // German - Austria
   { name: 'Deutsch (Österreich)', code: 'de-AT' },
+
   // German - Switzerland
   { name: 'Deutsch (Schweiz)', code: 'de-CH' },
-  // Divehi/Maldivian - Maldives
-  { name: 'ދިވެހި', code: 'dv-MV' },
+
+  // // Divehi/Maldivian - Maldives
+  // { name: 'ދިވެހި', code: 'dv-MV' }, // Disabled because RTL
+
   // Greek - Greece
   { name: 'Ελληνικά', code: 'el-GR' },
+
   // English - Australia
   { name: 'English (Australia)', code: 'en-AU' },
+
   // English - Canada
   { name: 'English (Canada)', code: 'en-CA' },
+
   // English - United Kingdom
   { name: 'English (United Kingdom)', code: 'en-GB' },
+
   // English - Ireland
   { name: 'English (Ireland)', code: 'en-IE' },
+
   // English - Israel
   { name: 'English (Israel)', code: 'en-IL' },
+
   // English - India
   { name: 'English (India)', code: 'en-IN' },
+
   // English - New Zealand
   { name: 'English (New Zealand)', code: 'en-NZ' },
+
   // English - Singapore
   { name: 'English (Singapore)', code: 'en-SG' },
+
   // English - United States
   { name: 'English (United States)', code: 'en-US' },
+
   // Esperanto - International Auxiliary Language
-  { name: 'Esperanto', code: 'eo' },
+  // { name: 'Esperanto', code: 'eo' },
+
   // Spanish - Spain
   { name: 'Español', code: 'es-ES' },
+
   // Spanish - Dominican Republic
   { name: 'Español (República Dominicana)', code: 'es-DO' },
+
   // Spanish - Mexico
   { name: 'Español (México)', code: 'es-MX' },
+
   // Spanish - United States
   { name: 'Español (Estados Unidos)', code: 'es-US' },
+
   // Estonian - Estonia
   { name: 'Eesti keel', code: 'et-EE' },
+
   // Basque - Basque Country
   { name: 'Euskara', code: 'eu-ES' },
-  // Persian - Iran
-  { name: 'فارسی', code: 'fa-IR' },
+
+  // // Persian - Iran
+  // { name: 'فارسی', code: 'fa-IR' }, // Disabled because RTL
+
   // Filipino - Philippines
   { name: 'Wikang Filipino', code: 'fil-PH' },
+
   // Finnish - Finland
   { name: 'Suomi', code: 'fi-FI' },
+
   // Faroese - Faroe Islands
   { name: 'Føroyskt', code: 'fo-FO' },
+
   // French - France
   { name: 'Français', code: 'fr-FR' },
+
   // French - Canada
   { name: 'Français (Canada)', code: 'fr-CA' },
+
   // French - Switzerland
   { name: 'Français (Suisse)', code: 'fr-CH' },
+
   // West Frisian - Netherlands
   { name: 'Frysk', code: 'fy' },
+
   // Irish - Ireland
   { name: 'Gaeilge', code: 'ga-IE' },
+
   // Scottish Gaelic - Scotland (UK)
   { name: 'Gàidhlig', code: 'gd-GB' },
+
   // Galician - Galicia (Spain)
   { name: 'Galego', code: 'gl-ES' },
+
   // Konkani (Devanagari script) - India
   { name: 'कोंकणी', code: 'gom-Deva' },
+
   // Konkani (Latin script) - India
   { name: 'Konkani', code: 'gom-Latn' },
+
   // Gujarati - India
   { name: 'ગુજરાતી', code: 'gu-IN' },
-  // Hebrew - Israel
-  { name: 'עברית', code: 'he-IL' },
+
+  // // Hebrew - Israel
+  // { name: 'עברית', code: 'he-IL' }, // Disabled because RTL
+
   // Hindi - India
   { name: 'हिन्दी', code: 'hi' },
+
   // Croatian - Croatia
   { name: 'Hrvatski jezik', code: 'hr' },
+
   // Hungarian - Hungary
   { name: 'Magyar nyelv', code: 'hu-HU' },
+
   // Armenian - Armenia
   { name: 'Հայերեն', code: 'hy-AM' },
+
   // Indonesian - Indonesia
   { name: 'Bahasa Indonesia', code: 'id-ID' },
+
   // Icelandic - Iceland
   { name: 'Íslenska', code: 'is-IS' },
+
   // Italian - Italy
   { name: 'Italiano', code: 'it-IT' },
+
   // Italian - Switzerland
   { name: 'Italiano (Svizzera)', code: 'it-CH' },
+
   // Japanese - Japan
   { name: '日本語', code: 'ja-JP' },
+
   // Javanese - Indonesia
   { name: 'ꦧꦱꦗꦮ', code: 'jv' },
+
   // Georgian - Georgia
   { name: 'ქართული ენა', code: 'ka-GE' },
+
   // Kazakh - Kazakhstan
   { name: 'Қазақ тілі', code: 'kk-KZ' },
+
   // Khmer - Cambodia
   { name: 'ខ្មែរ', code: 'km-KH' },
+
   // Kannada - India
   { name: 'ಕನ್ನಡ', code: 'kn-IN' },
+
   // Korean - South Korea
   { name: '한국어', code: 'ko-KR' },
+
   // Kurdish - Kurdistan (Iraq, Iran, Syria, Turkey)
   { name: 'Kurdî', code: 'ku' },
+
   // Kyrgyz - Kyrgyzstan
   { name: 'Кыргыз тили', code: 'ky-KG' },
+
   // Luxembourgish - Luxembourg
   { name: 'Lëtzebuergesch', code: 'lb-LU' },
+
   // Lao - Laos
   { name: 'ພາສາລາວ', code: 'lo-LA' },
+
   // Lithuanian - Lithuania
   { name: 'Lietuvių kalba', code: 'lt-LT' },
+
   // Latvian - Latvia
   { name: 'Latviešu valoda', code: 'lv-LV' },
+
   // Macedonian - North Macedonia
   { name: 'Македонски јазик', code: 'mk-MK' },
+
   // Malayalam - Kerala (India)
   { name: 'മലയാളം', code: 'ml-IN' },
+
   // Māori - New Zealand
   { name: 'Te Reo Māori', code: 'mi-NZ' },
+
   // Montenegrin - Montenegro
   { name: 'Црногорски језик', code: 'cnr-ME' },
+
   // Marathi - Maharashtra (India)
   { name: 'मराठी', code: 'mr' },
+
   // Malay - Malaysia, Singapore, Brunei
   { name: 'Bahasa Melayu', code: 'ms' },
+
   // Maltese - Malta
   { name: 'Malti', code: 'mt-MT' },
+
   // Mongolian - Mongolia
   { name: 'Монгол хэл', code: 'mn-MN' },
+
   // Burmese - Myanmar
   { name: 'မြန်မာစာ', code: 'my-MM' },
+
   // Norwegian Bokmål - Norway
   { name: 'Norsk bokmål', code: 'nb' },
+
   // Nepali - Nepal and India
   { name: 'नेपाली', code: 'ne' },
+
   // Dutch - Netherlands
   { name: 'Nederlands', code: 'nl-NL' },
+
   // Dutch - Belgium (Flemish)
   { name: 'Nederlands (België)', code: 'nl-BE' },
+
   // Norwegian Nynorsk - Norway
   { name: 'Nynorsk', code: 'nn-NO' },
+
   // Occitan - Southern France, Monaco, Italy
   { name: 'Occitan', code: 'oc' },
+
   // Punjabi - Punjab (India and Pakistan)
   { name: 'ਪੰਜਾਬੀ', code: 'pa' },
+
   // Polish - Poland
   { name: 'Polski', code: 'pl-PL' },
+
   // Portuguese - Portugal
   { name: 'Português', code: 'pt-PT' },
+
   // Portuguese - Brazil
   { name: 'Português (Brasil)', code: 'pt-BR' },
+
   // Romanian - Romania
   { name: 'Română', code: 'ro-RO' },
+
   // Russian - Russia
   { name: 'Русский язык', code: 'ru-RU' },
+
   // Northern Sami - Northern Scandinavia
   { name: 'Davvisámegiella', code: 'se' },
-  // Sindhi - Pakistan and India
-  { name: 'سنڌي', code: 'sd' },
+
+  // // Sindhi - Pakistan and India
+  // { name: 'سنڌي', code: 'sd' }, // Disabled because RTL
+
   // Sinhala - Sri Lanka
   { name: 'සිංහල', code: 'si-LK' },
+
   // Slovak - Slovakia
   { name: 'Slovenský jazyk', code: 'sk-SK' },
+
   // Slovenian - Slovenia
   { name: 'Slovenski jezik', code: 'sl-SI' },
+
   // Albanian - Albania, Kosovo
   { name: 'Shqip', code: 'sq' },
+
   // Serbian - Serbia (Default)
   { name: 'Српски', code: 'sr' },
+
   // Serbian - Serbia (Cyrillic script)
   { name: 'Српски (ћирилица)', code: 'sr-Cyrl' },
+
   // Swati - Eswatini (Swaziland)
   { name: 'SiSwati', code: 'ss' },
+
   // Swahili - East Africa
   { name: 'Kiswahili', code: 'sw' },
+
   // Swedish - Sweden
   { name: 'Svenska', code: 'sv' },
+
   // Tamil - Tamil Nadu (India), Sri Lanka, Singapore
   { name: 'தமிழ்', code: 'ta' },
+
   // Telugu - Andhra Pradesh, Telangana (India)
   { name: 'తెలుగు', code: 'te' },
+
   // Tetum - East Timor
   { name: 'Tetun', code: 'tet' },
+
   // Tajik - Tajikistan
   { name: 'Тоҷикӣ', code: 'tg' },
+
   // Thai - Thailand
   { name: 'ภาษาไทย', code: 'th-TH' },
+
   // Turkmen - Turkmenistan
   { name: 'Türkmen dili', code: 'tk-TM' },
+
   // Tagalog - Philippines
   { name: 'Wikang Tagalog', code: 'tl-PH' },
+
   // Klingon - Constructed Language (Star Trek)
   { name: 'tlhIngan Hol', code: 'tlh' },
+
   // Turkish - Turkey
   { name: 'Türkçe', code: 'tr-TR' },
+
   // Talossan - Constructed Language
   { name: 'Talossan', code: 'tzl' },
+
   // Tamazight (Tifinagh script) - North Africa
   { name: 'ⵜⴰⵎⴰⵣⵉⵖⵜ', code: 'tzm' },
+
   // Tamazight (Latin script) - North Africa
   { name: 'Tamazight', code: 'tzm-Latn' },
-  // Uyghur - Xinjiang (China)
-  { name: 'ئۇيغۇرچە', code: 'ug-CN' },
+
+  // // Uyghur - Xinjiang (China)
+  // { name: 'ئۇيغۇرچە', code: 'ug-CN' }, // Disabled because RTL
+
   // Ukrainian - Ukraine
   { name: 'Українська мова', code: 'uk-UA' },
-  // Urdu - Pakistan and India
-  { name: 'اردو', code: 'ur-PK' },
+
+  // // Urdu - Pakistan and India
+  // { name: 'اردو', code: 'ur-PK' }, // Disabled because RTL
+
   // Uzbek - Uzbekistan (Cyrillic script)
   { name: 'Ўзбек тили', code: 'uz-UZ' },
+
   // Uzbek - Uzbekistan (Latin script)
   { name: "O'zbek tili", code: 'uz-Latn' },
+
   // Vietnamese - Vietnam
   { name: 'Tiếng Việt', code: 'vi-VN' },
+
   // Chinese - China
   { name: '中文', code: 'zh-CN' },
+
   // Chinese - Simplified
   { name: '简体中文', code: 'zh-Hans' },
+
   // Chinese - Traditional
   { name: '繁體中文', code: 'zh-Hant' },
+
   // Chinese - Hong Kong
   { name: '中文 (香港)', code: 'zh-HK' },
+
   // Chinese - Taiwan
   { name: '正體中文 (台灣)', code: 'zh-TW' },
+
   // Chinese - Macau
   { name: '中文 (澳門)', code: 'zh-MO' },
+
   // Yoruba - Nigeria, Benin, Togo
   { name: 'Yorùbá', code: 'yo' },
 ];


### PR DESCRIPTION
In preperation to start rolling out the regional format preference, i've made the following changes:
 - promoted the `localeFormatPreference` toggle to `FeatureStagePublicPreview`
 - updated the badge on the preferences page to `Preview`
 - Disabled RTL language locales to avoid confusion

Part of https://github.com/grafana/grafana/issues/101312