### PR TITLE
datasources: querier: adjusted names

### DIFF
--- a/pkg/registry/apis/query/client/instance_provider.go
+++ b/pkg/registry/apis/query/client/instance_provider.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-type singleTenantClientSupplier struct {
+type singleTenantInstanceProvider struct {
 	client   clientapi.QueryDataClient
 	features featuremgmt.FeatureToggles
 	cfg      *setting.Cfg
@@ -29,15 +29,15 @@ func (t *singleTenantInstance) GetDataSourceClient(_ context.Context, _ data.Dat
 	return t.client, nil
 }
 
-func NewSingleTenantClientSupplier(cfg *setting.Cfg, features featuremgmt.FeatureToggles, p plugins.Client, ctxProv *plugincontext.Provider, accessControl accesscontrol.AccessControl) clientapi.InstanceProvider {
-	return &singleTenantClientSupplier{
+func NewSingleTenantInstanceProvider(cfg *setting.Cfg, features featuremgmt.FeatureToggles, p plugins.Client, ctxProv *plugincontext.Provider, accessControl accesscontrol.AccessControl) clientapi.InstanceProvider {
+	return &singleTenantInstanceProvider{
 		cfg:      cfg,
 		features: features,
 		client:   newQueryClientForPluginClient(p, ctxProv, accessControl),
 	}
 }
 
-func (s *singleTenantClientSupplier) GetInstance(_ context.Context) (clientapi.Instance, error) {
+func (s *singleTenantInstanceProvider) GetInstance(_ context.Context) (clientapi.Instance, error) {
 	return &singleTenantInstance{
 		client:   s.client,
 		features: s.features,

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -246,7 +246,7 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	headers := ExtractKnownHeaders(httpreq.Header)
 
-	instance, err := b.clientSupplier.GetInstance(ctx)
+	instance, err := b.instanceProvider.GetInstance(ctx)
 	if err != nil {
 		connectLogger.Error("failed to get instance configuration settings", "err", err)
 		responder.Error(err)
@@ -257,7 +257,7 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	dsQuerierLoggerWithSlug := instance.GetLogger(connectLogger).New("ruleuid", headers["X-Rule-Uid"])
 
-	mtDsClientBuilder := mtdsclient.NewMtDatasourceClientBuilderWithClientSupplier(
+	mtDsClientBuilder := mtdsclient.NewMtDatasourceClientBuilderWithInstance(
 		instance,
 		ctx,
 		headers,

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -159,7 +159,7 @@ func TestQueryAPI(t *testing.T) {
 					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
 					Tracer:   tracing.InitializeTracerForTest(),
 				},
-				clientSupplier: mockClient{
+				instanceProvider: mockClient{
 					stubbedFrame: tc.stubbedFrame,
 				},
 				tracer:                 tracing.InitializeTracerForTest(),

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -45,7 +45,7 @@ type QueryAPIBuilder struct {
 
 	tracer                 tracing.Tracer
 	metrics                *metrics.ExprMetrics
-	clientSupplier         clientapi.InstanceProvider
+	instanceProvider       clientapi.InstanceProvider
 	registry               query.DataSourceApiServerRegistry
 	converter              *expr.ResultConverter
 	queryTypes             *query.QueryTypeDefinitionList
@@ -54,7 +54,7 @@ type QueryAPIBuilder struct {
 
 func NewQueryAPIBuilder(
 	features featuremgmt.FeatureToggles,
-	clientSupplier clientapi.InstanceProvider,
+	instanceProvider clientapi.InstanceProvider,
 	ar authorizer.Authorizer,
 	registry query.DataSourceApiServerRegistry,
 	registerer prometheus.Registerer,
@@ -79,7 +79,7 @@ func NewQueryAPIBuilder(
 	return &QueryAPIBuilder{
 		concurrentQueryLimit: 4,
 		log:                  log.New("query_apiserver"),
-		clientSupplier:       clientSupplier,
+		instanceProvider:     instanceProvider,
 		authorizer:           ar,
 		registry:             registry,
 		metrics:              metrics.NewQueryServiceExpressionsMetrics(registerer),
@@ -129,7 +129,7 @@ func RegisterAPIService(
 
 	builder, err := NewQueryAPIBuilder(
 		features,
-		client.NewSingleTenantClientSupplier(cfg, features, pluginClient, pCtxProvider, accessControl),
+		client.NewSingleTenantInstanceProvider(cfg, features, pluginClient, pCtxProvider, accessControl),
 		ar,
 		client.NewDataSourceRegistryFromStore(pluginStore, dataSourcesService),
 		registerer,

--- a/pkg/services/mtdsclient/mt_datasource_client_builder.go
+++ b/pkg/services/mtdsclient/mt_datasource_client_builder.go
@@ -23,14 +23,14 @@ func NewNullMTDatasourceClientBuilder() MTDatasourceClientBuilder {
 	return &nullBuilder{}
 }
 
-type MtDatasourceClientBuilderWithClientSupplier struct {
+type MtDatasourceClientBuilderWithInstance struct {
 	instance clientapi.Instance
 	ctx      context.Context
 	headers  map[string]string
 	logger   log.Logger
 }
 
-func (b *MtDatasourceClientBuilderWithClientSupplier) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool) {
+func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool) {
 	dsClient, err := b.instance.GetDataSourceClient(
 		b.ctx,
 		v0alpha1.DataSourceRef{
@@ -46,14 +46,14 @@ func (b *MtDatasourceClientBuilderWithClientSupplier) BuildClient(pluginId strin
 	return dsClient, true
 }
 
-// TODO: I think we might be able to refactor this to just use the client supplier directly
-func NewMtDatasourceClientBuilderWithClientSupplier(
+// TODO: I think we might be able to refactor this to just use the instance
+func NewMtDatasourceClientBuilderWithInstance(
 	instance clientapi.Instance,
 	ctx context.Context,
 	headers map[string]string,
 	logger log.Logger,
 ) MTDatasourceClientBuilder {
-	return &MtDatasourceClientBuilderWithClientSupplier{
+	return &MtDatasourceClientBuilderWithInstance{
 		instance: instance,
 		ctx:      ctx,
 		headers:  headers,


### PR DESCRIPTION
this PR only renames things (types, variables, 1 file name), no changes in application logic.

we started to move from the `client-supplier` concept to the `instance-provider` concept in the previous pr (https://github.com/grafana/grafana/pull/108776),

but i did not rename all the things, to keep the previous PR smaller.

this PR just finishes the naming changes.