### PR TITLE
feat: add database config setting to drop automatically generated primary keys

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -200,6 +200,10 @@ transaction_retries = 5
 # Set to true to add metrics and tracing for database queries.
 instrument_queries = false
 
+# Set to true to delete auto-generated primary keys during migrations.
+# This is useful when databases have auto-generated primary keys enabled.
+delete_auto_gen_ids = false
+
 #################################### Cache server #############################
 [remote_cache]
 # Either "redis", "memcached" or "database" default is "database"

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -197,6 +197,10 @@
 # Set to true to add metrics and tracing for database queries.
 ;instrument_queries = false
 
+# Set to true to delete auto-generated primary keys during migrations.
+# This is useful when databases have auto-generated primary keys enabled.
+;delete_auto_gen_ids = false
+
 #################################### Cache server #############################
 [remote_cache]
 # Either "redis", "memcached" or "database" default is "database"

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -43,6 +43,7 @@ type DatabaseConfig struct {
 	MigrationLock               bool
 	MigrationLockAttemptTimeout int
 	LogQueries                  bool
+	DeleteAutoGenIDs            bool
 	// SQLite only
 	QueryRetries int
 	// SQLite only
@@ -123,6 +124,7 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.TransactionRetries = sec.Key("transaction_retries").MustInt(5)
 
 	dbCfg.LogQueries = sec.Key("log_queries").MustBool(false)
+	dbCfg.DeleteAutoGenIDs = sec.Key("delete_auto_gen_ids").MustBool(false)
 
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Introduces a setting `[database][delete_auto_gen_ids]` that can be turned on to automatically delete primary keys that some database engines automatically add when a table is missing one.

**Why do we need this feature?**

We want to introduce primary keys to the `settings`, `file` and `file_meta` tables, but some database engines have a setting that automatically creates a primary key if a table is missing one. These need to be dropped before the migration that creates the new PKs can run.

**Who is this feature for?**

Grafana Database Administrators.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/search-and-storage-team/issues/393

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
