### PR TITLE
Tempo: Add options to getTagKeys

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -1227,7 +1227,17 @@ describe('should provide functionality for ad-hoc filters', () => {
   });
 
   it('for getTagKeys', async () => {
-    const response = await datasource.getTagKeys();
+    const response = await datasource.getTagKeys({
+      filters: [],
+      timeRange: {
+        from: dateTime('2021-04-20T15:55:00Z'),
+        to: dateTime('2021-04-20T15:55:00Z'),
+        raw: {
+          from: 'now-15m',
+          to: 'now',
+        },
+      },
+    });
     expect(response).toEqual([{ text: 'span.label1' }, { text: 'span.label2' }]);
   });
 

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -11,6 +11,7 @@ import {
   DataQueryRequest,
   DataQueryResponse,
   DataQueryResponseData,
+  DataSourceGetTagKeysOptions,
   DataSourceGetTagValuesOptions,
   DataSourceInstanceSettings,
   dateTime,
@@ -238,8 +239,8 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   }
 
   // Allows to retrieve the list of tags for ad-hoc filters
-  async getTagKeys(): Promise<Array<{ text: string }>> {
-    await this.languageProvider.fetchTags();
+  async getTagKeys(options: DataSourceGetTagKeysOptions<TempoQuery>): Promise<Array<{ text: string }>> {
+    await this.languageProvider.fetchTags(this.timeRangeForTags, options.timeRange);
     const tags = this.languageProvider.tagsV2 || [];
     return tags
       .map(({ name, tags }) =>


### PR DESCRIPTION
**What is this feature?**

Add options to getTagKeys.

**Why do we need this feature?**

So the time range and timeRangeForTags can be passed into the Tempo language provider.

**Special notes for your reviewer:**

Companion [PR](https://github.com/grafana/traces-drilldown/pull/533) in Traces Drilldown.