### PR TITLE
Dev: Provision devenv dev-dashboards in frontend-service stack

### DIFF
--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -79,6 +79,7 @@ docker_build('grafana-fs-dev',
   # Paths relative to the docker context (root of the repo)
   only=[
     'devenv/frontend-service/build/grafana',
+    'devenv/frontend-service/provisioning',
     'conf/defaults.ini',
     'public/emails',
     'public/views',
@@ -96,6 +97,7 @@ docker_build('grafana-fs-dev',
     sync('../../public/dashboards', '/grafana/public/dashboards'),
     sync('../../public/app/plugins', '/grafana/public/app/plugins'),
     sync('../../public/build/assets-manifest.json', '/grafana/public/build/assets-manifest.json'),
+    sync('./provisioning', '/ignore/provisioning'),  # Just to trigger a restart instead of rebuild
     restart_container()
   ]
 )

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -32,7 +32,6 @@ services:
       GF_DATABASE_NAME: grafana
       GF_DATABASE_USER: grafana
       GF_DATABASE_PASSWORD: grafana
-      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /grafana/conf/dev-dashboards/home.json
     ports:
       - '3011:3000'
 

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -21,6 +21,9 @@ services:
     entrypoint: ['bin/grafana', 'server']
     volumes:
       - backend-data:/grafana/data
+      - ./provisioning/datasources:/grafana/conf/provisioning/datasources
+      - ./provisioning/dashboards:/grafana/conf/provisioning/dashboards
+      - ../dev-dashboards:/grafana/conf/dev-dashboards
     environment:
       GF_SERVER_CDN_URL: http://localhost:3010
       GF_FEATURE_TOGGLES_ENABLE: multiTenantFrontend
@@ -29,6 +32,7 @@ services:
       GF_DATABASE_NAME: grafana
       GF_DATABASE_USER: grafana
       GF_DATABASE_PASSWORD: grafana
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /grafana/conf/dev-dashboards/home.json
     ports:
       - '3011:3000'
 

--- a/devenv/frontend-service/provisioning/dashboards/devenv.yaml
+++ b/devenv/frontend-service/provisioning/dashboards/devenv.yaml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: 'gdev dashboards'
+    folder: 'gdev dashboards'
+    folderUid: ''
+    type: file
+    allowUiUpdates: false
+    updateIntervalSeconds: 3600
+    options:
+      # This path is relative to the WORKDIR in the docker container. It is mounted
+      # in the docker-compose.yml file.
+      path: conf/dev-dashboards

--- a/devenv/frontend-service/provisioning/datasources/default.yaml
+++ b/devenv/frontend-service/provisioning/datasources/default.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+prune: true
+
+datasources:
+  # From devenv/datasources.yaml
+  - name: Testdata
+    uid: PD8C576611E62080A
+    type: grafana-testdata-datasource


### PR DESCRIPTION
This'll be the first PR in a series that provisions a bunch of useful data sources and dashboards automatically for the local dev stack for frontend-service.

This PR just provisions the dev-dashboards we have in the repo as a start.

Part of https://github.com/grafana/grafana/issues/104503