### PR TITLE
RowsLayoutManager: Fix moving row with repeats present and add undo/redo action

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -23,13 +23,15 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
     useIsConditionallyHidden(model);
   const { isSelected, onSelect, isSelectable } = useElementSelection(key);
   const title = useInterpolatedTitle(model);
-  const { rows } = model.getParentLayout().useState();
   const styles = useStyles2(getStyles);
   const clearStyles = useStyles2(clearButtonStyles);
   const isTopLevel = model.parent?.parent instanceof DashboardScene;
   const pointerDistance = usePointerDistance();
 
-  const myIndex = rows.findIndex((row) => row === model);
+  const myIndex = model
+    .getParentLayout()
+    .getRowsWithRepeats()
+    .findIndex((row) => row === model);
 
   const shouldGrow = !isCollapsed && fillScreen;
   const isHidden = isConditionallyHidden && !isEditing;


### PR DESCRIPTION
After recent row repeats rework repeated rows would have drag and drop index of `-1` which would break row moving logic. 

Changes:
Adjusted indexes of repeated rows
Adjusted `moveRow()` functionality to account for repeats and find original rows when moving
Added undo/redo action for moving rows