### PR TITLE
Alerting: Remote Alertmanager to compare current hash with hash from response

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -727,7 +727,7 @@ func Test_isDefaultConfiguration(t *testing.T) {
 			}
 			raw, err := json.Marshal(test.config)
 			require.NoError(tt, err)
-			require.Equal(tt, test.expected, am.isDefaultConfiguration(md5.Sum(raw)))
+			require.Equal(tt, test.expected, am.isDefaultConfiguration(fmt.Sprintf("%x", md5.Sum(raw))))
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**
This PR updates remote Alertmanager service to compare the hash provided in the response rather than re-calculating it again. 

**Why do we need this feature?**
This saves resources on needless marshalling and hash calculation. The hash in the response is controlled by that service and just stored as is on the mimir side. Therefore, there is no reasons to not trust it. 
Also, in the future it will allow us to migrate to a new API introduced in https://github.com/grafana/mimir/pull/12129
