### PR TITLE
Fix: Prevent Rollup from treeshaking NPM packages

### DIFF
--- a/packages/grafana-alerting/rollup.config.ts
+++ b/packages/grafana-alerting/rollup.config.ts
@@ -10,10 +10,12 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-alerting')],
+    treeshake: false,
   },
   {
     input: 'src/unstable.ts',
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-alerting')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-data/rollup.config.ts
+++ b/packages/grafana-data/rollup.config.ts
@@ -10,10 +10,12 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-data')],
+    treeshake: false,
   },
   {
     input: 'src/unstable.ts',
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-data')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-e2e-selectors/rollup.config.ts
+++ b/packages/grafana-e2e-selectors/rollup.config.ts
@@ -10,5 +10,6 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-e2e-selectors')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-flamegraph/rollup.config.ts
+++ b/packages/grafana-flamegraph/rollup.config.ts
@@ -10,5 +10,6 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-flamegraph')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-i18n/rollup.config.ts
+++ b/packages/grafana-i18n/rollup.config.ts
@@ -16,5 +16,6 @@ export default [
       }),
     ],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-i18n')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-prometheus/rollup.config.ts
+++ b/packages/grafana-prometheus/rollup.config.ts
@@ -13,5 +13,6 @@ export default [
     input: entryPoint,
     plugins: [...plugins, image(), json(), dynamicImportVars()],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-prometheus')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-runtime/rollup.config.ts
+++ b/packages/grafana-runtime/rollup.config.ts
@@ -10,10 +10,12 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-runtime')],
+    treeshake: false,
   },
   {
     input: 'src/unstable.ts',
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-runtime')],
+    treeshake: false,
   },
 ];

--- a/packages/grafana-schema/rollup.config.ts
+++ b/packages/grafana-schema/rollup.config.ts
@@ -16,6 +16,7 @@ export default [
     input: entryPoint,
     plugins,
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-schema')],
+    treeshake: false,
   },
   {
     input: Object.fromEntries(
@@ -45,5 +46,6 @@ export default [
       format: 'esm',
       dir: path.dirname(pkg.publishConfig.module),
     },
+    treeshake: false,
   },
 ];

--- a/packages/grafana-ui/rollup.config.ts
+++ b/packages/grafana-ui/rollup.config.ts
@@ -25,6 +25,7 @@ export default [
       }),
     ],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-ui')],
+    treeshake: false,
   },
   {
     input: 'src/unstable.ts',
@@ -37,5 +38,6 @@ export default [
       }),
     ],
     output: [cjsOutput(pkg), esmOutput(pkg, 'grafana-ui')],
+    treeshake: false,
   },
 ];


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an issue where (during bundling the NPM packages in this repo) rollup is treeshaking any properties that aren't used in the libraries source code. 

**Why do we need this feature?**

Treeshaking the library at build seems rather prone to error as we want the consumer to treeshake it at application build time. ([Internal slack thread](https://raintank-corp.slack.com/archives/CHKLEJ668/p1753315605545179))

**before**
<img width="2520" height="1656" alt="image" src="https://github.com/user-attachments/assets/650113f0-83bd-4b7c-b130-a8a5b3f3ab62" />


**after**
<img width="2524" height="1892" alt="image" src="https://github.com/user-attachments/assets/989f3dba-c59c-422c-8d10-985648d72482" />



**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
