### PR TITLE
Improve indexing observability

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -9,11 +9,14 @@ import (
 )
 
 type BleveIndexMetrics struct {
-	IndexLatency      *prometheus.HistogramVec
-	IndexSize         prometheus.Gauge
-	IndexedKinds      *prometheus.GaugeVec
-	IndexCreationTime *prometheus.HistogramVec
-	OpenIndexes       *prometheus.GaugeVec
+	IndexLatency       *prometheus.HistogramVec
+	IndexSize          prometheus.Gauge
+	IndexedKinds       *prometheus.GaugeVec
+	IndexCreationTime  *prometheus.HistogramVec
+	OpenIndexes        *prometheus.GaugeVec
+	IndexBuilds        *prometheus.CounterVec
+	IndexBuildFailures prometheus.Counter
+	IndexBuildSkipped  prometheus.Counter
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -37,8 +40,8 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Help: "Number of indexed documents by kind",
 		}, []string{"kind"}),
 		IndexCreationTime: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-			Name:                            "index_server_index_creation_time_seconds",
-			Help:                            "Time (in seconds) it takes until index is created",
+			Name:                            "index_server_index_build_time_seconds",
+			Help:                            "Time it takes to successfully build an index. Failed or skipped builds are not counted.",
 			Buckets:                         IndexCreationBuckets,
 			NativeHistogramBucketFactor:     1.1, // enable native histograms
 			NativeHistogramMaxBucketNumber:  160,
@@ -48,5 +51,17 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Name: "index_server_open_indexes",
 			Help: "Number of open indexes per storage type. An open index corresponds to single resource group.",
 		}, []string{"index_storage"}), // index_storage is either "file" or "memory"
+		IndexBuilds: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_index_build_total",
+			Help: "Number of times index build was attempted due to specific reason",
+		}, []string{"reason"}),
+		IndexBuildFailures: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "index_server_index_build_failures_total",
+			Help: "Number of times index build failed",
+		}),
+		IndexBuildSkipped: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "index_server_index_build_skipped_total",
+			Help: "Number of times index build has been skipped due to existing valid index being found on disk",
+		}),
 	}
 }

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -22,7 +22,7 @@ type BleveIndexMetrics struct {
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
 
 func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
-	return &BleveIndexMetrics{
+	m := &BleveIndexMetrics{
 		IndexLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "index_server_index_latency_seconds",
 			Help:                            "Time (in seconds) until index is updated with new event",
@@ -64,4 +64,9 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Help: "Number of times index build has been skipped due to existing valid index being found on disk",
 		}),
 	}
+
+	// Initialize labels.
+	m.OpenIndexes.WithLabelValues("file").Set(0)
+	m.OpenIndexes.WithLabelValues("memory").Set(0)
+	return m
 }

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -19,7 +19,7 @@ type BleveIndexMetrics struct {
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
 
 func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
-	m := &BleveIndexMetrics{
+	return &BleveIndexMetrics{
 		IndexLatency: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Name:                            "index_server_index_latency_seconds",
 			Help:                            "Time (in seconds) until index is updated with new event",
@@ -49,10 +49,4 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Help: "Number of open indexes per storage type. An open index corresponds to single resource group.",
 		}, []string{"index_storage"}), // index_storage is either "file" or "memory"
 	}
-
-	// Initialize labels.
-	m.OpenIndexes.WithLabelValues("file").Set(0)
-	m.OpenIndexes.WithLabelValues("memory").Set(0)
-
-	return m
 }

--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -244,7 +244,7 @@ func (s *server) BulkProcess(stream resourcepb.BulkStore_BulkProcessServer) erro
 				Namespace: summary.Namespace,
 				Group:     summary.Group,
 				Resource:  summary.Resource,
-			}, summary.Count, summary.ResourceVersion)
+			}, summary.Count, summary.ResourceVersion, "rebuildAfterBatchLoad")
 			if err != nil {
 				s.log.Warn("error building search index after batch load", "err", err)
 				rsp.Error = &resourcepb.ErrorResult{

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -541,7 +541,7 @@ func (s *searchSupport) dispatchEvent(ctx context.Context, evt *WrittenEvent) {
 		Group:     evt.Key.Group,
 		Resource:  evt.Key.Resource,
 	}
-	index, err := s.getOrCreateIndex(ctx, nsr)
+	index, err := s.getOrCreateIndex(ctx, nsr, "dispatchEvent")
 	if err != nil {
 		s.log.Warn("error getting index for watch event", "error", err)
 		span.RecordError(err)

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -508,9 +508,6 @@ func (s *searchSupport) init(ctx context.Context) error {
 
 	end := time.Now().Unix()
 	s.log.Info("search index initialized", "duration_secs", end-start, "total_docs", s.search.TotalDocs())
-	if s.indexMetrics != nil {
-		s.indexMetrics.IndexCreationTime.WithLabelValues().Observe(float64(end - start))
-	}
 
 	return nil
 }
@@ -626,11 +623,6 @@ func (s *searchSupport) rebuildDashboardIndexes(ctx context.Context) error {
 		"duration", duration,
 		"rebuilt_indexes", totalBatchesIndexed,
 		"total_docs", s.search.TotalDocs())
-
-	if s.indexMetrics != nil {
-		s.indexMetrics.IndexCreationTime.WithLabelValues().Observe(duration.Seconds())
-	}
-
 	return nil
 }
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -197,6 +197,7 @@ func (b *bleveBackend) BuildIndex(
 	size int64,
 	resourceVersion int64,
 	fields resource.SearchableDocumentFields,
+	indexBuildReason string,
 	builder func(index resource.ResourceIndex) (int64, error),
 ) (resource.ResourceIndex, error) {
 	_, span := b.tracer.Start(ctx, tracingPrexfixBleve+"BuildIndex")
@@ -214,7 +215,7 @@ func (b *bleveBackend) BuildIndex(
 		return nil, err
 	}
 
-	logWithDetails := b.log.With("namespace", key.Namespace, "group", key.Group, "resource", key.Resource, "size", size, "rv", resourceVersion)
+	logWithDetails := b.log.With("namespace", key.Namespace, "group", key.Group, "resource", key.Resource, "size", size, "rv", resourceVersion, "reason", indexBuildReason)
 
 	// Close the newly created/opened index by default.
 	closeIndex := true

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -23,6 +23,7 @@ import (
 	"github.com/blevesearch/bleve/v2/search/query"
 	bleveSearch "github.com/blevesearch/bleve/v2/search/searcher"
 	index "github.com/blevesearch/bleve_index_api"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -201,6 +202,14 @@ func (b *bleveBackend) BuildIndex(
 ) (resource.ResourceIndex, error) {
 	_, span := b.tracer.Start(ctx, tracingPrexfixBleve+"BuildIndex")
 	defer span.End()
+
+	span.SetAttributes(
+		attribute.String("namespace", key.Namespace),
+		attribute.String("group", key.Group),
+		attribute.String("resource", key.Resource),
+		attribute.Int64("size", size),
+		attribute.Int64("rv", resourceVersion),
+	)
 
 	var index bleve.Index
 	fileIndexName := "" // Name of the file-based index, or empty for in-memory indexes.

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -553,7 +553,7 @@ func newTestDashboardsIndex(t TB, threshold int64, size int64, batchSize int64, 
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, rv, info.Fields, writer)
+	}, size, rv, info.Fields, "test", writer)
 	require.NoError(t, err)
 
 	return index, tmpdir

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -71,7 +71,7 @@ func TestBleveBackend(t *testing.T) {
 			Namespace: key.Namespace,
 			Group:     key.Group,
 			Resource:  key.Resource,
-		}, 2, rv, info.Fields, func(index resource.ResourceIndex) (int64, error) {
+		}, 2, rv, info.Fields, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
@@ -352,7 +352,7 @@ func TestBleveBackend(t *testing.T) {
 			Namespace: key.Namespace,
 			Group:     key.Group,
 			Resource:  key.Resource,
-		}, 2, rv, fields, func(index resource.ResourceIndex) (int64, error) {
+		}, 2, rv, fields, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{
@@ -766,7 +766,7 @@ func TestBleveInMemoryIndexExpiration(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	builtIndex, err := backend.BuildIndex(context.Background(), ns, 1 /* below FileThreshold */, 100, nil, indexTestDocs(ns, 1))
+	builtIndex, err := backend.BuildIndex(context.Background(), ns, 1 /* below FileThreshold */, 100, nil, "test", indexTestDocs(ns, 1))
 	require.NoError(t, err)
 
 	// Wait for index expiration, which is 1ns
@@ -798,7 +798,7 @@ func TestBleveFileIndexExpiration(t *testing.T) {
 	}
 
 	// size=100 is above FileThreshold, this will be file-based index
-	builtIndex, err := backend.BuildIndex(context.Background(), ns, 100, 100, nil, indexTestDocs(ns, 1))
+	builtIndex, err := backend.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 1))
 	require.NoError(t, err)
 
 	// Wait for index expiration, which is 1ns
@@ -830,7 +830,7 @@ func TestFileIndexIsReusedOnSameSizeAndRV(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, indexTestDocs(ns, 10))
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10))
 	require.NoError(t, err)
 
 	// Verify one open index.
@@ -853,7 +853,7 @@ func TestFileIndexIsReusedOnSameSizeAndRV(t *testing.T) {
 
 	// We open new backend using same directory, and run indexing with same size (10) and RV (100). This should reuse existing index, and skip indexing.
 	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, indexTestDocs(ns, 1000))
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000))
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -879,13 +879,13 @@ func TestFileIndexIsNotReusedOnDifferentSize(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, indexTestDocs(ns, 10))
+	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10))
 	require.NoError(t, err)
 	backend1.closeAllIndexes()
 
 	// We open new backend using same directory, but with different size. Index should be rebuilt.
 	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 100, 100, nil, indexTestDocs(ns, 100))
+	idx, err := backend2.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 100))
 	require.NoError(t, err)
 
 	// Verify that index has updated number of documents.
@@ -904,13 +904,13 @@ func TestFileIndexIsNotReusedOnDifferentRV(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, indexTestDocs(ns, 10))
+	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10))
 	require.NoError(t, err)
 	backend1.closeAllIndexes()
 
 	// We open new backend using same directory, but with different RV. Index should be rebuilt.
 	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 999999, nil, indexTestDocs(ns, 100))
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 999999, nil, "test", indexTestDocs(ns, 100))
 	require.NoError(t, err)
 
 	// Verify that index has updated number of documents.
@@ -942,7 +942,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 			if testCase.firstInMemory {
 				firstSize = 1
 			}
-			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), 100, nil, indexTestDocs(ns, firstSize))
+			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), 100, nil, "test", indexTestDocs(ns, firstSize))
 			require.NoError(t, err)
 
 			openInMemoryIndexes := 0
@@ -952,7 +952,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 				secondSize = 1
 				openInMemoryIndexes = 1
 			}
-			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), 100, nil, indexTestDocs(ns, secondSize))
+			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), 100, nil, "test", indexTestDocs(ns, secondSize))
 			require.NoError(t, err)
 
 			// Verify that first and second index are different, and first one is now closed.
@@ -1050,12 +1050,12 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 		// size=100 is above FileThreshold (5), make it a file-based index.
 		size = 100
 	}
-	_, err := backend.BuildIndex(context.Background(), ns, size, 100, nil, func(index resource.ResourceIndex) (int64, error) {
+	_, err := backend.BuildIndex(context.Background(), ns, size, 100, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 0, fmt.Errorf("fail")
 	})
 	require.Error(t, err)
 
 	// Even though previous build of the index failed, new building of the index should work.
-	_, err = backend.BuildIndex(context.Background(), ns, size, 100, nil, indexTestDocs(ns, int(size)))
+	_, err = backend.BuildIndex(context.Background(), ns, size, 100, nil, "test", indexTestDocs(ns, int(size)))
 	require.NoError(t, err)
 }

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -215,7 +215,7 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 
 	// Build initial index
 	size := int64(10000) // force the index to be on disk
-	index, err := backend.BuildIndex(ctx, nr, size, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, nr, size, 0, nil, "benchmark", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
 	})
 	if err != nil {

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -64,7 +64,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 	require.Nil(t, index)
 
 	// Build the index
-	index, err = backend.BuildIndex(ctx, ns, 0, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+	index, err = backend.BuildIndex(ctx, ns, 0, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		// Write a test document
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
@@ -111,7 +111,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 	}
 
 	// Build initial index with some test documents
-	index, err := backend.BuildIndex(ctx, ns, 3, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, ns, 3, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
 				{
@@ -235,7 +235,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 
 	t.Run("Search by LibraryPanel reference", func(t *testing.T) {
 		// Build index with dashboards that have LibraryPanel references
-		index, err := backend.BuildIndex(ctx, ns, 3, 0, nil, func(index resource.ResourceIndex) (int64, error) {
+		index, err := backend.BuildIndex(ctx, ns, 3, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 			err := index.BulkIndex(&resource.BulkIndexRequest{
 				Items: []*resource.BulkIndexItem{
 					{


### PR DESCRIPTION
This PR does several things to improve observability of indexing:

* Introduces "reason" parameter when building an index -- used for logging and metrics
* Introduces metrics to track indexing builds, failures and skipped indexing:
  * `grafana_index_server_index_build_total` (per reason)
  * `grafana_index_server_index_build_failures_total`
  * `grafana_index_server_index_build_skipped_total`
* Changes previous `grafana_index_server_index_creation_time_seconds` into `grafana_index_server_index_build_time_seconds`, and tracks build time of individual index, not all indexes.
* Adds attributes to Build and BuildIndex tracing events
* Adds events about individual indexed objects to span, and batch flushing.