### PR TITLE
Chore: Remove @grafana/tsconfig

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -685,6 +685,7 @@
 /project.json @grafana/frontend-ops
 /.nxignore @grafana/frontend-ops
 /tsconfig.json @grafana/frontend-ops
+/scripts/tsconfig.base.json @grafana/frontend-ops
 /.editorconfig @grafana/frontend-ops
 /eslint.config.js @grafana/frontend-ops
 /.betterer.eslint.config.js @grafana/frontend-ops

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,8 +1,8 @@
 {
+  "extends": "../scripts/tsconfig.base.json",
   "compilerOptions": {
     "types": ["cypress"],
     "resolveJsonModule": true
   },
-  "extends": "@grafana/tsconfig/base.json",
   "include": ["**/*.ts", "cypress/support/e2e.js", "cypress/support/index.d.ts"]
 }

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@grafana/eslint-plugin": "link:./packages/grafana-eslint-rules",
     "@grafana/plugin-e2e": "2.1.7",
     "@grafana/test-utils": "workspace:*",
-    "@grafana/tsconfig": "^2.0.0",
     "@manypkg/get-packages": "^3.0.0",
     "@npmcli/package-json": "^6.0.0",
     "@playwright/test": "1.54.1",

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@grafana/test-utils": "workspace:*",
-    "@grafana/tsconfig": "^2.0.0",
     "@rtk-query/codegen-openapi": "^2.0.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",

--- a/packages/grafana-alerting/tsconfig.json
+++ b/packages/grafana-alerting/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
@@ -8,7 +10,6 @@
     "moduleResolution": "bundler"
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["typings/jest", "../../public/app/types/*.d.ts", "../grafana-ui/src/types/*.d.ts", "src/**/*.ts*"],
   "ts-node": {
     "compilerOptions": {

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -84,7 +84,6 @@
     "xss": "^1.0.14"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@types/history": "4.7.11",
     "@types/lodash": "4.17.20",

--- a/packages/grafana-data/tsconfig.json
+++ b/packages/grafana-data/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
@@ -7,7 +9,6 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": [
     "src/**/*.ts*",
     "typings/jest",

--- a/packages/grafana-e2e-selectors/package.json
+++ b/packages/grafana-e2e-selectors/package.json
@@ -49,7 +49,6 @@
     "rollup-plugin-node-externals": "^8.0.0"
   },
   "dependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "semver": "^7.7.0",
     "tslib": "2.8.1",
     "typescript": "5.9.2"

--- a/packages/grafana-e2e-selectors/tsconfig.json
+++ b/packages/grafana-e2e-selectors/tsconfig.json
@@ -1,11 +1,12 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
     "isolatedModules": true,
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts"]
 }

--- a/packages/grafana-eslint-rules/tsconfig.json
+++ b/packages/grafana-eslint-rules/tsconfig.json
@@ -1,10 +1,10 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "module": "Node16",
     "moduleResolution": "Node16",
-    "declaration": false,
     "allowJs": true,
     "outDir": "./dist"
-  },
-  "extends": "@grafana/tsconfig"
+  }
 }

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -59,7 +59,6 @@
     "@babel/core": "7.28.0",
     "@babel/preset-env": "7.28.0",
     "@babel/preset-react": "7.27.1",
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "^6.1.2",

--- a/packages/grafana-flamegraph/tsconfig.json
+++ b/packages/grafana-flamegraph/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "declarationDir": "./dist/types",
@@ -8,6 +10,5 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts*", "../../public/app/types/*.d.ts", "../grafana-ui/src/types/*.d.ts"]
 }

--- a/packages/grafana-i18n/package.json
+++ b/packages/grafana-i18n/package.json
@@ -63,7 +63,6 @@
     "react-i18next": "^15.0.0"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@types/react": "18.3.18",
     "rollup": "^4.22.4",
     "rollup-plugin-copy": "3.5.0",

--- a/packages/grafana-i18n/tsconfig.json
+++ b/packages/grafana-i18n/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
@@ -7,6 +9,5 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts*"]
 }

--- a/packages/grafana-o11y-ds-frontend/package.json
+++ b/packages/grafana-o11y-ds-frontend/package.json
@@ -30,7 +30,6 @@
     "tslib": "2.8.1"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "16.3.0",

--- a/packages/grafana-o11y-ds-frontend/tsconfig.json
+++ b/packages/grafana-o11y-ds-frontend/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "declarationDir": "./compiled",
@@ -9,7 +11,6 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": [
     "../../public/test/setupTests.ts",
     "../../public/app/types/*.d.ts",

--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -8,6 +8,7 @@
   },
   "type": "module",
   "devDependencies": {
+    "@grafana/tsconfig": "^2.0.0",
     "@swc/core": "1.13.3",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",

--- a/packages/grafana-plugin-configs/package.json
+++ b/packages/grafana-plugin-configs/package.json
@@ -8,7 +8,6 @@
   },
   "type": "module",
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@swc/core": "1.13.3",
     "@swc/helpers": "^0.5.0",
     "@swc/jest": "^0.2.26",

--- a/packages/grafana-plugin-configs/tsconfig.json
+++ b/packages/grafana-plugin-configs/tsconfig.json
@@ -1,14 +1,14 @@
 {
-  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
-    "declaration": true,
     "jsx": "react-jsx",
     "alwaysStrict": true,
+    "declaration": false,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
+  "extends": "@grafana/tsconfig",
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
   "include": ["./types", "."]
 }

--- a/packages/grafana-plugin-configs/tsconfig.json
+++ b/packages/grafana-plugin-configs/tsconfig.json
@@ -1,14 +1,14 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "alwaysStrict": true,
-    "declaration": false,
     "resolveJsonModule": true,
     "moduleResolution": "bundler",
     "noEmit": true,
     "allowImportingTsExtensions": true
   },
-  "extends": "@grafana/tsconfig",
   "exclude": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
   "include": ["./types", "."]
 }

--- a/packages/grafana-prometheus/package.json
+++ b/packages/grafana-prometheus/package.json
@@ -78,7 +78,6 @@
     "uuid": "11.1.0"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-dynamic-import-vars": "2.1.5",
     "@rollup/plugin-image": "3.0.3",
     "@rollup/plugin-json": "6.1.0",

--- a/packages/grafana-prometheus/tsconfig.json
+++ b/packages/grafana-prometheus/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "alwaysStrict": true,
     "declarationDir": "./dist/types",
@@ -11,7 +13,6 @@
     "moduleResolution": "bundler"
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": [
     "../../public/test/setupTests.ts",
     "../../public/app/types/*.d.ts",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -67,7 +67,6 @@
     "tslib": "2.8.1"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@rollup/plugin-terser": "0.4.4",
     "@testing-library/dom": "10.4.1",

--- a/packages/grafana-runtime/tsconfig.json
+++ b/packages/grafana-runtime/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "declarationDir": "./dist/types",
@@ -9,7 +11,6 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": [
     "../../public/test/setupTests.ts",
     "../../public/app/types/jquery/*.ts",

--- a/packages/grafana-schema/package.json
+++ b/packages/grafana-schema/package.json
@@ -36,7 +36,6 @@
     "postpack": "mv package.json.bak package.json"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "esbuild": "0.25.8",
     "glob": "^11.0.0",

--- a/packages/grafana-schema/tsconfig.json
+++ b/packages/grafana-schema/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "declarationDir": "./dist/types",
     "emitDeclarationOnly": true,
@@ -7,6 +9,5 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts*"]
 }

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -36,7 +36,6 @@
     "uuid": "11.1.0"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@testing-library/dom": "10.4.1",
     "@testing-library/jest-dom": "^6.1.2",
     "@testing-library/react": "16.3.0",

--- a/packages/grafana-sql/tsconfig.json
+++ b/packages/grafana-sql/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "declarationDir": "./compiled",
@@ -9,6 +11,5 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts*", "../../public/app/types/*.d.ts", "../grafana-ui/src/types/*.d.ts"]
 }

--- a/packages/grafana-test-utils/package.json
+++ b/packages/grafana-test-utils/package.json
@@ -56,7 +56,6 @@
     "msw": "2.10.4"
   },
   "devDependencies": {
-    "@grafana/tsconfig": "^2.0.0",
     "@swc/core": "1.13.3",
     "@swc/jest": "^0.2.26",
     "@types/jest": "29.5.14",

--- a/packages/grafana-test-utils/tsconfig.json
+++ b/packages/grafana-test-utils/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "declarationDir": "./compiled",
     "emitDeclarationOnly": true,
@@ -14,6 +16,5 @@
     }
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["src/**/*.ts*"]
 }

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -136,7 +136,6 @@
   "devDependencies": {
     "@babel/core": "7.28.0",
     "@faker-js/faker": "^9.0.0",
-    "@grafana/tsconfig": "^2.0.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@storybook/addon-a11y": "^8.6.2",
     "@storybook/addon-actions": "^8.6.2",

--- a/packages/grafana-ui/tsconfig.json
+++ b/packages/grafana-ui/tsconfig.json
@@ -1,5 +1,7 @@
 {
+  "extends": "../../scripts/tsconfig.base.json",
   "compilerOptions": {
+    "declaration": true,
     "jsx": "react-jsx",
     "baseUrl": "./",
     "declarationDir": "./dist/types",
@@ -9,7 +11,6 @@
     "rootDirs": ["."]
   },
   "exclude": ["dist/**/*"],
-  "extends": "@grafana/tsconfig",
   "include": ["../../public/test/setupTests.ts", "../../public/app/types/*.d.ts", "src/**/*.ts*"],
   // override for storybook which uses ts-node to compile main.ts / preview.ts files.
   "ts-node": {

--- a/scripts/tsconfig.base.json
+++ b/scripts/tsconfig.base.json
@@ -1,0 +1,26 @@
+// Base config file for all Typescript prjects in the Grafana monorepo
+{
+  "compilerOptions": {
+    "alwaysStrict": true,
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "downlevelIteration": true,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "importHelpers": true,
+    "jsx": "react",
+    "lib": ["dom", "dom.iterable", "es2022"],
+    "module": "esnext",
+    "moduleResolution": "node",
+    "noEmitHelpers": true,
+    "noImplicitAny": true,
+    "noImplicitReturns": true,
+    "noImplicitThis": true,
+    "noUnusedLocals": true,
+    "pretty": true,
+    "skipLibCheck": true,
+    "sourceMap": true,
+    "target": "es2018"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "extends": "./scripts/tsconfig.base.json",
   "compilerOptions": {
     "jsx": "react-jsx",
     "baseUrl": "public/",
@@ -22,7 +23,6 @@
       "moduleResolution": "Node"
     }
   },
-  "extends": "@grafana/tsconfig/base.json",
   "include": [
     "public/app/**/*.ts*",
     "public/swagger/**/*.ts*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3405,6 +3405,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/plugin-configs@workspace:packages/grafana-plugin-configs"
   dependencies:
+    "@grafana/tsconfig": "npm:^2.0.0"
     "@swc/core": "npm:1.13.3"
     "@swc/helpers": "npm:^0.5.0"
     "@swc/jest": "npm:^0.2.26"
@@ -3703,6 +3704,13 @@ __metadata:
     typescript: "npm:5.9.2"
   languageName: unknown
   linkType: soft
+
+"@grafana/tsconfig@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "@grafana/tsconfig@npm:2.0.0"
+  checksum: 10/81e3c07e2f3f01e70b3e73a5f7e71871dc3a14c683b1d760828e0c4d609f55adf5111ff72b9148b7a7af3cdeb6199af1fdd295140b003ef2ff74f01a8b77bd09
+  languageName: node
+  linkType: hard
 
 "@grafana/ui@npm:12.2.0-pre, @grafana/ui@workspace:*, @grafana/ui@workspace:packages/grafana-ui":
   version: 0.0.0-use.local

--- a/yarn.lock
+++ b/yarn.lock
@@ -3027,7 +3027,6 @@ __metadata:
   dependencies:
     "@faker-js/faker": "npm:^9.8.0"
     "@grafana/test-utils": "workspace:*"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@rtk-query/codegen-openapi": "npm:^2.0.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
@@ -3107,7 +3106,6 @@ __metadata:
     "@braintree/sanitize-url": "npm:7.0.1"
     "@grafana/i18n": "npm:12.2.0-pre"
     "@grafana/schema": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@leeoniya/ufuzzy": "npm:1.0.18"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@types/d3-interpolate": "npm:^3.0.0"
@@ -3158,7 +3156,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/e2e-selectors@workspace:packages/grafana-e2e-selectors"
   dependencies:
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@types/node": "npm:22.17.0"
     "@types/semver": "npm:7.7.0"
@@ -3256,7 +3253,6 @@ __metadata:
     "@babel/preset-react": "npm:7.27.1"
     "@emotion/css": "npm:11.13.5"
     "@grafana/data": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:12.2.0-pre"
     "@leeoniya/ufuzzy": "npm:1.0.18"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
@@ -3311,7 +3307,6 @@ __metadata:
   resolution: "@grafana/i18n@workspace:packages/grafana-i18n"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@types/react": "npm:18.3.18"
     "@typescript-eslint/utils": "npm:^8.33.1"
     fast-deep-equal: "npm:^3.1.3"
@@ -3382,7 +3377,6 @@ __metadata:
     "@grafana/plugin-ui": "npm:0.10.8"
     "@grafana/runtime": "npm:12.2.0-pre"
     "@grafana/schema": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:12.2.0-pre"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/jest-dom": "npm:^6.1.2"
@@ -3411,7 +3405,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/plugin-configs@workspace:packages/grafana-plugin-configs"
   dependencies:
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@swc/core": "npm:1.13.3"
     "@swc/helpers": "npm:^0.5.0"
     "@swc/jest": "npm:^0.2.26"
@@ -3490,7 +3483,6 @@ __metadata:
     "@grafana/plugin-ui": "npm:0.10.8"
     "@grafana/runtime": "npm:12.2.0-pre"
     "@grafana/schema": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:12.2.0-pre"
     "@hello-pangea/dnd": "npm:18.0.1"
     "@leeoniya/ufuzzy": "npm:1.0.18"
@@ -3558,7 +3550,6 @@ __metadata:
     "@grafana/e2e-selectors": "npm:12.2.0-pre"
     "@grafana/faro-web-sdk": "npm:^1.13.2"
     "@grafana/schema": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:12.2.0-pre"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@rollup/plugin-terser": "npm:0.4.4"
@@ -3642,7 +3633,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/schema@workspace:packages/grafana-schema"
   dependencies:
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     esbuild: "npm:0.25.8"
     glob: "npm:^11.0.0"
@@ -3665,7 +3655,6 @@ __metadata:
     "@grafana/i18n": "npm:12.2.0-pre"
     "@grafana/plugin-ui": "npm:0.10.8"
     "@grafana/runtime": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "npm:12.2.0-pre"
     "@react-awesome-query-builder/ui": "npm:6.6.15"
     "@testing-library/dom": "npm:10.4.1"
@@ -3705,7 +3694,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@grafana/test-utils@workspace:packages/grafana-test-utils"
   dependencies:
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@swc/core": "npm:1.13.3"
     "@swc/jest": "npm:^0.2.26"
     "@types/jest": "npm:29.5.14"
@@ -3715,13 +3703,6 @@ __metadata:
     typescript: "npm:5.9.2"
   languageName: unknown
   linkType: soft
-
-"@grafana/tsconfig@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "@grafana/tsconfig@npm:2.0.0"
-  checksum: 10/81e3c07e2f3f01e70b3e73a5f7e71871dc3a14c683b1d760828e0c4d609f55adf5111ff72b9148b7a7af3cdeb6199af1fdd295140b003ef2ff74f01a8b77bd09
-  languageName: node
-  linkType: hard
 
 "@grafana/ui@npm:12.2.0-pre, @grafana/ui@workspace:*, @grafana/ui@workspace:packages/grafana-ui":
   version: 0.0.0-use.local
@@ -3738,7 +3719,6 @@ __metadata:
     "@grafana/faro-web-sdk": "npm:^1.13.2"
     "@grafana/i18n": "npm:12.2.0-pre"
     "@grafana/schema": "npm:12.2.0-pre"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@hello-pangea/dnd": "npm:18.0.1"
     "@monaco-editor/react": "npm:4.7.0"
     "@popperjs/core": "npm:2.11.8"
@@ -18227,7 +18207,6 @@ __metadata:
     "@grafana/schema": "workspace:*"
     "@grafana/sql": "workspace:*"
     "@grafana/test-utils": "workspace:*"
-    "@grafana/tsconfig": "npm:^2.0.0"
     "@grafana/ui": "workspace:*"
     "@hello-pangea/dnd": "npm:18.0.1"
     "@kusto/monaco-kusto": "npm:^10.0.0"


### PR DESCRIPTION
The Grafana tsconfig files all extend `@grafana/tsconfig` from https://github.com/grafana/tsconfig-grafana.

It's difficult to maintain Grafana's tsconfig in a seperate file, requiring it's own npm release process to pull the changes into Grafana core. Additionally, the needs of grafana plugins are different from grafana core, so it makes less sense to share a base config.[ Grafana core modifies the extended config](https://github.com/grafana/grafana/blob/main/tsconfig.json) significantly anyway, negating much of the benefit.

This PR copies the base config from https://github.com/grafana/tsconfig-grafana into `./scripts/tsconfig.base.json` and uses that for all tsconfigs in this repo. This is intended to be as close to a no-op as possible to minimise any breakages. 

In later PRs we can work on other changes to the configs.