### PR TITLE
Alerting: Rename draft new rule option

### DIFF
--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -155,11 +155,11 @@ describe('RuleList v2', () => {
 
 describe('RuleListActions', () => {
   const ui = {
-    newRuleButton: byRole('link', { name: /new alert rule/i }),
+    newRuleButton: byRole('link', { name: /^new alert rule$/i }),
     moreButton: byRole('button', { name: /more/i }),
     moreMenu: byRole('menu'),
     menuOptions: {
-      draftNewRule: byRole('link', { name: /draft a new rule/i }),
+      newAlertRuleForExport: byRole('link', { name: /new alert rule for export/i }),
       newGrafanaRecordingRule: byRole('link', { name: /new grafana recording rule/i }),
       newDataSourceRecordingRule: byRole('link', { name: /new data source recording rule/i }),
     },
@@ -191,7 +191,7 @@ describe('RuleListActions', () => {
     expect(ui.moreButton.get()).toBeInTheDocument();
   });
 
-  it('should only show Draft a new rule when the user has view Grafana rules permission', async () => {
+  it('should only show New alert rule for export when the user has view Grafana rules permission', async () => {
     grantUserPermissions([AccessControlAction.AlertingRuleRead]);
 
     const { user } = render(<RuleListActions />);
@@ -200,7 +200,7 @@ describe('RuleListActions', () => {
     const menu = await ui.moreMenu.find();
 
     expect(ui.newRuleButton.query()).not.toBeInTheDocument();
-    expect(ui.menuOptions.draftNewRule.query(menu)).toBeInTheDocument();
+    expect(ui.menuOptions.newAlertRuleForExport.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newGrafanaRecordingRule.query(menu)).not.toBeInTheDocument();
     expect(ui.menuOptions.newDataSourceRecordingRule.query(menu)).not.toBeInTheDocument();
   });
@@ -213,7 +213,7 @@ describe('RuleListActions', () => {
     await user.click(ui.moreButton.get());
     const menu = await ui.moreMenu.find();
 
-    expect(ui.menuOptions.draftNewRule.query(menu)).toBeInTheDocument();
+    expect(ui.menuOptions.newAlertRuleForExport.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newGrafanaRecordingRule.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newDataSourceRecordingRule.query(menu)).not.toBeInTheDocument();
   });
@@ -226,7 +226,7 @@ describe('RuleListActions', () => {
     await user.click(ui.moreButton.get());
     const menu = await ui.moreMenu.find();
 
-    expect(ui.menuOptions.draftNewRule.query(menu)).toBeInTheDocument();
+    expect(ui.menuOptions.newAlertRuleForExport.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newGrafanaRecordingRule.query(menu)).not.toBeInTheDocument();
     expect(ui.menuOptions.newDataSourceRecordingRule.query(menu)).toBeInTheDocument();
   });
@@ -239,7 +239,7 @@ describe('RuleListActions', () => {
     await user.click(ui.moreButton.get());
     const menu = await ui.moreMenu.find();
 
-    expect(ui.menuOptions.draftNewRule.query(menu)).toBeInTheDocument();
+    expect(ui.menuOptions.newAlertRuleForExport.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newGrafanaRecordingRule.query(menu)).toBeInTheDocument();
     expect(ui.menuOptions.newDataSourceRecordingRule.query(menu)).toBeInTheDocument();
   });

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -47,7 +47,7 @@ export function RuleListActions() {
       <Menu>
         <Menu.Group>
           <Menu.Item
-            label={t('alerting.rule-list.draft-new-rule', 'Draft a new rule')}
+            label={t('alerting.rule-list.draft-new-rule', 'New alert rule for export')}
             icon="file-export"
             url="/alerting/export-new-rule"
           />

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -47,7 +47,7 @@ export function RuleListActions() {
       <Menu>
         <Menu.Group>
           <Menu.Item
-            label={t('alerting.rule-list.draft-new-rule', 'New alert rule for export')}
+            label={t('alerting.rule-list.new-rule-for-export', 'New alert rule for export')}
             icon="file-export"
             url="/alerting/export-new-rule"
           />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2468,7 +2468,7 @@
     },
     "rule-list": {
       "configure-datasource": "Configure",
-      "draft-new-rule": "Draft a new rule",
+      "draft-new-rule": "New alert rule for export",
       "ds-error": {
         "title": "Cannot load rules for this datasource"
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2468,7 +2468,6 @@
     },
     "rule-list": {
       "configure-datasource": "Configure",
-      "draft-new-rule": "New alert rule for export",
       "ds-error": {
         "title": "Cannot load rules for this datasource"
       },
@@ -2494,6 +2493,7 @@
       "new-alert-rule": "New alert rule",
       "new-datasource-recording-rule": "New Data source recording rule",
       "new-grafana-recording-rule": "New Grafana recording rule",
+      "new-rule-for-export": "New alert rule for export",
       "pagination": {
         "next-page": "Show more…"
       },
@@ -3515,7 +3515,7 @@
       "this-folder-is-empty": "This folder is empty"
     },
     "bulk-action-resources-form": {
-      "failed-alert_one": "{{count}} item failed",
+      "failed-alert_one": "{{count}} items failed",
       "failed-alert_other": "{{count}} items failed"
     },
     "bulk-delete-resources-form": {
@@ -9256,9 +9256,9 @@
       "type": {
         "loki": {
           "indexed-label_one": "Indexed label",
-          "indexed-label_other": "Indexed labels",
+          "indexed-label_other": "Indexed label",
           "parsedl-label_one": "Parsed field",
-          "parsedl-label_other": "Parsed fields",
+          "parsedl-label_other": "Parsed field",
           "structured-metadata_one": "Structured metadata",
           "structured-metadata_other": "Structured metadata"
         }
@@ -10987,7 +10987,7 @@
     },
     "bootstrap-step": {
       "dashboards-count_one": "{{count}} dashboard",
-      "dashboards-count_other": "{{count}} dashboards",
+      "dashboards-count_other": "{{count}} dashboard",
       "description-clear-repository-connection": "Add a clear name for this repository connection",
       "empty": "Empty",
       "error-field-required": "This field is required.",
@@ -10995,7 +10995,7 @@
       "files-count_one": "{{count}} files",
       "files-count_other": "{{count}} files",
       "folders-count_one": "{{count}} folder",
-      "folders-count_other": "{{count}} folders",
+      "folders-count_other": "{{count}} folder",
       "grafana": "Grafana instance",
       "label-display-name": "Display name",
       "placeholder-my-repository-connection": "My repository connection",


### PR DESCRIPTION
This pull request updates the wording for a menu option in the rule list feature to improve clarity and align with export functionality. The changes include updates to the user interface and corresponding localization strings.

### User Interface Updates:
* Updated the label for the "Draft a new rule" menu item to "New alert rule for export" in the `RuleListActions` component (`RuleList.v2.tsx`).

### Localization Updates:
* Updated the English localization string for "draft-new-rule" to match the new label "New alert rule for export" in `grafana.json`.