### PR TITLE
[InfluxDB]: Fix max series bug

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import React, { useState } from 'react';
+import { useState } from 'react';
 
 import {
   onUpdateDatasourceJsonDataOption,

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 import {
   onUpdateDatasourceJsonDataOption,
@@ -31,7 +31,7 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
     () => !!options.jsonData.timeInterval || !!options.jsonData.insecureGrpc || !!options.jsonData.maxSeries
   );
 
-  const onMaxSeriesChange = (e: any) => {
+  const onMaxSeriesChange = (e: { currentTarget: { value: string } }) => {
     setMaxSeriesValue(e.currentTarget.value);
     const val = parseInt(e.currentTarget.value, 10);
     updateDatasourcePluginJsonDataOption(props, 'maxSeries', Number.isFinite(val) ? val : undefined);
@@ -133,7 +133,7 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
                 className="width-15"
                 data-testid="influxdb-v2-config-max-series"
                 onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked}
-                onChange={(e) => onMaxSeriesChange(e)}
+                onChange={onMaxSeriesChange}
                 placeholder="1000"
                 value={maxSeriesValue}
                 type="number"

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -28,8 +28,14 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
   const [maxSeriesValue, setMaxSeriesValue] = useState(options.jsonData.maxSeries?.toString() || '');
 
   const [advancedDbConnectionSettingsIsOpen, setAdvancedDbConnectionSettingsIsOpen] = useState(
-    () => !!options.jsonData.timeInterval || !!options.jsonData.insecureGrpc
+    () => !!options.jsonData.timeInterval || !!options.jsonData.insecureGrpc || !!options.jsonData.maxSeries
   );
+
+  const onMaxSeriesChange = (e: any) => {
+    setMaxSeriesValue(e.currentTarget.value);
+    const val = parseInt(e.currentTarget.value, 10);
+    updateDatasourcePluginJsonDataOption(props, 'maxSeries', Number.isFinite(val) ? val : undefined);
+  };
 
   return (
     <>
@@ -127,11 +133,7 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
                 className="width-15"
                 data-testid="influxdb-v2-config-max-series"
                 onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked}
-                onChange={(e) => {
-                  setMaxSeriesValue(e.currentTarget.value);
-                  const val = parseInt(e.currentTarget.value, 10);
-                  updateDatasourcePluginJsonDataOption(props, 'maxSeries', Number.isFinite(val) ? val : undefined);
-                }}
+                onChange={(e) => onMaxSeriesChange(e)}
                 placeholder="1000"
                 value={maxSeriesValue}
                 type="number"

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -5,6 +5,7 @@ import {
   onUpdateDatasourceJsonDataOption,
   onUpdateDatasourceJsonDataOptionChecked,
   onUpdateDatasourceJsonDataOptionSelect,
+  updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { InlineFieldRow, InlineField, Combobox, InlineSwitch, Input, Space, useStyles2 } from '@grafana/ui';
 
@@ -24,7 +25,7 @@ import { Props } from './types';
 export const AdvancedDbConnectionSettings = (props: Props) => {
   const { options } = props;
   const styles = useStyles2(getInlineLabelStyles);
-  const [maxSeriesValue, setMaxSeriesValue] = useState(options.jsonData.maxSeries || '');
+  const [maxSeriesValue, setMaxSeriesValue] = useState(options.jsonData.maxSeries?.toString() || '');
 
   const [advancedDbConnectionSettingsIsOpen, setAdvancedDbConnectionSettingsIsOpen] = useState(
     () => !!options.jsonData.timeInterval || !!options.jsonData.insecureGrpc
@@ -128,7 +129,8 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
                 onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked}
                 onChange={(e) => {
                   setMaxSeriesValue(e.currentTarget.value);
-                  onUpdateDatasourceJsonDataOption(props, 'maxSeries');
+                  const val = parseInt(e.currentTarget.value, 10);
+                  updateDatasourcePluginJsonDataOption(props, 'maxSeries', Number.isFinite(val) ? val : undefined);
                 }}
                 placeholder="1000"
                 value={maxSeriesValue}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/AdvancedDBConnectionSettings.tsx
@@ -24,6 +24,7 @@ import { Props } from './types';
 export const AdvancedDbConnectionSettings = (props: Props) => {
   const { options } = props;
   const styles = useStyles2(getInlineLabelStyles);
+  const [maxSeriesValue, setMaxSeriesValue] = useState(options.jsonData.maxSeries || '');
 
   const [advancedDbConnectionSettingsIsOpen, setAdvancedDbConnectionSettingsIsOpen] = useState(
     () => !!options.jsonData.timeInterval || !!options.jsonData.insecureGrpc
@@ -125,9 +126,13 @@ export const AdvancedDbConnectionSettings = (props: Props) => {
                 className="width-15"
                 data-testid="influxdb-v2-config-max-series"
                 onBlur={trackInfluxDBConfigV2AdvancedDbConnectionSettingsMaxSeriesClicked}
-                onChange={onUpdateDatasourceJsonDataOption(props, 'maxSeries')}
+                onChange={(e) => {
+                  setMaxSeriesValue(e.currentTarget.value);
+                  onUpdateDatasourceJsonDataOption(props, 'maxSeries');
+                }}
                 placeholder="1000"
-                value={options.jsonData.maxSeries || ''}
+                value={maxSeriesValue}
+                type="number"
               />
             </InlineField>
           </InlineFieldRow>


### PR DESCRIPTION
There was a bug in the new InfluxDB design that did not allow the user to properly update the `Max series` value. This PR fixes that bug so the value is updated properly.