### PR TITLE
datasources: querier: temporary concurrency fix

### DIFF
--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -216,6 +216,7 @@ func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheSer
 		dataSourceRequestValidator: validations.ProvideValidator(),
 		mtDatasourceClientBuilder:  mtDatasourceClientBuilder,
 		headers:                    headers,
+		concurrentQueryLimit:       16, // TODO: make it configurable
 	}
 	return s.QueryData(ctx, nil, false, reqDTO)
 }


### PR DESCRIPTION
when one runs a query-service request that contains queries for multiple datasources, the code tries to run each query concurrently.

at this line:
https://github.com/grafana/grafana/blob/f093b3d62070665bfb8c626382ecf9698aae7a79/pkg/services/query/query.go#L127

we set the concurrent query limit.

unfortunately, when running in query-service mode, `s.concurrentQueryLimit` is unset (so `0`). this causes no new goroutines from being run (see https://pkg.go.dev/golang.org/x/sync/errgroup#Group.SetLimit ), so the code locks up there.

this PR just sets the value to `4` in the query-service mode to avoid this problem. we will add a more proper solution in a later PR.