### PR TITLE
RepositoryCard: use RepoIcon to display repository icon

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryCard.tsx
@@ -1,13 +1,12 @@
 import { ReactNode } from 'react';
 
 import { Trans } from '@grafana/i18n';
-import { IconName, Stack, Text, TextLink, Icon, Card, LinkButton } from '@grafana/ui';
+import { Stack, Text, TextLink, Icon, Card, LinkButton } from '@grafana/ui';
 import { Repository, ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
 
 import { RepoIcon } from '../Shared/RepoIcon';
 import { StatusBadge } from '../Shared/StatusBadge';
 import { PROVISIONING_URL } from '../constants';
-import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 
 import { DeleteRepositoryButton } from './DeleteRepositoryButton';
 import { SyncRepository } from './SyncRepository';

--- a/public/app/features/provisioning/Repository/RepositoryCard.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryCard.tsx
@@ -4,8 +4,10 @@ import { Trans } from '@grafana/i18n';
 import { IconName, Stack, Text, TextLink, Icon, Card, LinkButton } from '@grafana/ui';
 import { Repository, ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
 
+import { RepoIcon } from '../Shared/RepoIcon';
 import { StatusBadge } from '../Shared/StatusBadge';
 import { PROVISIONING_URL } from '../constants';
+import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
 
 import { DeleteRepositoryButton } from './DeleteRepositoryButton';
 import { SyncRepository } from './SyncRepository';
@@ -53,14 +55,10 @@ export function RepositoryCard({ repository }: Props) {
     return meta;
   };
 
-  const getRepositoryIcon = (): IconName => {
-    return spec?.type === 'github' ? 'github' : 'database';
-  };
-
   return (
     <Card noMargin key={name}>
       <Card.Figure>
-        <Icon name={getRepositoryIcon()} size="xxl" />
+        <RepoIcon type={spec?.type} />
       </Card.Figure>
       <Card.Heading>
         <Stack gap={2} direction="row" alignItems="center">

--- a/public/app/features/provisioning/Shared/RepoIcon.tsx
+++ b/public/app/features/provisioning/Shared/RepoIcon.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/css';
+
+import { Icon, useStyles2 } from '@grafana/ui';
+
+import { RepoType } from '../Wizard/types';
+import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
+
+export function RepoIcon({ type }: { type: RepoType | undefined }) {
+  const styles = useStyles2(getStyles);
+  const config = type ? getRepositoryTypeConfig(type) : undefined;
+
+  if (!config) {
+    return <Icon name="database" size="xxl" />;
+  }
+  return (
+    <>
+      {config.logo ? (
+        <img src={config.logo} alt={config.label} className={styles.logo} />
+      ) : (
+        <Icon name={config.icon} size="xxl" />
+      )}
+    </>
+  );
+}
+
+function getStyles() {
+  return {
+    logo: css({
+      width: 34,
+      height: 34,
+    }),
+  };
+}

--- a/public/app/features/provisioning/Shared/RepoIcon.tsx
+++ b/public/app/features/provisioning/Shared/RepoIcon.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 
 import { Icon, useStyles2 } from '@grafana/ui';
+import { getSvgSize } from '@grafana/ui/internal';
 
 import { RepoType } from '../Wizard/types';
 import { getRepositoryTypeConfig } from '../utils/repositoryTypes';
@@ -26,8 +27,8 @@ export function RepoIcon({ type }: { type: RepoType | undefined }) {
 function getStyles() {
   return {
     logo: css({
-      width: 34,
-      height: 34,
+      width: getSvgSize('xxl'),
+      height: getSvgSize('xxl'),
     }),
   };
 }

--- a/public/app/features/provisioning/Shared/RepositoryTypeCards.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryTypeCards.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/css';
 
 import { Trans } from '@grafana/i18n';
-import { Card, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Card, Stack, Text, useStyles2 } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1/endpoints.gen';
 
 import { CONNECT_URL, DEFAULT_REPOSITORY_TYPES } from '../constants';
 import { getOrderedRepositoryConfigs } from '../utils/repositoryTypes';
+
+import { RepoIcon } from './RepoIcon';
 
 export function RepositoryTypeCards() {
   const styles = useStyles2(getStyles);
@@ -26,11 +28,7 @@ export function RepositoryTypeCards() {
             {gitProviders.map((config) => (
               <Card key={config.type} href={`${CONNECT_URL}/${config.type}`} className={styles.card} noMargin>
                 <Stack gap={2} alignItems="center">
-                  {config.logo ? (
-                    <img src={config.logo} alt={config.label} className={styles.logo} />
-                  ) : (
-                    <Icon name={config.icon} size="xxl" />
-                  )}
+                  <RepoIcon type={config.type} />
                   <Trans
                     i18nKey="provisioning.repository-type-cards.configure-with-provider"
                     values={{ provider: config.label }}
@@ -55,11 +53,7 @@ export function RepositoryTypeCards() {
           {otherProviders.map((config) => (
             <Card key={config.type} href={`${CONNECT_URL}/${config.type}`} className={styles.card} noMargin>
               <Stack gap={2} alignItems="center">
-                {config.logo ? (
-                  <img src={config.logo} alt={config.label} className={styles.logo} />
-                ) : (
-                  <Icon name={config.icon} size="xxl" />
-                )}
+                <RepoIcon type={config.type} />
                 {config.type === 'local' ? (
                   <Trans i18nKey="provisioning.repository-type-cards.configure-file">Configure file provisioning</Trans>
                 ) : (
@@ -83,10 +77,6 @@ function getStyles() {
   return {
     card: css({
       width: 220,
-    }),
-    logo: css({
-      width: 36,
-      height: 36,
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

- Created `RepoIcon` component to reuse in `RepositoryCard` and `RepositoryTypeCards`
<img width="683" height="439" alt="image" src="https://github.com/user-attachments/assets/40b1ec70-6bfe-4c71-a696-a62be2df124a" />


**Why do we need this feature?**

- To have consistent git provider icon/logo

**Who is this feature for?**

- git users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/411

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
