### PR TITLE
Mihai/refactor iam app cue files

### DIFF
--- a/apps/iam/Makefile
+++ b/apps/iam/Makefile
@@ -9,4 +9,3 @@ generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generation
 		--defencoding=none \
 		--noschemasinmanifest \
 		--postprocess \
-		--useoldmanifestkinds

--- a/apps/iam/kinds/manifest.cue
+++ b/apps/iam/kinds/manifest.cue
@@ -1,18 +1,78 @@
 package kinds
 
 manifest: {
-	appName:       "iam"
+	// appName is the unique name of your app. It is used to reference the app from other config objects,
+	// and to generate the group used by your app in the app platform API.
+	appName: 	   "iam"
+	// groupOverride can be used to specify a non-appName-based API group.
+	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.com,
+	// but there are cases where this needs to be changed.
+	// Keep in mind that changing this after an app is deployed can cause problems with clients and/or kind data.
 	groupOverride: "iam.grafana.app"
-	kinds: [
-		globalrole, 
-		globalrolebinding,
-		corerole,
-		role,
-		rolebinding,
-		resourcepermission,
-		user,
-		team,
-		teambinding,
-		serviceaccount,
+
+	// versions is a map of versions supported by your app. Version names should follow the format "v<integer>" or
+	// "v<integer>(alpha|beta)<integer>". Each version contains the kinds your app manages for that version.
+	// If your app needs access to kinds managed by another app, use permissions.accessKinds to allow your app access.
+	versions: {
+	    "v0alpha1": v0alpha1
+	}
+	// extraPermissions contains any additional permissions your app may require to function.
+	// Your app will always have all permissions for each kind it manages (the items defined in 'kinds').
+	extraPermissions: {
+		// If your app needs access to additional kinds supplied by other apps, you can list them here
+		accessKinds: [
+			// Here is an example for your app accessing the playlist kind for reads and watch
+			// {
+			//	group: "playlist.grafana.app"
+			//	resource: "playlists"
+			//	actions: ["get","list","watch"]
+			// }
+		]
+	}
+}
+
+// v1alpha1 is the v1alpha1 version of the app's API.
+// It includes kinds which the v1alpha1 API serves, and (future) custom routes served globally from the v1alpha1 version.
+v0alpha1: {
+    // kinds is the list of kinds served by this version
+    kinds: [
+		// globalrole, 
+		// globalrolebinding,
+		// corerole,
+		// role,
+		// rolebinding,
+		resourcepermissionv0alpha1,
+		// user,
+		// team,
+		// teambinding,
+		// serviceaccount,
 	]
+    // [OPTIONAL]
+    // served indicates whether this particular version is served by the API server.
+    // served should be set to false before a version is removed from the manifest entirely.
+    // served defaults to true if not present.
+    served: true
+    // [OPTIONAL]
+    // Codegen is a trait that tells the grafana-app-sdk, or other code generation tooling, how to process this kind.
+    // If not present, default values within the codegen trait are used.
+    // If you wish to specify codegen per-version, put this section in the version's object
+    // (for example, <no value>v1alpha1) instead.
+    codegen: {
+        // [OPTIONAL]
+        // ts contains TypeScript code generation properties for the kind
+        ts: {
+            // [OPTIONAL]
+            // enabled indicates whether the CLI should generate front-end TypeScript code for the kind.
+            // Defaults to true if not present.
+            enabled: false
+        }
+        // [OPTIONAL]
+        // go contains go code generation properties for the kind
+        go: {
+            // [OPTIONAL]
+            // enabled indicates whether the CLI should generate back-end go code for the kind.
+            // Defaults to true if not present.
+            enabled: true
+        }
+    }
 }

--- a/apps/iam/kinds/manifest.cue
+++ b/apps/iam/kinds/manifest.cue
@@ -36,16 +36,16 @@ manifest: {
 v0alpha1: {
     // kinds is the list of kinds served by this version
     kinds: [
-		// globalrole, 
-		// globalrolebinding,
-		// corerole,
-		// role,
-		// rolebinding,
+		globalrolev0alpha1, 
+		globalrolebindingv0alpha1,
+		corerolev0alpha1,
+		rolev0alpha1,
+		rolebindingv0alpha1,
 		resourcepermissionv0alpha1,
-		// user,
-		// team,
-		// teambinding,
-		// serviceaccount,
+		userv0alpha1,
+		teamv0alpha1,
+		teambindingv0alpha1,
+		serviceaccountv0alpha1,
 	]
     // [OPTIONAL]
     // served indicates whether this particular version is served by the API server.

--- a/apps/iam/kinds/manifest.cue
+++ b/apps/iam/kinds/manifest.cue
@@ -1,40 +1,14 @@
 package kinds
 
 manifest: {
-	// appName is the unique name of your app. It is used to reference the app from other config objects,
-	// and to generate the group used by your app in the app platform API.
 	appName: 	   "iam"
-	// groupOverride can be used to specify a non-appName-based API group.
-	// By default, an app's API group is LOWER(REPLACE(appName, '-', '')).ext.grafana.com,
-	// but there are cases where this needs to be changed.
-	// Keep in mind that changing this after an app is deployed can cause problems with clients and/or kind data.
 	groupOverride: "iam.grafana.app"
-
-	// versions is a map of versions supported by your app. Version names should follow the format "v<integer>" or
-	// "v<integer>(alpha|beta)<integer>". Each version contains the kinds your app manages for that version.
-	// If your app needs access to kinds managed by another app, use permissions.accessKinds to allow your app access.
 	versions: {
 	    "v0alpha1": v0alpha1
 	}
-	// extraPermissions contains any additional permissions your app may require to function.
-	// Your app will always have all permissions for each kind it manages (the items defined in 'kinds').
-	extraPermissions: {
-		// If your app needs access to additional kinds supplied by other apps, you can list them here
-		accessKinds: [
-			// Here is an example for your app accessing the playlist kind for reads and watch
-			// {
-			//	group: "playlist.grafana.app"
-			//	resource: "playlists"
-			//	actions: ["get","list","watch"]
-			// }
-		]
-	}
 }
 
-// v1alpha1 is the v1alpha1 version of the app's API.
-// It includes kinds which the v1alpha1 API serves, and (future) custom routes served globally from the v1alpha1 version.
 v0alpha1: {
-    // kinds is the list of kinds served by this version
     kinds: [
 		globalrolev0alpha1, 
 		globalrolebindingv0alpha1,
@@ -47,32 +21,4 @@ v0alpha1: {
 		teambindingv0alpha1,
 		serviceaccountv0alpha1,
 	]
-    // [OPTIONAL]
-    // served indicates whether this particular version is served by the API server.
-    // served should be set to false before a version is removed from the manifest entirely.
-    // served defaults to true if not present.
-    served: true
-    // [OPTIONAL]
-    // Codegen is a trait that tells the grafana-app-sdk, or other code generation tooling, how to process this kind.
-    // If not present, default values within the codegen trait are used.
-    // If you wish to specify codegen per-version, put this section in the version's object
-    // (for example, <no value>v1alpha1) instead.
-    codegen: {
-        // [OPTIONAL]
-        // ts contains TypeScript code generation properties for the kind
-        ts: {
-            // [OPTIONAL]
-            // enabled indicates whether the CLI should generate front-end TypeScript code for the kind.
-            // Defaults to true if not present.
-            enabled: false
-        }
-        // [OPTIONAL]
-        // go contains go code generation properties for the kind
-        go: {
-            // [OPTIONAL]
-            // enabled indicates whether the CLI should generate back-end go code for the kind.
-            // Defaults to true if not present.
-            enabled: true
-        }
-    }
 }

--- a/apps/iam/kinds/resourcepermission.cue
+++ b/apps/iam/kinds/resourcepermission.cue
@@ -4,20 +4,17 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-resourcepermission: {
+resourcepermissionKind: {
 	kind:       "ResourcePermission"
 	pluralName: "ResourcePermissions"
-	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.ResourcePermission
-			}
-		}
+resourcepermissionv0alpha1: resourcepermissionKind & {
+	schema: {
+		spec:   v0alpha1.ResourcePermission
 	}
 }

--- a/apps/iam/kinds/role.cue
+++ b/apps/iam/kinds/role.cue
@@ -4,56 +4,47 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-role: {
+roleKind: {
 	kind:       "Role"
 	pluralName: "Roles"
-	current:    "v0alpha1"
-
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.RoleSpec
-			}
-		}
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
 	}
 }
 
-corerole: {
+coreroleKind: {
 	kind:       "CoreRole"
 	pluralName: "CoreRoles"
-	current:    "v0alpha1"
-
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.RoleSpec
-			}
-		}
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
 	}
 }
 
-globalrole: {
+globalroleKind: {
 	kind:       "GlobalRole"
 	pluralName: "GlobalRoles"
-	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.RoleSpec
-			}
-		}
+rolev0alpha1: roleKind & {
+	schema: {
+		spec:   v0alpha1.RoleSpec
+	}
+}
+
+corerolev0alpha1: coreroleKind & {
+	schema: {
+		spec:   v0alpha1.RoleSpec
+	}
+}
+
+globalrolev0alpha1: globalroleKind & {
+	schema: {
+		spec:   v0alpha1.RoleSpec
 	}
 }

--- a/apps/iam/kinds/rolebinding.cue
+++ b/apps/iam/kinds/rolebinding.cue
@@ -4,38 +4,32 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-rolebinding: {
+rolebindingKind: {
 	kind:       "RoleBinding"
 	pluralName: "RoleBindings"
-	current:    "v0alpha1"
-
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.RoleBindingSpec
-			}
-		}
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
 	}
 }
 
-globalrolebinding: {
+globalrolebindingKind: {
 	kind:       "GlobalRoleBinding"
 	pluralName: "GlobalRoleBindings"
-	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec:   v0alpha1.GlobalRoleBindingSpec
-			}
-		}
+rolebindingv0alpha1: rolebindingKind & {
+	schema: {
+		spec:   v0alpha1.RoleBindingSpec
+	}
+}
+
+globalrolebindingv0alpha1: globalrolebindingKind & {
+	schema: {
+		spec:   v0alpha1.GlobalRoleBindingSpec
 	}
 }

--- a/apps/iam/kinds/serviceaccount.cue
+++ b/apps/iam/kinds/serviceaccount.cue
@@ -4,20 +4,17 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-serviceaccount: {
+serviceaccountKind: {
 	kind:       "ServiceAccount"
 	pluralName: "ServiceAccounts"
-	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec: v0alpha1.ServiceAccountSpec
-			}
-		}
+serviceaccountv0alpha1: serviceaccountKind & {
+	schema: {
+		spec: v0alpha1.ServiceAccountSpec
 	}
 }

--- a/apps/iam/kinds/team.cue
+++ b/apps/iam/kinds/team.cue
@@ -4,20 +4,18 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-team: {
+teamKind: {
 	kind:       "Team"
 	pluralName: "Teams"
 	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec: v0alpha1.TeamSpec
-			}
-		}
+teamv0alpha1: teamKind & {
+	schema: {
+		spec: v0alpha1.TeamSpec
 	}
 }

--- a/apps/iam/kinds/teambinding.cue
+++ b/apps/iam/kinds/teambinding.cue
@@ -4,20 +4,17 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-teambinding: {
+teambindingKind: {
 	kind:       "TeamBinding"
 	pluralName: "TeamBindings"
-	current:    "v0alpha1"
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+}
 
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			schema: {
-				spec: v0alpha1.TeamBindingSpec
-			}
-		}
+teambindingv0alpha1: teambindingKind & {
+	schema: {
+		spec: v0alpha1.TeamBindingSpec
 	}
 }

--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -4,26 +4,23 @@ import (
 	"github.com/grafana/grafana/apps/iam/kinds/v0alpha1"
 )
 
-user: {
+userKind: {
 	kind:       "User"
 	pluralName: "Users"
-	current:    "v0alpha1"
-    
-	versions: {
-		"v0alpha1": {
-			codegen: {
-				ts: { enabled: false }
-				go: { enabled: true }
-			}
-			validation: {
-				operations: [
-					"CREATE",
-					"UPDATE",
-				]
-			}
-			schema: {
-				spec: v0alpha1.UserSpec
-			}
-		}
+	codegen: {
+		ts: { enabled: false }
+		go: { enabled: true }
+	}
+	validation: {
+		operations: [
+			"CREATE",
+			"UPDATE",
+		]
+	}
+}
+
+userv0alpha1: userKind & {
+	schema: {
+		spec: v0alpha1.UserSpec
 	}
 }

--- a/apps/iam/kinds/user.cue
+++ b/apps/iam/kinds/user.cue
@@ -11,12 +11,6 @@ userKind: {
 		ts: { enabled: false }
 		go: { enabled: true }
 	}
-	validation: {
-		operations: [
-			"CREATE",
-			"UPDATE",
-		]
-	}
 }
 
 userv0alpha1: userKind & {

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -70,14 +70,6 @@ var appManifestData = app.ManifestData{
 					Plural:     "Users",
 					Scope:      "Namespaced",
 					Conversion: false,
-					Admission: &app.AdmissionCapabilities{
-						Validation: &app.ValidationCapability{
-							Operations: []app.AdmissionOperation{
-								app.AdmissionOperationCreate,
-								app.AdmissionOperationUpdate,
-							},
-						},
-					},
 				},
 
 				{

--- a/apps/iam/pkg/apis/iam_manifest.go
+++ b/apps/iam/pkg/apis/iam_manifest.go
@@ -70,6 +70,14 @@ var appManifestData = app.ManifestData{
 					Plural:     "Users",
 					Scope:      "Namespaced",
 					Conversion: false,
+					Admission: &app.AdmissionCapabilities{
+						Validation: &app.ValidationCapability{
+							Operations: []app.AdmissionOperation{
+								app.AdmissionOperationCreate,
+								app.AdmissionOperationUpdate,
+							},
+						},
+					},
 				},
 
 				{


### PR DESCRIPTION
**What is this feature?**

A breaking change was introduced in [this](https://github.com/grafana/grafana-app-sdk/pull/795) grafana-app-sdk PR.

This PR refactors the definition of our CUE files (manifest and kinds) to match the new model in the latest version of grafana-app-sdk

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
