### PR TITLE
change method "GET" to "DELETE" with the "Delete a report" API

### DIFF
--- a/docs/sources/developers/http_api/reporting.md
+++ b/docs/sources/developers/http_api/reporting.md
@@ -401,7 +401,7 @@ See note in the [introduction](#reporting-api) for an explanation.
 ### Example request
 
 ```http
-GET /api/reports/6 HTTP/1.1
+DELETE /api/reports/6 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
 Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk


### PR DESCRIPTION
Hello, there seems to be an error in the Reporting API of http_api. In the example of Delete a report, the HTTP method should be Delete, but GET is displayed. The link is below
https://grafana.com/docs/grafana/latest/developers/http_api/reporting/#delete-a-report

`GET /api/reports/6 HTTP/1.1
Accept: application/json
Content-Type: application/json
Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk`

should be

`DELETE /api/reports/6 HTTP/1.1
Accept: application/json
Content-Type: application/json
Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk`