### PR TITLE
Canvas: Fix on constraint change during zoom

### DIFF
--- a/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
@@ -77,7 +77,7 @@ export function PlacementEditor({ item }: Props) {
 
   const onHorizontalConstraintChange = (h: HorizontalConstraint) => {
     element.options.constraint!.horizontal = h;
-    element.setPlacementFromConstraint();
+    element.setPlacementFromConstraint(undefined, undefined, settings.scene.scale);
     settings.scene.revId++;
     settings.scene.save(true);
     reselectElementAfterChange();
@@ -89,7 +89,7 @@ export function PlacementEditor({ item }: Props) {
 
   const onVerticalConstraintChange = (v: VerticalConstraint) => {
     element.options.constraint!.vertical = v;
-    element.setPlacementFromConstraint();
+    element.setPlacementFromConstraint(undefined, undefined, settings.scene.scale);
     settings.scene.revId++;
     settings.scene.save(true);
     reselectElementAfterChange();


### PR DESCRIPTION
When changing vertical or horizontal constraint during zoom, element is growing / shrinking. This PR fixes this by passing scale into placement calcs properly on change.