### PR TITLE
Dashboard: Fix for viewing a repeated panel that is out of view

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneUrlSync.ts
@@ -208,8 +208,11 @@ export class DashboardSceneUrlSync implements SceneObjectUrlSyncHandler {
         if (panel) {
           this._viewEventSub?.unsubscribe();
           this._scene.setState({ viewPanelScene: new ViewPanelScene({ panelRef: panel.getRef() }) });
+          this._viewEventSub = undefined;
         }
       });
+
+      this._scene.state.body.activateRepeaters?.();
     }
   }
 


### PR DESCRIPTION
**What is this feature?**

When we try to view a repeated panel that is outside of viewport, it might not appear until we scroll the dashboard to the respective panel.

This is happening because the panels are not active until they are in the viewport, hence their repeats are not processed.

This PR fixes it by forcing a repeats activate process when trying to view a repeated panel.

**Why do we need this feature?**

Allow repeated panels to be viewed correctly even when they are outside of the viewport.

**Who is this feature for?**

Everybody.

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/70f76176-a283-42d5-b297-a8645e9ddf10


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
