### PR TITLE
Provisioning: Change decrypter service identity to api group name

### DIFF
--- a/pkg/registry/apis/provisioning/secrets/secret.go
+++ b/pkg/registry/apis/provisioning/secrets/secret.go
@@ -10,9 +10,11 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 )
 
-const svcName = "provisioning"
+const svcName = provisioning.GROUP
 
 //go:generate mockery --name SecureValueClient --structname MockSecureValueClient --inpackage --filename secure_value_client_mock.go --with-expecter
 type SecureValueClient = secret.SecureValueClient


### PR DESCRIPTION
**What is this feature?**

Updates the Provisioning service identity name to the API group name.

**Why do we need this feature?**

Secrets UI will try to discover all APIs available with Service Discovery, and thus having a standardised name will make it easier to list available decrypters based on their API group name rather than an arbitrary string.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
