### PR TITLE
Secrets: Add missing indices for secure value (list) and data key (list+read)

### DIFF
--- a/pkg/storage/secret/migrator/migrator.go
+++ b/pkg/storage/secret/migrator/migrator.go
@@ -45,7 +45,7 @@ func (*SecretDB) AddMigration(mg *migrator.Migrator) {
 
 	tables := []migrator.Table{}
 
-	tables = append(tables, migrator.Table{
+	secureValueTable := migrator.Table{
 		Name: TableNameSecureValue,
 		Columns: []*migrator.Column{
 			// Kubernetes Metadata
@@ -74,7 +74,8 @@ func (*SecretDB) AddMigration(mg *migrator.Migrator) {
 			{Cols: []string{"namespace", "name", "version", "active"}, Type: migrator.UniqueIndex},
 			{Cols: []string{"namespace", "name", "version"}, Type: migrator.UniqueIndex},
 		},
-	})
+	}
+	tables = append(tables, secureValueTable)
 
 	tables = append(tables, migrator.Table{
 		Name: TableNameKeeper,
@@ -101,22 +102,21 @@ func (*SecretDB) AddMigration(mg *migrator.Migrator) {
 		},
 	})
 
-	// TODO -- document how the seemingly arbitrary column lengths were chosen
-	// The answer for now is that they come from the legacy secrets service, but it would be good to know that they will still work in the new service
-	tables = append(tables, migrator.Table{
+	dataKeyTable := migrator.Table{
 		Name: TableNameDataKey,
 		Columns: []*migrator.Column{
-			{Name: "uid", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: true},
+			{Name: "uid", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: true},    // Arbitrarily chosen.
 			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 253, Nullable: false}, // Limit enforced by K8s.
-			{Name: "label", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: false},
+			{Name: "label", Type: migrator.DB_NVarchar, Length: 100, IsPrimaryKey: false}, // Arbitrarily chosen.
 			{Name: "active", Type: migrator.DB_Bool, Nullable: false},
-			{Name: "provider", Type: migrator.DB_NVarchar, Length: 50, Nullable: false},
+			{Name: "provider", Type: migrator.DB_NVarchar, Length: 50, Nullable: false}, // Arbitrarily chosen.
 			{Name: "encrypted_data", Type: migrator.DB_Blob, Nullable: false},
 			{Name: "created", Type: migrator.DB_DateTime, Nullable: false},
 			{Name: "updated", Type: migrator.DB_DateTime, Nullable: false},
 		},
-		Indices: []*migrator.Index{}, // TODO: add indexes based on the queries we make.
-	})
+		Indices: []*migrator.Index{},
+	}
+	tables = append(tables, dataKeyTable)
 
 	encryptedValueTable := migrator.Table{
 		Name: TableNameEncryptedValue,
@@ -142,4 +142,14 @@ func (*SecretDB) AddMigration(mg *migrator.Migrator) {
 			mg.AddMigration(fmt.Sprintf("create table %s, index: %d", tables[t].Name, i), migrator.NewAddIndexMigration(tables[t], tables[t].Indices[i]))
 		}
 	}
+
+	mg.AddMigration("create index for list on "+TableNameSecureValue, migrator.NewAddIndexMigration(secureValueTable, &migrator.Index{
+		Cols: []string{"namespace", "active", "updated"},
+		Type: migrator.IndexType,
+	}))
+
+	mg.AddMigration("create index for list and read current on "+TableNameDataKey, migrator.NewAddIndexMigration(dataKeyTable, &migrator.Index{
+		Cols: []string{"namespace", "label", "active"},
+		Type: migrator.IndexType,
+	}))
 }


### PR DESCRIPTION
Using MySQL, I ran each query manually to see if/how indices were being used. I found that 3 queries were not using any or partially.

## Secure Value Table
### Before
```
MySQL [secret_grafana_app]> EXPLAIN SELECT *  FROM secret_secure_value WHERE `namespace`='stacks-5225' AND `active`= TRUE ORDER BY `updated` DESC \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_secure_value
   partitions: NULL
         type: ref
possible_keys: UQE_secret_secure_value_namespace_name_version_active,UQE_secret_secure_value_namespace_name_version
          key: UQE_secret_secure_value_namespace_name_version_active
      key_len: 1014
          ref: const
         rows: 4
     filtered: 25.00
        Extra: Using index condition; Using filesort
1 row in set, 1 warning (0.003 sec)
```

### After
```
MySQL [secret_grafana_app]> EXPLAIN SELECT *  FROM secret_secure_value WHERE `namespace`='stacks-5225' AND `active`= TRUE ORDER BY `updated` DESC \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_secure_value
   partitions: NULL
         type: ref
possible_keys: UQE_secret_secure_value_namespace_name_version_active,UQE_secret_secure_value_namespace_name_version,IDX_namespace_active_updated
          key: IDX_namespace_active_updated
      key_len: 1015
          ref: const,const
         rows: 3
     filtered: 100.00
        Extra: Backward index scan
1 row in set, 1 warning (0.002 sec)
```

## Data Keys Table
### Before
```
MySQL [secret_grafana_app]> EXPLAIN SELECT * FROM secret_data_key WHERE namespace='stacks-5225' \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_data_key
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 1
     filtered: 100.00
        Extra: Using where

MySQL [secret_grafana_app]> EXPLAIN SELECT * FROM secret_data_key WHERE namespace='stacks-5225' AND label='2025-07-28@secret_key.v1' AND active=TRUE \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_data_key
   partitions: NULL
         type: ALL
possible_keys: NULL
          key: NULL
      key_len: NULL
          ref: NULL
         rows: 1
     filtered: 100.00
        Extra: Using where
```

### After
```
MySQL [secret_grafana_app]> EXPLAIN SELECT * FROM secret_data_key WHERE namespace='stacks-5225' \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_data_key
   partitions: NULL
         type: ref
possible_keys: IDX_namespace_label_active
          key: IDX_namespace_label_active
      key_len: 1014
          ref: const
         rows: 1
     filtered: 100.00
        Extra: NULL

MySQL [secret_grafana_app]> EXPLAIN SELECT * FROM secret_data_key WHERE namespace='stacks-5225' AND label='2025-07-28@secret_key.v1' AND active=TRUE \G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: secret_data_key
   partitions: NULL
         type: ref
possible_keys: IDX_namespace_label_active
          key: IDX_namespace_label_active
      key_len: 1417
          ref: const,const,const
         rows: 1
     filtered: 100.00
        Extra: NULL
```