### PR TITLE
DatasourcePicker: Include the number of datasources in reported event

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.test.tsx
@@ -241,6 +241,7 @@ jest.mock('@grafana/runtime', () => ({
       // if datasource is not found, return default instance settings
       return instance1SettingsMock;
     },
+    getList: () => [],
   }),
   config: {
     ...jest.requireActual('@grafana/runtime').config,

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -9,7 +9,7 @@ import { Trans } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 
-import { useDatasources, useKeyboardNavigatableList, useRecentlyUsedDataSources } from '../../hooks';
+import { useKeyboardNavigatableList, useRecentlyUsedDataSources } from '../../hooks';
 
 import { AddNewDataSourceButton } from './AddNewDataSourceButton';
 import { DataSourceCard } from './DataSourceCard';

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -9,7 +9,7 @@ import { Trans } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useStyles2, useTheme2 } from '@grafana/ui';
 
-import { useKeyboardNavigatableList, useRecentlyUsedDataSources } from '../../hooks';
+import { useDatasources, useKeyboardNavigatableList, useRecentlyUsedDataSources } from '../../hooks';
 
 import { AddNewDataSourceButton } from './AddNewDataSourceButton';
 import { DataSourceCard } from './DataSourceCard';
@@ -43,7 +43,7 @@ export interface DataSourceListProps {
   onClear?: () => void;
   onClickEmptyStateCTA?: () => void;
   enableKeyboardNavigation?: boolean;
-  dataSources: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
+  dataSources?: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
 }
 
 export function DataSourceList(props: DataSourceListProps) {
@@ -58,7 +58,20 @@ export function DataSourceList(props: DataSourceListProps) {
   const styles = getStyles(theme, selectedItemCssSelector);
 
   const { className, current, onChange, enableKeyboardNavigation, onClickEmptyStateCTA } = props;
-  const dataSources = props.dataSources;
+  const dataSources =
+    props.dataSources ||
+    useDatasources({
+      alerting: props.alerting,
+      annotations: props.annotations,
+      dashboard: props.dashboard,
+      logs: props.logs,
+      metrics: props.metrics,
+      mixed: props.mixed,
+      pluginId: props.pluginId,
+      tracing: props.tracing,
+      type: props.type,
+      variables: props.variables,
+    });
 
   const [recentlyUsedDataSources, pushRecentlyUsedDataSource] = useRecentlyUsedDataSources();
   const filteredDataSources = props.filter ? dataSources.filter(props.filter) : dataSources;

--- a/public/app/features/datasources/components/picker/DataSourceList.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceList.tsx
@@ -3,7 +3,7 @@ import { useRef } from 'react';
 import * as React from 'react';
 import { Observable } from 'rxjs';
 
-import { DataSourceInstanceSettings, DataSourceRef, GrafanaTheme2 } from '@grafana/data';
+import { DataSourceInstanceSettings, DataSourceJsonData, DataSourceRef, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
@@ -43,6 +43,7 @@ export interface DataSourceListProps {
   onClear?: () => void;
   onClickEmptyStateCTA?: () => void;
   enableKeyboardNavigation?: boolean;
+  dataSources: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
 }
 
 export function DataSourceList(props: DataSourceListProps) {
@@ -57,18 +58,7 @@ export function DataSourceList(props: DataSourceListProps) {
   const styles = getStyles(theme, selectedItemCssSelector);
 
   const { className, current, onChange, enableKeyboardNavigation, onClickEmptyStateCTA } = props;
-  const dataSources = useDatasources({
-    alerting: props.alerting,
-    annotations: props.annotations,
-    dashboard: props.dashboard,
-    logs: props.logs,
-    metrics: props.metrics,
-    mixed: props.mixed,
-    pluginId: props.pluginId,
-    tracing: props.tracing,
-    type: props.type,
-    variables: props.variables,
-  });
+  const dataSources = props.dataSources;
 
   const [recentlyUsedDataSources, pushRecentlyUsedDataSource] = useRecentlyUsedDataSources();
   const filteredDataSources = props.filter ? dataSources.filter(props.filter) : dataSources;

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -54,6 +54,7 @@ const setup = (partialProps: Partial<DataSourceModalProps> = {}) => {
     onChange: partialProps.onChange || jest.fn(),
     onDismiss: partialProps.onDismiss || jest.fn(),
     current: partialProps.current || mockDS1,
+    dataSources: partialProps.dataSources || mockDSList,
   };
 
   return render(<DataSourceModal {...props} />);
@@ -163,6 +164,7 @@ describe('DataSourceDropdown', () => {
         onDismiss: () => {},
         current: mockDS1.name,
         ...filters,
+        dataSources: mockDSList,
       };
 
       getListMock.mockClear();

--- a/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.test.tsx
@@ -54,7 +54,6 @@ const setup = (partialProps: Partial<DataSourceModalProps> = {}) => {
     onChange: partialProps.onChange || jest.fn(),
     onDismiss: partialProps.onDismiss || jest.fn(),
     current: partialProps.current || mockDS1,
-    dataSources: partialProps.dataSources || mockDSList,
   };
 
   return render(<DataSourceModal {...props} />);

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import { DataSourceInstanceSettings, DataSourceRef, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataQuery, DataSourceJsonData } from '@grafana/schema';
+import { DataQuery } from '@grafana/schema';
 import {
   Modal,
   FileDropzone,
@@ -56,7 +56,6 @@ export interface DataSourceModalProps {
   pluginId?: string;
   logs?: boolean;
   uploadFile?: boolean;
-  dataSources: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
 }
 
 export function DataSourceModal({
@@ -76,7 +75,6 @@ export function DataSourceModal({
   current,
   onDismiss,
   reportedInteractionFrom,
-  dataSources,
 }: DataSourceModalProps) {
   const styles = useStyles2(getDataSourceModalStyles);
   const [search, setSearch] = useState('');
@@ -189,7 +187,6 @@ export function DataSourceModal({
             logs={logs}
             dashboard={dashboard}
             mixed={mixed}
-            dataSources={dataSources}
           />
           <BuiltInList className={styles.appendBuiltInDataSourcesList} />
         </ScrollContainer>

--- a/public/app/features/datasources/components/picker/DataSourceModal.tsx
+++ b/public/app/features/datasources/components/picker/DataSourceModal.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from 'react';
 import { DataSourceInstanceSettings, DataSourceRef, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 import {
   Modal,
   FileDropzone,
@@ -56,6 +56,7 @@ export interface DataSourceModalProps {
   pluginId?: string;
   logs?: boolean;
   uploadFile?: boolean;
+  dataSources: Array<DataSourceInstanceSettings<DataSourceJsonData>>;
 }
 
 export function DataSourceModal({
@@ -75,6 +76,7 @@ export function DataSourceModal({
   current,
   onDismiss,
   reportedInteractionFrom,
+  dataSources,
 }: DataSourceModalProps) {
   const styles = useStyles2(getDataSourceModalStyles);
   const [search, setSearch] = useState('');
@@ -187,6 +189,7 @@ export function DataSourceModal({
             logs={logs}
             dashboard={dashboard}
             mixed={mixed}
+            dataSources={dataSources}
           />
           <BuiltInList className={styles.appendBuiltInDataSourcesList} />
         </ScrollContainer>

--- a/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.test.tsx
@@ -82,6 +82,7 @@ jest.mock('../../hooks', () => {
   return {
     ...actual,
     useRecentlyUsedDataSources: () => [[mockDS2.name], pushRecentlyUsedDataSourceMock],
+    useDatasources: () => mockDSList,
   };
 });
 

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -298,7 +298,6 @@ export function DataSourcePicker(props: DataSourcePickerProps) {
                   reportInteraction(INTERACTION_EVENT_NAME, {
                     item: INTERACTION_ITEM.SELECT_DS,
                     ds_type: ds.type,
-                    total_configured: dataSources.length,
                   });
                 }
               }}

--- a/public/app/features/datasources/components/picker/DataSourcePicker.tsx
+++ b/public/app/features/datasources/components/picker/DataSourcePicker.tsx
@@ -470,6 +470,7 @@ function Footer({ onClose, onChange, onClickAddCSV, ...props }: FooterProps) {
                   onChange(ds, defaultQueries);
                   hideModal();
                 },
+                dataSources: props.dataSources,
               });
               reportInteraction(INTERACTION_EVENT_NAME, { item: INTERACTION_ITEM.OPEN_ADVANCED_DS_PICKER });
             }}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

First part of https://github.com/grafana/grafana-community-team/issues/506, adding the `total_configured` number of datasources in the event reported when opening the DS picker.

Please, also review https://github.com/grafana/grafana-enterprise/pull/9269 as part of this.