### PR TITLE
Chore: Omit integration tests if short test flag is passed

### DIFF
--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -419,6 +419,9 @@ func TestHTTPServer_GetDashboardVersions_AccessControl(t *testing.T) {
 }
 
 func TestIntegrationDashboardAPIEndpoint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("Given two dashboards with the same title in different folders", func(t *testing.T) {
 		dashOne := dashboards.NewDashboard("dash")
 		dashOne.ID = 2

--- a/pkg/api/frontendsettings_test.go
+++ b/pkg/api/frontendsettings_test.go
@@ -114,6 +114,9 @@ func setupTestEnvironment(t *testing.T, cfg *setting.Cfg, features featuremgmt.F
 }
 
 func TestIntegrationHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type buildInfo struct {
 		Version string `json:"version"`
 		Commit  string `json:"commit"`
@@ -183,6 +186,9 @@ func TestIntegrationHTTPServer_GetFrontendSettings_hideVersionAnonymous(t *testi
 }
 
 func TestIntegrationHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type settings struct {
 		PluginsCDNBaseURL string `json:"pluginsCDNBaseURL"`
 	}
@@ -233,6 +239,9 @@ func TestIntegrationHTTPServer_GetFrontendSettings_pluginsCDNBaseURL(t *testing.
 }
 
 func TestIntegrationHTTPServer_GetFrontendSettings_apps(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type settings struct {
 		Apps map[string]*plugins.AppDTO `json:"apps"`
 	}
@@ -463,6 +472,9 @@ func newAppSettings(id string, enabled bool) map[string]*pluginsettings.DTO {
 }
 
 func TestIntegrationHTTPServer_GetFrontendSettings_translations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type settings struct {
 		Datasources map[string]plugins.DataSourceDTO `json:"datasources"`
 		Panels      map[string]*plugins.PanelDTO     `json:"panels"`

--- a/pkg/api/org_users_test.go
+++ b/pkg/api/org_users_test.go
@@ -65,6 +65,9 @@ func setUpGetOrgUsersDB(t *testing.T, sqlStore db.DB, cfg *setting.Cfg) {
 }
 
 func TestIntegrationOrgUsersAPIEndpoint_userLoggedIn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	hs := setupSimpleHTTPServer(featuremgmt.WithFeatures())
 	settings := hs.Cfg
 

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -42,6 +42,9 @@ import (
 )
 
 func TestIntegrationCallResource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	staticRootPath, err := filepath.Abs("../../public/")
 	require.NoError(t, err)
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -61,6 +61,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	cfg := &setting.Cfg{}
 
 	t.Run("Plugin with routes", func(t *testing.T) {

--- a/pkg/api/user_test.go
+++ b/pkg/api/user_test.go
@@ -58,6 +58,9 @@ import (
 const newEmail = "newemail@localhost"
 
 func TestIntegrationUserAPIEndpoint_userLoggedIn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t, sqlstore.InitTestDBOpt{Cfg: settings})
 	hs := &HTTPServer{
@@ -405,6 +408,9 @@ func Test_GetUserByID(t *testing.T) {
 }
 
 func TestIntegrationHTTPServer_UpdateUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
 
@@ -479,6 +485,9 @@ func setupUpdateEmailTests(t *testing.T, cfg *setting.Cfg) (*user.User, *HTTPSer
 }
 
 func TestIntegrationUser_UpdateEmail(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	cases := []struct {
 		Name  string
 		Field user.UpdateEmailActionType
@@ -1154,6 +1163,9 @@ func updateUserScenario(t *testing.T, ctx updateUserContext, hs *HTTPServer) {
 }
 
 func TestIntegrationHTTPServer_UpdateSignedInUser(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	settings := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
 

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
@@ -21,12 +21,11 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationPasswordMigrationCommand(t *testing.T) {
-	if testing.
-		// setup datasources with password, basic_auth and none
-		Short() {
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 
+	// setup datasources with password, basic_auth and none
 	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
 		passwordMigration(t, sess, store)

--- a/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/encrypt_datasource_passwords_test.go
@@ -21,7 +21,12 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationPasswordMigrationCommand(t *testing.T) {
-	// setup datasources with password, basic_auth and none
+	if testing.
+		// setup datasources with password, basic_auth and none
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
 		passwordMigration(t, sess, store)

--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
@@ -11,9 +11,8 @@ import (
 )
 
 func TestIntegrationUnifiedStorageCommand(t *testing.T) {
-	if testing.
-		// setup datasources with password, basic_auth and none
-		Short() {
+	// setup datasources with password, basic_auth and none
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
+++ b/pkg/cmd/grafana-cli/commands/datamigrations/to_unified_storage_test.go
@@ -11,7 +11,12 @@ import (
 )
 
 func TestIntegrationUnifiedStorageCommand(t *testing.T) {
-	// setup datasources with password, basic_auth and none
+	if testing.
+		// setup datasources with password, basic_auth and none
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	store := db.InitTestDB(t)
 	err := store.WithDbSession(context.Background(), func(sess *db.Session) error {
 		unistoreMigrationTest(t, sess, store)

--- a/pkg/infra/kvstore/kvstore_test.go
+++ b/pkg/infra/kvstore/kvstore_test.go
@@ -249,6 +249,9 @@ func TestIntegrationKVStore(t *testing.T) {
 }
 
 func TestIntegrationGetItems(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	kv := createTestableKVStore(t)
 
 	ctx := context.Background()

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestIntegrationDatabaseStorageGarbageCollection(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlstore := db.InitTestDB(t)
 
 	db := &databaseCache{
@@ -59,6 +62,9 @@ func TestIntegrationDatabaseStorageGarbageCollection(t *testing.T) {
 }
 
 func TestIntegrationSecondSet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	var err error
 	sqlstore := db.InitTestDB(t)
 

--- a/pkg/infra/remotecache/remotecache_test.go
+++ b/pkg/infra/remotecache/remotecache_test.go
@@ -34,6 +34,9 @@ func createTestClient(t *testing.T, opts *setting.RemoteCacheSettings, sqlstore 
 }
 
 func TestIntegrationCachedBasedOnConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, cfg := sqlstore.InitTestDB(t)
 	err := cfg.Load(setting.CommandLineArgs{
 		HomePath: "../../../",

--- a/pkg/infra/serverlock/serverlock_test.go
+++ b/pkg/infra/serverlock/serverlock_test.go
@@ -31,6 +31,9 @@ func createTestableServerLock(t *testing.T) *ServerLockService {
 }
 
 func TestIntegrationServerLock(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sl := createTestableServerLock(t)
 	operationUID := "test-operation"
 
@@ -67,6 +70,9 @@ func TestIntegrationServerLock(t *testing.T) {
 }
 
 func TestIntegrationLockAndRelease(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	operationUID := "test-operation-release"
 
 	t.Run("create lock and then release it", func(t *testing.T) {

--- a/pkg/infra/usagestats/service/usage_stats_test.go
+++ b/pkg/infra/usagestats/service/usage_stats_test.go
@@ -156,6 +156,9 @@ func TestMetrics(t *testing.T) {
 }
 
 func TestIntegrationGetUsageReport_IncludesMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := dbtest.NewFakeDB()
 	uss := createService(t, sqlStore, true)
 	metricName := "stats.test_metric.count"

--- a/pkg/infra/usagestats/statscollector/concurrent_users_test.go
+++ b/pkg/infra/usagestats/statscollector/concurrent_users_test.go
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationConcurrentUsersMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore, cfg := db.InitTestDBWithCfg(t)
 	statsService := statsimpl.ProvideService(&setting.Cfg{}, sqlStore, &dashboards.FakeDashboardService{}, &foldertest.FakeService{}, &orgtest.FakeOrgService{}, featuremgmt.WithFeatures())
 	s := createService(t, cfg, sqlStore, statsService)
@@ -46,6 +49,9 @@ func TestIntegrationConcurrentUsersMetrics(t *testing.T) {
 }
 
 func TestIntegrationConcurrentUsersStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore, cfg := db.InitTestDBWithCfg(t)
 	statsService := statsimpl.ProvideService(&setting.Cfg{}, sqlStore, &dashboards.FakeDashboardService{}, &foldertest.FakeService{}, &orgtest.FakeOrgService{}, featuremgmt.WithFeatures())
 	s := createService(t, cfg, sqlStore, statsService)

--- a/pkg/login/social/socialimpl/service_test.go
+++ b/pkg/login/social/socialimpl/service_test.go
@@ -29,6 +29,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationSocialService_ProvideService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		name                                string
 		setup                               func(t *testing.T)
@@ -125,6 +128,9 @@ func TestIntegrationSocialService_ProvideService(t *testing.T) {
 }
 
 func TestIntegrationSocialService_ProvideService_GrafanaComGrafanaNet(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		name                        string
 		rawIniContent               string

--- a/pkg/plugins/manager/client/client_test.go
+++ b/pkg/plugins/manager/client/client_test.go
@@ -157,6 +157,9 @@ func TestCheckHealth(t *testing.T) {
 }
 
 func TestIntegrationCallResource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	registry := fakes.NewFakePluginRegistry()
 	p := &plugins.Plugin{
 		JSONData: plugins.JSONData{

--- a/pkg/registry/apis/secret/secure_value_client_test.go
+++ b/pkg/registry/apis/secret/secure_value_client_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIntegration_SecureValueClient_CRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	setup := testutils.Setup(t)
 
 	validator := validator.ProvideSecureValueValidator()

--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -50,6 +50,9 @@ func setupTestEnv(t testing.TB) *Service {
 }
 
 func TestIntegrationUsageMetrics(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name          string
 		expectedValue int
@@ -81,6 +84,9 @@ func TestIntegrationUsageMetrics(t *testing.T) {
 }
 
 func TestIntegrationService_DeclareFixedRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name          string
 		registrations []accesscontrol.RoleRegistration
@@ -166,6 +172,9 @@ func TestIntegrationService_DeclareFixedRoles(t *testing.T) {
 }
 
 func TestIntegrationService_DeclarePluginRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name          string
 		pluginID      string
@@ -279,6 +288,9 @@ func TestIntegrationService_DeclarePluginRoles(t *testing.T) {
 }
 
 func TestIntegrationService_RegisterFixedRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name          string
 		token         licensing.Licensing
@@ -381,6 +393,9 @@ func TestIntegrationService_RegisterFixedRoles(t *testing.T) {
 }
 
 func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	searchOption := accesscontrol.SearchOptions{ActionPrefix: "teams"}
 	ctx := context.Background()
 	listAllPerms := map[string][]string{accesscontrol.ActionUsersPermissionsRead: {"users:*"}}
@@ -602,6 +617,9 @@ func TestIntegrationService_SearchUsersPermissions(t *testing.T) {
 }
 
 func TestIntegrationService_SearchUserPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	tests := []struct {
 		name           string
@@ -833,6 +851,9 @@ func TestIntegrationService_SearchUserPermissions(t *testing.T) {
 }
 
 func TestIntegrationService_SaveExternalServiceRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type run struct {
 		cmd     accesscontrol.SaveExternalServiceRoleCommand
 		wantErr bool
@@ -919,6 +940,9 @@ func TestIntegrationService_SaveExternalServiceRole(t *testing.T) {
 }
 
 func TestIntegrationService_DeleteExternalServiceRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name              string
 		initCmd           *accesscontrol.SaveExternalServiceRoleCommand
@@ -972,6 +996,9 @@ func TestIntegrationService_DeleteExternalServiceRole(t *testing.T) {
 }
 
 func TestIntegrationService_GetRoleByName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Parallel()
 
 	ctx := context.Background()

--- a/pkg/services/accesscontrol/database/database_test.go
+++ b/pkg/services/accesscontrol/database/database_test.go
@@ -45,6 +45,9 @@ type getUserPermissionsTestCase struct {
 }
 
 func TestIntegrationAccessControlStore_GetUserPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []getUserPermissionsTestCase{
 		{
 			desc:               "should successfully get user, team and builtin permissions",
@@ -159,6 +162,9 @@ type getTeamsPermissionsTestCase struct {
 }
 
 func TestIntegrationAccessControlStore_GetTeamsPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []getTeamsPermissionsTestCase{
 		{
 			desc:  "should successfully get team permissions",
@@ -231,6 +237,9 @@ func TestIntegrationAccessControlStore_GetTeamsPermissions(t *testing.T) {
 }
 
 func TestIntegrationAccessControlStore_DeleteUserPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("expect permissions in all orgs to be deleted", func(t *testing.T) {
 		store, permissionsStore, usrSvc, teamSvc, _, sql := setupTestEnv(t)
 		user, _ := createUserAndTeam(t, sql, usrSvc, teamSvc, 1)
@@ -313,6 +322,9 @@ func TestIntegrationAccessControlStore_DeleteUserPermissions(t *testing.T) {
 }
 
 func TestIntegrationAccessControlStore_DeleteTeamPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("expect permissions related to team to be deleted", func(t *testing.T) {
 		store, permissionsStore, usrSvc, teamSvc, _, sql := setupTestEnv(t)
 		user, team := createUserAndTeam(t, sql, usrSvc, teamSvc, 1)
@@ -493,6 +505,9 @@ func setupTestEnv(t testing.TB) (*database.AccessControlStore, rs.Store, user.Se
 }
 
 func TestIntegrationAccessControlStore_SearchUsersPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	readTeamPerm := func(teamID string) rs.SetResourcePermissionCommand {
 		return rs.SetResourcePermissionCommand{
@@ -768,6 +783,9 @@ func TestIntegrationAccessControlStore_SearchUsersPermissions(t *testing.T) {
 }
 
 func TestIntegrationAccessControlStore_GetUsersBasicRoles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	tests := []struct {
 		name       string

--- a/pkg/services/accesscontrol/database/externalservices_test.go
+++ b/pkg/services/accesscontrol/database/externalservices_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestIntegrationAccessControlStore_SaveExternalServiceRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type run struct {
 		cmd     accesscontrol.SaveExternalServiceRoleCommand
 		wantErr bool
@@ -153,6 +156,9 @@ func TestIntegrationAccessControlStore_SaveExternalServiceRole(t *testing.T) {
 }
 
 func TestIntegrationAccessControlStore_DeleteExternalServiceRole(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	extID := "app1"
 	tests := []struct {
 		name    string

--- a/pkg/services/accesscontrol/filter_test.go
+++ b/pkg/services/accesscontrol/filter_test.go
@@ -33,6 +33,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationFilter_Datasources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []filterDatasourcesTestCase{
 		{
 			desc:    "expect all data sources to be returned",

--- a/pkg/services/accesscontrol/migrator/migrator_test.go
+++ b/pkg/services/accesscontrol/migrator/migrator_test.go
@@ -46,6 +46,9 @@ func batchInsertPermissions(cnt int, sqlStore db.DB) error {
 // TestIntegrationMigrateScopeSplit tests the scope split migration
 // also tests the scope split truncation logic
 func TestIntegrationMigrateScopeSplitTruncation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	logger := log.New("accesscontrol.migrator.test")
 

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -31,6 +31,9 @@ type getDescriptionTestCase struct {
 }
 
 func TestIntegrationApi_getDescription(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []getDescriptionTestCase{
 		{
 			desc: "should return description",
@@ -136,6 +139,9 @@ type getPermissionsTestCase struct {
 }
 
 func TestIntegrationApi_getPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []getPermissionsTestCase{
 		{
 			desc:       "expect permissions for resource with id 1",
@@ -182,6 +188,9 @@ type setBuiltinPermissionTestCase struct {
 }
 
 func TestIntegrationApi_setBuiltinRolePermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setBuiltinPermissionTestCase{
 		{
 			desc:           "should set Edit permission for Viewer",
@@ -261,6 +270,9 @@ type setTeamPermissionTestCase struct {
 }
 
 func TestIntegrationApi_setTeamPermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setTeamPermissionTestCase{
 		{
 			desc:           "should set Edit permission for team 1",
@@ -368,6 +380,9 @@ type setUserPermissionTestCase struct {
 }
 
 func TestIntegrationApi_setUserPermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setUserPermissionTestCase{
 		{
 			desc:           "should set Edit permission for user 1",
@@ -443,6 +458,9 @@ func TestIntegrationApi_setUserPermission(t *testing.T) {
 }
 
 func TestIntegrationApi_setUserPermissionForTeams(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type setUserPermissionForTeamsTestCase struct {
 		setUserPermissionTestCase
 		teamCmd *team.CreateTeamCommand

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -32,6 +32,9 @@ type setUserPermissionTest struct {
 }
 
 func TestIntegrationService_SetUserPermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setUserPermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -76,6 +79,9 @@ type setTeamPermissionTest struct {
 }
 
 func TestIntegrationService_SetTeamPermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setTeamPermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -125,6 +131,9 @@ type setBuiltInRolePermissionTest struct {
 }
 
 func TestIntegrationService_SetBuiltInRolePermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setBuiltInRolePermissionTest{
 		{
 			desc:     "should call hook when updating user permissions",
@@ -167,6 +176,9 @@ type setPermissionsTest struct {
 }
 
 func TestIntegrationService_SetPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []setPermissionsTest{
 		{
 			desc: "should set all permissions",
@@ -236,6 +248,9 @@ func TestIntegrationService_SetPermissions(t *testing.T) {
 }
 
 func TestIntegrationService_RegisterActionSets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type registerActionSetsTest struct {
 		desc               string
 		options            Options

--- a/pkg/services/anonymous/anonimpl/anonstore/database_test.go
+++ b/pkg/services/anonymous/anonimpl/anonstore/database_test.go
@@ -17,6 +17,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationAnonStore_DeleteDevicesOlderThan(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store := db.InitTestDB(t)
 	anonDBStore := ProvideAnonDBStore(store, 0)
 	const keepFor = time.Hour * 24 * 61
@@ -54,6 +57,9 @@ func TestIntegrationAnonStore_DeleteDevicesOlderThan(t *testing.T) {
 }
 
 func TestIntegrationBeyondDeviceLimit(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store := db.InitTestDB(t)
 	anonDBStore := ProvideAnonDBStore(store, 1)
 
@@ -75,6 +81,9 @@ func TestIntegrationBeyondDeviceLimit(t *testing.T) {
 }
 
 func TestIntegrationAnonStore_DeleteDevice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store := db.InitTestDB(t)
 	anonDBStore := ProvideAnonDBStore(store, 0)
 	const keepFor = time.Hour * 24 * 61

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -33,6 +33,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationUserAuthToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := createTestContext(t)
 	usr := &user.User{ID: int64(10)}
 
@@ -787,6 +790,9 @@ func (c *testContext) updateRotatedAt(id, rotatedAt int64) (bool, error) {
 }
 
 func TestIntegrationTokenCount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := createTestContext(t)
 	user := &user.User{ID: int64(10)}
 
@@ -824,6 +830,9 @@ func TestIntegrationTokenCount(t *testing.T) {
 }
 
 func TestIntegrationRevokeAllUserTokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		usr := &user.User{ID: int64(10)}
@@ -857,6 +866,9 @@ func TestIntegrationRevokeAllUserTokens(t *testing.T) {
 }
 
 func TestIntegrationRevokeToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		usr := &user.User{ID: int64(10)}
@@ -888,6 +900,9 @@ func TestIntegrationRevokeToken(t *testing.T) {
 }
 
 func TestIntegrationBatchRevokeAllUserTokens(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should not fail if the external sessions could not be removed", func(t *testing.T) {
 		ctx := createTestContext(t)
 		userIds := []int64{1, 2, 3}

--- a/pkg/services/auth/jwt/auth_test.go
+++ b/pkg/services/auth/jwt/auth_test.go
@@ -45,6 +45,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationVerifyUsingPKIXPublicKeyFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	key := rsaKeys[0]
 	unknownKey := rsaKeys[1]
 
@@ -80,6 +83,9 @@ func TestIntegrationVerifyUsingPKIXPublicKeyFile(t *testing.T) {
 }
 
 func TestIntegrationVerifyUsingJWKSetFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	configure := func(t *testing.T, cfg *setting.Cfg) {
 		t.Helper()
 
@@ -119,6 +125,9 @@ func TestIntegrationVerifyUsingJWKSetFile(t *testing.T) {
 }
 
 func TestIntegrationVerifyUsingJWKSetURL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should refuse to start with non-https URL", func(t *testing.T) {
 		var err error
 
@@ -161,6 +170,9 @@ func TestIntegrationVerifyUsingJWKSetURL(t *testing.T) {
 }
 
 func TestIntegrationCachingJWKHTTPResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	jwkCachingScenario(t, "caches the jwk response", func(t *testing.T, sc cachingScenarioContext) {
 		for i := 0; i < 5; i++ {
 			token := sign(t, &jwKeys[0], jwt.Claims{Subject: subject}, nil)
@@ -201,6 +213,9 @@ func TestIntegrationCachingJWKHTTPResponse(t *testing.T) {
 }
 
 func TestIntegrationSignatureWithNoneAlgorithm(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenario(t, "rejects a token signed with \"none\" algorithm", func(t *testing.T, sc scenarioContext) {
 		token := signNone(t, jwt.Claims{Subject: "foo"})
 		_, err := sc.authJWTSvc.Verify(sc.ctx, token)
@@ -209,6 +224,9 @@ func TestIntegrationSignatureWithNoneAlgorithm(t *testing.T) {
 }
 
 func TestIntegrationClaimValidation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	key := rsaKeys[0]
 
 	scenario(t, "validates iss field for equality", func(t *testing.T, sc scenarioContext) {
@@ -369,6 +387,9 @@ func jwkCachingScenario(t *testing.T, desc string, fn cachingScenarioFunc, cbs .
 }
 
 func TestIntegrationBase64Paddings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	key := rsaKeys[0]
 
 	scenario(t, "verifies a token with base64 padding (non compliant rfc7515#section-2 but accepted)", func(t *testing.T, sc scenarioContext) {

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2644,6 +2644,9 @@ func TestCleanUpDashboard(t *testing.T) {
 }
 
 func TestIntegrationK8sDashboardCleanupJob(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests := []struct {
 		name            string
 		featureEnabled  bool

--- a/pkg/services/dashboardsnapshots/service/service_test.go
+++ b/pkg/services/dashboardsnapshots/service/service_test.go
@@ -39,6 +39,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationDashboardSnapshotsService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	dsStore := dashsnapdb.ProvideStore(sqlStore, cfg)
@@ -98,6 +101,9 @@ func TestIntegrationDashboardSnapshotsService(t *testing.T) {
 }
 
 func TestIntegrationValidateDashboardExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	dsStore := dashsnapdb.ProvideStore(sqlStore, cfg)

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -63,6 +63,9 @@ func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *data
 }
 
 func TestIntegrationService_AddDataSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should not fail if the plugin is not installed", func(t *testing.T) {
 		dsService := initDSService(t)
 		dsService.pluginStore = &pluginstore.FakePluginStore{
@@ -354,6 +357,9 @@ func TestService_getAvailableName(t *testing.T) {
 }
 
 func TestIntegrationService_UpdateDataSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should return not found error if datasource not found", func(t *testing.T) {
 		dsService := initDSService(t)
 
@@ -804,6 +810,9 @@ func TestIntegrationService_UpdateDataSource(t *testing.T) {
 }
 
 func TestIntegrationService_DeleteDataSource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should not return an error if data source doesn't exist", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
@@ -1081,6 +1090,9 @@ func TestService_awsServiceNamespace(t *testing.T) {
 
 //nolint:goconst
 func TestIntegrationService_GetHttpTransport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	cfg := &setting.Cfg{}
 
 	t.Run("Should use cached proxy", func(t *testing.T) {
@@ -1493,6 +1505,9 @@ func TestIntegrationService_GetHttpTransport(t *testing.T) {
 }
 
 func TestIntegrationService_getProxySettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))
@@ -1571,6 +1586,9 @@ func TestIntegrationService_getProxySettings(t *testing.T) {
 }
 
 func TestIntegrationService_getTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	cfg := &setting.Cfg{}
 	originalTimeout := sdkhttpclient.DefaultTimeoutOptions.Timeout
 	sdkhttpclient.DefaultTimeoutOptions.Timeout = time.Minute
@@ -1605,6 +1623,9 @@ func TestIntegrationService_getTimeout(t *testing.T) {
 }
 
 func TestIntegrationService_GetDecryptedValues(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should migrate and retrieve values from secure json data", func(t *testing.T) {
 		ds := &datasources.DataSource{
 			ID:   1,
@@ -1664,6 +1685,9 @@ func TestIntegrationService_GetDecryptedValues(t *testing.T) {
 }
 
 func TestIntegrationDataSource_CustomHeaders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))

--- a/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
+++ b/pkg/services/folder/folderimpl/dashboard_folder_store_test.go
@@ -26,6 +26,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationDashboardFolderStore(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	var sqlStore db.DB
 	var cfg *setting.Cfg
 	var dashboardStore dashboards.Store

--- a/pkg/services/folder/folderimpl/folder_test.go
+++ b/pkg/services/folder/folderimpl/folder_test.go
@@ -727,6 +727,9 @@ func TestIntegrationNestedFolderServiceBasicOperations(t *testing.T) {
 }
 
 func TestIntegrationNestedFolderServiceFeatureToggle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	nestedFolderStore := folder.NewFakeStore()
 
 	dashStore := dashboards.FakeDashboardStore{}
@@ -758,6 +761,9 @@ func TestIntegrationNestedFolderServiceFeatureToggle(t *testing.T) {
 }
 
 func TestIntegrationFolderServiceDualWrite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, _ := sqlstore.InitTestDB(t)
 	cfg := setting.NewCfg()
 	features := featuremgmt.WithFeatures()
@@ -817,6 +823,9 @@ func TestIntegrationFolderServiceDualWrite(t *testing.T) {
 }
 
 func TestIntegrationNestedFolderService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("with feature flag unset", func(t *testing.T) {
 		t.Run("Should create a folder in both dashboard and folders tables", func(t *testing.T) {
 			// dash is needed here because folderSvc.Create expects SaveDashboard to return it
@@ -1691,6 +1700,9 @@ func TestIntegrationNestedFolderSharedWithMe(t *testing.T) {
 }
 
 func TestIntegrationFolderServiceGetFolder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, _ := sqlstore.InitTestDB(t)
 
 	signedInAdminUser := user.SignedInUser{UserID: 1, OrgID: orgID, Permissions: map[int64]map[string][]string{
@@ -1802,6 +1814,9 @@ func TestIntegrationFolderServiceGetFolder(t *testing.T) {
 }
 
 func TestIntegrationFolderServiceGetFolders(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, cfg := sqlstore.InitTestDB(t)
 	folderStore := ProvideDashboardFolderStore(db)
 
@@ -1873,6 +1888,9 @@ func TestIntegrationFolderServiceGetFolders(t *testing.T) {
 // TODO replace it with an API test under /pkg/tests/api/folders
 // whenever the golang client with get updated to allow filtering child folders by permission
 func TestIntegrationGetChildrenFilterByPermission(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, cfg := sqlstore.InitTestDB(t)
 
 	signedInAdminUser := user.SignedInUser{UserID: 1, OrgID: orgID, Permissions: map[int64]map[string][]string{

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -848,6 +848,9 @@ func TestGetFoldersFromApiServer(t *testing.T) {
 }
 
 func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	fakeK8sClient := new(client.MockK8sHandler)
 	fakeK8sClient.On("GetNamespace", mock.Anything, mock.Anything).Return("default")
 	dashboardK8sclient := new(client.MockK8sHandler)

--- a/pkg/services/libraryelements/libraryelements_create_test.go
+++ b/pkg/services/libraryelements/libraryelements_create_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestIntegration_CreateLibraryElement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to create a library panel that already exists, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// nolint:staticcheck

--- a/pkg/services/libraryelements/libraryelements_delete_test.go
+++ b/pkg/services/libraryelements/libraryelements_delete_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIntegration_DeleteLibraryElement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to delete a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.deleteHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_get_all_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_all_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIntegration_GetAllLibraryElements(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testScenario(t, "When an admin tries to get all library panels and none exists, it should return none",
 		func(t *testing.T, sc scenarioContext) {
 			resp := sc.service.getAllHandler(sc.reqContext)

--- a/pkg/services/libraryelements/libraryelements_get_test.go
+++ b/pkg/services/libraryelements/libraryelements_get_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestIntegration_GetLibraryElement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to get a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			// by uid

--- a/pkg/services/libraryelements/libraryelements_patch_test.go
+++ b/pkg/services/libraryelements/libraryelements_patch_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIntegration_PatchLibraryElement(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to patch a library panel that does not exist, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			cmd := model.PatchLibraryElementCommand{Kind: int64(model.PanelElement), Version: 1}

--- a/pkg/services/libraryelements/libraryelements_test.go
+++ b/pkg/services/libraryelements/libraryelements_test.go
@@ -62,6 +62,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration_DeleteLibraryPanelsInFolder(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to delete a folder that contains connected library elements, it should fail",
 		func(t *testing.T, sc scenarioContext) {
 			dashJSON := map[string]any{
@@ -140,6 +143,9 @@ func TestIntegration_DeleteLibraryPanelsInFolder(t *testing.T) {
 }
 
 func TestIntegration_GetLibraryPanelConnections(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithPanel(t, "When an admin tries to get connections of library panel, it should succeed and return correct result",
 		func(t *testing.T, sc scenarioContext) {
 			dashJSON := map[string]any{

--- a/pkg/services/librarypanels/librarypanels_test.go
+++ b/pkg/services/librarypanels/librarypanels_test.go
@@ -56,6 +56,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationConnectLibraryPanelsForDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	scenarioWithLibraryPanel(t, "When an admin tries to store a dashboard with a library panel, it should connect the two",
 		func(t *testing.T, sc scenarioContext) {
 			dashJSON := map[string]any{
@@ -349,6 +352,9 @@ func TestIntegrationConnectLibraryPanelsForDashboard(t *testing.T) {
 }
 
 func TestIntegrationImportLibraryPanelsForDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testScenario(t, "When an admin tries to import a dashboard with a library panel that does not exist, it should import the library panel",
 		func(t *testing.T, sc scenarioContext) {
 			var missingUID = "jL6MrxCMz"

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -30,6 +30,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration_provideLiveService_RedisUnavailable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	cfg := setting.NewCfg()
 
 	cfg.LiveHAEngine = "testredisunavailable"

--- a/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
+++ b/pkg/services/loginattempt/loginattemptimpl/login_attempt_test.go
@@ -87,6 +87,9 @@ func TestService_Validate(t *testing.T) {
 }
 
 func TestIntegrationUserLoginAttempts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	cfg := setting.NewCfg()
 	cfg.DisableBruteForceLoginProtection = false
@@ -185,6 +188,9 @@ func TestService_ValidateIPAddress(t *testing.T) {
 }
 
 func TestIntegrationIPLoginAttempts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	cfg := setting.NewCfg()
 	cfg.DisableIPAddressLoginProtection = false

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -68,6 +68,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationProvisioningApi(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("policies", func(t *testing.T) {
 		t.Run("successful GET returns 200", func(t *testing.T) {
 			sut := createProvisioningSrvSut(t)
@@ -1626,6 +1629,9 @@ func TestIntegrationProvisioningApi(t *testing.T) {
 }
 
 func TestIntegrationProvisioningApiContactPointExport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	createTestEnv := func(t *testing.T, testConfig string) testEnvironment {
 		env := createTestEnv(t, testConfig)
 		env.ac = &recordingAccessControlFake{

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -121,9 +121,8 @@ func TestIntegration_Validate(t *testing.T) {
 }
 
 func TestIntegration_WithExistingSecureFields(t *testing.T) {
-	if testing.
-		// Test that WithExistingSecureFields will copy over the secure fields from the existing integration.
-		Short() {
+	// Test that WithExistingSecureFields will copy over the secure fields from the existing integration.
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -243,9 +243,8 @@ func TestIntegration_WithExistingSecureFields(t *testing.T) {
 }
 
 func TestIntegrationConfig(t *testing.T) {
-	if testing.
-		// Test that all known integration types have a config and correctly mark their secrets as secure.
-		Short() {
+	// Test that all known integration types have a config and correctly mark their secrets as secure.
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -68,6 +68,9 @@ func TestReceiver_EncryptDecrypt(t *testing.T) {
 }
 
 func TestIntegration_Redact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	redactFn := func(key string) string {
 		return "TESTREDACTED"
 	}
@@ -98,7 +101,12 @@ func TestIntegration_Redact(t *testing.T) {
 }
 
 func TestIntegration_Validate(t *testing.T) {
-	// Test that all known integration types are valid.
+	if testing.
+		// Test that all known integration types are valid.
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	for integrationType := range alertingNotify.AllKnownConfigsForTesting {
 		t.Run(integrationType, func(t *testing.T) {
 			validIntegration := IntegrationGen(IntegrationMuts.WithValidConfig(integrationType))()
@@ -113,7 +121,12 @@ func TestIntegration_Validate(t *testing.T) {
 }
 
 func TestIntegration_WithExistingSecureFields(t *testing.T) {
-	// Test that WithExistingSecureFields will copy over the secure fields from the existing integration.
+	if testing.
+		// Test that WithExistingSecureFields will copy over the secure fields from the existing integration.
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	testCases := []struct {
 		name         string
 		integration  Integration
@@ -231,7 +244,12 @@ func TestIntegration_WithExistingSecureFields(t *testing.T) {
 }
 
 func TestIntegrationConfig(t *testing.T) {
-	// Test that all known integration types have a config and correctly mark their secrets as secure.
+	if testing.
+		// Test that all known integration types have a config and correctly mark their secrets as secure.
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	for integrationType := range alertingNotify.AllKnownConfigsForTesting {
 		t.Run(integrationType, func(t *testing.T) {
 			config, err := IntegrationConfigFromType(integrationType)
@@ -262,7 +280,12 @@ func TestIntegrationConfig(t *testing.T) {
 }
 
 func TestIntegration_SecureFields(t *testing.T) {
-	// Test that all known integration types have a config and correctly mark their secrets as secure.
+	if testing.
+		// Test that all known integration types have a config and correctly mark their secrets as secure.
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	for integrationType := range alertingNotify.AllKnownConfigsForTesting {
 		t.Run(integrationType, func(t *testing.T) {
 			t.Run("contains SecureSettings", func(t *testing.T) {

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -101,9 +101,8 @@ func TestIntegration_Redact(t *testing.T) {
 }
 
 func TestIntegration_Validate(t *testing.T) {
-	if testing.
-		// Test that all known integration types are valid.
-		Short() {
+	// Test that all known integration types are valid.
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -277,9 +277,8 @@ func TestIntegrationConfig(t *testing.T) {
 }
 
 func TestIntegration_SecureFields(t *testing.T) {
-	if testing.
-		// Test that all known integration types have a config and correctly mark their secrets as secure.
-		Short() {
+	// Test that all known integration types have a config and correctly mark their secrets as secure.
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -64,6 +64,9 @@ func setupAMTest(t *testing.T) *alertmanager {
 }
 
 func TestIntegrationAlertmanager_newAlertmanager(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	am := setupAMTest(t)
 	require.False(t, am.Ready())
 }

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -34,6 +34,9 @@ import (
 )
 
 func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -62,6 +65,9 @@ func TestIntegrationReceiverService_GetReceiver(t *testing.T) {
 }
 
 func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -92,6 +98,9 @@ func TestIntegrationReceiverService_GetReceivers(t *testing.T) {
 }
 
 func TestIntegrationReceiverService_DecryptRedact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 

--- a/pkg/services/ngalert/notifier/templates_test.go
+++ b/pkg/services/ngalert/notifier/templates_test.go
@@ -58,6 +58,9 @@ var (
 )
 
 func TestIntegrationTemplateDefaultData(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	am := setupAMTest(t)
 
 	tests := []struct {

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -42,6 +42,9 @@ import (
 )
 
 func TestIntegrationAlertRuleService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ruleService := createAlertRuleService(t, nil)
 	var orgID int64 = 1
 	u := &user.SignedInUser{
@@ -755,6 +758,9 @@ func TestIntegrationAlertRuleService(t *testing.T) {
 }
 
 func TestIntegrationCreateAlertRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	orgID := rand.Int63()
 	u := &user.SignedInUser{OrgID: orgID, UserUID: util.GenerateShortUID()}
 	groupKey := models.GenerateGroupKey(orgID)
@@ -1984,6 +1990,9 @@ func TestDeleteRuleGroups(t *testing.T) {
 }
 
 func TestIntegrationProvisiongWithFullpath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tracer := tracing.InitializeTracerForTest()
 	inProcBus := bus.ProvideBus(tracer)
 	sqlStore, cfg := db.InitTestDBWithCfg(t)

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -36,6 +36,9 @@ import (
 )
 
 func TestIntegrationContactPointService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(sqlStore))
 
@@ -361,6 +364,9 @@ func TestIntegrationContactPointService(t *testing.T) {
 }
 
 func TestIntegrationContactPointServiceDecryptRedact(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	secretsService := manager.SetupTestService(t, database.ProvideSecretsStore(db.InitTestDB(t)))
 
 	redactedUser := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -257,8 +257,13 @@ func TestGetRemoteState(t *testing.T) {
 }
 
 func TestIntegrationApplyConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// errorHandler returns an error response for the readiness check and state sync.
+	}
 	const tenantID = "test"
-	// errorHandler returns an error response for the readiness check and state sync.
+
 	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
 		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))

--- a/pkg/services/ngalert/sender/notifier_test.go
+++ b/pkg/services/ngalert/sender/notifier_test.go
@@ -1067,6 +1067,9 @@ func TestStop_DrainingEnabled(t *testing.T) {
 }
 
 func TestIntegrationApplyConfig(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	targetURL := "alertmanager:9093"
 	targetGroup := &targetgroup.Group{
 		Targets: []model.LabelSet{

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -47,6 +47,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationWarmStateCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	evaluationTime, err := time.Parse("2006-01-02", "2021-03-25")
 	require.NoError(t, err)
 	ctx := context.Background()
@@ -272,6 +275,9 @@ func TestIntegrationWarmStateCache(t *testing.T) {
 }
 
 func TestIntegrationDashboardAnnotations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	evaluationTime, err := time.Parse("2006-01-02", "2022-01-01")
 	require.NoError(t, err)
 
@@ -1451,7 +1457,11 @@ func printAllAnnotations(annos map[int64]annotations.Item) string {
 }
 
 func TestIntegrationStaleResultsHandler(t *testing.T) {
-	evaluationTime := time.Now().Truncate(time.Second).UTC() // Truncate to the second since we don't store sub-second precision.
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+		// Truncate to the second since we don't store sub-second precision.
+	}
+	evaluationTime := time.Now().Truncate(time.Second).UTC()
 	interval := time.Minute
 
 	ctx := context.Background()
@@ -1738,6 +1748,9 @@ func TestStaleResults(t *testing.T) {
 }
 
 func TestIntegrationDeleteStateByRuleUID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	interval := time.Minute
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(t, 1)
@@ -1884,6 +1897,9 @@ func TestIntegrationDeleteStateByRuleUID(t *testing.T) {
 }
 
 func TestIntegrationResetStateByRuleUID(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	interval := time.Minute
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(t, 1)

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -301,6 +301,9 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 }
 
 func TestIntegrationFullSync(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	batchSize := 1
 
 	ctx := context.Background()

--- a/pkg/services/ngalert/store/org_test.go
+++ b/pkg/services/ngalert/store/org_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestIntegrationFetchOrgIds(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 
 	t.Run("returns empty result when no orgs exist", func(t *testing.T) {

--- a/pkg/services/ngalert/store/range_to_instant_test.go
+++ b/pkg/services/ngalert/store/range_to_instant_test.go
@@ -146,6 +146,9 @@ func TestCanBeInstant(t *testing.T) {
 }
 
 func TestIntegrationMigrateLokiQueryToInstant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	original := createMigrateableLokiRule(t)
 	migrated := createMigrateableLokiRule(t, func(r *models.AlertRule) {
 		r.Data[0] = lokiQuery(t, "A", "instant", "grafanacloud-logs")
@@ -169,6 +172,9 @@ func TestIntegrationMigrateLokiQueryToInstant(t *testing.T) {
 }
 
 func TestIntegrationMigrateMultiLokiQueryToInstant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	original := createMultiQueryMigratableLokiRule(t)
 	migrated := createMultiQueryMigratableLokiRule(t, func(r *models.AlertRule) {
 		r.Data[0] = lokiQuery(t, "TotalRequests", "instant", "grafanacloud-logs")
@@ -206,6 +212,9 @@ func TestIntegrationMigrateMultiLokiQueryToInstant(t *testing.T) {
 }
 
 func TestIntegrationMigratePromQueryToInstant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	original := createMigratablePromRule(t)
 	migrated := createMigratablePromRule(t, func(r *models.AlertRule) {
 		r.Data[0] = prometheusQuery(t, "A", promExternalDS, promIsInstant)
@@ -227,6 +236,9 @@ func TestIntegrationMigratePromQueryToInstant(t *testing.T) {
 }
 
 func TestIntegrationMigrateMultiPromQueryToInstant(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	original := createMultiQueryMigratablePromRule(t)
 	migrated := createMultiQueryMigratablePromRule(t, func(r *models.AlertRule) {
 		r.Data[0] = prometheusQuery(t, "TotalRequests", promExternalDS, promIsInstant)

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -109,6 +109,9 @@ func TestCreatingNewDashboardFileReader(t *testing.T) {
 }
 
 func TestIntegrationDashboardFileReader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	logger := log.New("test-logger")
 	cfg := &config{}
 

--- a/pkg/services/provisioning/dashboards/validator_test.go
+++ b/pkg/services/provisioning/dashboards/validator_test.go
@@ -32,6 +32,9 @@ const (
 )
 
 func TestIntegrationDuplicatesValidator(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	fakeService := &dashboards.FakeDashboardProvisioning{}
 	defer fakeService.AssertExpectations(t)
 

--- a/pkg/services/publicdashboards/database/database_test.go
+++ b/pkg/services/publicdashboards/database/database_test.go
@@ -683,6 +683,9 @@ func TestIntegrationDelete(t *testing.T) {
 }
 
 func TestIntegrationDeleteByDashboardUIDs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	var sqlStore db.DB
 	var cfg *setting.Cfg
 	var dashboardStore dashboards.Store

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -308,6 +308,9 @@ const (
 )
 
 func TestIntegrationGetQueryDataResponse(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, _ := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 	fakeQueryService := &query.FakeQueryService{}
@@ -362,6 +365,9 @@ func TestIntegrationGetQueryDataResponse(t *testing.T) {
 }
 
 func TestIntegrationFindAnnotations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	color := "red"
 	name := "annoName"
 	t.Run("service identity has correct permissions to get annotations dashboards and query datasources", func(t *testing.T) {
@@ -718,6 +724,9 @@ func TestIntegrationFindAnnotations(t *testing.T) {
 }
 
 func TestIntegrationGetMetricRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, nil, nil)
 	dashboardStore, err := dashboardsDB.ProvideDashboardStore(sqlStore, cfg, featuremgmt.WithFeatures(), tagimpl.ProvideService(sqlStore))
 	require.NoError(t, err)
@@ -757,6 +766,9 @@ func TestIntegrationGetMetricRequest(t *testing.T) {
 }
 
 func TestIntegrationBuildMetricRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 

--- a/pkg/services/publicdashboards/service/service_test.go
+++ b/pkg/services/publicdashboards/service/service_test.go
@@ -61,6 +61,9 @@ func TestLogPrefix(t *testing.T) {
 }
 
 func TestIntegrationGetPublicDashboardForView(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -453,6 +456,9 @@ func TestIntegrationGetPublicDashboardForView(t *testing.T) {
 }
 
 func TestIntegrationGetPublicDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -530,6 +536,9 @@ func TestIntegrationGetPublicDashboard(t *testing.T) {
 }
 
 func TestIntegrationGetEnabledPublicDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	type storeResp struct {
 		pd  *PublicDashboard
 		d   *dashboards.Dashboard
@@ -595,6 +604,9 @@ func TestIntegrationGetEnabledPublicDashboard(t *testing.T) {
 // We're using sqlite here because testing all of the behaviors with mocks in
 // the correct order is convoluted.
 func TestIntegrationCreatePublicDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("Create public dashboard", func(t *testing.T) {
 		fakeDashboardService := &dashboards.FakeDashboardService{}
 		service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
@@ -976,6 +988,9 @@ func assertFalseIfNull(t *testing.T, expectedValue bool, nullableValue *bool) {
 }
 
 func TestIntegrationUpdatePublicDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	fakeDashboardService := &dashboards.FakeDashboardService{}
 	service, sqlStore, cfg := newPublicDashboardServiceImpl(t, nil, nil, nil, fakeDashboardService, nil)
 
@@ -1220,6 +1235,9 @@ func assertOldValueIfNull(t *testing.T, expectedValue bool, oldValue bool, nulla
 }
 
 func TestIntegrationDeletePublicDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	pubdash := &PublicDashboard{Uid: "2", OrgId: 1, DashboardUid: "uid"}
 
 	type mockFindResponse struct {
@@ -1390,6 +1408,9 @@ func TestDashboardEnabledChanged(t *testing.T) {
 }
 
 func TestIntegrationPublicDashboardServiceImpl_ListPublicDashboards(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	features := featuremgmt.WithFeatures()
 	testDB, cfg := db.InitTestDBWithCfg(t)
 	dashStore, err := dashboardsDB.ProvideDashboardStore(testDB, cfg, features, tagimpl.ProvideService(testDB))

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -51,6 +51,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationParseMetricRequest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("Test a simple single datasource query", func(t *testing.T) {
 		tc := setup(t, false, nil)
 		mr := metricRequestWithQueries(t, `{
@@ -272,6 +275,9 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 }
 
 func TestIntegrationQueryDataMultipleSources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("can query multiple datasources", func(t *testing.T) {
 		tc := setup(t, false, nil)
 		query1, err := simplejson.NewJson([]byte(`
@@ -455,6 +461,9 @@ func TestIntegrationQueryDataMultipleSources(t *testing.T) {
 }
 
 func TestIntegrationQueryDataWithMTDSClient(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("can run a simple datasource query with a mt ds client", func(t *testing.T) {
 		stubbedResponse := &backend.QueryDataResponse{Responses: make(backend.Responses)}
 		testClient := &testClient{

--- a/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
+++ b/pkg/services/secrets/kvstore/migrations/datasource_mig_test.go
@@ -45,6 +45,9 @@ func SetupTestDataSourceSecretMigrationService(t *testing.T, sqlStore db.DB, kvS
 }
 
 func TestIntegrationMigrate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("should migrate from legacy to unified with compatibility", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		kvStore := kvstore.ProvideService(sqlStore)

--- a/pkg/services/secrets/kvstore/sql_test.go
+++ b/pkg/services/secrets/kvstore/sql_test.go
@@ -31,6 +31,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationSecretsKVStoreSQL(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	sqlStore := db.InitTestDB(t)
 	secretsService := manager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	kv := NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))

--- a/pkg/services/secrets/manager/manager_test.go
+++ b/pkg/services/secrets/manager/manager_test.go
@@ -30,6 +30,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationSecretsService_EnvelopeEncryption(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
 	svc := SetupTestService(t, store)
@@ -91,6 +94,9 @@ func TestIntegrationSecretsService_EnvelopeEncryption(t *testing.T) {
 }
 
 func TestIntegrationSecretsService_DataKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
 	ctx := context.Background()
@@ -169,6 +175,9 @@ func TestIntegrationSecretsService_DataKeys(t *testing.T) {
 }
 
 func TestIntegrationSecretsService_UseCurrentProvider(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("When encryption_provider is not specified explicitly, should use 'secretKey' as a current provider", func(t *testing.T) {
 		testDB := db.InitTestDB(t)
 		svc := SetupTestService(t, database.ProvideSecretsStore(testDB))
@@ -274,6 +283,9 @@ func (f *fakeKMS) Provide() (map[secrets.ProviderID]secrets.Provider, error) {
 }
 
 func TestIntegrationSecretsService_Run(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
@@ -324,6 +336,9 @@ func TestIntegrationSecretsService_Run(t *testing.T) {
 }
 
 func TestIntegrationSecretsService_ReEncryptDataKeys(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)
@@ -371,6 +386,9 @@ func TestIntegrationSecretsService_ReEncryptDataKeys(t *testing.T) {
 }
 
 func TestIntegrationSecretsService_Decrypt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	testDB := db.InitTestDB(t)
 	store := database.ProvideSecretsStore(testDB)

--- a/pkg/services/serviceaccounts/database/store_test.go
+++ b/pkg/services/serviceaccounts/database/store_test.go
@@ -51,6 +51,9 @@ func TestIntegrationStore_CreateServiceAccountOrgNonExistant(t *testing.T) {
 }
 
 func TestIntegration_Store_CreateServiceAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	serviceAccountName := "new Service Account"
 	t.Run("create service account", func(t *testing.T) {
 		_, store := setupTestDatabase(t)

--- a/pkg/services/serviceaccounts/database/token_store_test.go
+++ b/pkg/services/serviceaccounts/database/token_store_test.go
@@ -12,6 +12,9 @@ import (
 )
 
 func TestIntegration_Store_AddServiceAccountToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
 	user := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)
@@ -74,6 +77,9 @@ func TestIntegration_Store_AddServiceAccountToken(t *testing.T) {
 }
 
 func TestIntegration_Store_AddServiceAccountToken_WrongServiceAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	saToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
 	sa := tests.SetupUserServiceAccount(t, db, store.cfg, saToCreate)
@@ -94,6 +100,9 @@ func TestIntegration_Store_AddServiceAccountToken_WrongServiceAccount(t *testing
 }
 
 func TestIntegration_Store_RevokeServiceAccountToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
 	sa := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)
@@ -134,6 +143,9 @@ func TestIntegration_Store_RevokeServiceAccountToken(t *testing.T) {
 }
 
 func TestIntegration_Store_DeleteServiceAccountToken(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	userToCreate := tests.TestUser{Login: "servicetestwithTeam@admin", IsServiceAccount: true}
 	db, store := setupTestDatabase(t)
 	sa := tests.SetupUserServiceAccount(t, db, store.cfg, userToCreate)

--- a/pkg/services/serviceaccounts/manager/service_test.go
+++ b/pkg/services/serviceaccounts/manager/service_test.go
@@ -118,6 +118,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationProvideServiceAccount_DeleteServiceAccount(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	storeMock := newServiceAccountStoreFake()
 	acSvc := actest.FakeService{}
 	pSvc := &actest.FakePermissionsService{}

--- a/pkg/services/shorturls/shorturlimpl/shorturl_test.go
+++ b/pkg/services/shorturls/shorturlimpl/shorturl_test.go
@@ -18,6 +18,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationShortURLService(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	user := &user.SignedInUser{UserID: 1}
 	store := db.InitTestDB(t)
 

--- a/pkg/services/sqlstore/permissions/dashboard_test.go
+++ b/pkg/services/sqlstore/permissions/dashboard_test.go
@@ -382,6 +382,9 @@ func TestIntegration_DashboardPermissionFilter_WithSelfContainedPermissions(t *t
 }
 
 func TestIntegration_DashboardNestedPermissionFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		desc           string
 		queryType      string
@@ -489,6 +492,9 @@ func TestIntegration_DashboardNestedPermissionFilter(t *testing.T) {
 }
 
 func TestIntegration_DashboardNestedPermissionFilter_WithSelfContainedPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		desc                    string
 		queryType               string
@@ -601,6 +607,9 @@ func TestIntegration_DashboardNestedPermissionFilter_WithSelfContainedPermission
 }
 
 func TestIntegration_DashboardNestedPermissionFilter_WithActionSets(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		desc                    string
 		queryType               string

--- a/pkg/services/sqlstore/searchstore/filters_test.go
+++ b/pkg/services/sqlstore/searchstore/filters_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestIntegrationFolderUIDFilter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testCases := []struct {
 		description          string
 		uids                 []string

--- a/pkg/services/sqlstore/searchstore/search_test.go
+++ b/pkg/services/sqlstore/searchstore/search_test.go
@@ -32,6 +32,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationBuilder_EqualResults_Basic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	user := &user.SignedInUser{
 		UserID:  1,
 		OrgID:   1,
@@ -76,6 +79,9 @@ func TestIntegrationBuilder_EqualResults_Basic(t *testing.T) {
 }
 
 func TestIntegrationBuilder_Pagination(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	user := &user.SignedInUser{
 		UserID:  1,
 		OrgID:   1,
@@ -123,6 +129,9 @@ func TestIntegrationBuilder_Pagination(t *testing.T) {
 }
 
 func TestIntegrationBuilder_RBAC(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testsCases := []struct {
 		desc            string
 		userPermissions []accesscontrol.Permission

--- a/pkg/services/sqlstore/session_test.go
+++ b/pkg/services/sqlstore/session_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestIntegration_RetryingDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store, _ := InitTestDB(t)
 	retryErrors := getRetryErrors(t, store)
 
@@ -61,6 +64,9 @@ func TestIntegration_RetryingDisabled(t *testing.T) {
 }
 
 func TestIntegration_RetryingOnFailures(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store, _ := InitTestDB(t)
 	retryErrors := getRetryErrors(t, store)
 	store.dbCfg.QueryRetries = 5

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -24,6 +24,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	store, _ := InitTestDB(t)
 
 	testCases := []struct {

--- a/pkg/services/star/starimpl/store_test.go
+++ b/pkg/services/star/starimpl/store_test.go
@@ -149,6 +149,9 @@ func testIntegrationUserStarsDataAccess(t *testing.T, fn getStore) {
 }
 
 func TestIntegration_StarMigrations(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testDB := db.InitTestDB(t)
 
 	d := dashboards.Dashboard{

--- a/pkg/services/store/service_test.go
+++ b/pkg/services/store/service_test.go
@@ -74,6 +74,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationListFiles(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	roots := []storageRuntime{publicStaticFilesStorage}
 
 	store := newStandardStorageService(db.InitTestDB(t), roots, func(orgId int64) []storageRuntime {
@@ -95,6 +98,9 @@ func TestIntegrationListFiles(t *testing.T) {
 }
 
 func TestIntegrationListFilesWithoutPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	roots := []storageRuntime{publicStaticFilesStorage}
 
 	store := newStandardStorageService(db.InitTestDB(t), roots, func(orgId int64) []storageRuntime {
@@ -129,6 +135,9 @@ func setupUploadStore(t *testing.T, authService storageAuthService) (StorageServ
 }
 
 func TestIntegrationShouldUploadWhenNoFileAlreadyExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.jpg"
@@ -148,6 +157,9 @@ func TestIntegrationShouldUploadWhenNoFileAlreadyExists(t *testing.T) {
 }
 
 func TestIntegrationShouldFailUploadWithoutAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, _, storageName := setupUploadStore(t, denyAllAuthService)
 
 	err := service.Upload(context.Background(), dummyUser, &UploadRequest{
@@ -159,6 +171,9 @@ func TestIntegrationShouldFailUploadWithoutAccess(t *testing.T) {
 }
 
 func TestIntegrationShouldFailUploadWhenFileAlreadyExists(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("Get", mock.Anything, "/myFile.jpg", &filestorage.GetFileOptions{WithContents: false}).Return(&filestorage.File{Contents: make([]byte, 0)}, true, nil)
@@ -172,6 +187,9 @@ func TestIntegrationShouldFailUploadWhenFileAlreadyExists(t *testing.T) {
 }
 
 func TestIntegrationShouldDelegateFileDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("Delete", mock.Anything, "/myFile.jpg").Return(nil)
@@ -181,6 +199,9 @@ func TestIntegrationShouldDelegateFileDeletion(t *testing.T) {
 }
 
 func TestIntegrationShouldDelegateFolderCreation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	mockStorage.On("CreateFolder", mock.Anything, "/nestedFolder/mostNestedFolder").Return(nil)
@@ -190,6 +211,9 @@ func TestIntegrationShouldDelegateFolderCreation(t *testing.T) {
 }
 
 func TestIntegrationShouldDelegateFolderDeletion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 	cmds := []*DeleteFolderCmd{
 		{
@@ -214,6 +238,9 @@ func TestIntegrationShouldDelegateFolderDeletion(t *testing.T) {
 }
 
 func TestIntegrationShouldUploadSvg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -233,6 +260,9 @@ func TestIntegrationShouldUploadSvg(t *testing.T) {
 }
 
 func TestIntegrationShouldNotUploadHtmlDisguisedAsSvg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -247,6 +277,9 @@ func TestIntegrationShouldNotUploadHtmlDisguisedAsSvg(t *testing.T) {
 }
 
 func TestIntegrationShouldNotUploadJpgDisguisedAsSvg(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	service, mockStorage, storageName := setupUploadStore(t, nil)
 
 	fileName := "/myFile.svg"
@@ -261,6 +294,9 @@ func TestIntegrationShouldNotUploadJpgDisguisedAsSvg(t *testing.T) {
 }
 
 func TestIntegrationSetupWithNonUniqueStoragePrefixes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	prefix := "resources"
 	sqlStorage := newSQLStorage(RootStorageMeta{}, prefix, "Testing upload", "dummy descr", &StorageSQLConfig{}, db.InitTestDB(t), 1, false)
 	sqlStorage2 := newSQLStorage(RootStorageMeta{}, prefix, "Testing upload", "dummy descr", &StorageSQLConfig{}, db.InitTestDB(t), 1, false)
@@ -277,6 +313,9 @@ func TestIntegrationSetupWithNonUniqueStoragePrefixes(t *testing.T) {
 }
 
 func TestIntegrationContentRootWithNestedStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	globalOrgID := int64(accesscontrol.GlobalOrgID)
 	testDB := db.InitTestDB(t)
 	orgedUser := &user.SignedInUser{OrgID: 1}
@@ -523,6 +562,9 @@ func TestIntegrationContentRootWithNestedStorage(t *testing.T) {
 }
 
 func TestIntegrationShadowingExistingFolderByNestedContentRoot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db := db.InitTestDB(t)
 	ctx := context.Background()
 	nestedStorage := newSQLStorage(RootStorageMeta{}, "nested", "Testing upload", "dummy descr", &StorageSQLConfig{}, db, accesscontrol.GlobalOrgID, true)

--- a/pkg/services/user/userimpl/store_test.go
+++ b/pkg/services/user/userimpl/store_test.go
@@ -1063,6 +1063,9 @@ func createFiveTestUsers(t *testing.T, svc user.Service, fn func(i int) *user.Cr
 }
 
 func TestIntegrationMetricsUsage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ss, cfg := db.InitTestDBWithCfg(t)
 	userStore := ProvideStore(ss, setting.NewCfg())
 	quotaService := quotaimpl.ProvideService(ss, cfg)

--- a/pkg/storage/unified/apistore/watcher_test.go
+++ b/pkg/storage/unified/apistore/watcher_test.go
@@ -190,6 +190,9 @@ func testSetup(t testing.TB, opts ...setupOption) (context.Context, storage.Inte
 }
 
 func TestIntegrationWatch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	for _, s := range []StorageType{StorageTypeFile, StorageTypeUnified} {
 		t.Run(string(s), func(t *testing.T) {
 			ctx, store, destroyFunc, err := testSetup(t, withStorageType(s))

--- a/pkg/storage/unified/federated/federatedtests/stats_test.go
+++ b/pkg/storage/unified/federated/federatedtests/stats_test.go
@@ -39,6 +39,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationDirectSQLStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	db, cfg := db.InitTestDBWithCfg(t)
 	ctx := context.Background()
 

--- a/pkg/storage/unified/sql/list_iterator_test.go
+++ b/pkg/storage/unified/sql/list_iterator_test.go
@@ -25,6 +25,9 @@ func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
 func TestIntegrationListIter(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 
 	grafanaDB := db.InitTestDB(t)

--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -39,6 +39,9 @@ func newTestBackend(b testing.TB) resource.StorageBackend {
 }
 
 func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests.SkipIntegrationTestInShortMode(t)
 	opts := test.DefaultBenchmarkOptions()
 	if db.IsTestDbSQLite() {
@@ -48,6 +51,9 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationBenchmarkResourceServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -36,6 +36,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationStorageServer(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	unitest.RunStorageServerTest(t, func(ctx context.Context) resource.StorageBackend {
 		dbstore := db.InitTestDB(t)
 		eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
@@ -56,6 +59,9 @@ func TestIntegrationStorageServer(t *testing.T) {
 
 // TestStorageBackend is a test for the StorageBackend interface.
 func TestIntegrationSQLStorageBackend(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("IsHA (polling notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
 			dbstore := db.InitTestDB(t)
@@ -96,6 +102,9 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationSearchAndStorage(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	tests.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()

--- a/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_enterprise_test.go
@@ -18,6 +18,9 @@ import (
 )
 
 func TestIntegration_AdminApiReencrypt_Enterprise(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	getSecretsFunctions := map[string]func(*testing.T, *server.TestEnv) map[int]secret{}
 	getSecretsFunctions["settings"] = func(t *testing.T, env *server.TestEnv) map[int]secret {
 		return getSettingSecrets(t, env.SQLStore)

--- a/pkg/tests/api/admin/encryption/reencrypt_test.go
+++ b/pkg/tests/api/admin/encryption/reencrypt_test.go
@@ -28,6 +28,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegration_AdminApiReencrypt(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	const (
 		dataSourceTable              = "data_source"
 		secretsTable                 = "secrets"

--- a/pkg/tests/api/alerting/api_admin_configuration_test.go
+++ b/pkg/tests/api/alerting/api_admin_configuration_test.go
@@ -27,6 +27,9 @@ import (
 )
 
 func TestIntegrationAdminConfiguration_SendingToExternalAlertmanagers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	const disableOrgID int64 = 2

--- a/pkg/tests/api/alerting/api_alertmanager_silence_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_silence_test.go
@@ -26,6 +26,9 @@ import (
 )
 
 func TestIntegrationSilenceAuth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_alertmanager_test.go
@@ -25,6 +25,9 @@ import (
 )
 
 func TestIntegrationAMConfigAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -354,6 +357,9 @@ func TestIntegrationAMConfigAccess(t *testing.T) {
 }
 
 func TestIntegrationAlertmanagerCreateSilence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -504,9 +510,13 @@ func TestIntegrationAlertmanagerCreateSilence(t *testing.T) {
 }
 
 func TestIntegrationAlertmanagerStatus(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_available_channel_test.go
+++ b/pkg/tests/api/alerting/api_available_channel_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestIntegrationAvailableChannels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -32,9 +32,13 @@ inhibit_rules:
 `
 
 func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana with alerting import feature flag enabled
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana with alerting import feature flag enabled
 	dir, gpath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -333,6 +337,9 @@ receivers:
 }
 
 func TestIntegrationConvertPrometheusAlertmanagerEndpoints_FeatureFlagDisabled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, gpath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_convert_prometheus_notification_settings_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_notification_settings_test.go
@@ -20,9 +20,13 @@ const (
 )
 
 func TestIntegrationConvertPrometheusNotificationSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_convert_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_test.go
@@ -106,6 +106,9 @@ var (
 )
 
 func TestIntegrationConvertPrometheusEndpoints_RecordingRuleTargetDatasource(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -172,6 +175,9 @@ func TestIntegrationConvertPrometheusEndpoints_RecordingRuleTargetDatasource(t *
 }
 
 func TestIntegrationConvertPrometheusEndpoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool, postContentType string) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -377,6 +383,9 @@ func TestIntegrationConvertPrometheusEndpoints(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_UpdateRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -457,6 +466,9 @@ func TestIntegrationConvertPrometheusEndpoints_UpdateRule(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_Conflict(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -538,6 +550,9 @@ func TestIntegrationConvertPrometheusEndpoints_Conflict(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_CreatePausedRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -645,6 +660,9 @@ func TestIntegrationConvertPrometheusEndpoints_CreatePausedRules(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_FolderUIDHeader(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -741,6 +759,9 @@ func TestIntegrationConvertPrometheusEndpoints_FolderUIDHeader(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_Provenance(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -850,6 +871,9 @@ func TestIntegrationConvertPrometheusEndpoints_Provenance(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_Delete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	runTest := func(t *testing.T, enableLokiPaths bool) {
 		testinfra.SQLiteIntegrationTest(t)
 
@@ -1144,6 +1168,9 @@ func TestIntegrationConvertPrometheusEndpoints_Delete(t *testing.T) {
 }
 
 func TestIntegrationConvertPrometheusEndpoints_GroupLabels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, gpath := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_notification_channel_test.go
+++ b/pkg/tests/api/alerting/api_notification_channel_test.go
@@ -40,6 +40,9 @@ import (
 )
 
 func TestIntegrationTestReceivers(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	t.Run("assert no receivers returns 400 Bad Request", func(t *testing.T) {
@@ -544,6 +547,9 @@ func TestIntegrationTestReceivers(t *testing.T) {
 }
 
 func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	t.Run("assert custom annotations and labels are sent", func(t *testing.T) {
@@ -831,6 +837,9 @@ func TestIntegrationTestReceiversAlertCustomization(t *testing.T) {
 }
 
 func TestIntegrationNotificationChannels(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_prometheus_test.go
+++ b/pkg/tests/api/alerting/api_prometheus_test.go
@@ -31,6 +31,9 @@ import (
 var respModel apimodels.UpdateRuleGroupResponse
 
 func TestIntegrationPrometheusRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -359,6 +362,9 @@ func TestIntegrationPrometheusRules(t *testing.T) {
 }
 
 func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -690,6 +696,9 @@ func TestIntegrationPrometheusRulesFilterByDashboard(t *testing.T) {
 }
 
 func TestIntegrationPrometheusRulesPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -77,6 +77,9 @@ func createRuleWithNotificationSettings(t *testing.T, client apiClient, folder s
 }
 
 func TestIntegrationProvisioning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -559,6 +562,9 @@ func TestIntegrationProvisioning(t *testing.T) {
 }
 
 func TestIntegrationProvisioningRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -980,6 +986,9 @@ func createTestRequest(method string, url string, user string, body string) *htt
 }
 
 func TestIntegrationExportFileProvision(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -1068,6 +1077,9 @@ func TestIntegrationExportFileProvision(t *testing.T) {
 }
 
 func TestIntegrationExportFileProvisionMixed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -1114,6 +1126,9 @@ func TestIntegrationExportFileProvisionMixed(t *testing.T) {
 }
 
 func TestIntegrationExportFileProvisionContactPoints(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_remote_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_remote_alertmanager_test.go
@@ -18,6 +18,9 @@ import (
 // TestIntegrationRemoteAlertmanagerConfigUpload tests that when we post an alertmanager
 // configuration to Grafana with remote alertmanager enabled, it gets uploaded to the remote Mimir.
 func TestIntegrationRemoteAlertmanagerConfigUpload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	s, err := alertmanager.NewAlertmanagerScenario()
@@ -133,6 +136,9 @@ receivers:
 // a historical alertmanager configuration with extra configs, it gets properly decrypted
 // and uploaded to the remote Mimir.
 func TestIntegrationRemoteAlertmanagerHistoricalConfigActivation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	s, err := alertmanager.NewAlertmanagerScenario()

--- a/pkg/tests/api/alerting/api_ruler_pause_test.go
+++ b/pkg/tests/api/alerting/api_ruler_pause_test.go
@@ -15,9 +15,13 @@ import (
 )
 
 func TestIntegrationAlertRulePauseNamespace(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4723,8 +4723,6 @@ func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
 func TestIntegrationRuleVersions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-
-		// Setup Grafana and its Database
 	}
 	testinfra.SQLiteIntegrationTest(t)
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -45,9 +45,13 @@ import (
 var testData embed.FS
 
 func TestIntegrationAlertRulePermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -349,9 +353,13 @@ func TestIntegrationAlertRulePermissions(t *testing.T) {
 }
 
 func TestIntegrationAlertRuleNestedPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		EnableFeatureToggles:  []string{featuremgmt.FlagNestedFolders},
 		DisableLegacyAlerting: true,
@@ -784,6 +792,9 @@ func TestAlertRulePostExport(t *testing.T) {
 }
 
 func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	const folderName = "folder1"
@@ -956,9 +967,13 @@ func TestIntegrationAlertRuleEditorSettings(t *testing.T) {
 }
 
 func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -1036,6 +1051,9 @@ func TestIntegrationAlertRuleConflictingTitle(t *testing.T) {
 }
 
 func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -1406,9 +1424,13 @@ func TestIntegrationRulerRulesFilterByDashboard(t *testing.T) {
 }
 
 func TestIntegrationRuleGroupSequence(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -1512,6 +1534,9 @@ func TestIntegrationRuleGroupSequence(t *testing.T) {
 }
 
 func TestIntegrationRuleCreate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
@@ -1647,9 +1672,13 @@ func TestIntegrationRuleCreate(t *testing.T) {
 }
 
 func TestIntegrationRuleUpdate(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -1921,6 +1950,9 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 }
 
 func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
@@ -2080,9 +2112,13 @@ func TestIntegrationAlertAndGroupsQuery(t *testing.T) {
 }
 
 func TestIntegrationRulerAccess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -2192,9 +2228,13 @@ func TestIntegrationRulerAccess(t *testing.T) {
 }
 
 func TestIntegrationEval(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -2472,9 +2512,13 @@ func TestIntegrationEval(t *testing.T) {
 }
 
 func TestIntegrationQuota(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -2683,6 +2727,9 @@ func TestIntegrationQuota(t *testing.T) {
 }
 
 func TestIntegrationDeleteFolderWithRules(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
 	opts := testinfra.GrafanaOpts{
@@ -2849,9 +2896,13 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 }
 
 func TestIntegrationAlertRuleCRUD(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -4130,9 +4181,13 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 }
 
 func TestIntegrationRulePause(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -4260,9 +4315,13 @@ func TestIntegrationRulePause(t *testing.T) {
 }
 
 func TestIntegrationHysteresisRule(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database. Scheduler is set to evaluate every 1 second
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database. Scheduler is set to evaluate every 1 second
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting:        true,
 		EnableUnifiedAlerting:        true,
@@ -4334,9 +4393,13 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 }
 
 func TestIntegrationRuleNotificationSettings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database. Scheduler is set to evaluate every 1 second
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database. Scheduler is set to evaluate every 1 second
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting:        true,
 		EnableUnifiedAlerting:        true,
@@ -4603,7 +4666,12 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 }
 
 func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
-	// Setup Grafana and its Database
+	if testing.
+		// Setup Grafana and its Database
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -4655,9 +4723,13 @@ func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
 }
 
 func TestIntegrationRuleVersions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -4745,9 +4817,13 @@ func TestIntegrationRuleVersions(t *testing.T) {
 }
 
 func TestIntegrationRuleSoftDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,
@@ -4856,9 +4932,13 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 }
 
 func TestIntegrationRulePermanentlyDelete(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+
+		// Setup Grafana and its Database
+	}
 	testinfra.SQLiteIntegrationTest(t)
 
-	// Setup Grafana and its Database
 	dir, p := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
 		DisableLegacyAlerting: true,
 		EnableUnifiedAlerting: true,

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4666,9 +4666,7 @@ func TestIntegrationRuleNotificationSettings(t *testing.T) {
 }
 
 func TestIntegrationRuleUpdateAllDatabases(t *testing.T) {
-	if testing.
-		// Setup Grafana and its Database
-		Short() {
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4395,8 +4395,6 @@ func TestIntegrationHysteresisRule(t *testing.T) {
 func TestIntegrationRuleNotificationSettings(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-
-		// Setup Grafana and its Database. Scheduler is set to evaluate every 1 second
 	}
 	testinfra.SQLiteIntegrationTest(t)
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4930,8 +4930,6 @@ func TestIntegrationRuleSoftDelete(t *testing.T) {
 func TestIntegrationRulePermanentlyDelete(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-
-		// Setup Grafana and its Database
 	}
 	testinfra.SQLiteIntegrationTest(t)
 

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -4817,8 +4817,6 @@ func TestIntegrationRuleVersions(t *testing.T) {
 func TestIntegrationRuleSoftDelete(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
-
-		// Setup Grafana and its Database
 	}
 	testinfra.SQLiteIntegrationTest(t)
 

--- a/pkg/tests/api/stats/admin_test.go
+++ b/pkg/tests/api/stats/admin_test.go
@@ -26,6 +26,9 @@ func TestMain(m *testing.M) {
 }
 
 func TestIntegrationAdminStats(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	t.Run("with unified alerting enabled", func(t *testing.T) {
 		url := grafanaSetup(t, testinfra.GrafanaOpts{
 			DisableLegacyAlerting: true,

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -218,6 +218,9 @@ func TestIntegrationDashboardsAppV2alpha2(t *testing.T) {
 }
 
 func TestIntegrationLegacySupport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		EnableFeatureToggles: []string{

--- a/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
@@ -21,6 +21,9 @@ import (
 //
 // it also ensures we create the connection in modes 0-2 if a dashboard v1 is created with a reference
 func TestIntegrationLibraryPanelConnections(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
@@ -84,6 +87,9 @@ func TestIntegrationLibraryPanelConnections(t *testing.T) {
 // this tests the /apis path to ensure authorization is being enforced. /api integration tests are within the service package
 // only works in modes 0-2 because the library element is created through the /api path
 func TestIntegrationLibraryElementPermissions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	dualWriterModes := []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2}
 	for _, dualWriterMode := range dualWriterModes {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/secrets_test.go
+++ b/pkg/tests/apis/provisioning/secrets_test.go
@@ -286,6 +286,9 @@ func TestIntegrationProvisioning_Secrets(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_Secrets_Update(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	ctx := context.Background()
 	helper := runGrafana(t, useAppPlatformSecrets)
 	secretsService := helper.GetEnv().RepositorySecrets

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -30,7 +30,12 @@ var updateGoldenFiles = false
 // Use the docker/blocks/postgres_tests/docker-compose.yaml to spin up a
 // preconfigured Postgres server suitable for running these tests.
 func TestIntegrationPostgresSnapshots(t *testing.T) {
-	// the logic in this function is copied from postgres_tests.go
+	if testing.
+		// the logic in this function is copied from postgres_tests.go
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	shouldRunTest := func() bool {
 		if testing.Short() {
 			return false

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_snapshot_test.go
@@ -30,9 +30,8 @@ var updateGoldenFiles = false
 // Use the docker/blocks/postgres_tests/docker-compose.yaml to spin up a
 // preconfigured Postgres server suitable for running these tests.
 func TestIntegrationPostgresSnapshots(t *testing.T) {
-	if testing.
-		// the logic in this function is copied from postgres_tests.go
-		Short() {
+	// the logic in this function is copied from postgres_tests.go
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -60,6 +60,9 @@ func TestFSQLTestSuite(t *testing.T) {
 }
 
 func (suite *FSQLTestSuite) TestIntegration_QueryData() {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	suite.Run("should run simple query data", func() {
 		resp, err := Query(
 			context.Background(),

--- a/pkg/tsdb/influxdb/fsql/fsql_test.go
+++ b/pkg/tsdb/influxdb/fsql/fsql_test.go
@@ -56,13 +56,13 @@ func (suite *FSQLTestSuite) AfterTest(suiteName, testName string) {
 }
 
 func TestFSQLTestSuite(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
 	suite.Run(t, new(FSQLTestSuite))
 }
 
 func (suite *FSQLTestSuite) TestIntegration_QueryData() {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
 	suite.Run("should run simple query data", func() {
 		resp, err := Query(
 			context.Background(),

--- a/pkg/tsdb/mysql/mysql_snapshot_test.go
+++ b/pkg/tsdb/mysql/mysql_snapshot_test.go
@@ -32,7 +32,12 @@ var updateGoldenFiles = false
 // Use the docker/blocks/mysql_tests/docker-compose.yaml to spin up a
 // preconfigured MySQL server suitable for running these tests.
 func TestIntegrationMySQLSnapshots(t *testing.T) {
-	// the logic in this function is copied from mysql_tests.go
+	if testing.
+		// the logic in this function is copied from mysql_tests.go
+		Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
 	shouldRunTest := func() bool {
 		if testing.Short() {
 			return false

--- a/pkg/tsdb/mysql/mysql_snapshot_test.go
+++ b/pkg/tsdb/mysql/mysql_snapshot_test.go
@@ -32,9 +32,8 @@ var updateGoldenFiles = false
 // Use the docker/blocks/mysql_tests/docker-compose.yaml to spin up a
 // preconfigured MySQL server suitable for running these tests.
 func TestIntegrationMySQLSnapshots(t *testing.T) {
-	if testing.
-		// the logic in this function is copied from mysql_tests.go
-		Short() {
+	// the logic in this function is copied from mysql_tests.go
+	if testing.Short() {
 		t.Skip("skipping integration test in short mode")
 	}
 


### PR DESCRIPTION
It's a large one, but automated.

We have Integration tests that are not skipped when "short" test is requested (that's how we tell unit tests from integration tests). This PR unifies it.

If it helps, that's how it was done:
```go
package main

import (
	"flag"
	"fmt"
	"go/ast"
	"go/format"
	"go/parser"
	"go/token"
	"io/ioutil"
	"os"
	"path/filepath"
)

var root = flag.String("root", "./pkg", "root directory of Go code")

func main() {
	flag.Parse()
	errs := 0
	filepath.Walk(*root, func(path string, info os.FileInfo, err error) error {
		if err != nil || info.IsDir() {
			return err
		}
		if filepath.Ext(path) != ".go" {
			return nil
		}
		processFile(path, &errs)
		return nil
	})
	if errs > 0 {
		os.Exit(1)
	}
}

func processFile(path string, errs *int) {
	src, err := ioutil.ReadFile(path)
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to read %s: %v\n", path, err)
		*errs++
		return
	}
	fset := token.NewFileSet()
	f, err := parser.ParseFile(fset, path, src, parser.ParseComments)
	if err != nil {
		fmt.Fprintf(os.Stderr, "failed to parse %s: %v\n", path, err)
		*errs++
		return
	}
	changed := false

	for _, decl := range f.Decls {
		fn, ok := decl.(*ast.FuncDecl)
		if !ok || fn.Name == nil {
			continue
		}
		if !ast.IsExported(fn.Name.Name) ||
			!hasPrefix(fn.Name.Name, "TestIntegration") {
			continue
		}
		// ensure it has param t *testing.T
		if fn.Body == nil {
			continue
		}
		if !hasShortCheck(fn.Body.List) {
			// insert skip at start
			skip := makeSkipStmt()
			fn.Body.List = append([]ast.Stmt{skip}, fn.Body.List...)
			changed = true
		}
	}
	if changed {
		out, err := format.Source(renderAST(fset, f))
		if err != nil {
			fmt.Fprintf(os.Stderr, "failed to format %s: %v\n", path, err)
			*errs++
			return
		}
		ioutil.WriteFile(path, out, 0644)
		fmt.Println("Patched", path)
	}
}

func hasPrefix(s, prefix string) bool {
	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
}

func hasShortCheck(stmts []ast.Stmt) bool {
	for i, stmt := range stmts {
		if i >= 5 {
			break
		}
		if ifstmt, ok := stmt.(*ast.IfStmt); ok {
			// check condition is testing.Short()
			if call, ok := ifstmt.Cond.(*ast.CallExpr); ok {
				if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
					if id, ok := sel.X.(*ast.Ident); ok && id.Name == "testing" && sel.Sel.Name == "Short" {
						return true
					}
				}
			}
		}
	}
	return false
}

func makeSkipStmt() ast.Stmt {
	// if testing.Short() { t.Skip("skipping integration test in short mode") }
	return &ast.IfStmt{
		Cond: &ast.CallExpr{
			Fun: &ast.SelectorExpr{
				X:   ast.NewIdent("testing"),
				Sel: ast.NewIdent("Short"),
			},
		},
		Body: &ast.BlockStmt{List: []ast.Stmt{
			&ast.ExprStmt{
				X: &ast.CallExpr{
					Fun: &ast.SelectorExpr{
						X:   ast.NewIdent("t"),
						Sel: ast.NewIdent("Skip"),
					},
					Args: []ast.Expr{&ast.BasicLit{Kind: token.STRING, Value: "\"skipping integration test in short mode\""}},
				},
			},
		}},
	}
}

func renderAST(fset *token.FileSet, f *ast.File) []byte {
	var buf []byte
	w := appendWriter{buf: &buf}
	format.Node(&w, fset, f)
	return buf
}

type appendWriter struct{ buf *[]byte }

func (w *appendWriter) Write(p []byte) (int, error) {
	*w.buf = append(*w.buf, p...)
	return len(p), nil
}
```