### PR TITLE
ElasticSearch: Fix inline casting bug when validating the index

### DIFF
--- a/pkg/tsdb/elasticsearch/healthcheck.go
+++ b/pkg/tsdb/elasticsearch/healthcheck.go
@@ -191,11 +191,15 @@ func validateIndex(ctx context.Context, ds *es.DatasourceInfo) (message string, 
 		return "Failed to unmarshal field capabilities response", "error"
 	}
 	if fieldCaps["error"] != nil {
-		if errorMessage, ok := fieldCaps["error"].(map[string]any)["reason"].(string); ok {
-			return fmt.Sprintf("Error validating index: %s", errorMessage), "warning"
-		} else {
+		errorMap, ok := fieldCaps["error"].(map[string]any)
+		if !ok {
 			return "Error validating index", "warning"
 		}
+		errorMessage, ok := errorMap["reason"].(string)
+		if !ok {
+			return "Error validating index", "warning"
+		}
+		return fmt.Sprintf("Error validating index: %s", errorMessage), "warning"
 	}
 
 	fields, ok := fieldCaps["fields"].(map[string]any)

--- a/pkg/tsdb/elasticsearch/healthcheck_test.go
+++ b/pkg/tsdb/elasticsearch/healthcheck_test.go
@@ -58,6 +58,16 @@ func Test_validateIndex_Warning_ErrorValidatingIndex(t *testing.T) {
 	assert.Equal(t, "Elasticsearch data source is healthy. Warning: Error validating index: index_not_found", res.Message)
 }
 
+func Test_validateIndex_Warning_ErrorValidatingIndex2(t *testing.T) {
+	service := GetMockService(http.StatusOK, "200 OK", `{"status":"green"}`, `{"error":"not a map"}`)
+	res, _ := service.CheckHealth(mockedCfg, &backend.CheckHealthRequest{
+		PluginContext: backend.PluginContext{},
+		Headers:       nil,
+	})
+	assert.Equal(t, backend.HealthStatusOk, res.Status)
+	assert.Equal(t, "Elasticsearch data source is healthy. Warning: Error validating index", res.Message)
+}
+
 func Test_validateIndex_Warning_WrongTimestampType(t *testing.T) {
 	service := GetMockService(http.StatusOK, "200 OK", `{"status":"green"}`, `{"fields":{"timestamp":{"float":{"metadata_field":true}}}}`)
 	res, _ := service.CheckHealth(mockedCfg, &backend.CheckHealthRequest{


### PR DESCRIPTION
If `error` does not have a `map[string]any` then casting it to `string` will error.
Added a check to make sure it is `map[string]any]` before checking `string`
Fixes: https://github.com/grafana/support-escalations/issues/17581