### PR TITLE
chore: use native histogram for search shadow traffic match percentage

### DIFF
--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -24,11 +24,12 @@ var (
 	// searchResultsMatchHistogram tracks the percentage match between legacy and unified search results
 	searchResultsMatchHistogram = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Namespace: "grafana",
-			Subsystem: "unified_storage",
-			Name:      "search_results_match_percentage",
-			Help:      "Histogram of percentage match between legacy and unified search results",
-			Buckets:   []float64{0, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100},
+			Namespace:                      "grafana",
+			Subsystem:                      "unified_storage",
+			Name:                           "search_results_match_percentage",
+			Help:                           "Native histogram of percentage match between legacy and unified search results",
+			NativeHistogramBucketFactor:    1.1,
+			NativeHistogramMaxBucketNumber: 100,
 		},
 		[]string{"resource_type"},
 	)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Changes `unified_storage_search_results_match_percentage_bucket` to be a native histogram.

**Why do we need this feature?**

Native histograms are all-around better than standard histograms, so we should strive to use those.

**Who is this feature for?**

Grafana Search & Storage.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Small fix for https://github.com/grafana/search-and-storage-team/issues/414

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
