### PR TITLE
Fix: Adding sparse checkout to issue triage workflow

### DIFF
--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -88,7 +88,12 @@ jobs:
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
           permission-members: read
           permission-issues: write
-
+      - name: Checkout
+        uses: actions/checkout@v4 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/auto-triager
       - name: Check if member of grafana org
         id: check-if-grafana-org-member
         continue-on-error: true

--- a/.github/workflows/issue-opened.yml
+++ b/.github/workflows/issue-opened.yml
@@ -88,12 +88,6 @@ jobs:
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
           permission-members: read
           permission-issues: write
-      - name: Checkout
-        uses: actions/checkout@v4 # v4.2.2
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            .github/workflows/auto-triager
       - name: Check if member of grafana org
         id: check-if-grafana-org-member
         continue-on-error: true
@@ -101,6 +95,13 @@ jobs:
         env:
             GH_TOKEN: ${{ steps.generate_token.outputs.token }}
             ACTOR: ${{ github.actor }}
+      - name: Checkout
+        if: steps.check-if-grafana-org-member.outputs.is_grafana_org_member != 'true' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'OWNER'
+        uses: actions/checkout@v4 # v4.2.2
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows/auto-triager
       - name: Send issue to the auto triager action
         id: auto_triage
         if: steps.check-if-grafana-org-member.outputs.is_grafana_org_member != 'true' && github.event.issue.author_association != 'MEMBER' && github.event.issue.author_association != 'OWNER'


### PR DESCRIPTION
Fixing issue triage failures like this https://github.com/grafana/grafana/actions/runs/16672755321/job/47192695492#step:5:298

Broken by https://github.com/grafana/grafana/pull/108578