### PR TITLE
Transforms: GroupToMatrix transform should retain keyRowField config

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -21,7 +21,7 @@ describe('Grouping to Matrix', () => {
     const seriesA = toDataFrame({
       name: 'A',
       fields: [
-        { name: 'Time', type: FieldType.time, values: [1000, 1001, 1002] },
+        { name: 'Time', type: FieldType.time, values: [1000, 1001, 1002], config: { interval: 60000 } },
         { name: 'Value', type: FieldType.number, values: [1, 2, 3] },
       ],
     });
@@ -33,7 +33,9 @@ describe('Grouping to Matrix', () => {
           name: 'Time\\Time',
           type: FieldType.time,
           values: [1000, 1001, 1002],
-          config: {},
+          config: {
+            interval: 60000,
+          },
         },
         {
           name: '1000',

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -107,7 +107,7 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
             name: rowColumnField,
             values: rowValues,
             type: keyRowField.type,
-            config: {},
+            config: { ...keyRowField.config },
           },
         ];
 


### PR DESCRIPTION
Fixes an issue when using the GroupToMatrix transform in conjunction with time-based panels (like TimeSeries or State timeline). In cases where data would have missing data points, the transform would cause the data to fail to fill in `null` data points for times throughout the series where data was missing.

Related to https://github.com/grafana/support-escalations/issues/17646

Debugged this one with @leeoniya. 

- `applyNullInsertThreshold` runs as part of `preparePlotFrame` on `GraphNG`, which powers StateTimeline. That depends on the `interval` value of config being present on the time field's config.
  -  `applyNullInsertThreshold`: https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/nulls/nullInsertThreshold.ts#L51
- in the escalation we were working on, it became clear that the interval was missing for this customer, so we checked the transformation and noticed the config is initialized empty and the config is dropped on the floor.
  - **I have no familiarity with this transformation personally yet.** please let me know if this change should be more targeted, like if we ought to only target it to interval. but I figure it could mirror the way other field configs work in the transformation.
- updated an existing a unit test to prove the fix does what's expected.