### PR TITLE
Alerting: Add rule group name validation to the Prometheus conversion API

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -291,6 +291,30 @@ func TestRouteConvertPrometheusPostRuleGroup(t *testing.T) {
 		}
 	})
 
+	t.Run("with empty rule group name should return 400", func(t *testing.T) {
+		srv, _, _ := createConvertPrometheusSrv(t)
+		rc := createRequestCtx()
+
+		emptyNameGroup := apimodels.PrometheusRuleGroup{
+			Name:     "",
+			Interval: prommodel.Duration(1 * time.Minute),
+			Rules: []apimodels.PrometheusRule{
+				{
+					Alert: "TestAlert",
+					Expr:  "up == 0",
+					For:   util.Pointer(prommodel.Duration(5 * time.Minute)),
+					Labels: map[string]string{
+						"severity": "critical",
+					},
+				},
+			},
+		}
+
+		response := srv.RouteConvertPrometheusPostRuleGroup(rc, "test", emptyNameGroup)
+		require.Equal(t, http.StatusBadRequest, response.Status())
+		require.Contains(t, string(response.Body()), "rule group name must not be empty")
+	})
+
 	t.Run("with valid request should return 202", func(t *testing.T) {
 		srv, _, _ := createConvertPrometheusSrv(t)
 		rc := createRequestCtx()

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -144,6 +144,22 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:      "rule group with empty name",
+			orgID:     1,
+			namespace: "namespaceUID",
+			promGroup: PrometheusRuleGroup{
+				Name: "",
+				Rules: []PrometheusRule{
+					{
+						Alert: "alert-1",
+						Expr:  "up == 0",
+					},
+				},
+			},
+			expectError: true,
+			errorMsg:    "rule group name must not be empty",
+		},
+		{
 			name:      "recording rule",
 			orgID:     1,
 			namespace: "namespaceUID",


### PR DESCRIPTION
What is this feature?

Adds rule group name validation to the the Alerting Prometheus conversion API. Currently it's possible to send a rule group with an empty name, and this PR makes this impossible.

Also improves error handling in the conversion API by propagating error messages to API responses. 
