### PR TITLE
[release-12.1.1] Config: Fix date_formats options being moved to a different section

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1997,16 +1997,16 @@ provider = static
 # instance = "grafana"
 # version = 11.0.0
 
+[time_picker]
+# Custom quick ranges for the time picker. Each quick range has a display name, a from value, and a to value.
+# Format: [{"from":"now-5m","to":"now","display":"Last 5 minutes"},{"from":"now-15m","to":"now","display":"Last 15 minutes"}]
+quick_ranges =
+
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/
 
 # Default system date format used in time range picker and other places where full time is displayed
 full_date = YYYY-MM-DD HH:mm:ss
-
-[time_picker]
-# Custom quick ranges for the time picker. Each quick range has a display name, a from value, and a to value.
-# Format: [{"from":"now-5m","to":"now","display":"Last 5 minutes"},{"from":"now-15m","to":"now","display":"Last 15 minutes"}]
-quick_ranges =
 
 # Used by graph and other places where we only show small intervals
 interval_second = HH:mm:ss


### PR DESCRIPTION
Backport 0069d112fc16106d127826d6ce967da4a8b6b184 from #109339

---

PR https://github.com/grafana/grafana/pull/102254 added its options to the wrong section, which removed some default values for `[date_formats]` config options, and prevented them from being able to be overridden by environment variables. This fixes it my just moving it up to the end of a previous section.

Fixes #108808
