### PR TITLE
CloudWatch: Append query type to the request id

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/mocks/LogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/LogsQueryRunner.ts
@@ -4,7 +4,7 @@ import { CustomVariableModel, DataFrame, DataSourceInstanceSettings } from '@gra
 import { BackendDataSourceResponse, toDataQueryResponse } from '@grafana/runtime';
 
 import { CloudWatchLogsQueryRunner } from '../query-runner/CloudWatchLogsQueryRunner';
-import { CloudWatchJsonData, CloudWatchLogsQueryStatus, CloudWatchLogsRequest } from '../types';
+import { CloudWatchJsonData, CloudWatchLogsQueryStatus } from '../types';
 
 import { CloudWatchSettings, setupMockedTemplateService } from './CloudWatchDataSource';
 
@@ -51,20 +51,4 @@ export function genMockFrames(numResponses: number): DataFrame[] {
   }
 
   return mockFrames;
-}
-
-export function genMockCloudWatchLogsRequest(overrides: Partial<CloudWatchLogsRequest> = {}) {
-  const request: CloudWatchLogsRequest = {
-    queryString: 'fields @timestamp, @message | sort @timestamp desc',
-    logGroupNames: ['log-group-name-1', 'log-group-name-2'],
-    logGroups: [
-      { arn: 'log-group-arn-1', name: 'log-group-name-1' },
-      { arn: 'log-group-arn-2', name: 'log-group-name-2' },
-    ],
-    refId: 'A',
-    region: 'us-east-1',
-    ...overrides,
-  };
-
-  return request;
 }

--- a/public/app/plugins/datasource/cloudwatch/mocks/MetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/MetricsQueryRunner.ts
@@ -26,7 +26,7 @@ export function setupMockedMetricsQueryRunner({
     range: TimeRangeMock,
     rangeRaw: { from: '1483228800', to: '1483232400' },
     targets: [],
-    requestId: '',
+    requestId: 'mockId',
     interval: '',
     intervalMs: 0,
     scopedVars: {},

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -64,6 +64,18 @@ describe('CloudWatchLogsQueryRunner', () => {
   });
 
   describe('handleLogQueries', () => {
+    it('appends -logs to the requestId', async () => {
+      const { runner, queryMock } = setupMockedLogsQueryRunner();
+
+      const request = {
+        ...LogsRequestMock,
+        requestId: 'mockId',
+      };
+      await expect(runner.handleLogQueries(LogsRequestMock.targets, request, queryMock)).toEmitValuesWith(() => {
+        expect(queryMock.mock.calls[0][0].requestId).toEqual('mockId-logs');
+      });
+    });
+
     it('should request to start each query and then request to get the query results', async () => {
       const { runner } = setupMockedLogsQueryRunner();
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -420,7 +420,7 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       ...options,
       range,
       skipQueryCache: true,
-      requestId: options?.requestId || '', // dummy
+      requestId: options?.requestId + '-logs' || '', // adding -logs to prevent requestId from matching metric queries from the same panel
       interval: options?.interval || '', // dummy
       intervalMs: options?.intervalMs || 1, // dummy
       scopedVars: options?.scopedVars || {}, // dummy

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -255,7 +255,7 @@ describe('CloudWatchMetricsQueryRunner', () => {
         });
       });
 
-       it('should append -metrics to the request id', async () => {
+      it('should append -metrics to the request id', async () => {
         const queries: CloudWatchMetricsQuery[] = [
           {
             id: '',

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -255,6 +255,36 @@ describe('CloudWatchMetricsQueryRunner', () => {
         });
       });
 
+       it('should append -metrics to the request id', async () => {
+        const queries: CloudWatchMetricsQuery[] = [
+          {
+            id: '',
+            metricQueryType: MetricQueryType.Search,
+            metricEditorMode: MetricEditorMode.Builder,
+            queryMode: 'Metrics',
+            refId: 'A',
+            region: 'us-east-1',
+            namespace: 'AWS/EC2',
+            metricName: 'CPUUtilization',
+            dimensions: {
+              InstanceId: 'i-12345678',
+            },
+            statistic: 'Average',
+            period: '[[period]]',
+          },
+        ];
+
+        const { runner, queryMock, request } = setupMockedMetricsQueryRunner({
+          // DataSourceWithBackend runs toDataQueryResponse({response from CW backend})
+          response: toDataQueryResponse(resultsFromBEQuery),
+          variables: [periodIntervalVariable],
+        });
+
+        await expect(runner.handleMetricQueries(queries, request, queryMock)).toEmitValuesWith(() => {
+          expect(queryMock.mock.calls[0][0].requestId).toEqual('mockId-metrics');
+        });
+      });
+
       it('should return series list', async () => {
         const { runner, request, queryMock } = setupMockedMetricsQueryRunner({
           // DataSourceWithBackend runs toDataQueryResponse({response from CW backend})

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
@@ -77,6 +77,7 @@ export class CloudWatchMetricsQueryRunner extends CloudWatchRequest {
 
     const request: DataQueryRequest<CloudWatchQuery> = {
       ...options,
+      requestId: options.requestId + '-metrics', // adding -metrics to prevent requestId from matching logs queries sent from the same panel
       targets: validMetricsQueries,
     };
 


### PR DESCRIPTION
We got a [bug report](https://github.com/grafana/grafana/issues/106584) that from v12 on two cloudwatch queries of different types (metrics + logs) are not shown in the panel. 
The reason for this is that the first query is always cancelled:
<img width="500" height="51" alt="Screenshot 2025-08-01 at 16 03 49" src="https://github.com/user-attachments/assets/8b7ba954-db43-49af-aad2-e35db5046495" />

I think at some point backend srv started cancelling queries if they had the same requestId as another query. In Cloudwatch we merge the logs and the metrics observables, but they're still separate calls (with the same id), however they have the same id. 
Appending the query type seems to get the queries to finish executing:
<img width="1298" height="461" alt="Screenshot 2025-08-01 at 15 53 15" src="https://github.com/user-attachments/assets/dce4c28a-81b0-48db-91c8-c9cb209a48b0" />
