### PR TITLE
SQLStore: Use new test infra

### DIFF
--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -1,7 +1,6 @@
 package sqlstore
 
 import (
-	"context"
 	"os"
 	"testing"
 	"time"
@@ -65,7 +64,7 @@ func TestIntegrationIsUniqueConstraintViolation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := store.WithDbSession(context.Background(), func(sess *DBSession) error {
+			err := store.WithDbSession(t.Context(), func(sess *DBSession) error {
 				return tc.f(t, sess)
 			})
 			require.Error(t, err)

--- a/pkg/services/sqlstore/sqlstore_testinfra_test.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra_test.go
@@ -1,7 +1,6 @@
 package sqlstore_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -23,7 +22,7 @@ func TestIntegrationTempDatabaseConnect(t *testing.T) {
 	}
 
 	sqlStore := sqlstore.NewTestStore(t, sqlstore.WithoutMigrator())
-	err := sqlStore.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	err := sqlStore.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
 		_, err := sess.Query("SELECT 1")
 		return err
 	})
@@ -83,7 +82,7 @@ func TestIntegrationUniqueConstraintViolation(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
 			store := sqlstore.NewTestStore(t)
-			err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+			err := store.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
 				return tc.f(t, sess, store.GetDialect())
 			})
 			require.Error(t, err)
@@ -101,7 +100,7 @@ func TestIntegrationTruncateDatabase(t *testing.T) {
 	store := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator), sqlstore.WithTruncation())
 
 	var beans []*truncateBean
-	err := store.WithDbSession(context.Background(), func(sess *sqlstore.DBSession) error {
+	err := store.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
 		return sess.Find(&beans)
 	})
 	require.NoError(t, err, "could not find truncateBeans")

--- a/pkg/services/sqlstore/sqlstore_testinfra_test.go
+++ b/pkg/services/sqlstore/sqlstore_testinfra_test.go
@@ -20,6 +20,7 @@ func TestIntegrationTempDatabaseConnect(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 
 	sqlStore := sqlstore.NewTestStore(t, sqlstore.WithoutMigrator())
 	err := sqlStore.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
@@ -36,6 +37,7 @@ func TestIntegrationTempDatabaseOSSMigrate(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 
 	_ = sqlstore.NewTestStore(t, sqlstore.WithOSSMigrations())
 }
@@ -44,6 +46,7 @@ func TestIntegrationUniqueConstraintViolation(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 
 	testCases := []struct {
 		desc string
@@ -81,6 +84,7 @@ func TestIntegrationUniqueConstraintViolation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
 			store := sqlstore.NewTestStore(t)
 			err := store.WithDbSession(t.Context(), func(sess *sqlstore.DBSession) error {
 				return tc.f(t, sess, store.GetDialect())
@@ -95,6 +99,7 @@ func TestIntegrationTruncateDatabase(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 
 	migrator := &truncateDatabaseSetup{}
 	store := sqlstore.NewTestStore(t, sqlstore.WithMigrator(migrator), sqlstore.WithTruncation())

--- a/pkg/services/sqlstore/transactions_test.go
+++ b/pkg/services/sqlstore/transactions_test.go
@@ -13,6 +13,7 @@ func TestIntegrationReuseSessionWithTransaction(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 	ss := NewTestStore(t)
 
 	t.Run("top level transaction", func(t *testing.T) {
@@ -72,6 +73,7 @@ func TestIntegrationPublishAfterCommitWithNestedTransactions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
+	t.Parallel()
 
 	ss := NewTestStore(t)
 	ctx := t.Context()

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -1,7 +1,6 @@
 package sqlstore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,9 +13,9 @@ func TestIntegrationGetOrCreateOrg(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
-	ss, _ := InitTestDB(t)
+	ss := NewTestStore(t)
 
-	err := ss.WithDbSession(context.Background(), func(sess *DBSession) error {
+	err := ss.WithDbSession(t.Context(), func(sess *DBSession) error {
 		// Create the org only:
 		ss.cfg.AutoAssignOrg = true
 		ss.cfg.DisableInitAdminCreation = true
@@ -28,7 +27,7 @@ func TestIntegrationGetOrCreateOrg(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = ss.WithDbSession(context.Background(), func(sess *DBSession) error {
+	err = ss.WithDbSession(t.Context(), func(sess *DBSession) error {
 		// Run it a second time and verify that it finds the org that was
 		// created above.
 		gotOrgId, err := ss.getOrCreateOrg(sess, mainOrgName)

--- a/pkg/services/sqlstore/user_test.go
+++ b/pkg/services/sqlstore/user_test.go
@@ -13,6 +13,7 @@ func TestIntegrationGetOrCreateOrg(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode")
 	}
+	t.Parallel()
 	ss := NewTestStore(t)
 
 	err := ss.WithDbSession(t.Context(), func(sess *DBSession) error {


### PR DESCRIPTION
It's time we start migrating some code over to the new (i.e. 5 months old) infra that uses database clones rather than requiring being run sequentially.