### PR TITLE
datasources: querier: report metrics related to the whole request

### DIFF
--- a/pkg/registry/apis/query/client/instance_provider.go
+++ b/pkg/registry/apis/query/client/instance_provider.go
@@ -25,7 +25,7 @@ type singleTenantInstance struct {
 	cfg      *setting.Cfg
 }
 
-func (t *singleTenantInstance) GetDataSourceClient(_ context.Context, _ data.DataSourceRef, _ map[string]string) (clientapi.QueryDataClient, error) {
+func (t *singleTenantInstance) GetDataSourceClient(_ context.Context, _ data.DataSourceRef) (clientapi.QueryDataClient, error) {
 	return t.client, nil
 }
 
@@ -37,7 +37,7 @@ func NewSingleTenantInstanceProvider(cfg *setting.Cfg, features featuremgmt.Feat
 	}
 }
 
-func (s *singleTenantInstanceProvider) GetInstance(_ context.Context) (clientapi.Instance, error) {
+func (s *singleTenantInstanceProvider) GetInstance(_ context.Context, _ map[string]string) (clientapi.Instance, error) {
 	return &singleTenantInstance{
 		client:   s.client,
 		features: s.features,

--- a/pkg/registry/apis/query/client/instance_provider.go
+++ b/pkg/registry/apis/query/client/instance_provider.go
@@ -59,3 +59,7 @@ func (s *singleTenantInstance) GetLogger(parent log.Logger) log.Logger {
 	// currently we do not add any extra info
 	return parent.New()
 }
+
+func (s *singleTenantInstance) ReportMetrics() {
+	// we do not report any metrics currently
+}

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -33,6 +33,7 @@ type Instance interface {
 	// fetch information on the grafana instance (e.g. feature toggles)
 	GetSettings() InstanceConfigurationSettings
 	GetLogger(parent log.Logger) log.Logger
+	ReportMetrics() // some metrics are only reported at the end
 }
 
 type InstanceProvider interface {

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -29,12 +29,12 @@ type InstanceConfigurationSettings struct {
 }
 
 type Instance interface {
-	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef, headers map[string]string) (QueryDataClient, error)
+	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef) (QueryDataClient, error)
 	// fetch information on the grafana instance (e.g. feature toggles)
 	GetSettings() InstanceConfigurationSettings
 	GetLogger(parent log.Logger) log.Logger
 }
 
 type InstanceProvider interface {
-	GetInstance(ctx context.Context) (Instance, error)
+	GetInstance(ctx context.Context, headers map[string]string) (Instance, error)
 }

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -280,6 +280,10 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	qdr, err := service.QueryData(ctx, dsQuerierLoggerWithSlug, cache, exprService, mReq, mtDsClientBuilder, headers)
 
+	// tell the `instance` structure that it can now report
+	// metrics that are only reported once during a request
+	instance.ReportMetrics()
+
 	if err != nil {
 		return qdr, err
 	}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -246,7 +246,7 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	headers := ExtractKnownHeaders(httpreq.Header)
 
-	instance, err := b.instanceProvider.GetInstance(ctx)
+	instance, err := b.instanceProvider.GetInstance(ctx, headers)
 	if err != nil {
 		connectLogger.Error("failed to get instance configuration settings", "err", err)
 		responder.Error(err)
@@ -260,7 +260,6 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 	mtDsClientBuilder := mtdsclient.NewMtDatasourceClientBuilderWithInstance(
 		instance,
 		ctx,
-		headers,
 		dsQuerierLoggerWithSlug,
 	)
 

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -257,6 +257,9 @@ func (m mockClient) GetInstance(ctx context.Context, headers map[string]string) 
 	return mclient, nil
 }
 
+func (m mockClient) ReportMetrics() {
+}
+
 func (m mockClient) GetLogger(parent log.Logger) log.Logger {
 	return parent.New()
 }

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -250,7 +250,7 @@ type mockClient struct {
 	stubbedFrame *data.Frame
 }
 
-func (m mockClient) GetInstance(ctx context.Context) (clientapi.Instance, error) {
+func (m mockClient) GetInstance(ctx context.Context, headers map[string]string) (clientapi.Instance, error) {
 	mclient := mockClient{
 		stubbedFrame: m.stubbedFrame,
 	}
@@ -261,7 +261,7 @@ func (m mockClient) GetLogger(parent log.Logger) log.Logger {
 	return parent.New()
 }
 
-func (m mockClient) GetDataSourceClient(ctx context.Context, ref dataapi.DataSourceRef, headers map[string]string) (clientapi.QueryDataClient, error) {
+func (m mockClient) GetDataSourceClient(ctx context.Context, ref dataapi.DataSourceRef) (clientapi.QueryDataClient, error) {
 	mclient := mockClient{
 		stubbedFrame: m.stubbedFrame,
 	}

--- a/pkg/services/mtdsclient/mt_datasource_client_builder.go
+++ b/pkg/services/mtdsclient/mt_datasource_client_builder.go
@@ -26,7 +26,6 @@ func NewNullMTDatasourceClientBuilder() MTDatasourceClientBuilder {
 type MtDatasourceClientBuilderWithInstance struct {
 	instance clientapi.Instance
 	ctx      context.Context
-	headers  map[string]string
 	logger   log.Logger
 }
 
@@ -37,7 +36,6 @@ func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid
 			Type: pluginId,
 			UID:  uid,
 		},
-		b.headers,
 	)
 	if err != nil {
 		b.logger.Debug("failed to get mt ds client", "error", err)
@@ -50,13 +48,11 @@ func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid
 func NewMtDatasourceClientBuilderWithInstance(
 	instance clientapi.Instance,
 	ctx context.Context,
-	headers map[string]string,
 	logger log.Logger,
 ) MTDatasourceClientBuilder {
 	return &MtDatasourceClientBuilderWithInstance{
 		instance: instance,
 		ctx:      ctx,
-		headers:  headers,
 		logger:   logger,
 	}
 }


### PR DESCRIPTION
one incoming request to the queriere may contain multiple queries in them. sometimes we need to record a single metric for a single request. this PR provides the support for that.

unfortunately we need to refactor our current architecture a little, to allow this.

how it works before the PR (let's assume the incoming request contains 3 queries)
request comes in, we do:
```go
instance := instanceProvider.getInstance(context)
c1 := instance.getDataSourceClient( ...., headers)
c1.QueryData(...)
c2 := instance.getDataSourceClient( ...., headers)
c2.QueryData(...)
c3 := instance.getDataSourceClient( ...., headers)
c3.QueryData(...)
```

(technically speaking, we call the them in parallel, but that's not important here)

 the important thing is that we call a method on `instance` 3 times, and we always give it the same `headers` structure.

we could alternatively just give the headers once to the instance, at the beginning. this is what we do here.
the flow becomes: request comes in, we do:
```go
instance := instanceProvider.getInstance(context, headers)
c1 := instance.getDataSourceClient( ....)
c1.QueryData(...)
c2 := instance.getDataSourceClient( ....)
c2.QueryData(...)
c3 := instance.getDataSourceClient( ....)
c3.QueryData(...)
```
this is done in the first commit  named "refactor".

the second commit (named "add metric" )deals with adding support for metrics that provide a single value for a single request, regardless of how many queries are in the request: we tell the `instance` object that it is time to report it's metrics. we could also rename `ReportMetrics` to something like `Finish` or similar.