### PR TITLE
Correlations: Fix flaky test

### DIFF
--- a/pkg/tests/api/correlations/correlations_update_test.go
+++ b/pkg/tests/api/correlations/correlations_update_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/correlations"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -234,7 +234,7 @@ func TestIntegrationUpdateCorrelation(t *testing.T) {
 				user: adminUser,
 				page: "",
 			})
-			assert.Equal(collect, http.StatusOK, res.StatusCode, "Correlation should be available before update")
+			require.Equal(collect, http.StatusOK, res.StatusCode, "Correlation should be available before update")
 			require.NoError(collect, res.Body.Close())
 		}, 5*time.Second, 10*time.Millisecond, "Correlation should be available for reading before update")
 


### PR DESCRIPTION
### What does this PR do? 📓 

We had a report of a flaky test: 

> `TestIntegrationUpdateCorrelation/updating_a_correlation_pointing_to_a_read-only_data_source_should_work`. 

The result of the failing test was: 

```go
expected: "Correlation updated"
actual  : "Correlation not found"
```

My _suspicion_ is that there's some kind of race condition causing flake between **creating** and **updating** the correlation. At least just from looking at the test, the test step goes straight from 1) `ctx.createCorrelation` to  2)`ctx.Patch`. 

My solution is copied from other patterns in Grafana, which is to _WAIT_ and verify the correlation is available before updating it. I have no idea if this is correct or not. I tested it locally and it passes 🤷 

> [!CAUTION]
> I am not proficient in `go` at all, so keep that in mind 😄 