### PR TITLE
Schema V2: Fix apiVersion for conversion to v2beta1

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.complete.v2beta1.json
@@ -1,6 +1,6 @@
 {
   "kind": "Dashboard",
-  "apiVersion": "v2beta1",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
   "metadata": {
     "name": "test-v2alpha1-complete",
     "creationTimestamp": null,

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.ds-data-query.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.ds-data-query.v2beta1.json
@@ -1,6 +1,6 @@
 {
   "kind": "Dashboard",
-  "apiVersion": "v2beta1",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
   "metadata": {
     "name": "test-v2alpha1-annotations",
     "creationTimestamp": null

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.groupby-adhoc-vars.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.groupby-adhoc-vars.v2beta1.json
@@ -1,6 +1,6 @@
 {
   "kind": "Dashboard",
-  "apiVersion": "v2beta1",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
   "metadata": {
     "name": "test-v2alpha1-groupby-adhoc-vars",
     "creationTimestamp": null

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.viz-config.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2alpha1.viz-config.v2beta1.json
@@ -1,6 +1,6 @@
 {
   "kind": "Dashboard",
-  "apiVersion": "v2beta1",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
   "metadata": {
     "name": "test-v2alpha1-viz-config",
     "creationTimestamp": null

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v2beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v2beta1.go
@@ -39,7 +39,7 @@ import (
 
 func ConvertDashboard_V2alpha1_to_V2beta1(in *dashv2alpha1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.APIVersion = dashv2beta1.VERSION
+	out.APIVersion = dashv2beta1.APIVERSION
 	out.Kind = in.Kind
 
 	return convertDashboardSpec_V2alpha1_to_V2beta1(&in.Spec, &out.Spec, scope)


### PR DESCRIPTION
**Problem**
The `apiVersion` generated from conversions doesn't include app group.

**Solution**
Use `dashv2beta1.APIVERSION` instead.
