### PR TITLE
CloudWatch: Fix handling region for legacy alerts

### DIFF
--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query.go
@@ -382,7 +382,7 @@ func (q *CloudWatchQuery) validateAndSetDefaults(refId string, metricsDataQuery 
 		}
 	}
 
-	if q.Region == defaultRegion {
+	if q.Region == defaultRegion || q.Region == "" {
 		q.Region = defaultRegionValue
 	}
 

--- a/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/tsdb/cloudwatch/models/cloudwatch_query_test.go
@@ -1195,12 +1195,39 @@ func Test_ParseMetricDataQueries_account_Id(t *testing.T) {
 }
 
 func Test_ParseMetricDataQueries_default_region(t *testing.T) {
-	t.Run("default region is used when when region not set", func(t *testing.T) {
+	t.Run("default region is used when when region is default", func(t *testing.T) {
 		query := []backend.DataQuery{
 			{
 				JSON: json.RawMessage(`{
 				   "refId":"ref1",
 				   "region":"default",
+				   "namespace":"ec2",
+				   "metricName":"CPUUtilization",
+				   "id": "",
+				   "expression": "",
+				   "dimensions":{
+					  "InstanceId":["test"],
+					  "InstanceType":["test2"]
+				   },
+				   "statistic":"Average",
+				   "period":"900",
+				   "hide":false
+				}`),
+			},
+		}
+
+		region := "us-east-2"
+		res, err := ParseMetricDataQueries(query, time.Now().Add(-2*time.Hour), time.Now().Add(-time.Hour), region, logger, false)
+		assert.NoError(t, err)
+		require.Len(t, res, 1)
+		require.NotNil(t, res[0])
+		assert.Equal(t, region, res[0].Region)
+	})
+	t.Run("default region is used when when region not set", func(t *testing.T) {
+		query := []backend.DataQuery{
+			{
+				JSON: json.RawMessage(`{
+				   "refId":"ref1",
 				   "namespace":"ec2",
 				   "metricName":"CPUUtilization",
 				   "id": "",

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.tsx
@@ -4,6 +4,7 @@ import { QueryEditorProps } from '@grafana/data';
 
 import { CloudWatchDatasource } from '../../datasource';
 import { isCloudWatchLogsQuery, isCloudWatchMetricsQuery } from '../../guards';
+import useMigratedQuery from '../../migrations/useMigratedQuery';
 import { CloudWatchJsonData, CloudWatchQuery } from '../../types';
 
 import LogsQueryEditor from './LogsQueryEditor/LogsQueryEditor';
@@ -14,6 +15,7 @@ export type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, Clou
 
 export const QueryEditor = (props: Props) => {
   const { query, onChange, data } = props;
+  const migratedQuery = useMigratedQuery(query, props.onChange);
   const [dataIsStale, setDataIsStale] = useState(false);
   const [extraHeaderElementLeft, setExtraHeaderElementLeft] = useState<JSX.Element>();
   const [extraHeaderElementRight, setExtraHeaderElementRight] = useState<JSX.Element>();
@@ -39,20 +41,20 @@ export const QueryEditor = (props: Props) => {
         dataIsStale={dataIsStale}
       />
 
-      {isCloudWatchMetricsQuery(query) && (
+      {isCloudWatchMetricsQuery(migratedQuery) && (
         <MetricsQueryEditor
           {...props}
-          query={query}
+          query={migratedQuery}
           onRunQuery={() => {}}
           onChange={onChangeInternal}
           extraHeaderElementLeft={setExtraHeaderElementLeft}
           extraHeaderElementRight={setExtraHeaderElementRight}
         />
       )}
-      {isCloudWatchLogsQuery(query) && (
+      {isCloudWatchLogsQuery(migratedQuery) && (
         <LogsQueryEditor
           {...props}
-          query={query}
+          query={migratedQuery}
           onChange={onChangeInternal}
           extraHeaderElementLeft={setExtraHeaderElementLeft}
         />

--- a/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.test.ts
@@ -1,6 +1,6 @@
-import { CloudWatchMetricsQuery } from '../types';
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../types';
 
-import { migrateAliasPatterns } from './metricQueryMigrations';
+import { migrateAliasPatterns, migrateMetricQuery } from './metricQueryMigrations';
 
 describe('metricQueryMigrations', () => {
   interface TestScenario {
@@ -72,5 +72,24 @@ describe('metricQueryMigrations', () => {
         expect(result.alias).toBe(alias);
       });
     });
+  });
+
+  it('migrates type and mode', () => {
+    const baseQuery: CloudWatchMetricsQuery = {
+      statistic: 'Average',
+      refId: 'A',
+      id: '',
+      region: 'us-east-2',
+      namespace: 'AWS/EC2',
+      period: '300',
+      alias: '',
+      metricName: 'CPUUtilization',
+      dimensions: {},
+      matchExact: false,
+      expression: '',
+    };
+    const migratedQuery = migrateMetricQuery(baseQuery);
+    expect(migratedQuery.metricQueryType).toBe(MetricQueryType.Search);
+    expect(migratedQuery.metricEditorMode).toBe(MetricEditorMode.Builder);
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.ts
@@ -2,10 +2,14 @@ import deepEqual from 'fast-deep-equal';
 
 import { CloudWatchMetricsQuery } from '../types';
 
+import { migrateCloudWatchQuery } from './dashboardMigrations';
+
 // Call this function to migrate queries from within the plugin.
 export function migrateMetricQuery(query: CloudWatchMetricsQuery): CloudWatchMetricsQuery {
+  const newQuery = { ...query };
+  migrateCloudWatchQuery(newQuery);
   //add metric query migrations here
-  const migratedQuery = migrateAliasPatterns(query);
+  const migratedQuery = migrateAliasPatterns(newQuery);
   return deepEqual(migratedQuery, query) ? query : migratedQuery;
 }
 

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.ts
@@ -11,15 +11,15 @@ const useMigratedMetricsQuery = (
   query: CloudWatchMetricsQuery,
   onChangeQuery: (newQuery: CloudWatchMetricsQuery) => void
 ) => {
-  const migratedQUery = useMemo(() => migrateMetricQuery(query), [query]);
+  const migratedQuery = useMemo(() => migrateMetricQuery(query), [query]);
 
   useEffect(() => {
-    if (migratedQUery !== query) {
-      onChangeQuery(migratedQUery);
+    if (migratedQuery !== query) {
+      onChangeQuery(migratedQuery);
     }
-  }, [migratedQUery, query, onChangeQuery]);
+  }, [migratedQuery, query, onChangeQuery]);
 
-  return migratedQUery;
+  return migratedQuery;
 };
 
 export default useMigratedMetricsQuery;

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.test.ts
@@ -1,0 +1,22 @@
+import { migrateQuery } from './useMigratedQuery';
+
+describe('useMigratedQuery', () => {
+  it('adds region and queryMode', () => {
+    const legacyQuery = {
+      statistic: 'Average',
+      refId: 'A',
+      id: '',
+      region: '',
+      namespace: 'AWS/EC2',
+      period: '300',
+      alias: '',
+      metricName: 'CPUUtilization',
+      dimensions: {},
+      matchExact: false,
+      expression: '',
+    };
+    const migratedQuery = migrateQuery(legacyQuery);
+    expect(migratedQuery.region).toBe('default');
+    expect(migratedQuery.queryMode).toBe('Metrics');
+  });
+});

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.ts
@@ -1,3 +1,4 @@
+import deepEqual from 'fast-deep-equal';
 import { useEffect, useMemo } from 'react';
 
 import { CloudWatchQuery } from '../types';
@@ -26,7 +27,7 @@ export function migrateQuery(query: CloudWatchQuery): CloudWatchQuery {
   if (!newQuery.region) {
     newQuery.region = 'default';
   }
-  return newQuery;
+  return deepEqual(newQuery, query) ? query : newQuery;
 }
 
 export default useMigratedQuery;

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedQuery.ts
@@ -1,0 +1,32 @@
+import { useEffect, useMemo } from 'react';
+
+import { CloudWatchQuery } from '../types';
+
+/**
+ * Returns queries with migrations, and calls onChange function to notify if it changes
+ */
+const useMigratedQuery = (query: CloudWatchQuery, onChangeQuery: (newQuery: CloudWatchQuery) => void) => {
+  const migratedQuery = useMemo(() => migrateQuery(query), [query]);
+
+  useEffect(() => {
+    if (migratedQuery !== query) {
+      onChangeQuery(migratedQuery);
+    }
+  }, [migratedQuery, query, onChangeQuery]);
+
+  return migratedQuery;
+};
+
+// The frontend doesn't run legacy queries if we don't set the queryMode and region
+export function migrateQuery(query: CloudWatchQuery): CloudWatchQuery {
+  const newQuery = { ...query };
+  if (!newQuery.queryMode) {
+    newQuery.queryMode = 'Metrics';
+  }
+  if (!newQuery.region) {
+    newQuery.region = 'default';
+  }
+  return newQuery;
+}
+
+export default useMigratedQuery;


### PR DESCRIPTION
This pr fixes the alerts by fixing the place in the backend that wasn't checking for region == "". i had to go into the db for my local instance and edit the alert entry there to test this if someone wants to repro it.
It also makes it so that the legacy queries run in the frontend by setting the queryMode and region fields. I was messing with it and I'm not sure why but the frontend doesn't even send them to the backend unless these fields are filled.
