### PR TITLE
Alerting: Enable alertingSaveStateCompressed by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -447,7 +447,7 @@ export interface FeatureToggles {
   alertingSaveStatePeriodic?: boolean;
   /**
   * Enables the compressed protobuf-based alert state storage
-  * @default false
+  * @default true
   */
   alertingSaveStateCompressed?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -759,7 +759,7 @@ var (
 			Stage:        FeatureStagePublicPreview,
 			FrontendOnly: false,
 			Owner:        grafanaAlertingSquad,
-			Expression:   "false",
+			Expression:   "true",
 		},
 		{
 			Name:              "scopeApi",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -444,14 +444,17 @@
     {
       "metadata": {
         "name": "alertingSaveStateCompressed",
-        "resourceVersion": "1753448760331",
-        "creationTimestamp": "2025-01-27T17:47:33Z"
+        "resourceVersion": "1754657532777",
+        "creationTimestamp": "2025-01-27T17:47:33Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-08-08 12:52:12.777935 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the compressed protobuf-based alert state storage",
         "stage": "preview",
         "codeowner": "@grafana/alerting-squad",
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
**What is this feature?**

Enables the `alertingSaveStateCompressed` feature flag by default.

**Why do we need this feature?**

In https://github.com/grafana/grafana/pull/99193 we added a new Alerting state storage that is significantly faster than the previous implementation. It [was promoted](https://github.com/grafana/grafana/pull/99935) to public preview in Grafana 11.6. This PR enables it by default.

This is technically a breaking change because an experimental `alertingSaveStatePeriodic` (disabled by default) is not compatible with `alertingSaveStateCompressed` and is automatically disabled.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

# Release notice breaking change

`alertingSaveStateCompressed` is now enabled by default. This change introduces a new storage format for alert rule state that improves performance, especially for rules with many alert instances. When active, this feature overrides and disables the experimental `alertingSaveStatePeriodic`, which will be deprecated in the future.