### PR TITLE
AppInit: Add hiring console message

### DIFF
--- a/public/app/core/lifecycle-hooks.ts
+++ b/public/app/core/lifecycle-hooks.ts
@@ -1,5 +1,5 @@
 import { initDevFeatures } from 'app/dev';
-import { notifyIfMockApiEnabled } from 'app/dev-utils';
+import { notifyIfMockApiEnabled, notifyWeAreHiring } from 'app/dev-utils';
 
 /**
  * Lifecycle tasks that need to be run prior to app initialization,
@@ -14,5 +14,6 @@ export async function preInitTasks() {
  * such as notifying if mock APIs are enabled
  */
 export async function postInitTasks() {
+  notifyWeAreHiring();
   notifyIfMockApiEnabled();
 }

--- a/public/app/dev-utils.ts
+++ b/public/app/dev-utils.ts
@@ -44,6 +44,23 @@ export const notifyIfMockApiEnabled = () => {
   }
 };
 
+export const notifyWeAreHiring = () => {
+  const logoMessageStyle = 'color: #ff671d;';
+  const hiringMessageStyle = 'font-size: medium; font-weight: bold; color: #ff671d;';
+  const linkMessageStyle = 'color: #ff671d; text-decoration: underline;';
+  console.log(
+    `%c⠀⠀⠀⠀⠀⣠⣶⣶⣄⠀⢀
+⠀⢰⣶⣶⣾⣿⠿⠿⠿⠿⢿⣇
+⠀⠈⢻⡟⠋⠁⠀⣀⣀⣀⣀⠙⢧
+⠀⣰⣾⠇⠀⢰⠀⠉⠉⠉⠿⡇⠈
+⠾⣿⣿⣇⡀⠈⠀⠀⠀⠀⢀⣇⣀
+⠀⠈⠉⢻⣿⣆⣀⣀⣀⣠⣿⠟⠛
+⠀⠀⠀⠸⠿⠿⠿⠿⢿⣿⠇`,
+    logoMessageStyle
+  );
+  console.log(`%cWe are hiring! Come find us at https://grafana.com/about/careers/`, hiringMessageStyle);
+};
+
 export const togglePseudoLocale = async () => {
   const prefsService = new PreferencesService('user');
   const prefs = await prefsService.load();


### PR DESCRIPTION
**What is this feature?**

It adds a console message with our logo and a hiring message pointing to our careers page.

**Why do we need this feature?**

It will direct devs who are inspecting the page to our careers page and encourage them to apply. It's something I saw other tools do and I thought it would be valuable.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] There are no new security concerns related to this change.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
