### PR TITLE
Docs: Update for certutil in container

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
+++ b/docs/sources/setup-grafana/image-rendering/troubleshooting/index.md
@@ -112,6 +112,11 @@ RUN update-ca-certificates --fresh
 
 # Reassume the nonroot user for the service execution.
 USER nonroot
+
+# Some CA certificates also need to explicitly be included in the user's network security services database.
+# certutil is shipped in v4.0.8 and onwards of the image.
+RUN mkdir -p /home/nonroot/.pki/nssdb
+RUN certutil -d sql:/home/nonroot/.pki/nssdb -A -n internal-root-ca -t C -i /usr/local/share/ca-certificates/rootCA.crt
 ```
 
 {{< admonition type="note" >}}


### PR DESCRIPTION
We sometimes require certutil in the container.

Related GIR PR for adding the util: https://github.com/grafana/grafana-image-renderer/pull/685

Ticket: https://github.com/grafana/grafana-image-renderer/issues/676