### PR TITLE
Swagger: Display operation IDs on API docs

### DIFF
--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -125,6 +125,7 @@ export const Page = () => {
               tryItOutEnabled={true}
               queryConfigEnabled={false}
               persistAuthorization={false}
+              displayOperationId
             />
           )}
           {!url?.value && <div>...{/** TODO, we can make an api docs loading page here */}</div>}


### PR DESCRIPTION
**What is this feature?**
Displays the operation IDs on the swagger docs

**Why do we need this feature?**
Makes it easier to know what endpoints you might want to consume in generated API clients etc:
<img width="1485" height="564" alt="image" src="https://github.com/user-attachments/assets/bed61e39-d86b-4a8f-9485-ed728424ebac" />


**Who is this feature for?**
UI devs/any consumer of the Swagger API docs
