### PR TITLE
Updating trace link

### DIFF
--- a/docs/sources/explore/get-started-with-explore.md
+++ b/docs/sources/explore/get-started-with-explore.md
@@ -204,5 +204,5 @@ Now that you are familiar with Explore you can:
 - [Build dashboards](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/)
 - Create a wide variety of [visualizations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/)
 - [Work with logs](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/logs-integration/)
-- [Work with traces](https://grafana.com/docs/grafana/<GRAFANA_VERSION>)
+- [Work with traces](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/trace-integration/)
 - [Create and use correlations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/explore/correlations-editor-in-explore/)


### PR DESCRIPTION
As reported in https://github.com/grafana/grafana/issues/101443.

In the [Get started with Explore page](https://grafana.com/docs/grafana-cloud/visualizations/explore/get-started-with-explore/#next-steps), the link [Work with traces](https://grafana.com/docs/grafana/next/) at the bottom does not link to the right document. It links to the first Grafana documentation page.
