### PR TITLE
LogLineMenu: improve options and dividers

### DIFF
--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -83,6 +83,8 @@ export const LogLineMenu = ({ log, styles }: Props) => {
     }
   }, [log, onPinLine, onUnpinLine, pinned]);
 
+  const showFirstDivider = enableLogDetails || shouldlogSupportsContext || onPinLine || onUnpinLine;
+
   const menu = useCallback(
     () => (
       <Menu ref={menuRef}>
@@ -105,17 +107,10 @@ export const LogLineMenu = ({ log, styles }: Props) => {
         {pinned && onUnpinLine && (
           <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.unpin-from-outline', 'Unpin log')} />
         )}
-        <Menu.Divider />
+        {showFirstDivider && <Menu.Divider />}
         <Menu.Item onClick={copyLogLine} label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
         {onPermalinkClick && log.rowId !== undefined && log.uid && (
           <Menu.Item onClick={copyLinkToLogLine} label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
-        )}
-        {isAssistantAvailable && (
-          <Menu.Item
-            onClick={() => openAssistantByLog?.(log)}
-            icon="ai-sparkle"
-            label={t('logs.log-line-menu.open-assistant', 'Explain this log line in Assistant')}
-          />
         )}
         {logLineMenuCustomItems.map((item, i) => {
           if (isDivider(item)) {
@@ -126,23 +121,34 @@ export const LogLineMenu = ({ log, styles }: Props) => {
           }
           return null;
         })}
+        {isAssistantAvailable && (
+          <>
+            <Menu.Divider />
+            <Menu.Item
+              onClick={() => openAssistantByLog?.(log)}
+              icon="ai-sparkle"
+              label={t('logs.log-line-menu.open-assistant', 'Explain this log line in Assistant')}
+            />
+          </>
+        )}
       </Menu>
     ),
     [
-      copyLinkToLogLine,
-      copyLogLine,
-      detailsDisplayed,
       enableLogDetails,
+      toggleLogDetails,
+      detailsDisplayed,
       log,
-      logLineMenuCustomItems,
-      onPermalinkClick,
-      onPinLine,
-      onUnpinLine,
-      pinned,
       shouldlogSupportsContext,
       showContext,
-      toggleLogDetails,
+      pinned,
+      onPinLine,
       togglePinning,
+      onUnpinLine,
+      showFirstDivider,
+      copyLogLine,
+      onPermalinkClick,
+      copyLinkToLogLine,
+      logLineMenuCustomItems,
       isAssistantAvailable,
       openAssistantByLog,
     ]


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

This PR reorganizes items inside LogLineMenu so that:

1. We don't show an empty divider when there are no options on top.
2. The assistant is after custom options and has a divider.

Before:

<img width="319" height="225" alt="Before" src="https://github.com/user-attachments/assets/3c63e8cd-9ddb-44f9-b247-94d360f53163" />

Now:

<img width="312" height="238" alt="Now" src="https://github.com/user-attachments/assets/01de7d80-cc3f-4d5c-a31c-af080a5f7786" />