### PR TITLE
FolderRepo: change badge from text to exchange-alt icon, matches dash…

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -15,5 +15,5 @@ export function FolderRepo({ folder }: Props) {
     return null;
   }
 
-  return <Badge text={t('folder-repo.badge-text', 'Provisioned')} color={'darkgrey'} />;
+  return <Badge color="purple" icon="exchange-alt" tooltip={t('folder-repo.badge-tooltip', 'Provisioned')} />;
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7435,7 +7435,7 @@
     "loading": "Loading folders..."
   },
   "folder-repo": {
-    "badge-text": "Provisioned"
+    "badge-tooltip": "Provisioned"
   },
   "folders": {
     "get-loading-nav": {


### PR DESCRIPTION
**What is this feature?**

- Use `exchange-alt` for folder provisioning status badge.   

<img width="682" height="322" alt="image" src="https://github.com/user-attachments/assets/89e3f448-b29f-44ec-9bba-9732256cd391" />. 
  
<img width="682" height="322" alt="image" src="https://github.com/user-attachments/assets/f63febbf-8de8-4bfa-a9e7-e1071db9ad2e" />



**Why do we need this feature?**

- To provide user consistent UX

**Who is this feature for?**

- git user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/417

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
