### PR TITLE
Log Line Details header: add more space between icons

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -279,7 +279,8 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, wrapLogMessag
   }),
   icons: css({
     display: 'flex',
-    gap: theme.spacing(0.75),
+    gap: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
   }),
   copyLogButton: css({
     padding: 0,


### PR DESCRIPTION
I recently looked at the icons and felt they were too close in general. Adding a bit more space between them, and between the input.

Before:

<img width="813" height="70" alt="Before" src="https://github.com/user-attachments/assets/a0621ecc-4bcb-4c22-b529-9edd7682c969" />

After:

<img width="817" height="69" alt="After" src="https://github.com/user-attachments/assets/32e24ab9-2d00-4955-a6ee-e28ccf9e2be2" />
