### PR TITLE
CloudWatch: Improve smithy error handling

### DIFF
--- a/pkg/tsdb/cloudwatch/services/accounts.go
+++ b/pkg/tsdb/cloudwatch/services/accounts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	oam "github.com/aws/aws-sdk-go-v2/service/oam"
 	oamtypes "github.com/aws/aws-sdk-go-v2/service/oam/types"
 	"github.com/aws/smithy-go"

--- a/pkg/tsdb/cloudwatch/services/accounts.go
+++ b/pkg/tsdb/cloudwatch/services/accounts.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
-
 	oam "github.com/aws/aws-sdk-go-v2/service/oam"
 	oamtypes "github.com/aws/aws-sdk-go-v2/service/oam/types"
+	"github.com/aws/smithy-go"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"
 )
@@ -28,9 +27,9 @@ func (a *AccountsService) GetAccountsForCurrentUserOrRole(ctx context.Context) (
 	for {
 		response, err := a.ListSinks(ctx, &oam.ListSinksInput{NextToken: nextToken})
 		if err != nil {
-			// TODO: this is a bit hacky, figure out how to do it right in v2
-			if strings.Contains(err.Error(), "AccessDeniedException") {
-				return nil, fmt.Errorf("%w: %s", ErrAccessDeniedException, err.Error())
+			smithyErr := &smithy.GenericAPIError{}
+			if errors.As(err, &smithyErr) && smithyErr.Code == "AccessDeniedException" {
+				return nil, fmt.Errorf("%w: %s", ErrAccessDeniedException, smithyErr.Message)
 			}
 			return nil, fmt.Errorf("ListSinks error: %w", err)
 		}

--- a/pkg/tsdb/cloudwatch/services/accounts_test.go
+++ b/pkg/tsdb/cloudwatch/services/accounts_test.go
@@ -3,12 +3,12 @@ package services
 import (
 	"context"
 	"fmt"
-	"github.com/aws/smithy-go"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 	oamtypes "github.com/aws/aws-sdk-go-v2/service/oam/types"
+	"github.com/aws/smithy-go"
 
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/models/resources"

--- a/pkg/tsdb/cloudwatch/services/accounts_test.go
+++ b/pkg/tsdb/cloudwatch/services/accounts_test.go
@@ -2,8 +2,8 @@ package services
 
 import (
 	"context"
-	"errors"
 	"fmt"
+	"github.com/aws/smithy-go"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -20,14 +20,14 @@ import (
 func TestHandleGetAccounts(t *testing.T) {
 	t.Run("Should return an error in case of insufficient permissions from ListSinks", func(t *testing.T) {
 		fakeOAMClient := &mocks.FakeOAMClient{}
-		fakeOAMClient.On("ListSinks", mock.Anything).Return(&oam.ListSinksOutput{}, errors.New("AccessDeniedException"))
+		fakeOAMClient.On("ListSinks", mock.Anything).Return(&oam.ListSinksOutput{}, fmt.Errorf("%w", &smithy.GenericAPIError{Code: "AccessDeniedException", Message: "this is bad"}))
 		accounts := NewAccountsService(fakeOAMClient)
 
 		resp, err := accounts.GetAccountsForCurrentUserOrRole(context.Background())
 
 		assert.Error(t, err)
 		assert.Nil(t, resp)
-		assert.Equal(t, "access denied. please check your IAM policy: AccessDeniedException", err.Error())
+		assert.Equal(t, "access denied. please check your IAM policy: this is bad", err.Error())
 		assert.ErrorIs(t, err, ErrAccessDeniedException)
 	})
 


### PR DESCRIPTION
**What is this feature?**
Cleaning up the backlog - this takes care of a TODO to handle access denied errors in a slightly nicer way.
