### PR TITLE
Air: Keep binary after exiting

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -7,7 +7,7 @@ exclude_unchanged = true
 follow_symlink = true
 include_dir = ["apps", "conf", "devenv/dev-dashboards", "pkg", "public/views"]
 include_ext = ["go", "ini", "toml", "html", "json"]
-stop_on_error = true
+stop_on_error = false
 send_interrupt = true
 kill_delay = 500
 


### PR DESCRIPTION
The `stop_on_error` setting not only stops the reload when there's an error (like compilation error) but also has the side effect of deleting the binary when the program (air) exits.
  
By setting it to false, when there's a compilation error, it will try re-running using the existing binary, and it also does not delete it after air exits.