### PR TITLE
Alerting: Pass exact matchers to the backend in the state history UI

### DIFF
--- a/public/app/features/alerting/unified/api/stateHistoryApi.ts
+++ b/public/app/features/alerting/unified/api/stateHistoryApi.ts
@@ -4,11 +4,29 @@ import { alertingApi } from './alertingApi';
 
 export const stateHistoryApi = alertingApi.injectEndpoints({
   endpoints: (build) => ({
-    getRuleHistory: build.query<DataFrameJSON, { ruleUid?: string; from?: number; to?: number; limit?: number }>({
-      query: ({ ruleUid, from, to, limit = 100 }) => ({
-        url: '/api/v1/rules/history',
-        params: { ruleUID: ruleUid, from, to, limit },
-      }),
+    getRuleHistory: build.query<
+      DataFrameJSON,
+      { ruleUid?: string; from?: number; to?: number; limit?: number; labels?: Record<string, string> }
+    >({
+      query: ({ ruleUid, from, to, limit = 100, labels }) => {
+        const params: Record<string, string | number | undefined> = {
+          ruleUID: ruleUid,
+          from,
+          to,
+          limit,
+        };
+
+        if (labels) {
+          Object.entries(labels).forEach(([key, value]) => {
+            params[`labels_${key}`] = value;
+          });
+        }
+
+        return {
+          url: '/api/v1/rules/history',
+          params,
+        };
+      },
     }),
   }),
 });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -788,7 +788,7 @@
       },
       "filterBy": "Filter by:",
       "too-many-events": {
-        "text": "The selected time period has too many events to display. Diplaying the latest 5000 events. Try using a shorter time period.",
+        "text": "The selected time period has too many events to display. Displaying the latest 5000 events. Try using a shorter time period.",
         "title": "Unable to display all events"
       }
     },


### PR DESCRIPTION
**What is this feature?**

This PR adds backend filtering support for label filters in the Alert State History UI. Previously, all filtering was done on the client side after fetching up to 5000 events, but the backend supports exact matchers for labels which are sent in the request now.

**Special notes for your reviewer:**

[Preview](https://ephemeral15111821109292alexan.grafana-dev.net/alerting/history?var-STATE_FILTER_FROM=all&var-STATE_FILTER_TO=all) with 2 alerts in two different folders.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
