### PR TITLE
AutoGridItemRenderer: Fix repeated panel lazy loading and drag and drop

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
@@ -1,15 +1,13 @@
 import { css, cx } from '@emotion/css';
-import { useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { LazyLoader, SceneComponentProps, sceneGraph } from '@grafana/scenes';
+import { SceneComponentProps, sceneGraph } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
 import { useHasClonedParents } from '../../utils/clone';
 import { useDashboardState } from '../../utils/utils';
 import { CanvasGridAddActions } from '../layouts-shared/CanvasGridAddActions';
 import { dashboardCanvasAddButtonHoverStyles } from '../layouts-shared/styles';
-import { getIsLazy } from '../layouts-shared/utils';
 
 import { AutoGridLayout, AutoGridLayoutState } from './AutoGridLayout';
 import { AutoGridLayoutManager } from './AutoGridLayoutManager';
@@ -18,11 +16,9 @@ export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLa
   const { children, isHidden } = model.useState();
   const hasClonedParents = useHasClonedParents(model);
   const styles = useStyles2(getStyles, model.state);
-  const { layoutOrchestrator, isEditing, preload } = useDashboardState(model);
+  const { layoutOrchestrator, isEditing } = useDashboardState(model);
   const layoutManager = sceneGraph.getAncestor(model, AutoGridLayoutManager);
   const { fillScreen } = layoutManager.useState();
-
-  const isLazy = useMemo(() => getIsLazy(preload), [preload]);
 
   if (isHidden || !layoutOrchestrator) {
     return null;
@@ -35,15 +31,9 @@ export function AutoGridLayoutRenderer({ model }: SceneComponentProps<AutoGridLa
       className={cx(styles.container, fillScreen && styles.containerFillScreen, isEditing && styles.containerEditing)}
       ref={model.containerRef}
     >
-      {children.map((item) =>
-        isLazy ? (
-          <LazyLoader key={item.state.key!} className={styles.container}>
-            <item.Component key={item.state.key} model={item} />
-          </LazyLoader>
-        ) : (
-          <item.Component key={item.state.key} model={item} />
-        )
-      )}
+      {children.map((item) => (
+        <item.Component key={item.state.key} model={item} />
+      ))}
       {showCanvasActions && <CanvasGridAddActions layoutManager={layoutManager} />}
     </div>
   );
@@ -75,24 +65,6 @@ const getStyles = (theme: GrafanaTheme2, state: AutoGridLayoutState) => ({
     // Show add action when hovering over the grid
     ...dashboardCanvasAddButtonHoverStyles,
   }),
-  containerFillScreen: css({
-    flexGrow: 1,
-  }),
-  containerEditing: css({
-    paddingBottom: theme.spacing(5),
-    position: 'relative',
-  }),
-  wrapper: css({
-    display: 'grid',
-    position: 'relative',
-    width: '100%',
-    height: '100%',
-  }),
-  dragging: css({
-    position: 'fixed',
-    top: 0,
-    left: 0,
-    zIndex: theme.zIndex.portal + 1,
-    pointerEvents: 'none',
-  }),
+  containerFillScreen: css({ flexGrow: 1 }),
+  containerEditing: css({ paddingBottom: theme.spacing(5), position: 'relative' }),
 });


### PR DESCRIPTION
After we introduced lazy loading in Auto Grid it broke repeated panels.
While fixing lazy loaded repeated panels found out that drag and drop is not implemented for repeated panels in auto grid.

Fixes:
- lazy loaded repeated panels
- repeated panels drag and drop
- refactored to use single render logic for lazy/non-lazy repeated/non-repeated panel