### PR TITLE
Plugin Extensions: Support core plugins

### DIFF
--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -29,6 +29,7 @@ export function usePluginComponents<Props extends object = {}>({
 
   return useMemo(() => {
     const isInsidePlugin = Boolean(pluginContext);
+    const isCoreGrafanaPlugin = pluginContext?.meta.module.startsWith('core:') ?? false;
     const components: Array<ComponentTypeWithExtensionMeta<Props>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
@@ -38,7 +39,10 @@ export function usePluginComponents<Props extends object = {}>({
     });
 
     // Don't show extensions if the extension-point id is invalid in DEV mode
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
+    if (
+      isGrafanaDevMode() &&
+      !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, isCoreGrafanaPlugin, log: pointLog })
+    ) {
       return {
         isLoading: false,
         components: [],

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -50,7 +50,12 @@ export function usePluginComponents<Props extends object = {}>({
     }
 
     // Don't show extensions if the extension-point misses meta info (plugin.json) in DEV mode
-    if (isGrafanaDevMode() && pluginContext && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
+    if (
+      isGrafanaDevMode() &&
+      !isCoreGrafanaPlugin &&
+      pluginContext &&
+      isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)
+    ) {
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,

--- a/public/app/features/plugins/extensions/usePluginFunctions.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.tsx
@@ -24,6 +24,7 @@ export function usePluginFunctions<Signature>({
 
   return useMemo(() => {
     const isInsidePlugin = Boolean(pluginContext);
+    const isCoreGrafanaPlugin = pluginContext?.meta.module.startsWith('core:') ?? false;
     const results: Array<PluginExtensionFunction<Signature>> = [];
     const extensionsByPlugin: Record<string, number> = {};
     const pluginId = pluginContext?.meta.id ?? '';
@@ -32,7 +33,10 @@ export function usePluginFunctions<Signature>({
       extensionPointId,
     });
 
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
+    if (
+      isGrafanaDevMode() &&
+      !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, isCoreGrafanaPlugin, log: pointLog })
+    ) {
       return {
         isLoading: false,
         functions: [],

--- a/public/app/features/plugins/extensions/usePluginFunctions.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.tsx
@@ -43,7 +43,12 @@ export function usePluginFunctions<Signature>({
       };
     }
 
-    if (isGrafanaDevMode() && pluginContext && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
+    if (
+      isGrafanaDevMode() &&
+      !isCoreGrafanaPlugin &&
+      pluginContext &&
+      isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)
+    ) {
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -50,7 +50,12 @@ export function usePluginLinks({
       };
     }
 
-    if (isGrafanaDevMode() && pluginContext && isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)) {
+    if (
+      isGrafanaDevMode() &&
+      !isCoreGrafanaPlugin &&
+      pluginContext &&
+      isExtensionPointMetaInfoMissing(extensionPointId, pluginContext)
+    ) {
       pointLog.error(errors.EXTENSION_POINT_META_INFO_MISSING);
       return {
         isLoading: false,

--- a/public/app/features/plugins/extensions/usePluginLinks.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.tsx
@@ -34,12 +34,16 @@ export function usePluginLinks({
   return useMemo(() => {
     const isInsidePlugin = Boolean(pluginContext);
     const pluginId = pluginContext?.meta.id ?? '';
+    const isCoreGrafanaPlugin = pluginContext?.meta.module.startsWith('core:') ?? false;
     const pointLog = log.child({
       pluginId,
       extensionPointId,
     });
 
-    if (isGrafanaDevMode() && !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, log: pointLog })) {
+    if (
+      isGrafanaDevMode() &&
+      !isExtensionPointIdValid({ extensionPointId, pluginId, isInsidePlugin, isCoreGrafanaPlugin, log: pointLog })
+    ) {
       return {
         isLoading: false,
         links: [],

--- a/public/app/features/plugins/extensions/validators.test.tsx
+++ b/public/app/features/plugins/extensions/validators.test.tsx
@@ -217,6 +217,7 @@ describe('Plugin Extension Validators', () => {
           extensionPointId,
           pluginId,
           isInsidePlugin: pluginId !== 'grafana' && pluginId !== '',
+          isCoreGrafanaPlugin: false,
           log: createLogMock(),
         })
       ).toBe(true);
@@ -244,9 +245,22 @@ describe('Plugin Extension Validators', () => {
           extensionPointId,
           pluginId,
           isInsidePlugin: pluginId !== 'grafana' && pluginId !== '',
+          isCoreGrafanaPlugin: false,
           log: createLogMock(),
         })
       ).toBe(false);
+    });
+
+    it('should return FALSE true if the extension point id is set by a core plugin', () => {
+      expect(
+        isExtensionPointIdValid({
+          extensionPointId: 'traces',
+          pluginId: 'traces',
+          isInsidePlugin: true,
+          isCoreGrafanaPlugin: true,
+          log: createLogMock(),
+        })
+      ).toBe(true);
     });
   });
 

--- a/public/app/features/plugins/extensions/validators.ts
+++ b/public/app/features/plugins/extensions/validators.ts
@@ -69,17 +69,19 @@ export function isExtensionPointIdValid({
   extensionPointId,
   pluginId,
   isInsidePlugin,
+  isCoreGrafanaPlugin,
   log,
 }: {
   extensionPointId: string;
   pluginId: string;
   isInsidePlugin: boolean;
+  isCoreGrafanaPlugin: boolean;
   log: ExtensionsLog;
 }) {
   const startsWithPluginId =
     extensionPointId.startsWith(`${pluginId}/`) || extensionPointId.startsWith(`plugins/${pluginId}/`);
 
-  if (isInsidePlugin && !startsWithPluginId) {
+  if (isInsidePlugin && !isCoreGrafanaPlugin && !startsWithPluginId) {
     log.error(errors.INVALID_EXTENSION_POINT_ID_PLUGIN(pluginId, extensionPointId));
     return false;
   }


### PR DESCRIPTION
**Related thread:** https://raintank-corp.slack.com/archives/C01C4K8DETW/p1753345730229169
**Related PR:** https://github.com/grafana/grafana/pull/108473

### What changed?
Allowing core Grafana plugins to use core Grafana extension point ids. This can happen for example when a core panel plugin is importing components from core Grafana, which define extension points.