### PR TITLE
Provisioning: Use commit only once mode in bulk delete

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -46,9 +46,12 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		return w.deleteFiles(ctx, rw, progress, opts, paths...)
 	}
 
+	msg := fmt.Sprintf("Delete from Grafana %s", job.Name)
 	stageOptions := repository.StageOptions{
-		PushOnWrites: false,
-		Timeout:      10 * time.Minute,
+		Mode:                  repository.StageModeCommitOnlyOnce,
+		CommitOnlyOnceMessage: msg,
+		PushOnWrites:          false,
+		Timeout:               10 * time.Minute,
 	}
 
 	err := w.wrapFn(ctx, repo, stageOptions, fn)

--- a/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
@@ -93,7 +93,10 @@ func TestDeleteWorker_ProcessNotReaderWriter(t *testing.T) {
 	mockWrapFn := repository.NewMockWrapWithStageFn(t)
 
 	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.MatchedBy(func(opts repository.StageOptions) bool {
-		return !opts.PushOnWrites && opts.Timeout == 10*time.Minute
+		return !opts.PushOnWrites &&
+			opts.Timeout == 10*time.Minute &&
+			opts.Mode == repository.StageModeCommitOnlyOnce &&
+			opts.CommitOnlyOnceMessage == "Delete from Grafana "+job.Name
 	}), mock.Anything).Return(errors.New("delete job submitted targeting repository that is not a ReaderWriter"))
 
 	mockProgress.On("SetTotal", mock.Anything, 1).Return()
@@ -145,7 +148,10 @@ func TestDeleteWorker_ProcessDeleteFilesSuccess(t *testing.T) {
 	mockWrapFn := repository.NewMockWrapWithStageFn(t)
 
 	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.MatchedBy(func(opts repository.StageOptions) bool {
-		return !opts.PushOnWrites && opts.Timeout == 10*time.Minute
+		return !opts.PushOnWrites &&
+			opts.Timeout == 10*time.Minute &&
+			opts.Mode == repository.StageModeCommitOnlyOnce &&
+			opts.CommitOnlyOnceMessage == "Delete from Grafana "+job.Name
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(mockRepo, false)
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Use commit only once mode in bulk delete job.

**Why do we need this feature?**

To avoid cluttering the job history with a commit per file.

**Who is this feature for?**

Users of Git Sync.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/378>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


**Testing**

I queued a delete job with a bunch of paths and see that they were removed in a single commit with the expected commit message name. 
<img width="1827" height="441" alt="image" src="https://github.com/user-attachments/assets/07faf8ac-cac6-484d-ac54-bfbcac5f21fe" />

<img width="900" height="575" alt="image" src="https://github.com/user-attachments/assets/019eea1c-85e2-4a82-a10a-355c0036883e" />

