### PR TITLE
Alerting: Use the official maildev image again

### DIFF
--- a/devenv/docker/blocks/maildev/docker-compose.yaml
+++ b/devenv/docker/blocks/maildev/docker-compose.yaml
@@ -1,5 +1,5 @@
   maildev:
-    image: gillesdemey/maildev
+    image: maildev/maildev:2.2.1
     ports:
       - "12080:1080"
       - "1025:1025"


### PR DESCRIPTION
The [original issue](https://github.com/grafana/grafana/pull/43624) with certificate validation seems to be fixed for non-TLS setups.

Tested with

```
[smtp]
enabled = true
host = "localhost:1025"
```