### PR TITLE
Alerting: Add Extended List Query for Alert Rules w/pagination

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -954,6 +954,15 @@ type ListAlertRulesQuery struct {
 	HasPrometheusRuleDefinition *bool
 }
 
+type ListAlertRulesExtendedQuery struct {
+	ListAlertRulesQuery
+
+	RuleType RuleTypeFilter
+
+	Limit         int64
+	ContinueToken string
+}
+
 // CountAlertRulesQuery is the query for counting alert rules
 type CountAlertRulesQuery struct {
 	OrgID        int64

--- a/pkg/services/ngalert/provisioning/accesscontrol.go
+++ b/pkg/services/ngalert/provisioning/accesscontrol.go
@@ -14,6 +14,7 @@ type RuleAccessControlService interface {
 	AuthorizeAccessToRuleGroup(ctx context.Context, user identity.Requester, rules models.RulesGroup) error
 	AuthorizeAccessInFolder(ctx context.Context, user identity.Requester, namespaced models.Namespaced) error
 	AuthorizeRuleChanges(ctx context.Context, user identity.Requester, change *store.GroupDelta) error
+	HasAccessInFolder(ctx context.Context, user identity.Requester, folder models.Namespaced) (bool, error)
 }
 
 func newRuleAccessControlService(ac RuleAccessControlService) *provisioningRuleAccessControl {

--- a/pkg/services/ngalert/provisioning/persist.go
+++ b/pkg/services/ngalert/provisioning/persist.go
@@ -32,6 +32,7 @@ type TransactionManager interface {
 type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *models.GetAlertRuleByUIDQuery) (*models.AlertRule, error)
 	ListAlertRules(ctx context.Context, query *models.ListAlertRulesQuery) (models.RulesGroup, error)
+	ListAlertRulesPaginated(ctx context.Context, query *models.ListAlertRulesExtendedQuery) (models.RulesGroup, string, error)
 	GetRuleGroupInterval(ctx context.Context, orgID int64, namespaceUID string, ruleGroup string) (int64, error)
 	InsertAlertRules(ctx context.Context, user *models.UserUID, rule []models.AlertRule) ([]models.AlertRuleKeyWithId, error)
 	UpdateAlertRules(ctx context.Context, user *models.UserUID, rule []models.UpdateRule) error

--- a/pkg/services/ngalert/provisioning/testing.go
+++ b/pkg/services/ngalert/provisioning/testing.go
@@ -113,6 +113,7 @@ type fakeRuleAccessControlService struct {
 	AuthorizeRuleChangesFunc       func(ctx context.Context, user identity.Requester, change *store.GroupDelta) error
 	CanReadAllRulesFunc            func(ctx context.Context, user identity.Requester) (bool, error)
 	CanWriteAllRulesFunc           func(ctx context.Context, user identity.Requester) (bool, error)
+	HasAccessInFolderFunc          func(ctx context.Context, user identity.Requester, folder models.Namespaced) (bool, error)
 }
 
 func (s *fakeRuleAccessControlService) RecordCall(method string, args ...interface{}) {
@@ -165,6 +166,14 @@ func (s *fakeRuleAccessControlService) CanWriteAllRules(ctx context.Context, use
 		return s.CanWriteAllRulesFunc(ctx, user)
 	}
 	return false, nil
+}
+
+func (s *fakeRuleAccessControlService) HasAccessInFolder(ctx context.Context, user identity.Requester, folder models.Namespaced) (bool, error) {
+	s.RecordCall("HasAccessInFolder", ctx, user, folder)
+	if s.HasAccessInFolderFunc != nil {
+		return s.HasAccessInFolderFunc(ctx, user, folder)
+	}
+	return true, nil
 }
 
 type fakeAlertRuleNotificationStore struct {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 	"slices"
 	"strings"
 
@@ -860,8 +861,10 @@ func (st DBstore) ListAlertRulesPaginated(ctx context.Context, query *ngmodels.L
 		}
 
 		if query.Limit > 0 {
+			// Ensure we clamp to the max int available on the platform
+			lim := min(query.Limit, math.MaxInt)
 			// Fetch one extra rule to determine if there are more results
-			q = q.Limit(int(query.Limit) + 1)
+			q = q.Limit(int(lim) + 1)
 		}
 
 		alertRules := make([]*ngmodels.AlertRule, 0)

--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -19,8 +19,8 @@ type alertRule struct {
 	DashboardUID                *string `xorm:"dashboard_uid"`
 	PanelID                     *int64  `xorm:"panel_id"`
 	RuleGroup                   string
-	RuleGroupIndex              int `xorm:"rule_group_idx"`
-	Record                      string
+	RuleGroupIndex              int    `xorm:"rule_group_idx"`
+	Record                      string // FIXME: record is nullable but we don't save it as null when it's nil
 	NoDataState                 string
 	ExecErrState                string
 	For                         time.Duration

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -268,6 +268,22 @@ func (f *RuleStore) ListAlertRulesByGroup(_ context.Context, q *models.ListAlert
 	return outputRules, nextToken, nil
 }
 
+// TODO: implement pagination for this fake
+func (f *RuleStore) ListAlertRulesPaginated(_ context.Context, q *models.ListAlertRulesExtendedQuery) (models.RulesGroup, string, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+	f.RecordedOps = append(f.RecordedOps, *q)
+
+	if err := f.Hook(*q); err != nil {
+		return nil, "", err
+	}
+	rules, err := f.listAlertRules(&q.ListAlertRulesQuery)
+	if err != nil {
+		return nil, "", err
+	}
+	return rules, "", nil
+}
+
 func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()


### PR DESCRIPTION
This adds an extended query which allows filtering by the kind of rule (Recording or Alerting) and supports pagination.

Pagination tokens will allow us to list all rules paginated, regardless of the rule group.

Co-authored-by: William Wernert <william.wernert@grafana.com>
