### PR TITLE
BrowseActions: Prevent cross provisioned folder selection in bulk dashboard operations

### DIFF
--- a/public/app/features/browse-dashboards/components/BrowseActions/useRepositoryValidation.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/useRepositoryValidation.ts
@@ -1,0 +1,73 @@
+import { ManagerKind } from 'app/features/apiserver/types';
+import { useSelector } from 'app/types/store';
+
+import { useChildrenByParentUIDState, rootItemsSelector } from '../../state/hooks';
+import { findItem } from '../../state/utils';
+import { DashboardTreeSelection } from '../../types';
+
+export function useRepositoryValidation(selectedItems: Omit<DashboardTreeSelection, 'panel' | '$all'>) {
+  const childrenByParentUID = useChildrenByParentUIDState();
+  const rootItems = useSelector(rootItemsSelector);
+
+  // Get repository for any item (folder or dashboard)
+  const getRepositoryForItem = (uid: string, kind: 'folder' | 'dashboard'): string | null => {
+    const item = findItem(rootItems?.items || [], childrenByParentUID, uid);
+    if (!item) {
+      return null;
+    }
+
+    // If it's a root provisioned folder, the UID is the repository name
+    if (item.managedBy === ManagerKind.Repo && !item.parentUID && kind === 'folder') {
+      return uid;
+    }
+
+    // If it's a nested item, traverse up to find root provisioned folder
+    if (item.parentUID) {
+      let currentUID: string | undefined = item.parentUID;
+      while (currentUID) {
+        const parent = findItem(rootItems?.items || [], childrenByParentUID, currentUID);
+        if (!parent) {
+          break;
+        }
+
+        if (parent.managedBy === ManagerKind.Repo && !parent.parentUID) {
+          return currentUID; // Found root provisioned folder
+        }
+        currentUID = parent.parentUID;
+      }
+    }
+
+    return null; // Non-provisioned item
+  };
+
+  // Validate repository consistency
+  const selectedFolderUids = Object.keys(selectedItems.folder).filter((uid) => selectedItems.folder[uid]);
+  const selectedDashboardUids = Object.keys(selectedItems.dashboard).filter((uid) => selectedItems.dashboard[uid]);
+
+  let commonRepository: string | null = null;
+  let allFromSameRepo = true;
+
+  // Check all selected items
+  const allSelectedItems = [
+    ...selectedFolderUids.map((uid) => ({ uid, kind: 'folder' as const })),
+    ...selectedDashboardUids.map((uid) => ({ uid, kind: 'dashboard' as const })),
+  ];
+
+  for (const { uid, kind } of allSelectedItems) {
+    const itemRepo = getRepositoryForItem(uid, kind);
+
+    if (commonRepository === null) {
+      commonRepository = itemRepo;
+    } else if (commonRepository !== itemRepo) {
+      allFromSameRepo = false;
+      break;
+    }
+  }
+
+  return {
+    allFromSameRepo,
+    commonRepository: commonRepository || undefined,
+    selectedCount: allSelectedItems.length,
+    hasSelection: allSelectedItems.length > 0,
+  };
+}

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -1,6 +1,8 @@
 import { t } from '@grafana/i18n';
+import { DashboardViewItem } from 'app/features/search/types';
 
 import { findItem } from '../../state/utils';
+import { DashboardViewItemCollection } from '../../types';
 
 export function buildBreakdownString(
   folderCount: number,
@@ -32,7 +34,10 @@ export function buildBreakdownString(
 // Utility: Get root folder for any item (reusing existing pattern from reducers.ts)
 export function getItemRootFolder(
   item: { uid: string; parentUID?: string; kind?: string },
-  browseState: { rootItems?: { items: any[] }; childrenByParentUID: Record<string, any> }
+  browseState: {
+    rootItems?: { items: DashboardViewItem[] };
+    childrenByParentUID: Record<string, DashboardViewItemCollection>;
+  }
 ): string | undefined {
   const rootItems = browseState.rootItems?.items || [];
 

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -1,5 +1,7 @@
 import { t } from '@grafana/i18n';
 
+import { findItem } from '../../state/utils';
+
 export function buildBreakdownString(
   folderCount: number,
   dashboardCount: number,
@@ -25,4 +27,38 @@ export function buildBreakdownString(
     breakdownString += `: ${parts.join(', ')}`;
   }
   return breakdownString;
+}
+
+// Utility: Get root folder for any item (reusing existing pattern from reducers.ts)
+export function getItemRootFolder(
+  item: { uid: string; parentUID?: string; kind?: string },
+  browseState: { rootItems?: { items: any[] }; childrenByParentUID: Record<string, any> }
+): string | undefined {
+  const rootItems = browseState.rootItems?.items || [];
+
+  // If it's already a root-level item, return its UID (only for folders)
+  if (!item.parentUID) {
+    return item.kind === 'folder' ? item.uid : undefined;
+  }
+
+  // For nested items, traverse up to find root folder (same pattern as reducers.ts)
+  let nextParentUID = item.parentUID;
+
+  while (nextParentUID) {
+    const parent = findItem(rootItems, browseState.childrenByParentUID, nextParentUID);
+
+    // Safety check to prevent infinite loops (same as reducers.ts)
+    if (!parent) {
+      break;
+    }
+
+    // Found the root folder (no parent)
+    if (!parent.parentUID) {
+      return parent.uid;
+    }
+
+    nextParentUID = parent.parentUID;
+  }
+
+  return undefined;
 }

--- a/public/app/features/browse-dashboards/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/browse-dashboards/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -202,6 +202,8 @@ export function BulkDeleteProvisionedResource({
   selectedItems,
   onDismiss,
 }: BulkActionProvisionResourceProps) {
+  // repo name
+
   const { repository, folder } = useGetResourceRepositoryView({ folderName: folderUid });
 
   const workflowOptions = getWorkflowOptions(repository);
@@ -213,6 +215,9 @@ export function BulkDeleteProvisionedResource({
     ref: `bulk-delete/${timestamp}`,
     workflow: getDefaultWorkflow(repository),
   };
+
+  console.log('selectedItems', selectedItems);
+  console.log(repository, folderUid, folder);
 
   if (!repository) {
     return null;

--- a/public/app/features/browse-dashboards/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/browse-dashboards/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -15,6 +15,7 @@ import { ResourceEditFormSharedFields } from 'app/features/dashboard-scene/compo
 import { getDefaultWorkflow, getWorkflowOptions } from 'app/features/dashboard-scene/saving/provisioned/defaults';
 import { generateTimestamp } from 'app/features/dashboard-scene/saving/provisioned/utils/timestamp';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { useSelector } from 'app/types/store';
 
 import { useChildrenByParentUIDState, rootItemsSelector } from '../../state/hooks';
@@ -202,9 +203,18 @@ export function BulkDeleteProvisionedResource({
   selectedItems,
   onDismiss,
 }: BulkActionProvisionResourceProps) {
-  // repo name
+  // Check if we're on the root browser dashboards page
+  const isRootPage = !folderUid || folderUid === GENERAL_FOLDER_UID;
 
-  const { repository, folder } = useGetResourceRepositoryView({ folderName: folderUid });
+  // If no folderUid, get repository name from selected items
+  const selectedFolderUid = isRootPage
+    ? Object.keys(selectedItems.folder).filter((uid) => selectedItems.folder[uid])[0]
+    : undefined;
+
+  // For root provisioned folders, the folder UID is the repository name
+  const { repository, folder } = useGetResourceRepositoryView({
+    folderName: folderUid || selectedFolderUid,
+  });
 
   const workflowOptions = getWorkflowOptions(repository);
   const folderPath = folder?.metadata?.annotations?.[AnnoKeySourcePath] || '';
@@ -215,9 +225,6 @@ export function BulkDeleteProvisionedResource({
     ref: `bulk-delete/${timestamp}`,
     workflow: getDefaultWorkflow(repository),
   };
-
-  console.log('selectedItems', selectedItems);
-  console.log(repository, folderUid, folder);
 
   if (!repository) {
     return null;

--- a/public/app/features/browse-dashboards/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/browse-dashboards/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -20,6 +20,7 @@ import { ResourceEditFormSharedFields } from 'app/features/dashboard-scene/compo
 import { getDefaultWorkflow, getWorkflowOptions } from 'app/features/dashboard-scene/saving/provisioned/defaults';
 import { generateTimestamp } from 'app/features/dashboard-scene/saving/provisioned/utils/timestamp';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
+import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { useSelector } from 'app/types/store';
 
 import { useChildrenByParentUIDState, rootItemsSelector } from '../../state/hooks';
@@ -277,7 +278,15 @@ function FormContent({ initialValues, selectedItems, repository, workflowOptions
 }
 
 export function BulkMoveProvisionedResource({ folderUid, selectedItems, onDismiss }: BulkActionProvisionResourceProps) {
-  const { repository, folder } = useGetResourceRepositoryView({ folderName: folderUid });
+  // Check if we're on the root browser dashboards page
+  const isRootPage = !folderUid || folderUid === GENERAL_FOLDER_UID;
+
+  // If no folderUid, get repository name from selected items
+  const selectedFolderUid = isRootPage
+    ? Object.keys(selectedItems.folder).filter((uid) => selectedItems.folder[uid])[0]
+    : undefined;
+
+  const { repository, folder } = useGetResourceRepositoryView({ folderName: folderUid || selectedFolderUid });
 
   const workflowOptions = getWorkflowOptions(repository);
   const folderPath = folder?.metadata?.annotations?.[AnnoKeySourcePath] || '';

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -3,10 +3,13 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { Checkbox, useStyles2 } from '@grafana/ui';
+import { Checkbox, Tooltip, useStyles2 } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
+import { useSelector } from 'app/types/store';
 
 import { DashboardsTreeCellProps, SelectionState } from '../types';
 
+import { useSelectionProvisioningStatus } from './BrowseActions/useSelectionProvisioningStatus';
 import { isSharedWithMe, canEditItemType } from './utils';
 
 export default function CheckboxCell({
@@ -16,6 +19,13 @@ export default function CheckboxCell({
   permissions,
 }: DashboardsTreeCellProps) {
   const item = row.item;
+
+  // Get current selection state to check for root folder conflicts
+  const selectedItems = useSelector((state) => state.browseDashboards.selectedItems);
+  const { firstSelectedRootFolder, getItemRootFolder } = useSelectionProvisioningStatus(
+    selectedItems,
+    false // We don't need parent provisioned check for checkbox logic
+  );
 
   if (!isSelected) {
     return <CheckboxSpacer />;
@@ -33,9 +43,33 @@ export default function CheckboxCell({
     return <CheckboxSpacer />;
   }
 
+  // we don't want to select root provisioned folder
+  const isRootProvisionedFolder = item.managedBy === ManagerKind.Repo && !item.parentUID;
+  if (isRootProvisionedFolder) {
+    return <CheckboxSpacer />;
+  }
+
   // Check if user can edit this specific item type
   if (permissions && !canEditItemType(item.kind, permissions)) {
     return <CheckboxSpacer />;
+  }
+
+  // Check if this item is from a different root folder than already selected items
+  const itemRootFolder = getItemRootFolder(item);
+  const isFromDifferentRootFolder =
+    firstSelectedRootFolder && itemRootFolder && itemRootFolder !== firstSelectedRootFolder;
+
+  if (isFromDifferentRootFolder) {
+    return (
+      <Tooltip
+        content={t(
+          'browse-dashboards.different-folder-disabled',
+          'Items from another folder are already selected. Cannot mix folders in bulk actions.'
+        )}
+      >
+        <Checkbox disabled value={false} />
+      </Tooltip>
+    );
   }
 
   const state = isSelected(item);

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { Checkbox, Tooltip, useStyles2 } from '@grafana/ui';
+import { Checkbox, useStyles2 } from '@grafana/ui';
 import { ManagerKind } from 'app/features/apiserver/types';
 import { useSelector } from 'app/types/store';
 
@@ -60,16 +60,7 @@ export default function CheckboxCell({
     firstSelectedRootFolder && itemRootFolder && itemRootFolder !== firstSelectedRootFolder;
 
   if (isFromDifferentRootFolder) {
-    return (
-      <Tooltip
-        content={t(
-          'browse-dashboards.different-folder-disabled',
-          'Items from another folder are already selected. Cannot mix folders in bulk actions.'
-        )}
-      >
-        <Checkbox disabled value={false} />
-      </Tooltip>
-    );
+    return <Checkbox disabled value={false} />;
   }
 
   const state = isSelected(item);

--- a/public/app/features/browse-dashboards/components/CheckboxCell.tsx
+++ b/public/app/features/browse-dashboards/components/CheckboxCell.tsx
@@ -5,11 +5,9 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Checkbox, useStyles2 } from '@grafana/ui';
 import { ManagerKind } from 'app/features/apiserver/types';
-import { useSelector } from 'app/types/store';
 
 import { DashboardsTreeCellProps, SelectionState } from '../types';
 
-import { useSelectionProvisioningStatus } from './BrowseActions/useSelectionProvisioningStatus';
 import { isSharedWithMe, canEditItemType } from './utils';
 
 export default function CheckboxCell({
@@ -20,12 +18,7 @@ export default function CheckboxCell({
 }: DashboardsTreeCellProps) {
   const item = row.item;
 
-  // Get current selection state to check for root folder conflicts
-  const selectedItems = useSelector((state) => state.browseDashboards.selectedItems);
-  const { firstSelectedRootFolder, getItemRootFolder } = useSelectionProvisioningStatus(
-    selectedItems,
-    false // We don't need parent provisioned check for checkbox logic
-  );
+  // We can remove the complex root folder conflict logic for now
 
   if (!isSelected) {
     return <CheckboxSpacer />;
@@ -43,7 +36,7 @@ export default function CheckboxCell({
     return <CheckboxSpacer />;
   }
 
-  // we don't want to select root provisioned folder
+  // We don't want to select root provisioned folder
   const isRootProvisionedFolder = item.managedBy === ManagerKind.Repo && !item.parentUID;
   if (isRootProvisionedFolder) {
     return <CheckboxSpacer />;
@@ -54,14 +47,7 @@ export default function CheckboxCell({
     return <CheckboxSpacer />;
   }
 
-  // Check if this item is from a different root folder than already selected items
-  const itemRootFolder = getItemRootFolder(item);
-  const isFromDifferentRootFolder =
-    firstSelectedRootFolder && itemRootFolder && itemRootFolder !== firstSelectedRootFolder;
-
-  if (isFromDifferentRootFolder) {
-    return <Checkbox disabled value={false} />;
-  }
+  // Simplified: removed complex root folder conflict logic
 
   const state = isSelected(item);
 

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -1,5 +1,6 @@
 import { PayloadAction } from '@reduxjs/toolkit';
 
+import { ManagerKind } from 'app/features/apiserver/types';
 import { DashboardViewItem, DashboardViewItemKind } from 'app/features/search/types';
 
 import { isSharedWithMe } from '../components/utils';
@@ -95,6 +96,11 @@ export function setItemSelectionState(
     return;
   }
 
+  // Prevent selection of root provisioned folders (but allow subitems)
+  if (item.managedBy === ManagerKind.Repo && !item.parentUID) {
+    return;
+  }
+
   // Selecting a folder selects all children, and unselecting a folder deselects all children
   // so propagate the new selection state to all descendants
   function markChildren(kind: DashboardViewItemKind, uid: string) {
@@ -174,6 +180,11 @@ export function setAllSelection(
       for (const child of collection.items) {
         // Don't traverse into the sharedwithme folder
         if (isSharedWithMe(child.uid)) {
+          continue;
+        }
+
+        // Skip entire provisioned repository tree during "select all"
+        if (child.managedBy === ManagerKind.Repo && !child.parentUID) {
           continue;
         }
 

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -96,7 +96,7 @@ export function setItemSelectionState(
     return;
   }
 
-  // Prevent selection of root provisioned folders (but allow subitems)
+  // Prevent selection of root provisioned folders
   if (item.managedBy === ManagerKind.Repo && !item.parentUID) {
     return;
   }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3526,7 +3526,9 @@
       "button-delete": "Delete",
       "button-deleting": "Deleting...",
       "delete-warning": "This will delete selected folders and their descendants. In total, this will affect:",
-      "error-path-not-found": "Path not found"
+      "error-path-not-found": "Path not found",
+      "error-repository-not-found": "Repository not found",
+      "error-repository-not-same": "All selected items must be from the same repository"
     },
     "bulk-move-resources-form": {
       "button-cancel": "Cancel",


### PR DESCRIPTION
**What is this feature?**

- Disables checkboxes when items from different root folders are selected
- Hides checkboxes for root provisioned folders entirely

**Why do we need this feature?**

- Prevents user confusion in bulk move/delete operations

**Who is this feature for?**

Users who use git sync

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/400

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
