### PR TITLE
InlineSecureValues: Only add decrypter if owner is different than svc identity

### DIFF
--- a/pkg/registry/apis/secret/inline/inline_secure_value.go
+++ b/pkg/registry/apis/secret/inline/inline_secure_value.go
@@ -198,6 +198,11 @@ func (s *LocalInlineSecureValueService) CreateInline(ctx context.Context, owner 
 	// TODO(2025-07-31): when we migrate to using the common type, we don't need this conversion.
 	secret := secretv1beta1.ExposedSecureValue(value)
 
+	decrypters := []string{serviceIdentity}
+	if owner.APIGroup != serviceIdentity {
+		decrypters = append(decrypters, owner.APIGroup)
+	}
+
 	spec := &secretv1beta1.SecureValue{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "sv-" + util.GenerateShortUID(),
@@ -207,10 +212,7 @@ func (s *LocalInlineSecureValueService) CreateInline(ctx context.Context, owner 
 		Spec: secretv1beta1.SecureValueSpec{
 			Description: fmt.Sprintf("Inline secure value for %s/%s in %s/%s", owner.Kind, owner.Name, owner.APIGroup, owner.APIVersion),
 			Value:       &secret,
-			Decrypters: []string{
-				serviceIdentity,
-				owner.APIGroup,
-			},
+			Decrypters:  decrypters,
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

Only sets the owner's API Group in the decrypters if it is different than the serviceIdentity found in the request token.

**Why do we need this feature?**

Avoid duplicates in case they are the same!

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
