### PR TITLE
Fix: Preserve Jaeger base path when constructing search request

### DIFF
--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -115,7 +115,7 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 }
 
 func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) ([]TraceResponse, error) {
-	u, err := url.JoinPath(j.url, "api/traces")
+	u, err := url.JoinPath(j.url, "/api/traces")
 	if err != nil {
 		return []TraceResponse{}, fmt.Errorf("failed to parse Jaeger URL: %w", err)
 	}

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -117,7 +117,7 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) ([]TraceResponse, error) {
 	u, err := url.JoinPath(j.url, "/api/traces")
 	if err != nil {
-		return []TraceResponse{}, fmt.Errorf("failed to parse Jaeger URL: %w", err)
+		return []TraceResponse{}, fmt.Errorf("failed to join url path: %w", err)
 	}
 
 	jaegerURL, err := url.Parse(u)

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -115,11 +115,15 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 }
 
 func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) ([]TraceResponse, error) {
-	jaegerURL, err := url.Parse(j.url)
+	u, err := url.JoinPath(j.url, "api/traces")
 	if err != nil {
 		return []TraceResponse{}, fmt.Errorf("failed to parse Jaeger URL: %w", err)
 	}
-	jaegerURL.Path = "/api/traces"
+
+	jaegerURL, err := url.Parse(u)
+	if err != nil {
+		return []TraceResponse{}, fmt.Errorf("failed to parse Jaeger URL: %w", err)
+	}
 
 	var queryTags string
 	if query.Tags != "" {

--- a/pkg/tsdb/jaeger/client.go
+++ b/pkg/tsdb/jaeger/client.go
@@ -117,12 +117,12 @@ func (j *JaegerClient) Operations(s string) ([]string, error) {
 func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) ([]TraceResponse, error) {
 	u, err := url.JoinPath(j.url, "/api/traces")
 	if err != nil {
-		return []TraceResponse{}, fmt.Errorf("failed to join url path: %w", err)
+		return []TraceResponse{}, backend.DownstreamError(fmt.Errorf("failed to join url path: %w", err))
 	}
 
 	jaegerURL, err := url.Parse(u)
 	if err != nil {
-		return []TraceResponse{}, fmt.Errorf("failed to parse Jaeger URL: %w", err)
+		return []TraceResponse{}, backend.DownstreamError(fmt.Errorf("failed to parse Jaeger URL: %w", err))
 	}
 
 	var queryTags string
@@ -139,7 +139,7 @@ func (j *JaegerClient) Search(query *JaegerQuery, start, end int64) ([]TraceResp
 
 		marshaledTags, err := json.Marshal(tagMap)
 		if err != nil {
-			return []TraceResponse{}, fmt.Errorf("failed to convert tags to JSON: %w", err)
+			return []TraceResponse{}, backend.DownstreamError(fmt.Errorf("failed to convert tags to JSON: %w", err))
 		}
 
 		queryTags = string(marshaledTags)

--- a/pkg/tsdb/jaeger/client_test.go
+++ b/pkg/tsdb/jaeger/client_test.go
@@ -187,6 +187,19 @@ func TestJaegerClient_Search(t *testing.T) {
 		expectedError  error
 	}{
 		{
+			name: "Preserves base path in Jaeger URL",
+			query: &JaegerQuery{
+				Service: "test-service",
+			},
+			start:          1735689600000000,
+			end:            1738368000000000,
+			mockResponse:   `{"data":[{"traceID":"test-trace-id"}]}`,
+			mockStatusCode: http.StatusOK,
+			expectedURL:    "/abc/api/traces?end=1738368000000000&service=test-service&start=1735689600000000",
+			expectError:    false,
+			expectedError:  nil,
+		},
+		{
 			name: "Successful search with all parameters",
 			query: &JaegerQuery{
 				Service:     "test-service",
@@ -245,6 +258,11 @@ func TestJaegerClient_Search(t *testing.T) {
 			settings := backend.DataSourceInstanceSettings{
 				URL: server.URL,
 			}
+
+			if tt.name == "Preserves base path in Jaeger URL" {
+				settings.URL = server.URL + "/abc"
+			}
+
 			client, err := New(server.Client(), log.NewNullLogger(), settings)
 			assert.NoError(t, err)
 			traces, err := client.Search(tt.query, tt.start, tt.end)


### PR DESCRIPTION
this pr fixes https://github.com/grafana/grafana/issues/108651, where jaeger search requests fail if the configured data source url include a subpath.

before this fix:
a url like `http://localhost:1234/abc/` would become `http://localhost:1234/api/traces`, losing the `/abc/` subpath.

this has been fixed by using `url.JoinPath` to correctly append the `/api/traces` segment, preserving any existing path. the url now resolves properly as: `http://localhost:1234/abc/api/traces`