### PR TITLE
Unistore/dualwriter: delegate SetDefaultPermissions to Unified on Mode3

### DIFF
--- a/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter_mode3_test.go
@@ -109,39 +109,11 @@ func TestMode3_Get(t *testing.T) {
 				},
 			},
 			{
-				name: "should return an error when getting an object in the unified store fails",
+				name: "should return an error when getting an object in the unified store fails, and should not go to legacy",
 				setupStorageFn: func(m *mock.Mock, name string) {
 					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
 				},
 				wantErr: true,
-			},
-			{
-				name: "should return an error when getting an object in the unified store fails with not found error, and legacy fails as well",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
-				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "dashboards.dashboard.grafana.app", Resource: "dashboard"}, "uid"))
-				},
-				wantErr: true,
-			},
-			{
-				name: "should succeed when getting an object in the UnifiedStorage fails with NotFound, but Legacy succeeds",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
-				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, apierrors.NewNotFound(schema.GroupResource{Group: "dashboards.dashboard.grafana.app", Resource: "dashboard"}, "uid"))
-				},
-			},
-			{
-				name: "should succeed when getting an object in the LegacyStorage fails",
-				setupLegacyFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(nil, errors.New("error"))
-				},
-				setupStorageFn: func(m *mock.Mock, name string) {
-					m.On("Get", mock.Anything, name, mock.Anything).Return(exampleObj, nil)
-				},
 			},
 		}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR is doing two things:
- Reverting https://github.com/grafana/grafana/pull/108092
- Modifying the legacysql dualwriter to SetDefaultPermissions on Unified, instead Legacy, when we are reading from Unified and Writing to both storages (this is the actual **Mode 3**)  

The idea is that the apistore.Store object will call `grantPermissions` only when the `grafana.app/grant-permissions` annotation is present. 

So the approach here is:
- If we are reading from Unified and Writing to both storages (Mode3)
- We remove the `grafana.app/grant-permissions` annotation when writing to Legacy (but keep it in a temporary variable)
- We add the annotation back before writing to Unified, which will trigger the setting of permissions after create

**Why do we need this feature?**

The fix implemented on https://github.com/grafana/grafana/pull/108092 was hiding NotFound errors 

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/411

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
