### PR TITLE
iam/authn: Introduce feature flag for authn resource mutations

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -995,6 +995,10 @@ export interface FeatureToggles {
   */
   kubernetesAuthzApis?: boolean;
   /**
+  * Enables create, delete, and update mutations for resoruces owned by IAM identity
+  */
+  kubernetesAuthnMutation?: boolean;
+  /**
   * Enables restore deleted dashboards feature
   * @default false
   */

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -995,7 +995,7 @@ export interface FeatureToggles {
   */
   kubernetesAuthzApis?: boolean;
   /**
-  * Enables create, delete, and update mutations for resoruces owned by IAM identity
+  * Enables create, delete, and update mutations for resources owned by IAM identity
   */
   kubernetesAuthnMutation?: boolean;
   /**

--- a/pkg/registry/apis/iam/models.go
+++ b/pkg/registry/apis/iam/models.go
@@ -44,6 +44,9 @@ type IdentityAccessManagementAPIBuilder struct {
 	// Toggle for enabling authz management apis
 	enableAuthZApis bool
 
+	// Toggle for enabling authn mutation
+	enableAuthnMutation bool
+
 	// Toggle for enabling dual writer
 	enableDualWriter bool
 }

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -56,16 +56,17 @@ func RegisterAPIService(
 	authorizer := newIAMAuthorizer(accessClient, legacyAccessClient)
 
 	builder := &IdentityAccessManagementAPIBuilder{
-		store:              store,
-		coreRolesStorage:   coreRolesStorage,
-		sso:                ssoService,
-		authorizer:         authorizer,
-		legacyAccessClient: legacyAccessClient,
-		accessClient:       accessClient,
-		display:            user.NewLegacyDisplayREST(store),
-		reg:                reg,
-		enableAuthZApis:    features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthzApis),
-		enableDualWriter:   true,
+		store:               store,
+		coreRolesStorage:    coreRolesStorage,
+		sso:                 ssoService,
+		authorizer:          authorizer,
+		legacyAccessClient:  legacyAccessClient,
+		accessClient:        accessClient,
+		display:             user.NewLegacyDisplayREST(store),
+		reg:                 reg,
+		enableAuthZApis:     features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthzApis),
+		enableAuthnMutation: features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthnMutation),
+		enableDualWriter:    true,
 	}
 	apiregistration.RegisterAPI(builder)
 
@@ -127,7 +128,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	storage[teamBindingResource.StoragePath()] = team.NewLegacyBindingStore(b.store)
 
 	userResource := legacyiamv0.UserResourceInfo
-	legacyStore := user.NewLegacyStore(b.store, b.legacyAccessClient)
+	legacyStore := user.NewLegacyStore(b.store, b.legacyAccessClient, b.enableAuthnMutation)
 	storage[userResource.StoragePath()] = legacyStore
 
 	if b.enableDualWriter {

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1717,7 +1717,7 @@ var (
 		},
 		{
 			Name:              "kubernetesAuthnMutation",
-			Description:       "Enables create, delete, and update mutations for resoruces owned by IAM identity",
+			Description:       "Enables create, delete, and update mutations for resources owned by IAM identity",
 			Stage:             FeatureStageExperimental,
 			Owner:             identityAccessTeam,
 			HideFromAdminPage: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1716,6 +1716,14 @@ var (
 			HideFromDocs:      true,
 		},
 		{
+			Name:              "kubernetesAuthnMutation",
+			Description:       "Enables create, delete, and update mutations for resoruces owned by IAM identity",
+			Stage:             FeatureStageExperimental,
+			Owner:             identityAccessTeam,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+		},
+		{
 			Name:              "restoreDashboards",
 			Description:       "Enables restore deleted dashboards feature",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -223,6 +223,7 @@ alertingListViewV2PreviewToggle,privatePreview,@grafana/alerting-squad,false,fal
 alertRuleUseFiredAtForStartsAt,experimental,@grafana/alerting-squad,false,false,false
 alertingBulkActionsInUI,GA,@grafana/alerting-squad,false,false,true
 kubernetesAuthzApis,experimental,@grafana/identity-access-team,false,false,false
+kubernetesAuthnMutation,experimental,@grafana/identity-access-team,false,false,false
 restoreDashboards,experimental,@grafana/grafana-frontend-platform,false,false,false
 skipTokenRotationIfRecent,GA,@grafana/identity-access-team,false,false,false
 alertEnrichment,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -903,6 +903,10 @@ const (
 	// Registers AuthZ /apis endpoint
 	FlagKubernetesAuthzApis = "kubernetesAuthzApis"
 
+	// FlagKubernetesAuthnMutation
+	// Enables create, delete, and update mutations for resoruces owned by IAM identity
+	FlagKubernetesAuthnMutation = "kubernetesAuthnMutation"
+
 	// FlagRestoreDashboards
 	// Enables restore deleted dashboards feature
 	FlagRestoreDashboards = "restoreDashboards"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -904,7 +904,7 @@ const (
 	FlagKubernetesAuthzApis = "kubernetesAuthzApis"
 
 	// FlagKubernetesAuthnMutation
-	// Enables create, delete, and update mutations for resoruces owned by IAM identity
+	// Enables create, delete, and update mutations for resources owned by IAM identity
 	FlagKubernetesAuthnMutation = "kubernetesAuthnMutation"
 
 	// FlagRestoreDashboards

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1672,6 +1672,23 @@
     },
     {
       "metadata": {
+        "name": "kubernetesAuthnMutation",
+        "resourceVersion": "1753453186265",
+        "creationTimestamp": "2025-07-25T14:12:51Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-07-25 14:19:46.265568 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables create, delete, and update mutations for resoruces owned by IAM identity",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesAuthzApis",
         "resourceVersion": "1753285129398",
         "creationTimestamp": "2025-06-18T07:43:01Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1673,14 +1673,14 @@
     {
       "metadata": {
         "name": "kubernetesAuthnMutation",
-        "resourceVersion": "1753453186265",
+        "resourceVersion": "1753454405614",
         "creationTimestamp": "2025-07-25T14:12:51Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2025-07-25 14:19:46.265568 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2025-07-25 14:40:05.614358 +0000 UTC"
         }
       },
       "spec": {
-        "description": "Enables create, delete, and update mutations for resoruces owned by IAM identity",
+        "description": "Enables create, delete, and update mutations for resources owned by IAM identity",
         "stage": "experimental",
         "codeowner": "@grafana/identity-access-team",
         "hideFromAdminPage": true,

--- a/pkg/tests/apis/iam/iam_test.go
+++ b/pkg/tests/apis/iam/iam_test.go
@@ -198,6 +198,7 @@ func TestIntegrationUsers(t *testing.T) {
 				},
 				EnableFeatureToggles: []string{
 					featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+					featuremgmt.FlagKubernetesAuthnMutation,
 				},
 			})
 			doUserCRUDTestsUsingTheNewAPIs(t, helper)


### PR DESCRIPTION
**What is this feature?**

This PR introduces a feature flag for us to be able enable/disable create, update, and delete operations of the resources owned by the IAM Identity squad.

**Why do we need this feature?**

To reduce the blast radius of changes that will be introduced over the next few days.

**Who is this feature for?**

IAM Identity squad.

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/identity-access-team/issues/1457
Precursor to https://github.com/grafana/grafana/pull/108489.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
