### PR TITLE
Unified Search: Randomise instance selected by distributor

### DIFF
--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -151,7 +151,7 @@ func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, n
 		md = make(metadata.MD)
 	}
 
-	ds.log.Info("distributing request to ", "methodName", methodName, "instanceId", inst.Id)
+	ds.log.Info("distributing request to ", "methodName", methodName, "instanceId", inst.Id, "namespace", namespace)
 
 	_ = grpc.SetHeader(ctx, metadata.Pairs("proxied-instance-id", inst.Id))
 

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -3,6 +3,7 @@ package resource
 import (
 	"context"
 	"hash/fnv"
+	"math/rand"
 	"time"
 
 	"github.com/grafana/dskit/ring"
@@ -138,7 +139,9 @@ func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, n
 		return ctx, nil, err
 	}
 
-	client, err := ds.clientPool.GetClientForInstance(rs.Instances[0])
+	// Randomly select an instance for primitive load balancing
+	inst := rs.Instances[rand.Intn(len(rs.Instances))]
+	client, err := ds.clientPool.GetClientForInstance(inst)
 	if err != nil {
 		return ctx, nil, err
 	}
@@ -148,9 +151,9 @@ func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, n
 		md = make(metadata.MD)
 	}
 
-	ds.log.Info("distributing request to ", "methodName", methodName, "instanceId", rs.Instances[0].Id)
+	ds.log.Info("distributing request to ", "methodName", methodName, "instanceId", inst.Id)
 
-	_ = grpc.SetHeader(ctx, metadata.Pairs("proxied-instance-id", rs.Instances[0].Id))
+	_ = grpc.SetHeader(ctx, metadata.Pairs("proxied-instance-id", inst.Id))
 
 	return userutils.InjectOrgID(metadata.NewOutgoingContext(ctx, md), namespace), client.(*RingClient).Client, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

As part of sharding namespaces across index servers, we need to make sure to "update distributor to pick a random, ACTIVE, instance to receive the request".

We're already selecting from a pool of instances with ACTIVE state since we include [searchRingRead](https://github.com/grafana/grafana/blob/f61ec391faacaf79795c1466dad4694317c5b153/pkg/storage/unified/resource/search_server_distributor.go#L86-L89) when calling `GetWithOptions` [here](https://github.com/grafana/grafana/blob/f61ec391faacaf79795c1466dad4694317c5b153/pkg/storage/unified/resource/search_server_distributor.go#L137-L140).

**Why do we need this feature?**

For primitive load balancing. We'll improve the mechanism at a later point.

**Who is this feature for?**

Grafana Search and Storage.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/search-and-storage-team/issues/370

**Special notes for your reviewer:**

We already have an [integration test](https://github.com/grafana/grafana/blob/52d32b1ca13925f0060b73065421d682e8bb2847/pkg/server/search_server_distributor_test.go) that tests `GetWithOptions`. So from my perspective the integration test plus checking our resource overview dashboards should be sufficient to verify the change works as expected.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
