### PR TITLE
auth: Restore Authentication UI access

### DIFF
--- a/public/app/routes/routes.tsx
+++ b/public/app/routes/routes.tsx
@@ -301,13 +301,9 @@ export function getAppRoutes(): RouteDescriptor[] {
     {
       path: '/admin/authentication',
       roles: () => contextSrv.evaluatePermission([AccessControlAction.SettingsWrite]),
-      component:
-        config.licenseInfo.enabledFeatures?.saml || config.ldapEnabled
-          ? SafeDynamicImport(
-              () =>
-                import(/* webpackChunkName: "AdminAuthentication" */ '../features/auth-config/AuthProvidersListPage')
-            )
-          : () => <Navigate replace to="/admin" />,
+      component: SafeDynamicImport(
+        () => import(/* webpackChunkName: "AdminAuthentication" */ '../features/auth-config/AuthProvidersListPage')
+      ),
     },
     {
       path: '/admin/authentication/ldap',


### PR DESCRIPTION
**What is this feature?**

This PR restores access to the `Authentication` UI page.

**Why do we need this feature?**

While removing the SSO Settings feature toggle, we didn't adjust the conditional that controls access to this page. Before this change, the SSO Settings feature toggle was enabled by default and upon removing the feature toggle, the behaviour of this component broke.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/108575