### PR TITLE
Advisor - mark as public preview

### DIFF
--- a/docs/sources/administration/grafana-advisor/_index.md
+++ b/docs/sources/administration/grafana-advisor/_index.md
@@ -7,7 +7,6 @@ labels:
     - oss
     - cloud
     - enterprise
-  stage: experimental
 keywords:
   - grafana
   - grafana advisor
@@ -17,7 +16,7 @@ keywords:
 
 # Grafana Advisor
 
-{{< docs/experimental product="Grafana Advisor" featureFlag="grafanaAdvisor" >}}
+{{< docs/public-preview product="Grafana Advisor" featureFlag="grafanaAdvisor" >}}
 
 ## Overview
 


### PR DESCRIPTION
As per https://github.com/grafana/grafana/issues/106893.

Advisor is no longer experimental and is officially public preview.
