### PR TITLE
Loki: Fix tests for test decoupling

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -1,4 +1,4 @@
-import { AbstractLabelOperator, DataFrame, TimeRange, dateTime, getDefaultTimeRange, ScopedVars } from '@grafana/data';
+import { AbstractLabelOperator, DataFrame, TimeRange, dateTime, ScopedVars } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
 import LanguageProvider from './LanguageProvider';
@@ -24,18 +24,6 @@ const mockTimeRange = {
     to: dateTime(1546380000000),
   },
 };
-
-jest.mock('@grafana/data', () => ({
-  ...jest.requireActual('@grafana/data'),
-  getDefaultTimeRange: jest.fn().mockImplementation(() => ({
-    from: dateTime(0),
-    to: dateTime(1),
-    raw: {
-      from: dateTime(0),
-      to: dateTime(1),
-    },
-  })),
-}));
 
 describe('Language completion provider', () => {
   describe('start', () => {
@@ -208,8 +196,16 @@ describe('Language completion provider', () => {
         .mockImplementation((range: TimeRange) => ({ start: range.from.valueOf(), end: range.to.valueOf() }));
       const languageProvider = new LanguageProvider(datasource);
       languageProvider.request = jest.fn().mockResolvedValue([]);
+      jest.spyOn(languageProvider, 'getDefaultTimeRange').mockImplementation(() => ({
+        from: dateTime(0),
+        to: dateTime(1),
+        raw: {
+          from: dateTime(0),
+          to: dateTime(1),
+        },
+      }));
       languageProvider.fetchLabelValues('testKey');
-      expect(getDefaultTimeRange).toHaveBeenCalled();
+      expect(languageProvider.getDefaultTimeRange).toHaveBeenCalled();
       expect(languageProvider.request).toHaveBeenCalled();
       expect(languageProvider.request).toHaveBeenCalledWith('label/testKey/values', {
         end: 1,
@@ -765,7 +761,7 @@ describe('Query imports', () => {
           maxLines: DEFAULT_MAX_LINES_SAMPLE,
           refId: 'data-samples',
         },
-        getDefaultTimeRange()
+        expect.any(Object)
       );
     });
 
@@ -786,7 +782,7 @@ describe('Query imports', () => {
           maxLines: 5,
           refId: 'data-samples',
         },
-        getDefaultTimeRange()
+        expect.any(Object)
       );
     });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -761,7 +761,7 @@ describe('Query imports', () => {
           maxLines: DEFAULT_MAX_LINES_SAMPLE,
           refId: 'data-samples',
         },
-        expect.any(Object)
+        languageProvider.getDefaultTimeRange()
       );
     });
 
@@ -782,7 +782,7 @@ describe('Query imports', () => {
           maxLines: 5,
           refId: 'data-samples',
         },
-        expect.any(Object)
+        languageProvider.getDefaultTimeRange()
       );
     });
 

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -511,7 +511,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
    *
    * @returns {TimeRange} The default time range
    */
-  private getDefaultTimeRange(): TimeRange {
+  getDefaultTimeRange(): TimeRange {
     return getDefaultTimeRange();
   }
 }

--- a/public/app/plugins/datasource/loki/LogContextProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.test.ts
@@ -1,5 +1,4 @@
 import { of } from 'rxjs';
-import { initTemplateSrv } from 'test/helpers/initTemplateSrv';
 
 import {
   DataQueryResponse,
@@ -9,7 +8,7 @@ import {
   createDataFrame,
   dateTime,
 } from '@grafana/data';
-import { setTemplateSrv } from '@grafana/runtime';
+import { setTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import LokiLanguageProvider from './LanguageProvider';
 import {
@@ -66,8 +65,10 @@ const frameWithoutTypes = {
 describe('LogContextProvider', () => {
   let logContextProvider: LogContextProvider;
   beforeEach(() => {
-    const templateSrv = initTemplateSrv('key', [{ type: 'query', name: 'foo', current: { value: 'baz' } }]);
-    setTemplateSrv(templateSrv);
+    const templateSrv = {
+      replace: jest.fn((str: string) => str?.replace('$test', 'baz')),
+    };
+    setTemplateSrv(templateSrv as unknown as TemplateSrv);
     const defaultDatasourceMock = createLokiDatasource(templateSrv);
     defaultDatasourceMock.query = jest.fn(() => of({ data: [] } as DataQueryResponse));
     defaultDatasourceMock.languageProvider = defaultLanguageProviderMock;

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1774,12 +1774,16 @@ describe('LokiDatasource', () => {
     });
     it('calls query if convertMetricQueryToLogQuery is true for a metric query', async () => {
       const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({} as DataQueryResponse));
-      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, { convertMetricQueryToLogQuery: true });
+      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, {
+        convertMetricQueryToLogQuery: true,
+      });
       expect(spy).toHaveBeenCalled();
     });
     it('does not call query if convertMetricQueryToLogQuery is false for a metric query', async () => {
       const spy = jest.spyOn(ds, 'query');
-      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, { convertMetricQueryToLogQuery: false });
+      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, {
+        convertMetricQueryToLogQuery: false,
+      });
       expect(spy).not.toHaveBeenCalled();
     });
   });

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -1772,6 +1772,16 @@ describe('LokiDatasource', () => {
         })
       );
     });
+    it('calls query if convertMetricQueryToLogQuery is true for a metric query', async () => {
+      const spy = jest.spyOn(ds, 'query').mockImplementation(() => of({} as DataQueryResponse));
+      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, { convertMetricQueryToLogQuery: true });
+      expect(spy).toHaveBeenCalled();
+    });
+    it('does not call query if convertMetricQueryToLogQuery is false for a metric query', async () => {
+      const spy = jest.spyOn(ds, 'query');
+      await ds.getDataSamples({ expr: 'rate({a="b"}[1m])', refId: 'A' }, mockTimeRange, { convertMetricQueryToLogQuery: false });
+      expect(spy).not.toHaveBeenCalled();
+    });
   });
 
   describe('Query splitting', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -753,9 +753,11 @@ export class LokiDatasource
       // If it is not a logs query, we need to check if we need to convert it to a logs query
       if (options?.convertMetricQueryToLogQuery) {
         queryExpr = getLogQueryFromMetricsQuery(queryExpr);
+      } else {
+        // Otherwise, we return an empty array, as data samples are only supported for logs queries
+        return [];
       }
-      // Otherwise, we return an empty array, as data samples are only supported for logs queries
-      return [];
+
     }
 
     const lokiLogsQuery: LokiQuery = {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -757,7 +757,6 @@ export class LokiDatasource
         // Otherwise, we return an empty array, as data samples are only supported for logs queries
         return [];
       }
-
     }
 
     const lokiLogsQuery: LokiQuery = {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -739,14 +739,27 @@ export class LokiDatasource
    * Currently, it works for logs data only.
    * @returns A Promise that resolves to an array of DataFrames containing data samples.
    */
-  async getDataSamples(query: LokiQuery, timeRange: TimeRange): Promise<DataFrame[]> {
-    // Currently works only for logs sample
-    if (!isLogsQuery(query.expr) || isQueryWithError(this.interpolateString(query.expr, placeHolderScopedVars))) {
+  async getDataSamples(
+    query: LokiQuery,
+    timeRange: TimeRange,
+    options?: { convertMetricQueryToLogQuery?: boolean }
+  ): Promise<DataFrame[]> {
+    let queryExpr = query.expr;
+    if (isQueryWithError(this.interpolateString(queryExpr, placeHolderScopedVars))) {
+      return [];
+    }
+
+    if (!isLogsQuery(queryExpr)) {
+      // If it is not a logs query, we need to check if we need to convert it to a logs query
+      if (options?.convertMetricQueryToLogQuery) {
+        queryExpr = getLogQueryFromMetricsQuery(queryExpr);
+      }
+      // Otherwise, we return an empty array, as data samples are only supported for logs queries
       return [];
     }
 
     const lokiLogsQuery: LokiQuery = {
-      expr: query.expr,
+      expr: queryExpr,
       queryType: LokiQueryType.Range,
       refId: REF_ID_DATA_SAMPLES,
       maxLines: query.maxLines || DEFAULT_MAX_LINES_SAMPLE,

--- a/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/UnwrapParamEditor.tsx
@@ -1,12 +1,9 @@
 import { useState } from 'react';
 
-import { SelectableValue, getDefaultTimeRange, toOption } from '@grafana/data';
+import { DataSourceApi, SelectableValue, getDefaultTimeRange, toOption } from '@grafana/data';
 import { QueryBuilderOperationParamEditorProps, VisualQueryModeller } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
-import { placeHolderScopedVars } from '../../components/monaco-query-field/monaco-completion-provider/validation';
-import { LokiDatasource } from '../../datasource';
-import { getLogQueryFromMetricsQuery, isQueryWithError } from '../../queryUtils';
 import { extractUnwrapLabelKeysFromDataFrame } from '../../responseUtils';
 import { getOperationParamId } from '../operationUtils';
 import { LokiVisualQuery } from '../types';
@@ -31,11 +28,9 @@ export function UnwrapParamEditor({
       inputId={getOperationParamId(operationId, index)}
       onOpenMenu={async () => {
         // This check is always true, we do it to make typescript happy
-        if (datasource instanceof LokiDatasource) {
-          setState({ isLoading: true });
-          const options = await loadUnwrapOptions(query, datasource, queryModeller, timeRange);
-          setState({ options, isLoading: undefined });
-        }
+        setState({ isLoading: true });
+        const options = await loadUnwrapOptions(query, datasource, queryModeller, timeRange);
+        setState({ options, isLoading: undefined });
       }}
       isLoading={state.isLoading}
       allowCustomValue
@@ -54,17 +49,18 @@ export function UnwrapParamEditor({
 
 async function loadUnwrapOptions(
   query: LokiVisualQuery,
-  datasource: LokiDatasource,
+  datasource: DataSourceApi,
   queryModeller: VisualQueryModeller,
   timeRange = getDefaultTimeRange()
 ): Promise<Array<SelectableValue<string>>> {
   const queryExpr = queryModeller.renderQuery(query);
-  const logExpr = getLogQueryFromMetricsQuery(queryExpr);
-  if (isQueryWithError(datasource.interpolateString(logExpr, placeHolderScopedVars))) {
+  if (!('getDataSamples' in datasource) || typeof datasource.getDataSamples !== 'function') {
     return [];
   }
-
-  const samples = await datasource.getDataSamples({ expr: logExpr, refId: 'unwrap_samples' }, timeRange);
+  // the query is a metric query, we need to set metricQueryToLogConversion to true to getSamples use the log query
+  const samples = await datasource.getDataSamples({ expr: queryExpr, refId: 'unwrap_samples' }, timeRange, {
+    convertMetricQueryToLogQuery: true,
+  });
   const unwrapLabels = extractUnwrapLabelKeysFromDataFrame(samples[0]);
 
   const labelOptions = unwrapLabels.map((label) => ({


### PR DESCRIPTION
As mentioned in https://github.com/grafana/grafana/pull/107942:
*Currently Loki and MSSQL plugins cannot join the fun due to their tests using helpers (createFetchResponse), matchers (.toEmitValues) from public/test along with some core code imports.*

This PR fixes all failing tests when that happen when we run `yarn nx run @grafana-plugins/loki:test`. I have added comments and more details to the each change down below.

### How to test this

1. **Add `jest` to your `package.json` devDependencies:**
   ```json
   "devDependencies": {
     "jest": "^29.0.0"
   }
   ```

1. **Add the following file to your plugin directory:**
`jest-setup.js`
   ```js
   import '@grafana/plugin-configs/jest/jest-setup';
   ```

1.  **Add the following file to your plugin directory:**
`jest.config.js`
   ```js
   module.exports = {
     setupFilesAfterEnv: ['<rootDir>/jest-setup.js'],
     testEnvironment: 'jsdom',
   };
   ```

1. **Run your tests:**
  ```sh
   yarn nx run @grafana-plugins/loki:test
 ```

1. **Check that only 52 tests are failing** 
These are all `TypeError: expect(...).toEmitValuesWith is not a function` errors that will be fixed by https://github.com/grafana/grafana/pull/108610
 
```
Test Suites: 5 failed, 1 skipped, 57 passed, 62 of 63 total
Tests:       52 failed, 2 skipped, 1122 passed, 1176 total
```

Part of https://github.com/grafana/grafana/pull/107942
Related to https://github.com/grafana/grafana/pull/108610