### PR TITLE
docs: clarifying alert rule limits in Grafana cloud for migration assistant

### DIFF
--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -198,7 +198,19 @@ The `grafana-default-email` contact point that's provisioned with every new Graf
 
 This is sufficient to have your Alerting configuration up and running in Grafana Cloud with minimal effort.
 
+#### Migration assistant limitations on Grafana Alerting resources
+
 Migration of Silences is not supported by the migration assistant and needs to be configured manually. Alert History is also not available for migration.
+
+Attempting to migrate a large number of alert rules might result in the following error:
+
+```
+Maximum number of alert rule groups reached: Delete some alert rule groups or upgrade your plan and try again.
+```
+
+To avoid this, refer to the [Alert rule limits in Grafana Cloud](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/#alert-rule-limits-in-grafana-cloud).
+
+#### Prevent duplicated alert notifications
 
 Successfully migrating Alerting resources to your Grafana Cloud instance could result in 2 sets of notifications being generated:
 

--- a/docs/sources/administration/migration-guide/cloud-migration-assistant.md
+++ b/docs/sources/administration/migration-guide/cloud-migration-assistant.md
@@ -208,7 +208,7 @@ Attempting to migrate a large number of alert rules might result in the followin
 Maximum number of alert rule groups reached: Delete some alert rule groups or upgrade your plan and try again.
 ```
 
-To avoid this, refer to the [Alert rule limits in Grafana Cloud](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/#alert-rule-limits-in-grafana-cloud).
+To avoid this, refer to the [Alert rule limits in Grafana Cloud](https://grafana.com/docs/grafana-cloud/alerting-and-irm/alerting/alerting-rules/create-grafana-managed-rule/#alert-rule-limits-in-grafana-cloud) when migrating alert rules.
 
 #### Prevent duplicated alert notifications
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds information on alert rule limits in Grafana Cloud and adds subheadings for alerting resources section of migration assistant docs

**Why do we need this feature?**

Currently, when trying to migrate alert rules in excess of the limits in Grafana Cloud, users are simply met with an error telling them to delete alert rules or change their cloud plan. This is not helpful as they have no context as to what the limits are so there is no way they can triage (even paid customers need to contact support manually to exceed the soft limit in cloud). This PR adds a reference to what the limits are so people reading the docs are provided actionable information. Additionally, this PR breaks the "Grafana Alerting" subheading into 2 sections, previously it all kind of ran together. This way the information is more structured and clear as to what the sections are describing.

**Who is this feature for?**

All users of the Grafana Cloud Migration Assistant.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
