### PR TITLE
AppPlatform: Add "folder" and "dashboard" tags to search API

### DIFF
--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -63,7 +63,7 @@ func (s *SearchHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *
 				Spec: &spec3.PathProps{
 					Get: &spec3.Operation{
 						OperationProps: spec3.OperationProps{
-							Tags:        []string{"Search"},
+							Tags:        []string{"Search", "Folder", "Dashboard"},
 							Description: "Dashboard search",
 							Parameters: []*spec3.Parameter{
 								{

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -918,7 +918,9 @@
     "/apis/dashboard.grafana.app/v0alpha1/namespaces/{namespace}/search": {
       "get": {
         "tags": [
-          "Search"
+          "Search",
+          "Folder",
+          "Dashboard"
         ],
         "description": "Dashboard search",
         "parameters": [


### PR DESCRIPTION
**What is this feature?**
Adds tags to the search API, so that the generated OpenAPI spec includes the right entities.

**Why do we need this feature?**
This means that then when we generate the frontend clients, we'll end up including the right tag invalidation so that data doesn't end up stale in the UI

**Who is this feature for?**
UI developers using the alpha dashboards search API
