### PR TITLE
Secrets: Simplify CanReference interface to only pass secure value names

### DIFF
--- a/pkg/registry/apis/secret/contracts/inline.go
+++ b/pkg/registry/apis/secret/contracts/inline.go
@@ -7,8 +7,8 @@ import (
 )
 
 type InlineSecureValueSupport interface {
-	// Check that the request user can reference a secret in the context of a given resource (owner)
-	CanReference(ctx context.Context, owner common.ObjectReference, values common.InlineSecureValues) error
+	// Check that the request user can reference secure value names in the context of a given resource (owner)
+	CanReference(ctx context.Context, owner common.ObjectReference, names ...string) error
 
 	// CreateInline creates a secret that is owned by the referenced object
 	// returns the name of the created secret or an error


### PR DESCRIPTION
**What is this feature?**

We don't need the whole object of `common.InlineSecureValues` since only those with `name` are acceptable anyways, so we can simplify to accept just the names.

**Why do we need this feature?**

Simplifying interface in face of Protobuf+gRPC! 

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1480

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
