### PR TITLE
Plugins: Add grafana-iot-twinmaker-datasource to forward_settings_to_plugins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -992,7 +992,7 @@ session_duration = "15m"
 
 # Set the plugins that will receive AWS settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned AWS plugins, or those that make use of AWS settings (ElasticSearch, Prometheus).
-forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-app, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
+forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-app, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
 
 #################################### Azure ###############################
 [azure]

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -992,7 +992,7 @@ session_duration = "15m"
 
 # Set the plugins that will receive AWS settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned AWS plugins, or those that make use of AWS settings (ElasticSearch, Prometheus).
-forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-app, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
+forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
 
 #################################### Azure ###############################
 [azure]


### PR DESCRIPTION
**What is this feature?**

Fixes issue where we get `attempting to use an auth type that is not allowed: \"ec2_iam_role\".` due to grafana-iot-twinmaker-datasource not getting forwarded AWS settings. It's not clear to me whether we still need to keep `grafana-iot-twinmaker-app`.

**Which issue(s) does this PR fix?**:

Fixes #108559 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
