### PR TITLE
Chore: Don't show a "Not found" for public-dashboard fetches if the service is disabled via config

### DIFF
--- a/public/app/features/dashboard/api/publicDashboardApi.ts
+++ b/public/app/features/dashboard/api/publicDashboardApi.ts
@@ -43,7 +43,7 @@ export const publicDashboardApi = createApi({
         try {
           await queryFulfilled;
         } catch (e) {
-          if (isFetchBaseQueryError(e) && isFetchError(e.error)) {
+          if (isFetchBaseQueryError(e) && isFetchError(e.error) && config.publicDashboardsEnabled) {
             dispatch(notifyApp(createErrorNotification(e.error.data.message)));
           }
         }


### PR DESCRIPTION
**What is this feature?**

A user reported that they disabled public dashboards altogether and started receiving "Not found" toasts on their dashboards. This suppresses the toast if the feature is disabled.

```
[public_dashboards]
enabled = false # this was causing the error to happen on dashboard loads
```