### PR TITLE
Plugins: loading check for rendererDisableAppPluginsPreload and log a…

### DIFF
--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -67,17 +67,31 @@ export async function importPluginModule({
   }
 
   return SystemJS.import(modulePath).catch((e) => {
-    let error = new Error('Could not load plugin: ' + e);
-    console.error(error);
-    pluginsLogger.logError(error, {
-      path,
-      pluginId,
-      pluginVersion: version ?? '',
-      expectedHash: moduleHash ?? '',
-      loadingStrategy: loadingStrategy.toString(),
-      sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
-      newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
-    });
-    throw error;
+    // If rendererDisableAppPluginsPreload is enabled log a specific error message
+    if (config.featureToggles.rendererDisableAppPluginsPreload) {
+      let error = new Error('Plugin loading skipped due to rendererDisableAppPluginsPreload: ' + e);
+      console.error(error);
+      pluginsLogger.logError(error, {
+        path,
+        pluginId,
+        pluginVersion: version ?? '',
+        loadingStrategy: loadingStrategy.toString(),
+      });
+
+      throw error;
+    } else {
+      let error = new Error('Could not load plugin: ' + e);
+      console.error(error);
+      pluginsLogger.logError(error, {
+        path,
+        pluginId,
+        pluginVersion: version ?? '',
+        expectedHash: moduleHash ?? '',
+        loadingStrategy: loadingStrategy.toString(),
+        sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
+        newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
+      });
+      throw error;
+    }
   });
 }

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -67,31 +67,23 @@ export async function importPluginModule({
   }
 
   return SystemJS.import(modulePath).catch((e) => {
+    let error = new Error('Could not load plugin: ' + e);
+
     // If rendererDisableAppPluginsPreload is enabled log a specific error message
     if (config.featureToggles.rendererDisableAppPluginsPreload) {
-      let error = new Error('Plugin loading skipped due to rendererDisableAppPluginsPreload: ' + e);
-      console.error(error);
-      pluginsLogger.logError(error, {
-        path,
-        pluginId,
-        pluginVersion: version ?? '',
-        loadingStrategy: loadingStrategy.toString(),
-      });
-
-      throw error;
-    } else {
-      let error = new Error('Could not load plugin: ' + e);
-      console.error(error);
-      pluginsLogger.logError(error, {
-        path,
-        pluginId,
-        pluginVersion: version ?? '',
-        expectedHash: moduleHash ?? '',
-        loadingStrategy: loadingStrategy.toString(),
-        sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
-        newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
-      });
-      throw error;
+      error = new Error('Plugin loading skipped due to rendererDisableAppPluginsPreload: ' + e);
     }
+
+    console.error(error);
+    pluginsLogger.logError(error, {
+      path,
+      pluginId,
+      pluginVersion: version ?? '',
+      expectedHash: moduleHash ?? '',
+      loadingStrategy: loadingStrategy.toString(),
+      sriChecksEnabled: String(Boolean(config.featureToggles.pluginsSriChecks)),
+      newPluginLoadingEnabled: String(Boolean(config.featureToggles.enablePluginImporter)),
+    });
+    throw error;
   });
 }

--- a/public/app/features/plugins/importer/importPluginModule.ts
+++ b/public/app/features/plugins/importer/importPluginModule.ts
@@ -2,6 +2,7 @@ import { DEFAULT_LANGUAGE } from '@grafana/i18n';
 import { getResolvedLanguage } from '@grafana/i18n/internal';
 import { config } from '@grafana/runtime';
 
+import { contextSrv } from '../../../core/services/context_srv';
 import builtInPlugins from '../built_in_plugins';
 import { registerPluginInCache } from '../loader/cache';
 import { SystemJS } from '../loader/systemjs';
@@ -70,7 +71,7 @@ export async function importPluginModule({
     let error = new Error('Could not load plugin: ' + e);
 
     // If rendererDisableAppPluginsPreload is enabled log a specific error message
-    if (config.featureToggles.rendererDisableAppPluginsPreload) {
+    if (config.featureToggles.rendererDisableAppPluginsPreload && contextSrv.user.authenticatedBy === 'render') {
       error = new Error('Plugin loading skipped due to rendererDisableAppPluginsPreload: ' + e);
     }
 


### PR DESCRIPTION
What is this feature?

The Logs Drilldown plugin is trying to create alerts from the log line `Could not load plugin:` This error we believe is unintentionally triggered by this feature flag `rendererDisableAppPluginsPreload` [PR](https://github.com/grafana/grafana/pull/100221).  In an effort to reduce the noise for `Could not load plugin:`, but still have an error message. A specific error message was added per the feature flag.

If there is a better way to achieve this, please let me know!

Why do we need this feature?
This will help reduce noise in our logs.

Who is this feature for?
Logs Drilldown, but potentially any plugin making alerts.

Special notes for your reviewer:

Please check that:

 It works as expected from a user's perspective.
 If this is a pre-GA feature, it is behind a feature toggle.
 The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.