### PR TITLE
Remote Alertmanager: Remove unneeded SmtpFrom and StaticHeaders fields

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -216,10 +216,6 @@ func (ng *AlertNG) init() error {
 			ExternalURL:       ng.Cfg.AppURL,
 			SmtpConfig:        smtpCfg,
 			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
-
-			// TODO: Remove once everything can be sent in the 'smtp_config' field.
-			SmtpFrom:      ng.Cfg.Smtp.FromAddress,
-			StaticHeaders: ng.Cfg.Smtp.StaticHeaders,
 		}
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, skipInvalid bool) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, skipInvalid)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -63,7 +63,6 @@ type Alertmanager struct {
 	orgID             int64
 	ready             bool
 	sender            *sender.ExternalAlertmanager
-	smtpFrom          string
 	state             stateStore
 	tenantID          string
 	url               string

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -63,6 +63,7 @@ type Alertmanager struct {
 	orgID             int64
 	ready             bool
 	sender            *sender.ExternalAlertmanager
+	smtp              remoteClient.SmtpConfig
 	state             stateStore
 	tenantID          string
 	url               string
@@ -72,8 +73,6 @@ type Alertmanager struct {
 
 	amClient    *remoteClient.Alertmanager
 	mimirClient remoteClient.MimirClient
-
-	smtp remoteClient.SmtpConfig
 }
 
 type AlertmanagerConfig struct {

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -276,7 +276,9 @@ func TestIntegrationApplyConfig(t *testing.T) {
 
 		if r.Method == http.MethodPost {
 			if strings.Contains(r.URL.Path, "/config") {
-				require.NoError(t, json.NewDecoder(r.Body).Decode(&configSent))
+				var cfg client.UserGrafanaConfig
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&cfg))
+				configSent = cfg
 				configSyncs++
 			} else {
 				stateSyncs++

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -389,7 +389,7 @@ func TestIntegrationApplyConfig(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, am.ApplyConfig(ctx, config))
 	require.Equal(t, 3, configSyncs)
-	require.Equal(t, am.smtpFrom, configSent.SmtpConfig.FromAddress)
+	require.Equal(t, am.smtp.FromAddress, configSent.SmtpConfig.FromAddress)
 
 	// Changing fields in the SMTP config should result in the configuration being updated.
 	cfg.SmtpConfig = client.SmtpConfig{

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -37,10 +37,6 @@ type UserGrafanaConfig struct {
 	Promoted                  bool                      `json:"promoted"`
 	ExternalURL               string                    `json:"external_url"`
 	SmtpConfig                SmtpConfig                `json:"smtp_config"`
-
-	// TODO: Remove once everything can be sent in the 'SmtpConfig' field.
-	SmtpFrom      string            `json:"smtp_from"`
-	StaticHeaders map[string]string `json:"static_headers"`
 }
 
 func (mc *Mimir) ShouldPromoteConfig() bool {
@@ -75,10 +71,6 @@ func (mc *Mimir) CreateGrafanaAlertmanagerConfig(ctx context.Context, cfg Grafan
 		Promoted:                  mc.promoteConfig,
 		ExternalURL:               mc.externalURL,
 		SmtpConfig:                mc.smtpConfig,
-
-		// TODO: Remove once everything can be sent only in the 'smtp_config' field.
-		SmtpFrom:      mc.smtpFrom,
-		StaticHeaders: mc.staticHeaders,
 	})
 	if err != nil {
 		return err

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -50,10 +50,6 @@ type Mimir struct {
 	promoteConfig bool
 	externalURL   string
 	smtpConfig    SmtpConfig
-
-	// TODO: Remove once everything can be sent in the 'smtp' field.
-	smtpFrom      string
-	staticHeaders map[string]string
 }
 
 type SmtpConfig struct {
@@ -77,10 +73,6 @@ type Config struct {
 	PromoteConfig bool
 	ExternalURL   string
 	Smtp          SmtpConfig
-
-	// TODO: Remove once everything can be sent in the 'smtp_config' field.
-	SmtpFrom      string
-	StaticHeaders map[string]string
 }
 
 // successResponse represents a successful response from the Mimir API.
@@ -125,10 +117,6 @@ func New(cfg *Config, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer
 		promoteConfig: cfg.PromoteConfig,
 		externalURL:   cfg.ExternalURL,
 		smtpConfig:    cfg.Smtp,
-
-		// TODO: Remove once everything can be sent in the 'smtp_config' field.
-		smtpFrom:      cfg.SmtpFrom,
-		staticHeaders: cfg.StaticHeaders,
 	}, nil
 }
 


### PR DESCRIPTION
Since https://github.com/grafana/alerting-squad/issues/1160, the SMTP From address and static headers are sent inside the `SmtpConfig` fields.