### PR TITLE
CloudWatch: Clear log groups when region is changed

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.test.tsx
@@ -26,14 +26,19 @@ describe('QueryHeader', () => {
       { value: 'us-east-2', label: 'us-east-2' },
       { value: 'us-east-1', label: 'us-east-1' },
     ]);
-    it('should reset account id if new region is not monitoring account', async () => {
+    it('should reset account id and log groups if new region is not monitoring account', async () => {
       config.featureToggles.cloudWatchCrossAccountQuerying = true;
       const onChange = jest.fn();
       datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(false);
       render(
         <QueryHeader
           datasource={datasource}
-          query={{ ...validMetricSearchBuilderQuery, region: 'us-east-1', accountId: 'all' }}
+          query={{
+            ...validMetricSearchBuilderQuery,
+            region: 'us-east-1',
+            accountId: 'all',
+            logGroups: [{ arn: 'arn', name: 'name' }],
+          }}
           onChange={onChange}
           onRunQuery={jest.fn()}
           dataIsStale={false}
@@ -45,10 +50,11 @@ describe('QueryHeader', () => {
         ...validMetricSearchBuilderQuery,
         region: 'us-east-2',
         accountId: undefined,
+        logGroups: [],
       });
     });
 
-    it('should not reset account id if new region is a monitoring account', async () => {
+    it('should reset log groups but not account id if new region is a monitoring account', async () => {
       config.featureToggles.cloudWatchCrossAccountQuerying = true;
       const onChange = jest.fn();
       datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(true);
@@ -56,7 +62,12 @@ describe('QueryHeader', () => {
       render(
         <QueryHeader
           datasource={datasource}
-          query={{ ...validMetricSearchBuilderQuery, region: 'us-east-1', accountId: '123' }}
+          query={{
+            ...validMetricSearchBuilderQuery,
+            region: 'us-east-1',
+            accountId: '123',
+            logGroups: [{ arn: 'arn', name: 'name' }],
+          }}
           onChange={onChange}
           onRunQuery={jest.fn()}
           dataIsStale={false}
@@ -68,6 +79,7 @@ describe('QueryHeader', () => {
         ...validMetricSearchBuilderQuery,
         region: 'us-east-2',
         accountId: '123',
+        logGroups: [],
       });
     });
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
@@ -47,9 +47,9 @@ const QueryHeader = ({
   const onRegionChange = async (region: string) => {
     if (config.featureToggles.cloudWatchCrossAccountQuerying && isCloudWatchMetricsQuery(query)) {
       const isMonitoringAccount = await datasource.resources.isMonitoringAccount(region);
-      onChange({ ...query, region, accountId: isMonitoringAccount ? query.accountId : undefined });
+      onChange({ ...query, logGroups: [], region, accountId: isMonitoringAccount ? query.accountId : undefined });
     } else {
-      onChange({ ...query, region });
+      onChange({ ...query, logGroups: [], region });
     }
   };
 


### PR DESCRIPTION
Updates the query editor to clear the log groups when the region is updated

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #105934 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
