### PR TITLE
RepositoryOverview: hide job status from cloud version

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -1,7 +1,9 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
+import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Box, Card, CellProps, Grid, InteractiveTable, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { Repository, ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -249,9 +251,14 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
             </div>
           )}
         </Grid>
-        <div className={styles.cardContainer}>
-          <RecentJobs repo={repo} />
-        </div>
+
+        {/* job status is not ready for Cloud yet */}
+        {config.buildInfo.edition === GrafanaEdition.OpenSource ||
+          (config.buildInfo.edition === GrafanaEdition.Enterprise && (
+            <div className={styles.cardContainer}>
+              <RecentJobs repo={repo} />
+            </div>
+          ))}
       </Stack>
     </Box>
   );


### PR DESCRIPTION
**What is this feature?**

Hide RepositoryOverview job status from Grafana Cloud

**Why do we need this feature?**

Job status is not ready yet for Cloud. See linked ticket

**Who is this feature for?**

- Git user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/424

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
