### PR TITLE
Alerting: Add store level pagination of rules

### DIFF
--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -23,6 +23,7 @@ type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
 	GetAlertRulesGroupByRuleUID(ctx context.Context, query *ngmodels.GetAlertRulesGroupByRuleUIDQuery) ([]*ngmodels.AlertRule, error)
 	ListAlertRules(ctx context.Context, query *ngmodels.ListAlertRulesQuery) (ngmodels.RulesGroup, error)
+	ListAlertRulesByGroup(ctx context.Context, query *ngmodels.ListAlertRulesByGroupQuery) (ngmodels.RulesGroup, string, error)
 	ListDeletedRules(ctx context.Context, orgID int64) ([]*ngmodels.AlertRule, error)
 
 	// InsertAlertRules will insert all alert rules passed into the function

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -541,18 +540,6 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 	}
 
 	return ruleResponse
-}
-
-func getRuleGroupNextToken(namespace, group string) string {
-	return base64.URLEncoding.EncodeToString([]byte(namespace + "/" + group))
-}
-
-// Returns true if tokenA >= tokenB
-func tokenGreaterThanOrEqual(tokenA string, tokenB string) bool {
-	decodedTokenA, _ := base64.URLEncoding.DecodeString(tokenA)
-	decodedTokenB, _ := base64.URLEncoding.DecodeString(tokenB)
-
-	return string(decodedTokenA) >= string(decodedTokenB)
 }
 
 type ruleGroup struct {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -848,6 +848,38 @@ type GetAlertRulesGroupByRuleUIDQuery struct {
 	OrgID int64
 }
 
+type RuleTypeFilter int
+
+const (
+	RuleTypeFilterAll RuleTypeFilter = iota
+	RuleTypeFilterAlerting
+	RuleTypeFilterRecording
+)
+
+// Add this new struct
+type ListAlertRulesByGroupQuery struct {
+	OrgID         int64
+	RuleUIDs      []string
+	NamespaceUIDs []string
+	ExcludeOrgs   []int64
+	RuleGroups    []string
+
+	// DashboardUID and PanelID are optional and allow filtering rules
+	// to return just those for a dashboard and panel.
+	DashboardUID string
+	PanelID      int64
+
+	ReceiverName     string
+	TimeIntervalName string
+
+	HasPrometheusRuleDefinition *bool
+
+	RuleType RuleTypeFilter
+
+	GroupLimit         int64  // Number of groups to fetch
+	GroupContinueToken string // Token for per-group pagination
+}
+
 // ListAlertRulesQuery is the query for listing alert rules
 type ListAlertRulesQuery struct {
 	OrgID         int64

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -857,7 +857,6 @@ const (
 	RuleTypeFilterRecording
 )
 
-// Add this new struct
 type ListAlertRulesByGroupQuery struct {
 	OrgID         int64
 	RuleUIDs      []string

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -878,6 +879,30 @@ type ListAlertRulesByGroupQuery struct {
 
 	GroupLimit         int64  // Number of groups to fetch
 	GroupContinueToken string // Token for per-group pagination
+}
+
+type GroupCursor struct {
+	NamespaceUID string `json:"n"`
+	RuleGroup    string `json:"g"`
+}
+
+func EncodeGroupCursor(c GroupCursor) string {
+	data, _ := json.Marshal(c)
+	return base64.URLEncoding.EncodeToString(data)
+}
+
+func DecodeGroupCursor(token string) (GroupCursor, error) {
+	var c GroupCursor
+	data, err := base64.URLEncoding.DecodeString(token)
+	if err != nil {
+		return c, fmt.Errorf("failed to decode group token: %w", err)
+	}
+
+	if err := json.Unmarshal(data, &c); err != nil {
+		return c, fmt.Errorf("failed to unmarshal group cursor: %w", err)
+	}
+
+	return c, nil
 }
 
 // ListAlertRulesQuery is the query for listing alert rules

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -677,7 +677,7 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 		}()
 
 		// Process rules and implement per-group pagination
-		groupsFetched := 0
+		var groupsFetched int64
 		for rows.Next() {
 			rule := new(alertRule)
 			err = rows.Scan(rule)
@@ -699,7 +699,7 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 			}
 			if key != cursor {
 				// Check if we've reached the group limit
-				if query.GroupLimit > 0 && groupsFetched == int(query.GroupLimit) {
+				if query.GroupLimit > 0 && groupsFetched == query.GroupLimit {
 					// Generate next token for the next group
 					nextToken = ngmodels.EncodeGroupCursor(cursor)
 					break

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/ngalert/testutil"
-	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/user"
 
@@ -1628,27 +1627,6 @@ func createRule(tb testing.TB, store *DBstore, generator *models.AlertRuleGenera
 	return rule
 }
 
-func createFolder(tb testing.TB, store *DBstore, uid, title string, orgID int64, parentUID string) {
-	tb.Helper()
-	u := &user.SignedInUser{
-		UserID:         1,
-		OrgID:          orgID,
-		OrgRole:        org.RoleAdmin,
-		IsGrafanaAdmin: true,
-	}
-
-	_, err := store.FolderService.Create(context.Background(), &folder.CreateFolderCommand{
-		UID:          uid,
-		OrgID:        orgID,
-		Title:        title,
-		Description:  "",
-		SignedInUser: u,
-		ParentUID:    parentUID,
-	})
-
-	require.NoError(tb, err)
-}
-
 func setupFolderService(t testing.TB, sqlStore db.DB, cfg *setting.Cfg, features featuremgmt.FeatureToggles) folder.Service {
 	tracer := tracing.InitializeTracerForTest()
 	inProcBus := bus.ProvideBus(tracer)
@@ -2174,7 +2152,6 @@ func createManyRules(tb testing.TB, store *DBstore, ruleGen *models.AlertRuleGen
 	namespaceUIDs := make([]string, numFolders)
 	for i := range namespaceUIDs {
 		namespaceUIDs[i] = fmt.Sprintf("ns-%d", i)
-		createFolder(tb, store, namespaceUIDs[i], fmt.Sprintf("folder-%d", i), 1, "")
 	}
 	for i := 0; i < numRules; i++ {
 		gen := ruleGen.With(

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -239,7 +239,7 @@ func (f *RuleStore) ListAlertRulesByGroup(_ context.Context, q *models.ListAlert
 	}
 
 	outputRules := make([]*models.AlertRule, 0, len(ruleList))
-	groupsFetched := 0
+	var groupsFetched int64
 	initialCursor := cursor
 	for _, r := range ruleList {
 		// skip rules before the initial cursor
@@ -254,7 +254,7 @@ func (f *RuleStore) ListAlertRulesByGroup(_ context.Context, q *models.ListAlert
 			RuleGroup:    r.RuleGroup,
 		}
 		if key != cursor {
-			if q.GroupLimit > 0 && groupsFetched == int(q.GroupLimit) {
+			if q.GroupLimit > 0 && groupsFetched == q.GroupLimit {
 				nextToken = models.EncodeGroupCursor(cursor)
 				break
 			}

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/rand"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -185,6 +186,91 @@ func (f *RuleStore) GetAlertRulesGroupByRuleUID(_ context.Context, q *models.Get
 	return ruleList, nil
 }
 
+func (f *RuleStore) ListAlertRulesByGroup(_ context.Context, q *models.ListAlertRulesByGroupQuery) (models.RulesGroup, string, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, *q)
+
+	if err := f.Hook(*q); err != nil {
+		return nil, "", err
+	}
+
+	query := &models.ListAlertRulesQuery{
+		OrgID:                       q.OrgID,
+		NamespaceUIDs:               q.NamespaceUIDs,
+		DashboardUID:                q.DashboardUID,
+		PanelID:                     q.PanelID,
+		RuleGroups:                  q.RuleGroups,
+		RuleUIDs:                    q.RuleUIDs,
+		ReceiverName:                q.ReceiverName,
+		HasPrometheusRuleDefinition: q.HasPrometheusRuleDefinition,
+	}
+
+	ruleList, err := f.listAlertRules(query)
+	if err != nil {
+		return nil, "", err
+	}
+
+	// < group limit logic >
+
+	// sort rules to ensure order is consistent, pagination depends on this
+	slices.SortFunc(ruleList, func(a, b *models.AlertRule) int {
+		nsCmp := strings.Compare(a.NamespaceUID, b.NamespaceUID)
+		if nsCmp != 0 {
+			return nsCmp
+		}
+		rgCmp := strings.Compare(a.RuleGroup, b.RuleGroup)
+		if rgCmp != 0 {
+			return rgCmp
+		}
+		return models.RulesGroupComparer(a, b)
+	})
+
+	var nextToken string
+	var cursor models.GroupCursor
+	if q.GroupContinueToken != "" {
+		if cur, err := models.DecodeGroupCursor(q.GroupContinueToken); err == nil {
+			cursor = cur
+		}
+	}
+
+	if q.GroupLimit < 0 {
+		return ruleList, "", nil
+	}
+
+	outputRules := make([]*models.AlertRule, 0, len(ruleList))
+	groupsFetched := 0
+	initialCursor := cursor
+	for _, r := range ruleList {
+		// skip rules before the initial cursor
+		if initialCursor.NamespaceUID != "" &&
+			(strings.Compare(r.NamespaceUID, initialCursor.NamespaceUID) < 0 ||
+				(strings.Compare(r.NamespaceUID, initialCursor.NamespaceUID) == 0 && strings.Compare(r.RuleGroup, initialCursor.RuleGroup) <= 0)) {
+			continue
+		}
+
+		key := models.GroupCursor{
+			NamespaceUID: r.NamespaceUID,
+			RuleGroup:    r.RuleGroup,
+		}
+		if key != cursor {
+			if q.GroupLimit > 0 && groupsFetched == int(q.GroupLimit) {
+				nextToken = models.EncodeGroupCursor(cursor)
+				break
+			}
+			cursor = key
+			groupsFetched++
+		}
+
+		outputRules = append(outputRules, r)
+		if groupsFetched == 0 {
+			groupsFetched++
+		}
+	}
+
+	return outputRules, nextToken, nil
+}
+
 func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
@@ -194,6 +280,10 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 		return nil, err
 	}
 
+	return f.listAlertRules(q)
+}
+
+func (f *RuleStore) listAlertRules(q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
 	hasDashboard := func(r *models.AlertRule, dashboardUID string, panelID int64) bool {
 		if dashboardUID != "" {
 			if r.DashboardUID == nil || *r.DashboardUID != dashboardUID {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -263,9 +263,6 @@ func (f *RuleStore) ListAlertRulesByGroup(_ context.Context, q *models.ListAlert
 		}
 
 		outputRules = append(outputRules, r)
-		if groupsFetched == 0 {
-			groupsFetched++
-		}
 	}
 
 	return outputRules, nextToken, nil


### PR DESCRIPTION
**What is this feature?**

This PR adds a new `ListByRuleGroup` method to the rule store that allows us to paginate by group while serializing results from the database, and pipes this through to the Prometheus api that previously handled pagination.

**Why do we need this feature?**

This provides significant speedups vs listing and serializing all rules, especially with larger datasets. In local testing on the store method this results in a fairly linearly scaling speed increase (100x at 1% of total rules, 10x at 10%) as shown by the benchmark results below. 

Benchmark (10000 rules, 100 rules per group)

<img width="1000" alt="Benchmark showing results" src="https://github.com/user-attachments/assets/252630c0-6a3a-4863-97a0-9ddc4bed17de" />

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
