### PR TITLE
Loki: Decouple unit tests from core

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -83,6 +83,7 @@ module.exports = {
     '<rootDir>/public/app/plugins/datasource/grafana-pyroscope-datasource',
     '<rootDir>/public/app/plugins/datasource/grafana-testdata-datasource',
     '<rootDir>/public/app/plugins/datasource/jaeger',
+    '<rootDir>/public/app/plugins/datasource/loki',
     '<rootDir>/public/app/plugins/datasource/mysql',
     '<rootDir>/public/app/plugins/datasource/parca',
     '<rootDir>/public/app/plugins/datasource/tempo',

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "plugin:build": "nx run-many -t build --projects='tag:scope:plugin'",
     "plugin:build:commit": "nx run-many -t build:commit --projects='tag:scope:plugin'",
     "plugin:build:dev": "nx run-many -t dev --projects='tag:scope:plugin' --maxParallel=100",
-    "plugin:test:ci": "nx run-many -t test:ci --projects='tag:scope:plugin'",
+    "plugin:test:ci": "nx run-many -t test:ci --projects='tag:scope:plugin' --maxParallel=2",
     "plugin:i18n-extract": "nx run-many -t i18n-extract --projects='tag:scope:plugin'",
     "process-specs": "node --experimental-strip-types scripts/process-specs.ts",
     "generate-apis": "yarn process-specs && rtk-query-codegen-openapi ./scripts/generate-rtk-apis.ts",

--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -761,7 +761,8 @@ describe('Query imports', () => {
           maxLines: DEFAULT_MAX_LINES_SAMPLE,
           refId: 'data-samples',
         },
-        languageProvider.getDefaultTimeRange()
+        // We are not interested in the time range here
+        expect.any(Object)
       );
     });
 
@@ -782,7 +783,8 @@ describe('Query imports', () => {
           maxLines: 5,
           refId: 'data-samples',
         },
-        languageProvider.getDefaultTimeRange()
+        // We are not interested in the time range here
+        expect.any(Object)
       );
     });
 

--- a/public/app/plugins/datasource/loki/jest-setup.js
+++ b/public/app/plugins/datasource/loki/jest-setup.js
@@ -1,0 +1,1 @@
+import '@grafana/plugin-configs/jest/jest-setup';

--- a/public/app/plugins/datasource/loki/jest.config.js
+++ b/public/app/plugins/datasource/loki/jest.config.js
@@ -1,0 +1,3 @@
+import defaultConfig from '@grafana/plugin-configs/jest/jest.config.js';
+
+export default defaultConfig;

--- a/public/app/plugins/datasource/loki/package.json
+++ b/public/app/plugins/datasource/loki/package.json
@@ -37,6 +37,7 @@
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
     "@types/uuid": "10.0.0",
+    "jest": "29.7.0",
     "ts-node": "10.9.2",
     "typescript": "5.7.3",
     "webpack": "5.97.1"
@@ -47,7 +48,9 @@
   "scripts": {
     "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
     "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development"
+    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "test": "jest --watch --onlyChanged",
+    "test:ci": "jest --maxWorkers 4"
   },
   "packageManager": "yarn@4.9.2"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,6 +2771,7 @@ __metadata:
     "@types/react-dom": "npm:18.3.5"
     "@types/uuid": "npm:10.0.0"
     d3-random: "npm:^3.0.1"
+    jest: "npm:29.7.0"
     lodash: "npm:4.17.21"
     micro-memoize: "npm:^4.1.2"
     react: "npm:18.3.1"


### PR DESCRIPTION
Related to https://github.com/grafana/grafana/pull/107942

This PR splits the Loki unit tests from the core grafana jest config and runs them separately. 