### PR TITLE
IAM: Instantiate DualWriter only when in single-tenant mode

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -28,6 +28,9 @@ import (
 	_ "github.com/russellhaering/goxmldsig"
 	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
 	_ "github.com/stretchr/testify/require"
+	_ "gocloud.dev/secrets/awskms"
+	_ "gocloud.dev/secrets/azurekeyvault"
+	_ "gocloud.dev/secrets/gcpkms"
 	_ "gocloud.dev/secrets/hashivault"
 	_ "golang.org/x/time/rate"
 	_ "k8s.io/api"

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -28,9 +28,6 @@ import (
 	_ "github.com/russellhaering/goxmldsig"
 	_ "github.com/spf13/cobra" // used by the standalone apiserver cli
 	_ "github.com/stretchr/testify/require"
-	_ "gocloud.dev/secrets/awskms"
-	_ "gocloud.dev/secrets/azurekeyvault"
-	_ "gocloud.dev/secrets/gcpkms"
 	_ "gocloud.dev/secrets/hashivault"
 	_ "golang.org/x/time/rate"
 	_ "k8s.io/api"

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -43,4 +43,7 @@ type IdentityAccessManagementAPIBuilder struct {
 
 	// Toggle for enabling authz management apis
 	enableAuthZApis bool
+
+	// Toggle for enabling dual writer
+	enableDualWriter bool
 }

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -130,7 +130,6 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	legacyStore := user.NewLegacyStore(b.store, b.legacyAccessClient)
 	storage[userResource.StoragePath()] = legacyStore
 
-	// We only need dual writer in single-tenant mode
 	if b.enableDualWriter {
 		store, err := grafanaregistry.NewRegistryStore(opts.Scheme, userResource, opts.OptsGetter)
 		if err != nil {
@@ -145,9 +144,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 		storage[userResource.StoragePath()] = dw
 	}
 
-	// TODO: figure out when teams is ready for dual writer
 	storage[userResource.StoragePath("teams")] = user.NewLegacyTeamMemberREST(b.store)
-
 	serviceAccountResource := legacyiamv0.ServiceAccountResourceInfo
 	storage[serviceAccountResource.StoragePath()] = serviceaccount.NewLegacyStore(b.store, b.legacyAccessClient)
 	storage[serviceAccountResource.StoragePath("tokens")] = serviceaccount.NewLegacyTokenREST(b.store)


### PR DESCRIPTION
**What is this feature?**

This PR changes the IAM registration so that the DualWriter is only instantiated in ST mode.  It solves the issue https://github.com/grafana/grafana/pull/108241 was created to temporarily avoid.

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/grafana/pull/108241.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
