### PR TITLE
Annotations: Optimize Get queries

### DIFF
--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -100,7 +100,6 @@ func addAnnotationMig(mg *Migrator) {
 		},
 		Indices: []*Index{
 			{Cols: []string{"annotation_id", "tag_id"}, Type: UniqueIndex},
-			{Cols: []string{"tag_id", "annotation_id"}, Type: UniqueIndex},
 		},
 	}
 
@@ -200,6 +199,10 @@ func addAnnotationMig(mg *Migrator) {
 	}))
 
 	mg.AddMigration("Add missing dashboard_uid to annotation table", &SetDashboardUIDMigration{})
+
+	mg.AddMigration("Add an additional index (tag_id, annotation_id) to the annotation_tag table", NewAddIndexMigration(annotationTagTableV3, &Index{
+		Cols: []string{"tag_id", "annotation_id"}, Type: UniqueIndex,
+	}))
 }
 
 type AddMakeRegionSingleRowMigration struct {

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -100,6 +100,7 @@ func addAnnotationMig(mg *Migrator) {
 		},
 		Indices: []*Index{
 			{Cols: []string{"annotation_id", "tag_id"}, Type: UniqueIndex},
+			{Cols: []string{"tag_id", "annotation_id"}, Type: UniqueIndex},
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

This pull request adds a new index for `annotation_tag` table and modifies the query used for getting annotations. The main change ensures annotation queries are more efficient and accurate by utilizing the new index.

**Why do we need this feature?**

We have approximately the following data size per every month:

`1M` annotations (in `annotation` table)
`50K` tags (in `tag` table)
`7M` connections between annotations and tags (in `annotation_tag` table)
_On average, each annotation has 7 tags, resulting in about 7M relationships._

With this amount of data, we encountered the issue that the current annotation retrieval implementation puts a heavy load on the database cluster.
The reason is that the current implementation uses a `DEPENDENT SUBQUERY` pattern. The proposed implementation uses several `JOIN`s with `GROUP BY` and `HAVING(DISTINCT)`, which is more efficient.

For comparison, a single query with certain filters in the current implementation takes 30 seconds, while in the new one it takes 200 milliseconds.

**Who is this feature for?**

For installations with a large number of unique annotations/tags that are experiencing annotation performance issues

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Current implementation generates query like this:
```sql
SELECT
        annotation.id,
        annotation.epoch as time,
        annotation.epoch_end as time_end,
        annotation.dashboard_uid,
        annotation.dashboard_id,
        annotation.panel_id,
        annotation.new_state,
        annotation.prev_state,
        annotation.alert_id,
        annotation.text,
        annotation.tags,
        annotation.data,
        annotation.created,
        annotation.updated,
        usr.email,
        usr.login,
        r.title as alert_name
FROM annotation
LEFT OUTER JOIN `user` as usr on usr.id = annotation.user_id
LEFT OUTER JOIN alert_rule as r on r.id = annotation.alert_id
INNER JOIN (
        SELECT a.id from annotation a
        WHERE a.org_id = ? AND a.user_id = ? AND a.epoch <= ? AND a.epoch_end >= ? AND a.alert_id = 0 AND (
                SELECT SUM(1) FROM annotation_tag `at`
                INNER JOIN tag on tag.id = `at`.tag_id
                WHERE `at`.annotation_id = a.id AND (
                        (tag.key = ? OR tag.key = ?)
                )
        ) = 2
        ORDER BY a.org_id, a.epoch_end DESC, a.epoch DESC LIMIT ?
) dt on dt.id = annotation.id
```

Which `EXPLAIN` looks like:
```
+----+--------------------+------------+------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+--------+----------+---------------------------------------------------------+
| id | select_type        | table      | partitions | type   | possible_keys                                                                                                                                                                                                                          | key                                     | key_len | ref                                           | rows   | filtered | Extra                                                   |
+----+--------------------+------------+------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+--------+----------+---------------------------------------------------------+
|  1 | PRIMARY            | <derived2> | NULL       | ALL    | NULL                                                                                                                                                                                                                                   | NULL                                    | NULL    | NULL                                          |     10 |   100.00 | NULL                                                    |
|  1 | PRIMARY            | annotation | NULL       | eq_ref | PRIMARY                                                                                                                                                                                                                                | PRIMARY                                 | 8       | dt.id                                         |      1 |   100.00 | NULL                                                    |
|  1 | PRIMARY            | usr        | NULL       | eq_ref | PRIMARY                                                                                                                                                                                                                                | PRIMARY                                 | 8       | grafana-original.annotation.user_id           |      1 |   100.00 | NULL                                                    |
|  1 | PRIMARY            | r          | NULL       | ALL    | PRIMARY                                                                                                                                                                                                                                | NULL                                    | NULL    | NULL                                          |      1 |   100.00 | Using where; Using join buffer (hash join)              |
|  2 | DERIVED            | a          | NULL       | range  | IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch,IDX_annotation_alert_id | IDX_annotation_org_id_epoch_end_epoch   | 16      | NULL                                          | 752438 |     1.67 | Using index condition; Using where; Backward index scan |
|  3 | DEPENDENT SUBQUERY | tag        | NULL       | range  | PRIMARY,UQE_tag_key_value                                                                                                                                                                                                              | UQE_tag_key_value                       | 402     | NULL                                          |      2 |   100.00 | Using where; Using index                                |
|  3 | DEPENDENT SUBQUERY | at         | NULL       | eq_ref | UQE_annotation_tag_annotation_id_tag_id                                                                                                                                                                                                | UQE_annotation_tag_annotation_id_tag_id | 16      | grafana-original.a.id,grafana-original.tag.id |      1 |   100.00 | Using index                                             |
+----+--------------------+------------+------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+--------+----------+---------------------------------------------------------+
```

New query (with index) looks like this:
```sql
SELECT
        annotation.id,
        annotation.epoch as time,
        annotation.epoch_end as time_end,
        annotation.dashboard_uid,
        annotation.dashboard_id,
        annotation.panel_id,
        annotation.new_state,
        annotation.prev_state,
        annotation.alert_id,
        annotation.text,
        annotation.tags,
        annotation.data,
        annotation.created,
        annotation.updated,
        usr.email,
        usr.login,
        r.title as alert_name
FROM annotation
LEFT OUTER JOIN `user` as usr on usr.id = annotation.user_id
LEFT OUTER JOIN alert_rule as r on r.id = annotation.alert_id
INNER JOIN (
        SELECT a.id from annotation a
        JOIN (
            SELECT
                annotation_tag.annotation_id
            FROM annotation_tag
            JOIN `tag` ON tag.id = annotation_tag.tag_id
            WHERE
                (tag.key = ? OR tag.key = ?)
            GROUP BY annotation_tag.annotation_id
            HAVING COUNT(DISTINCT tag.id) = 2
        ) at ON at.annotation_id = a.id
        WHERE a.org_id = ? AND a.user_id = ? AND a.epoch <= ? AND a.epoch_end >= ? AND a.alert_id = 0
        ORDER BY a.org_id, a.epoch_end DESC, a.epoch DESC LIMIT ?
) dt on dt.id = annotation.id
```

Which `EXPLAIN` looks like:
```
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+------+----------+-----------------------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys                                                                                                                                                                                                                                  | key                                     | key_len | ref                                 | rows | filtered | Extra                                                     |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+------+----------+-----------------------------------------------------------+
|  1 | PRIMARY     | <derived2>     | NULL       | ALL    | NULL                                                                                                                                                                                                                                           | NULL                                    | NULL    | NULL                                |   10 |   100.00 | NULL                                                      |
|  1 | PRIMARY     | annotation     | NULL       | eq_ref | PRIMARY                                                                                                                                                                                                                                        | PRIMARY                                 | 8       | dt.id                               |    1 |   100.00 | NULL                                                      |
|  1 | PRIMARY     | usr            | NULL       | eq_ref | PRIMARY                                                                                                                                                                                                                                        | PRIMARY                                 | 8       | grafana-version2.annotation.user_id |    1 |   100.00 | NULL                                                      |
|  1 | PRIMARY     | r              | NULL       | ALL    | PRIMARY                                                                                                                                                                                                                                        | NULL                                    | NULL    | NULL                                |    1 |   100.00 | Using where; Using join buffer (hash join)                |
|  2 | DERIVED     | <derived3>     | NULL       | ALL    | NULL                                                                                                                                                                                                                                           | NULL                                    | NULL    | NULL                                |  440 |   100.00 | Using temporary; Using filesort                           |
|  2 | DERIVED     | a              | NULL       | eq_ref | PRIMARY,IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch,IDX_annotation_alert_id | PRIMARY                                 | 8       | at.annotation_id                    |    1 |     5.00 | Using where                                               |
|  3 | DERIVED     | tag            | NULL       | range  | PRIMARY,UQE_tag_key_value                                                                                                                                                                                                                      | UQE_tag_key_value                       | 402     | NULL                                |    2 |   100.00 | Using where; Using index; Using temporary; Using filesort |
|  3 | DERIVED     | annotation_tag | NULL       | ref    | UQE_annotation_tag_annotation_id_tag_id,UQE_annotation_tag_tag_id_annotation_id                                                                                                                                                                | UQE_annotation_tag_tag_id_annotation_id | 8       | grafana-version2.tag.id             |  220 |   100.00 | Using index                                               |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-------------------------------------+------+----------+-----------------------------------------------------------+
```

And about `GetTags` handler - it generates next query:
```sql
EXPLAIN SELECT
        tag.key,
        tag.value,
        count(*) as count
FROM tag
INNER JOIN annotation_tag ON tag.id = annotation_tag.tag_id
INNER JOIN annotation ON annotation.id = annotation_tag.annotation_id
WHERE annotation.org_id = ? AND (tag.key LIKE ? OR tag.value LIKE ?)
GROUP BY tag.key, tag.value
ORDER BY tag.key, tag.value
```

Current implementation (without `tag_id`, `annotation_id` index) produces next `EXPLAIN`
```
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+----------------------------------------+--------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys                                                                                                                                                                                                          | key                                     | key_len | ref                                    | rows   | filtered | Extra                                        |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+----------------------------------------+--------+----------+----------------------------------------------+
|  1 | SIMPLE      | annotation     | NULL       | ref    | PRIMARY,IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch | IDX_annotation_org_id_alert_id          | 8       | const                                  | 752438 |   100.00 | Using index; Using temporary; Using filesort |
|  1 | SIMPLE      | annotation_tag | NULL       | ref    | UQE_annotation_tag_annotation_id_tag_id                                                                                                                                                                                | UQE_annotation_tag_annotation_id_tag_id | 8       | grafana-original.annotation.id         |      4 |   100.00 | Using index                                  |
|  1 | SIMPLE      | tag            | NULL       | eq_ref | PRIMARY,UQE_tag_key_value                                                                                                                                                                                              | PRIMARY                                 | 8       | grafana-original.annotation_tag.tag_id |      1 |    20.99 | Using where                                  |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+----------------------------------------+--------+----------+----------------------------------------------+
```

With index this is:
```
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+-------+----------+--------------------------+
| id | select_type | table          | partitions | type   | possible_keys                                                                                                                                                                                                          | key                                     | key_len | ref                                           | rows  | filtered | Extra                    |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+-------+----------+--------------------------+
|  1 | SIMPLE      | tag            | NULL       | index  | PRIMARY,UQE_tag_key_value                                                                                                                                                                                              | UQE_tag_key_value                       | 804     | NULL                                          | 46016 |    20.99 | Using where; Using index |
|  1 | SIMPLE      | annotation_tag | NULL       | ref    | UQE_annotation_tag_annotation_id_tag_id,UQE_annotation_tag_tag_id_annotation_id                                                                                                                                        | UQE_annotation_tag_tag_id_annotation_id | 8       | grafana-version2.tag.id                       |   220 |   100.00 | Using index              |
|  1 | SIMPLE      | annotation     | NULL       | eq_ref | PRIMARY,IDX_annotation_org_id_alert_id,IDX_annotation_org_id_type,IDX_annotation_org_id_created,IDX_annotation_org_id_updated,IDX_annotation_org_id_dashboard_id_epoch_end_epoch,IDX_annotation_org_id_epoch_end_epoch | PRIMARY                                 | 8       | grafana-version2.annotation_tag.annotation_id |     1 |    50.00 | Using where              |
+----+-------------+----------------+------------+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------+---------+-----------------------------------------------+-------+----------+--------------------------+
```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
