### PR TITLE
Alerting: List V2 - datasource icons for rules

### DIFF
--- a/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
@@ -53,6 +53,7 @@ export function GrafanaRuleListItem({
     isPaused: rule?.isPaused,
     application: 'grafana' as const,
     actions: <RuleActionsButtons promRule={rule} groupIdentifier={groupIdentifier} compact />,
+    querySourceUIDs: rule?.queriedDatasourceUIDs,
   };
 
   if (prometheusRuleType.grafana.alertingRule(rule)) {

--- a/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
@@ -39,7 +39,7 @@ export const ListItem = (props: ListItemProps) => {
           </Stack>
 
           {/* metadata */}
-          <Stack direction="row" gap={0.5} alignItems="center">
+          <Stack direction="row" gap={1} alignItems="center">
             {meta?.map((item, index) => (
               <React.Fragment key={index}>
                 {index > 0 && <Separator />}
@@ -72,7 +72,7 @@ export const SkeletonListItem = () => {
 
 const Separator = () => (
   <Text color="secondary" variant="bodySmall">
-    {'·'}
+    {'|'}
   </Text>
 );
 


### PR DESCRIPTION
This pull request introduces changes to enhance the display of metadata in alerting rule list items by adding support for data source icons and improving the visual layout. The most important changes include the addition of `QuerySourceIcons` to display queried data sources, updates to the `ListItem` component for better metadata separation, and the introduction of a reusable `DataSourceLogo` component.

<img width="557" height="334" alt="image" src="https://github.com/user-attachments/assets/279faf7c-1660-4f45-aa5c-ea1744737540" />


### Enhancements to Metadata Display:
* Added a new `QuerySourceIcons` component to display icons for queried data sources in the metadata section. This component deduplicates data source UIDs and uses tooltips to show data source names. (`[public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsxR307-R329](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R307-R329)`)
* Included `querySourceUIDs` as a new prop in `AlertRuleListItemProps` and `RecordingRuleListItemProps`, allowing metadata to display queried data sources when provided. (`[[1]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R52)`, `[[2]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R79)`, `[[3]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R99-R102)`, `[[4]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R188)`, `[[5]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R205-R208)`)

### Visual Improvements:
* Updated the `ListItem` component to use a pipe (`|`) separator instead of a dot (`·`) for better visual distinction between metadata items. (`[public/app/features/alerting/unified/rule-list/components/ListItem.tsxL75-R75](diffhunk://#diff-cf3f32cce00fda0d4bb7b0b303ca2b1904b791dba7f522a63fe53d9d803d091cL75-R75)`)
* Adjusted the spacing in the `ListItem` metadata stack to improve readability. (`[public/app/features/alerting/unified/rule-list/components/ListItem.tsxL42-R42](diffhunk://#diff-cf3f32cce00fda0d4bb7b0b303ca2b1904b791dba7f522a63fe53d9d803d091cL42-R42)`)

### Reusable Components:
* Introduced a `DataSourceLogo` component to render data source logos with consistent styling, including support for light and dark themes. (`[public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsxR454-R483](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82R454-R483)`)

### Codebase Refinements:
* Added new imports (`cx`, `DataSourceInstanceSettings`, and `getDataSourceByUid`) to support the new functionality. (`[[1]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82L1-R5)`, `[[2]](diffhunk://#diff-8173c287466af2530acb215830e6e8fb6b94d9525eaadffd9ddc6e61fbb58b82L16-R16)`)