### PR TITLE
Alerting: Fix backtick handling when hashing queries

### DIFF
--- a/public/app/features/alerting/unified/utils/__snapshots__/rule-id.test.tsx.snap
+++ b/public/app/features/alerting/unified/utils/__snapshots__/rule-id.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`hashRulerRule should hash alerting rule 1`] = `"7317348"`;
+exports[`hashRulerRule should hash alerting rule 1`] = `"852037155"`;
 
-exports[`hashRulerRule should hash recording rules 1`] = `"-447747460"`;
+exports[`hashRulerRule should hash recording rules 1`] = `"914562864"`;

--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -311,9 +311,21 @@ export function hashQuery(query: string) {
   if (query.length > 1 && query[0] === '(' && query[query.length - 1] === ')') {
     query = query.slice(1, -1);
   }
+
   // whitespace could be added or removed
   query = query.replace(/\s|\n/g, '');
-  // labels matchers can be reordered, so sort the enitre string, esentially comparing just the character counts
+
+  // normalize escaped quotes in template strings like {{\"REQ_SENT\"}} -> {{"REQ_SENT"}}
+  query = query.replace(/\\"/g, '"');
+
+  // normalize backtick template strings to double quotes for consistency
+  // Convert `{{.field}}` to "{{.field}}"
+  query = query.replace(/`([^`]*)`/g, '"$1"');
+
+  // remove quotes, brackets, parentheses, backslashes, and backticks
+  query = query.replace(/['"()\[\]\\`]/g, '');
+
+  // labels matchers can be reordered, so sort the entire string, essentially comparing just the character counts
   return query.split('').sort().join('');
 }
 


### PR DESCRIPTION
This pull request enhances the functionality of the `hashQuery` function and its associated tests in the unified alerting utilities. The changes focus on improving query normalization and ensuring consistent hash generation for various query formats. Additionally, snapshot updates reflect the changes in hash values.

### Enhancements to Query Normalization:

* [`public/app/features/alerting/unified/utils/rule-id.ts`](diffhunk://#diff-d39aa8bb5f5c32177ba0cef60b1277b58288013d5d2ac2daaa68930771e4c350R314-R328): Enhanced the `hashQuery` function to handle escaped quotes, normalize backtick template strings to double quotes, and remove unnecessary characters like quotes, brackets, parentheses, backslashes, and backticks. This ensures consistent hashing for queries with different formatting or special characters.

### Expanded Test Coverage:

* [`public/app/features/alerting/unified/utils/rule-id.test.tsx`](diffhunk://#diff-5ac1e46d893d96f52104318a0d54e05b68c53bf9928531db078783fdeaef9c41R269-R376): Added comprehensive test cases for `hashQuery` to validate consistent hash generation across various query formats, including whitespace differences, label matcher reordering, quote normalization, and complex nested structures.

### Snapshot Updates:

* [`public/app/features/alerting/unified/utils/__snapshots__/rule-id.test.tsx.snap`](diffhunk://#diff-698eaad5779ec96e7fd4f37b71a21822cd2b821b5cec9b74d7df0e7fb29e622cL3-R5): Updated snapshot values to reflect the new hash outputs generated by the enhanced `hashQuery` function.

### Import Adjustments:

* [`public/app/features/alerting/unified/utils/rule-id.test.tsx`](diffhunk://#diff-5ac1e46d893d96f52104318a0d54e05b68c53bf9928531db078783fdeaef9c41L16-R24): Updated imports to include the newly introduced `hashQuery` function.