### PR TITLE
Dashboards Migrations: V24 set defaults when no thresholds are defined

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v24.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v24.go
@@ -514,23 +514,23 @@ func migrateDefaults(prevDefaults map[string]interface{}) map[string]interface{}
 		"mappings": []interface{}{},
 	}
 
-	// Only add default thresholds if we have prevDefaults (meaning this is a table panel being migrated)
-	// and no specific thresholds exist in prevDefaults
+	// Add default thresholds for all table panels to match frontend behavior
+	// The frontend applies the table panel's default field config which includes thresholds
 	hasThresholds := false
 	if prevDefaults != nil {
 		if thresholds, ok := prevDefaults["thresholds"].([]interface{}); ok && len(thresholds) > 0 {
 			hasThresholds = true
 		}
+	}
 
-		// Only add default thresholds for table panels (when prevDefaults exists) without existing thresholds
-		if !hasThresholds {
-			defaults["thresholds"] = map[string]interface{}{
-				"mode": "absolute",
-				"steps": []interface{}{
-					map[string]interface{}{"color": "green"},
-					map[string]interface{}{"color": "red", "value": 80},
-				},
-			}
+	// Add default thresholds for all table panels (when prevDefaults exists) without existing thresholds
+	if !hasThresholds {
+		defaults["thresholds"] = map[string]interface{}{
+			"mode": "absolute",
+			"steps": []interface{}{
+				map[string]interface{}{"color": "green"},
+				map[string]interface{}{"color": "red", "value": 80},
+			},
 		}
 	}
 

--- a/apps/dashboard/pkg/migration/testdata/output/v22.table_panel_align.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v22.table_panel_align.json
@@ -15,7 +15,19 @@
             },
             "inspect": false
           },
-          "mappings": []
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
         },
         "overrides": [
           {

--- a/public/app/features/dashboard/state/DashboardMigratorToBackend.test.ts
+++ b/public/app/features/dashboard/state/DashboardMigratorToBackend.test.ts
@@ -113,7 +113,7 @@ describe('Backend / Frontend result comparison', () => {
   const jsonInputs = readdirSync(inputDir);
 
   jsonInputs.forEach((inputFile) => {
-    it.skip(`should migrate ${inputFile} correctly`, async () => {
+    it(`should migrate ${inputFile} correctly`, async () => {
       const jsonInput = JSON.parse(readFileSync(path.join(inputDir, inputFile), 'utf8'));
       const backendOutput = JSON.parse(readFileSync(path.join(outputDir, inputFile), 'utf8'));
 


### PR DESCRIPTION
The backend migration for table panels was not adding default thresholds during the v24 migration, causing a mismatch with the frontend migration behavior. The frontend correctly applies the table panel's default field config (which includes default thresholds) to all migrated table panels, but the backend was only adding thresholds when there was a default style with pattern `/.*/`. This caused the v22 table panel migration test to fail because the frontend and backend produced different outputs.

The fix ensures the backend migration matches the frontend behavior by adding default thresholds to all table panels during migration.