### PR TITLE
Fix: plugin loader cache not matching on decoupled plugin paths

### DIFF
--- a/devenv/local_cdn/default.conf
+++ b/devenv/local_cdn/default.conf
@@ -19,6 +19,6 @@ server {
 		add_header 'Access-Control-Allow-Headers' '*' always;
 		add_header 'Access-Control-Allow-Credentials' 'true' always;
 
-		rewrite ^/grafana-oss/11.4.0-pre/public(.*)$ $1 last;
+		rewrite ^/grafana/12.1.0-pre/public(.*)$ $1 last;
 	}
 }

--- a/devenv/local_cdn/default.conf
+++ b/devenv/local_cdn/default.conf
@@ -19,6 +19,6 @@ server {
 		add_header 'Access-Control-Allow-Headers' '*' always;
 		add_header 'Access-Control-Allow-Credentials' 'true' always;
 
-		rewrite ^/grafana/12.1.0-pre/public(.*)$ $1 last;
+		rewrite ^/grafana-oss/12.1.0-pre/public(.*)$ $1 last;
 	}
 }

--- a/public/app/features/plugins/loader/cache.ts
+++ b/public/app/features/plugins/loader/cache.ts
@@ -52,9 +52,15 @@ export function getPluginFromCache(path: string): CachedPlugin | undefined {
 }
 
 export function extractCacheKeyFromPath(path: string) {
-  const regex = /\/?public\/plugins\/([^\/]+)\//;
+  // match against both plugin and decoupled core datasource paths
+  const regex = /\/?public\/(?:plugins\/([^\/]+)|app\/plugins\/datasource\/([^\/]+))\//;
   const match = path.match(regex);
-  return match ? match[1] : null;
+
+  if (match) {
+    return match[1] || match[2];
+  }
+
+  return null;
 }
 
 function getCacheKey(address: string): string | undefined {

--- a/public/app/features/plugins/loader/cache.ts
+++ b/public/app/features/plugins/loader/cache.ts
@@ -52,12 +52,19 @@ export function getPluginFromCache(path: string): CachedPlugin | undefined {
 }
 
 export function extractCacheKeyFromPath(path: string) {
-  // match against both plugin and decoupled core datasource paths
-  const regex = /\/?public\/(?:plugins\/([^\/]+)|app\/plugins\/datasource\/([^\/]+))\//;
+  const regex = /\/?public\/plugins\/([^\/]+)\//;
   const match = path.match(regex);
 
   if (match) {
-    return match[1] || match[2];
+    return match[1];
+  }
+
+  // Decoupled core plugins can be loaded by alternative paths
+  const decoupledPluginRegex = /\/?public\/app\/plugins\/(?:datasource|panel)\/([^\/]+)\//;
+  const decoupledPluginMatch = path.match(decoupledPluginRegex);
+
+  if (decoupledPluginMatch) {
+    return decoupledPluginMatch[1];
   }
 
   return null;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an issue due to Decoupled core plugins now loading from different asset paths to regular plugins which prevented the loader cache (which stores information related to which version to append to the cache buster query param and loadingStrategy) from having any effect.

<img width="1679" height="231" alt="Screenshot 2025-07-23 at 16 24 11" src="https://github.com/user-attachments/assets/852b8a39-6fea-4ac2-a7e0-70ea3edffdf2" />


**Why do we need this feature?**

So decoupled plugins continue to load using the version as a cache buster and the correct loading strategy

<img width="1679" height="225" alt="Screenshot 2025-07-23 at 16 22 13" src="https://github.com/user-attachments/assets/36d904dd-3ff4-4df4-ac6d-0639052a5bb0" />


**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #107132

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
