### PR TITLE
datasources: querier: better handling of timestamps

### DIFF
--- a/pkg/expr/query_convert.go
+++ b/pkg/expr/query_convert.go
@@ -1,0 +1,51 @@
+package expr
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+)
+
+func convertBackendQueryToDataQuery(q backend.DataQuery) (data.DataQuery, error) {
+	// we first restore it from the raw json data,
+	// this should take care of all datasource-specific (for example, specific
+	// for prometheus or loki) fields
+	var dataQuery data.DataQuery
+	err := json.Unmarshal(q.JSON, &dataQuery)
+	if err != nil {
+		return data.DataQuery{}, err
+	}
+
+	// then we override the result with values that are available as fields in backend.DataQuery
+	dataQuery.RefID = q.RefID
+	dataQuery.QueryType = q.QueryType
+	dataQuery.MaxDataPoints = q.MaxDataPoints
+	dataQuery.IntervalMS = float64(q.Interval.Nanoseconds()) / 1000000.0
+	dataQuery.TimeRange = &data.TimeRange{
+		From: strconv.FormatInt(q.TimeRange.From.UnixMilli(), 10),
+		To:   strconv.FormatInt(q.TimeRange.To.UnixMilli(), 10),
+	}
+
+	return dataQuery, nil
+}
+
+func ConvertBackendRequestToDataRequest(req *backend.QueryDataRequest) (*data.QueryDataRequest, error) {
+	k8sReq := &data.QueryDataRequest{
+		// `backend.QueryDataRequest` does not have a concept of a top-level global from/to.
+		// timeRanges are always inside the queries,
+		// so we leave them empty here too.
+	}
+
+	for _, q := range req.Queries {
+		dataQuery, err := convertBackendQueryToDataQuery(q)
+		if err != nil {
+			return nil, err
+		}
+
+		k8sReq.Queries = append(k8sReq.Queries, dataQuery)
+	}
+
+	return k8sReq, nil
+}

--- a/pkg/expr/query_convert_test.go
+++ b/pkg/expr/query_convert_test.go
@@ -1,0 +1,50 @@
+package expr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertBackendRequestToDataRequest(t *testing.T) {
+	input1 := backend.DataQuery{
+		RefID:         "A",
+		QueryType:     "large",
+		MaxDataPoints: 42,
+		Interval:      time.Millisecond * 10,
+		TimeRange: backend.TimeRange{
+			From: time.UnixMilli(1753959290000),
+			To:   time.UnixMilli(1753959390000),
+		},
+		JSON: []byte(`{ "field1": "value1" }`),
+	}
+
+	result1 := data.DataQuery{
+		CommonQueryProperties: data.CommonQueryProperties{
+			RefID:         "A",
+			QueryType:     "large",
+			MaxDataPoints: 42,
+			IntervalMS:    10.0,
+			TimeRange: &data.TimeRange{
+				From: "1753959290000",
+				To:   "1753959390000",
+			},
+		},
+	}
+	result1.Set("field1", "value1")
+
+	req := backend.QueryDataRequest{
+		Queries: []backend.DataQuery{input1},
+	}
+
+	expected := data.QueryDataRequest{
+		Queries: []data.DataQuery{result1},
+	}
+
+	result, err := ConvertBackendRequestToDataRequest(&req)
+	require.NoError(t, err)
+	require.Equal(t, &expected, result)
+}

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -413,7 +413,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		}`)
 		mr.From = ""
 		mr.To = ""
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.Len(t, parsedReq.parsedQueries, 1)

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -372,7 +372,6 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 
 			assert.Equal(t, ts3, queries[1].query.TimeRange.From.UnixMilli())
 			assert.Equal(t, ts4, queries[1].query.TimeRange.To.UnixMilli())
-
 		}
 
 		// with flag enabled

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -69,7 +69,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 				"type": "postgres"
 			}
 		}`)
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.False(t, parsedReq.hasExpression)
@@ -95,7 +95,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		}`)
 		mr.From = ""
 		mr.To = ""
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.False(t, parsedReq.hasExpression)
@@ -128,7 +128,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 			"type": "math",
 			"expression": "$A - 50"
 		}`)
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		require.True(t, parsedReq.hasExpression)
@@ -171,7 +171,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 				"type": "testdata"
 			}
 		}`)
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.False(t, parsedReq.hasExpression)
@@ -231,7 +231,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 			"type": "math",
 			"expression": "$A_resample + $B_resample"
 		}`)
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.True(t, parsedReq.hasExpression)
@@ -271,18 +271,18 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		reqCtx.Req = httpreq
 
 		httpreq.Header.Add("X-Datasource-Uid", "gIEkMvIVz")
-		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr)
+		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 
 		// With the second value it is OK
 		httpreq.Header.Add("X-Datasource-Uid", "sEx6ZvSVk")
-		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr)
+		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 
 		// Single header with comma syntax
 		httpreq, _ = http.NewRequest(http.MethodPost, "http://localhost/", bytes.NewReader([]byte{}))
 		httpreq.Header.Set("X-Datasource-Uid", "gIEkMvIVz, sEx6ZvSVk")
-		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr)
+		_, err = tc.queryService.parseMetricRequest(httpreq.Context(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 	})
 
@@ -301,7 +301,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 				"type": "postgres"
 			}
 		}`)
-		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.Error(t, err)
 	})
 
@@ -322,7 +322,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		}`)
 		mr.From = "1753944628000"
 		mr.To = "1753944629000"
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.Len(t, parsedReq.parsedQueries, 1)
@@ -359,19 +359,37 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		}`)
 		mr.From = ""
 		mr.To = ""
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+
+		verifyTimestamps := func(parsedReq *parsedRequest, ts1 int64, ts2 int64, ts3 int64, ts4 int64) {
+			require.NotNil(t, parsedReq)
+			assert.Len(t, parsedReq.parsedQueries, 1)
+			assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
+			queries := parsedReq.getFlattenedQueries()
+			assert.Len(t, queries, 2)
+
+			assert.Equal(t, ts1, queries[0].query.TimeRange.From.UnixMilli())
+			assert.Equal(t, ts2, queries[0].query.TimeRange.To.UnixMilli())
+
+			assert.Equal(t, ts3, queries[1].query.TimeRange.From.UnixMilli())
+			assert.Equal(t, ts4, queries[1].query.TimeRange.To.UnixMilli())
+
+		}
+
+		// with flag enabled
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
 		require.NoError(t, err)
-		require.NotNil(t, parsedReq)
-		assert.Len(t, parsedReq.parsedQueries, 1)
-		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
-		queries := parsedReq.getFlattenedQueries()
-		assert.Len(t, queries, 2)
 
-		assert.Equal(t, int64(1753944618000), queries[0].query.TimeRange.From.UnixMilli())
-		assert.Equal(t, int64(1753944619000), queries[0].query.TimeRange.To.UnixMilli())
+		verifyTimestamps(parsedReq,
+			int64(1753944618000),
+			int64(1753944619000),
+			int64(1753944628000),
+			int64(1753944629000))
 
-		assert.Equal(t, int64(1753944628000), queries[1].query.TimeRange.From.UnixMilli())
-		assert.Equal(t, int64(1753944629000), queries[1].query.TimeRange.To.UnixMilli())
+		// with flag disabled
+		parsedReq2, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
+		require.NoError(t, err)
+
+		verifyTimestamps(parsedReq2, int64(0), int64(0), int64(0), int64(0))
 	})
 
 	t.Run("Test a datasource query with malformed local time range", func(t *testing.T) {
@@ -396,7 +414,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		}`)
 		mr.From = ""
 		mr.To = ""
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr)
+		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, false)
 		require.NoError(t, err)
 		require.NotNil(t, parsedReq)
 		assert.Len(t, parsedReq.parsedQueries, 1)

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -638,17 +638,13 @@ func TestIntegrationQueryDataWithMTDSClient(t *testing.T) {
 				"type": "postgres"
 			}
 		}`)
-		mr.From = "2022-01-01"
-		mr.To = "2022-01-02"
+		mr.From = "1754309340000"
+		mr.To = "1754309370000"
 		ctx := context.Background()
 		_, err := tc.queryService.QueryData(ctx, tc.signedInUser, true, mr)
 		require.NoError(t, err)
 
 		assert.Equal(t, data.QueryDataRequest{
-			TimeRange: data.TimeRange{
-				From: "2022-01-01T00:00:00Z",
-				To:   "2022-01-02T00:00:00Z",
-			},
 			Queries: []data.DataQuery{
 				{
 					CommonQueryProperties: data.CommonQueryProperties{
@@ -657,6 +653,12 @@ func TestIntegrationQueryDataWithMTDSClient(t *testing.T) {
 							Type: "postgres",
 							UID:  "gIEkMvIVz",
 						},
+						TimeRange: &data.TimeRange{
+							From: "1754309340000",
+							To:   "1754309370000",
+						},
+						MaxDataPoints: 100,
+						IntervalMS:    1000,
 					},
 				},
 				{
@@ -666,6 +668,12 @@ func TestIntegrationQueryDataWithMTDSClient(t *testing.T) {
 							Type: "postgres",
 							UID:  "gIEkMvIVz",
 						},
+						TimeRange: &data.TimeRange{
+							From: "1754309340000",
+							To:   "1754309370000",
+						},
+						MaxDataPoints: 100,
+						IntervalMS:    1000,
 					},
 				},
 			},


### PR DESCRIPTION
we need to handle the timestamps in the query-service case better. this allows us to treat in-query timestamps more natively.