### PR TITLE
feat: compare legacy and unified search results via histogram

### DIFF
--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -62,22 +62,22 @@ type searchWrapper struct {
 }
 
 // extractUIDs extracts unique UIDs from search response results
-func extractUIDs(response *resourcepb.ResourceSearchResponse) map[string]bool {
-	uids := make(map[string]bool)
+func extractUIDs(response *resourcepb.ResourceSearchResponse) map[string]struct{} {
+	uids := make(map[string]struct{})
 	if response == nil || response.Results == nil || response.Results.Rows == nil {
 		return uids
 	}
 
 	for _, row := range response.Results.Rows {
 		if row.Key != nil && row.Key.Name != "" {
-			uids[row.Key.Name] = true
+			uids[row.Key.Name] = struct{}{}
 		}
 	}
 	return uids
 }
 
 // calculateMatchPercentage calculates the percentage of matching UIDs between two result sets
-func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]bool) float64 {
+func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]struct{}) float64 {
 	if len(legacyUIDs) == 0 && len(unifiedUIDs) == 0 {
 		return 100.0 // Both empty, consider as 100% match
 	}
@@ -88,7 +88,7 @@ func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]bool) float64 {
 	// Count matches
 	matches := 0
 	for uid := range legacyUIDs {
-		if unifiedUIDs[uid] {
+		if _, exists := unifiedUIDs[uid]; exists {
 			matches++
 		}
 	}
@@ -96,7 +96,7 @@ func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]bool) float64 {
 	// Calculate percentage based on the union of both sets
 	totalUnique := len(legacyUIDs)
 	for uid := range unifiedUIDs {
-		if !legacyUIDs[uid] {
+		if _, exists := legacyUIDs[uid]; !exists {
 			totalUnique++
 		}
 	}

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -175,7 +175,11 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 				s.logger.Debug("Background Search call to unified succeeded")
 
 				// Compare results when both are successful
-				s.compareSearchResults(legacyResponse, unifiedResponse, in.Options.Key)
+				var requestKey *resourcepb.ResourceKey
+				if in.Options != nil {
+					requestKey = in.Options.Key
+				}
+				s.compareSearchResults(legacyResponse, unifiedResponse, requestKey)
 			}
 		}()
 
@@ -196,7 +200,11 @@ func (s *searchWrapper) compareSearchResults(legacyResponse, unifiedResponse *re
 
 	matchPercentage := calculateMatchPercentage(legacyUIDs, unifiedUIDs)
 
-	resourceType := requestKey.Resource
+	// Determine resource type for labeling - handle nil safely
+	resourceType := "unknown"
+	if requestKey != nil && requestKey.Resource != "" {
+		resourceType = requestKey.Resource
+	}
 
 	s.logger.Debug("Search results comparison completed",
 		"resource_type", resourceType,

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -2,8 +2,11 @@ package resource
 
 import (
 	"context"
+	"fmt"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -15,6 +18,20 @@ import (
 const (
 	// backgroundRequestTimeout is the timeout for background shadow traffic requests
 	backgroundRequestTimeout = 500 * time.Millisecond
+)
+
+var (
+	// searchResultsMatchHistogram tracks the percentage match between legacy and unified search results
+	searchResultsMatchHistogram = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "grafana",
+			Subsystem: "unified_storage",
+			Name:      "search_results_match_percentage",
+			Help:      "Histogram of percentage match between legacy and unified search results",
+			Buckets:   []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+		},
+		[]string{"resource_type"},
+	)
 )
 
 type DualWriter interface {
@@ -42,6 +59,53 @@ type searchWrapper struct {
 	legacyClient  resourcepb.ResourceIndexClient
 	features      featuremgmt.FeatureToggles
 	logger        log.Logger
+}
+
+// extractUIDs extracts unique UIDs from search response results
+func extractUIDs(response *resourcepb.ResourceSearchResponse) map[string]bool {
+	uids := make(map[string]bool)
+	if response == nil || response.Results == nil || response.Results.Rows == nil {
+		return uids
+	}
+
+	for _, row := range response.Results.Rows {
+		if row.Key != nil && row.Key.Name != "" {
+			uids[row.Key.Name] = true
+		}
+	}
+	return uids
+}
+
+// calculateMatchPercentage calculates the percentage of matching UIDs between two result sets
+func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]bool) float64 {
+	if len(legacyUIDs) == 0 && len(unifiedUIDs) == 0 {
+		return 100.0 // Both empty, consider as 100% match
+	}
+	if len(legacyUIDs) == 0 || len(unifiedUIDs) == 0 {
+		return 0.0 // One empty, other not
+	}
+
+	// Count matches
+	matches := 0
+	for uid := range legacyUIDs {
+		if unifiedUIDs[uid] {
+			matches++
+		}
+	}
+
+	// Calculate percentage based on the union of both sets
+	totalUnique := len(legacyUIDs)
+	for uid := range unifiedUIDs {
+		if !legacyUIDs[uid] {
+			totalUnique++
+		}
+	}
+
+	if totalUnique == 0 {
+		return 100.0
+	}
+
+	return float64(matches) / float64(totalUnique) * 100.0
 }
 
 func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest,
@@ -89,23 +153,59 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 	}
 
 	// If dual reader feature flag is enabled, and legacy is the main storage,
-	// make a background call to unified
+	// make a background call to unified and compare results
 	if s.features != nil && s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) && !unified {
+		// Get the legacy result first
+		legacyResponse, legacyErr := s.legacyClient.Search(ctx, in, opts...)
+		if legacyErr != nil {
+			return nil, legacyErr
+		}
+
 		// Create background context with timeout but ignore parent cancelation
 		ctxBg := context.WithoutCancel(ctx)
 		ctxBgWithTimeout, cancel := context.WithTimeout(ctxBg, backgroundRequestTimeout)
 
-		// Make background call without blocking the main request
+		// Make background call and compare results
 		go func() {
 			defer cancel() // Ensure we clean up the context
-			_, bgErr := s.unifiedClient.Search(ctxBgWithTimeout, in, opts...)
+			unifiedResponse, bgErr := s.unifiedClient.Search(ctxBgWithTimeout, in, opts...)
 			if bgErr != nil {
 				s.logger.Error("Background Search call to unified failed", "error", bgErr, "timeout", backgroundRequestTimeout)
 			} else {
 				s.logger.Debug("Background Search call to unified succeeded")
+
+				// Compare results when both are successful
+				s.compareSearchResults(legacyResponse, unifiedResponse, in.Options.Key)
 			}
 		}()
+
+		return legacyResponse, nil
 	}
 
 	return client.Search(ctx, in, opts...)
+}
+
+// compareSearchResults compares legacy and unified search results and logs/metrics the outcome
+func (s *searchWrapper) compareSearchResults(legacyResponse, unifiedResponse *resourcepb.ResourceSearchResponse, requestKey *resourcepb.ResourceKey) {
+	if legacyResponse == nil || unifiedResponse == nil {
+		return
+	}
+
+	legacyUIDs := extractUIDs(legacyResponse)
+	unifiedUIDs := extractUIDs(unifiedResponse)
+
+	matchPercentage := calculateMatchPercentage(legacyUIDs, unifiedUIDs)
+
+	resourceType := requestKey.Resource
+
+	s.logger.Debug("Search results comparison completed",
+		"resource_type", resourceType,
+		"legacy_count", len(legacyUIDs),
+		"unified_count", len(unifiedUIDs),
+		"match_percentage", fmt.Sprintf("%.1f%%", matchPercentage),
+		"legacy_total_hits", legacyResponse.TotalHits,
+		"unified_total_hits", unifiedResponse.TotalHits,
+	)
+
+	searchResultsMatchHistogram.WithLabelValues(resourceType).Observe(matchPercentage)
 }

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -452,7 +452,7 @@ func TestExtractUIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]struct{}{"test-uid-1": struct{}{}},
+			expected: map[string]struct{}{"test-uid-1": {}},
 		},
 		{
 			name: "multiple results",
@@ -472,7 +472,7 @@ func TestExtractUIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]struct{}{"test-uid-1": struct{}{}, "test-uid-2": struct{}{}},
+			expected: map[string]struct{}{"test-uid-1": {}, "test-uid-2": {}},
 		},
 	}
 
@@ -500,38 +500,38 @@ func TestCalculateMatchPercentage(t *testing.T) {
 		{
 			name:        "legacy empty, unified has results",
 			legacyUIDs:  map[string]struct{}{},
-			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}},
+			unifiedUIDs: map[string]struct{}{"uid1": {}},
 			expected:    0.0,
 		},
 		{
 			name:        "legacy has results, unified empty",
-			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}},
+			legacyUIDs:  map[string]struct{}{"uid1": {}},
 			unifiedUIDs: map[string]struct{}{},
 			expected:    0.0,
 		},
 		{
 			name:        "perfect match",
-			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
-			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
+			legacyUIDs:  map[string]struct{}{"uid1": {}, "uid2": {}},
+			unifiedUIDs: map[string]struct{}{"uid1": {}, "uid2": {}},
 			expected:    100.0,
 		},
 		{
 			name:        "partial match",
-			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
-			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid3": struct{}{}},
-			expected:    33.33333333333333, // 1 match out of 3 unique UIDs
+			legacyUIDs:  map[string]struct{}{"uid1": {}, "uid2": {}},
+			unifiedUIDs: map[string]struct{}{"uid1": {}, "uid3": {}},
+			expected:    50.0, // 1 match out of 2 legacy UIDs (recall)
 		},
 		{
 			name:        "no match",
-			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
-			unifiedUIDs: map[string]struct{}{"uid3": struct{}{}, "uid4": struct{}{}},
+			legacyUIDs:  map[string]struct{}{"uid1": {}, "uid2": {}},
+			unifiedUIDs: map[string]struct{}{"uid3": {}, "uid4": {}},
 			expected:    0.0,
 		},
 		{
 			name:        "legacy subset of unified",
-			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}},
-			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
-			expected:    50.0, // 1 match out of 2 unique UIDs
+			legacyUIDs:  map[string]struct{}{"uid1": {}},
+			unifiedUIDs: map[string]struct{}{"uid1": {}, "uid2": {}},
+			expected:    100.0, // 1 match out of 1 legacy UID (perfect recall)
 		},
 	}
 

--- a/pkg/storage/unified/resource/search_client_test.go
+++ b/pkg/storage/unified/resource/search_client_test.go
@@ -423,12 +423,12 @@ func TestExtractUIDs(t *testing.T) {
 	tests := []struct {
 		name     string
 		response *resourcepb.ResourceSearchResponse
-		expected map[string]bool
+		expected map[string]struct{}
 	}{
 		{
 			name:     "nil response",
 			response: nil,
-			expected: map[string]bool{},
+			expected: map[string]struct{}{},
 		},
 		{
 			name: "empty results",
@@ -437,7 +437,7 @@ func TestExtractUIDs(t *testing.T) {
 					Rows: []*resourcepb.ResourceTableRow{},
 				},
 			},
-			expected: map[string]bool{},
+			expected: map[string]struct{}{},
 		},
 		{
 			name: "single result",
@@ -452,7 +452,7 @@ func TestExtractUIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]bool{"test-uid-1": true},
+			expected: map[string]struct{}{"test-uid-1": struct{}{}},
 		},
 		{
 			name: "multiple results",
@@ -472,7 +472,7 @@ func TestExtractUIDs(t *testing.T) {
 					},
 				},
 			},
-			expected: map[string]bool{"test-uid-1": true, "test-uid-2": true},
+			expected: map[string]struct{}{"test-uid-1": struct{}{}, "test-uid-2": struct{}{}},
 		},
 	}
 
@@ -487,50 +487,50 @@ func TestExtractUIDs(t *testing.T) {
 func TestCalculateMatchPercentage(t *testing.T) {
 	tests := []struct {
 		name        string
-		legacyUIDs  map[string]bool
-		unifiedUIDs map[string]bool
+		legacyUIDs  map[string]struct{}
+		unifiedUIDs map[string]struct{}
 		expected    float64
 	}{
 		{
 			name:        "both empty",
-			legacyUIDs:  map[string]bool{},
-			unifiedUIDs: map[string]bool{},
+			legacyUIDs:  map[string]struct{}{},
+			unifiedUIDs: map[string]struct{}{},
 			expected:    100.0,
 		},
 		{
 			name:        "legacy empty, unified has results",
-			legacyUIDs:  map[string]bool{},
-			unifiedUIDs: map[string]bool{"uid1": true},
+			legacyUIDs:  map[string]struct{}{},
+			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}},
 			expected:    0.0,
 		},
 		{
 			name:        "legacy has results, unified empty",
-			legacyUIDs:  map[string]bool{"uid1": true},
-			unifiedUIDs: map[string]bool{},
+			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}},
+			unifiedUIDs: map[string]struct{}{},
 			expected:    0.0,
 		},
 		{
 			name:        "perfect match",
-			legacyUIDs:  map[string]bool{"uid1": true, "uid2": true},
-			unifiedUIDs: map[string]bool{"uid1": true, "uid2": true},
+			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
+			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
 			expected:    100.0,
 		},
 		{
 			name:        "partial match",
-			legacyUIDs:  map[string]bool{"uid1": true, "uid2": true},
-			unifiedUIDs: map[string]bool{"uid1": true, "uid3": true},
+			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
+			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid3": struct{}{}},
 			expected:    33.33333333333333, // 1 match out of 3 unique UIDs
 		},
 		{
 			name:        "no match",
-			legacyUIDs:  map[string]bool{"uid1": true, "uid2": true},
-			unifiedUIDs: map[string]bool{"uid3": true, "uid4": true},
+			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
+			unifiedUIDs: map[string]struct{}{"uid3": struct{}{}, "uid4": struct{}{}},
 			expected:    0.0,
 		},
 		{
 			name:        "legacy subset of unified",
-			legacyUIDs:  map[string]bool{"uid1": true},
-			unifiedUIDs: map[string]bool{"uid1": true, "uid2": true},
+			legacyUIDs:  map[string]struct{}{"uid1": struct{}{}},
+			unifiedUIDs: map[string]struct{}{"uid1": struct{}{}, "uid2": struct{}{}},
 			expected:    50.0, // 1 match out of 2 unique UIDs
 		},
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When `unifiedStorageSearchDualReaderEnabled` is turned on, results from legacy and unified search are compared in the background. The percentage match is then aggregated into a histogram metric.

**Why do we need this feature?**

It's important to be able to compare quality of results returned by unified search, not just response time and latency.

**Who is this feature for?**

Grafana Search & Storage

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/414

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
