### PR TITLE
Fix grafana github issue 109182

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
+++ b/packages/grafana-ui/src/components/Combobox/ComboboxList.tsx
@@ -136,9 +136,6 @@ export const ComboboxList = <T extends string | number>({
                       value={allItemsSelected || isOptionSelected(item)}
                       indeterminate={item.value === ALL_OPTION_VALUE && selectedItems.length > 0 && !allItemsSelected}
                       aria-labelledby={itemId}
-                      onClick={(e) => {
-                        e.stopPropagation();
-                      }}
                     />
                   </div>
                 )}

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -378,6 +378,46 @@ describe('MultiCombobox', () => {
       expect(asyncOptions).toHaveBeenCalledTimes(1);
       expect(asyncOptions).toHaveBeenCalledWith('abc');
     });
+
+    it('should allow deselection via checkbox click with async options', async () => {
+      const asyncOptions = jest.fn(() => Promise.resolve(simpleAsyncOptions));
+      
+      const ControlledMultiCombobox = () => {
+        const [value, setValue] = React.useState<Array<ComboboxOption<string>>>([]);
+        return (
+          <MultiCombobox
+            options={asyncOptions}
+            value={value}
+            onChange={(val) => {
+              setValue(val ?? []);
+              onChangeHandler(val);
+            }}
+          />
+        );
+      };
+
+      render(<ControlledMultiCombobox />);
+
+      const input = screen.getByRole('combobox');
+      await user.click(input);
+
+      // Debounce
+      await act(async () => jest.advanceTimersByTime(200));
+
+      // Select an option by clicking the option
+      const option1 = await screen.findByRole('option', { name: 'Option 1' });
+      await user.click(option1);
+
+      expect(onChangeHandler).toHaveBeenCalledWith([simpleAsyncOptions[0]]);
+
+      // Now try to deselect by clicking the checkbox for Option 1
+      const option1Element = screen.getByRole('option', { name: 'Option 1' });
+      const option1Checkbox = option1Element.querySelector('input[type="checkbox"]') as HTMLInputElement;
+      await user.click(option1Checkbox);
+
+      // This should call onChange with empty array but currently doesn't work
+      expect(onChangeHandler).toHaveBeenCalledWith([]);
+    });
   });
 });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an issue in the MultiComboBox component where users could not deselect items via checkbox when using async options.

**Why do we need this feature?**

Previously, the `e.stopPropagation()` on the checkbox's `onClick` handler prevented the click event from reaching the parent option's selection logic, leading to a broken deselection experience for async MultiComboBoxes. This change restores the expected functionality.

**Who is this feature for?**

All Grafana users who interact with MultiComboBox components, especially those using async data sources.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #109182

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

The core change is removing `e.stopPropagation()` from the checkbox's `onClick` handler in `ComboboxList.tsx`. A new test case has been added to `MultiCombobox.test.tsx` to specifically cover async option deselection via checkbox.

---
[Slack Thread](https://raintank-corp.slack.com/archives/D095PAP3B4J/p1754900024460459?thread_ts=1754900024.460459&cid=D095PAP3B4J)

<a href="https://cursor.com/background-agent?bcId=bc-78469fbd-ce97-4eed-a943-2c1464ab248a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78469fbd-ce97-4eed-a943-2c1464ab248a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

