### PR TITLE
K8s: Add API Enablement for apps

### DIFF
--- a/pkg/registry/apps/playlist/register.go
+++ b/pkg/registry/apps/playlist/register.go
@@ -26,7 +26,6 @@ import (
 var (
 	_ appsdkapiserver.AppInstaller       = (*PlaylistAppInstaller)(nil)
 	_ appinstaller.LegacyStorageProvider = (*PlaylistAppInstaller)(nil)
-	_ appinstaller.APIEnablementProvider = (*PlaylistAppInstaller)(nil)
 )
 
 type PlaylistAppInstaller struct {
@@ -101,11 +100,4 @@ func (p *PlaylistAppInstaller) GetLegacyStorage(requested schema.GroupVersionRes
 		},
 	)
 	return legacyStore
-}
-
-// GetAllowedV0Alpha1Resources returns the list of resources that are allowed to be accessed in v0alpha1.
-func (p *PlaylistAppInstaller) GetAllowedV0Alpha1Resources() []string {
-	return []string{
-		playlistv0alpha1.PlaylistKind().Plural(),
-	}
 }

--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -8,17 +8,19 @@ import (
 
 	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
 	"github.com/grafana/grafana-app-sdk/logging"
-	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	grafanaapiserveroptions "github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
+	serverstore "k8s.io/apiserver/pkg/server/storage"
 	"k8s.io/kube-openapi/pkg/common"
+
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	grafanaapiserveroptions "github.com/grafana/grafana/pkg/services/apiserver/options"
 )
 
 type LegacyStorageGetterFunc func(schema.GroupVersionResource) grafanarest.Storage
@@ -29,13 +31,6 @@ type LegacyStorageProvider interface {
 
 type AuthorizerProvider interface {
 	GetAuthorizer() authorizer.Authorizer
-}
-
-type APIEnablementProvider interface {
-	// Do not implement this unless you have special circumstances! This is a list of resources that are allowed to be accessed in v0alpha1,
-	// to prevent accidental exposure of experimental APIs. While developing, use the feature flag `grafanaAPIServerWithExperimentalAPIs`.
-	// And then, when you're ready to expose this to the end user, go to v1beta1 instead.
-	GetAllowedV0Alpha1Resources() []string
 }
 
 type AppInstallerConfig struct {
@@ -132,6 +127,7 @@ func InstallAPIs(
 	dualWriteService dualwrite.Service,
 	dualWriterMetrics *grafanarest.DualWriterMetrics,
 	builderMetrics *builder.BuilderMetrics,
+	apiResourceConfig *serverstore.ResourceConfig,
 ) error {
 	logger := logging.FromContext(ctx)
 	for _, installer := range appInstallers {
@@ -148,6 +144,7 @@ func InstallAPIs(
 			dualWriteService:  dualWriteService,
 			dualWriterMetrics: dualWriterMetrics,
 			builderMetrics:    builderMetrics,
+			apiResourceConfig: apiResourceConfig,
 		}
 		if err := installer.InstallAPIs(wrapper, restOpsGetter); err != nil {
 			return fmt.Errorf("failed to install APIs for app %s: %w", installer.ManifestData().AppName, err)

--- a/pkg/services/apiserver/appinstaller/resourceconfig.go
+++ b/pkg/services/apiserver/appinstaller/resourceconfig.go
@@ -1,0 +1,32 @@
+package appinstaller
+
+import (
+	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	serverstorage "k8s.io/apiserver/pkg/server/storage"
+)
+
+func NewAPIResourceConfig(installers []appsdkapiserver.AppInstaller) *serverstorage.ResourceConfig {
+	ret := serverstorage.NewResourceConfig()
+	enable := []schema.GroupVersion{}
+	disable := []schema.GroupVersion{}
+
+	for _, installer := range installers {
+		for _, version := range installer.ManifestData().Versions {
+			gv := schema.GroupVersion{
+				Group:   installer.ManifestData().Group,
+				Version: version.Name,
+			}
+			if version.Served {
+				enable = append(enable, gv)
+			} else {
+				disable = append(disable, gv)
+			}
+		}
+	}
+
+	ret.EnableVersions(enable...)
+	ret.DisableVersions(disable...)
+
+	return ret
+}

--- a/pkg/services/apiserver/config.go
+++ b/pkg/services/apiserver/config.go
@@ -39,6 +39,13 @@ func applyGrafanaConfig(cfg *setting.Cfg, features featuremgmt.FeatureToggles, o
 
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
 
+	runtimeConfig := apiserverCfg.Key("runtime_config").String()
+	if runtimeConfig != "" {
+		if err := o.APIEnablementOptions.RuntimeConfig.Set(runtimeConfig); err != nil {
+			return fmt.Errorf("failed to set runtime config: %w", err)
+		}
+	}
+
 	o.RecommendedOptions.Etcd.StorageConfig.Transport.ServerList = apiserverCfg.Key("etcd_servers").Strings(",")
 
 	o.RecommendedOptions.SecureServing.BindAddress = ip

--- a/pkg/services/apiserver/options/options.go
+++ b/pkg/services/apiserver/options/options.go
@@ -21,6 +21,7 @@ const defaultEtcdPathPrefix = "/registry/grafana.app"
 
 type Options struct {
 	RecommendedOptions       *genericoptions.RecommendedOptions
+	APIEnablementOptions     *genericoptions.APIEnablementOptions
 	GrafanaAggregatorOptions *GrafanaAggregatorOptions
 	StorageOptions           *StorageOptions
 	ExtraOptions             *ExtraOptions
@@ -30,6 +31,7 @@ type Options struct {
 func NewOptions(codec runtime.Codec) *Options {
 	return &Options{
 		RecommendedOptions:       NewRecommendedOptions(codec),
+		APIEnablementOptions:     genericoptions.NewAPIEnablementOptions(),
 		GrafanaAggregatorOptions: NewGrafanaAggregatorOptions(),
 		StorageOptions:           NewStorageOptions(),
 		ExtraOptions:             NewExtraOptions(),
@@ -38,6 +40,7 @@ func NewOptions(codec runtime.Codec) *Options {
 
 func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	o.RecommendedOptions.AddFlags(fs)
+	o.APIEnablementOptions.AddFlags(fs)
 	o.GrafanaAggregatorOptions.AddFlags(fs)
 	o.StorageOptions.AddFlags(fs)
 	o.ExtraOptions.AddFlags(fs)

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -304,8 +304,16 @@ func (s *service) start(ctx context.Context) error {
 		return errs[0]
 	}
 
+	if errs := o.APIEnablementOptions.Validate(s.scheme); len(errs) != 0 {
+		return errs[0]
+	}
+
 	serverConfig := genericapiserver.NewRecommendedConfig(s.codecs)
 	if err := o.ApplyTo(serverConfig); err != nil {
+		return err
+	}
+
+	if err := o.APIEnablementOptions.ApplyTo(&serverConfig.Config, appinstaller.NewAPIResourceConfig(s.appInstallers), s.scheme); err != nil {
 		return err
 	}
 
@@ -395,6 +403,7 @@ func (s *service) start(ctx context.Context) error {
 		s.storageStatus,
 		s.dualWriterMetrics,
 		s.builderMetrics,
+		serverConfig.MergedResourceConfig,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds support for API Enablement for apps that are registered with app installers. The default behavior is driven by the `Served` property in the app's manifest.

API Enablement options are normally controlled with `--runtime-config` in `kube-apiserver`.

```
--runtime-config <comma-separated 'key=value' pairs>
A set of key=value pairs that enable or disable built-in APIs. Supported options are:
v1=true|false for the core API group
<group>/<version>=true|false for a specific API group and version (e.g. apps/v1=true)
api/all=true|false controls all API versions
api/ga=true|false controls all API versions of the form v[0-9]+
api/beta=true|false controls all API versions of the form v[0-9]+beta[0-9]+
api/alpha=true|false controls all API versions of the form v[0-9]+alpha[0-9]+
api/legacy is deprecated, and will be removed in a future version
```

The same format can be used to set the options in `grafana.ini`:
```ini
[grafana-apiserver]
runtime_config = playlist.grafana.app/v0alpha1=false
```

**Why do we need this feature?**

To make it easier to control the APIs that are exposed at runtime without a complex set of feature toggles.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
