### PR TITLE
E2E: Disable flaky Table e2e tests for DataLinks for now

### DIFF
--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -269,7 +269,8 @@ test.describe(
       expect(fourthPageStatus.total).toBe(largeRowStatus.total);
     });
 
-    test('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
+    // TODO: skipping this test for now due to flakiness in adding DataLinks.
+    test.skip('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
       const addDataLink = async (title: string, url: string) => {
         await dashboardPage
           .getByGrafanaSelector(


### PR DESCRIPTION
After reported flakiness in this test, we will temporarily disable it while we investigate the root cause of the flakiness and attempt to address it.