### PR TITLE
Sharing: Export dashboard as image match user's window width

### DIFF
--- a/e2e-playwright/dashboards-suite/dashboard-export-image.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-export-image.spec.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'ZqZnVvFZz';
+
+test.use({
+  featureToggles: {
+    scenes: true,
+    newDashboardSharingComponent: true,
+    sharingDashboardImage: true, // Enable the export image feature
+  },
+});
+
+test.describe(
+  'Export as Image',
+  {
+    tag: ['@dashboards'],
+  },
+  () => {
+    test('Show renderer not available message when plugin not installed', async ({
+      gotoDashboardPage,
+      page,
+      selectors,
+    }) => {
+      // Navigate to a dashboard
+      const dashboardPage = await gotoDashboardPage({
+        uid: DASHBOARD_UID,
+      });
+
+      // Open the export dropdown
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.DashNav.NewExportButton.arrowMenu).click();
+
+      // Click export as image option
+      await dashboardPage
+        .getByGrafanaSelector(selectors.pages.Dashboard.DashNav.NewExportButton.Menu.exportAsImage)
+        .click();
+
+      // Verify we're on the export image view
+      await expect(page).toHaveURL(/.*shareView=image/);
+
+      // Verify the "renderer not available" alert is displayed
+      const rendererAlert = page.getByRole('status');
+      await expect(rendererAlert).toBeVisible();
+      await expect(rendererAlert).toContainText(/Image renderer plugin not installed/i);
+      await expect(rendererAlert).toContainText(
+        /To render an image, you must install the Grafana image renderer plugin/i
+      );
+
+      // Verify the generate button is NOT present when renderer is unavailable
+      await expect(page.getByRole('button', { name: /Generate image/i })).not.toBeVisible();
+    });
+  }
+);

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportMenu.tsx
@@ -52,6 +52,7 @@ export default function ExportMenu({ dashboard }: { dashboard: DashboardScene })
 
     menuItems.push({
       shareId: shareDashboardType.image,
+      testId: newExportButtonSelector.exportAsImage,
       icon: 'camera',
       label: t('share-dashboard.menu.export-image-title', 'Export as image'),
       renderCondition: Boolean(config.featureToggles.sharingDashboardImage),

--- a/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
@@ -46,7 +46,7 @@ export async function generateDashboardImage({
       absolute: true,
       updateQuery: {
         height: -1, // image renderer will scroll through the dashboard and set the appropriate height
-        width: config.rendererDefaultImageWidth || 1000,
+        width: window.innerWidth || config.rendererDefaultImageWidth || 1000,
         scale,
         kiosk: true,
         hideNav: true,

--- a/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
@@ -28,7 +28,7 @@ export interface ImageGenerationResult {
  */
 export async function generateDashboardImage({
   dashboard,
-  scale = config.rendererDefaultImageScale || 1,
+  scale = config.rendererDefaultImageScale || 2,
 }: ImageGenerationOptions): Promise<ImageGenerationResult> {
   try {
     // Check if renderer plugin is available


### PR DESCRIPTION
Address recent user feedback around export dashboard as image feature. Mainly that the exported image width is too narrow for certain use cases. This PR updates the approach to use the user's window width. 

Also sets the fallback scale to 2 instead of 1 for better image quality as these screenshots are meant to be shared more widely.

Add a few basic unit tests and one playwright e2e test to feature

Before


https://github.com/user-attachments/assets/4f607ae6-1b02-4d4c-bac8-3c69c252bee4



After


https://github.com/user-attachments/assets/cfc74dde-4e76-4800-bfd5-4382a3e26f7e

