### PR TITLE
CloudWatch: Use default region when query region is unset

### DIFF
--- a/pkg/tsdb/cloudwatch/accounts_test.go
+++ b/pkg/tsdb/cloudwatch/accounts_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/resource/httpadapter"
 	"github.com/grafana/grafana/pkg/tsdb/cloudwatch/mocks"
@@ -23,6 +24,9 @@ func newTestDatasource(opts ...func(*DataSource)) *DataSource {
 		AWSConfigProvider: awsauth.NewFakeConfigProvider(false),
 		logger:            log.NewNullLogger(),
 		tagValueCache:     cache.New(0, 0),
+		Settings: models.CloudWatchSettings{
+			AWSDatasourceSettings: awsds.AWSDatasourceSettings{Region: "us-east-1"},
+		},
 	}
 	ds.resourceHandler = httpadapter.New(ds.newResourceMux())
 	for _, opt := range opts {

--- a/pkg/tsdb/cloudwatch/cloudwatch.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch.go
@@ -59,7 +59,7 @@ type DataSource struct {
 }
 
 func (ds *DataSource) newAWSConfig(ctx context.Context, region string) (aws.Config, error) {
-	if region == defaultRegion {
+	if region == defaultRegion || region == "" {
 		if len(ds.Settings.Region) == 0 {
 			return aws.Config{}, models.ErrMissingRegion
 		}

--- a/pkg/tsdb/cloudwatch/cloudwatch_integration_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_integration_test.go
@@ -269,6 +269,7 @@ func Test_CloudWatch_CallResource_Integration_Test(t *testing.T) {
 	t.Run("Should error for any request when a default region is not selected", func(t *testing.T) {
 		ds := newTestDatasource(func(ds *DataSource) {
 			ds.Settings.GrafanaSettings.ListMetricsPageLimit = 1000
+			ds.Settings.Region = ""
 		})
 
 		req := &backend.CallResourceRequest{


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Cloudwatch should use the default region if the query region is ""

Copy of https://github.com/grafana/grafana-cloudwatch-datasource/pull/92

