### PR TITLE
datasources: strict local-time-range parsing

### DIFF
--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -401,7 +401,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 			},
 			"timeRange": {
 				"from": "1753944618000",
-				"not_to": "1753944619000"
+				"to": 1753944619000
 			}
 		}`)
 		mr.From = ""
@@ -437,7 +437,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 				"type": "postgres"
 			},
 			"timeRange": {
-				"not_from": "1753944618000",
+				"from": 1753944618000,
 				"to": "1753944619000"
 			}
 		}`)

--- a/pkg/services/query/query_test.go
+++ b/pkg/services/query/query_test.go
@@ -391,7 +391,7 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 		verifyTimestamps(parsedReq2, int64(0), int64(0), int64(0), int64(0))
 	})
 
-	t.Run("Test a datasource query with malformed local time range", func(t *testing.T) {
+	t.Run("Test a datasource query with local time range, malformed to-value", func(t *testing.T) {
 		tc := setup(t, false, nil)
 		mr := metricRequestWithQueries(t, `{
 			"refId": "A",
@@ -403,29 +403,67 @@ func TestIntegrationParseMetricRequest(t *testing.T) {
 				"from": "1753944618000",
 				"not_to": "1753944619000"
 			}
-		}`, `{
-			"refId": "B",
+		}`)
+		mr.From = ""
+		mr.To = ""
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "'to'")
+	})
+	t.Run("Test a datasource query with local time range, missing to-value", func(t *testing.T) {
+		tc := setup(t, false, nil)
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
 			"datasource": {
 				"uid": "gIEkMvIVz",
 				"type": "postgres"
 			},
-			"timeRange": 42
+			"timeRange": {
+				"from": "1753944618000"
+			}
 		}`)
 		mr.From = ""
 		mr.To = ""
-		parsedReq, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
-		require.NoError(t, err)
-		require.NotNil(t, parsedReq)
-		assert.Len(t, parsedReq.parsedQueries, 1)
-		assert.Contains(t, parsedReq.parsedQueries, "gIEkMvIVz")
-		queries := parsedReq.getFlattenedQueries()
-		assert.Len(t, queries, 2)
-
-		assert.Equal(t, int64(1753944618000), queries[0].query.TimeRange.From.UnixMilli())
-		assert.Equal(t, int64(0), queries[0].query.TimeRange.To.UnixMilli())
-
-		assert.Equal(t, int64(0), queries[1].query.TimeRange.From.UnixMilli())
-		assert.Equal(t, int64(0), queries[1].query.TimeRange.To.UnixMilli())
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "'to'")
+	})
+	t.Run("Test a datasource query with local time range, malformed from-value", func(t *testing.T) {
+		tc := setup(t, false, nil)
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			},
+			"timeRange": {
+				"not_from": "1753944618000",
+				"to": "1753944619000"
+			}
+		}`)
+		mr.From = ""
+		mr.To = ""
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "'from'")
+	})
+	t.Run("Test a datasource query with local time range, missing from-value", func(t *testing.T) {
+		tc := setup(t, false, nil)
+		mr := metricRequestWithQueries(t, `{
+			"refId": "A",
+			"datasource": {
+				"uid": "gIEkMvIVz",
+				"type": "postgres"
+			},
+			"timeRange": {
+				"to": "1753944619000"
+			}
+		}`)
+		mr.From = ""
+		mr.To = ""
+		_, err := tc.queryService.parseMetricRequest(context.Background(), tc.signedInUser, true, mr, true)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "'from'")
 	})
 }
 


### PR DESCRIPTION
when we parse a request that contains local time ranges (so the time range is specified inside each query), we should be stricter on what formats we accept.

this PR makes sure the time range section contains both `from` and `to` fields, and that they are both strings.

NOTE: unfortunately, right now this code cannot be exercised from the query-service, because when the request enters through the query-service endpoint, there is a separate parsing step happening there, which already rejects bad things. still, i think it's good to have this parsing be strict too.