### PR TITLE
Remote Alertmanager: Wire up remoteSecondaryAlertmanagerWithRemoteState and fix path

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -274,10 +274,11 @@ func (ng *AlertNG) init() error {
 
 					// Use both Alertmanager implementations in the forked Alertmanager.
 					rsCfg := remote.RemoteSecondaryConfig{
-						Logger:       log.New("ngalert.forked-alertmanager.remote-secondary"),
-						OrgID:        orgID,
-						Store:        ng.store,
-						SyncInterval: ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
+						Logger:          log.New("ngalert.forked-alertmanager.remote-secondary"),
+						OrgID:           orgID,
+						Store:           ng.store,
+						SyncInterval:    ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
+						WithRemoteState: remoteSecondaryWithRemoteState,
 					}
 					return remote.NewRemoteSecondaryForkedAlertmanager(rsCfg, internalAM, remoteAM)
 				}

--- a/pkg/services/ngalert/remote/client/alertmanager_state.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_state.go
@@ -33,7 +33,7 @@ func (mc *Mimir) getState(ctx context.Context, path string) (*UserState, error) 
 	}
 	// nolint:bodyclose
 	// closed within `do`
-	_, err := mc.do(ctx, grafanaAlertmanagerStatePath, http.MethodGet, nil, &response)
+	_, err := mc.do(ctx, path, http.MethodGet, nil, &response)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixing two issues with https://github.com/grafana/grafana/pull/107710:
- Use the value from the feature flag when creating a remote Alertmanager in _remote secondary_ mode
- Fix the path we use to fetch the full state