### PR TITLE
Debug query library test notification issue

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -221,7 +221,7 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
             <MultiSelect
               className={styles.multiselect}
               options={listOfDatasources.map((ds) => {
-                return { value: ds.name, label: ds.name };
+                return { value: ds.name, label: ds.name, key: ds.uid };
               })}
               value={richHistorySearchFilters.datasourceFilters}
               placeholder={t(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR addresses a React warning by adding unique `key` props to the options rendered within the `MultiSelect` component in the Rich History Queries tab in Explore.

**Why do we need this feature?**

React relies on unique keys to efficiently identify and re-render list items. Missing keys can lead to console warnings, potential performance issues, and incorrect component updates, making debugging more challenging. Adding these keys ensures proper component reconciliation and a cleaner development experience.

**Who is this feature for?**

This is a technical improvement primarily for developers, ensuring better React component behavior and a cleaner console. It indirectly benefits users by improving the stability and correctness of the Explore feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes # (Addresses a React warning, no specific issue number)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

This PR specifically addresses the React key warning identified during the debugging session. The other issues discussed in the conversation, such as the missing form submission handler and success notification for saving queries to the library, are not included in this PR.

---
<a href="https://cursor.com/background-agent?bcId=bc-9311ab74-2fe6-4560-8f81-c9ee74a05e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9311ab74-2fe6-4560-8f81-c9ee74a05e32">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

