### PR TITLE
Chore: Disable cgo for postgres/mysql tests

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          go test -p=1 -tags=mysql -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -tags=mysql -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
   postgres:
     strategy:
       matrix:
@@ -138,7 +138,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -tags=postgres -timeout=5m -run '^TestIntegration' "${PACKAGES[@]}"
 
   # This is the job that is actually required by rulesets.
   # We want to only require one job instead of all the individual tests and shards.

--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -2,7 +2,28 @@
 
 package sqlite
 
-import "modernc.org/sqlite"
+import (
+	"database/sql"
+	"errors"
+
+	"modernc.org/sqlite"
+)
+
+const DriverName = "sqlite"
+
+// The errors below are used in tests to simulate specific SQLite errors. It's a temporary solution
+// until we rewrite the tests not to depend on the sqlite3 package internals directly.
+// Note: Since modernc.org/sqlite driver does not expose error codes like sqlite3, we cannot use the same approach.
+var (
+	TestErrUniqueConstraintViolation = errors.New("unique constraint violation (simulated)")
+	TestErrBusy                      = errors.New("database is busy (simulated)")
+	TestErrLocked                    = errors.New("database is locked (simulated)")
+)
+
+func init() {
+	// alias the driver name to match the CGo driver
+	sql.Register("sqlite3", &Driver{})
+}
 
 //
 // FIXME (@zserge)


### PR DESCRIPTION
Decided to split https://github.com/grafana/grafana/pull/108764 in two parts, since SQLite tests take a bit longer to resolve.

Some tests are flaky, but no more than usual after testinfra changes.