### PR TITLE
Plugin Extensions: Make it work for nested plugins

### DIFF
--- a/packages/grafana-data/src/context/plugins/PluginContext.tsx
+++ b/packages/grafana-data/src/context/plugins/PluginContext.tsx
@@ -5,6 +5,10 @@ import { DataSourceInstanceSettings } from '../../types/datasource';
 import { PluginMeta } from '../../types/plugin';
 
 export interface PluginContextType<T extends KeyValue = KeyValue> {
+  // In certain cases it's possible that plugins are nested into each other.
+  // Example: an app plugin using scenes which is rendering panel plugins for visualisations.
+  // In those cases the `parent` property would hold the plugin meta of the original plugin.
+  parent: PluginContextType | null;
   meta: PluginMeta<T>;
 }
 

--- a/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
+++ b/packages/grafana-data/src/context/plugins/PluginContextProvider.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren, ReactElement } from 'react';
 import { PluginMeta } from '../../types/plugin';
 
 import { PluginContext } from './PluginContext';
+import { usePluginContext } from './usePluginContext';
 
 export type PluginContextProviderProps = {
   meta: PluginMeta;
@@ -10,5 +11,7 @@ export type PluginContextProviderProps = {
 
 export function PluginContextProvider(props: PropsWithChildren<PluginContextProviderProps>): ReactElement {
   const { children, ...rest } = props;
-  return <PluginContext.Provider value={rest}>{children}</PluginContext.Provider>;
+  const parentPluginContext = usePluginContext();
+
+  return <PluginContext.Provider value={{ ...rest, parent: parentPluginContext }}>{children}</PluginContext.Provider>;
 }


### PR DESCRIPTION
**Related Slack thread:** https://raintank-corp.slack.com/archives/C04FRQ2S0AV/p1751917692269079

### Background
In certain edge cases it's possible that plugins are rendered inside each other, for example when an app plugin is using scenes, and scenes is rendering panel plugins for visualisations. If the app plugin is passing in components for these visualisations (e.g. [here for table panel](https://github.com/grafana/grafana-k8s-plugin/pull/2361/files)). 

### The problem
If any of the passed in components are using extensions, then the validations will fail, as the panel plugin is overriding the `PluginContext`, and the overriden context won't have the right metadata.

### What changed?
The idea behind this PR is to extend the `PluginContext` to also hold the meta information for parent plugins (if there's any).

- [x] Extend the `PluginContext` to be aware of parent plugins
- [ ] Update the extensions validation logic to check for parent plugin contexts as well
- [ ] Update the tests