### PR TITLE
CloudWatch: Fix broken test

### DIFF
--- a/pkg/tsdb/cloudwatch/time_series_query_test.go
+++ b/pkg/tsdb/cloudwatch/time_series_query_test.go
@@ -138,9 +138,6 @@ func TestTimeSeriesQuery(t *testing.T) {
 func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMetricData_is_called_once_per_grouping_of_queries_by_region(t *testing.T) {
 	/* TODO: This test aims to verify the logic to group regions which has been extracted from ParseMetricDataQueries.
 	It should be replaced by a test at a lower level when grouping by regions is incorporated into a separate business logic layer */
-	// FIXME: this test is broken - it only works because we're recovering from the panic that the Mock
-	// produces - see time_series_query.go line 78. If that recover is commented out, the test fails.
-	t.Skip("skipping broken test")
 	ds := newTestDatasource()
 
 	origNewCWClient := NewCWClient
@@ -152,6 +149,8 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 	NewCWClient = func(aws.Config) models.CWClient {
 		return &mockMetricClient
 	}
+	oneToTwoHoursAgo := backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)}
+	twoToThreeHoursAgo := backend.TimeRange{From: time.Now().Add(time.Hour * -3), To: time.Now().Add(time.Hour * -2)}
 
 	t.Run("Queries with the same region should call GetMetricData 1 time", func(t *testing.T) {
 		mockMetricClient = mocks.MetricsAPI{}
@@ -164,7 +163,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 			Queries: []backend.DataQuery{
 				{
 					RefID:     "A",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -176,7 +175,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 				},
 				{
 					RefID:     "B",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -206,7 +205,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 			Queries: []backend.DataQuery{
 				{
 					RefID:     "A",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -218,7 +217,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 				},
 				{
 					RefID:     "A2",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -230,7 +229,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 				},
 				{
 					RefID:     "B",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -260,7 +259,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 			Queries: []backend.DataQuery{
 				{
 					RefID:     "A",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now()},
+					TimeRange: twoToThreeHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -272,7 +271,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 				},
 				{
 					RefID:     "A2",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now()},
+					TimeRange: twoToThreeHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",
@@ -284,7 +283,7 @@ func Test_executeTimeSeriesQuery_getCWClient_is_called_once_per_region_and_GetMe
 				},
 				{
 					RefID:     "B",
-					TimeRange: backend.TimeRange{From: time.Now().Add(time.Hour * -2), To: time.Now().Add(time.Hour * -1)},
+					TimeRange: oneToTwoHoursAgo,
 					JSON: json.RawMessage(`{
 						"type":      "timeSeriesQuery",
 						"namespace": "AWS/EC2",


### PR DESCRIPTION
**What is this feature?**

This fixes a test that has been skipped because it was not working correctly. It used `time.Now()` to construct query time ranges, rather than basing them off a static time. This meant the queries had slightly different time ranges and were not batched together as the test expected.

The test was incorrectly passing before the aws-sdk-go-v2 migration because the mocked `GetSessionWithAuthSettings` defined [here](https://github.com/grafana/grafana/blob/069598c454d9f0874072342ed06830abfb231c9c/pkg/tsdb/cloudwatch/time_series_query_test.go#L160-L164) with a `.Once()` was actually being called multiple times. When this happens the call panics, but the panic was being recovered and converted into an error [here](https://github.com/grafana/grafana/blob/069598c454d9f0874072342ed06830abfb231c9c/pkg/tsdb/cloudwatch/time_series_query.go#L77-L88). This panic prevented the extra calls to `GetMetricData` a few lines later that the test was meant to protect against.

The aws-sdk-go-v2 migration obviated the panicking mock, which made the test (correctly) fail, so I skipped it until I could come back and either fix or remove the test.