### PR TITLE
SecretsManager: Refactor and clean metrics

### DIFF
--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -27,7 +27,7 @@ type DecryptAuthorizer interface {
 	Authorize(ctx context.Context, secureValueName string, secureValueDecrypters []string) (identity string, allowed bool)
 }
 
-// DecryptService is the inferface for the decrypt service.
+// DecryptService is the interface for the decrypt service.
 type DecryptService interface {
 	Decrypt(ctx context.Context, namespace string, names ...string) (map[string]DecryptResult, error)
 	Close() error

--- a/pkg/registry/apis/secret/service/metrics/metrics.go
+++ b/pkg/registry/apis/secret/service/metrics/metrics.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sync"
+)
+
+const (
+	namespace = "grafana_secrets_manager"
+	subsystem = "service"
+)
+
+// SecureValueServiceMetrics is a struct that contains all the metrics for SecureValue.
+type SecureValueServiceMetrics struct {
+	SecureValueCreateDuration *prometheus.HistogramVec
+	SecureValueCreateCount    *prometheus.CounterVec
+	SecureValueUpdateDuration *prometheus.HistogramVec
+	SecureValueUpdateCount    *prometheus.CounterVec
+	SecureValueReadDuration   *prometheus.HistogramVec
+	SecureValueReadCount      *prometheus.CounterVec
+	SecureValueListDuration   *prometheus.HistogramVec
+	SecureValueListCount      *prometheus.CounterVec
+	SecureValueDeleteDuration *prometheus.HistogramVec
+	SecureValueDeleteCount    *prometheus.CounterVec
+}
+
+func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
+	return &SecureValueServiceMetrics{
+		SecureValueCreateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_create_duration_seconds",
+			Help:      "Duration of Secure Value create operations",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"success"}),
+		SecureValueCreateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_create_count",
+			Help:      "Count of Secure Value create operations",
+		}, []string{"success"}),
+		SecureValueReadDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_read_duration_seconds",
+			Help:      "Duration of Secure Value read operations",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"success"}),
+		SecureValueReadCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_read_count",
+			Help:      "Count of Secure Value read operations",
+		}, []string{"success"}),
+		SecureValueUpdateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_update_duration_seconds",
+			Help:      "Duration of Secure Value update operations",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"success"}),
+		SecureValueUpdateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_update_count",
+			Help:      "Count of Secure Value update operations",
+		}, []string{"success"}),
+		SecureValueListDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_list_duration_seconds",
+			Help:      "Duration of Secure Value list operations",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"success"}),
+		SecureValueListCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_list_count",
+			Help:      "Count of Secure Value list operations",
+		}, []string{"success"}),
+		SecureValueDeleteDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_delete_duration_seconds",
+			Help:      "Duration of Secure Value delete operations",
+			Buckets:   prometheus.DefBuckets,
+		}, []string{"success"}),
+		SecureValueDeleteCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "secure_value_delete_count",
+			Help:      "Count of Secure Value delete operations",
+		}, []string{"success"}),
+	}
+}
+
+var (
+	initOnce        sync.Once
+	metricsInstance *SecureValueServiceMetrics
+)
+
+func NewSecureValueServiceMetrics(reg prometheus.Registerer) *SecureValueServiceMetrics {
+	initOnce.Do(func() {
+		m := newSecureValueServiceMetrics()
+
+		if reg != nil {
+			reg.MustRegister(
+				m.SecureValueCreateDuration,
+				m.SecureValueCreateCount,
+				m.SecureValueReadDuration,
+				m.SecureValueReadCount,
+				m.SecureValueUpdateDuration,
+				m.SecureValueUpdateCount,
+				m.SecureValueListDuration,
+				m.SecureValueListCount,
+				m.SecureValueDeleteDuration,
+				m.SecureValueDeleteCount,
+			)
+		}
+		metricsInstance = m
+	})
+	return metricsInstance
+}
+
+func NewTestMetrics() *SecureValueServiceMetrics {
+	return newSecureValueServiceMetrics()
+}

--- a/pkg/registry/apis/secret/service/metrics/metrics.go
+++ b/pkg/registry/apis/secret/service/metrics/metrics.go
@@ -1,8 +1,9 @@
 package metrics
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
 	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 const (

--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -120,7 +120,7 @@ func Setup(t *testing.T, opts ...func(*SetupConfig)) Sut {
 		keeperService = setupCfg.KeeperService
 	}
 
-	secureValueService := service.ProvideSecureValueService(tracer, accessClient, database, secureValueMetadataStorage, keeperMetadataStorage, keeperService)
+	secureValueService := service.ProvideSecureValueService(tracer, accessClient, database, secureValueMetadataStorage, keeperMetadataStorage, keeperService, nil)
 
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer)
 

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -780,7 +780,7 @@ func Initialize(cfg *setting.Cfg, opts Options, apiOpts api.ServerOptions) (*Ser
 	if err != nil {
 		return nil, err
 	}
-	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService)
+	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService, registerer)
 	secureValueValidator := validator3.ProvideSecureValueValidator()
 	secureValueClient := secret.ProvideSecureValueClient(secureValueService, secureValueValidator, accessClient)
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer)
@@ -1341,7 +1341,7 @@ func InitializeForTest(t sqlutil.ITestDB, testingT interface {
 	if err != nil {
 		return nil, err
 	}
-	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService)
+	secureValueService := service12.ProvideSecureValueService(tracer, accessClient, databaseDatabase, secureValueMetadataStorage, keeperMetadataStorage, ossKeeperService, registerer)
 	secureValueValidator := validator3.ProvideSecureValueValidator()
 	secureValueClient := secret.ProvideSecureValueClient(secureValueService, secureValueValidator, accessClient)
 	decryptAuthorizer := decrypt.ProvideDecryptAuthorizer(tracer)

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -292,8 +292,13 @@ func TestIntegrationDecrypt(t *testing.T) {
 		require.NotEmpty(t, exposed)
 		require.Equal(t, "value", exposed.DangerouslyExposeAndConsumeValue())
 
-		require.Len(t, fakeLogger.InfoArgs, 1)
-		args := fakeLogger.InfoArgs[0]
+		require.Len(t, fakeLogger.InfoMsgs, 2)
+		require.Equal(t, fakeLogger.InfoMsgs[0], "SecureValueMetadataStorage.Read")
+		require.Equal(t, fakeLogger.InfoMsgs[1], "Secrets Audit Log")
+
+		require.Len(t, fakeLogger.InfoArgs, 2)
+		// we only want to check the audit log args
+		args := fakeLogger.InfoArgs[1]
 		require.Contains(t, args, "grafana_decrypter_identity")
 		require.Contains(t, args, "decrypter_identity")
 		for i, arg := range args {

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -25,8 +25,8 @@ type StorageMetrics struct {
 	KeeperMetadataListCount               prometheus.Counter
 	KeeperMetadataGetKeeperConfigDuration prometheus.Histogram
 
-	SecureValueMetadataCreateDuration prometheus.Histogram
-	SecureValueMetadataCreateCount    prometheus.Counter
+	SecureValueMetadataCreateDuration *prometheus.HistogramVec
+	SecureValueMetadataCreateCount    *prometheus.CounterVec
 	SecureValueMetadataUpdateDuration prometheus.Histogram
 	SecureValueMetadataUpdateCount    prometheus.Counter
 	SecureValueMetadataDeleteDuration prometheus.Histogram
@@ -119,19 +119,19 @@ func newStorageMetrics() *StorageMetrics {
 		}),
 
 		// Secure value metrics
-		SecureValueMetadataCreateDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		SecureValueMetadataCreateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_metadata_create_duration_seconds",
 			Help:      "Duration of secure value metadata create operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueMetadataCreateCount: prometheus.NewCounter(prometheus.CounterOpts{
+		}, []string{"successful"}),
+		SecureValueMetadataCreateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_metadata_create_count",
 			Help:      "Count of secure value metadata create operations",
-		}),
+		}, []string{"successful"}),
 		SecureValueMetadataUpdateDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -27,8 +27,6 @@ type StorageMetrics struct {
 
 	SecureValueMetadataCreateDuration *prometheus.HistogramVec
 	SecureValueMetadataCreateCount    *prometheus.CounterVec
-	SecureValueMetadataDeleteDuration prometheus.Histogram
-	SecureValueMetadataDeleteCount    prometheus.Counter
 	SecureValueMetadataGetDuration    prometheus.Histogram
 	SecureValueMetadataGetCount       prometheus.Counter
 	SecureValueMetadataListDuration   prometheus.Histogram
@@ -130,19 +128,6 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "secure_value_metadata_create_count",
 			Help:      "Count of secure value metadata create operations",
 		}, []string{"successful"}),
-		SecureValueMetadataDeleteDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_delete_duration_seconds",
-			Help:      "Duration of secure value metadata delete operations",
-			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueMetadataDeleteCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_delete_count",
-			Help:      "Count of secure value metadata delete operations",
-		}),
 		SecureValueMetadataGetDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -226,8 +211,6 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 				m.KeeperMetadataGetKeeperConfigDuration,
 				m.SecureValueMetadataCreateDuration,
 				m.SecureValueMetadataCreateCount,
-				m.SecureValueMetadataDeleteDuration,
-				m.SecureValueMetadataDeleteCount,
 				m.SecureValueMetadataGetDuration,
 				m.SecureValueMetadataGetCount,
 				m.SecureValueMetadataListDuration,

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -27,8 +27,6 @@ type StorageMetrics struct {
 
 	SecureValueMetadataCreateDuration *prometheus.HistogramVec
 	SecureValueMetadataCreateCount    *prometheus.CounterVec
-	SecureValueMetadataUpdateDuration prometheus.Histogram
-	SecureValueMetadataUpdateCount    prometheus.Counter
 	SecureValueMetadataDeleteDuration prometheus.Histogram
 	SecureValueMetadataDeleteCount    prometheus.Counter
 	SecureValueMetadataGetDuration    prometheus.Histogram
@@ -132,19 +130,6 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "secure_value_metadata_create_count",
 			Help:      "Count of secure value metadata create operations",
 		}, []string{"successful"}),
-		SecureValueMetadataUpdateDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_update_duration_seconds",
-			Help:      "Duration of secure value metadata update operations",
-			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueMetadataUpdateCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_update_count",
-			Help:      "Count of secure value metadata update operations",
-		}),
 		SecureValueMetadataDeleteDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -241,8 +226,6 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 				m.KeeperMetadataGetKeeperConfigDuration,
 				m.SecureValueMetadataCreateDuration,
 				m.SecureValueMetadataCreateCount,
-				m.SecureValueMetadataUpdateDuration,
-				m.SecureValueMetadataUpdateCount,
 				m.SecureValueMetadataDeleteDuration,
 				m.SecureValueMetadataDeleteCount,
 				m.SecureValueMetadataGetDuration,

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -3,18 +3,21 @@ package metadata
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/xkube"
 	"github.com/grafana/grafana/pkg/storage/secret/metadata/metrics"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"go.opentelemetry.io/otel/codes"
 )
 
 var _ contracts.SecureValueMetadataStorage = (*secureValueMetadataStorage)(nil)
@@ -40,16 +43,39 @@ type secureValueMetadataStorage struct {
 	tracer  trace.Tracer
 }
 
-func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1beta1.SecureValue, actorUID string) (*secretv1beta1.SecureValue, error) {
+func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1beta1.SecureValue, actorUID string) (_ *secretv1beta1.SecureValue, svmCreateErr error) {
 	start := time.Now()
+	name := sv.GetName()
+	namespace := sv.GetNamespace()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.Create", trace.WithAttributes(
-		attribute.String("name", sv.GetName()),
-		attribute.String("namespace", sv.GetNamespace()),
+		attribute.String("name", name),
+		attribute.String("namespace", namespace),
 		attribute.String("actorUID", actorUID),
 	))
 	defer span.End()
 
-	// Set inside of the transaction callback
+	defer func() {
+		args := []any{
+			"namespace", namespace,
+			"secret_name", name,
+			"actorUID", actorUID,
+		}
+
+		success := svmCreateErr == nil
+		args = append(args, "success", success)
+		if !success {
+			span.SetStatus(codes.Error, "SecretValueMetadata creation failed")
+			span.RecordError(svmCreateErr)
+			args = append(args, "error", svmCreateErr)
+		}
+
+		logging.FromContext(ctx).Info("SecretValueMetadata created", args...)
+
+		s.metrics.SecureValueMetadataCreateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
+		s.metrics.SecureValueMetadataCreateCount.WithLabelValues(strconv.FormatBool(success)).Inc()
+	}()
+
+	// Set inside the transaction callback
 	var row *secureValueDB
 
 	err := s.db.Transaction(ctx, func(ctx context.Context) error {
@@ -144,9 +170,6 @@ func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1bet
 	if err != nil {
 		return nil, fmt.Errorf("convert to kubernetes object: %w", err)
 	}
-
-	s.metrics.SecureValueMetadataCreateDuration.Observe(time.Since(start).Seconds())
-	s.metrics.SecureValueMetadataCreateCount.Inc()
 
 	return createdSecureValue, nil
 }

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -64,12 +64,12 @@ func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1bet
 		success := svmCreateErr == nil
 		args = append(args, "success", success)
 		if !success {
-			span.SetStatus(codes.Error, "SecretValueMetadata creation failed")
+			span.SetStatus(codes.Error, "SecureValueMetadataStorage.Create failed")
 			span.RecordError(svmCreateErr)
 			args = append(args, "error", svmCreateErr)
 		}
 
-		logging.FromContext(ctx).Info("SecretValueMetadata created", args...)
+		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Create", args...)
 
 		s.metrics.SecureValueMetadataCreateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
 		s.metrics.SecureValueMetadataCreateCount.WithLabelValues(strconv.FormatBool(success)).Inc()
@@ -263,7 +263,7 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 	defer span.End()
 
 	defer func() {
-		logging.FromContext(ctx).Info("SecretValueMetadata read", "namespace", namespace, "name", name, "success", readErr != nil, "error", readErr)
+		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Read", "namespace", namespace, "name", name, "success", readErr != nil, "error", readErr)
 
 		s.metrics.SecureValueMetadataGetDuration.Observe(time.Since(start).Seconds())
 		s.metrics.SecureValueMetadataGetCount.Inc()


### PR DESCRIPTION
Changes: 
- Changes SecureValueMetadataCreateDuration and SecureValueMetadataCreateCount to HistogramVec to be able to store success status
- Adds logs for SecureValueMetadataCreate final result (info)
- Adds logs for SecureValue service functions
- Removed these unused metrics (because operations don't exist at the moment):
  - SecureValueMetadataUpdateDuration
  - SecureValueMetadataUpdateCount   
  - SecureValueMetadataDeleteDuration
  - SecureValueMetadataDeleteCount 
- Add metrics for SecureValue service
  - Create
  - Read
  - List
  - Delete
  - Update

Not added:
- Decrypt service metrics and logs, since it is in the storage for now