### PR TITLE
`grafana-iam`: Update `iam` app to work with v.40 of grafana-app-sdk

### DIFF
--- a/apps/iam/kinds/manifest.cue
+++ b/apps/iam/kinds/manifest.cue
@@ -3,6 +3,7 @@ package kinds
 manifest: {
 	appName:       "iam"
 	groupOverride: "iam.grafana.app"
+	preferredVersion: "v0alpha1"
 	kinds: [
 		globalrole, 
 		globalrolebinding,

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -15,6 +15,8 @@ import (
 	v0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
 
+var ()
+
 var appManifestData = app.ManifestData{
 	AppName: "iam",
 	Group:   "iam.grafana.app",


### PR DESCRIPTION
**What is this feature?**
Updates the manifest to include the preferredVersion which is needed in v.40 of `grafana-app-sdk`. this way we can safely run `grafana-app-sdk project component add operator` this will be a follow up PR from this.


**Why do we need this feature?**
We were getting the following error when running the sdk
```bash
eleijonmarck@Mac iam % grafana-app-sdk project component add operator
Error: error parsing manifest 'kinds': manifest.preferredVersion: cannot convert non-concrete value string
eleijonmarck@Mac iam %

**Which issue(s) does this PR fix?**:
https://github.com/grafana/identity-access-team/issues/1564