### PR TITLE
AutoGridLayoutManager: Add undo/redo functionality for pasting a panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,4 +1,5 @@
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2alpha1/types.spec.gen';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
@@ -117,8 +118,25 @@ export class AutoGridLayoutManager
 
   public pastePanel() {
     const panel = getAutoGridItemFromClipboard(getDashboardSceneFor(this));
-    this.state.layout.setState({ children: [...this.state.layout.state.children, panel] });
-    this.publishEvent(new NewObjectAddedToCanvasEvent(panel), true);
+    if (config.featureToggles.dashboardNewLayouts) {
+      dashboardEditActions.edit({
+        description: t('dashboard.edit-actions.paste-panel', 'Paste panel'),
+        addedObject: panel.state.body,
+        source: this,
+        perform: () => {
+          this.state.layout.setState({ children: [...this.state.layout.state.children, panel] });
+        },
+        undo: () => {
+          this.state.layout.setState({
+            children: this.state.layout.state.children.filter((child) => child !== panel),
+          });
+        },
+      });
+    } else {
+      this.state.layout.setState({ children: [...this.state.layout.state.children, panel] });
+      this.publishEvent(new NewObjectAddedToCanvasEvent(panel), true);
+    }
+
     clearClipboard();
   }
 


### PR DESCRIPTION
Adds undo/redo support for pasting a panel with AutoGridLayoutManager. I tried writing a test to validate the copy/paste behavior but I didn't have much luck. Seems the DefaultGridLayoutManager doesn't have a test either.