### PR TITLE
useProvisionedRequestHandler: Refactor to support more resource type

### DIFF
--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
@@ -49,6 +49,26 @@ jest.mock('app/features/dashboard-scene/components/Provisioned/ResourceEditFormS
   ResourceEditFormSharedFields: () => <div data-testid="shared-fields" />,
 }));
 
+const MOCK_DATA = {
+  repository: {
+    name: 'test-repo',
+    namespace: 'default',
+    title: 'Test Repository',
+    type: 'git',
+  },
+  resource: {
+    type: {
+      kind: 'Folder',
+    },
+    upsert: {
+      apiVersion: 'v1',
+      kind: 'Folder',
+      metadata: { name: 'test-folder', uid: 'test-folder-uid' },
+      spec: { title: 'Test Folder' },
+    },
+  },
+};
+
 const mockUseDeleteRepositoryFilesMutation = useDeleteRepositoryFilesWithPathMutation as jest.MockedFunction<
   typeof useDeleteRepositoryFilesWithPathMutation
 >;
@@ -267,7 +287,13 @@ describe('DeleteProvisionedFolderForm', () => {
 
   describe('success handling', () => {
     it('should navigate to parent folder on successful write workflow', async () => {
-      const successState = { isLoading: false, isSuccess: true, isError: false, error: null };
+      const successState = {
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+        error: null,
+        data: MOCK_DATA,
+      };
       setup({}, defaultHookData, successState);
 
       await waitFor(() => {
@@ -277,7 +303,13 @@ describe('DeleteProvisionedFolderForm', () => {
 
     it('should navigate to dashboards root when parent folder has no parentUid', async () => {
       const folderWithoutParent = { ...mockParentFolder, parentUid: undefined };
-      const successState = { isLoading: false, isSuccess: true, isError: false, error: null };
+      const successState = {
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+        error: null,
+        data: MOCK_DATA,
+      };
       setup({ parentFolder: folderWithoutParent }, defaultHookData, successState);
 
       await waitFor(() => {
@@ -292,13 +324,35 @@ describe('DeleteProvisionedFolderForm', () => {
         isSuccess: true,
         isError: false,
         error: null,
-        data: { urls: { newPullRequestURL: 'https://github.com/test/repo/pull/new' } },
+        data: {
+          urls: { newPullRequestURL: 'https://github.com/test/repo/pull/new' },
+          repository: {
+            name: 'test-repo',
+            namespace: 'default',
+            title: 'Test Repository',
+            type: 'git',
+          },
+          resource: {
+            type: {
+              kind: 'Folder',
+            },
+            upsert: {
+              apiVersion: 'v1',
+              kind: 'Folder',
+              metadata: { name: 'test-folder', uid: 'test-folder-uid' },
+              spec: { title: 'Test Folder' },
+            },
+          },
+          ref: 'feature-branch',
+          path: 'folders/test-folder.json',
+        },
       };
       const { mockNavigate } = setup({}, { ...defaultHookData, initialValues: branchFormData }, successState);
 
       await waitFor(() => {
         const expectedParams = new URLSearchParams();
         expectedParams.set('new_pull_request_url', 'https://github.com/test/repo/pull/new');
+        expectedParams.set('repo_type', 'git');
         const expectedUrl = `/dashboards?${expectedParams.toString()}`;
 
         expect(mockNavigate).toHaveBeenCalledWith(expectedUrl);

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.test.tsx
@@ -325,26 +325,10 @@ describe('DeleteProvisionedFolderForm', () => {
         isError: false,
         error: null,
         data: {
-          urls: { newPullRequestURL: 'https://github.com/test/repo/pull/new' },
-          repository: {
-            name: 'test-repo',
-            namespace: 'default',
-            title: 'Test Repository',
-            type: 'git',
-          },
-          resource: {
-            type: {
-              kind: 'Folder',
-            },
-            upsert: {
-              apiVersion: 'v1',
-              kind: 'Folder',
-              metadata: { name: 'test-folder', uid: 'test-folder-uid' },
-              spec: { title: 'Test Folder' },
-            },
-          },
+          ...MOCK_DATA,
           ref: 'feature-branch',
           path: 'folders/test-folder.json',
+          urls: { newPullRequestURL: 'https://github.com/test/repo/pull/new' },
         },
       };
       const { mockNavigate } = setup({}, { ...defaultHookData, initialValues: branchFormData }, successState);

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -13,7 +13,7 @@ import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/sha
 import { buildResourceBranchRedirectUrl } from 'app/features/dashboard-scene/settings/utils';
 import {
   useProvisionedRequestHandler,
-  ProvisionedResourceContext,
+  ProvisionedOperationInfo,
 } from 'app/features/dashboard-scene/utils/useProvisionedRequestHandler';
 import { FolderDTO } from 'app/types/folders';
 
@@ -62,20 +62,20 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
 
   const handleBranchSuccess = (
     { path, urls }: { ref: string; path: string; urls?: Record<string, string> },
-    context: ProvisionedResourceContext
+    info: ProvisionedOperationInfo
   ) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
         paramName: 'new_pull_request_url',
         paramValue: prUrl,
-        repoType: context.repoType,
+        repoType: info.repoType,
       });
       navigate(url);
     }
   };
 
-  const handleWriteSuccess = (context: ProvisionedResourceContext) => {
+  const handleWriteSuccess = (info: ProvisionedOperationInfo) => {
     getAppEvents().publish({
       type: AppEvents.alertSuccess.name,
       payload: [
@@ -93,7 +93,7 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     }
   };
 
-  const handleError = (error: unknown, context: ProvisionedResourceContext) => {
+  const handleError = (error: unknown, info: ProvisionedOperationInfo) => {
     getAppEvents().publish({
       type: AppEvents.alertError.name,
       payload: [t('browse-dashboards.delete-provisioned-folder-form.api-error', 'Failed to delete folder'), error],

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -60,10 +60,7 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     });
   };
 
-  const handleBranchSuccess = (
-    { path, urls }: { ref: string; path: string; urls?: Record<string, string> },
-    info: ProvisionedOperationInfo
-  ) => {
+  const handleBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
@@ -76,15 +73,6 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
   };
 
   const handleWriteSuccess = (info: ProvisionedOperationInfo) => {
-    getAppEvents().publish({
-      type: AppEvents.alertSuccess.name,
-      payload: [
-        t(
-          'browse-dashboards.delete-provisioned-folder-form.alert-folder-deleted-successfully',
-          'Folder deleted successfully'
-        ),
-      ],
-    });
     // Navigate back to parent folder if it exists, otherwise go to dashboards root
     if (parentFolder?.parentUid) {
       window.location.href = getFolderURL(parentFolder.parentUid);
@@ -104,6 +92,10 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
   useProvisionedRequestHandler({
     request,
     workflow,
+    successMessage: t(
+      'browse-dashboards.delete-provisioned-folder-form.success-message',
+      'Folder deleted successfully'
+    ),
     resourceType: 'folder',
     repository,
     handlers: {

--- a/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/DeleteProvisionedFolderForm.tsx
@@ -60,7 +60,7 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     });
   };
 
-  const handleBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
+  const onBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
@@ -72,7 +72,7 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     }
   };
 
-  const handleWriteSuccess = (info: ProvisionedOperationInfo) => {
+  const onWriteSuccess = () => {
     // Navigate back to parent folder if it exists, otherwise go to dashboards root
     if (parentFolder?.parentUid) {
       window.location.href = getFolderURL(parentFolder.parentUid);
@@ -81,7 +81,7 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     }
   };
 
-  const handleError = (error: unknown, info: ProvisionedOperationInfo) => {
+  const onError = (error: unknown) => {
     getAppEvents().publish({
       type: AppEvents.alertError.name,
       payload: [t('browse-dashboards.delete-provisioned-folder-form.api-error', 'Failed to delete folder'), error],
@@ -100,9 +100,9 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
     repository,
     handlers: {
       onDismiss,
-      onBranchSuccess: handleBranchSuccess,
-      onWriteSuccess: handleWriteSuccess,
-      onError: handleError,
+      onBranchSuccess,
+      onWriteSuccess,
+      onError,
     },
   });
 

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -14,7 +14,7 @@ import { BaseProvisionedFormData } from 'app/features/dashboard-scene/saving/sha
 import { buildResourceBranchRedirectUrl } from 'app/features/dashboard-scene/settings/utils';
 import {
   useProvisionedRequestHandler,
-  ProvisionedResourceContext,
+  ProvisionedOperationInfo,
 } from 'app/features/dashboard-scene/utils/useProvisionedRequestHandler';
 import { PROVISIONING_URL } from 'app/features/provisioning/constants';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
@@ -51,38 +51,38 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
 
   const handleBranchSuccess = (
     { path, urls }: { ref: string; path: string; urls?: Record<string, string> },
-    context: ProvisionedResourceContext
+    info: ProvisionedOperationInfo
   ) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
         paramName: 'new_pull_request_url',
         paramValue: prUrl,
-        repoType: context.repoType,
+        repoType: info.repoType,
       });
       navigate(url);
     }
   };
 
-  const handleNewResourceSuccess = (resource: Resource, context: ProvisionedResourceContext) => {
+  const handleNewResourceSuccess = (resource: Resource, info: ProvisionedOperationInfo) => {
+    // Navigation for new folders (resource-specific concern)
     if (resource?.metadata?.name) {
       navigate(`/dashboards/f/${resource.metadata.name}/`);
       return;
     }
 
-    // Fallback to provisioning URL with repository type context
+    // Fallback to provisioning URL
     if (repository?.name && request.data?.path) {
       let url = `${PROVISIONING_URL}/${repository.name}/file/${request.data.path}`;
       if (request.data.ref?.length) {
         url += '?ref=' + request.data.ref;
       }
-      // Could add provider-specific URL modifications here in the future
       navigate(url);
     }
   };
 
-  const handleError = (error: unknown, context: ProvisionedResourceContext) => {
-    // Provider-specific error handling could be added here based on context.repoType
+  const handleError = (error: unknown, info: ProvisionedOperationInfo) => {
+    // Provider-specific error handling could be added here based on info.repoType
     const errorMessage = t(
       'browse-dashboards.new-provisioned-folder-form.alert-error-creating-folder',
       'Error creating folder'

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -49,7 +49,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
 
   const [workflow, title] = watch(['workflow', 'title']);
 
-  const handleBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
+  const onBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
@@ -61,7 +61,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     }
   };
 
-  const handleWriteSuccess = (resource: Resource<FolderDTO>) => {
+  const onWriteSuccess = (resource: Resource<FolderDTO>) => {
     // Navigation for new folders (resource-specific concern)
     if (resource?.metadata?.name) {
       navigate(`/dashboards/f/${resource.metadata.name}/`);
@@ -78,16 +78,13 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     }
   };
 
-  const handleError = (error: unknown) => {
-    // Provider-specific error handling could be added here based on info.repoType
-    const errorMessage = t(
-      'browse-dashboards.new-provisioned-folder-form.alert-error-creating-folder',
-      'Error creating folder'
-    );
-
+  const onError = (error: unknown) => {
     getAppEvents().publish({
       type: AppEvents.alertError.name,
-      payload: [errorMessage, error],
+      payload: [
+        t('browse-dashboards.new-provisioned-folder-form.alert-error-creating-folder', 'Error creating folder'),
+        error,
+      ],
     });
   };
 
@@ -99,9 +96,9 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     resourceType: 'folder',
     handlers: {
       onDismiss,
-      onBranchSuccess: handleBranchSuccess,
-      onWriteSuccess: (_, resource) => handleWriteSuccess(resource),
-      onError: handleError,
+      onBranchSuccess,
+      onWriteSuccess: (_, resource) => onWriteSuccess(resource),
+      onError,
     },
   });
 

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -47,12 +47,9 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
   });
   const { handleSubmit, watch, register, formState } = methods;
 
-  const [workflow, ref, title] = watch(['workflow', 'ref', 'title']);
+  const [workflow, title] = watch(['workflow', 'title']);
 
-  const handleBranchSuccess = (
-    { path, urls }: { ref: string; path: string; urls?: Record<string, string> },
-    info: ProvisionedOperationInfo
-  ) => {
+  const handleBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
     const prUrl = urls?.newPullRequestURL;
     if (prUrl) {
       const url = buildResourceBranchRedirectUrl({
@@ -64,7 +61,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     }
   };
 
-  const handleNewResourceSuccess = (resource: Resource, info: ProvisionedOperationInfo) => {
+  const handleWriteSuccess = (resource: Resource<FolderDTO>) => {
     // Navigation for new folders (resource-specific concern)
     if (resource?.metadata?.name) {
       navigate(`/dashboards/f/${resource.metadata.name}/`);
@@ -81,7 +78,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     }
   };
 
-  const handleError = (error: unknown, info: ProvisionedOperationInfo) => {
+  const handleError = (error: unknown) => {
     // Provider-specific error handling could be added here based on info.repoType
     const errorMessage = t(
       'browse-dashboards.new-provisioned-folder-form.alert-error-creating-folder',
@@ -95,20 +92,15 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
   };
 
   // Use the repository-type and resource-type aware provisioned request handler
-  useProvisionedRequestHandler({
+  useProvisionedRequestHandler<FolderDTO>({
     request,
     workflow,
-    isNew: true,
     repository,
-    resourceType: 'folder', // Specify this is a folder resource
-    successMessage: t(
-      'browse-dashboards.new-provisioned-folder-form.alert-folder-created-successfully',
-      'Folder created successfully'
-    ),
+    resourceType: 'folder',
     handlers: {
       onDismiss,
       onBranchSuccess: handleBranchSuccess,
-      onNewResourceSuccess: handleNewResourceSuccess,
+      onWriteSuccess: (_, resource) => handleWriteSuccess(resource),
       onError: handleError,
     },
   });

--- a/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/provisioned/SaveProvisionedDashboardForm.tsx
@@ -68,7 +68,7 @@ export function SaveProvisionedDashboardForm({
   };
 
   const handleNewDashboard = (upsert: Resource<Dashboard>) => {
-    // Navigation for new dashboards (resource-specific concern)
+    // Navigation for new dashboards
     const url = locationUtil.assureBaseUrl(
       getDashboardUrl({
         uid: upsert.metadata.name,
@@ -79,7 +79,7 @@ export function SaveProvisionedDashboardForm({
     navigate(url);
   };
 
-  const onWriteSuccess = (info: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
+  const onWriteSuccess = (_: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
     if (isNew && upsert?.metadata.name) {
       handleNewDashboard(upsert);
     } else {
@@ -105,7 +105,6 @@ export function SaveProvisionedDashboardForm({
   };
 
   const onDismiss = () => {
-    // Reset the dirty state and close the drawer
     dashboard.setState({ isDirty: false });
     panelEditor?.onDiscard();
     drawer.onClose();
@@ -118,11 +117,9 @@ export function SaveProvisionedDashboardForm({
     handlers: {
       onBranchSuccess: ({ ref, path }, info, resource) => onBranchSuccess(ref, path, info, resource),
       onWriteSuccess,
-      // onNewResourceSuccess: onNewDashboardSuccess,
       onError: onRequestError,
       onDismiss,
     },
-    isNew,
   });
 
   // Submit handler for saving the form data

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
@@ -67,25 +67,22 @@ export function DeleteProvisionedDashboardForm({
 
   const navigate = useNavigate();
 
-  const onRequestError = (error: unknown, info: ProvisionedOperationInfo) => {
+  const onRequestError = (error: unknown) => {
     getAppEvents().publish({
       type: AppEvents.alertError.name,
       payload: [t('dashboard-scene.delete-provisioned-dashboard-form.api-error', 'Failed to delete dashboard'), error],
     });
   };
 
-  const onWriteSuccess = (info: ProvisionedOperationInfo) => {
-    // Dashboard state management (now in the correct place)
+  const onWriteSuccess = () => {
     dashboard.setState({ isDirty: false });
     panelEditor?.onDiscard();
-    onDismiss();
     // TODO reset search state instead
     window.location.href = '/dashboards';
   };
 
   const onBranchSuccess = (path: string, info: ProvisionedOperationInfo, urls?: Record<string, string>) => {
     panelEditor?.onDiscard();
-    onDismiss();
     const url = buildResourceBranchRedirectUrl({
       baseUrl: `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}`,
       paramName: 'pull_request_url',
@@ -99,7 +96,12 @@ export function DeleteProvisionedDashboardForm({
     request,
     workflow,
     resourceType: 'dashboard',
+    successMessage: t(
+      'dashboard-scene.delete-provisioned-dashboard-form.success-message',
+      'Dashboard deleted successfully'
+    ),
     handlers: {
+      onDismiss,
       onBranchSuccess: ({ path, urls }, info) => onBranchSuccess(path, info, urls),
       onWriteSuccess,
       onError: onRequestError,

--- a/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/DeleteProvisionedDashboardForm.tsx
@@ -67,7 +67,7 @@ export function DeleteProvisionedDashboardForm({
 
   const navigate = useNavigate();
 
-  const onRequestError = (error: unknown) => {
+  const onError = (error: unknown) => {
     getAppEvents().publish({
       type: AppEvents.alertError.name,
       payload: [t('dashboard-scene.delete-provisioned-dashboard-form.api-error', 'Failed to delete dashboard'), error],
@@ -104,7 +104,7 @@ export function DeleteProvisionedDashboardForm({
       onDismiss,
       onBranchSuccess: ({ path, urls }, info) => onBranchSuccess(path, info, urls),
       onWriteSuccess,
-      onError: onRequestError,
+      onError,
     },
   });
 

--- a/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
@@ -127,6 +127,7 @@ export function MoveProvisionedDashboardForm({
   };
 
   const onBranchSuccess = (info: ProvisionedOperationInfo) => {
+    dashboard.setState({ isDirty: false });
     panelEditor?.onDiscard();
     const url = buildResourceBranchRedirectUrl({
       paramName: 'new_pull_request_url',
@@ -134,6 +135,16 @@ export function MoveProvisionedDashboardForm({
       repoType: info.repoType,
     });
     navigate(url);
+  };
+
+  const onError = (error: unknown) => {
+    getAppEvents().publish({
+      type: AppEvents.alertError.name,
+      payload: [
+        t('dashboard-scene.move-provisioned-dashboard-form.alert-error-moving-dashboard', 'Error moving dashboard'),
+        error,
+      ],
+    });
   };
 
   useProvisionedRequestHandler({
@@ -147,6 +158,8 @@ export function MoveProvisionedDashboardForm({
     handlers: {
       onBranchSuccess: (_, info) => onBranchSuccess(info),
       onWriteSuccess,
+      onDismiss,
+      onError,
     },
   });
 

--- a/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
@@ -18,7 +18,7 @@ import { getTargetFolderPathInRepo } from 'app/features/browse-dashboards/compon
 import { ResourceEditFormSharedFields } from '../components/Provisioned/ResourceEditFormSharedFields';
 import { ProvisionedDashboardFormData } from '../saving/shared';
 import { DashboardScene } from '../scene/DashboardScene';
-import { useProvisionedRequestHandler, ProvisionedResourceContext } from '../utils/useProvisionedRequestHandler';
+import { useProvisionedRequestHandler, ProvisionedOperationInfo } from '../utils/useProvisionedRequestHandler';
 
 import { buildResourceBranchRedirectUrl } from './utils';
 
@@ -117,7 +117,9 @@ export function MoveProvisionedDashboardForm({
     }
   };
 
-  const onWriteSuccess = (context: ProvisionedResourceContext) => {
+  const onWriteSuccess = (info: ProvisionedOperationInfo) => {
+    // Dashboard state management (now in the correct place)
+    dashboard.setState({ isDirty: false });
     panelEditor?.onDiscard();
     if (targetFolderUID && targetFolderTitle) {
       onSuccess(targetFolderUID, targetFolderTitle);
@@ -125,12 +127,12 @@ export function MoveProvisionedDashboardForm({
     navigate('/dashboards');
   };
 
-  const onBranchSuccess = (context: ProvisionedResourceContext) => {
+  const onBranchSuccess = (info: ProvisionedOperationInfo) => {
     panelEditor?.onDiscard();
     const url = buildResourceBranchRedirectUrl({
       paramName: 'new_pull_request_url',
       paramValue: moveRequest?.data?.urls?.newPullRequestURL,
-      repoType: context.repoType,
+      repoType: info.repoType,
     });
     navigate(url);
   };
@@ -140,11 +142,7 @@ export function MoveProvisionedDashboardForm({
     workflow,
     resourceType: 'dashboard',
     handlers: {
-      // Dashboard-specific state management (decoupled from hook)
-      onSuccess: () => {
-        dashboard.setState({ isDirty: false });
-      },
-      onBranchSuccess: (data, context) => onBranchSuccess(context),
+      onBranchSuccess: (data, info) => onBranchSuccess(info),
       onWriteSuccess,
     },
   });

--- a/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/settings/MoveProvisionedDashboardForm.tsx
@@ -117,8 +117,7 @@ export function MoveProvisionedDashboardForm({
     }
   };
 
-  const onWriteSuccess = (info: ProvisionedOperationInfo) => {
-    // Dashboard state management (now in the correct place)
+  const onWriteSuccess = () => {
     dashboard.setState({ isDirty: false });
     panelEditor?.onDiscard();
     if (targetFolderUID && targetFolderTitle) {
@@ -140,9 +139,13 @@ export function MoveProvisionedDashboardForm({
   useProvisionedRequestHandler({
     request: moveRequest,
     workflow,
+    successMessage: t(
+      'dashboard-scene.move-provisioned-dashboard-form.success-message',
+      'Dashboard moved successfully'
+    ),
     resourceType: 'dashboard',
     handlers: {
-      onBranchSuccess: (data, info) => onBranchSuccess(info),
+      onBranchSuccess: (_, info) => onBranchSuccess(info),
       onWriteSuccess,
     },
   });

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
@@ -3,18 +3,10 @@ import { renderHook } from '@testing-library/react';
 import { AppEvents } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import {
-  DeleteRepositoryFilesWithPathApiResponse,
-  GetRepositoryFilesWithPathApiResponse,
-  ResourceWrapper,
-} from 'app/api/clients/provisioning/v0alpha1';
-import { Resource } from 'app/features/apiserver/types';
+import { ResourceWrapper } from 'app/api/clients/provisioning/v0alpha1';
 
-import { DashboardScene } from '../scene/DashboardScene';
+import { useProvisionedRequestHandler, RequestHandlers } from './useProvisionedRequestHandler';
 
-import { useProvisionedRequestHandler } from './useProvisionedRequestHandler';
-
-// Mock dependencies
 jest.mock('@grafana/runtime', () => ({
   getAppEvents: jest.fn(),
 }));
@@ -30,9 +22,9 @@ describe('useProvisionedRequestHandler', () => {
     jest.clearAllMocks();
   });
 
-  describe('when request has an error', () => {
-    it('should call onError handler', () => {
-      const { request, handlers, dashboard } = setup({
+  describe('error handling', () => {
+    it('should call onError handler with correct parameters', () => {
+      const { request, handlers } = setup({
         requestOverrides: {
           isError: true,
           isSuccess: false,
@@ -42,30 +34,6 @@ describe('useProvisionedRequestHandler', () => {
 
       renderHook(() =>
         useProvisionedRequestHandler({
-          dashboard,
-          request,
-          handlers,
-        })
-      );
-
-      expect(handlers.onError).toHaveBeenCalledWith(new Error('Test error'));
-      expect(handlers.onBranchSuccess).not.toHaveBeenCalled();
-      expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
-      expect(handlers.onNewDashboardSuccess).not.toHaveBeenCalled();
-    });
-
-    it('should call onError handler with repository type', () => {
-      const { request, handlers, dashboard } = setup({
-        requestOverrides: {
-          isError: true,
-          isSuccess: false,
-          error: new Error('Test error'),
-        },
-      });
-
-      renderHook(() =>
-        useProvisionedRequestHandler({
-          dashboard,
           request,
           repository: {
             type: 'github',
@@ -78,48 +46,30 @@ describe('useProvisionedRequestHandler', () => {
         })
       );
 
-      expect(handlers.onError).toHaveBeenCalledWith(new Error('Test error'), 'github');
+      expect(handlers.onError).toHaveBeenCalledWith(
+        new Error('Test error'),
+        expect.objectContaining({
+          resourceType: 'dashboard',
+          repoType: 'github',
+        })
+      );
+      expect(handlers.onBranchSuccess).not.toHaveBeenCalled();
+      expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
     });
   });
 
-  describe('when request is successful', () => {
-    it('should set dashboard isDirty to false', () => {
-      const { request, handlers, dashboard } = setup({
+  describe('success handling', () => {
+    it('should publish success event and call onDismiss', () => {
+      const { request, handlers, mockPublish } = setup({
         requestOverrides: {
           isError: false,
           isSuccess: true,
-          data: {
-            ref: 'main',
-            path: '/path/to/dashboard',
-          },
-        },
-        workflowOverride: 'branch',
-      });
-
-      renderHook(() =>
-        useProvisionedRequestHandler({
-          dashboard,
-          request,
-          workflow: 'branch',
-          handlers,
-        })
-      );
-
-      expect(dashboard.setState).toHaveBeenCalledWith({ isDirty: false });
-    });
-
-    it('should publish success event', () => {
-      const { request, handlers, dashboard, mockPublish } = setup({
-        requestOverrides: {
-          isError: false,
-          isSuccess: true,
-          data: {},
+          data: createMockResourceWrapper(),
         },
       });
 
       renderHook(() =>
         useProvisionedRequestHandler({
-          dashboard,
           request,
           handlers,
         })
@@ -127,206 +77,80 @@ describe('useProvisionedRequestHandler', () => {
 
       expect(mockPublish).toHaveBeenCalledWith({
         type: AppEvents.alertSuccess.name,
-        payload: ['Dashboard changes saved successfully'],
+        payload: ['Dashboard saved successfully'],
       });
+      expect(handlers.onDismiss).toHaveBeenCalled();
     });
 
-    describe('branch workflow', () => {
-      it('should call onBranchSuccess when workflow is branch and data has ref and path', () => {
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {
-              ref: 'feature-branch',
-              path: '/path/to/dashboard.json',
-              urls: { compareURL: 'http://example.com/edit' },
-            },
-          },
-          workflowOverride: 'branch',
-        });
+    it('should call onBranchSuccess for branch workflow', () => {
+      const { request, handlers } = setup({
+        requestOverrides: {
+          isError: false,
+          isSuccess: true,
+          data: createMockResourceWrapper({
+            ref: 'feature-branch',
+            path: '/path/to/dashboard.json',
+            urls: { compareURL: 'http://example.com/edit' },
+          }),
+        },
+      });
 
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            workflow: 'branch',
-            handlers,
-          })
-        );
+      renderHook(() =>
+        useProvisionedRequestHandler({
+          request,
+          workflow: 'branch',
+          handlers,
+        })
+      );
 
-        expect(handlers.onBranchSuccess).toHaveBeenCalledWith({
+      expect(handlers.onBranchSuccess).toHaveBeenCalledWith(
+        {
           ref: 'feature-branch',
           path: '/path/to/dashboard.json',
           urls: { compareURL: 'http://example.com/edit' },
-        });
-        expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
-      });
-
-      it('should not call onBranchSuccess when ref is missing', () => {
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {
-              path: '/path/to/dashboard.json',
-            },
-          },
-          workflowOverride: 'branch',
-        });
-
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            workflow: 'branch',
-            handlers,
-          })
-        );
-
-        expect(handlers.onBranchSuccess).not.toHaveBeenCalled();
-        expect(handlers.onWriteSuccess).toHaveBeenCalled();
-      });
+        },
+        expect.objectContaining({
+          resourceType: 'dashboard',
+          repoType: 'git',
+          workflow: 'branch',
+        }),
+        expect.any(Object)
+      );
+      expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
     });
 
-    describe('new dashboard flow', () => {
-      it('should call onNewDashboardSuccess when isNew is true and resource.upsert exists', () => {
-        const mockUpsertResource = {
-          metadata: {
-            name: 'test-dashboard',
-            uid: 'test-uid',
-            resourceVersion: '1',
-            creationTimestamp: new Date().toISOString(),
-          },
-          spec: { title: 'Test Dashboard' } as Dashboard,
-          apiVersion: 'v1',
-          kind: 'Dashboard',
-        };
-
-        const mockResource = {
-          metadata: {
-            name: 'test-dashboard',
-            uid: 'test-uid',
-            resourceVersion: '1',
-            creationTimestamp: new Date().toISOString(),
-          },
-          spec: { title: 'Test Dashboard' } as Dashboard,
-          apiVersion: 'v1',
-          kind: 'Dashboard',
-          upsert: mockUpsertResource,
-        } as Resource<Dashboard> & { upsert: Resource<Dashboard> };
-
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {
-              repository: 'test-repo',
-              resource: mockResource,
-            } as unknown as ProvisionedRequestData,
-          },
-        });
-
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            handlers,
-            isNew: true,
-          })
-        );
-
-        expect(handlers.onNewDashboardSuccess).toHaveBeenCalledWith(mockResource.upsert);
-        expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
+    it('should call onWriteSuccess for write workflow', () => {
+      const { request, handlers } = setup({
+        requestOverrides: {
+          isError: false,
+          isSuccess: true,
+          data: createMockResourceWrapper(),
+        },
       });
 
-      it('should not call onNewDashboardSuccess when isNew is false', () => {
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {
-              repository: 'test-repo',
-              resource: {
-                upsert: {
-                  apiVersion: 'v1',
-                  kind: 'Dashboard',
-                  metadata: { name: 'test-dashboard' },
-                  spec: { title: 'Test Dashboard' } as Dashboard,
-                },
-                metadata: { name: 'test-dashboard' },
-                spec: { title: 'Test Dashboard' } as Dashboard,
-                apiVersion: 'v1',
-                kind: 'Dashboard',
-              } as unknown as Resource<Dashboard>,
-            } as unknown as ProvisionedRequestData,
-          },
-        });
+      renderHook(() =>
+        useProvisionedRequestHandler({
+          request,
+          workflow: 'write',
+          handlers,
+        })
+      );
 
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            handlers,
-            isNew: false,
-          })
-        );
-
-        expect(handlers.onNewDashboardSuccess).not.toHaveBeenCalled();
-        expect(handlers.onWriteSuccess).toHaveBeenCalled();
-      });
-
-      it('should not call onNewDashboardSuccess when resource.upsert is missing', () => {
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {
-              resource: {},
-            } as ResourceWrapper,
-          },
-        });
-
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            handlers,
-            isNew: true,
-          })
-        );
-
-        expect(handlers.onNewDashboardSuccess).not.toHaveBeenCalled();
-        expect(handlers.onWriteSuccess).toHaveBeenCalled();
-      });
-    });
-
-    describe('write workflow', () => {
-      it('should call onWriteSuccess as fallback', () => {
-        const { request, handlers, dashboard } = setup({
-          requestOverrides: {
-            isError: false,
-            isSuccess: true,
-            data: {} as GetRepositoryFilesWithPathApiResponse,
-          },
-        });
-
-        renderHook(() =>
-          useProvisionedRequestHandler({
-            dashboard,
-            request,
-            handlers,
-          })
-        );
-
-        expect(handlers.onWriteSuccess).toHaveBeenCalled();
-      });
+      expect(handlers.onWriteSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({
+          resourceType: 'dashboard',
+          repoType: 'git',
+          workflow: 'write',
+        }),
+        expect.any(Object)
+      );
+      expect(handlers.onDismiss).toHaveBeenCalled();
     });
   });
 
-  describe('when request is neither error nor success', () => {
-    it('should not call any handlers', () => {
-      const { request, handlers, dashboard, mockPublish } = setup({
+  describe('edge cases', () => {
+    it('should not call any handlers when request is loading', () => {
+      const { request, handlers, mockPublish } = setup({
         requestOverrides: {
           isError: false,
           isSuccess: false,
@@ -336,7 +160,6 @@ describe('useProvisionedRequestHandler', () => {
 
       renderHook(() =>
         useProvisionedRequestHandler({
-          dashboard,
           request,
           handlers,
         })
@@ -345,15 +168,11 @@ describe('useProvisionedRequestHandler', () => {
       expect(handlers.onError).not.toHaveBeenCalled();
       expect(handlers.onBranchSuccess).not.toHaveBeenCalled();
       expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
-      expect(handlers.onNewDashboardSuccess).not.toHaveBeenCalled();
-      expect(dashboard.setState).not.toHaveBeenCalled();
       expect(mockPublish).not.toHaveBeenCalled();
     });
-  });
 
-  describe('when request success but no data', () => {
-    it('should not call any handlers when data is undefined', () => {
-      const { request, handlers, dashboard, mockPublish } = setup({
+    it('should not call handlers when success but no data', () => {
+      const { request, handlers, mockPublish } = setup({
         requestOverrides: {
           isError: false,
           isSuccess: true,
@@ -363,7 +182,6 @@ describe('useProvisionedRequestHandler', () => {
 
       renderHook(() =>
         useProvisionedRequestHandler({
-          dashboard,
           request,
           handlers,
         })
@@ -371,25 +189,18 @@ describe('useProvisionedRequestHandler', () => {
 
       expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
       expect(handlers.onBranchSuccess).not.toHaveBeenCalled();
-      expect(dashboard.setState).not.toHaveBeenCalled();
       expect(mockPublish).not.toHaveBeenCalled();
     });
-  });
 
-  describe('optional handlers', () => {
     it('should not throw when optional handlers are not provided', () => {
-      const { request, dashboard } = setup({
-        requestOverrides: {
-          isError: false,
-          isSuccess: true,
-        },
+      const { request } = setup({
+        requestOverrides: { isError: false, isSuccess: true },
         handlersOverrides: {},
       });
 
       expect(() => {
         renderHook(() =>
           useProvisionedRequestHandler({
-            dashboard,
             request,
             handlers: {},
           })
@@ -399,38 +210,48 @@ describe('useProvisionedRequestHandler', () => {
   });
 });
 
-type ProvisionedRequestData = DeleteRepositoryFilesWithPathApiResponse | GetRepositoryFilesWithPathApiResponse;
+// Helper function to create a properly structured mock ResourceWrapper
+function createMockResourceWrapper(overrides: Partial<ResourceWrapper> = {}): ResourceWrapper {
+  return {
+    repository: {
+      name: 'test-repo',
+      namespace: 'default',
+      title: 'Test Repository',
+      type: 'git',
+    },
+    resource: {
+      type: {
+        kind: 'Dashboard',
+      },
+      upsert: {
+        apiVersion: 'v1',
+        kind: 'Dashboard',
+        metadata: { name: 'test-dashboard', uid: 'test-uid' },
+        spec: { title: 'Test Dashboard' },
+      },
+    },
+    ...overrides,
+  };
+}
 
 function setup({
   requestOverrides = {},
   handlersOverrides = {},
-  workflowOverride,
 }: {
   requestOverrides?: Partial<{
     isError: boolean;
     isSuccess: boolean;
     isLoading?: boolean;
     error?: unknown;
-    data?: Partial<ProvisionedRequestData>;
+    data?: ResourceWrapper;
   }>;
-  handlersOverrides?: Partial<{
-    onBranchSuccess?: jest.Mock;
-    onWriteSuccess?: jest.Mock;
-    onNewDashboardSuccess?: jest.Mock;
-    onError?: jest.Mock;
-  }>;
-  workflowOverride?: string;
+  handlersOverrides?: Partial<RequestHandlers<Dashboard>>;
 } = {}) {
   const mockPublish = jest.fn();
-  const mockSetState = jest.fn();
 
   mockGetAppEvents.mockReturnValue({
     publish: mockPublish,
   } as unknown as ReturnType<typeof getAppEvents>);
-
-  const dashboard = {
-    setState: mockSetState,
-  } as unknown as DashboardScene;
 
   const request = {
     isError: false,
@@ -438,23 +259,20 @@ function setup({
     isLoading: false,
     error: undefined,
     data: undefined,
-    ...(requestOverrides as ResourceWrapper),
+    ...requestOverrides,
   };
 
-  const handlers = {
+  const handlers: RequestHandlers<Dashboard> = {
     onError: jest.fn(),
     onBranchSuccess: jest.fn(),
     onWriteSuccess: jest.fn(),
-    onNewDashboardSuccess: jest.fn(),
+    onDismiss: jest.fn(),
     ...handlersOverrides,
   };
 
   return {
-    dashboard,
     request,
     handlers,
     mockPublish,
-    mockSetState,
-    workflow: workflowOverride,
   };
 }

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
@@ -53,6 +53,33 @@ describe('useProvisionedRequestHandler', () => {
       expect(handlers.onWriteSuccess).not.toHaveBeenCalled();
       expect(handlers.onNewDashboardSuccess).not.toHaveBeenCalled();
     });
+
+    it('should call onError handler with repository type', () => {
+      const { request, handlers, dashboard } = setup({
+        requestOverrides: {
+          isError: true,
+          isSuccess: false,
+          error: new Error('Test error'),
+        },
+      });
+
+      renderHook(() =>
+        useProvisionedRequestHandler({
+          dashboard,
+          request,
+          repository: {
+            type: 'github',
+            name: 'test-repo',
+            target: 'folder',
+            title: 'Test Repository',
+            workflows: [],
+          },
+          handlers,
+        })
+      );
+
+      expect(handlers.onError).toHaveBeenCalledWith(new Error('Test error'), 'github');
+    });
   });
 
   describe('when request is successful', () => {

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.test.ts
@@ -42,6 +42,7 @@ describe('useProvisionedRequestHandler', () => {
             title: 'Test Repository',
             workflows: [],
           },
+          resourceType: 'dashboard',
           handlers,
         })
       );
@@ -71,6 +72,7 @@ describe('useProvisionedRequestHandler', () => {
       renderHook(() =>
         useProvisionedRequestHandler({
           request,
+          resourceType: 'dashboard',
           handlers,
         })
       );
@@ -99,6 +101,7 @@ describe('useProvisionedRequestHandler', () => {
         useProvisionedRequestHandler({
           request,
           workflow: 'branch',
+          resourceType: 'dashboard',
           handlers,
         })
       );
@@ -132,6 +135,7 @@ describe('useProvisionedRequestHandler', () => {
         useProvisionedRequestHandler({
           request,
           workflow: 'write',
+          resourceType: 'dashboard',
           handlers,
         })
       );

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
@@ -110,14 +110,14 @@ export function useProvisionedRequestHandler<T>({
 function getContextualSuccessMessage(info: ProvisionedOperationInfo): string {
   const { resourceType } = info;
 
-  if (resourceType === 'dashboard') {
-    return t('provisioned-resource-request-handler-dashboard', 'Dashboard saved successfully');
-  } else if (resourceType === 'folder') {
-    return t('provisioned-resource-request-handler-folder', 'Folder created successfully');
+  switch (resourceType) {
+    case 'dashboard':
+      return t('provisioned-resource-request-handler-dashboard', 'Dashboard saved successfully');
+    case 'folder':
+      return t('provisioned-resource-request-handler-folder', 'Folder created successfully');
+    default:
+      return t('provisioned-resource-request-handler', 'Resource saved successfully');
   }
-
-  // Fallback for new resource types
-  return t('provisioned-resource-request-handler', 'Resource saved successfully');
 }
 
 export type { ResourceType, ProvisionedOperationInfo, RequestHandlers, ResourceConfig };

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
@@ -15,8 +15,8 @@ import { RepoType } from 'app/features/provisioning/Wizard/types';
 // Resource type definitions for scalability
 type ResourceType = 'dashboard' | 'folder'; // Add more as needed, e.g., 'alert', etc.
 
-// Context object that gets passed to all handlers
-interface ProvisionedResourceContext {
+// Information object that gets passed to all handlers
+interface ProvisionedOperationInfo {
   repoType: RepoType;
   resourceType: ResourceType;
   isNew?: boolean;
@@ -28,18 +28,15 @@ interface RequestHandlers {
   // Modern contextual handlers
   onBranchSuccess?: (
     data: { ref: string; path: string; urls?: Record<string, string> },
-    context: ProvisionedResourceContext
+    info: ProvisionedOperationInfo
   ) => void;
-  onWriteSuccess?: (context: ProvisionedResourceContext) => void;
-  onNewResourceSuccess?: (resource: Resource, context: ProvisionedResourceContext) => void;
-  onError?: (error: unknown, context: ProvisionedResourceContext) => void;
+  onWriteSuccess?: (info: ProvisionedOperationInfo) => void;
+  onNewResourceSuccess?: (resource: Resource, info: ProvisionedOperationInfo) => void;
+  onError?: (error: unknown, info: ProvisionedOperationInfo) => void;
 
   // Special handlers for backward compatibility
   onNewDashboardSuccess?: (resource: Resource<Dashboard>) => void;
   onDismiss?: () => void;
-
-  // Component-level state management (called before other handlers)
-  onSuccess?: (context: ProvisionedResourceContext) => void;
 }
 
 interface ProvisionedRequest {
@@ -50,78 +47,17 @@ interface ProvisionedRequest {
   data?: DeleteRepositoryFilesWithPathApiResponse | GetRepositoryFilesWithPathApiResponse;
 }
 
-// Provider-specific configuration
-interface ProviderConfig {
-  supportsRichAPI: boolean;
-  urlPattern: string;
-  defaultWorkflows: string[];
-  branchPrefix?: string;
-}
-
 // Resource-specific configuration for different resource types
 interface ResourceConfig {
   defaultSuccessMessage: string;
-  navigationPattern: string;
   supportedWorkflows: string[];
-  requiresRefresh?: boolean;
 }
-
-// Combined configuration for provider + resource combinations
-interface ProvisionedResourceConfig {
-  provider: ProviderConfig;
-  resource: ResourceConfig;
-}
-
-const PROVIDER_CONFIGS: Record<RepoType, ProviderConfig> = {
-  github: {
-    supportsRichAPI: true,
-    urlPattern: '/tree/{branch}',
-    defaultWorkflows: ['branch', 'write'],
-    branchPrefix: 'grafana',
-  },
-  gitlab: {
-    supportsRichAPI: true,
-    urlPattern: '/-/tree/{branch}',
-    defaultWorkflows: ['branch', 'write'],
-    branchPrefix: 'grafana',
-  },
-  bitbucket: {
-    supportsRichAPI: true,
-    urlPattern: '/src/{branch}',
-    defaultWorkflows: ['branch', 'write'],
-    branchPrefix: 'grafana',
-  },
-  git: {
-    supportsRichAPI: false,
-    urlPattern: '',
-    defaultWorkflows: ['write'],
-  },
-  local: {
-    supportsRichAPI: false,
-    urlPattern: '',
-    defaultWorkflows: ['write'],
-  },
-};
-
-const RESOURCE_CONFIGS: Record<ResourceType, ResourceConfig> = {
-  dashboard: {
-    defaultSuccessMessage: 'Dashboard saved successfully',
-    navigationPattern: '/dashboards/{uid}',
-    supportedWorkflows: ['branch', 'write'],
-  },
-  folder: {
-    defaultSuccessMessage: 'Folder created successfully',
-    navigationPattern: '/dashboards/f/{uid}/',
-    supportedWorkflows: ['branch', 'write'],
-  },
-  // Add more resource types as needed
-};
 
 /**
  * Generic hook for handling provisioned resource operations across any resource type and repository provider.
  *
  * This hook is intentionally decoupled from specific components (like DashboardScene) to promote reusability.
- * Components are responsible for their own state management through the onSuccess handler.
+ * Components are responsible for their own state management through specific workflow handlers.
  *
  * @example
  * // Dashboard component handles its own state
@@ -129,8 +65,10 @@ const RESOURCE_CONFIGS: Record<ResourceType, ResourceConfig> = {
  *   request,
  *   resourceType: 'dashboard',
  *   handlers: {
- *     onSuccess: () => dashboard.setState({ isDirty: false }),
- *     onWriteSuccess: () => navigate('/dashboards'),
+ *     onWriteSuccess: (info) => {
+ *       dashboard.setState({ isDirty: false });
+ *       navigate('/dashboards');
+ *     },
  *   }
  * });
  *
@@ -163,7 +101,7 @@ export function useProvisionedRequestHandler({
 }) {
   useEffect(() => {
     const repoType = repository?.type || 'git';
-    const context: ProvisionedResourceContext = {
+    const info: ProvisionedOperationInfo = {
       repoType,
       resourceType,
       isNew,
@@ -171,14 +109,11 @@ export function useProvisionedRequestHandler({
     };
 
     if (request.isError) {
-      handlers.onError?.(request.error, context);
+      handlers.onError?.(request.error, info);
       return;
     }
 
     if (request.isSuccess && request.data) {
-      // Call component-level state management first
-      handlers.onSuccess?.(context);
-
       // Call onDismiss if provided (typically for modals/forms)
       handlers.onDismiss?.();
 
@@ -187,112 +122,58 @@ export function useProvisionedRequestHandler({
       // Branch workflow
       if (workflow === 'branch' && ref && path) {
         const branchData = { ref, path, urls };
-        handlers.onBranchSuccess?.(branchData, context);
+        handlers.onBranchSuccess?.(branchData, info);
         return;
       }
 
-      // Success message (configurable, resource-specific, or provider-specific)
-      const message = successMessage || getContextualSuccessMessage(context);
+      // Success message (configurable or resource-specific)
+      const message = successMessage || getContextualSuccessMessage(info);
       getAppEvents().publish({
         type: AppEvents.alertSuccess.name,
         payload: [message],
       });
 
-      // New dashboard flow (legacy handler for backward compatibility)
-      // if (isNew && resource?.upsert && handlers.onNewDashboardSuccess && resourceType === 'dashboard') {
-      //   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      //   handlers.onNewDashboardSuccess(resource.upsert as Resource<Dashboard>);
-      //   return;
-      // }
-
-      // New resource flow
+      // Handle new resource creation (orthogonal to workflow type)
       if (isNew && resource?.upsert && handlers.onNewResourceSuccess) {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
         const resourceData = resource.upsert as Resource;
-        handlers.onNewResourceSuccess(resourceData, context);
-        return;
+        handlers.onNewResourceSuccess(resourceData, info);
       }
 
-      // Write workflow
-      handlers.onWriteSuccess?.(context);
+      // Handle write workflow (can happen for both new and existing resources)
+      if (workflow === 'write' && handlers.onWriteSuccess) {
+        console.log('hook ------- onWriteSuccess', info);
+        handlers.onWriteSuccess(info);
+      }
+
+      // Legacy dashboard handler for backward compatibility
+      if (isNew && resource?.upsert && handlers.onNewDashboardSuccess && resourceType === 'dashboard') {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        handlers.onNewDashboardSuccess(resource.upsert as Resource<Dashboard>);
+      }
     }
   }, [request, workflow, handlers, isNew, successMessage, repository, resourceType]);
 }
 
-// Helper function to get combined configuration for provider + resource
-function getProvisionedResourceConfig(repoType: RepoType, resourceType: ResourceType): ProvisionedResourceConfig {
-  return {
-    provider: PROVIDER_CONFIGS[repoType],
-    resource: RESOURCE_CONFIGS[resourceType],
-  };
-}
-
 // Helper function to get contextual success messages
-function getContextualSuccessMessage(context: ProvisionedResourceContext): string {
-  const { repoType, resourceType, isNew } = context;
-  const action = isNew ? 'created' : 'saved';
-  const resourceConfig = RESOURCE_CONFIGS[resourceType];
+function getContextualSuccessMessage(info: ProvisionedOperationInfo): string {
+  const { resourceType } = info;
 
-  // Provider-specific messages with resource context
-  switch (repoType) {
-    case 'github':
-      return t(
-        `provisioned-request-handler.${resourceType}-github-success`,
-        `${resourceConfig.defaultSuccessMessage} via GitHub`
-      );
-    case 'gitlab':
-      return t(
-        `provisioned-request-handler.${resourceType}-gitlab-success`,
-        `${resourceConfig.defaultSuccessMessage} via GitLab`
-      );
-    case 'bitbucket':
-      return t(
-        `provisioned-request-handler.${resourceType}-bitbucket-success`,
-        `${resourceConfig.defaultSuccessMessage} via Bitbucket`
-      );
-    case 'git':
-      return t(
-        `provisioned-request-handler.${resourceType}-git-success`,
-        `${resourceConfig.defaultSuccessMessage} via Git`
-      );
-    case 'local':
-      return t(`provisioned-request-handler.${resourceType}-local-success`, resourceConfig.defaultSuccessMessage);
-    default:
-      return resourceConfig.defaultSuccessMessage;
+  // Use proper i18n with fallback messages
+  if (resourceType === 'dashboard') {
+    return t('provisioned-resource-request-handler-dashboard', 'Dashboard saved successfully');
+  } else if (resourceType === 'folder') {
+    return t('provisioned-resource-request-handler-folder', 'Folder created successfully');
   }
-}
 
-// Export utility functions for external use
-export function getProviderConfig(repoType: RepoType): ProviderConfig {
-  return PROVIDER_CONFIGS[repoType];
-}
-
-export function getResourceConfig(resourceType: ResourceType): ResourceConfig {
-  return RESOURCE_CONFIGS[resourceType];
-}
-
-export function getCombinedConfig(repoType: RepoType, resourceType: ResourceType): ProvisionedResourceConfig {
-  return getProvisionedResourceConfig(repoType, resourceType);
-}
-
-export function supportsRichAPI(repoType: RepoType): boolean {
-  return PROVIDER_CONFIGS[repoType]?.supportsRichAPI || false;
-}
-
-export function getSupportedWorkflows(repoType: RepoType, resourceType: ResourceType): string[] {
-  const providerWorkflows = PROVIDER_CONFIGS[repoType].defaultWorkflows;
-  const resourceWorkflows = RESOURCE_CONFIGS[resourceType].supportedWorkflows;
-
-  // Return intersection of supported workflows
-  return providerWorkflows.filter((workflow) => resourceWorkflows.includes(workflow));
+  // Fallback for new resource types
+  return t('provisioned-resource-request-handler', 'Resource saved successfully');
 }
 
 // Type exports for external use
 export type {
   ResourceType,
-  ProvisionedResourceContext,
+  ProvisionedOperationInfo,
   RequestHandlers,
-  ProviderConfig,
   ResourceConfig,
-  ProvisionedResourceConfig,
 };

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
@@ -7,16 +7,39 @@ import { Dashboard } from '@grafana/schema';
 import {
   DeleteRepositoryFilesWithPathApiResponse,
   GetRepositoryFilesWithPathApiResponse,
+  RepositoryView,
 } from 'app/api/clients/provisioning/v0alpha1';
 import { Resource } from 'app/features/apiserver/types';
+import { RepoType } from 'app/features/provisioning/Wizard/types';
 
-import { DashboardScene } from '../scene/DashboardScene';
+// Resource type definitions for scalability
+type ResourceType = 'dashboard' | 'folder'; // Add more as needed, e.g., 'alert', etc.
 
+// Context object that gets passed to all handlers
+interface ProvisionedResourceContext {
+  repoType: RepoType;
+  resourceType: ResourceType;
+  isNew?: boolean;
+  workflow?: string;
+}
+
+// Clean, decoupled handlers interface
 interface RequestHandlers {
-  onBranchSuccess?: (data: { ref: string; path: string; urls?: Record<string, string> }) => void;
-  onWriteSuccess?: () => void;
+  // Modern contextual handlers
+  onBranchSuccess?: (
+    data: { ref: string; path: string; urls?: Record<string, string> },
+    context: ProvisionedResourceContext
+  ) => void;
+  onWriteSuccess?: (context: ProvisionedResourceContext) => void;
+  onNewResourceSuccess?: (resource: Resource, context: ProvisionedResourceContext) => void;
+  onError?: (error: unknown, context: ProvisionedResourceContext) => void;
+
+  // Special handlers for backward compatibility
   onNewDashboardSuccess?: (resource: Resource<Dashboard>) => void;
-  onError?: (error: unknown) => void;
+  onDismiss?: () => void;
+
+  // Component-level state management (called before other handlers)
+  onSuccess?: (context: ProvisionedResourceContext) => void;
 }
 
 interface ProvisionedRequest {
@@ -27,51 +50,249 @@ interface ProvisionedRequest {
   data?: DeleteRepositoryFilesWithPathApiResponse | GetRepositoryFilesWithPathApiResponse;
 }
 
-// This hook handles save new dashboard, edit existing dashboard, and delete dashboard response logic for provisioned dashboards.
+// Provider-specific configuration
+interface ProviderConfig {
+  supportsRichAPI: boolean;
+  urlPattern: string;
+  defaultWorkflows: string[];
+  branchPrefix?: string;
+}
+
+// Resource-specific configuration for different resource types
+interface ResourceConfig {
+  defaultSuccessMessage: string;
+  navigationPattern: string;
+  supportedWorkflows: string[];
+  requiresRefresh?: boolean;
+}
+
+// Combined configuration for provider + resource combinations
+interface ProvisionedResourceConfig {
+  provider: ProviderConfig;
+  resource: ResourceConfig;
+}
+
+const PROVIDER_CONFIGS: Record<RepoType, ProviderConfig> = {
+  github: {
+    supportsRichAPI: true,
+    urlPattern: '/tree/{branch}',
+    defaultWorkflows: ['branch', 'write'],
+    branchPrefix: 'grafana',
+  },
+  gitlab: {
+    supportsRichAPI: true,
+    urlPattern: '/-/tree/{branch}',
+    defaultWorkflows: ['branch', 'write'],
+    branchPrefix: 'grafana',
+  },
+  bitbucket: {
+    supportsRichAPI: true,
+    urlPattern: '/src/{branch}',
+    defaultWorkflows: ['branch', 'write'],
+    branchPrefix: 'grafana',
+  },
+  git: {
+    supportsRichAPI: false,
+    urlPattern: '',
+    defaultWorkflows: ['write'],
+  },
+  local: {
+    supportsRichAPI: false,
+    urlPattern: '',
+    defaultWorkflows: ['write'],
+  },
+};
+
+const RESOURCE_CONFIGS: Record<ResourceType, ResourceConfig> = {
+  dashboard: {
+    defaultSuccessMessage: 'Dashboard saved successfully',
+    navigationPattern: '/dashboards/{uid}',
+    supportedWorkflows: ['branch', 'write'],
+  },
+  folder: {
+    defaultSuccessMessage: 'Folder created successfully',
+    navigationPattern: '/dashboards/f/{uid}/',
+    supportedWorkflows: ['branch', 'write'],
+  },
+  // Add more resource types as needed
+};
+
+/**
+ * Generic hook for handling provisioned resource operations across any resource type and repository provider.
+ *
+ * This hook is intentionally decoupled from specific components (like DashboardScene) to promote reusability.
+ * Components are responsible for their own state management through the onSuccess handler.
+ *
+ * @example
+ * // Dashboard component handles its own state
+ * useProvisionedRequestHandler({
+ *   request,
+ *   resourceType: 'dashboard',
+ *   handlers: {
+ *     onSuccess: () => dashboard.setState({ isDirty: false }),
+ *     onWriteSuccess: () => navigate('/dashboards'),
+ *   }
+ * });
+ *
+ * @example
+ * // Folder component doesn't need dashboard state
+ * useProvisionedRequestHandler({
+ *   request,
+ *   resourceType: 'folder',
+ *   handlers: {
+ *     onNewResourceSuccess: (resource) => navigate(`/folders/${resource.metadata.name}`),
+ *   }
+ * });
+ */
 export function useProvisionedRequestHandler({
-  dashboard,
   request,
   workflow,
   handlers,
   isNew,
+  successMessage,
+  repository,
+  resourceType = 'dashboard', // Default to dashboard for backward compatibility
 }: {
-  dashboard: DashboardScene;
   request: ProvisionedRequest;
   workflow?: string;
   handlers: RequestHandlers;
   isNew?: boolean;
+  successMessage?: string;
+  repository?: RepositoryView;
+  resourceType?: ResourceType;
 }) {
   useEffect(() => {
+    const repoType = repository?.type || 'git';
+    const context: ProvisionedResourceContext = {
+      repoType,
+      resourceType,
+      isNew,
+      workflow,
+    };
+
     if (request.isError) {
-      handlers.onError?.(request.error);
+      handlers.onError?.(request.error, context);
       return;
     }
 
     if (request.isSuccess && request.data) {
-      dashboard.setState({ isDirty: false });
+      // Call component-level state management first
+      handlers.onSuccess?.(context);
+
+      // Call onDismiss if provided (typically for modals/forms)
+      handlers.onDismiss?.();
+
       const { ref, path, urls, resource } = request.data;
 
       // Branch workflow
       if (workflow === 'branch' && ref && path) {
-        handlers.onBranchSuccess?.({ ref, path, urls });
+        const branchData = { ref, path, urls };
+        handlers.onBranchSuccess?.(branchData, context);
         return;
       }
 
-      // Success message (could be configurable)
+      // Success message (configurable, resource-specific, or provider-specific)
+      const message = successMessage || getContextualSuccessMessage(context);
       getAppEvents().publish({
         type: AppEvents.alertSuccess.name,
-        payload: [t('dashboard-scene.edit-provisioned-dashboard-form.success', 'Dashboard changes saved successfully')],
+        payload: [message],
       });
 
-      // New dashboard flow
-      if (isNew && resource?.upsert && handlers.onNewDashboardSuccess) {
+      // New dashboard flow (legacy handler for backward compatibility)
+      // if (isNew && resource?.upsert && handlers.onNewDashboardSuccess && resourceType === 'dashboard') {
+      //   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      //   handlers.onNewDashboardSuccess(resource.upsert as Resource<Dashboard>);
+      //   return;
+      // }
+
+      // New resource flow
+      if (isNew && resource?.upsert && handlers.onNewResourceSuccess) {
         // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        handlers.onNewDashboardSuccess(resource.upsert as Resource<Dashboard>);
+        const resourceData = resource.upsert as Resource;
+        handlers.onNewResourceSuccess(resourceData, context);
         return;
       }
 
       // Write workflow
-      handlers.onWriteSuccess?.();
+      handlers.onWriteSuccess?.(context);
     }
-  }, [request, workflow, handlers, isNew, dashboard]);
+  }, [request, workflow, handlers, isNew, successMessage, repository, resourceType]);
 }
+
+// Helper function to get combined configuration for provider + resource
+function getProvisionedResourceConfig(repoType: RepoType, resourceType: ResourceType): ProvisionedResourceConfig {
+  return {
+    provider: PROVIDER_CONFIGS[repoType],
+    resource: RESOURCE_CONFIGS[resourceType],
+  };
+}
+
+// Helper function to get contextual success messages
+function getContextualSuccessMessage(context: ProvisionedResourceContext): string {
+  const { repoType, resourceType, isNew } = context;
+  const action = isNew ? 'created' : 'saved';
+  const resourceConfig = RESOURCE_CONFIGS[resourceType];
+
+  // Provider-specific messages with resource context
+  switch (repoType) {
+    case 'github':
+      return t(
+        `provisioned-request-handler.${resourceType}-github-success`,
+        `${resourceConfig.defaultSuccessMessage} via GitHub`
+      );
+    case 'gitlab':
+      return t(
+        `provisioned-request-handler.${resourceType}-gitlab-success`,
+        `${resourceConfig.defaultSuccessMessage} via GitLab`
+      );
+    case 'bitbucket':
+      return t(
+        `provisioned-request-handler.${resourceType}-bitbucket-success`,
+        `${resourceConfig.defaultSuccessMessage} via Bitbucket`
+      );
+    case 'git':
+      return t(
+        `provisioned-request-handler.${resourceType}-git-success`,
+        `${resourceConfig.defaultSuccessMessage} via Git`
+      );
+    case 'local':
+      return t(`provisioned-request-handler.${resourceType}-local-success`, resourceConfig.defaultSuccessMessage);
+    default:
+      return resourceConfig.defaultSuccessMessage;
+  }
+}
+
+// Export utility functions for external use
+export function getProviderConfig(repoType: RepoType): ProviderConfig {
+  return PROVIDER_CONFIGS[repoType];
+}
+
+export function getResourceConfig(resourceType: ResourceType): ResourceConfig {
+  return RESOURCE_CONFIGS[resourceType];
+}
+
+export function getCombinedConfig(repoType: RepoType, resourceType: ResourceType): ProvisionedResourceConfig {
+  return getProvisionedResourceConfig(repoType, resourceType);
+}
+
+export function supportsRichAPI(repoType: RepoType): boolean {
+  return PROVIDER_CONFIGS[repoType]?.supportsRichAPI || false;
+}
+
+export function getSupportedWorkflows(repoType: RepoType, resourceType: ResourceType): string[] {
+  const providerWorkflows = PROVIDER_CONFIGS[repoType].defaultWorkflows;
+  const resourceWorkflows = RESOURCE_CONFIGS[resourceType].supportedWorkflows;
+
+  // Return intersection of supported workflows
+  return providerWorkflows.filter((workflow) => resourceWorkflows.includes(workflow));
+}
+
+// Type exports for external use
+export type {
+  ResourceType,
+  ProvisionedResourceContext,
+  RequestHandlers,
+  ProviderConfig,
+  ResourceConfig,
+  ProvisionedResourceConfig,
+};

--- a/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
+++ b/public/app/features/dashboard-scene/utils/useProvisionedRequestHandler.ts
@@ -27,7 +27,6 @@ interface RequestHandlers<T> {
     resource: Resource<T>
   ) => void;
   onWriteSuccess?: (info: ProvisionedOperationInfo, resource: Resource<T>) => void;
-  onNewResourceSuccess?: (resource: Resource<T>, info: ProvisionedOperationInfo) => void;
   onError?: (error: unknown, info: ProvisionedOperationInfo) => void;
   onDismiss?: () => void;
 }
@@ -51,29 +50,6 @@ interface ResourceConfig {
  *
  * This hook is intentionally decoupled from specific components (like DashboardScene) to promote reusability.
  * Components are responsible for their own state management through specific workflow handlers.
- *
- * @example
- * // Dashboard component handles its own state
- * useProvisionedRequestHandler({
- *   request,
- *   resourceType: 'dashboard',
- *   handlers: {
- *     onWriteSuccess: (info) => {
- *       dashboard.setState({ isDirty: false });
- *       navigate('/dashboards');
- *     },
- *   }
- * });
- *
- * @example
- * // Folder component doesn't need dashboard state
- * useProvisionedRequestHandler({
- *   request,
- *   resourceType: 'folder',
- *   handlers: {
- *     onNewResourceSuccess: (resource) => navigate(`/folders/${resource.metadata.name}`),
- *   }
- * });
  */
 export function useProvisionedRequestHandler<T>({
   request,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5818,6 +5818,7 @@
       "move-action": "Move dashboard",
       "move-read-only-message": "This dashboard cannot be moved directly from Grafana because the repository is read-only. To move this dashboard, please move the file in your Git repository.",
       "moving": "Moving...",
+      "success-message": "Dashboard moved successfully",
       "target-path-label": "Target path",
       "title-this-repository-is-read-only": "This repository is read only"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5809,6 +5809,7 @@
       "usage-count_other": "Used on {{count}} dashboards"
     },
     "move-provisioned-dashboard-form": {
+      "alert-error-moving-dashboard": "Error moving dashboard",
       "api-error": "Failed to move dashboard",
       "cancel-action": "Cancel",
       "current-file-not-found": "Current dashboard file could not be found",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5651,9 +5651,6 @@
         }
       }
     },
-    "edit-provisioned-dashboard-form": {
-      "success": "Dashboard changes saved successfully"
-    },
     "email-list": {
       "aria-label-emailmenu": "Toggle email menu"
     },
@@ -11000,6 +10997,9 @@
     "title-created-branch-in-repo": "A new resource has been created in a branch in {{repoType}}.",
     "title-loaded-pull-request-in-repo": "This resource is loaded from the branch you just created in {{repoType}} and it is only visible to you"
   },
+  "provisioned-resource-request-handler": "Resource saved successfully",
+  "provisioned-resource-request-handler-dashboard": "Dashboard saved successfully",
+  "provisioned-resource-request-handler-folder": "Folder created successfully",
   "provisioning": {
     "banner": {
       "message": "This feature is currently under active development. For the best experience and latest improvements, we recommend using the <2>nightly build</2> of Grafana."

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3565,12 +3565,12 @@
       "tags-column": "Tags"
     },
     "delete-provisioned-folder-form": {
-      "alert-folder-deleted-successfully": "Folder deleted successfully",
       "api-error": "Failed to delete folder",
       "button-cancel": "Cancel",
       "button-delete": "Delete",
       "button-deleting": "Deleting...",
-      "delete-warning": "This will delete this folder and all its descendants. In total, this will affect:"
+      "delete-warning": "This will delete this folder and all its descendants. In total, this will affect:",
+      "success-message": "Folder deleted successfully"
     },
     "descendant-count": {
       "title-unable-to-retrieve-descendant-information": "Unable to retrieve descendant information"
@@ -3613,7 +3613,6 @@
     },
     "new-provisioned-folder-form": {
       "alert-error-creating-folder": "Error creating folder",
-      "alert-folder-created-successfully": "Folder created successfully",
       "button-create": "Create",
       "button-creating": "Creating...",
       "cancel": "Cancel",
@@ -5639,6 +5638,7 @@
       "delete-read-only-file-message": "This dashboard cannot be deleted directly from Grafana because the repository is read-only. To delete this dashboard, please remove the file from your Git repository.",
       "deleting": "Deleting...",
       "drawer-title": "Delete Provisioned Dashboard",
+      "success-message": "Dashboard deleted successfully",
       "title-this-repository-is-read-only": "This repository is read only"
     },
     "description-label": {


### PR DESCRIPTION
**What is this feature?**

- Refactor `useProvisionedRequestHandler` to be able to use with flexible resource type (folder, dashboard, and more)
- Update following components to use updated hook:
  - SaveProvisionedDashboardForm
  - DeleteProvisionedDashboardForm
  - NewProvisionedFolderForm
  - DeleteProvisionedFolderForm
  - MoveProvisionedDashboardForm

In future, any new component can follow the pattern: 
```
  const onWriteSuccess = (...) => {
     ...
  };

  const onBranchSuccess = (...) => {
    ...
  };

  useProvisionedRequestHandler({
    request,
    workflow,
    resourceType: 'dashboard',
    successMessage: ...,
    handlers: {
      onDismiss,
      onBranchSuccess,
      onWriteSuccess,
      onError,
    },
  });

```

**Why do we need this feature?**

- The refactor makes it easier to add new resource and workflow types in the future

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/305

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
