### PR TITLE
CI: remove ppcle64 and 390x from viceroy dpkg

### DIFF
--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -72,6 +72,7 @@ func ViceroyContainer(
 	container = container.
 		WithExec([]string{"dpkg", "--remove-architecture", "ppc64el"}).
 		WithExec([]string{"dpkg", "--remove-architecture", "s390x"}).
+		WithExec([]string{"dpkg", "--remove-architecture", "armel"}).
 		WithExec([]string{"apt-get", "update", "-yq"}).
 		WithExec([]string{"apt-get", "install", "-yq", "curl", "make", "git"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("curl -L %s | tar -C /usr/local -xzf -", goURL)}).

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -72,7 +72,7 @@ func ViceroyContainer(
 	container = container.
 		WithExec([]string{"dpkg", "--remove-architecture", "ppc64el"}).
 		WithExec([]string{"dpkg", "--remove-architecture", "s390x"}).
-		WithExec([]string{"apt-get", "update"}).
+		WithExec([]string{"apt-get", "update", "-yq"}).
 		WithExec([]string{"apt-get", "install", "-yq", "curl", "make", "git"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("curl -L %s | tar -C /usr/local -xzf -", goURL)}).
 		WithEnvVariable("PATH", "/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/usr/osxcross/bin")

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -69,7 +69,10 @@ func ViceroyContainer(
 	container := d.Container(containerOpts).From(fmt.Sprintf("rfratto/viceroy:%s", viceroyVersion))
 
 	// Install Go manually, and install make, git, and curl from the package manager.
-	container = container.WithExec([]string{"apt-get", "update"}).
+	container = container.
+		WithExec([]string{"dpkg", "--remove-architecture", "ppc64el"}).
+		WithExec([]string{"dpkg", "--remove-architecture", "s390x"}).
+		WithExec([]string{"apt-get", "update"}).
 		WithExec([]string{"apt-get", "install", "-yq", "curl", "make", "git"}).
 		WithExec([]string{"/bin/sh", "-c", fmt.Sprintf("curl -L %s | tar -C /usr/local -xzf -", goURL)}).
 		WithEnvVariable("PATH", "/bin:/usr/bin:/usr/local/bin:/usr/local/go/bin:/usr/osxcross/bin")


### PR DESCRIPTION
This is a temporary measure until we can start building our own osxcross container or something. :\ 