### PR TITLE
[release-11.4.8] Go: Update to 1.24.6

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build verify-drone
@@ -75,7 +75,7 @@ steps:
   - go install github.com/bazelbuild/buildtools/buildifier@latest
   - buildifier --lint=warn -mode=check -r .
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: lint-starlark
 trigger:
   event:
@@ -140,7 +140,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -150,7 +150,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -159,7 +159,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -210,7 +210,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-package
   pull: always
   volumes:
@@ -472,7 +472,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-cue
 trigger:
   event:
@@ -542,7 +542,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-cue
 trigger:
   branch: main
@@ -609,7 +609,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - '# It is required that code generated from Thema/CUE be committed and in sync
@@ -619,7 +619,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-cue
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-cue
 - commands:
   - '# It is required that generated jsonnet is committed and in sync with its inputs.'
@@ -628,7 +628,7 @@ steps:
   - apk add --update make
   - CODEGEN_VERIFY=1 make gen-jsonnet
   depends_on: []
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: verify-gen-jsonnet
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -678,7 +678,7 @@ steps:
   environment:
     _EXPERIMENTAL_DAGGER_CLOUD_TOKEN:
       from_secret: dagger_token
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-package
   pull: always
   volumes:
@@ -1156,7 +1156,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -1286,7 +1286,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts docker fetch --edition oss
@@ -1427,7 +1427,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build artifacts packages --artifacts-editions=oss --tag $${DRONE_TAG} --src-bucket
@@ -1519,7 +1519,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - yarn install --immutable || yarn install --immutable
@@ -1619,7 +1619,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - depends_on:
   - compile-build-cmd
@@ -1716,7 +1716,7 @@ steps:
   depends_on: []
   environment:
     CGO_ENABLED: 0
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: compile-build-cmd
 - commands:
   - ./bin/build publish grafana-com --edition oss ${DRONE_TAG}
@@ -1790,7 +1790,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-build
   pull: always
   volumes:
@@ -1884,7 +1884,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-build
   pull: always
   volumes:
@@ -2007,7 +2007,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-build
   pull: always
   volumes:
@@ -2114,7 +2114,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-build
   pull: always
   volumes:
@@ -2260,7 +2260,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-publish
   pull: always
   volumes:
@@ -2390,7 +2390,7 @@ steps:
     STORYBOOK_DESTINATION:
       from_secret: rgm_storybook_destination
     UBUNTU_BASE: ubuntu:22.04
-  image: golang:1.24.5-alpine
+  image: golang:1.24.6-alpine
   name: rgm-build
   pull: always
   volumes:
@@ -2732,7 +2732,7 @@ steps:
 - commands:
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM docker:27-cli
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM alpine/git:2.40.1
-  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.24.5-alpine
+  - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM golang:1.24.6-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22.16.0-alpine
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM node:22-bookworm
   - trivy --exit-code 0 --severity UNKNOWN,LOW,MEDIUM google/cloud-sdk:431.0.0
@@ -2760,7 +2760,7 @@ steps:
 - commands:
   - trivy --exit-code 1 --severity HIGH,CRITICAL docker:27-cli
   - trivy --exit-code 1 --severity HIGH,CRITICAL alpine/git:2.40.1
-  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.24.5-alpine
+  - trivy --exit-code 1 --severity HIGH,CRITICAL golang:1.24.6-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22.16.0-alpine
   - trivy --exit-code 1 --severity HIGH,CRITICAL node:22-bookworm
   - trivy --exit-code 1 --severity HIGH,CRITICAL google/cloud-sdk:431.0.0
@@ -3007,6 +3007,6 @@ kind: secret
 name: gcr_credentials
 ---
 kind: signature
-hmac: c38baa8613d2cf1a5506f6b6568b0869204ba8b2e7281e117c31f3a64bf64447
+hmac: dcbbfb33fcbd1546e1bf3346f64fe0fd1d7c8b18bc148a93b45389273e90f6d2
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG JS_SRC=js-builder
 # By using FROM instructions we can delegate dependency updates to dependabot
 FROM alpine:3.21.3 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
-FROM golang:1.24.5-alpine AS go-builder-base
+FROM golang:1.24.6-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:22-alpine AS js-builder-base
 
 # Javascript build stage

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .bingo/Variables.mk
 
 GO = go
-GO_VERSION = 1.24.5
+GO_VERSION = 1.24.6
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.24.5
+go 1.24.6
 
 // contains openapi encoder fixes. remove ASAP
 replace cuelang.org/go => github.com/grafana/cue v0.0.0-20230926092038-971951014e3f // @grafana/grafana-as-code

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.24.5
+go 1.24.6
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/pkg/aggregator/go.mod
+++ b/pkg/aggregator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/aggregator
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/emicklei/go-restful/v3 v3.11.0

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/grafana/authlib v0.0.0-20240919120951-58259833c564 // @grafana/identity-access-team

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/build/go.mod
+++ b/pkg/build/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build
 
-go 1.24.5
+go 1.24.6
 
 // Override docker/docker to avoid:
 // go: github.com/drone-runners/drone-runner-docker@v1.8.2 requires

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/promlib
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/grafana/dskit v0.0.0-20240805174438-dfa83b4ed2d3

--- a/pkg/semconv/go.mod
+++ b/pkg/semconv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/semconv
 
-go 1.24.5
+go 1.24.6
 
 require go.opentelemetry.io/otel v1.37.0
 

--- a/scripts/drone/variables.star
+++ b/scripts/drone/variables.star
@@ -3,7 +3,7 @@ global variables
 """
 
 grabpl_version = "v3.1.2"
-golang_version = "1.24.5"
+golang_version = "1.24.6"
 
 # nodejs_version should match what's in ".nvmrc", but without the v prefix.
 nodejs_version = "22.16.0"

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.24.5
+go 1.24.6
 
 require golang.org/x/mod v0.24.0

--- a/scripts/modowners/go.mod
+++ b/scripts/modowners/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/modowners
 
-go 1.24.5
+go 1.24.6
 
 require golang.org/x/mod v0.24.0


### PR DESCRIPTION
This updates us from Go 1.24.5 to 1.24.6. This is due to several security fixes in Go.

See parent PR: https://github.com/grafana/grafana/pull/109313

Fixes: CVE-2025-47906
Fixes: CVE-2025-47907