### PR TITLE
Chore: Bump semver version for pa11y

### DIFF
--- a/package.json
+++ b/package.json
@@ -433,8 +433,7 @@
   "resolutions": {
     "underscore": "1.13.7",
     "@types/slate": "0.47.11",
-    "semver@~7.0.0": "7.5.4",
-    "semver@7.3.4": "7.5.4",
+    "semver@npm:~7.3.5": "^7.3.5",
     "debug@npm:^0.7.2": "2.6.9",
     "debug@npm:^0.7.4": "2.6.9",
     "slate-dev-environment@^0.2.2": "patch:slate-dev-environment@npm:0.2.5#.yarn/patches/slate-dev-environment-npm-0.2.5-9aeb7da7b5.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28093,17 +28093,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:~7.3.5":
-  version: 7.3.8
-  resolution: "semver@npm:7.3.8"
-  dependencies:
-    lru-cache: "npm:^6.0.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/c8c04a4d41d30cffa7277904e0ad6998623dd61e36bca9578b0128d8c683b705a3924beada55eae7fa004fb30a9359a53a4ead2b68468d778b602f3b1a28f8e3
-  languageName: node
-  linkType: hard
-
 "send@npm:0.19.0":
   version: 0.19.0
   resolution: "send@npm:0.19.0"


### PR DESCRIPTION
Forces resolution of semver in pa11y to mitigate warnings for https://avd.aquasec.com/nvd/2022/cve-2022-25883/

Not exploitable for Grafana because this version is only included in pa11y which is a CI test runner, doesn't run with user input, and is not included in runtime code.