### PR TITLE
Dashboard versions: Cleanup logic

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -159,23 +159,6 @@ func (s *Service) getDashUIDMaybeEmpty(ctx context.Context, id int64) (string, e
 	return result.UID, nil
 }
 
-// getDashIDMaybeEmpty is a helper function which takes a dashboardUID and
-// returns the ID. If the dashboard is not found, it will return -1.
-func (s *Service) getDashIDMaybeEmpty(ctx context.Context, uid string, orgID int64) (int64, error) {
-	q := dashboards.GetDashboardQuery{UID: uid, OrgID: orgID}
-	result, err := s.dashSvc.GetDashboard(ctx, &q)
-	if err != nil {
-		if errors.Is(err, dashboards.ErrDashboardNotFound) {
-			s.log.Debug("dashboard not found")
-			return -1, nil
-		} else {
-			s.log.Error("error getting dashboard", err)
-			return -1, err
-		}
-	}
-	return result.ID, nil
-}
-
 func (s *Service) getHistoryThroughK8s(ctx context.Context, orgID int64, dashboardUID string, version int64) (*dashver.DashboardVersionDTO, error) {
 	// this is an unideal implementation - we have to list all versions and filter here, since there currently is no way to query for the
 	// generation id in unified storage, so we cannot query for the dashboard version directly, and we cannot use search as history is not indexed.

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -69,24 +69,12 @@ func ProvideService(cfg *setting.Cfg, db db.DB, dashboardService dashboards.Dash
 }
 
 func (s *Service) Get(ctx context.Context, query *dashver.GetDashboardVersionQuery) (*dashver.DashboardVersionDTO, error) {
-	// Get the DashboardUID if not populated
 	if query.DashboardUID == "" {
 		u, err := s.getDashUIDMaybeEmpty(ctx, query.DashboardID)
 		if err != nil {
 			return nil, err
 		}
 		query.DashboardUID = u
-	}
-
-	// The store methods require the dashboard ID (uid is not in the dashboard
-	// versions table, at time of this writing), so get the DashboardID if it
-	// was not populated.
-	if query.DashboardID == 0 {
-		id, err := s.getDashIDMaybeEmpty(ctx, query.DashboardUID, query.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		query.DashboardID = id
 	}
 
 	version, err := s.getHistoryThroughK8s(ctx, query.OrgID, query.DashboardUID, query.Version)
@@ -128,7 +116,6 @@ func (s *Service) DeleteExpired(ctx context.Context, cmd *dashver.DeleteExpiredV
 
 // List all dashboard versions for the given dashboard ID.
 func (s *Service) List(ctx context.Context, query *dashver.ListDashboardVersionsQuery) (*dashver.DashboardVersionResponse, error) {
-	// Get the DashboardUID if not populated
 	if query.DashboardUID == "" {
 		u, err := s.getDashUIDMaybeEmpty(ctx, query.DashboardID)
 		if err != nil {
@@ -137,16 +124,6 @@ func (s *Service) List(ctx context.Context, query *dashver.ListDashboardVersions
 		query.DashboardUID = u
 	}
 
-	// The store methods require the dashboard ID (uid is not in the dashboard
-	// versions table, at time of this writing), so get the DashboardID if it
-	// was not populated.
-	if query.DashboardID == 0 {
-		id, err := s.getDashIDMaybeEmpty(ctx, query.DashboardUID, query.OrgID)
-		if err != nil {
-			return nil, err
-		}
-		query.DashboardID = id
-	}
 	if query.Limit == 0 {
 		query.Limit = 1000
 	}


### PR DESCRIPTION
After removing the k8s feature toggle, the query no longer needs to have the dashboard id populated. 

This PR removes a query that doesn't need to happen :)