### PR TITLE
Secrets: Add inline secure value create method

### DIFF
--- a/pkg/registry/apis/secret/testutils/testutils.go
+++ b/pkg/registry/apis/secret/testutils/testutils.go
@@ -244,12 +244,42 @@ func CreateUserAuthContext(ctx context.Context, namespace string, permissions ma
 	return types.WithAuthInfo(ctx, requester)
 }
 
-func CreateServiceAuthContext(ctx context.Context, serviceIdentity string, permissions []string) context.Context {
+func CreateServiceAuthContext(ctx context.Context, serviceIdentity string, namespace string, permissions []string) context.Context {
 	requester := &identity.StaticRequester{
+		Namespace: namespace,
 		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
 			Rest: authn.AccessTokenClaims{
 				Permissions:     permissions,
 				ServiceIdentity: serviceIdentity,
+			},
+		},
+	}
+
+	return types.WithAuthInfo(ctx, requester)
+}
+
+// CreateOBOAuthContext emulates a context where the request is made on-behalf-of (OBO) a user, with an access token.
+func CreateOBOAuthContext(
+	ctx context.Context,
+	serviceIdentity string,
+	namespace string,
+	userPermissions map[string][]string,
+	delegatedPermissions []string,
+) context.Context {
+	requester := &identity.StaticRequester{
+		Namespace: namespace,
+		Type:      types.TypeUser,
+		UserID:    1,
+		Permissions: map[int64]map[string][]string{
+			1: userPermissions,
+		},
+		AccessTokenClaims: &authn.Claims[authn.AccessTokenClaims]{
+			Rest: authn.AccessTokenClaims{
+				ServiceIdentity:      serviceIdentity,
+				DelegatedPermissions: delegatedPermissions,
+				Actor: &authn.ActorClaims{
+					Subject: "user:1",
+				},
 			},
 		},
 	}

--- a/pkg/storage/secret/metadata/secure_value_test.go
+++ b/pkg/storage/secret/metadata/secure_value_test.go
@@ -403,7 +403,7 @@ func TestStateMachine(t *testing.T) {
 			},
 			"decrypt": func(t *rapid.T) {
 				input := decryptGen.Draw(t, "decryptInput")
-				authCtx := testutils.CreateServiceAuthContext(t.Context(), input.decrypter, []string{fmt.Sprintf("secret.grafana.app/securevalues/%+v:decrypt", input.name)})
+				authCtx := testutils.CreateServiceAuthContext(t.Context(), input.decrypter, input.namespace, []string{fmt.Sprintf("secret.grafana.app/securevalues/%+v:decrypt", input.name)})
 				modelResult, modelErr := model.decrypt(input.decrypter, input.namespace, input.name)
 				result, err := sut.DecryptService.Decrypt(authCtx, input.namespace, input.name)
 				if err != nil || modelErr != nil {
@@ -440,7 +440,7 @@ func TestSecureValueServiceExampleBased(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, sv.Status.Version, deletedSv.Status.Version)
 
-		authCtx := testutils.CreateServiceAuthContext(t.Context(), sv.Spec.Decrypters[0], []string{fmt.Sprintf("secret.grafana.app/securevalues/%+v:decrypt", sv.Name)})
+		authCtx := testutils.CreateServiceAuthContext(t.Context(), sv.Spec.Decrypters[0], sv.Namespace, []string{fmt.Sprintf("secret.grafana.app/securevalues/%+v:decrypt", sv.Name)})
 		result, err := sut.DecryptService.Decrypt(authCtx, sv.Namespace, sv.Name)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(result))


### PR DESCRIPTION
**What is this feature?**

Adds **in-process** implementation of `CreateInline` for secure values.

**Why do we need this feature?**

Will be used by Unified Storage's apistore to create inline secure values that are owned by a resource.

**Who is this feature for?**

Developers integrating with secrets.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1480

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
