### PR TITLE
Auth: Support JWT configs `tls_client_ca` and `jwk_set_bearer_token_file`

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -956,6 +956,7 @@ auto_sign_up = false
 url_login = false
 allow_assign_grafana_admin = false
 skip_org_role_sync = false
+tls_client_ca =
 tls_skip_verify_insecure = false
 
 #################################### Auth LDAP ###########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -942,6 +942,7 @@ username_claim =
 email_attribute_path =
 username_attribute_path =
 jwk_set_url =
+jwk_set_bearer_token_file =
 jwk_set_file =
 cache_ttl = 60m
 expect_claims = {}

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -905,6 +905,7 @@
 ;email_attribute_path = jmespath.email
 ;username_attribute_path = jmespath.username
 ;jwk_set_url = https://foo.bar/.well-known/jwks.json
+;jwk_set_bearer_token_file = /path/to/token/file
 ;jwk_set_file = /path/to/jwks.json
 ;cache_ttl = 60m
 ;expect_claims = {"aud": ["foo", "bar"]}

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -921,6 +921,7 @@
 ;allow_assign_grafana_admin = false
 ;skip_org_role_sync = false
 ;signout_redirect_url =
+;tls_client_ca =
 ;tls_skip_verify_insecure = false
 
 #################################### Auth LDAP ##########################

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -171,7 +171,8 @@ cache_ttl = 60m
 ```
 
 {{< admonition type="note" >}}
-If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, no caching is performed. `no-store` and `no-cache` cache control headers are ignored.
+If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored.
+To disable jwks caching, set `cache_ttl = 0s`
 {{< /admonition >}}
 
 ### Verify token using a JSON Web Key Set loaded from JSON file

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -163,9 +163,9 @@ jwk_set_url = https://your-auth-provider.example.com/.well-known/jwks.json
 # Cache duration for https endpoint response.
 cache_ttl = 60m
 
-# File containing one or more custom PEM Encoded CA Certificates
-# Used with jwk_set_url when the root CA is not trusted by the pre-packaged certifcates
-# Which is always true for selfsigned certificates.
+# Path to file containing one or more custom PEM-encoded CA certificates.
+# Used with jwk_set_url when the JWKS endpoint uses a certificate that is not
+# trusted by the default CA bundle (e.g. self-signed certificates).
 # tls_client_ca = /path/to/ca.crt
 
 # Skip CA Verification entirely

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -173,7 +173,7 @@ cache_ttl = 60m
 ```
 
 {{< admonition type="note" >}}
-If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored. To disable jwks caching, set `cache_ttl = 0s`
+If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored. To disable JWKS caching, set `cache_ttl = 0s`
 {{< /admonition >}}
 
 ### Verify token using a JSON Web Key Set loaded from JSON file

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -157,8 +157,17 @@ For more information on JWKS endpoints, refer to [Auth0 docs](https://auth0.com/
 
 jwk_set_url = https://your-auth-provider.example.com/.well-known/jwks.json
 
-# Cache TTL for data loaded from http endpoint.
+# When the JWKS url requires an 'Authorization: Bearer <TOKEN>' header
+# jwk_set_bearer_token_file = /path/to/bearer_token
+
+# Cache duration for https endpoint response.
 cache_ttl = 60m
+
+# File containing one or more custom PEM Encoded CA Certificates
+# tls_client_ca = /path/to/ca.crt
+
+# Skip CA Verification entirely
+# tls_skip_verify_insecure = false
 ```
 
 {{< admonition type="note" >}}

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/jwt/index.md
@@ -164,6 +164,8 @@ jwk_set_url = https://your-auth-provider.example.com/.well-known/jwks.json
 cache_ttl = 60m
 
 # File containing one or more custom PEM Encoded CA Certificates
+# Used with jwk_set_url when the root CA is not trusted by the pre-packaged certifcates
+# Which is always true for selfsigned certificates.
 # tls_client_ca = /path/to/ca.crt
 
 # Skip CA Verification entirely
@@ -171,8 +173,7 @@ cache_ttl = 60m
 ```
 
 {{< admonition type="note" >}}
-If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored.
-To disable jwks caching, set `cache_ttl = 0s`
+If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored. To disable jwks caching, set `cache_ttl = 0s`
 {{< /admonition >}}
 
 ### Verify token using a JSON Web Key Set loaded from JSON file

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -263,6 +263,7 @@ func (ks *keySetHTTP) getJWKS(ctx context.Context) (keySetJWKS, error) {
 	}
 
 	if ks.bearerTokenPath != "" {
+		// Always read the token before fetching JWKS to handle potential key rotation (e.g. short-lived kubernetes ServiceAccount tokens)
 		token, err := getBearerToken(ks.bearerTokenPath)
 		if err != nil {
 			return jwks, err

--- a/pkg/services/auth/jwt/key_sets.go
+++ b/pkg/services/auth/jwt/key_sets.go
@@ -71,7 +71,7 @@ func (s *AuthService) checkKeySetConfiguration() error {
 	return nil
 }
 
-// Initialize a provider for JWKSet, either file, or https
+// initKeySet creates a provider for JWKSet, either file, or https
 // nolint:gocyclo
 func (s *AuthService) initKeySet() error {
 	if err := s.checkKeySetConfiguration(); err != nil {

--- a/pkg/setting/setting_jwt.go
+++ b/pkg/setting/setting_jwt.go
@@ -19,6 +19,7 @@ type AuthJWTSettings struct {
 	UsernameClaim           string
 	ExpectClaims            string
 	JWKSetURL               string
+	JWKSetBearerTokenFile   string
 	CacheTTL                time.Duration
 	KeyFile                 string
 	KeyID                   string
@@ -65,6 +66,7 @@ func (cfg *Cfg) readAuthJWTSettings() {
 	jwtSettings.UsernameClaim = valueAsString(authJWT, "username_claim", "")
 	jwtSettings.ExpectClaims = valueAsString(authJWT, "expect_claims", "{}")
 	jwtSettings.JWKSetURL = valueAsString(authJWT, "jwk_set_url", "")
+	jwtSettings.JWKSetBearerTokenFile = valueAsString(authJWT, "jwk_set_bearer_token_file", "")
 	jwtSettings.CacheTTL = authJWT.Key("cache_ttl").MustDuration(time.Minute * 60)
 	jwtSettings.KeyFile = valueAsString(authJWT, "key_file", "")
 	jwtSettings.KeyID = authJWT.Key("key_id").MustString("")

--- a/pkg/setting/setting_jwt.go
+++ b/pkg/setting/setting_jwt.go
@@ -33,6 +33,7 @@ type AuthJWTSettings struct {
 	GroupsAttributePath     string
 	EmailAttributePath      string
 	UsernameAttributePath   string
+	TlsClientCa             string
 	TlsSkipVerify           bool
 }
 
@@ -76,6 +77,7 @@ func (cfg *Cfg) readAuthJWTSettings() {
 	jwtSettings.GroupsAttributePath = valueAsString(authJWT, "groups_attribute_path", "")
 	jwtSettings.EmailAttributePath = valueAsString(authJWT, "email_attribute_path", "")
 	jwtSettings.UsernameAttributePath = valueAsString(authJWT, "username_attribute_path", "")
+	jwtSettings.TlsClientCa = valueAsString(authJWT, "tls_client_ca", "")
 	jwtSettings.TlsSkipVerify = authJWT.Key("tls_skip_verify_insecure").MustBool(false)
 	jwtSettings.OrgAttributePath = valueAsString(authJWT, "org_attribute_path", "")
 	jwtSettings.OrgMapping = util.SplitString(valueAsString(authJWT, "org_mapping", ""))


### PR DESCRIPTION
**What is this feature?**

Two new options have been added to `[auth.jwt]` that are active when `jwk_set_url` is set.
1. `tls_client_ca` path to a file containing custom PEM CA Certs
2. `jwk_set_bearer_token_file` path to a file containing a Bearer token in the `Authorization` header when requesting the `jwks.json`

**Why do we need this feature?**

Right now, it's not possible to configure Grafana to authenticate or accept a CA when requesting the jwks from a url.

This does not match other auth sections like the various OIDC configs that allow significantly more options for configuring the client.
https://github.com/grafana/grafana/blob/8ac74e24df1ff9e5de0c1d0f78dcd8be12305b4e/conf/sample.ini#L845-L873

**Who is this feature for?**

System administrators that work with authenticated /jwks.json endpoints with selfsigned certificates.

**Which issue(s) does this PR fix?**:

None, I did not open any, if it helps merging this PR I can open one?

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
