### PR TITLE
Trendline: Add higher polynomial degrees

### DIFF
--- a/public/app/features/transformers/regression/constants.ts
+++ b/public/app/features/transformers/regression/constants.ts
@@ -1,0 +1,31 @@
+import { FieldMatcherID, fieldMatchers } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { FieldNamePicker } from '@grafana/ui/internal';
+
+import { ModelType } from './regression';
+
+export const getModelTypeOptions = () =>
+  [
+    {
+      label: t('transformers.regression-transformer-editor.model-type-options.label.linear', 'Linear'),
+      value: ModelType.linear,
+    },
+    {
+      label: t('transformers.regression-transformer-editor.model-type-options.label.polynomial', 'Polynomial'),
+      value: ModelType.polynomial,
+    },
+  ] as const satisfies Array<{ label: string; value: ModelType }>;
+
+export const fieldNamePickerSettings = {
+  editor: FieldNamePicker,
+  id: '',
+  name: '',
+  settings: { width: 24, isClearable: false },
+} as const;
+
+export const LABEL_WIDTH = 20;
+
+export const FIELD_MATCHERS = {
+  timeMatcher: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+  numericMatcher: fieldMatchers.get(FieldMatcherID.numeric).get({}),
+};

--- a/public/app/features/transformers/regression/constants.ts
+++ b/public/app/features/transformers/regression/constants.ts
@@ -26,6 +26,6 @@ export const fieldNamePickerSettings = {
 export const LABEL_WIDTH = 20;
 
 export const FIELD_MATCHERS = {
-  timeMatcher: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+  firstTimeMatcher: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
   numericMatcher: fieldMatchers.get(FieldMatcherID.numeric).get({}),
 };

--- a/public/app/features/transformers/regression/regression.ts
+++ b/public/app/features/transformers/regression/regression.ts
@@ -33,6 +33,11 @@ export const DEGREES = [
   { label: () => t('transformers.regression-transformer-editor.label.cubic', 'Cubic'), value: 3 },
   { label: () => t('transformers.regression-transformer-editor.label.quartic', 'Quartic'), value: 4 },
   { label: () => t('transformers.regression-transformer-editor.label.quintic', 'Quintic'), value: 5 },
+  { label: () => t('transformers.regression-transformer-editor.label.sextic', 'Sextic'), value: 6 },
+  { label: () => t('transformers.regression-transformer-editor.label.septic', 'Septic'), value: 7 },
+  { label: () => t('transformers.regression-transformer-editor.label.octic', 'Octic'), value: 8 },
+  { label: () => t('transformers.regression-transformer-editor.label.nonic', 'Nonic'), value: 9 },
+  { label: () => t('transformers.regression-transformer-editor.label.decic', 'Decic'), value: 10 },
 ];
 
 export const getRegressionTransformer: () => SynchronousDataTransformerInfo<RegressionTransformerOptions> = () => ({

--- a/public/app/features/transformers/regression/regressionEditor.tsx
+++ b/public/app/features/transformers/regression/regressionEditor.tsx
@@ -18,7 +18,7 @@ import lightImage from '../images/light/regression.svg';
 
 import { FIELD_MATCHERS, LABEL_WIDTH, fieldNamePickerSettings, getModelTypeOptions } from './constants';
 import { DEFAULTS, DEGREES, ModelType, getRegressionTransformer, RegressionTransformerOptions } from './regression';
-import { findFieldByMatcher } from './utils';
+import { findFirstFieldByMatcher } from './utils';
 
 export const RegressionTransformerEditor = ({
   input,
@@ -52,11 +52,11 @@ export const RegressionTransformerEditor = ({
 
     if (!options.xFieldName) {
       x =
-        findFieldByMatcher(input, FIELD_MATCHERS.timeMatcher) ||
-        findFieldByMatcher(input, FIELD_MATCHERS.numericMatcher);
+        findFirstFieldByMatcher(input, FIELD_MATCHERS.firstTimeMatcher) ||
+        findFirstFieldByMatcher(input, FIELD_MATCHERS.numericMatcher);
     }
     if (!options.yFieldName) {
-      y = findFieldByMatcher(input, FIELD_MATCHERS.numericMatcher, x);
+      y = findFirstFieldByMatcher(input, FIELD_MATCHERS.numericMatcher, x);
     }
 
     if (x && y) {

--- a/public/app/features/transformers/regression/regressionEditor.tsx
+++ b/public/app/features/transformers/regression/regressionEditor.tsx
@@ -10,7 +10,7 @@ import {
   Field,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { InlineField, Select } from '@grafana/ui';
+import { Combobox, InlineField } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';
 import { NumberInput } from 'app/core/components/OptionsUI/NumberInput';
 
@@ -94,7 +94,7 @@ export const RegressionTransformerEditor = ({
           onChange={(v) => {
             onChange({ ...options, xFieldName: v });
           }}
-        ></FieldNamePicker>
+        />
       </InlineField>
       <InlineField
         labelWidth={LABEL_WIDTH}
@@ -107,19 +107,19 @@ export const RegressionTransformerEditor = ({
           onChange={(v) => {
             onChange({ ...options, yFieldName: v });
           }}
-        ></FieldNamePicker>
+        />
       </InlineField>
       <InlineField
         labelWidth={LABEL_WIDTH}
         label={t('transformers.regression-transformer-editor.label-model-type', 'Model type')}
       >
-        <Select
+        <Combobox
           value={options.modelType ?? DEFAULTS.modelType}
           onChange={(v) => {
             onChange({ ...options, modelType: v.value ?? DEFAULTS.modelType });
           }}
           options={modelTypeOptions}
-        ></Select>
+        />
       </InlineField>
       <InlineField
         labelWidth={LABEL_WIDTH}
@@ -134,14 +134,18 @@ export const RegressionTransformerEditor = ({
           onChange={(v) => {
             onChange({ ...options, predictionCount: v });
           }}
-        ></NumberInput>
+        />
       </InlineField>
       {options.modelType === ModelType.polynomial && (
         <InlineField
           labelWidth={LABEL_WIDTH}
           label={t('transformers.regression-transformer-editor.label-degree', 'Degree')}
+          tooltip={t(
+            'transformers.regression-transformer-editor.tooltip-high-degree-polynomial',
+            'Higher-degree polynomials (e.g., degree 4 or higher) can result in misleading trends and unstable fits. Proceed with caution.'
+          )}
         >
-          <Select<number>
+          <Combobox
             value={options.degree ?? DEFAULTS.degree}
             options={DEGREES.map((deg) => {
               return {
@@ -150,9 +154,9 @@ export const RegressionTransformerEditor = ({
               };
             })}
             onChange={(v) => {
-              onChange({ ...options, degree: v.value });
+              onChange({ ...options, degree: Number(v.value) });
             }}
-          ></Select>
+          />
         </InlineField>
       )}
     </>

--- a/public/app/features/transformers/regression/utils.ts
+++ b/public/app/features/transformers/regression/utils.ts
@@ -1,0 +1,15 @@
+import { DataFrame, Field } from '@grafana/data';
+
+export const findFieldByMatcher = (
+  input: DataFrame[],
+  matcher: (field: Field, frame: DataFrame, input: DataFrame[]) => boolean,
+  excludeField?: Field
+): Field | undefined => {
+  for (const frame of input) {
+    const field = frame.fields.find((field) => matcher(field, frame, input) && field !== excludeField);
+    if (field) {
+      return field;
+    }
+  }
+  return undefined;
+};

--- a/public/app/features/transformers/regression/utils.ts
+++ b/public/app/features/transformers/regression/utils.ts
@@ -1,6 +1,6 @@
 import { DataFrame, Field } from '@grafana/data';
 
-export const findFieldByMatcher = (
+export const findFirstFieldByMatcher = (
   input: DataFrame[],
   matcher: (field: Field, frame: DataFrame, input: DataFrame[]) => boolean,
   excludeField?: Field

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13499,9 +13499,14 @@
     "regression-transformer-editor": {
       "label": {
         "cubic": "Cubic",
+        "decic": "Decic",
+        "nonic": "Nonic",
+        "octic": "Octic",
         "quadratic": "Quadratic",
         "quartic": "Quartic",
-        "quintic": "Quintic"
+        "quintic": "Quintic",
+        "septic": "Septic",
+        "sextic": "Sextic"
       },
       "label-degree": "Degree",
       "label-model-type": "Model type",
@@ -13518,6 +13523,7 @@
       "tags": {
         "regression-analysis": "Regression analysis"
       },
+      "tooltip-high-degree-polynomial": "Higher-degree polynomials (e.g., degree 4 or higher) can result in misleading trends and unstable fits. Proceed with caution.",
       "tooltip-number-of-xy-points-to-predict": "Number of X,Y points to predict"
     },
     "rename-by-regex-transformer": {


### PR DESCRIPTION
### What does this PR do? 📓 

Fixes #103369

A user is requesting higher polynomial degrees in the trendline transformation. We currently only offer up to quintic, but there _are_ use cases for higher polynomial degrees. A mathematician I am **not**, so reached out to folks on the ML and data and analytics teams. The suggestion was to allow higher polynomial degrees, but to add a warning so that users understand the risks.

I also took the time to update a deprecated component: `<Select />` to `<Combobox />`

>[!WARNING]
> I was looking at the `regressionEditor.tsx` file and noticed a few items I have questions about
> 1. There's a `useEffect` that doesn't have any dependency array so it runs on every single re-render. This is generally an anti-pattern in React. I wonder if we should do some investigation to see if this is an issue, especially because of the `onChange` in the effect.
> 2. Within this `useEffect`, there are three different nested loops, which I think is **O(3n²) complexity** (only if they all run, which probably doesn't happen). Granted, there is defensive programming in the form of `if` blocks, so I don't think we ever loop through all three, but it looks like on load two of the nested loops are run (**O(frames × fields)**). I wonder if we should try to optimize this or if this would ever be an issue.
>
> Any thoughts @gelicia? 😄 

#### Demo 💻 

https://github.com/user-attachments/assets/00a13fed-8f64-429a-84ae-57b72082d204