### PR TITLE
Alerting: Do not apply extra labels in the Prometheus conversion API to recording rules

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -236,7 +236,9 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	}
 
 	labels := make(map[string]string, len(rule.Labels)+len(promGroup.Labels)+len(p.cfg.ExtraLabels)+1)
-	maps.Copy(labels, p.cfg.ExtraLabels)
+	if !isRecordingRule {
+		maps.Copy(labels, p.cfg.ExtraLabels)
+	}
 	maps.Copy(labels, promGroup.Labels)
 	maps.Copy(labels, rule.Labels)
 

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -705,7 +705,7 @@ func TestPrometheusRulesToGrafana_ExtraLabels(t *testing.T) {
 		require.Equal(t, expectedLabels, grafanaGroup.Rules[0].Labels)
 	})
 
-	t.Run("extra labels are applied to recording rules", func(t *testing.T) {
+	t.Run("extra labels are not applied to recording rules", func(t *testing.T) {
 		promGroup := PrometheusRuleGroup{
 			Name:     "test-group-2",
 			Interval: prommodel.Duration(10 * time.Second),
@@ -721,8 +721,12 @@ func TestPrometheusRulesToGrafana_ExtraLabels(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, grafanaGroup.Rules, 1)
 
-		expectedLabels := withInternalLabel(cfg.ExtraLabels)
+		expectedLabels := withInternalLabel(make(map[string]string))
 		require.Equal(t, expectedLabels, grafanaGroup.Rules[0].Labels)
+
+		for key := range cfg.ExtraLabels {
+			require.NotContains(t, grafanaGroup.Rules[0].Labels, key)
+		}
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Follow-up to https://github.com/grafana/grafana/pull/109136. Ensures that extra labels passed to the Prometheus conversion API in headers apply only to alerting rules. 

Applying these labels to recording rules creates unwanted metric dimensions during the transition from Prometheus to Grafana-managed alert rules, when Prometheus rules were writing metrics without the label, but Grafana begins writing with the label. 

The initial PR was intended only for alerting rules, so this PR changes that behavior.