### PR TITLE
Unistore: Fix federated stats

### DIFF
--- a/pkg/storage/unified/federated/federatedtests/stats_test.go
+++ b/pkg/storage/unified/federated/federatedtests/stats_test.go
@@ -9,13 +9,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apiserver/pkg/endpoints/request"
 
-	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/infra/tracing"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
-	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -23,12 +19,9 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngalertstore "github.com/grafana/grafana/pkg/services/ngalert/store"
-	"github.com/grafana/grafana/pkg/services/search/sort"
-	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
-	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/federated"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
@@ -38,6 +31,7 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 
+// tests stats are correctly reported from legacy tables
 func TestIntegrationDirectSQLStats(t *testing.T) {
 	db, cfg := db.InitTestDBWithCfg(t)
 	ctx := context.Background()
@@ -45,21 +39,42 @@ func TestIntegrationDirectSQLStats(t *testing.T) {
 	dashStore, err := database.ProvideDashboardStore(db, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(db))
 	require.NoError(t, err)
 	fStore := folderimpl.ProvideStore(db)
-	folderSvc := folderimpl.ProvideService(
-		fStore, actest.FakeAccessControl{ExpectedEvaluate: true}, bus.ProvideBus(tracing.InitializeTracerForTest()), dashStore, folderimpl.ProvideDashboardFolderStore(db),
-		nil, db, featuremgmt.WithFeatures(), supportbundlestest.NewFakeBundleService(), nil, cfg, nil, tracing.InitializeTracerForTest(), nil, dualwrite.ProvideTestService(), sort.ProvideService(), apiserver.WithoutRestConfig)
-
-	// create parent folder
-
 	tempUser := &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{}}
 
-	// create folders - test2 is nested in test1
+	// legacy expects the folder to be in both the dashboards and folder tables
 	folder1UID := "test1"
 	now := time.Now()
-	_, err = folderSvc.Create(ctx, &folder.CreateFolderCommand{Title: "test1", UID: folder1UID, OrgID: 1, SignedInUser: tempUser})
+	dashFolder1 := dashboards.NewDashboardFolder("test1")
+	dashFolder1.SetUID(folder1UID)
+	dashFolder1.OrgID = 1
+	dashFolder1.CreatedBy = tempUser.UserID
+	dashFolder1.UpdatedBy = tempUser.UserID
+	_, err = dashStore.SaveDashboard(ctx, dashboards.SaveDashboardCommand{
+		Dashboard: dashFolder1.Data,
+		OrgID:     1,
+		UserID:    tempUser.UserID,
+		IsFolder:  true,
+	})
 	require.NoError(t, err)
+	_, err = fStore.Create(ctx, folder.CreateFolderCommand{Title: "test1", UID: folder1UID, OrgID: 1, SignedInUser: tempUser})
+	require.NoError(t, err)
+
 	folder2UID := "test2"
-	_, err = folderSvc.Create(ctx, &folder.CreateFolderCommand{Title: "test2", UID: folder2UID, OrgID: 1, ParentUID: folder1UID, SignedInUser: tempUser})
+	dashFolder2 := dashboards.NewDashboardFolder("test2")
+	dashFolder2.SetUID(folder2UID)
+	dashFolder2.OrgID = 1
+	dashFolder2.FolderUID = folder1UID
+	dashFolder2.CreatedBy = tempUser.UserID
+	dashFolder2.UpdatedBy = tempUser.UserID
+	_, err = dashStore.SaveDashboard(ctx, dashboards.SaveDashboardCommand{
+		Dashboard: dashFolder2.Data,
+		OrgID:     1,
+		UserID:    tempUser.UserID,
+		IsFolder:  true,
+		FolderUID: folder1UID,
+	})
+	require.NoError(t, err)
+	_, err = fStore.Create(ctx, folder.CreateFolderCommand{Title: "test2", UID: folder2UID, OrgID: 1, ParentUID: folder1UID, SignedInUser: tempUser})
 	require.NoError(t, err)
 
 	// create an alert rule inside of folder test2

--- a/pkg/storage/unified/federated/stats.go
+++ b/pkg/storage/unified/federated/stats.go
@@ -64,7 +64,7 @@ func (s *LegacyStatsGetter) GetStats(ctx context.Context, in *resourcepb.Resourc
 		}
 
 		// Legacy dashboard table
-		err = fn("dashboard", "org_id=? AND folder_uid=?", group, "dashboards", true)
+		err = fn("dashboard", "org_id=? AND folder_uid=? AND is_folder=false", group, "dashboards", true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
While working on https://github.com/grafana/grafana/pull/108626 -- found this bug, where we are counting folders as dashboards in the federated stats.

Also updated the test to be compatible with what we need for removing the `kubernetesClientDashboardsFolders` feature toggle