### PR TITLE
Chore: Use proper database type from env in testinfra integration tests

### DIFF
--- a/pkg/services/sqlstore/sqlutil/sqlutil.go
+++ b/pkg/services/sqlstore/sqlutil/sqlutil.go
@@ -22,6 +22,11 @@ type TestDB struct {
 	DriverName string
 	ConnStr    string
 	Path       string
+	Host       string
+	Port       string
+	User       string
+	Password   string
+	Database   string
 	Cleanup    func()
 }
 
@@ -132,6 +137,11 @@ func mySQLTestDB() (*TestDB, error) {
 	return &TestDB{
 		DriverName: "mysql",
 		ConnStr:    conn_str,
+		Host:       host,
+		Port:       port,
+		User:       "grafana",
+		Password:   "password",
+		Database:   "grafana_tests",
 		Cleanup:    func() {},
 	}, nil
 }
@@ -149,6 +159,11 @@ func postgresTestDB() (*TestDB, error) {
 	return &TestDB{
 		DriverName: "postgres",
 		ConnStr:    connStr,
+		Host:       host,
+		Port:       port,
+		User:       "grafanatest",
+		Password:   "grafanatest",
+		Database:   "grafanatest",
 		Cleanup:    func() {},
 	}, nil
 }

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -1036,8 +1036,10 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 
 		// Verify dashboard still exists in Grafana with same content but may have updated path references
 		helper.SyncAndWait(t, repo, nil)
-		_, err = helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
-		require.NoError(t, err, "dashboard should still exist in Grafana after move")
+		require.Eventually(t, func() bool {
+			_, err = helper.DashboardsV1.Resource.Get(ctx, allPanelsUID, metav1.GetOptions{})
+			return err == nil
+		}, 10*time.Second, 100*time.Millisecond, "dashboard should still exist in Grafana after move") // Using Eventually to account for potential delays in dashboards APIs.
 	})
 
 	t.Run("move file to nested path without ref", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/provisioning_test.go
+++ b/pkg/tests/apis/provisioning/provisioning_test.go
@@ -161,14 +161,21 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 	// Viewer can see settings listing
 	t.Run("viewer has access to list", func(t *testing.T) {
 		settings := &provisioning.RepositoryViewList{}
-		rsp := helper.ViewerREST.Get().
-			Namespace("default").
-			Suffix("settings").
-			Do(context.Background())
-		require.NoError(t, rsp.Error())
-		err := rsp.Into(settings)
-		require.NoError(t, err)
-		require.Len(t, settings.Items, len(inputFiles))
+		// Wait for unified storage to make the data available
+		require.Eventually(t, func() bool {
+			rsp := helper.ViewerREST.Get().
+				Namespace("default").
+				Suffix("settings").
+				Do(context.Background())
+			if rsp.Error() != nil {
+				return false
+			}
+			err := rsp.Into(settings)
+			if err != nil {
+				return false
+			}
+			return len(settings.Items) == len(inputFiles)
+		}, time.Second*10, time.Millisecond*100, "Expected settings to have len(inputFiles) items")
 
 		// FIXME: this should be an enterprise integration test
 		if extensions.IsEnterprise {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/services/sqlstore/sqlutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,6 +86,20 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 
 	err = featuremgmt.InitOpenFeatureWithCfg(cfg)
 	require.NoError(t, err)
+
+	// Use proper database type based on the environment variable GRAFANA_TEST_DB in tests
+	testDB, err := sqlutil.GetTestDB(sqlutil.GetTestDBType())
+	require.NoError(t, err)
+	t.Cleanup(testDB.Cleanup)
+
+	dbCfg := cfg.Raw.Section("database")
+	dbCfg.Key("type").SetValue(testDB.DriverName)
+	dbCfg.Key("host").SetValue(testDB.Host)
+	dbCfg.Key("port").SetValue(testDB.Port)
+	dbCfg.Key("user").SetValue(testDB.User)
+	dbCfg.Key("password").SetValue(testDB.Password)
+	dbCfg.Key("name").SetValue(testDB.Database)
+
 	env, err := server.InitializeForTest(t, t, cfg, serverOpts, apiServerOpts)
 	require.NoError(t, err)
 


### PR DESCRIPTION
As a side quest from [this PR](https://github.com/grafana/grafana/pull/108764) I thought it would be easier to move this fix into a separate changeset.

Previously, tests that used `testinfra` always ran on SQLite even though Postgres/MySQL has been requested on the CI. Tests appeared green until I broke SQLite and realised we haven't been testing what we thought we have.

This PR extends TestDB from `sqlutil` to contain all the information about the test database, so that it can be injected into `Cfg` or used in other ways to configure the database with test credentials/parameters.