### PR TITLE
Alerting: Fix active time intervals when time interval is renamed

### DIFF
--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -440,6 +440,12 @@ func replaceMuteTiming(route *definitions.Route, oldName, newName string) int {
 			updated++
 		}
 	}
+	for idx := range route.ActiveTimeIntervals {
+		if route.ActiveTimeIntervals[idx] == oldName {
+			route.ActiveTimeIntervals[idx] = newName
+			updated++
+		}
+	}
 	for _, route := range route.Routes {
 		updated += replaceMuteTiming(route, oldName, newName)
 	}

--- a/pkg/tests/apis/alerting/notifications/timeinterval/test-data/notification-settings.json
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/test-data/notification-settings.json
@@ -15,6 +15,9 @@
           ],
           "mute_time_intervals": [
             "test-interval", "persisted-interval"
+          ],
+          "active_time_intervals": [
+            "test-interval", "persisted-interval"
           ]
         }
       ]

--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -725,7 +725,9 @@ func TestIntegrationTimeIntervalReferentialIntegrity(t *testing.T) {
 			updatedRoute := legacyCli.GetRoute(t)
 			for idx, route := range updatedRoute.Routes {
 				expectedTimeIntervals := replace(currentRoute.Routes[idx].MuteTimeIntervals, interval.Spec.Name, actual.Spec.Name)
-				assert.Equalf(t, expectedTimeIntervals, route.MuteTimeIntervals, "time interval in routes should have been renamed but it did not")
+				assert.Equalf(t, expectedTimeIntervals, route.MuteTimeIntervals, "mute time interval in routes should have been renamed but it did not")
+				expectedTimeIntervals = replace(currentRoute.Routes[idx].ActiveTimeIntervals, interval.Spec.Name, actual.Spec.Name)
+				assert.Equalf(t, expectedTimeIntervals, route.ActiveTimeIntervals, "active time interval in routes should have been renamed but it did not")
 			}
 
 			interval = *actual


### PR DESCRIPTION
**What is this feature?**
Fixes a bug that causes alertmanager configuration to break when a time interval that is referred in active timings gets renamed. 
