### PR TITLE
docs: alerting list view UI changes

### DIFF
--- a/docs/sources/alerting/alerting-rules/create-recording-rules/create-data-source-managed-recording-rules.md
+++ b/docs/sources/alerting/alerting-rules/create-recording-rules/create-data-source-managed-recording-rules.md
@@ -47,7 +47,7 @@ Note that in data source-managed groups, the alert rules and recording rules wit
 To create a new data source-managed recording rule:
 
 1. Click **Alerts & IRM** -> **Alerting** -> **Alert rules**.
-1. Scroll to the **Data source-managed section** and click **+New recording rule**.
+1. At the top of the Alert rules page, click **More** -> **New Grafana recording rule**.
 
 ## Enter recording rule name
 

--- a/docs/sources/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules.md
+++ b/docs/sources/alerting/alerting-rules/create-recording-rules/create-grafana-managed-recording-rules.md
@@ -81,7 +81,7 @@ To create a new Grafana-managed recording rule:
 
 1. Click **Alerts & IRM** -> **Alerting** ->
    **Alert rules**.
-1. Scroll to the **Grafana-managed section** and click **+New recording rule**.
+1. At the top of the Alert rules page, click **More** -> **New Grafana recording rule**.
 
 1. Enter the names to identify your recording rule and metric.
 

--- a/docs/sources/alerting/alerting-rules/create-recording-rules/migrate-recorded-queries.md
+++ b/docs/sources/alerting/alerting-rules/create-recording-rules/migrate-recorded-queries.md
@@ -24,15 +24,15 @@ Users can transpose their [now-depreciated recorded queries](/docs/grafana/lates
 
 ## Migrate your recorded queries to Grafana-managed alert rules
 
-1. Navigate to **Administration > Plugins and Data > Recorded queries.**
+1. Navigate to **Administration** -> **Plugins and Data** -> **Recorded queries.**
 
 1. Note the data source, query PromQL, interval, and time range, and copy them somewhere accessible.
 
    {{< figure alt="Example of relevant recorded query information"  src="/media/docs/alerting/rec-query-example.png" max-width="800px" >}}
 
-1. Now navigate to **Alerting > Alert rules.**
+1. Now navigate to **Alerting** -> **Alert rules.**
 
-1. In the Grafana-managed section of the Alert rules page, click **+ New recording**.
+1. At the top of the Alert rules page, click **More** -> **New Grafana recording rule**.
 
    Add a name for your Recording Rule and a name for the new metric that the recording rule generates.
 

--- a/docs/sources/alerting/monitor-status/declare-incident-from-alert.md
+++ b/docs/sources/alerting/monitor-status/declare-incident-from-alert.md
@@ -29,7 +29,7 @@ Declare an incident from a firing alert to streamline your alert to incident wor
 To declare an incident from a firing alert, complete the following steps.
 
 1. Navigate to **Alerts & IRM** -> **Alerting** -> **Alert rules**.
-1. From the Alert rules page, find the firing alert that you want to declare an incident for.
+1. From the Alert rules page, click the **Firing** filter to display firing alerts. Find the firing alert that you want to declare an incident for.
 1. Click **More** -> **Declare Incident**.
 
    Alternatively, you can declare an incident from the Alert details page.

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -35,12 +35,11 @@ To access the Alert rules page, click **Alerts & IRM** -> **Alerting** -> **Aler
 
 {{< figure src="/media/docs/alerting/alert-rules-page-2.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
 
-By default, alert rules are grouped in separate sections—one for Grafana-managed alerts, and another for data source-managed alerts. 
+By default, alert rules are grouped in separate sections—one for Grafana-managed alerts, and another for data source-managed alerts.
 Inside the Grafana-managed alert rules section, the rules are organized in a hierarchial structure, from folder -> rule group -> rules.
 Inside the data source-managed alert rules section, the rules are organized from namespace ->rule group -> rules.
 
 Select a group to expand it and view the list of alert rules within that group.
-
 
 The view includes filters to simplify managing large volumes of alerts.
 
@@ -50,7 +49,7 @@ You can filter by data sources, dashboards, and alert rule properties such as st
 
 You can also change how the rule list is displayed using the **View as** option.
 
-- **Grouped**:  Displays Grafana rules grouped in a hierarchial structure, from folder/namespace, to evaluation group, to the individual rules. This is the default view.
+- **Grouped**: Displays Grafana rules grouped in a hierarchial structure, from folder/namespace, to evaluation group, to the individual rules. This is the default view.
 
 - **List**: Displays all rules from all data sources in a flat, unpaginated list.
 

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -36,7 +36,7 @@ To access the Alert rules page, click **Alerts & IRM** -> **Alerting** -> **Aler
 {{< figure src="/media/docs/alerting/alert-rules-page-2.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
 
 By default, alert rules are grouped in separate sections—one for Grafana-managed alerts, and another for data source-managed alerts.
-Inside the Grafana-managed alert rules section, the rules are organized in a hierarchial structure, from folder -> rule group -> rules.
+Inside the Grafana-managed alert rules section, the rules are organized in a hierarchical structure, from folder -> rule group -> rules.
 Inside the data source-managed alert rules section, the rules are organized from namespace ->rule group -> rules.
 
 Select a group to expand it and view the list of alert rules within that group.
@@ -49,7 +49,7 @@ You can filter by data sources, dashboards, and alert rule properties such as st
 
 You can also change how the rule list is displayed using the **View as** option.
 
-- **Grouped**: Displays Grafana rules grouped in a hierarchial structure, from folder/namespace, to evaluation group, to the individual rules. This is the default view.
+- **Grouped**: Displays Grafana rules grouped in a hierarchical structure, from folder/namespace, to evaluation group, to the individual rules. This is the default view.
 
 - **List**: Displays all rules from all data sources in a flat, unpaginated list.
 

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -35,7 +35,12 @@ To access the Alert rules page, click **Alerts & IRM** -> **Alerting** -> **Aler
 
 {{< figure src="/media/docs/alerting/alert-rules-page-2.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
 
-By default, alert rules are grouped by folder. Select a group to expand it and view the list of alert rules within that group.
+By default, alert rules are grouped in separate sections—one for Grafana-managed alerts, and another for data source-managed alerts. 
+Inside the Grafana-managed alert rules section, the rules are organized in a hierarchial structure, from folder -> rule group -> rules.
+Inside the data source-managed alert rules section, the rules are organized from namespace ->rule group -> rules.
+
+Select a group to expand it and view the list of alert rules within that group.
+
 
 The view includes filters to simplify managing large volumes of alerts.
 
@@ -45,9 +50,9 @@ You can filter by data sources, dashboards, and alert rule properties such as st
 
 You can also change how the rule list is displayed using the **View as** option.
 
-- **Grouped**:  Displays Grafana rules grouped by folder and evaluation group, and data-source rules by namespace and evaluation group. This is the default view.
+- **Grouped**:  Displays Grafana rules grouped in a hierarchial structure, from folder/namespace, to evaluation group, to the individual rules. This is the default view.
 
-- **List**: Displays Grafana rules in an unpaginated list.
+- **List**: Displays all rules from all data sources in a flat, unpaginated list.
 
 {{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions-2.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
 

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -33,13 +33,11 @@ The Alert rules list view page lists all existing recording and alert rules, inc
 
 To access the Alert rules page, click **Alerts & IRM** -> **Alerting** -> **Alert rules**.
 
-{{< figure src="/media/docs/alerting/alert-rules-page.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
+{{< figure src="/media/docs/alerting/alert-rules-page-2.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
 
-By default, alert rules are grouped by alert rule type: Grafana-managed or data source-managed.
+By default, alert rules are grouped by folder. Select a group to expand it and view the list of alert rules within that group.
 
-In this view, you can find and edit rules created in Grafana. However, rules created in Prometheus-compatible data sources are displayed but cannot be edited.
-
-This view includes filters to simplify managing large volumes of alerts.
+Filters to simplify managing large volumes of alerts.
 
 You can filter by data sources, dashboards, and alert rule properties such as state, type, health, and contact points. The **Search** input allows you to filter by additional parameters like folders, evaluation groups, labels, and more.
 
@@ -47,15 +45,11 @@ You can filter by data sources, dashboards, and alert rule properties such as st
 
 You can also change how the rule list is displayed using the **View as** option.
 
-- **Grouped**: Displays Grafana rules grouped by folder and evaluation group, and data-source rules by namespace and evaluation group. This is the default view.
+- **Grouped**:  Displays Grafana rules grouped by folder and evaluation group, and data-source rules by namespace and evaluation group. This is the default view.
 
-- **List**: Displays Grafana rules grouped only by folder.
+- **List**: Displays Grafana rules in an unpaginated list.
 
-- **State**: Displays rules grouped by state, providing an overview for each state.
-
-Select a group to expand it and view the list of alert rules within that group.
-
-{{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
+{{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions-2.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
 
 For details on how rule states and alert instance states are displayed, refer to [View alert state](ref:view-alert-state).
 
@@ -69,7 +63,7 @@ In Grafana OSS and Enterprise, the number of alert rule versions is limited. Fre
 
 To view or restore previous versions for an alert rule, complete the following steps.
 
-1. Navigate to **Alerts & IRM -> Alerting -> Alert rules**.
+1. Navigate to **Alerts & IRM** -> **Alerting** -> **Alert rules**.
 1. Select an alert rule and click **View**.
 1. Click the **Versions** tab.  
    The page displays a list of the previous rule versions.
@@ -89,7 +83,7 @@ Admin users can delete all of the alert rules within a folder. To delete all the
 
 Only users with an Admin role can restore deleted Grafana-managed alert rules. After an alert rule is restored, it is restored with a new, different UID from the one it had before.
 
-1. Go to **Alerts & IRM > Alerting > Recently deleted**.
+1. Go to **Alerts & IRM** -> **Alerting** -> **Recently deleted**.
 1. Click the **Restore** button to restore the alert rule or click **Delete permanently** to delete the alert rule.
 
 {{< admonition type="note" >}}

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -37,7 +37,7 @@ To access the Alert rules page, click **Alerts & IRM** -> **Alerting** -> **Aler
 
 By default, alert rules are grouped by folder. Select a group to expand it and view the list of alert rules within that group.
 
-Filters to simplify managing large volumes of alerts.
+The view includes filters to simplify managing large volumes of alerts.
 
 You can filter by data sources, dashboards, and alert rule properties such as state, type, health, and contact points. The **Search** input allows you to filter by additional parameters like folders, evaluation groups, labels, and more.
 

--- a/docs/sources/alerting/monitor-status/view-alert-state.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state.md
@@ -71,7 +71,7 @@ To view the details of your alert rules and the status of alert instances:
 1. Click **Alerts & IRM** -> **Alerting**.
 1. Click **Alert rules** to view the list of existing alert rules.
 
-   {{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions-2.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
+   {{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions2.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
 
    Each alert rule shows its state, summary, and available actions such as **Pause evaluation**, **Silence notifications**, **Export**, **Delete**, and more.
 

--- a/docs/sources/alerting/monitor-status/view-alert-state.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state.md
@@ -66,18 +66,16 @@ There are three key components that helps us understand the behavior of our aler
 
 ## View alert rule and instance states
 
-To view the state and health of your alert rules and the status of alert instances:
+To view the details of your alert rules and the status of alert instances:
 
 1. Click **Alerts & IRM** -> **Alerting**.
 1. Click **Alert rules** to view the list of existing alert rules.
 
-   {{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
+   {{< figure src="/media/docs/alerting/view-alert-rule-list-with-actions-2.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
 
-   Each alert rule shows its state, health, summary, next evaluation time, and available actions such as **Pause evaluation**, **Silence notifications**, **Export**, **Delete**, and more.
+   Each alert rule shows its state, summary, and available actions such as **Pause evaluation**, **Silence notifications**, **Export**, **Delete**, and more.
 
 1. Click on an alert rule to view additional details and its resulting alert instances.
-
-   {{< figure src="/media/docs/alerting/view-alert-instance-state.png" max-width="750px" alt="View alert rule state and alert rule health in Grafana Alerting" >}}
 
 ### View from the alert rule details page
 
@@ -85,7 +83,7 @@ To view more alert rule details, complete the following steps.
 
 1. Click **Alerts & IRM** -> **Alerting** -> **Alert rules**.
 1. Click to expand an alert rule.
-1. In **Actions**, click **View** (the eye icon).
+1. Click the alert name to go to the alert details view.
 
    {{< figure src="/media/docs/alerting/alert-rule-view-page-with-breadcrumb.png" max-width="750px" alt="Alert rule view page in Grafana Alerting" >}}
 


### PR DESCRIPTION
changes to the alerting docs:
- updated the docs so the procedure to create a new recording rule reflects the UI change.
- updated the procedure for declaring a new incident to mention the "Firing" filter for declaring alerts.
- updated the [View alert rules page](https://deploy-preview-grafana-108876-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/monitor-status/view-alert-rules/) with new images, deleted references to the now-removed Grafana-managed and Data-source-managed alert rule sections, removed the "State" filter view reference, and made some other formatting changes.
- updated the [View alert state](https://deploy-preview-grafana-108876-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/monitor-status/view-alert-state/) page with new image and deleted refences to old UI navigation artifacts.