### PR TITLE
Provisioning: Fix missing ref in staging options

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -70,6 +70,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		CommitOnlyOnceMessage: msg,
 		PushOnWrites:          false,
 		Timeout:               10 * time.Minute,
+		Ref:                   opts.Ref,
 	}
 
 	err := w.wrapFn(ctx, repo, stageOptions, fn)

--- a/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
@@ -164,6 +164,7 @@ func TestDeleteWorker_ProcessDeleteFilesSuccess(t *testing.T) {
 		return !opts.PushOnWrites &&
 			opts.Timeout == 10*time.Minute &&
 			opts.Mode == repository.StageModeCommitOnlyOnce &&
+			opts.Ref == "main" &&
 			opts.CommitOnlyOnceMessage == "Delete from Grafana "+job.Name
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(mockRepo, false)

--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -81,6 +81,7 @@ func (w *Worker) Process(ctx context.Context, repo repository.Repository, job pr
 		CommitOnlyOnceMessage: msg,
 		PushOnWrites:          false,
 		Timeout:               10 * time.Minute,
+		Ref:                   opts.Ref,
 	}
 
 	err := w.wrapFn(ctx, repo, stageOptions, fn)

--- a/pkg/registry/apis/provisioning/jobs/move/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker_test.go
@@ -202,7 +202,7 @@ func TestMoveWorker_ProcessMoveFilesSuccess(t *testing.T) {
 	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.MatchedBy(func(opts repository.StageOptions) bool {
 		return !opts.PushOnWrites && opts.Timeout == 10*time.Minute &&
 			opts.Mode == repository.StageModeCommitOnlyOnce &&
-			opts.CommitOnlyOnceMessage != ""
+			opts.CommitOnlyOnceMessage != "" && opts.Ref == "main"
 	}), mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
 		return fn(mockRepo, false)
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix missing ref in staging option used for move and bulk operations.

**Why do we need this feature?**

It's a bug in the code that makes those operation fail when pushing changes to other branch.

**Who is this feature for?**

Users of Git Sync / Provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of <https://github.com/grafana/git-ui-sync-project/issues/387#issuecomment-3161594126>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
