### PR TITLE
AWS Datasources: Fix forward_settings_to_plugins default value

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -992,7 +992,7 @@ session_duration = "15m"
 
 # Set the plugins that will receive AWS settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned AWS plugins, or those that make use of AWS settings (ElasticSearch, Prometheus).
-forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-app, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
+forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
 
 #################################### Azure ###############################
 [azure]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This fixes the `aws.forward_settings_to_plugins` default config value to work with the AWS IoT TwinMaker App. Although its plugin id is defined as `grafana-iot-twinmaker-app`, the datasource type, which is used to check `foward_settings_to_plugins`, is `grafana-iot-twinmaker-datasource`.
[Add a brief description of what the feature or update does.]

**Why do we need this feature?**
Currently only the default value for `allowed_auth_providers`, `default,keys,credentials` is sent to the twinmaker datasource. This makes it impossible to configure the `ec2_iam_role` auth method.

**Which issue(s) does this PR fix?**:
Fixes #108559.