### PR TITLE
DataSourceSrv: isDataSourceRef should match type-only ds ref

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -472,7 +472,7 @@
 /packages/grafana-data/src/utils/binaryOperators.ts @grafana/datapro
 /packages/grafana-data/src/utils/csv* @grafana/dataviz-squad
 /packages/grafana-data/src/utils/dataLinks* @grafana/dashboards-squad
-/packages/grafana-data/src/utils/datasource.ts @grafana/grafana-datasources-core-services
+/packages/grafana-data/src/utils/datasource* @grafana/grafana-datasources-core-services
 /packages/grafana-data/src/utils/docs.ts @grafana/grafana-frontend-platform
 /packages/grafana-data/src/utils/deprecationWarning* @grafana/grafana-frontend-platform
 /packages/grafana-data/src/utils/featureToggles.ts @grafana/grafana-frontend-platform

--- a/packages/grafana-data/src/utils/datasource.test.ts
+++ b/packages/grafana-data/src/utils/datasource.test.ts
@@ -1,0 +1,22 @@
+import { isDataSourceRef } from './datasource';
+
+describe('isDataSourceRef', () => {
+  it('returns true for DataSourceRef with only a uid', () => {
+    const ref = { uid: '123', type: 'prometheus' };
+    expect(isDataSourceRef(ref)).toBe(true);
+  });
+
+  it('returns true for DataSourceRef with only a type', () => {
+    const ref = { type: 'prometheus' };
+    expect(isDataSourceRef(ref)).toBe(true);
+  });
+
+  it('returns true for DataSourceRef with both a uid and a type', () => {
+    const ref = { uid: '123', type: 'prometheus' };
+    expect(isDataSourceRef(ref)).toBe(true);
+  });
+
+  it.each(['prometheus', null, undefined, {}, 123])('returns false for %s', (input) => {
+    expect(isDataSourceRef(input)).toBe(false);
+  });
+});

--- a/packages/grafana-data/src/utils/datasource.ts
+++ b/packages/grafana-data/src/utils/datasource.ts
@@ -29,8 +29,14 @@ export function getDataSourceRef(ds: DataSourceInstanceSettings): DataSourceRef 
  *
  * @public
  */
-export function isDataSourceRef(ref: DataSourceRef | string | null | undefined): ref is DataSourceRef {
-  return typeof ref === 'object' && typeof ref?.uid === 'string';
+export function isDataSourceRef(ref: unknown): ref is DataSourceRef {
+  if (typeof ref !== 'object' || ref === null) {
+    return false;
+  }
+
+  const hasUid = 'uid' in ref && typeof ref.uid === 'string';
+  const hasType = 'type' in ref && typeof ref.type === 'string';
+  return hasUid || hasType;
 }
 
 /**

--- a/public/app/features/dashboard/state/DashboardMigrator.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.test.ts
@@ -1846,6 +1846,16 @@ describe('DashboardModel', () => {
               },
             ],
           },
+          // @ts-expect-error
+          {
+            id: 7,
+            datasource: { type: 'prometheus', uid: 'prom-uid' },
+          },
+          // @ts-expect-error
+          {
+            id: 8,
+            datasource: { type: 'prometheus' },
+          },
         ],
       });
     });
@@ -1874,6 +1884,14 @@ describe('DashboardModel', () => {
 
     it('should update datasources in panels collapsed rows', () => {
       expect(model.panels[3].panels?.[0].datasource).toEqual({ type: 'prometheus', uid: 'prom-uid' });
+    });
+
+    it("should not migrate datasource if it's already a ref", () => {
+      expect(model.panels[4].datasource).toEqual({ type: 'prometheus', uid: 'prom-uid' });
+    });
+
+    it("should not migrate datasource if it's already a ref with only a type", () => {
+      expect(model.panels[5].datasource).toEqual({ type: 'prometheus' });
     });
   });
 


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/101495 

`{ type: "prometheus" }` is a valid `DataSourceRef`, but `isDataSourceRef` would return false for it which prevented the `migrateDatasourceNameToRef` logic from working correctly if it's already a datasource ref. This is a problem at the moment with our dev-dashboards which only work concidentally if the default datasource is the correct one.

This PR changes `isDataSourceRef` to say that any object with _either_ `uid` or `type` is a valid `DataSourceRef`. It adds some tests for this function specifically, and in the DashboardMigrator to make sure it works correctly.