### PR TITLE
InfluxDB: Fix backend queries sharing time ranges

### DIFF
--- a/pkg/tsdb/influxdb/flux/flux.go
+++ b/pkg/tsdb/influxdb/flux/flux.go
@@ -27,9 +27,8 @@ func Query(ctx context.Context, dsInfo *models.DatasourceInfo, tsdbQuery backend
 	}
 	defer r.client.Close()
 
-	timeRange := tsdbQuery.Queries[0].TimeRange
 	for _, query := range tsdbQuery.Queries {
-		qm, err := getQueryModel(query, timeRange, dsInfo)
+		qm, err := getQueryModel(query, query.TimeRange, dsInfo)
 		if err != nil {
 			tRes.Responses[query.RefID] = backend.DataResponse{
 				Error:       err,


### PR DESCRIPTION
Fixes #108070.

This PR fixes the codepath for Flux queries using the same time range from position 0 in the array for all queries, when in fact this may not be appropriate.

It would have been nice to add tests for this, but `flux.go` is already untested. It seems this is the case because the `Query` function within it is extremely tightly coupled to other parts, and the separation of concerns here is poor. I've started work on a refactor of the datasource, but this is too much code and out-of-scope for this fix.