### PR TITLE
Secrets: Remove Close from decrypt client interface

### DIFF
--- a/pkg/registry/apis/provisioning/secrets/mocks/decrypt_service_mock.go
+++ b/pkg/registry/apis/provisioning/secrets/mocks/decrypt_service_mock.go
@@ -22,51 +22,6 @@ func (_m *MockDecryptService) EXPECT() *MockDecryptService_Expecter {
 	return &MockDecryptService_Expecter{mock: &_m.Mock}
 }
 
-// Close provides a mock function with no fields
-func (_m *MockDecryptService) Close() error {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for Close")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// MockDecryptService_Close_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Close'
-type MockDecryptService_Close_Call struct {
-	*mock.Call
-}
-
-// Close is a helper method to define mock.On call
-func (_e *MockDecryptService_Expecter) Close() *MockDecryptService_Close_Call {
-	return &MockDecryptService_Close_Call{Call: _e.mock.On("Close")}
-}
-
-func (_c *MockDecryptService_Close_Call) Run(run func()) *MockDecryptService_Close_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockDecryptService_Close_Call) Return(_a0 error) *MockDecryptService_Close_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockDecryptService_Close_Call) RunAndReturn(run func() error) *MockDecryptService_Close_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Decrypt provides a mock function with given fields: ctx, serviceName, namespace, names
 func (_m *MockDecryptService) Decrypt(ctx context.Context, serviceName string, namespace string, names []string) (map[string]contracts.DecryptResult, error) {
 	ret := _m.Called(ctx, serviceName, namespace, names)

--- a/pkg/registry/apis/secret/contracts/decrypt.go
+++ b/pkg/registry/apis/secret/contracts/decrypt.go
@@ -30,7 +30,6 @@ type DecryptAuthorizer interface {
 // DecryptService is the interface for the decrypt service.
 type DecryptService interface {
 	Decrypt(ctx context.Context, serviceName string, namespace string, names []string) (map[string]DecryptResult, error)
-	Close() error
 }
 
 // DecryptResult is the (union) result of a decryption operation.

--- a/pkg/registry/apis/secret/decrypt/grpc_client.go
+++ b/pkg/registry/apis/secret/decrypt/grpc_client.go
@@ -108,14 +108,6 @@ func createTLSCredentials(config TLSConfig) (credentials.TransportCredentials, e
 	return credentials.NewTLS(tlsConfig), nil
 }
 
-// Close will close the underlying gRPC connection. After it is closed, the client cannot be used anymore.
-func (g *GRPCDecryptClient) Close() error {
-	if g.conn != nil {
-		return g.conn.Close()
-	}
-	return nil
-}
-
 // Decrypt a set of secure value names in a given namespace for a specific service name.
 func (g *GRPCDecryptClient) Decrypt(ctx context.Context, serviceName string, namespace string, names []string) (map[string]contracts.DecryptResult, error) {
 	_, err := types.ParseNamespace(namespace)

--- a/pkg/registry/apis/secret/decrypt/local_client.go
+++ b/pkg/registry/apis/secret/decrypt/local_client.go
@@ -42,7 +42,3 @@ func (c *LocalDecryptClient) Decrypt(ctx context.Context, serviceName, namespace
 
 	return results, nil
 }
-
-func (c *LocalDecryptClient) Close() error {
-	return nil
-}

--- a/pkg/registry/apis/secret/decrypt/service_test.go
+++ b/pkg/registry/apis/secret/decrypt/service_test.go
@@ -219,8 +219,6 @@ func TestDecryptService(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, decryptService)
 
-		t.Cleanup(func() { require.NoError(t, decryptService.Close()) })
-
 		svcIdentity := "provsysoning-test"
 
 		result, err := decryptService.Decrypt(t.Context(), svcIdentity, namespace, []string{"secure-value-1"})


### PR DESCRIPTION
**What is this feature?**

Removes Close() method in the Decrypt client.

**Why do we need this feature?**

Remainings from when the client was namespaced and had to be created on every request.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
