### PR TITLE
search: Handle index build errors gracefully

### DIFF
--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1029,7 +1029,7 @@ func TestCleanOldIndexes(t *testing.T) {
 
 func TestBleveIndexWithFailures(t *testing.T) {
 	t.Run("in-memory index", func(t *testing.T) {
-		testBleveIndexWithFailures(t, true)
+		testBleveIndexWithFailures(t, false)
 	})
 	t.Run("file-based index", func(t *testing.T) {
 		testBleveIndexWithFailures(t, true)


### PR DESCRIPTION
While testing building index at larger scale, we have identified some problems. This PR fixes two of them:

* When indexing fails, we didn't properly close newly built index. This is a problem for file-based indexes, that stay on the disk, and are locked. On next attempt to build an index, previous lock prevented the check of existing directory, and goroutine got stuck instead.

* Goroutines stuck in singleflight method for getting or creation of index piled up and eventually caused out of memory error. With this PR, getOrCreteIndex respects context cancellation.