### PR TITLE
Gops: Change IRM configuration tracker URL and label

### DIFF
--- a/public/app/features/gops/configuration-tracker/irmHooks.ts
+++ b/public/app/features/gops/configuration-tracker/irmHooks.ts
@@ -305,8 +305,9 @@ export function useGetEssentialsConfiguration(): EssentialsConfigurationData {
                   },
                   label: t('gops.use-get-essentials-configuration.essential-content.label.connect', 'Connect'),
                   urlLinkOnDone: {
-                    url: `/a/${getIrmIfPresentOrIncidentPluginId()}/integrations`,
+                    url: `/a/${getIrmIfPresentOrIncidentPluginId()}/integrations/apps/grate.irm.slack`,
                   },
+                  labelOnDone: 'View',
                 },
                 done: isChatOpsInstalled,
               },


### PR DESCRIPTION
**What is this feature?**

Fixes the IRM configuration tracker:

- If Slack is already connected, display `View` instead of `Connect`
- Route to the correct URL to view the Slack integration in IRM

**Why do we need this feature?**

This is a fix. Currently even if Slack is connected, we prompt the user to `Connect` the integration. Also, pressing `Connect` routes to the wrong page.

**Who is this feature for?**

Admin users
