### PR TITLE
Explore: Fix units overflow for trace durations

### DIFF
--- a/public/app/features/explore/TraceView/components/utils/date.test.ts
+++ b/public/app/features/explore/TraceView/components/utils/date.test.ts
@@ -58,4 +58,9 @@ describe('formatDuration', () => {
     const input = 0;
     expect(formatDuration(input)).toBe('0μs');
   });
+
+  it('skips secondary units that are a whole multiple of the primary unit', () => {
+    const input = 299898037.75;
+    expect(formatDuration(input)).toBe('5m');
+  });
 });

--- a/public/app/features/explore/TraceView/components/utils/date.tsx
+++ b/public/app/features/explore/TraceView/components/utils/date.tsx
@@ -98,6 +98,11 @@ export function formatDuration(duration: number): string {
   const primaryValue = Math.floor(duration / primaryUnit.microseconds);
   const primaryUnitString = `${primaryValue}${primaryUnit.unit}`;
   const secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
+
+  if (secondaryValue === 0) {
+    return primaryUnitString;
+  }
+
   const secondaryUnitString = `${secondaryValue}${secondaryUnit.unit}`;
-  return secondaryValue === 0 ? primaryUnitString : `${primaryUnitString} ${secondaryUnitString}`;
+  return `${primaryUnitString} ${secondaryUnitString}`;
 }

--- a/public/app/features/explore/TraceView/components/utils/date.tsx
+++ b/public/app/features/explore/TraceView/components/utils/date.tsx
@@ -95,9 +95,19 @@ export function formatDuration(duration: number): string {
     return `${_round(duration / primaryUnit.microseconds, 2)}${primaryUnit.unit}`;
   }
 
-  const primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let primaryValue = Math.floor(duration / primaryUnit.microseconds);
+  let secondaryValue = (duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious;
+  const secondaryValueRounded = Math.round(secondaryValue);
+
+  // Handle rollover case before rounding (e.g., 60s should become 1m, not 0m 60s)
+  if (secondaryValueRounded === primaryUnit.ofPrevious) {
+    primaryValue += 1;
+    secondaryValue = 0;
+  } else {
+    secondaryValue = secondaryValueRounded;
+  }
+
   const primaryUnitString = `${primaryValue}${primaryUnit.unit}`;
-  const secondaryValue = Math.round((duration / secondaryUnit.microseconds) % primaryUnit.ofPrevious);
 
   if (secondaryValue === 0) {
     return primaryUnitString;


### PR DESCRIPTION
**What is this feature?**

While viewing some traces I noticed one of my traces was showing a strange looking duration:

<img width="883" height="252" alt="image" src="https://github.com/user-attachments/assets/21e7664f-88f3-4417-b786-8f82f07d0cda" />

The raw values from the trace associated with the screenshot were:

```json
{
  "startTimeUnixNano": 1753205496140410000,
  "endTimeUnixNano": 1753205796038447900
}
```

I used these values to derive the input for the test case.

This PR fixes the `formatDuration()` function to adjust the values to render _after_ they've been rounded to provide a more natural display string when the rounded secondary value is an exact multiple of the primary value. While I was at it, I also changed the code to stop formatting the secondary value if it isn't going to be used for the return value.

Looks like this was introduced by #37420.

**Why do we need this feature?**

Fixes the above issue.

**Who is this feature for?**

Users who view traces.

**Which issue(s) does this PR fix?**:

None.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~~If this is a pre-GA feature, it is behind a feature toggle.~~
- [ ] ~~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~~
