### PR TITLE
InlineSecureValue: Add owner API group to decrypters list

### DIFF
--- a/pkg/registry/apis/secret/inline/inline_secure_value.go
+++ b/pkg/registry/apis/secret/inline/inline_secure_value.go
@@ -207,6 +207,7 @@ func (s *LocalInlineSecureValueService) CreateInline(ctx context.Context, owner 
 			Value:       &secret,
 			Decrypters: []string{
 				serviceIdentity,
+				owner.APIGroup,
 			},
 		},
 	}

--- a/pkg/registry/apis/secret/inline/inline_secure_value_test.go
+++ b/pkg/registry/apis/secret/inline/inline_secure_value_test.go
@@ -242,7 +242,8 @@ func TestIntegration_InlineSecureValue_CreateInline(t *testing.T) {
 
 		tu := testutils.Setup(t)
 
-		secret := common.NewSecretValue("test-value")
+		rawSecret := "test-value"
+		secret := common.NewSecretValue(rawSecret)
 
 		serviceIdentity := "service-identity"
 
@@ -259,7 +260,15 @@ func TestIntegration_InlineSecureValue_CreateInline(t *testing.T) {
 
 		decryptedResult, ok := decryptedValues[createdName]
 		require.True(t, ok)
-		require.Equal(t, decryptedResult.Value().DangerouslyExposeAndConsumeValue(), secret.DangerouslyExposeAndConsumeValue())
+		require.Equal(t, decryptedResult.Value().DangerouslyExposeAndConsumeValue(), rawSecret)
+
+		// can also decrypt with the owner.APIGroup as a decrypter
+		decryptedValues, err = tu.DecryptService.Decrypt(t.Context(), owner.APIGroup, owner.Namespace, []string{createdName})
+		require.NoError(t, err)
+
+		decryptedResult, ok = decryptedValues[createdName]
+		require.True(t, ok)
+		require.Equal(t, decryptedResult.Value().DangerouslyExposeAndConsumeValue(), rawSecret)
 	})
 
 	t.Run("when the auth info is missing it returns an error", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Adds the API Group i.e. `testdata.datasource.grafana.app` as one of the decrypters when creating a secure value inline.

**Why do we need this feature?**

When these Apps try to Decrypt, they need to have their service identity in the SecureValue decrypters field.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
