### PR TITLE
Plugins: Move AppChrome extension point to top of stack

### DIFF
--- a/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
@@ -1,25 +1,16 @@
-import { useLocation } from 'react-router-dom';
-
 import { PluginExtensionPoints } from '@grafana/data';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
-
-const excludedRoutes: Record<string, boolean> = {
-  '/login': true,
-  '/signup': true,
-  '/verify': true,
-  '/user/password/send-reset-email': true,
-  '/user/password/reset': true,
-  '/sandbox/benchmarks': true,
-};
+import { useGrafana } from 'app/core/context/GrafanaContext';
 
 export function AppChromeExtensionPoint(): JSX.Element | null {
-  const location = useLocation();
+  const { chrome } = useGrafana();
+  const state = chrome.useState();
 
   if (config.featureToggles.enableAppChromeExtensions !== true) {
     return null;
   }
 
-  if (excludedRoutes[location.pathname]) {
+  if (state.chromeless) {
     return null;
   }
 

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -34,6 +34,7 @@ export function RouterWrapper(props: RouterWrapperProps) {
                 <AppChrome>
                   <AppNotificationList />
                   <Stack gap={0} grow={1} direction="column">
+                    <AppChromeExtensionPoint />
                     {props.pageBanners.map((Banner, index) => (
                       <Banner key={index.toString()} />
                     ))}
@@ -42,7 +43,6 @@ export function RouterWrapper(props: RouterWrapperProps) {
                   {props.bodyRenderHooks.map((Hook, index) => (
                     <Hook key={index.toString()} />
                   ))}
-                  <AppChromeExtensionPoint />
                 </AppChrome>
                 <ModalRoot />
               </ModalsContextProvider>


### PR DESCRIPTION
**What is this feature?**

Moves the AppChrome extension point, which was introduced for setupguide-app, to be at the top of the app chrome stack at the same point other page banners are rendered, instead of at the bottom of the app chrome.

**Why do we need this feature?**

To allow us to make use of this extension point to inject global banners (replacing the "old" [event bus mechanism in grafana-enterprise](https://github.com/grafana/grafana-enterprise/blob/main/src/public/banners/PageBanner.tsx) 🔐 used by [cloud-home-app](https://github.com/grafana/hg-cloud-home-admin/blob/main/src/feature/notification-banners/components/InitNotificationBanners.tsx) 🔐), as well as global UI overlays, without relying on a `order: -9999` hack that we're currently using to test this out in [setupguide-app](https://github.com/grafana/grafana-setupguide-app/blob/main/src/components/overlay/banner.tsx) 🔐.

Once we've migrated the in-app Cloud banners from the event bus mechanism in cloud-home-app to this extension point in setupguide-app, the event bus mechanism in grafana-enterprise can be removed, and that will leave the [grafana-enterprise announcement banner](https://github.com/grafana/grafana-enterprise/blob/main/src/public/announcement-banner/index.ts) 🔐 as the only feature utilising `pageBanners` in the app chrome.

**Who is this feature for?**

setupguide-app Cloud plugin.

**Which issue(s) does this PR fix?**:

Resolves https://github.com/grafana/OGPM/issues/303 🔐

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
