### PR TITLE
Checkbox: aria-checked property to include true and false

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -39,7 +39,7 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     );
     const styles = useStyles2(getCheckboxStyles, invalid);
 
-    const ariaChecked = indeterminate ? 'mixed' : undefined;
+    const ariaChecked = indeterminate ? 'mixed' : value;
 
     return (
       <label className={cx(styles.wrapper, className)}>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

While doing some e2e testing on a plugin, I noticed that the `mixed` value was being set on `aria-checked` for the `Checkbox` component when `indeterminate` was true, but nothing was being set for the non-`indeterminate` case. I realized that `true` and `false` were also legal values, and wanted to be able to see them in my e2e tests. This change will set `aria-checked` to true or false (depending on the `value` prop), if the `indeterminate` prop isn't already setting it to `mixed`.

**Why do we need this feature?**

To be more complete on this component's use of `aria-checked`.

As per https://developer.mozilla.org/en-US/docs/Web/API/Element/ariaChecked:

> "true"
> The element is checked.
> 
> "mixed"
> Indicates a mixed mode value for a tri-state checkbox or menuitemcheckbox.
> 
> "false"
> The element supports being checked but is not currently checked.
> 
> "undefined"
> The element does not support being checked.

This PR addresses the current behavior, which is setting both "true" and "false" cases to "undefined," when they should be "true" or "false".

**Who is this feature for?**

Anyone who relies on `aria-checked` to know the state of the component.

**Which issue(s) does this PR fix?**:


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [ ] ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
