### PR TITLE
New Logs Panel: always show horizontal scroll when unwrapped

### DIFF
--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -475,7 +475,7 @@ const LogListComponent = ({
               outerRef={scrollRef}
               overscanCount={5}
               ref={listRef}
-              style={{ overflowY: 'scroll' }}
+              style={wrapLogMessage ? { overflowY: 'scroll' } : { overflow: 'scroll' }}
               width="100%"
             >
               {Renderer}


### PR DESCRIPTION
The new logs panel is virtualized so, when the wrapping mode is "unwrapped", the horizontal scroll depends on the currently displayed content, as longer lines before or after are not rendered. These changes keep the horizontal scroll when unwrapped mode is used, so the scroll doesn't appear and reappear as the user scrolls.

This is the simplest way to improve this without introducing unnecessary complexity to an already complex panel.

Before.

https://github.com/user-attachments/assets/ec32c44b-003d-471c-9d4e-89d428ec87b3

After.

https://github.com/user-attachments/assets/ea6a8e48-2154-4ee6-b316-f52dbc103b75

Part of https://github.com/grafana/grafana/issues/99075