### PR TITLE
Actions: Don't specify ref on clone 

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: ${{ steps.fetch_depth.outputs.fetch_depth }}
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Trufflehog
         uses: trufflesecurity/trufflehog@eafb8c5f6a06175141c27f17bcc17941853d0047 # v3.90.0
         with:


### PR DESCRIPTION
It would appear that if you specify a ref, even if it is the same as the PR's ref, it will clone the parent repository
rather than the fork.

This should fix Trufflehog on forks; tested on #109441 