### PR TITLE
Alerting Provisioning: Don't error on recording rules without conditions

### DIFF
--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -151,10 +151,6 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		noDataState = models.NoData
 	}
 	alertRule.NoDataState = noDataState
-	alertRule.Condition = rule.Condition.Value()
-	if alertRule.Condition == "" {
-		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no condition set", alertRule.Title)
-	}
 	alertRule.Annotations = rule.Annotations.Raw
 	alertRule.Labels = rule.Labels.Value()
 	for _, queryV1 := range rule.Data {
@@ -181,6 +177,10 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 			return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: %w", alertRule.Title, err)
 		}
 		alertRule.Record = &record
+	}
+	alertRule.Condition = rule.Condition.Value()
+	if alertRule.Condition == "" && alertRule.Record == nil {
+		return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse: no condition set", alertRule.Title)
 	}
 	return alertRule, nil
 }

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -355,7 +355,6 @@ func validRuleV1(t *testing.T) AlertRuleV1 {
 	}
 }
 
-
 func validRecordingRuleV1(t *testing.T) AlertRuleV1 {
 	t.Helper()
 	var (
@@ -376,14 +375,14 @@ func validRecordingRuleV1(t *testing.T) AlertRuleV1 {
 	err = yaml.Unmarshal([]byte("A"), &from)
 	require.NoError(t, err)
 	return AlertRuleV1{
-		Title:     title,
-		UID:       uid,
-		For:       forDuration,
-		Record:    &RecordV1{
+		Title: title,
+		UID:   uid,
+		For:   forDuration,
+		Record: &RecordV1{
 			Metric: metric,
-			From: from,
+			From:   from,
 		},
-		Data:      []QueryV1{{}},
+		Data: []QueryV1{{}},
 	}
 }
 

--- a/pkg/services/provisioning/alerting/rules_types_test.go
+++ b/pkg/services/provisioning/alerting/rules_types_test.go
@@ -202,6 +202,14 @@ func TestRules(t *testing.T) {
 	})
 }
 
+func TestRecordingRules(t *testing.T) {
+	t.Run("a valid rule should not error", func(t *testing.T) {
+		rule := validRecordingRuleV1(t)
+		_, err := rule.mapToModel(1)
+		require.NoError(t, err)
+	})
+}
+
 func TestNotificationsSettingsV1MapToModel(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -343,6 +351,38 @@ func validRuleV1(t *testing.T) AlertRuleV1 {
 		UID:       uid,
 		For:       forDuration,
 		Condition: condition,
+		Data:      []QueryV1{{}},
+	}
+}
+
+
+func validRecordingRuleV1(t *testing.T) AlertRuleV1 {
+	t.Helper()
+	var (
+		title       values.StringValue
+		uid         values.StringValue
+		forDuration values.StringValue
+		metric      values.StringValue
+		from        values.StringValue
+	)
+	err := yaml.Unmarshal([]byte("test"), &title)
+	require.NoError(t, err)
+	err = yaml.Unmarshal([]byte("test_uid"), &uid)
+	require.NoError(t, err)
+	err = yaml.Unmarshal([]byte("10s"), &forDuration)
+	require.NoError(t, err)
+	err = yaml.Unmarshal([]byte("test_metric"), &metric)
+	require.NoError(t, err)
+	err = yaml.Unmarshal([]byte("A"), &from)
+	require.NoError(t, err)
+	return AlertRuleV1{
+		Title:     title,
+		UID:       uid,
+		For:       forDuration,
+		Record:    &RecordV1{
+			Metric: metric,
+			From: from,
+		},
 		Data:      []QueryV1{{}},
 	}
 }


### PR DESCRIPTION
The provisioning model doesn't include conditions for recording rules.

Only return an error for a missing condition if the rule isn't a recording rule.

Also, added a test case to show the failure.

There may be a better way to resolve this, but I'm not familiar enough with the code to find it.

Fixes #109398

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
