### PR TITLE
Config: Fix date_formats options being moved to a different section

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/cache@v4
         id: cache
         with:
-          key: "build-grafana-${{ runner.os }}-${{ hashFiles('yarn.lock', 'public/*',  'packages/*', 'pkg/**/*.go', '**/go.mod', '**/go.sum', '!**_test.go', '!**.test.ts', '!**.test.tsx', 'Dockerfile') }}"
+          key: "build-grafana-${{ runner.os }}-${{ hashFiles('yarn.lock', 'public/*',  'packages/*', 'conf/*', 'pkg/**/*.go', '**/go.mod', '**/go.sum', '!**_test.go', '!**.test.ts', '!**.test.tsx', 'Dockerfile') }}"
           path: |
             build-dir
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2030,16 +2030,16 @@ provider = static
 # This is EXPERIMENTAL. Please, do not use this section
 # foo = bar
 
+[time_picker]
+# Custom quick ranges for the time picker. Each quick range has a display name, a from value, and a to value.
+# Format: [{"from":"now-5m","to":"now","display":"Last 5 minutes"},{"from":"now-15m","to":"now","display":"Last 15 minutes"}]
+quick_ranges =
+
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/
 
 # Default system date format used in time range picker and other places where full time is displayed
 full_date = YYYY-MM-DD HH:mm:ss
-
-[time_picker]
-# Custom quick ranges for the time picker. Each quick range has a display name, a from value, and a to value.
-# Format: [{"from":"now-5m","to":"now","display":"Last 5 minutes"},{"from":"now-15m","to":"now","display":"Last 15 minutes"}]
-quick_ranges =
 
 # Used by graph and other places where we only show small intervals
 interval_second = HH:mm:ss


### PR DESCRIPTION
PR https://github.com/grafana/grafana/pull/102254 added its options to the wrong section, which removed some default values for `[date_formats]` config options, and prevented them from being able to be overridden by environment variables. This fixes it my just moving it up to the end of a previous section.

Fixes #108808