### PR TITLE
DataSourcePicker: Refactor as function component and tests

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -1,17 +1,60 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { DataSourceInstanceSettings, PluginMetaInfo, PluginType } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+
 import { DataSourcePicker } from './DataSourcePicker';
 
+const mockDataSourceSrv = {
+  getList: jest.fn(),
+  getInstanceSettings: jest.fn(),
+  get: jest.fn(),
+};
+
 jest.mock('../services/dataSourceSrv', () => ({
-  getDataSourceSrv: () => ({
-    getList: () => [],
-    getInstanceSettings: () => undefined,
-    get: () => undefined,
-  }),
+  getDataSourceSrv: () => mockDataSourceSrv,
 }));
 
+const createMockDataSource = (overrides: Partial<DataSourceInstanceSettings> = {}): DataSourceInstanceSettings => ({
+  id: 1,
+  uid: 'test-uid',
+  name: 'Test DataSource',
+  type: 'test',
+  url: 'http://test.com',
+  database: '',
+  basicAuth: '',
+  isDefault: false,
+  jsonData: {},
+  readOnly: false,
+  withCredentials: false,
+  meta: {
+    id: 'test',
+    name: 'Test',
+    type: PluginType.datasource,
+    info: {
+      author: { name: 'Test' },
+      description: 'Test datasource',
+      links: [],
+      logos: { small: 'test.svg', large: 'test.svg' },
+      updated: '',
+      version: '1.0.0',
+      screenshots: [],
+    } as PluginMetaInfo,
+    module: '',
+    baseUrl: '',
+  },
+  access: 'proxy',
+  ...overrides,
+});
+
 describe('DataSourcePicker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataSourceSrv.getList.mockReturnValue([]);
+    mockDataSourceSrv.getInstanceSettings.mockReturnValue(undefined);
+  });
+
   describe('onClear', () => {
     it('should call onClear when function is passed', async () => {
       const onClear = jest.fn();
@@ -35,6 +78,245 @@ describe('DataSourcePicker', () => {
 
       const input = screen.getByLabelText('Select a data source');
       expect(input).toHaveProperty('disabled', true);
+    });
+  });
+
+  describe('rendering', () => {
+    it('should render data source picker', () => {
+      render(<DataSourcePicker />);
+
+      expect(screen.getByLabelText('Select a data source')).toBeInTheDocument();
+    });
+
+    it('should render container with correct test id', () => {
+      render(<DataSourcePicker />);
+
+      expect(screen.getByTestId(selectors.components.DataSourcePicker.container)).toBeInTheDocument();
+    });
+
+    it('should show loading state', () => {
+      render(<DataSourcePicker isLoading={true} />);
+
+      expect(screen.getByTestId('Spinner')).toBeInTheDocument();
+    });
+  });
+
+  describe('data source options', () => {
+    it('should call getList with correct parameters for alerting', () => {
+      render(<DataSourcePicker alerting={true} />);
+
+      expect(mockDataSourceSrv.getList).toHaveBeenCalledWith({
+        alerting: true,
+        tracing: undefined,
+        metrics: undefined,
+        logs: undefined,
+        dashboard: undefined,
+        mixed: undefined,
+        variables: undefined,
+        annotations: undefined,
+        pluginId: undefined,
+        filter: undefined,
+        type: undefined,
+      });
+    });
+
+    it('should call getList with multiple filter parameters', () => {
+      const customFilter = jest.fn();
+
+      render(
+        <DataSourcePicker metrics={true} logs={true} pluginId="prometheus" type="prometheus" filter={customFilter} />
+      );
+
+      expect(mockDataSourceSrv.getList).toHaveBeenCalledWith({
+        alerting: undefined,
+        tracing: undefined,
+        metrics: true,
+        logs: true,
+        dashboard: undefined,
+        mixed: undefined,
+        variables: undefined,
+        annotations: undefined,
+        pluginId: 'prometheus',
+        filter: customFilter,
+        type: 'prometheus',
+      });
+    });
+
+    it('should display data source options with default label', async () => {
+      const mockDS = createMockDataSource({ name: 'Prometheus', isDefault: true });
+      mockDataSourceSrv.getList.mockReturnValue([mockDS]);
+
+      render(<DataSourcePicker />);
+
+      const select = screen.getByRole('combobox');
+      await userEvent.click(select);
+
+      expect(screen.getByText('Prometheus (default)')).toBeInTheDocument();
+    });
+
+    it('should display data source options without default label', async () => {
+      const mockDS = createMockDataSource({ name: 'Prometheus', isDefault: false });
+      mockDataSourceSrv.getList.mockReturnValue([mockDS]);
+
+      render(<DataSourcePicker />);
+
+      const select = screen.getByRole('combobox');
+      await userEvent.click(select);
+
+      expect(screen.getByText('Prometheus')).toBeInTheDocument();
+    });
+  });
+
+  describe('current value handling', () => {
+    it('should display current data source when provided', () => {
+      const mockDS = createMockDataSource({ uid: 'current-ds', name: 'Current DataSource' });
+      mockDataSourceSrv.getInstanceSettings.mockReturnValueOnce(mockDS);
+
+      render(<DataSourcePicker current="current-ds" />);
+
+      expect(mockDataSourceSrv.getInstanceSettings).toHaveBeenCalledWith('current-ds');
+    });
+
+    it('should handle data source ref as current value', () => {
+      const dsRef = { uid: 'ref-uid', type: 'prometheus' };
+      const mockDS = createMockDataSource({ uid: 'ref-uid', name: 'Ref DataSource' });
+      mockDataSourceSrv.getInstanceSettings.mockReturnValueOnce(mockDS);
+
+      render(<DataSourcePicker current={dsRef} />);
+
+      expect(mockDataSourceSrv.getInstanceSettings).toHaveBeenCalledWith(dsRef);
+    });
+
+    it('should handle noDefault prop correctly', () => {
+      render(<DataSourcePicker current={null} noDefault={true} />);
+
+      // Should not try to get default data source when noDefault is true and current is null
+      expect(screen.getByRole('combobox')).toHaveValue('');
+    });
+
+    it('should truncate long data source names', () => {
+      const longName = 'This is a very long data source name that should be truncated';
+      const mockDS = createMockDataSource({ uid: 'long-name-ds', name: longName });
+      mockDataSourceSrv.getInstanceSettings.mockReturnValue(mockDS);
+
+      render(<DataSourcePicker current="long-name-ds" />);
+
+      // Name should be truncated to 37 characters
+      expect(
+        screen.queryByText('This is a very long data source name that should be truncated')
+      ).not.toBeInTheDocument();
+      expect(screen.getByText('This is a very long data source name')).toBeInTheDocument();
+    });
+
+    it('should hide text when hideTextValue is true', () => {
+      const mockDS = createMockDataSource({ uid: 'test-ds', name: 'Test DataSource' });
+      mockDataSourceSrv.getInstanceSettings.mockReturnValue(mockDS);
+
+      render(<DataSourcePicker current="test-ds" hideTextValue={true} />);
+
+      // Text should be hidden, but image should still be visible
+      expect(screen.queryByText('Test DataSource')).not.toBeInTheDocument();
+    });
+
+    it('should show text when hideTextValue is false or undefined', () => {
+      const mockDS = createMockDataSource({ uid: 'test-ds', name: 'Test DataSource' });
+      mockDataSourceSrv.getInstanceSettings.mockReturnValue(mockDS);
+
+      render(<DataSourcePicker current="test-ds" hideTextValue={false} />);
+
+      // Text should be visible
+      expect(screen.getByText('Test DataSource')).toBeInTheDocument();
+    });
+  });
+
+  describe('onChange handling', () => {
+    it('should call onChange when data source is selected', async () => {
+      const onChange = jest.fn();
+      const mockDS = createMockDataSource({ name: 'Selected DS' });
+      mockDataSourceSrv.getList.mockReturnValue([mockDS]);
+      mockDataSourceSrv.getInstanceSettings.mockReturnValue(mockDS);
+
+      render(<DataSourcePicker onChange={onChange} />);
+
+      const select = screen.getByRole('combobox');
+      await userEvent.click(select);
+
+      const option = screen.getByRole('option');
+      await userEvent.click(option);
+
+      expect(onChange).toHaveBeenCalledWith(mockDS);
+    });
+
+    it('should not call onChange when no data source is found', async () => {
+      const onChange = jest.fn();
+
+      render(<DataSourcePicker onChange={onChange} />);
+
+      // Simulate selection of non-existent data source
+      const select = screen.getByRole('combobox');
+      await userEvent.type(select, 'non-existent');
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('event handlers', () => {
+    it('should call onBlur when select loses focus', async () => {
+      const onBlur = jest.fn();
+
+      render(<DataSourcePicker onBlur={onBlur} />);
+
+      const select = screen.getByRole('combobox');
+      await userEvent.click(select);
+      await userEvent.tab();
+
+      expect(onBlur).toHaveBeenCalled();
+    });
+
+    it('should set autoFocus when prop is true', () => {
+      render(<DataSourcePicker autoFocus={true} />);
+
+      const select = screen.getByRole('combobox');
+      expect(select).toHaveFocus();
+    });
+  });
+
+  describe('error handling', () => {
+    it('should set error state when current data source is not found', () => {
+      render(<DataSourcePicker current="non-existent-ds" />);
+
+      expect(mockDataSourceSrv.getInstanceSettings).toHaveBeenCalledWith('non-existent-ds');
+      expect(screen.getByText('non-existent-ds - not found')).toBeInTheDocument();
+      // Component should handle the error internally
+    });
+
+    it('should clear error when valid data source is selected', async () => {
+      const onChange = jest.fn();
+      const mockDS = createMockDataSource({ name: 'Valid DS' });
+
+      // First call returns undefined (error state), second call returns valid DS
+      mockDataSourceSrv.getInstanceSettings.mockReturnValueOnce(undefined).mockReturnValueOnce(mockDS);
+
+      mockDataSourceSrv.getList.mockReturnValue([mockDS]);
+
+      const { rerender } = render(<DataSourcePicker current="invalid-ds" onChange={onChange} />);
+
+      expect(screen.getByText('invalid-ds - not found')).toBeInTheDocument();
+
+      // Simulate selecting a valid data source
+      rerender(<DataSourcePicker current="valid-ds" onChange={onChange} />);
+
+      expect(mockDataSourceSrv.getInstanceSettings).toHaveBeenCalledWith('valid-ds');
+    });
+  });
+
+  describe('width prop', () => {
+    it('should pass width to Select component', () => {
+      const width = 300;
+      render(<DataSourcePicker width={width} />);
+
+      const selectContainer = screen.getByTestId(selectors.components.DataSourcePicker.container);
+      expect(selectContainer.querySelector('.select-container')).toBeInTheDocument();
     });
   });
 });

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -22,7 +22,7 @@ import { ExpressionDatasourceRef } from './../utils/DataSourceWithBackend';
  * @internal
  */
 export interface DataSourcePickerProps {
-  onChange?: (ds: DataSourceInstanceSettings) => void;
+  onChange: (ds: DataSourceInstanceSettings) => void;
   current?: DataSourceRef | string | null; // uid
   hideTextValue?: boolean;
   onBlur?: () => void;
@@ -54,7 +54,7 @@ export interface DataSourcePickerProps {
 /**
  * Component state description for the {@link DataSourcePicker}
  *
- * @deprecated. Not the real implementation used by core, left here for backwards compatibility.
+ * @deprecated. Not the real implementation used by the component, left here for backwards compatibility. Components should define their own state.
  * @internal
  */
 export interface DataSourcePickerState {
@@ -70,7 +70,7 @@ export interface DataSourcePickerState {
 export function DataSourcePicker(props: DataSourcePickerProps) {
   const {
     current = null,
-    onChange = () => {},
+    onChange,
     hideTextValue,
     onBlur,
     onClear,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a pre-requisite for https://github.com/grafana/grafana-community-team/issues/514

This PR migrates the DataSourcePicker that @grafana/runtime exposes as a function component.

It also increases the test coverage for the component.

The next step will be to replace the deprecated `Select` component by its replacement (`Combobox` ?) but I didn't want to add more than one change at time. [EDIT] Evaluated but discarded, more info in: https://github.com/grafana/grafana/pull/109326
