### PR TITLE
LogLineDetailsHeader: report scroll to log line interaction

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -59,7 +59,7 @@ export const LogLineDetailsHeader = ({ focusLogLine, log, search, onSearch }: Pr
   const scrollToLogLine = useCallback(() => {
     focusLogLine?.(log);
     reportInteractionWrapper('logs_log_line_details_header_scroll_to_clicked');
-  }, [focusLogLine, log]);
+  }, [focusLogLine, log, reportInteractionWrapper]);
 
   const copyLogLine = useCallback(() => {
     copyText(log.entry, containerRef);

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -58,6 +58,7 @@ export const LogLineDetailsHeader = ({ focusLogLine, log, search, onSearch }: Pr
 
   const scrollToLogLine = useCallback(() => {
     focusLogLine?.(log);
+    reportInteractionWrapper('logs_log_line_details_header_scroll_to_clicked');
   }, [focusLogLine, log]);
 
   const copyLogLine = useCallback(() => {


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/pull/106394

Adding a missing event for "click to log line", to check discoverability and usage.