### PR TITLE
Kubernetes Dashboards: Allow access when user has access to dashboard but not to parent folder

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -9,6 +9,7 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Alert, Icon, Input, LoadingBar, Stack, Text, useStyles2 } from '@grafana/ui';
+import { getStatusFromError } from 'app/core/utils/errors';
 import { useGetFolderQuery } from 'app/features/browse-dashboards/api/browseDashboardsAPI';
 import { DashboardViewItemWithUIItems, DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
@@ -72,6 +73,10 @@ export function NestedFolderPicker({
 }: NestedFolderPickerProps) {
   const styles = useStyles2(getStyles);
   const selectedFolder = useGetFolderQuery(value || skipToken);
+  // user might not have access to the folder, but they have access to the dashboard
+  // in this case we disable the folder picker - this is an edge case when user has edit access to a dashboard
+  // but doesn't have access to the folder
+  const isForbidden = getStatusFromError(selectedFolder.error) === 403;
 
   const nestedFoldersEnabled = Boolean(config.featureToggles.nestedFolders);
 
@@ -296,6 +301,7 @@ export function NestedFolderPicker({
             : undefined
         }
         {...getReferenceProps()}
+        disabled={isForbidden}
       />
     );
   }

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -162,7 +162,7 @@ describe('v1 dashboard API', () => {
     expect(result.dashboard.version).toBe(1);
   });
 
-  it('throws an error if folder is not found', async () => {
+  it('throws an error if folder service returns an error other than 403', async () => {
     mockGet.mockResolvedValueOnce({
       ...mockDashboardDto,
       metadata: {
@@ -176,6 +176,27 @@ describe('v1 dashboard API', () => {
 
     const api = new K8sDashboardAPI();
     await expect(api.getDashboardDTO('test')).rejects.toThrow('Failed to load folder');
+  });
+
+  it('should not throw an error if folder is not found and user has access to dashboard but not to folder', async () => {
+    mockGet.mockResolvedValueOnce({
+      ...mockDashboardDto,
+      metadata: { ...mockDashboardDto.metadata, annotations: { [AnnoKeyFolder]: 'new-folder' } },
+    });
+    jest.spyOn(backendSrv, 'getFolderByUid').mockRejectedValueOnce({ message: 'folder not found', status: 403 });
+
+    const api = new K8sDashboardAPI();
+    const dashboardDTO = await api.getDashboardDTO('test');
+    expect(dashboardDTO.dashboard).toMatchObject({
+      schemaVersion: 0,
+      title: 'test',
+      uid: 'dash-uid',
+      version: 1,
+    });
+    expect(dashboardDTO.meta.folderTitle).toBeUndefined();
+    expect(dashboardDTO.meta.folderUrl).toBeUndefined();
+    expect(dashboardDTO.meta.folderUid).toBeUndefined();
+    expect(dashboardDTO.meta.folderId).toBeUndefined();
   });
 
   describe('saveDashboard', () => {

--- a/public/app/features/dashboard/api/v1.test.ts
+++ b/public/app/features/dashboard/api/v1.test.ts
@@ -193,9 +193,10 @@ describe('v1 dashboard API', () => {
       uid: 'dash-uid',
       version: 1,
     });
+    // we still want to save the folder uid so that we can properly handle disabling the folder picker in Settings -> General
+    expect(dashboardDTO.meta.folderUid).toBe('new-folder');
     expect(dashboardDTO.meta.folderTitle).toBeUndefined();
     expect(dashboardDTO.meta.folderUrl).toBeUndefined();
-    expect(dashboardDTO.meta.folderUid).toBeUndefined();
     expect(dashboardDTO.meta.folderId).toBeUndefined();
   });
 

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -162,6 +162,9 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
           if (getStatusFromError(e) !== 403) {
             throw new Error('Failed to load folder');
           }
+          // we still want to save the folder uid so that we can properly handle disabling the folder picker in Settings -> General
+          // this is an edge case when user has edit access to a dashboard but doesn't have access to the folder
+          result.meta.folderUid = dash.metadata.annotations?.[AnnoKeyFolder];
         }
       }
 

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -158,7 +158,10 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
           result.meta.folderUid = folder.uid;
           result.meta.folderId = folder.id;
         } catch (e) {
-          throw new Error('Failed to load folder');
+          // If user has access to dashboard but not to folder, continue without folder info
+          if (getStatusFromError(e) !== 403) {
+            throw new Error('Failed to load folder');
+          }
         }
       }
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -64,7 +64,10 @@ export class K8sDashboardV2API
           dashboard.metadata.annotations[AnnoKeyFolderTitle] = folder.title;
           dashboard.metadata.annotations[AnnoKeyFolderUrl] = folder.url;
         } catch (e) {
-          throw new Error('Failed to load folder');
+          // If user has access to dashboard but not to folder, continue without folder info
+          if (getStatusFromError(e) !== 403) {
+            throw new Error('Failed to load folder');
+          }
         }
       } else if (dashboard.metadata.annotations && !dashboard.metadata.annotations[AnnoKeyFolder]) {
         // Set AnnoKeyFolder to empty string for top-level dashboards


### PR DESCRIPTION
**What is this feature?**

Users can be granted access to dashboards and should be able to access them even if they don't have access to the parent folder. With `kubernetesDashboards`, we currently don't allow this, which is a bug. The dashboard correctly appears in `Shared with me` folder, but clicking on it returns a "Folder not found" error. 

**Why do we need this feature?**

To enable users to access shared dashboards even if they don't have access to parent folder.

**Who is this feature for?**

Grafana users who want to share dashboard-level access while not granting parent folder-level access. 

**Which issue(s) does this PR fix?**:

- Automatically closes linked issue when the Pull Request is merged.

Fixes https://github.com/grafana/support-escalations/issues/16744
FIxes https://github.com/grafana/support-escalations/issues/17439

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
