### PR TITLE
Schema V2: Snapshot testing for migrations should fail when output doesn't match

### DIFF
--- a/apps/dashboard/pkg/migration/migrate_test.go
+++ b/apps/dashboard/pkg/migration/migrate_test.go
@@ -74,9 +74,11 @@ func testMigration(t *testing.T, dash map[string]interface{}, inputFileName stri
 	outBytes, err := json.MarshalIndent(dash, "", "  ")
 	require.NoError(t, err, "failed to marshal migrated dashboard")
 
-	// Overwrite the output file with the new output
-	err = os.WriteFile(outPath, outBytes, 0644)
-	require.NoError(t, err, "failed to write output file", outPath)
+	if _, err := os.Stat(outPath); os.IsNotExist(err) {
+		err = os.WriteFile(outPath, outBytes, 0644)
+		require.NoError(t, err, "failed to write new output file", outPath)
+		return
+	}
 
 	// We can ignore gosec G304 here since it's a test
 	// nolint:gosec

--- a/apps/dashboard/pkg/migration/testdata/output/v28.singlestat_and_variable_properties.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v28.singlestat_and_variable_properties.json
@@ -148,7 +148,7 @@
             {
               "options": {
                 "20": {
-                  "color": null,
+                  "color": "orange",
                   "text": "test"
                 }
               },
@@ -157,7 +157,7 @@
             {
               "options": {
                 "30": {
-                  "color": null,
+                  "color": "orange",
                   "text": "test1"
                 }
               },


### PR DESCRIPTION
**Problem** When schema versions are migrated, we use input test data to generate output once the migration runs. The output is automatically updated, which can hide mismatch errors, for example, when running tests in CLI.

The desired behavior is to fail when the output has changed, similar to Jest snapshot testing, so we can review what has changed and accept the update if it is correct.

**Solution** Restore changes introduced in #107835, where we updated the output regardless of whether it changed.