### PR TITLE
Secrets: Move token exchange interceptor into Decrypt method

### DIFF
--- a/pkg/registry/apis/secret/decrypt/grpc_client.go
+++ b/pkg/registry/apis/secret/decrypt/grpc_client.go
@@ -23,8 +23,9 @@ import (
 )
 
 type GRPCDecryptClient struct {
-	conn   *grpc.ClientConn
-	client decryptv1beta1.SecureValueDecrypterClient
+	conn           *grpc.ClientConn
+	tracer         trace.Tracer
+	tokenExchanger authnlib.TokenExchanger
 }
 
 var _ contracts.DecryptService = &GRPCDecryptClient{}
@@ -38,14 +39,13 @@ type TLSConfig struct {
 	InsecureSkipVerify bool
 }
 
-func NewGRPCDecryptClient(tokenExchanger authnlib.TokenExchanger, tracer trace.Tracer, namespace, address string) (*GRPCDecryptClient, error) {
-	return NewGRPCDecryptClientWithTLS(tokenExchanger, tracer, namespace, address, TLSConfig{})
+func NewGRPCDecryptClient(tokenExchanger authnlib.TokenExchanger, tracer trace.Tracer, address string) (*GRPCDecryptClient, error) {
+	return NewGRPCDecryptClientWithTLS(tokenExchanger, tracer, address, TLSConfig{})
 }
 
 func NewGRPCDecryptClientWithTLS(
 	tokenExchanger authnlib.TokenExchanger,
 	tracer trace.Tracer,
-	namespace string,
 	address string,
 	tlsConfig TLSConfig,
 ) (*GRPCDecryptClient, error) {
@@ -66,22 +66,10 @@ func NewGRPCDecryptClientWithTLS(
 		return nil, fmt.Errorf("failed to connect to grpc decrypt server at %s: %w", address, err)
 	}
 
-	tokenExchangerInterceptor := authnlib.NewGrpcClientInterceptor(
-		tokenExchanger,
-		authnlib.WithClientInterceptorTracer(tracer),
-		authnlib.WithClientInterceptorNamespace(namespace),
-		authnlib.WithClientInterceptorAudience([]string{secretv1beta1.APIGroup}),
-	)
-
-	clientConn := grpchan.InterceptClientConn(
-		conn,
-		tokenExchangerInterceptor.UnaryClientInterceptor,
-		tokenExchangerInterceptor.StreamClientInterceptor,
-	)
-
 	return &GRPCDecryptClient{
-		conn:   conn,
-		client: decryptv1beta1.NewSecureValueDecrypterClient(clientConn),
+		conn:           conn,
+		tracer:         tracer,
+		tokenExchanger: tokenExchanger,
 	}, nil
 }
 
@@ -120,6 +108,7 @@ func createTLSCredentials(config TLSConfig) (credentials.TransportCredentials, e
 	return credentials.NewTLS(tlsConfig), nil
 }
 
+// Close will close the underlying gRPC connection. After it is closed, the client cannot be used anymore.
 func (g *GRPCDecryptClient) Close() error {
 	if g.conn != nil {
 		return g.conn.Close()
@@ -127,11 +116,28 @@ func (g *GRPCDecryptClient) Close() error {
 	return nil
 }
 
+// Decrypt a set of secure value names in a given namespace for a specific service name.
 func (g *GRPCDecryptClient) Decrypt(ctx context.Context, serviceName string, namespace string, names []string) (map[string]contracts.DecryptResult, error) {
 	_, err := types.ParseNamespace(namespace)
 	if err != nil {
 		return nil, err
 	}
+
+	tokenExchangerInterceptor := authnlib.NewGrpcClientInterceptor(
+		g.tokenExchanger,
+		authnlib.WithClientInterceptorTracer(g.tracer),
+		authnlib.WithClientInterceptorNamespace(namespace),
+		authnlib.WithClientInterceptorAudience([]string{secretv1beta1.APIGroup}),
+	)
+
+	clientConn := grpchan.InterceptClientConn(
+		g.conn,
+		tokenExchangerInterceptor.UnaryClientInterceptor,
+		tokenExchangerInterceptor.StreamClientInterceptor,
+	)
+
+	client := decryptv1beta1.NewSecureValueDecrypterClient(clientConn)
+
 	req := &decryptv1beta1.SecureValueDecryptRequest{
 		Namespace: namespace,
 		Names:     names,
@@ -144,7 +150,7 @@ func (g *GRPCDecryptClient) Decrypt(ctx context.Context, serviceName string, nam
 	})
 	ctx = metadata.NewOutgoingContext(ctx, md)
 
-	resp, err := g.client.DecryptSecureValues(ctx, req)
+	resp, err := client.DecryptSecureValues(ctx, req)
 	if err != nil {
 		return nil, fmt.Errorf("grpc decrypt failed: %w", err)
 	}

--- a/pkg/registry/apis/secret/decrypt/service.go
+++ b/pkg/registry/apis/secret/decrypt/service.go
@@ -43,7 +43,7 @@ func ProvideDecryptService(cfg *setting.Cfg, tracer trace.Tracer, decryptStorage
 
 		tlsConfig := readTLSFromConfig(cfg)
 
-		client, err := NewGRPCDecryptClientWithTLS(tokenExchangeClient, tracer, grpcClientConfig.TokenNamespace, cfg.SecretsManagement.DecryptServerAddress, tlsConfig)
+		client, err := NewGRPCDecryptClientWithTLS(tokenExchangeClient, tracer, cfg.SecretsManagement.DecryptServerAddress, tlsConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create grpc decrypt client: %w", err)
 		}


### PR DESCRIPTION
**What is this feature?**

Remove the `namespace` from the gRPC decrypt client constructor, which means we move the token exchange interceptor into the Decrypt method.

**Why do we need this feature?**

Simplifies the setup for the gRPC client, as it will only need to be initialized once per application, and not every time it needs to call Decrypt.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
