### PR TITLE
Provisioning: commit only once staged changes

### DIFF
--- a/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -103,6 +103,9 @@ type SyncJobOptions struct {
 }
 
 type ExportJobOptions struct {
+	// Message to use when committing the changes in a single commit
+	Message string `json:"message,omitempty"`
+
 	// The source folder (or empty) to export
 	Folder string `json:"folder,omitempty"`
 
@@ -116,6 +119,9 @@ type ExportJobOptions struct {
 type MigrateJobOptions struct {
 	// Preserve history (if possible)
 	History bool `json:"history,omitempty"`
+
+	// Message to use when committing the changes in a single commit
+	Message string `json:"message,omitempty"`
 }
 
 // The job status

--- a/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -193,6 +193,13 @@ func schema_pkg_apis_provisioning_v0alpha1_ExportJobOptions(ref common.Reference
 			SchemaProps: spec.SchemaProps{
 				Type: []string{"object"},
 				Properties: map[string]spec.Schema{
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Message to use when committing the changes in a single commit",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"folder": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The source folder (or empty) to export",
@@ -1027,6 +1034,13 @@ func schema_pkg_apis_provisioning_v0alpha1_MigrateJobOptions(ref common.Referenc
 						SchemaProps: spec.SchemaProps{
 							Description: "Preserve history (if possible)",
 							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"message": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Message to use when committing the changes in a single commit",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -56,9 +56,16 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 		return err
 	}
 
+	msg := options.Message
+	if msg == "" {
+		msg = fmt.Sprintf("Export from Grafana %s", job.Name)
+	}
+
 	cloneOptions := repository.StageOptions{
-		Timeout:      10 * time.Minute,
-		PushOnWrites: false,
+		CommitOnlyOnce:        true,
+		CommitOnlyOnceMessage: msg,
+		Timeout:               10 * time.Minute,
+		PushOnWrites:          false,
 	}
 
 	fn := func(repo repository.Repository, _ bool) error {

--- a/pkg/registry/apis/provisioning/jobs/export/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker.go
@@ -62,10 +62,9 @@ func (r *ExportWorker) Process(ctx context.Context, repo repository.Repository, 
 	}
 
 	cloneOptions := repository.StageOptions{
-		CommitOnlyOnce:        true,
+		Mode:                  repository.StageModeCommitOnlyOnce,
 		CommitOnlyOnceMessage: msg,
 		Timeout:               10 * time.Minute,
-		PushOnWrites:          false,
 	}
 
 	fn := func(repo repository.Repository, _ bool) error {

--- a/pkg/registry/apis/provisioning/jobs/export/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/export/worker_test.go
@@ -260,7 +260,7 @@ func TestExportWorker_ProcessStageOptions(t *testing.T) {
 	mockStageFn := NewMockWrapWithStageFn(t)
 	// Verify clone and push options
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.MatchedBy(func(opts repository.StageOptions) bool {
-		return opts.Timeout == 10*time.Minute && !opts.PushOnWrites
+		return opts.Timeout == 10*time.Minute && opts.Mode == repository.StageModeCommitOnlyOnce
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})
@@ -406,7 +406,7 @@ func TestExportWorker_ProcessGitRepository(t *testing.T) {
 	mockStageFn := NewMockWrapWithStageFn(t)
 	// Verify clone and push options
 	mockStageFn.On("Execute", mock.Anything, mockRepo, mock.MatchedBy(func(opts repository.StageOptions) bool {
-		return opts.Timeout == 10*time.Minute && !opts.PushOnWrites
+		return opts.Timeout == 10*time.Minute && opts.Mode == repository.StageModeCommitOnlyOnce
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOpts repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(repo, true)
 	})

--- a/pkg/registry/apis/provisioning/jobs/migrate/legacy.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/legacy.go
@@ -35,10 +35,18 @@ func NewLegacyMigrator(
 
 func (m *LegacyMigrator) Migrate(ctx context.Context, rw repository.ReaderWriter, options provisioning.MigrateJobOptions, progress jobs.JobProgressRecorder) error {
 	namespace := rw.Config().Namespace
+	var stageMode repository.StageMode
+	if options.History {
+		// When History is true, we want to commit and push each file (previous PushOnWrites: true)
+		stageMode = repository.StageModeCommitAndPushOnEach
+	} else {
+		// When History is false, we want to commit only once (previous CommitOnlyOnce: true)
+		stageMode = repository.StageModeCommitOnlyOnce
+	}
+
 	stageOptions := repository.StageOptions{
-		CommitOnlyOnce:        !options.History,
+		Mode:                  stageMode,
 		CommitOnlyOnceMessage: options.Message,
-		PushOnWrites:          options.History,
 		// TODO: make this configurable
 		Timeout: 10 * time.Minute,
 	}

--- a/pkg/registry/apis/provisioning/jobs/migrate/legacy.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/legacy.go
@@ -36,7 +36,9 @@ func NewLegacyMigrator(
 func (m *LegacyMigrator) Migrate(ctx context.Context, rw repository.ReaderWriter, options provisioning.MigrateJobOptions, progress jobs.JobProgressRecorder) error {
 	namespace := rw.Config().Namespace
 	stageOptions := repository.StageOptions{
-		PushOnWrites: options.History,
+		CommitOnlyOnce:        !options.History,
+		CommitOnlyOnceMessage: options.Message,
+		PushOnWrites:          options.History,
 		// TODO: make this configurable
 		Timeout: 10 * time.Minute,
 	}

--- a/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage.go
@@ -37,7 +37,9 @@ func (m *UnifiedStorageMigrator) Migrate(ctx context.Context, repo repository.Re
 
 	exportJob := provisioning.Job{
 		Spec: provisioning.JobSpec{
-			Push: &provisioning.ExportJobOptions{},
+			Push: &provisioning.ExportJobOptions{
+				Message: options.Message,
+			},
 		},
 	}
 	if err := m.exportWorker.Process(ctx, repo, exportJob, progress); err != nil {

--- a/pkg/registry/apis/provisioning/repository/git/repository_test.go
+++ b/pkg/registry/apis/provisioning/repository/git/repository_test.go
@@ -2256,7 +2256,7 @@ func TestGitRepository_Stage(t *testing.T) {
 	t.Run("calls NewStagedGitRepository", func(t *testing.T) {
 		ctx := context.Background()
 		opts := repository.StageOptions{
-			PushOnWrites: true,
+			Mode: repository.StageModeCommitAndPushOnEach,
 		}
 
 		// Since NewStagedGitRepository is not mocked and may panic, we expect this to fail

--- a/pkg/registry/apis/provisioning/repository/git/staged.go
+++ b/pkg/registry/apis/provisioning/repository/git/staged.go
@@ -78,8 +78,10 @@ func (r *stagedGitRepository) Create(ctx context.Context, path, ref string, data
 		return err
 	}
 
-	if err := r.commit(ctx, r.writer, message); err != nil {
-		return err
+	if !r.opts.CommitOnlyOnce {
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
 	}
 
 	if r.opts.PushOnWrites {
@@ -116,8 +118,10 @@ func (r *stagedGitRepository) Write(ctx context.Context, path, ref string, data 
 		}
 	}
 
-	if err := r.commit(ctx, r.writer, message); err != nil {
-		return err
+	if !r.opts.CommitOnlyOnce {
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
 	}
 
 	if r.opts.PushOnWrites {
@@ -140,8 +144,10 @@ func (r *stagedGitRepository) Update(ctx context.Context, path, ref string, data
 		return err
 	}
 
-	if err := r.commit(ctx, r.writer, message); err != nil {
-		return err
+	if !r.opts.CommitOnlyOnce {
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
 	}
 
 	if r.opts.PushOnWrites {
@@ -160,8 +166,10 @@ func (r *stagedGitRepository) Delete(ctx context.Context, path, ref, message str
 		return err
 	}
 
-	if err := r.commit(ctx, r.writer, message); err != nil {
-		return err
+	if !r.opts.CommitOnlyOnce {
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
 	}
 
 	if r.opts.PushOnWrites {
@@ -176,6 +184,16 @@ func (r *stagedGitRepository) Push(ctx context.Context) error {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, r.opts.Timeout)
 		defer cancel()
+	}
+
+	if r.opts.CommitOnlyOnce {
+		message := r.opts.CommitOnlyOnceMessage
+		if message == "" {
+			message = "Staged changes"
+		}
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
 	}
 
 	return r.writer.Push(ctx)

--- a/pkg/registry/apis/provisioning/repository/git/staged.go
+++ b/pkg/registry/apis/provisioning/repository/git/staged.go
@@ -69,6 +69,25 @@ func (r *stagedGitRepository) ReadTree(ctx context.Context, ref string) ([]repos
 	return r.gitRepository.ReadTree(ctx, ref)
 }
 
+// handleCommitAndPush handles the commit and push logic based on the StageMode
+func (r *stagedGitRepository) handleCommitAndPush(ctx context.Context, message string) error {
+	switch r.opts.Mode {
+	case repository.StageModeCommitOnEach:
+		return r.commit(ctx, r.writer, message)
+	case repository.StageModeCommitAndPushOnEach:
+		if err := r.commit(ctx, r.writer, message); err != nil {
+			return err
+		}
+		return r.Push(ctx)
+	case repository.StageModeCommitOnlyOnce:
+		// No immediate commit, will commit on Push
+		return nil
+	default:
+		// Default to StageModeCommitOnEach for backward compatibility
+		return r.commit(ctx, r.writer, message)
+	}
+}
+
 func (r *stagedGitRepository) Create(ctx context.Context, path, ref string, data []byte, message string) error {
 	if ref != "" && ref != r.gitConfig.Branch {
 		return errors.New("ref is not supported for staged repository")
@@ -78,17 +97,7 @@ func (r *stagedGitRepository) Create(ctx context.Context, path, ref string, data
 		return err
 	}
 
-	if !r.opts.CommitOnlyOnce {
-		if err := r.commit(ctx, r.writer, message); err != nil {
-			return err
-		}
-	}
-
-	if r.opts.PushOnWrites {
-		return r.Push(ctx)
-	}
-
-	return nil
+	return r.handleCommitAndPush(ctx, message)
 }
 
 func (r *stagedGitRepository) blobExists(ctx context.Context, path string) (bool, error) {
@@ -118,17 +127,7 @@ func (r *stagedGitRepository) Write(ctx context.Context, path, ref string, data 
 		}
 	}
 
-	if !r.opts.CommitOnlyOnce {
-		if err := r.commit(ctx, r.writer, message); err != nil {
-			return err
-		}
-	}
-
-	if r.opts.PushOnWrites {
-		return r.Push(ctx)
-	}
-
-	return nil
+	return r.handleCommitAndPush(ctx, message)
 }
 
 func (r *stagedGitRepository) Update(ctx context.Context, path, ref string, data []byte, message string) error {
@@ -144,17 +143,7 @@ func (r *stagedGitRepository) Update(ctx context.Context, path, ref string, data
 		return err
 	}
 
-	if !r.opts.CommitOnlyOnce {
-		if err := r.commit(ctx, r.writer, message); err != nil {
-			return err
-		}
-	}
-
-	if r.opts.PushOnWrites {
-		return r.Push(ctx)
-	}
-
-	return nil
+	return r.handleCommitAndPush(ctx, message)
 }
 
 func (r *stagedGitRepository) Delete(ctx context.Context, path, ref, message string) error {
@@ -166,17 +155,7 @@ func (r *stagedGitRepository) Delete(ctx context.Context, path, ref, message str
 		return err
 	}
 
-	if !r.opts.CommitOnlyOnce {
-		if err := r.commit(ctx, r.writer, message); err != nil {
-			return err
-		}
-	}
-
-	if r.opts.PushOnWrites {
-		return r.Push(ctx)
-	}
-
-	return nil
+	return r.handleCommitAndPush(ctx, message)
 }
 
 func (r *stagedGitRepository) Push(ctx context.Context) error {
@@ -186,7 +165,7 @@ func (r *stagedGitRepository) Push(ctx context.Context) error {
 		defer cancel()
 	}
 
-	if r.opts.CommitOnlyOnce {
+	if r.opts.Mode == repository.StageModeCommitOnlyOnce {
 		message := r.opts.CommitOnlyOnceMessage
 		if message == "" {
 			message = "Staged changes"

--- a/pkg/registry/apis/provisioning/repository/git/staged_test.go
+++ b/pkg/registry/apis/provisioning/repository/git/staged_test.go
@@ -426,9 +426,12 @@ func TestStagedGitRepository_Create(t *testing.T) {
 			// Verify commit behavior based on CommitOnlyOnce option
 			if tt.opts.CommitOnlyOnce {
 				require.Equal(t, 0, mockWriter.CommitCallCount(), "No commits should be made when CommitOnlyOnce is true")
-			} else if tt.wantError == nil {
-				require.Equal(t, 1, mockWriter.CommitCallCount(), "One commit should be made when CommitOnlyOnce is false")
-			} else if tt.wantError != nil && !strings.Contains(tt.wantError.Error(), "commit") {
+			} else if tt.wantError == nil || strings.Contains(tt.wantError.Error(), "push failed") {
+				require.Equal(t, 1, mockWriter.CommitCallCount(), "One commit should be made when CommitOnlyOnce is false (even if push fails)")
+			} else if tt.wantError != nil && strings.Contains(tt.wantError.Error(), "commit") {
+				// Commit failed, so it should have been attempted but failed
+				require.Equal(t, 1, mockWriter.CommitCallCount(), "Commit should be attempted even if it fails")
+			} else if tt.wantError != nil {
 				require.Equal(t, 0, mockWriter.CommitCallCount(), "No commits should be made when error occurs before commit")
 			}
 		})

--- a/pkg/registry/apis/provisioning/repository/git/staged_test.go
+++ b/pkg/registry/apis/provisioning/repository/git/staged_test.go
@@ -851,11 +851,11 @@ func TestStagedGitRepository_Delete(t *testing.T) {
 
 func TestStagedGitRepository_Push(t *testing.T) {
 	tests := []struct {
-		name            string
-		opts            repository.StageOptions
-		setupMock       func(*mocks.FakeStagedWriter)
-		wantError       error
-		expectPushCalls int
+		name              string
+		opts              repository.StageOptions
+		setupMock         func(*mocks.FakeStagedWriter)
+		wantError         error
+		expectPushCalls   int
 		expectCommitCalls int
 	}{
 		{

--- a/pkg/registry/apis/provisioning/repository/github/repository_test.go
+++ b/pkg/registry/apis/provisioning/repository/github/repository_test.go
@@ -985,8 +985,8 @@ func TestGitHubRepositoryDelegation(t *testing.T) {
 		mockGitRepo := git.NewMockGitRepository(t)
 		mockStagedRepo := repository.NewMockStagedRepository(t)
 		opts := repository.StageOptions{
-			PushOnWrites: true,
-			Timeout:      10 * time.Second,
+			Mode:    repository.StageModeCommitOnEach,
+			Timeout: 10 * time.Second,
 		}
 		mockGitRepo.On("Stage", ctx, opts).Return(mockStagedRepo, nil)
 

--- a/pkg/registry/apis/provisioning/repository/staged.go
+++ b/pkg/registry/apis/provisioning/repository/staged.go
@@ -11,15 +11,15 @@ import (
 )
 
 // StageMode defines the staging and commit behavior
-type StageMode string
+type StageMode int
 
 const (
 	// StageModeCommitOnEach commits each file operation individually (default)
-	StageModeCommitOnEach StageMode = "commit_on_each"
+	StageModeCommitOnEach StageMode = iota
 	// StageModeCommitOnlyOnce stages all changes and commits them all at once on push
-	StageModeCommitOnlyOnce StageMode = "commit_only_once"
+	StageModeCommitOnlyOnce
 	// StageModeCommitAndPushOnEach commits and pushes each file operation individually
-	StageModeCommitAndPushOnEach StageMode = "commit_and_push_on_each"
+	StageModeCommitAndPushOnEach
 )
 
 type StageOptions struct {

--- a/pkg/registry/apis/provisioning/repository/staged.go
+++ b/pkg/registry/apis/provisioning/repository/staged.go
@@ -10,14 +10,24 @@ import (
 	"github.com/grafana/nanogit"
 )
 
+// StageMode defines the staging and commit behavior
+type StageMode string
+
+const (
+	// StageModeCommitOnEach commits each file operation individually (default)
+	StageModeCommitOnEach StageMode = "commit_on_each"
+	// StageModeCommitOnlyOnce stages all changes and commits them all at once on push
+	StageModeCommitOnlyOnce StageMode = "commit_only_once"
+	// StageModeCommitAndPushOnEach commits and pushes each file operation individually
+	StageModeCommitAndPushOnEach StageMode = "commit_and_push_on_each"
+)
+
 type StageOptions struct {
-	// Push on every write
-	PushOnWrites bool
+	// Mode defines the staging and commit behavior
+	Mode StageMode
 	// Maximum time allowed for clone operation in seconds (0 means no limit)
 	Timeout time.Duration
-	// Commit only once on push instead of intermediate commits
-	CommitOnlyOnce bool
-	// Commit message to use when CommitOnlyOnce is true
+	// Commit message to use when Mode is StageModeCommitOnlyOnce
 	CommitOnlyOnceMessage string
 }
 

--- a/pkg/registry/apis/provisioning/repository/staged.go
+++ b/pkg/registry/apis/provisioning/repository/staged.go
@@ -15,6 +15,10 @@ type StageOptions struct {
 	PushOnWrites bool
 	// Maximum time allowed for clone operation in seconds (0 means no limit)
 	Timeout time.Duration
+	// Commit only once on push instead of intermediate commits
+	CommitOnlyOnce bool
+	// Commit message to use when CommitOnlyOnce is true
+	CommitOnlyOnceMessage string
 }
 
 //go:generate mockery --name StageableRepository --structname MockStageableRepository --inpackage --filename stageable_repository_mock.go --with-expecter

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -2636,6 +2636,10 @@
             "description": "The source folder (or empty) to export",
             "type": "string"
           },
+          "message": {
+            "description": "Message to use when committing the changes in a single commit",
+            "type": "string"
+          },
           "path": {
             "description": "Prefix in target file system",
             "type": "string"
@@ -3156,6 +3160,10 @@
           "history": {
             "description": "Preserve history (if possible)",
             "type": "boolean"
+          },
+          "message": {
+            "description": "Message to use when committing the changes in a single commit",
+            "type": "string"
           }
         }
       },

--- a/public/app/api/clients/provisioning/v0alpha1/endpoints.gen.ts
+++ b/public/app/api/clients/provisioning/v0alpha1/endpoints.gen.ts
@@ -752,6 +752,8 @@ export type ObjectMeta = {
 export type MigrateJobOptions = {
   /** Preserve history (if possible) */
   history?: boolean;
+  /** Message to use when committing the changes in a single commit */
+  message?: string;
 };
 export type PullRequestJobOptions = {
   /** The specific commit hash that triggered this notice */
@@ -772,6 +774,8 @@ export type ExportJobOptions = {
   branch?: string;
   /** The source folder (or empty) to export */
   folder?: string;
+  /** Message to use when committing the changes in a single commit */
+  message?: string;
   /** Prefix in target file system */
   path?: string;
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add the ability to commit and push only once.

**Why do we need this feature?**

We want to reduce the number of commits for clarity and reliability on export and migrations.

**Who is this feature for?**

Users of Git Sync / Provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/376>

**How**:

- Introduce staged modes to implement different commit and push strategies.
- Add message to the expect of migration and export jobs for future frontend implementation.
- Default to `Export from Grafana` message in single commit and push mode.

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Testing notes:**

- Create a bunch of dashboards. 
- Connect to the repository. 
- After the migration finishes, check the history in the git repository and see it's only 1 commit for all of them: 
<img width="1690" height="946" alt="image" src="https://github.com/user-attachments/assets/1947b815-cff2-4683-a9b0-a5230be57749" />