### PR TITLE
New Logs Context: Logs context using the new Logs Panel

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1091,4 +1091,8 @@ export interface FeatureToggles {
   * Enable adhoc filter buttons in visualization tooltips
   */
   adhocFiltersInTooltips?: boolean;
+  /**
+  * New Log Context component
+  */
+  newLogContext?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1890,6 +1890,13 @@ var (
 			Owner:        grafanaDataProSquad,
 			FrontendOnly: true,
 		},
+		{
+			Name:         "newLogContext",
+			Description:  "New Log Context component",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaObservabilityLogsSquad,
+			FrontendOnly: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -244,3 +244,4 @@ dashboardDsAdHocFiltering,experimental,@grafana/datapro,false,false,true
 dashboardLevelTimeMacros,experimental,@grafana/dashboards-squad,false,false,true
 alertmanagerRemoteSecondaryWithRemoteState,experimental,@grafana/alerting-squad,false,false,false
 adhocFiltersInTooltips,experimental,@grafana/datapro,false,false,true
+newLogContext,experimental,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -986,4 +986,8 @@ const (
 	// FlagAdhocFiltersInTooltips
 	// Enable adhoc filter buttons in visualization tooltips
 	FlagAdhocFiltersInTooltips = "adhocFiltersInTooltips"
+
+	// FlagNewLogContext
+	// New Log Context component
+	FlagNewLogContext = "newLogContext"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2152,6 +2152,19 @@
     },
     {
       "metadata": {
+        "name": "newLogContext",
+        "resourceVersion": "1754044501326",
+        "creationTimestamp": "2025-08-01T10:35:01Z"
+      },
+      "spec": {
+        "description": "New Log Context component",
+        "stage": "experimental",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "newLogsPanel",
         "resourceVersion": "1753448760331",
         "creationTimestamp": "2025-02-04T17:40:17Z"

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -788,13 +788,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           getRowContext={(row, options) => getRowContext(row, contextRow, options)}
           getRowContextQuery={getRowContextQuery}
           getLogRowContextUi={getLogRowContextUi}
+          logOptionsStorageKey={SETTING_KEY_ROOT}
           logsSortOrder={logsSortOrder}
           timeZone={timeZone}
           displayedFields={displayedFields}
           onClickShowField={showField}
           onClickHideField={hideField}
-          showTime={showTime}
-          wrapLogMessage={wrapLogMessage}
         />
       )}
       <PanelChrome

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -52,6 +52,7 @@ import { ControlledLogRows } from 'app/features/logs/components/ControlledLogRow
 import { InfiniteScroll } from 'app/features/logs/components/InfiniteScroll';
 import { LogRows } from 'app/features/logs/components/LogRows';
 import { LogRowContextModal } from 'app/features/logs/components/log-context/LogRowContextModal';
+import { LogLineContext } from 'app/features/logs/components/panel/LogLineContext';
 import { LogList, LogListControlOptions } from 'app/features/logs/components/panel/LogList';
 import { isDedupStrategy, isLogsSortOrder } from 'app/features/logs/components/panel/LogListContext';
 import { LogLevelColor, dedupLogRows } from 'app/features/logs/logsModel';
@@ -767,7 +768,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   return (
     <>
-      {getRowContext && contextRow && (
+      {!config.featureToggles.newLogsPanel && getRowContext && contextRow && (
         <LogRowContextModal
           open={contextOpen}
           row={contextRow}
@@ -777,6 +778,23 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           getLogRowContextUi={getLogRowContextUi}
           logsSortOrder={logsSortOrder}
           timeZone={timeZone}
+        />
+      )}
+      {config.featureToggles.newLogsPanel && getRowContext && contextRow && (
+        <LogLineContext
+          open={contextOpen}
+          log={contextRow}
+          onClose={onCloseContext}
+          getRowContext={(row, options) => getRowContext(row, contextRow, options)}
+          getRowContextQuery={getRowContextQuery}
+          getLogRowContextUi={getLogRowContextUi}
+          logsSortOrder={logsSortOrder}
+          timeZone={timeZone}
+          displayedFields={displayedFields}
+          onClickShowField={showField}
+          onClickHideField={hideField}
+          showTime={showTime}
+          wrapLogMessage={wrapLogMessage}
         />
       )}
       <PanelChrome

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -789,7 +789,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           getRowContextQuery={getRowContextQuery}
           getLogRowContextUi={getLogRowContextUi}
           logOptionsStorageKey={SETTING_KEY_ROOT}
-          logsSortOrder={logsSortOrder}
           timeZone={timeZone}
           displayedFields={displayedFields}
           onClickShowField={showField}

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -768,7 +768,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   return (
     <>
-      {!config.featureToggles.newLogsPanel && getRowContext && contextRow && (
+      {(!config.featureToggles.newLogsPanel || !config.featureToggles.newLogContext) && getRowContext && contextRow && (
         <LogRowContextModal
           open={contextOpen}
           row={contextRow}
@@ -780,7 +780,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           timeZone={timeZone}
         />
       )}
-      {config.featureToggles.newLogsPanel && getRowContext && contextRow && (
+      {config.featureToggles.newLogsPanel && config.featureToggles.newLogContext && getRowContext && contextRow && (
         <LogLineContext
           open={contextOpen}
           log={contextRow}

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -310,7 +310,7 @@ function getNextRange(visibleRange: AbsoluteTimeRange, currentRange: TimeRange, 
 export const SCROLLING_THRESHOLD = 1e3;
 
 // To get more logs, the difference between the visible range and the current range should be 1 second or more.
-function canScrollTop(
+export function canScrollTop(
   visibleRange: AbsoluteTimeRange,
   currentRange: TimeRange,
   timeZone: TimeZone,

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -122,7 +122,7 @@ export const InfiniteScroll = ({
       loadMore?.(newRange ?? getVisibleRange(logs), scrollDirection);
 
       reportInteraction('grafana_logs_infinite_scrolling', {
-        direction: 'bottom',
+        direction: scrollDirection,
         sort_order: sortOrder,
       });
     },

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -7,7 +7,7 @@ import { t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { Spinner, useStyles2 } from '@grafana/ui';
 
-import { canScrollBottom, getVisibleRange, ScrollDirection, shouldLoadMore } from '../InfiniteScroll';
+import { canScrollBottom, canScrollTop, getVisibleRange, ScrollDirection, shouldLoadMore } from '../InfiniteScroll';
 
 import { getStyles, LogLine } from './LogLine';
 import { LogLineMessage } from './LogLineMessage';
@@ -105,7 +105,10 @@ export const InfiniteScroll = ({
 
   const onLoadMore = useCallback(
     (scrollDirection: ScrollDirection) => {
-      const newRange = canScrollBottom(getVisibleRange(logs), timeRange, timeZone, sortOrder);
+      const newRange =
+        scrollDirection === ScrollDirection.Bottom
+          ? canScrollBottom(getVisibleRange(logs), timeRange, timeZone, sortOrder)
+          : canScrollTop(getVisibleRange(logs), timeRange, timeZone, sortOrder);
       if (!newRange && infiniteScrollMode === 'interval') {
         setInfiniteLoaderState('out-of-bounds');
         return;

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -524,6 +524,14 @@ export const getStyles = (theme: GrafanaTheme2, virtualization?: LogLineVirtuali
       border: 'none',
       display: 'inline',
     }),
+    loadMoreTopContainer: css({
+      backgroundColor: tinycolor(theme.colors.background.primary).setAlpha(0.75).toString(),
+      left: 0,
+      position: 'absolute',
+      top: 0,
+      width: '100%',
+      zIndex: theme.zIndex.navbarFixed,
+    }),
     overflows: css({
       outline: 'solid 1px red',
     }),

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -181,11 +181,11 @@ describe('LogLineContext', () => {
         sortOrder={LogsSortOrder.Descending}
       />
     );
-    // 1 collapsible container, 1 in before, 1 in current, 1 in after
-    await waitFor(() => expect(screen.getAllByText('foo123').length).toBe(4));
+    // 1 in before, 1 in current, 1 in after
+    await waitFor(() => expect(screen.getAllByText('foo123').length).toBe(3));
   });
 
-  test('should render 4 lines containing `foo123` with the same ms timestamp', async () => {
+  test('should render 3 lines containing `foo123` with the same ms timestamp', async () => {
     const dfBeforeNs = createDataFrame({
       fields: [
         {
@@ -283,9 +283,9 @@ describe('LogLineContext', () => {
       />
     );
 
-    // 1 collapsible container, 1 in before, 1 in current, 1 in after
+    // 1 in before, 1 in current, 1 in after
     await waitFor(() => {
-      expect(screen.getAllByText('foo123').length).toBe(4);
+      expect(screen.getAllByText('foo123').length).toBe(3);
     });
   });
 

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -17,7 +17,6 @@ jest.mock('@grafana/assistant', () => ({
   useAssistant: jest.fn(() => [true, jest.fn()]),
 }));
 
-
 const dfBefore = createDataFrame({
   fields: [
     {

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -1,0 +1,546 @@
+import { render, screen, waitFor, fireEvent, userEvent } from 'test/test-utils';
+
+import {
+  createDataFrame,
+  FieldType,
+  LogRowContextQueryDirection,
+  LogsSortOrder,
+  SplitOpenOptions,
+} from '@grafana/data';
+
+import { dataFrameToLogsModel } from '../../logsModel';
+
+import { LogLineContext } from './LogLineContext';
+
+jest.mock('@grafana/assistant', () => ({
+  ...jest.requireActual('@grafana/assistant'),
+  useAssistant: jest.fn(() => [true, jest.fn()]),
+}));
+
+
+const dfBefore = createDataFrame({
+  fields: [
+    {
+      name: 'time',
+      type: FieldType.time,
+      values: ['2019-04-26T07:28:11.352440161Z', '2019-04-26T09:28:11.352440161Z'],
+    },
+    {
+      name: 'message',
+      type: FieldType.string,
+      values: ['foo123', 'foo123'],
+    },
+  ],
+});
+const dfNow = createDataFrame({
+  fields: [
+    {
+      name: 'time',
+      type: FieldType.time,
+      values: ['2019-04-26T09:28:11.352440161Z'],
+    },
+    {
+      name: 'message',
+      type: FieldType.string,
+      values: ['foo123'],
+    },
+  ],
+});
+const dfAfter = createDataFrame({
+  fields: [
+    {
+      name: 'time',
+      type: FieldType.time,
+      values: ['2019-04-26T14:42:50.991981292Z', '2019-04-26T16:28:11.352440161Z'],
+    },
+    {
+      name: 'message',
+      type: FieldType.string,
+      values: ['foo123', 'bar123'],
+    },
+  ],
+});
+
+let getRowContext = jest.fn();
+const dispatchMock = jest.fn();
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: () => dispatchMock,
+}));
+
+const splitOpenSym = Symbol('splitOpen');
+const splitOpen = jest.fn().mockReturnValue(splitOpenSym);
+jest.mock('app/features/explore/state/main', () => ({
+  ...jest.requireActual('app/features/explore/state/main'),
+  splitOpen: (arg?: SplitOpenOptions) => {
+    return splitOpen(arg);
+  },
+}));
+
+const logs = dataFrameToLogsModel([dfNow]);
+const row = logs.rows[0];
+
+const timeZone = 'UTC';
+
+describe('LogLineContext', () => {
+  let uniqueRefIdCounter = 1;
+
+  beforeEach(() => {
+    uniqueRefIdCounter = 1;
+    getRowContext = jest.fn().mockImplementation(async (_, options) => {
+      uniqueRefIdCounter += 1;
+      const refId = `refid_${uniqueRefIdCounter}`;
+      if (options.direction === LogRowContextQueryDirection.Forward) {
+        return {
+          data: [
+            {
+              refId,
+              ...dfBefore,
+            },
+          ],
+        };
+      } else {
+        return {
+          data: [
+            {
+              refId,
+              ...dfAfter,
+            },
+          ],
+        };
+      }
+    });
+  });
+
+  test('Should not render when it is closed', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={false}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(screen.queryByText('Log context')).not.toBeInTheDocument());
+  });
+
+  test('Should render when it is open', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(screen.queryByText('Log context')).toBeInTheDocument());
+  });
+
+  test('Should call not getRowContext when closed', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={false}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(getRowContext).not.toHaveBeenCalled());
+  });
+
+  test('Should call getRowContext on open', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+    await waitFor(() => expect(getRowContext).toHaveBeenCalledTimes(2));
+  });
+
+  test('should render 3 lines containing `foo123`', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+    // 1 collapsible container, 1 in before, 1 in current, 1 in after
+    await waitFor(() => expect(screen.getAllByText('foo123').length).toBe(4));
+  });
+
+  test('should render 4 lines containing `foo123` with the same ms timestamp', async () => {
+    const dfBeforeNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1, 1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['foo123', 'foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['1', '2'],
+        },
+      ],
+    });
+    const dfNowNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['2'],
+        },
+      ],
+    });
+    const dfAfterNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1, 1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['foo123', 'foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['2', '3'],
+        },
+      ],
+    });
+
+    let uniqueRefIdCounter = 1;
+    const logs = dataFrameToLogsModel([dfNowNs]);
+    const row = logs.rows[0];
+    const getRowContext = jest.fn().mockImplementation(async (_, options) => {
+      uniqueRefIdCounter += 1;
+      const refId = `refid_${uniqueRefIdCounter}`;
+      if (uniqueRefIdCounter === 2) {
+        return {
+          data: [
+            {
+              refId,
+              ...dfBeforeNs,
+            },
+          ],
+        };
+      } else if (uniqueRefIdCounter === 3) {
+        return {
+          data: [
+            {
+              refId,
+              ...dfAfterNs,
+            },
+          ],
+        };
+      }
+      return { data: [] };
+    });
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    // 1 collapsible container, 1 in before, 1 in current, 1 in after
+    await waitFor(() => {
+      expect(screen.getAllByText('foo123').length).toBe(4);
+    });
+  });
+
+  test('Should highlight the same `foo123` searchwords', async () => {
+    const dfBeforeNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1, 1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['this contains foo123', 'this contains foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['1', '2'],
+        },
+      ],
+    });
+    const dfNowNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['this contains foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['2'],
+        },
+      ],
+    });
+    const dfAfterNs = createDataFrame({
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          values: [1, 1],
+        },
+        {
+          name: 'message',
+          type: FieldType.string,
+          values: ['this contains foo123', 'this contains foo123'],
+        },
+        {
+          name: 'tsNs',
+          type: FieldType.string,
+          values: ['2', '3'],
+        },
+      ],
+    });
+
+    let uniqueRefIdCounter = 1;
+    const logs = dataFrameToLogsModel([dfNowNs]);
+    const row = logs.rows[0];
+    row.searchWords = ['foo123'];
+    const getRowContext = jest.fn().mockImplementation(async (_, options) => {
+      uniqueRefIdCounter += 1;
+      const refId = `refid_${uniqueRefIdCounter}`;
+      if (uniqueRefIdCounter === 2) {
+        return {
+          data: [
+            {
+              refId,
+              ...dfBeforeNs,
+            },
+          ],
+        };
+      } else if (uniqueRefIdCounter === 3) {
+        return {
+          data: [
+            {
+              refId,
+              ...dfAfterNs,
+            },
+          ],
+        };
+      }
+      return { data: [] };
+    });
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    // there need to be 3 lines with that message, all `foo123` should be highlighted
+    await waitFor(() => {
+      expect(screen.getAllByText('foo123')).toHaveLength(3);
+      expect(screen.getAllByText('this contains')).toHaveLength(3);
+    });
+  });
+
+  test('Should show a split view button', async () => {
+    const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', {
+          name: /open in split view/i,
+        })
+      ).toBeInTheDocument()
+    );
+  });
+
+  test('Should not show a split view button', async () => {
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('button', {
+          name: /open in split view/i,
+        })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  test('Should call getRowContextQuery', async () => {
+    const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    await waitFor(() => expect(getRowContextQuery).toHaveBeenCalledTimes(1));
+  });
+
+  test('Should close modal', async () => {
+    const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
+    const onClose = jest.fn();
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={onClose}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    const splitViewButton = await screen.findByRole('button', {
+      name: /open in split view/i,
+    });
+
+    await userEvent.click(splitViewButton);
+
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  test('Should create correct splitOpen', async () => {
+    const queryObj = { datasource: { uid: 'test-uid' } };
+    const getRowContextQuery = jest.fn().mockResolvedValue(queryObj);
+    const onClose = jest.fn();
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={onClose}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    const splitViewButton = await screen.findByRole('button', {
+      name: /open in split view/i,
+    });
+
+    await userEvent.click(splitViewButton);
+
+    await waitFor(() =>
+      expect(splitOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          queries: [queryObj],
+          panelsState: {
+            logs: {
+              id: row.uid,
+            },
+          },
+        })
+      )
+    );
+  });
+
+  test('Should dispatch splitOpen', async () => {
+    const getRowContextQuery = jest.fn().mockResolvedValue({ datasource: { uid: 'test-uid' } });
+    const onClose = jest.fn();
+
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={onClose}
+        getRowContext={getRowContext}
+        getRowContextQuery={getRowContextQuery}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+
+    const splitViewButton = await screen.findByRole('button', {
+      name: /open in split view/i,
+    });
+
+    await userEvent.click(splitViewButton);
+
+    await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(splitOpenSym));
+  });
+});

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent, userEvent } from 'test/test-utils';
+import { render, screen, waitFor, userEvent } from 'test/test-utils';
 
 import {
   createDataFrame,

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -52,10 +52,12 @@ const getStyles = (theme: GrafanaTheme2) => {
     loadingIndicator: css({
       height: theme.spacing(3),
     }),
+    wrapper: css({
+      border: `1px solid ${theme.colors.border.weak}`,
+      padding: theme.spacing(0, 1, 1, 0),
+    }),
     logsContainer: css({
       height: '59vh',
-      border: `1px solid ${theme.colors.border.weak}`,
-      padding: theme.spacing(0, 0.5, 1, 0),
     }),
     flexColumn: css({
       display: 'flex',
@@ -252,33 +254,35 @@ export const LogLineContext = memo(
             />
           )}
         </div>
-        <div className={styles.logsContainer} ref={containerRef}>
-          {containerRef.current && (
-            <LogList
-              app={CoreApp.Unknown}
-              containerElement={containerRef.current}
-              dedupStrategy={LogsDedupStrategy.none}
-              detailsMode="inline"
-              displayedFields={displayedFields}
-              enableLogDetails={true}
-              eventBus={eventBusRef.current}
-              infiniteScrollMode="unlimited"
-              loadMore={handleLoadMore}
-              logs={allLogs}
-              loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
-              permalinkedLogId={log.uid}
-              onClickHideField={onClickHideField}
-              onClickShowField={onClickShowField}
-              showControls
-              showTime={logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.showTime`, true) : true}
-              sortOrder={logsSortOrder}
-              timeRange={timeRange}
-              timeZone={timeZone}
-              wrapLogMessage={
-                logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true
-              }
-            />
-          )}
+        <div className={styles.wrapper}>
+          <div className={styles.logsContainer} ref={containerRef}>
+            {containerRef.current && (
+              <LogList
+                app={CoreApp.Unknown}
+                containerElement={containerRef.current}
+                dedupStrategy={LogsDedupStrategy.none}
+                detailsMode="inline"
+                displayedFields={displayedFields}
+                enableLogDetails={true}
+                eventBus={eventBusRef.current}
+                infiniteScrollMode="unlimited"
+                loadMore={handleLoadMore}
+                logs={allLogs}
+                loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
+                permalinkedLogId={log.uid}
+                onClickHideField={onClickHideField}
+                onClickShowField={onClickShowField}
+                showControls
+                showTime={logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.showTime`, true) : true}
+                sortOrder={logsSortOrder}
+                timeRange={timeRange}
+                timeZone={timeZone}
+                wrapLogMessage={
+                  logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true
+                }
+              />
+            )}
+          </div>
         </div>
         <div className={styles.loadingIndicator}>
           {belowState === LoadingState.Loading && (

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -232,14 +232,17 @@ export const LogLineContext = memo(
       ? store.getBool(`${logOptionsStorageKey}.syntaxHighlighting`, true)
       : true;
     // @todo: Remove when the LogRows are deprecated
-    const logListModel =
-      log instanceof LogListModel
-        ? log
-        : new LogListModel(log, {
-            escape: false,
-            timeZone,
-            wrapLogMessage,
-          });
+    const logListModel = useMemo(
+      () =>
+        log instanceof LogListModel
+          ? log
+          : new LogListModel(log, {
+              escape: false,
+              timeZone,
+              wrapLogMessage,
+            }),
+      [log, timeZone, wrapLogMessage]
+    );
 
     return (
       <Modal

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -15,6 +15,7 @@ import {
   LoadingState,
   CoreApp,
   LogRowModel,
+  AbsoluteTimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -25,6 +26,7 @@ import { useDispatch } from 'app/types/store';
 
 import { dataFrameToLogsModel } from '../../logsModel';
 import { sortLogRows } from '../../utils';
+import { ScrollDirection } from '../InfiniteScroll';
 
 import { LogList } from './LogList';
 
@@ -67,12 +69,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     logRowGroups: css({
       height: '60vh',
       alignSelf: 'stretch',
-      display: 'inline-block',
       border: `1px solid ${theme.colors.border.weak}`,
-      borderRadius: theme.shape.radius.default,
-      '& > table': {
-        minWidth: '100%',
-      },
+      padding: theme.spacing(0, 0.5, 1, 0),
     }),
     flexColumn: css({
       display: 'flex',
@@ -262,6 +260,15 @@ export const LogLineContext = memo(
       }
     }, [initialized, loadMore, log]);
 
+    const handleLoadMore = useCallback(
+      (_: AbsoluteTimeRange, direction: ScrollDirection) => {
+        if (direction === ScrollDirection.Bottom) {
+          loadMore('below', allLogs[allLogs.length - 1]);
+        }
+      },
+      [allLogs, loadMore]
+    );
+
     return (
       <Modal
         isOpen={open}
@@ -279,15 +286,17 @@ export const LogLineContext = memo(
               app={CoreApp.Unknown}
               containerElement={containerRef.current}
               dedupStrategy={LogsDedupStrategy.none}
+              detailsMode="inline"
               displayedFields={displayedFields}
               enableLogDetails={true}
-              detailsMode="inline"
+              infiniteScrollMode="unlimited"
+              loadMore={handleLoadMore}
               logs={allLogs}
               loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
               permalinkedLogId={log.uid}
               onClickHideField={onClickHideField}
               onClickShowField={onClickShowField}
-              showControls={false}
+              showControls
               showTime={showTime}
               sortOrder={logsSortOrder}
               timeRange={timeRange}

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -287,7 +287,7 @@ export const LogLineContext = memo(
               }
             />
           )}
-          {aboveState === LoadingState.Done && (
+          {belowState === LoadingState.Done && (
             <Trans i18nKey="logs.log-line-context.no-more-logs-available">No more logs available.</Trans>
           )}
         </div>

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -287,7 +287,7 @@ export const LogLineContext = memo(
                 syntaxHighlighting={syntaxHighlighting}
                 timeRange={timeRange}
                 timeZone={timeZone}
-                wrapLogMessage
+                wrapLogMessage={wrapLogMessage}
               />
             )}
           </div>

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -153,7 +153,10 @@ export const LogLineContext = memo(
     }, [log, getRowContextQuery]);
 
     const updateResults = useCallback(async () => {
+      setAboveLogs([]);
+      setBelowLogs([]);
       await updateContextQuery();
+      setInitialized(false);
     }, [updateContextQuery]);
 
     useEffect(() => {

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -374,6 +374,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     logsContainer: css({
       height: '57vh',
+      overflow: 'hidden',
     }),
     flexColumn: css({
       display: 'flex',

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -259,6 +259,7 @@ export const LogLineContext = memo(
           collapsible={true}
           isOpen={showLog}
           onToggle={() => setShowLog(!showLog)}
+          className={styles.referenceLogLine}
           label={
             <div className={styles.collapseLabel}>
               <div>{t('logs.log-line-context.title-log-line', 'Referenced log line')}</div>
@@ -387,20 +388,24 @@ const getStyles = (theme: GrafanaTheme2) => {
       height: theme.spacing(3),
       textAlign: 'center',
     }),
+    referenceLogLine: css({
+      flex: 0,
+    }),
     wrapper: css({
       border: `1px solid ${theme.colors.border.weak}`,
       padding: theme.spacing(0, 1, 1, 0),
+      flex: 1,
       height: '100%',
     }),
     logsContainer: css({
       height: '100%',
-      minHeight: '52vh',
       overflow: 'hidden',
     }),
     flexColumn: css({
       display: 'flex',
       flexDirection: 'column',
       padding: theme.spacing(0, 3, 3, 3),
+      height: '100%',
     }),
     link: css({
       color: theme.colors.text.secondary,

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -49,7 +49,7 @@ interface LogLineContextProps {
   sortOrder?: LogsSortOrder;
   runContextQuery?: () => void;
   getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
-  displayedFields: string[];
+  displayedFields?: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
 }
@@ -69,7 +69,7 @@ export const LogLineContext = memo(
     getRowContextQuery,
     onClose,
     getRowContext,
-    displayedFields,
+    displayedFields = [],
     onClickShowField,
     onClickHideField,
   }: LogLineContextProps) => {
@@ -182,11 +182,14 @@ export const LogLineContext = memo(
     );
 
     useEffect(() => {
+      if (!open) {
+        return;
+      }
       if (!initialized) {
         Promise.all([loadMore('above', log), loadMore('below', log)]).then(() => {});
         setInitialized(true);
       }
-    }, [initialized, loadMore, log]);
+    }, [initialized, loadMore, log, open]);
 
     const handleLoadMore = useCallback(
       (_: AbsoluteTimeRange, direction: ScrollDirection) => {

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -225,11 +225,7 @@ export const LogLineContext = memo(
           collapsible={true}
           isOpen={showLog}
           onToggle={() => setShowLog(!showLog)}
-          label={
-            <div className={styles.logPreview}>
-              {showLog ? t('logs.log-line-context.title-log-line', 'Log line') : log.entry.substring(0, 300)}
-            </div>
-          }
+          label={t('logs.log-line-context.title-log-line', 'Referenced log line')}
         >
           <div>{log.entry}</div>
         </Collapse>

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -371,6 +371,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     modal: css({
       width: '85vw',
+      height: '80%',
       [theme.breakpoints.down('md')]: {
         width: '100%',
       },
@@ -389,9 +390,11 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       border: `1px solid ${theme.colors.border.weak}`,
       padding: theme.spacing(0, 1, 1, 0),
+      height: '100%',
     }),
     logsContainer: css({
-      height: '57vh',
+      height: '100%',
+      minHeight: '52vh',
       overflow: 'hidden',
     }),
     flexColumn: css({

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -1,0 +1,377 @@
+import { css } from '@emotion/css';
+import { partition } from 'lodash';
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+import {
+  DataQueryResponse,
+  DataSourceWithLogsContextSupport,
+  GrafanaTheme2,
+  LogRowContextOptions,
+  LogRowContextQueryDirection,
+  LogsDedupStrategy,
+  LogsSortOrder,
+  dateTime,
+  TimeRange,
+  LoadingState,
+  CoreApp,
+  LogRowModel,
+} from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { config, reportInteraction } from '@grafana/runtime';
+import { DataQuery, TimeZone } from '@grafana/schema';
+import { Button, Modal, useTheme2 } from '@grafana/ui';
+import { splitOpen } from 'app/features/explore/state/main';
+import { useDispatch } from 'app/types/store';
+
+import { dataFrameToLogsModel } from '../../logsModel';
+import { sortLogRows } from '../../utils';
+
+import { LogList } from './LogList';
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    modal: css({
+      width: '85vw',
+      [theme.breakpoints.down('md')]: {
+        width: '100%',
+      },
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%)',
+    }),
+    sticky: css({
+      position: 'sticky',
+      zIndex: 1,
+      top: '-1px',
+      bottom: '-1px',
+    }),
+    entry: css({
+      '& > td': {
+        padding: theme.spacing(1, 0, 1, 0),
+      },
+      background: theme.colors.emphasize(theme.colors.background.secondary),
+
+      '& > table': {
+        marginBottom: 0,
+      },
+
+      '& .log-row-menu': {
+        marginTop: '-6px',
+      },
+    }),
+    datasourceUi: css({
+      paddingBottom: theme.spacing(1.25),
+      display: 'flex',
+      alignItems: 'center',
+    }),
+    logRowGroups: css({
+      height: '60vh',
+      alignSelf: 'stretch',
+      display: 'inline-block',
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      '& > table': {
+        minWidth: '100%',
+      },
+    }),
+    flexColumn: css({
+      display: 'flex',
+      flexDirection: 'column',
+      padding: theme.spacing(0, 3, 3, 3),
+    }),
+    flexRow: css({
+      display: 'flex',
+      flexDirection: 'row',
+      alignItems: 'center',
+      '& > div:last-child': {
+        marginLeft: 'auto',
+      },
+    }),
+    noMarginBottom: css({
+      '& > table': {
+        marginBottom: 0,
+      },
+    }),
+    hidden: css({
+      display: 'none',
+    }),
+    paddingTop: css({
+      paddingTop: theme.spacing(1),
+    }),
+    paddingBottom: css({
+      paddingBottom: theme.spacing(1),
+    }),
+    link: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      ':hover': {
+        color: theme.colors.text.link,
+      },
+    }),
+    loadingCell: css({
+      position: 'sticky',
+      left: '50%',
+      display: 'inline-block',
+      transform: 'translateX(-50%)',
+    }),
+  };
+};
+
+interface LogLineContextProps {
+  log: LogRowModel;
+  open: boolean;
+  timeZone: TimeZone;
+  onClose: () => void;
+  getRowContext: (row: LogRowModel, options: LogRowContextOptions) => Promise<DataQueryResponse>;
+  getRowContextQuery?: (
+    row: LogRowModel,
+    options?: LogRowContextOptions,
+    cacheFilters?: boolean
+  ) => Promise<DataQuery | null>;
+  logsSortOrder: LogsSortOrder;
+  runContextQuery?: () => void;
+  getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
+  displayedFields: string[];
+  onClickShowField?: (key: string) => void;
+  onClickHideField?: (key: string) => void;
+  wrapLogMessage: boolean;
+  showTime: boolean;
+}
+
+const PAGE_SIZE = 100;
+
+export const LogLineContext = memo(
+  ({
+    log,
+    open,
+    logsSortOrder,
+    timeZone,
+    getLogRowContextUi,
+    getRowContextQuery,
+    onClose,
+    getRowContext,
+    displayedFields,
+    onClickShowField,
+    onClickHideField,
+    showTime,
+    wrapLogMessage,
+  }: LogLineContextProps) => {
+    const containerRef = useRef<HTMLDivElement | null>(null);
+    const [contextQuery, setContextQuery] = useState<DataQuery | null>(null);
+    const [aboveLogs, setAboveLogs] = useState<LogRowModel[]>([]);
+    const [belowLogs, setBelowLogs] = useState<LogRowModel[]>([]);
+    const [initialized, setInitialized] = useState(false);
+    const allLogs = useMemo(() => [...aboveLogs, log, ...belowLogs], [log, belowLogs, aboveLogs]);
+    const [aboveState, setAboveState] = useState(LoadingState.NotStarted);
+    const [belowState, setBelowState] = useState(LoadingState.NotStarted);
+
+    const dispatch = useDispatch();
+    const theme = useTheme2();
+    const styles = getStyles(theme);
+
+    const timeRange = useMemo(() => {
+      const fromMs = allLogs[0].timeEpochMs;
+      let toMs = allLogs[allLogs.length - 1].timeEpochMs;
+      // In case we have a lot of logs and from and to have same millisecond
+      // we add 1 millisecond to toMs to make sure we have a range
+      if (fromMs === toMs) {
+        toMs += 1;
+      }
+      const from = dateTime(fromMs);
+      const to = dateTime(toMs);
+
+      const range: TimeRange = {
+        from,
+        to,
+        raw: {
+          from,
+          to,
+        },
+      };
+      return range;
+    }, [allLogs]);
+
+    const updateContextQuery = useCallback(async () => {
+      const contextQuery = getRowContextQuery ? await getRowContextQuery(log) : null;
+      setContextQuery(contextQuery);
+    }, [log, getRowContextQuery]);
+
+    const updateResults = useCallback(async () => {
+      await updateContextQuery();
+    }, [updateContextQuery]);
+
+    useEffect(() => {
+      if (open) {
+        updateContextQuery();
+      }
+    }, [updateContextQuery, open]);
+
+    const getContextLogs = useCallback(
+      async (place: 'above' | 'below', refLog: LogRowModel): Promise<LogRowModel[]> => {
+        /*const refLog = allLogs.at(place === 'above' ? 0 : -1);
+    if (refLog == null) {
+      throw new Error('should never happen. the array always contains at least 1 item (the middle row)');
+    }*/
+        const result = await getRowContext(normalizeLogRefId(refLog), {
+          limit: PAGE_SIZE,
+          direction: getLoadMoreDirection(place, logsSortOrder),
+        });
+
+        const newLogs = dataFrameToLogsModel(result.data).rows;
+        if (logsSortOrder === LogsSortOrder.Ascending) {
+          newLogs.reverse();
+        }
+        return newLogs.filter((r) => !containsRow(allLogs, r));
+      },
+      [allLogs, getRowContext, logsSortOrder]
+    );
+
+    const loadMore = useCallback(
+      async (place: 'above' | 'below', refLog: LogRowModel) => {
+        const setState = place === 'above' ? setAboveState : setBelowState;
+        setState(LoadingState.Loading);
+
+        try {
+          const newLogs = (await getContextLogs(place, refLog)).map((r) =>
+            // apply the original row's searchWords to all the rows for highlighting
+            !r.searchWords || !r.searchWords?.length ? { ...r, searchWords: log.searchWords } : r
+          );
+          const [older, newer] = partition(newLogs, (newRow) => newRow.timeEpochNs > log.timeEpochNs);
+          const newAbove = logsSortOrder === LogsSortOrder.Ascending ? newer : older;
+          const newBelow = logsSortOrder === LogsSortOrder.Ascending ? older : newer;
+
+          setAboveLogs((aboveLogs: LogRowModel[]) => {
+            return newAbove.length > 0 ? sortLogRows([...newAbove, ...aboveLogs], logsSortOrder) : aboveLogs;
+          });
+          setBelowLogs((belowLogs: LogRowModel[]) => {
+            return newBelow.length > 0 ? sortLogRows([...belowLogs, ...newBelow], logsSortOrder) : belowLogs;
+          });
+          setState(LoadingState.NotStarted);
+        } catch {
+          setState(LoadingState.Error);
+        }
+      },
+      [getContextLogs, log, logsSortOrder]
+    );
+
+    useEffect(() => {
+      if (!initialized) {
+        loadMore('above', log);
+        loadMore('below', log);
+        setInitialized(true);
+      }
+    }, [initialized, loadMore, log]);
+
+    return (
+      <Modal
+        isOpen={open}
+        title={t('logs.log-row-context-modal.title-log-context', 'Log context')}
+        contentClassName={styles.flexColumn}
+        className={styles.modal}
+        onDismiss={onClose}
+      >
+        {config.featureToggles.logsContextDatasourceUi && getLogRowContextUi && (
+          <div className={styles.datasourceUi}>{getLogRowContextUi(log, updateResults)}</div>
+        )}
+        <div className={styles.logRowGroups} ref={containerRef}>
+          {containerRef.current && (
+            <LogList
+              app={CoreApp.Unknown}
+              containerElement={containerRef.current}
+              dedupStrategy={LogsDedupStrategy.none}
+              displayedFields={displayedFields}
+              enableLogDetails={true}
+              detailsMode="inline"
+              logs={allLogs}
+              loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
+              permalinkedLogId={log.uid}
+              onClickHideField={onClickHideField}
+              onClickShowField={onClickShowField}
+              showControls={false}
+              showTime={showTime}
+              sortOrder={logsSortOrder}
+              timeRange={timeRange}
+              timeZone={timeZone}
+              wrapLogMessage={wrapLogMessage}
+            />
+          )}
+        </div>
+
+        <Modal.ButtonRow>
+          {contextQuery?.datasource?.uid && (
+            <Button
+              variant="secondary"
+              onClick={async () => {
+                let rowId = log.uid;
+                if (log.dataFrame.refId) {
+                  // the orignal row has the refid from the base query and not the refid from the context query, so we need to replace it.
+                  rowId = log.uid.replace(log.dataFrame.refId, contextQuery.refId);
+                }
+
+                dispatch(
+                  splitOpen({
+                    queries: [contextQuery],
+                    range: timeRange,
+                    datasourceUid: contextQuery.datasource!.uid!,
+                    panelsState: {
+                      logs: {
+                        id: rowId,
+                      },
+                    },
+                  })
+                );
+                onClose();
+                reportInteraction('grafana_explore_logs_log_context_open_split_view_clicked', {
+                  datasourceType: log.datasourceType,
+                  logRowUid: log.uid,
+                });
+              }}
+            >
+              <Trans i18nKey="logs.log-row-context-modal.open-in-split-view">Open in split view</Trans>
+            </Button>
+          )}
+        </Modal.ButtonRow>
+      </Modal>
+    );
+  }
+);
+LogLineContext.displayName = 'LogLineContext';
+
+const getLoadMoreDirection = (place: 'above' | 'below', sortOrder: LogsSortOrder): LogRowContextQueryDirection => {
+  if (place === 'above' && sortOrder === LogsSortOrder.Descending) {
+    return LogRowContextQueryDirection.Forward;
+  }
+  if (place === 'below' && sortOrder === LogsSortOrder.Ascending) {
+    return LogRowContextQueryDirection.Forward;
+  }
+
+  return LogRowContextQueryDirection.Backward;
+};
+
+const normalizeLogRefId = (log: LogRowModel): LogRowModel => {
+  // the datasoure plugins often create the context-query based on the row's dataframe's refId,
+  // by appending something to it. for example:
+  // - let's say the row's dataframe's refId is "query"
+  // - the datasource plugin will take "query" and append "-context" to it, so it becomes "query-context".
+  // - later we want to load even more lines, so we make a context query
+  // - the datasource plugin does the same transform again, but now the source is "query-context",
+  //   so the new refId becomes "query-context-context"
+  // - next time it becomes "query-context-context-context", and so on.
+  // we do not want refIds to grow unbounded.
+  // to avoid this, we set the refId to a value that does not grow.
+  // on the other hand, the refId is also used in generating the row's UID, so it is useful
+  // when the refId is not always the exact same string, otherwise UID duplication can occur,
+  // which may cause problems.
+  // so we go with an approach where the refId always changes, but does not grow.
+  return {
+    ...log,
+    dataFrame: {
+      ...log.dataFrame,
+      refId: `context_${log.uid ?? log.dataFrame.refId ?? log.timeEpochMs}`,
+    },
+  };
+};
+
+const containsRow = (rows: LogRowModel[], row: LogRowModel) => {
+  return rows.some((r) => r.entry === row.entry && r.timeEpochNs === row.timeEpochNs);
+};

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -356,6 +356,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       height: '80%',
       [theme.breakpoints.down('md')]: {
         width: '100%',
+        minHeight: '100%',
       },
       top: '50%',
       left: '50%',

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -31,11 +31,13 @@ import { sortLogRows } from '../../utils';
 import { ScrollDirection } from '../InfiniteScroll';
 import { LoadingIndicator } from '../LoadingIndicator';
 
+import { LogLineDetailsLog } from './LogLineDetailsLog';
 import { LogList } from './LogList';
+import { LogListModel } from './processing';
 import { ScrollToLogsEvent } from './virtualization';
 
 interface LogLineContextProps {
-  log: LogRowModel;
+  log: LogRowModel | LogListModel;
   logOptionsStorageKey?: string;
   open: boolean;
   timeZone: TimeZone;
@@ -225,6 +227,20 @@ export const LogLineContext = memo(
       };
     }, [log.uid]);
 
+    const wrapLogMessage = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true;
+    const syntaxHighlighting = logOptionsStorageKey
+      ? store.getBool(`${logOptionsStorageKey}.syntaxHighlighting`, true)
+      : true;
+    // @todo: Remove when the LogRows are deprecated
+    const logListModel =
+      log instanceof LogListModel
+        ? log
+        : new LogListModel(log, {
+            escape: false,
+            timeZone,
+            wrapLogMessage,
+          });
+
     return (
       <Modal
         isOpen={open}
@@ -249,7 +265,7 @@ export const LogLineContext = memo(
             </div>
           }
         >
-          <div>{log.entry}</div>
+          <LogLineDetailsLog log={logListModel} syntaxHighlighting={syntaxHighlighting} />
         </Collapse>
         <div className={styles.loadingIndicator}>
           {aboveState === LoadingState.Loading && (
@@ -286,11 +302,10 @@ export const LogLineContext = memo(
                 showControls
                 showTime={logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.showTime`, true) : true}
                 sortOrder={sortOrder}
+                syntaxHighlighting={syntaxHighlighting}
                 timeRange={timeRange}
                 timeZone={timeZone}
-                wrapLogMessage={
-                  logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true
-                }
+                wrapLogMessage
               />
             )}
           </div>

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -17,6 +17,7 @@ import {
   LogRowModel,
   AbsoluteTimeRange,
   EventBusSrv,
+  store,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -73,6 +74,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
 interface LogLineContextProps {
   log: LogRowModel;
+  logOptionsStorageKey?: string;
   open: boolean;
   timeZone: TimeZone;
   onClose: () => void;
@@ -88,8 +90,6 @@ interface LogLineContextProps {
   displayedFields: string[];
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  wrapLogMessage: boolean;
-  showTime: boolean;
 }
 
 const PAGE_SIZE = 100;
@@ -97,6 +97,7 @@ const PAGE_SIZE = 100;
 export const LogLineContext = memo(
   ({
     log,
+    logOptionsStorageKey,
     open,
     logsSortOrder,
     timeZone,
@@ -107,8 +108,6 @@ export const LogLineContext = memo(
     displayedFields,
     onClickShowField,
     onClickHideField,
-    showTime,
-    wrapLogMessage,
   }: LogLineContextProps) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
     const [contextQuery, setContextQuery] = useState<DataQuery | null>(null);
@@ -271,11 +270,13 @@ export const LogLineContext = memo(
               onClickHideField={onClickHideField}
               onClickShowField={onClickShowField}
               showControls
-              showTime={showTime}
+              showTime={logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.showTime`, true) : true}
               sortOrder={logsSortOrder}
               timeRange={timeRange}
               timeZone={timeZone}
-              wrapLogMessage={wrapLogMessage}
+              wrapLogMessage={
+                logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true
+              }
             />
           )}
         </div>

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -25,7 +25,8 @@ interface LogLineDetailsComponentProps {
 }
 
 export const LogLineDetailsComponent = memo(({ focusLogLine, log, logs }: LogLineDetailsComponentProps) => {
-  const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields } = useLogListContext();
+  const { displayedFields, noInteractions, logOptionsStorageKey, setDisplayedFields, syntaxHighlighting } =
+    useLogListContext();
   const [search, setSearch] = useState('');
   const inputRef = useRef('');
   const styles = useStyles2(getStyles);
@@ -111,7 +112,7 @@ export const LogLineDetailsComponent = memo(({ focusLogLine, log, logs }: LogLin
           isOpen={logLineOpen}
           onToggle={(isOpen: boolean) => handleToggle('logLineOpen', isOpen)}
         >
-          <LogLineDetailsLog log={log} />
+          <LogLineDetailsLog log={log} syntaxHighlighting={syntaxHighlighting ?? true} />
         </ControlledCollapse>
         {displayedFields.length > 0 && setDisplayedFields && (
           <ControlledCollapse

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -4,15 +4,14 @@ import { memo, useMemo } from 'react';
 import { useStyles2 } from '@grafana/ui';
 
 import { getStyles } from './LogLine';
-import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
 interface Props {
   log: LogListModel;
+  syntaxHighlighting: boolean;
 }
 
-export const LogLineDetailsLog = memo(({ log: originalLog }: Props) => {
-  const { syntaxHighlighting } = useLogListContext();
+export const LogLineDetailsLog = memo(({ log: originalLog, syntaxHighlighting }: Props) => {
   const logStyles = useStyles2(getStyles);
   const log = useMemo(() => {
     const log = originalLog.clone();

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -5,7 +5,6 @@ import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState, Mou
 import { Align, VariableSizeList } from 'react-window';
 
 import {
-  AbsoluteTimeRange,
   CoreApp,
   DataFrame,
   EventBus,
@@ -24,7 +23,7 @@ import { ConfirmModal, Icon, PopoverContent, useStyles2, useTheme2 } from '@graf
 import { PopoverMenu } from 'app/features/explore/Logs/PopoverMenu';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
-import { InfiniteScroll } from './InfiniteScroll';
+import { InfiniteScrollMode, InfiniteScroll, LoadMoreLogsType } from './InfiniteScroll';
 import { getGridTemplateColumns } from './LogLine';
 import { LogLineDetails, LogLineDetailsMode } from './LogLineDetails';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
@@ -50,10 +49,11 @@ export interface Props {
   getFieldLinks?: GetFieldLinksFn;
   getRowContextQuery?: GetRowContextQueryFn;
   grammar?: Grammar;
+  infiniteScrollMode?: InfiniteScrollMode;
   initialScrollPosition?: 'top' | 'bottom';
   isLabelFilterActive?: (key: string, value: string, refId?: string) => Promise<boolean>;
   loading?: boolean;
-  loadMore?: (range: AbsoluteTimeRange) => void;
+  loadMore?: LoadMoreLogsType;
   logLineMenuCustomItems?: LogLineMenuCustomItem[];
   logOptionsStorageKey?: string;
   logs: LogRowModel[];
@@ -117,6 +117,7 @@ export const LogList = ({
   getFieldLinks,
   getRowContextQuery,
   grammar,
+  infiniteScrollMode,
   initialScrollPosition = 'top',
   isLabelFilterActive,
   loading,
@@ -197,6 +198,7 @@ export const LogList = ({
           getFieldLinks={getFieldLinks}
           grammar={grammar}
           initialScrollPosition={initialScrollPosition}
+          infiniteScrollMode={infiniteScrollMode}
           loading={loading}
           loadMore={loadMore}
           logs={logs}
@@ -215,6 +217,7 @@ const LogListComponent = ({
   getFieldLinks,
   grammar,
   initialScrollPosition = 'top',
+  infiniteScrollMode = 'interval',
   loading,
   loadMore,
   logs,
@@ -443,6 +446,7 @@ const LogListComponent = ({
         <InfiniteScroll
           displayedFields={displayedFields}
           handleOverflow={handleOverflow}
+          infiniteScrollMode={infiniteScrollMode}
           logs={filteredLogs}
           loadMore={loadMore}
           onClick={handleLogLineClick}

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -408,6 +408,15 @@ const LogListComponent = ({
 
   return (
     <div className={styles.logListContainer}>
+      {showControls && <LogListControls eventBus={eventBus} />}
+      {detailsMode === 'sidebar' && showDetails.length > 0 && (
+        <LogLineDetails
+          containerElement={containerElement}
+          focusLogLine={focusLogLine}
+          logs={filteredLogs}
+          onResize={handleLogDetailsResize}
+        />
+      )}
       <div className={styles.logListWrapper} ref={wrapperRef}>
         {popoverState.selection && popoverState.selectedRow && (
           <PopoverMenu
@@ -487,15 +496,6 @@ const LogListComponent = ({
           )}
         </InfiniteScroll>
       </div>
-      {detailsMode === 'sidebar' && showDetails.length > 0 && (
-        <LogLineDetails
-          containerElement={containerElement}
-          focusLogLine={focusLogLine}
-          logs={filteredLogs}
-          onResize={handleLogDetailsResize}
-        />
-      )}
-      {showControls && <LogListControls eventBus={eventBus} />}
     </div>
   );
 };
@@ -519,6 +519,7 @@ function getStyles(
     }),
     logListContainer: css({
       display: 'flex',
+      flexDirection: 'row-reverse',
       // Minimum width to prevent rendering issues and a sausage-like logs panel.
       minWidth: theme.spacing(35),
     }),

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -370,7 +370,7 @@ export function getScrollbarWidth() {
 }
 
 export interface ScrollToLogsEventPayload {
-  scrollTo: 'top' | 'bottom';
+  scrollTo: 'top' | 'bottom' | string;
 }
 
 export class ScrollToLogsEvent extends BusEventWithPayload<ScrollToLogsEventPayload> {

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -532,7 +532,7 @@ export const LogsPanel = ({
 
   return (
     <>
-      {!config.featureToggles.newLogsPanel && contextRow && (
+      {(!config.featureToggles.newLogsPanel || !config.featureToggles.newLogContext) && contextRow && (
         <LogRowContextModal
           open={contextRow !== null}
           row={contextRow}
@@ -543,7 +543,7 @@ export const LogsPanel = ({
           getLogRowContextUi={getLogRowContextUi}
         />
       )}
-      {config.featureToggles.newLogsPanel && getLogRowContext && contextRow && (
+      {config.featureToggles.newLogsPanel && config.featureToggles.newLogContext && getLogRowContext && contextRow && (
         <LogLineContext
           open={contextRow !== null}
           log={contextRow}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -736,6 +736,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flex: 1,
     flexDirection: 'column',
+    overflow: 'hidden',
   }),
   controlledLogsContainer: css({
     height: '100%',

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -37,6 +37,7 @@ import { getFieldLinksForExplore } from 'app/features/explore/utils/links';
 import { ControlledLogRows } from 'app/features/logs/components/ControlledLogRows';
 import { InfiniteScroll } from 'app/features/logs/components/InfiniteScroll';
 import { LogRowContextModal } from 'app/features/logs/components/log-context/LogRowContextModal';
+import { LogLineContext } from 'app/features/logs/components/panel/LogLineContext';
 import { LogList } from 'app/features/logs/components/panel/LogList';
 import { PanelDataErrorView } from 'app/features/panel/components/PanelDataErrorView';
 import { combineResponses } from 'app/plugins/datasource/loki/mergeResponses';
@@ -531,7 +532,7 @@ export const LogsPanel = ({
 
   return (
     <>
-      {contextRow && (
+      {!config.featureToggles.newLogsPanel && contextRow && (
         <LogRowContextModal
           open={contextRow !== null}
           row={contextRow}
@@ -540,6 +541,20 @@ export const LogsPanel = ({
           logsSortOrder={sortOrder}
           timeZone={timeZone}
           getLogRowContextUi={getLogRowContextUi}
+        />
+      )}
+      {config.featureToggles.newLogsPanel && getLogRowContext && contextRow && (
+        <LogLineContext
+          open={contextRow !== null}
+          log={contextRow}
+          onClose={onCloseContext}
+          getRowContext={(row, options) => getLogRowContext(row, contextRow, options)}
+          getLogRowContextUi={getLogRowContextUi}
+          logOptionsStorageKey={controlsStorageKey}
+          timeZone={timeZone}
+          displayedFields={displayedFields}
+          onClickShowField={showField}
+          onClickHideField={hideField}
         />
       )}
       {config.featureToggles.newLogsPanel && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9363,7 +9363,7 @@
       "tooltip-error": "Error: {{errorMessage}}"
     },
     "log-line-context": {
-      "center-matched-line": "Center matched line",
+      "center-matched-line": "Center",
       "newer-logs": "newer",
       "no-more-logs-available": "No more logs available.",
       "older-logs": "older",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9369,7 +9369,7 @@
       "older-logs": "older",
       "open-in-split-view": "Open in split view",
       "title-log-context": "Log context",
-      "title-log-line": "Log line"
+      "title-log-line": "Referenced log line"
     },
     "log-line-details": {
       "clear-search": "Clear",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9362,6 +9362,15 @@
       "show-more": "show more",
       "tooltip-error": "Error: {{errorMessage}}"
     },
+    "log-line-context": {
+      "center-matched-line": "Center matched line",
+      "newer-logs": "newer",
+      "no-more-logs-available": "No more logs available.",
+      "older-logs": "older",
+      "open-in-split-view": "Open in split view",
+      "title-log-context": "Log context",
+      "title-log-line": "Log line"
+    },
     "log-line-details": {
       "clear-search": "Clear",
       "close": "Close log details",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9363,7 +9363,7 @@
       "tooltip-error": "Error: {{errorMessage}}"
     },
     "log-line-context": {
-      "center-matched-line": "Center",
+      "center-matched-line": "Center matched line",
       "newer-logs": "newer",
       "no-more-logs-available": "No more logs available.",
       "older-logs": "older",


### PR DESCRIPTION
This PR adds a new component that implements the Log Context feature showing logs using the New Logs panel. This new component has a few key differences with the old one:

- The reference log line is scrolled at the top by default. This has a more consistent behavior with the virtualized panel, than attempting to scroll to the center. This is also more consitent than the current Log Context component, where depending on running conditions, the reference log line is arbitrarily aligned on top, or at the bottom, or eventually centered. It can be more easily reproduced with long lines and wrapping enabled.
- Pinning of the reference log line has been removed. In replace, a collapsible with the reference log line has been added. Not only due to the challenge of implementing pinned log lines in the virtualized panel, but because in the current Log Context component, specially with long lines or log lines with json, when pinned, it will use the entire container space, hiding all other logs.

https://github.com/user-attachments/assets/f53d9283-a431-47c3-a9c2-1565bff0ae47

- The current component has 3 Logs Panen (LogRows) instances sharing a scrolling container. The new component uses a single Logs Panel instance.
- All the extra complexity of request [generations](https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/log-context/LogRowContextModal.tsx#L362) ref and intersection observers have been deprecated.
- https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/log-context/LogRowContextModal.tsx#L413-L489
- Infinite scroll have been implemented in both directions, with the same behavior as the one in the new panel: it doesn't immediately trigger. 

Extra changes:
- Improved a11y by reverting the DOM order of the components
- Hide overflow for better resizing in dashboards

### How to test

When testing, it's recommended to replicate the interactions using the current and new context components, to better understand the current limitations. It's also recommended to keep an eye on the network tab to see extra requests, which were common in the current implementation.

### Additional notes

Before merging this component, we'll create a feature flag, in case we need to disable this new component in general or for certain users.

Part of https://github.com/grafana/grafana/issues/99075