### PR TITLE
Secret: Fix create/delete basic role configuration for secure values

### DIFF
--- a/pkg/registry/apis/secret/accesscontrol.go
+++ b/pkg/registry/apis/secret/accesscontrol.go
@@ -45,7 +45,7 @@ func registerAccessControlRoles(service accesscontrol.Service) error {
 				},
 			},
 		},
-		Grants: []string{string(org.RoleEditor)},
+		Grants: []string{string(org.RoleAdmin)},
 	}
 
 	secureValuesReader := accesscontrol.RoleRegistration{
@@ -93,7 +93,7 @@ func registerAccessControlRoles(service accesscontrol.Service) error {
 				},
 			},
 		},
-		Grants: []string{string(org.RoleEditor)},
+		Grants: []string{string(org.RoleAdmin)},
 	}
 
 	// Keepers


### PR DESCRIPTION
**What is this feature?**

Set the basic role for Create/Delete Secure Values for Admins, rather than Editors.

**Why do we need this feature?**

We agreed it made more sense to keep them all as Admin.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
