### PR TITLE
Refactor: Use const for IsEnterprise

### DIFF
--- a/pkg/cmd/grafana-server/commands/buildinfo.go
+++ b/pkg/cmd/grafana-server/commands/buildinfo.go
@@ -4,7 +4,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/services/apiserver/standalone"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -23,6 +22,5 @@ func SetBuildInfo(opts standalone.BuildInfo) {
 	setting.EnterpriseBuildCommit = opts.EnterpriseCommit
 	setting.BuildStamp = getBuildstamp(opts)
 	setting.BuildBranch = opts.BuildBranch
-	setting.IsEnterprise = extensions.IsEnterprise
 	setting.Packaging = validPackaging(Packaging)
 }

--- a/pkg/extensions/main.go
+++ b/pkg/extensions/main.go
@@ -1,5 +1,8 @@
+//go:build !enterprise && !pro
+// +build !enterprise,!pro
+
 package extensions
 
 // Imports used by Grafana enterprise are in enterprise_imports.go (behind a build tag).
 
-var IsEnterprise bool = false
+const IsEnterprise bool = false

--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	pubdash "github.com/grafana/grafana/pkg/services/publicdashboards/models"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // ExporterName is used as namespace for exposing prometheus metrics
@@ -663,7 +663,7 @@ func init() {
 // SetBuildInformation sets the build information for this binary
 func SetBuildInformation(reg prometheus.Registerer, version, revision, branch string, buildTimestamp int64) {
 	edition := "oss"
-	if setting.IsEnterprise {
+	if extensions.IsEnterprise {
 		edition = "enterprise"
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/osutil"
@@ -67,7 +68,6 @@ var (
 	EnterpriseBuildCommit string
 	BuildBranch           string
 	BuildStamp            int64
-	IsEnterprise          bool
 
 	// packaging
 	Packaging = "unknown"
@@ -1145,7 +1145,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.EnterpriseBuildCommit = EnterpriseBuildCommit
 	cfg.BuildStamp = BuildStamp
 	cfg.BuildBranch = BuildBranch
-	cfg.IsEnterprise = IsEnterprise
+	cfg.IsEnterprise = extensions.IsEnterprise
 	cfg.Packaging = Packaging
 
 	cfg.ErrTemplateName = "error"

--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -36,7 +37,6 @@ import (
 	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -1694,7 +1694,7 @@ func TestIntegrationRuleUpdate(t *testing.T) {
 		Login:          "grafana",
 	})
 
-	if setting.IsEnterprise {
+	if extensions.IsEnterprise {
 		// add blanket access to data sources.
 		_, err := permissionsStore.SetUserResourcePermission(context.Background(),
 			1,
@@ -2407,13 +2407,13 @@ func TestIntegrationEval(t *testing.T) {
 			`,
 			expectedResponse: func() string { return "" },
 			expectedStatusCode: func() int {
-				if setting.IsEnterprise {
+				if extensions.IsEnterprise {
 					return http.StatusForbidden
 				}
 				return http.StatusBadRequest
 			},
 			expectedMessage: func() string {
-				if setting.IsEnterprise {
+				if extensions.IsEnterprise {
 					return "user is not authorized to access one or many data sources"
 				}
 				return "Failed to build evaluator for queries and expressions: failed to build query 'A': data source not found"
@@ -3106,13 +3106,13 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 					},
 				},
 				expectedCode: func() int {
-					if setting.IsEnterprise {
+					if extensions.IsEnterprise {
 						return http.StatusForbidden
 					}
 					return http.StatusBadRequest
 				}(),
 				expectedMessage: func() string {
-					if setting.IsEnterprise {
+					if extensions.IsEnterprise {
 						return "user is not authorized to create a new alert rule 'AlwaysFiring'"
 					}
 					return "failed to update rule group: invalid alert rule 'AlwaysFiring': failed to build query 'A': data source not found"

--- a/pkg/tests/api/alerting/api_testing_test.go
+++ b/pkg/tests/api/alerting/api_testing_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -21,7 +22,6 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util"
@@ -247,7 +247,7 @@ func TestGrafanaRuleConfig(t *testing.T) {
 	})
 
 	t.Run("authentication permissions", func(t *testing.T) {
-		if !setting.IsEnterprise {
+		if !extensions.IsEnterprise {
 			t.Skip("Enterprise-only test")
 		}
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/dskit/kv"
 
 	"github.com/grafana/grafana/pkg/api"
-	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/fs"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -48,7 +47,6 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 	t.Helper()
 	ctx := context.Background()
 
-	setting.IsEnterprise = extensions.IsEnterprise
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	cfg, err := setting.NewCfgFromArgs(setting.CommandLineArgs{Config: cfgPath, HomePath: grafDir})


### PR DESCRIPTION
There is no need for us to mutate this. Just use a const with build tags.

I'm working on simplifying and changing out our tests and spotted we have a non-Wire mutable, which shouldn't ever occur, really.