### PR TITLE
Dashboard: Fix for change detector in dashboards with live refresh

### DIFF
--- a/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
+++ b/public/app/features/dashboard-scene/saving/DashboardSceneChangeTracker.ts
@@ -46,19 +46,23 @@ export class DashboardSceneChangeTracker {
   }
 
   static isUpdatingPersistedState({ payload }: SceneObjectStateChangedEvent) {
+    const partialUpdateKeys = Object.keys(payload.partialUpdate);
+
     // If there are no changes in the state, the check is not needed
-    if (Object.keys(payload.partialUpdate).length === 0) {
+    if (partialUpdateKeys.length === 0) {
       return false;
     }
 
-    // Any change in the panel should trigger a change detection
+    // Any change in the grid item should trigger a change detection
     // The PanelTimeRange includes the overrides configuration
-    if (
-      payload.changedObject instanceof VizPanel ||
-      payload.changedObject instanceof DashboardGridItem ||
-      payload.changedObject instanceof PanelTimeRange
-    ) {
+    if (payload.changedObject instanceof DashboardGridItem || payload.changedObject instanceof PanelTimeRange) {
       return true;
+    }
+    // Panels contain a _renderCounter state prop which should not be marked as a change
+    if (payload.changedObject instanceof VizPanel) {
+      if (partialUpdateKeys.length > 1 || partialUpdateKeys[0] !== '_renderCounter') {
+        return true;
+      }
     }
     // SceneQueryRunner includes the DS configuration
     if (payload.changedObject instanceof SceneQueryRunner) {


### PR DESCRIPTION
**What is this feature?**

`VizPanel` contains a `_renderCount` property in the state. Because of live refresh, this property gets updated continuously, causing the change detector to:
- leak memory
- not detect actual changes
- spam `Discard dashboard changes` modal

**Why do we need this feature?**

Stop memory leaks and fix bugs.

**Who is this feature for?**

Everybody that uses `live refresh` property on dashboards.

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
