### PR TITLE
Finish building index even if original context is canceled.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -644,6 +644,10 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 	}
 
 	ch := s.buildIndex.DoChan(key.String(), func() (interface{}, error) {
+		// We want to finish building of the index even if original context is canceled.
+		// We reuse original context without cancel to keep the tracing spans correct.
+		ctx := context.WithoutCancel(ctx)
+
 		// Recheck if some other goroutine managed to build an index in the meantime.
 		// (That is, it finished running this function and stored the index into the cache)
 		idx, err := s.search.GetIndex(ctx, key)


### PR DESCRIPTION
We don't want to cancel building of the index if original context is canceled. This results in index that is never built. If we finish one build, all other accesses can reuse cached index.

Problem originally observed as stream of failed index builds:
```
ogger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:39.366495826Z level=error msg="Failed to build index" err="begin: context canceled"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:39.411396296Z level=error msg="Failed to build index" err="begin: context canceled"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:40.270327631Z level=error msg="Failed to build index" err="commit: sql: transaction has already been committed or rolled back"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:43.984662029Z level=error msg="Failed to build index" err="commit: sql: transaction has already been committed or rolled back"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:44.111183947Z level=error msg="Failed to build index" err="begin: context canceled"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:49.192863247Z level=error msg="Failed to build index" err="commit: sql: transaction has already been committed or rolled back"
logger=bleve-backend namespace=stacks-1691 group=dashboard.grafana.app resource=dashboards size=2141 rv=1753955233481853 reason=search t=2025-07-31T11:14:50.140024954Z level=error msg="Failed to build index" err="commit: sql: transaction has already been committed or rolled back"
```
