### PR TITLE
Alerting: Add meta-monitoring documentation for GRAFANA_ALERTS

### DIFF
--- a/docs/sources/alerting/set-up/meta-monitoring.md
+++ b/docs/sources/alerting/set-up/meta-monitoring.md
@@ -128,6 +128,16 @@ This metric is a gauge that shows you the number of seconds that the scheduler i
 
 This metric is a histogram that shows you the number of seconds taken to send notifications for firing and resolved alerts. This metric lets you observe slow or over-utilized integrations, such as an SMTP server that is being given emails faster than it can send them.
 
+#### grafana_alerting_state_history_writes_failed_total
+
+This metric is a counter that shows you the number of failed writes to the configured alert state history backend. It includes a `backend` label to distinguish between different backends (such as `loki` or `prometheus`).
+
+{{< admonition type="note" >}}
+In Grafana Cloud, this metric is named `grafanacloud_grafana_instance_alerting_state_history_writes_failed_total:5m` and is available in the `grafanacloud-usage` data source. Only `backend="prometheus"` failures are tracked in this metric. Loki backend failures are not included.
+{{< /admonition >}}
+
+For example, you might want to create an alert that fires when `grafana_alerting_state_history_writes_failed_total{backend="prometheus"}` is greater than 0 to detect when Prometheus remote write is failing.
+
 ## Logs for Grafana-managed alerts
 
 If you have configured [Loki for alert state history](/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alert-state-history/), logs related to state changes in Grafana-managed alerts are stored in the Loki data source.

--- a/docs/sources/alerting/set-up/meta-monitoring.md
+++ b/docs/sources/alerting/set-up/meta-monitoring.md
@@ -132,10 +132,6 @@ This metric is a histogram that shows you the number of seconds taken to send no
 
 This metric is a counter that shows you the number of failed writes to the configured alert state history backend. It includes a `backend` label to distinguish between different backends (such as `loki` or `prometheus`).
 
-{{< admonition type="note" >}}
-In Grafana Cloud, this metric is named `grafanacloud_grafana_instance_alerting_state_history_writes_failed_total:5m` and is available in the `grafanacloud-usage` data source. Only `backend="prometheus"` failures are tracked in this metric. Loki backend failures are not included.
-{{< /admonition >}}
-
 For example, you might want to create an alert that fires when `grafana_alerting_state_history_writes_failed_total{backend="prometheus"}` is greater than 0 to detect when Prometheus remote write is failing.
 
 ## Logs for Grafana-managed alerts


### PR DESCRIPTION
Adds documentation for `grafana_alerting_state_history_writes_failed_total` metric in the meta-monitoring section. 


[**Preview**](https://deploy-preview-grafana-108785-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/meta-monitoring/#grafana_alerting_state_history_writes_failed_total)

Cloud docs PR: https://github.com/grafana/website/pull/26804

Part of https://github.com/grafana/alerting-squad/issues/1024