### PR TITLE
Alerting: Enable HA clustering in remote primary mode

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -225,7 +225,6 @@ func (ng *AlertNG) init() error {
 		if remotePrimary {
 			ng.Log.Debug("Starting Grafana with remote primary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemotePrimary).Set(1)
-			ng.Cfg.UnifiedAlerting.SkipClustering = true
 			// This function will be used by the MOA to create new Alertmanagers.
 			override = notifier.WithAlertmanagerOverride(func(factoryFn notifier.OrgAlertmanagerFactory) notifier.OrgAlertmanagerFactory {
 				return func(ctx context.Context, orgID int64) (notifier.Alertmanager, error) {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -161,12 +161,8 @@ func NewMultiOrgAlertmanager(
 		peer:                        &NilPeer{},
 	}
 
-	if cfg.UnifiedAlerting.SkipClustering {
-		l.Info("Skipping setting up clustering for MOA")
-	} else {
-		if err := moa.setupClustering(cfg); err != nil {
-			return nil, err
-		}
+	if err := moa.setupClustering(cfg); err != nil {
+		return nil, err
 	}
 
 	// Set up the default per tenant Alertmanager factory.

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -121,7 +121,6 @@ type UnifiedAlertingSettings struct {
 	DefaultRuleEvaluationInterval time.Duration
 	Screenshots                   UnifiedAlertingScreenshotSettings
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
-	SkipClustering                bool
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	NotificationHistory           UnifiedAlertingNotificationHistorySettings
 	RemoteAlertmanager            RemoteAlertmanagerSettings


### PR DESCRIPTION
**What is this feature?**

Enable HA alerting clustering in remote primary mode.

**Why do we need this feature?**

When Grafana operates in remote primary mode, it synchronizes the local Alertmanager state with the remote Alertmanager during startup and shutdown. When clustering is disabled, this synchronization can result in inconsistent state being sent to the remote Alertmanager, potentially causing issues.
