### PR TITLE
Canvas: Center & scale select, resize, zoom bugs

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -802,12 +802,12 @@ export class ElementState implements LayerElement {
 
   // kinda like:
   // https://github.com/grafana/grafana-edge-app/blob/main/src/panels/draw/WrapItem.tsx#L44
-  applyResize = (event: OnResize, transformScale = 1) => {
+  applyResize = (event: OnResize) => {
     const placement = this.options.placement!;
 
     const style = event.target.style;
-    let deltaX = event.delta[0] / transformScale;
-    let deltaY = event.delta[1] / transformScale;
+    let deltaX = event.delta[0];
+    let deltaY = event.delta[1];
     let dirLR = event.direction[0];
     let dirTB = event.direction[1];
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -54,9 +54,6 @@ export class ElementState implements LayerElement {
   // Temp stored constraint for visualization purposes (switch to top / left constraint to simplify some functionality)
   tempConstraint: Constraint | undefined;
 
-  // Flag to track if element is currently being resized
-  isResizing = false;
-
   // Filled in by ref
   div?: HTMLDivElement;
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -54,6 +54,9 @@ export class ElementState implements LayerElement {
   // Temp stored constraint for visualization purposes (switch to top / left constraint to simplify some functionality)
   tempConstraint: Constraint | undefined;
 
+  // Flag to track if element is currently being resized
+  isResizing = false;
+
   // Filled in by ref
   div?: HTMLDivElement;
 
@@ -566,7 +569,7 @@ export class ElementState implements LayerElement {
         break;
       case VerticalConstraint.Center:
         const elementCenter = elementContainer ? relativeTop + height / 2 : 0;
-        const parentCenter = parentContainer ? parentContainer.height / 2 : 0;
+        const parentCenter = scene.height / 2; // Use scene height instead of scaled viewport height
         const distanceFromCenter = parentCenter - elementCenter;
         placement.top = distanceFromCenter;
         placement.height = height;
@@ -592,7 +595,7 @@ export class ElementState implements LayerElement {
         break;
       case HorizontalConstraint.Center:
         const elementCenter = elementContainer ? relativeLeft + width / 2 : 0;
-        const parentCenter = parentContainer ? parentContainer.width / 2 : 0;
+        const parentCenter = scene.width / 2; // Use scene width instead of scaled viewport width
         const distanceFromCenter = parentCenter - elementCenter;
         placement.left = distanceFromCenter;
         placement.width = width;
@@ -848,6 +851,9 @@ export class ElementState implements LayerElement {
     } else if (dirTB === 1) {
       placement.height = event.height;
       style.height = `${placement.height}px`;
+    }
+    if (config.featureToggles.canvasPanelPanZoom) {
+      style.transform = `translate(${placement.left ?? 0}px, ${placement.top ?? 0}px) rotate(${placement.rotation ?? 0}deg)`;
     }
   };
 

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -829,7 +829,7 @@ export class ElementState implements LayerElement {
       placement.left! -= deltaX;
       placement.width = event.width;
       if (config.featureToggles.canvasPanelPanZoom) {
-        style.transform = `translate(${placement.left}px, ${placement.top}px)`;
+        style.transform = `translate(${placement.left}px, ${placement.top}px) rotate(${placement.rotation ?? 0}deg)`;
       } else {
         style.left = `${placement.left}px`;
       }
@@ -840,7 +840,7 @@ export class ElementState implements LayerElement {
       placement.top! -= deltaY;
       placement.height = event.height;
       if (config.featureToggles.canvasPanelPanZoom) {
-        style.transform = `translate(${placement.left}px, ${placement.top}px)`;
+        style.transform = `translate(${placement.left}px, ${placement.top}px) rotate(${placement.rotation ?? 0}deg)`;
       } else {
         style.top = `${placement.top}px`;
       }
@@ -848,9 +848,6 @@ export class ElementState implements LayerElement {
     } else if (dirTB === 1) {
       placement.height = event.height;
       style.height = `${placement.height}px`;
-    }
-    if (config.featureToggles.canvasPanelPanZoom) {
-      style.transform = `translate(${placement.left ?? 0}px, ${placement.top ?? 0}px) rotate(${placement.rotation ?? 0}deg)`;
     }
   };
 

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -303,7 +303,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
     .on('resize', (event) => {
       const targetedElement = findElementByTarget(event.target, scene.root.elements);
       if (targetedElement) {
-        targetedElement.applyResize(event, scene.scale ?? 1);
+        targetedElement.applyResize(event);
 
         if (scene.connections.connectionsNeedUpdate(targetedElement) && scene.moveableActionCallback) {
           scene.moveableActionCallback(true);
@@ -316,7 +316,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
       for (let event of e.events) {
         const targetedElement = findElementByTarget(event.target, scene.root.elements);
         if (targetedElement) {
-          targetedElement.applyResize(event, scene.scale ?? 1);
+          targetedElement.applyResize(event);
 
           if (!needsUpdate) {
             needsUpdate = scene.connections.connectionsNeedUpdate(targetedElement);

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -287,6 +287,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
           }
         }
       }
+      // Temporarily set Top-Left constraints on each group element for predictable resizing; restore originals on end.
       for (let event of e.events) {
         const targetedElement = findElementByTarget(event.target, scene.root.elements);
         if (targetedElement) {

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -269,13 +269,11 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
           }
         }
 
-        if (!config.featureToggles.canvasPanelPanZoom) {
-          targetedElement.tempConstraint = { ...targetedElement.options.constraint };
-          targetedElement.options.constraint = {
-            vertical: VerticalConstraint.Top,
-            horizontal: HorizontalConstraint.Left,
-          };
-        }
+        targetedElement.tempConstraint = { ...targetedElement.options.constraint };
+        targetedElement.options.constraint = {
+          vertical: VerticalConstraint.Top,
+          horizontal: HorizontalConstraint.Left,
+        };
         targetedElement.setPlacementFromConstraint(undefined, undefined, scene.scale);
       }
     })
@@ -289,15 +287,22 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
           }
         }
       }
+      for (let event of e.events) {
+        const targetedElement = findElementByTarget(event.target, scene.root.elements);
+        if (targetedElement) {
+          targetedElement.tempConstraint = { ...targetedElement.options.constraint };
+          targetedElement.options.constraint = {
+            vertical: VerticalConstraint.Top,
+            horizontal: HorizontalConstraint.Left,
+          };
+          targetedElement.setPlacementFromConstraint(undefined, undefined, scene.scale);
+        }
+      }
     })
     .on('resize', (event) => {
       const targetedElement = findElementByTarget(event.target, scene.root.elements);
       if (targetedElement) {
-        if (config.featureToggles.canvasPanelPanZoom) {
-          targetedElement.applyResize(event);
-        } else {
-          targetedElement.applyResize(event, scene.scale);
-        }
+        targetedElement.applyResize(event, scene.scale ?? 1);
 
         if (scene.connections.connectionsNeedUpdate(targetedElement) && scene.moveableActionCallback) {
           scene.moveableActionCallback(true);
@@ -310,7 +315,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
       for (let event of e.events) {
         const targetedElement = findElementByTarget(event.target, scene.root.elements);
         if (targetedElement) {
-          targetedElement.applyResize(event);
+          targetedElement.applyResize(event, scene.scale ?? 1);
 
           if (!needsUpdate) {
             needsUpdate = scene.connections.connectionsNeedUpdate(targetedElement);
@@ -328,7 +333,7 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
       const targetedElement = findElementByTarget(event.target, scene.root.elements);
 
       if (targetedElement) {
-        if (targetedElement.tempConstraint && !config.featureToggles.canvasPanelPanZoom) {
+        if (targetedElement.tempConstraint) {
           targetedElement.options.constraint = targetedElement.tempConstraint;
           targetedElement.tempConstraint = undefined;
         }


### PR DESCRIPTION
For elements that are using center or scale constrained layouts, when zooming, selecting, resizing, and rotating said elements, they were jumping around the canvas unexpectedly. This PR attempts to address these irregularities and even seeks to fix behavior during multi-select of elements that are constrained using different modes.