### PR TITLE
Provisioning: Fix flake in delete resources integration test

### DIFF
--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -184,8 +184,12 @@ func (h *provisioningTestHelper) RenderObject(t *testing.T, filePath string, val
 // CopyToProvisioningPath copies a file to the provisioning path.
 // The from path is relative to test file's directory.
 func (h *provisioningTestHelper) CopyToProvisioningPath(t *testing.T, from, to string) {
+	fullPath := path.Join(h.ProvisioningPath, to)
+	err := os.MkdirAll(path.Dir(fullPath), 0755)
+	require.NoError(t, err, "failed to create directories for provisioning path")
+
 	file := h.LoadFile(from)
-	err := os.WriteFile(path.Join(h.ProvisioningPath, to), file, 0600)
+	err = os.WriteFile(fullPath, file, 0600)
 	require.NoError(t, err, "failed to write file to provisioning path")
 }
 

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -185,7 +185,7 @@ func (h *provisioningTestHelper) RenderObject(t *testing.T, filePath string, val
 // The from path is relative to test file's directory.
 func (h *provisioningTestHelper) CopyToProvisioningPath(t *testing.T, from, to string) {
 	fullPath := path.Join(h.ProvisioningPath, to)
-	err := os.MkdirAll(path.Dir(fullPath), 0755)
+	err := os.MkdirAll(path.Dir(fullPath), 0750)
 	require.NoError(t, err, "failed to create directories for provisioning path")
 
 	file := h.LoadFile(from)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the flake in the provisioning delete resources test.

**Why do we need this feature?**

Flaky CI.

**How**:

The reason the test fails some times is due to a race condition in the folder path creation as the `POST /files` will create / update the folder around the same time a sync job does some reconciliation.

The test itself can be fixed by not using those APIs and simply creating the folder directly in the filesystem and triggering a sync job before the scenario runs.

**Who is this feature for?**

Contributors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/357>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
