### PR TITLE
chore(plugin name): added new name for docs plugin

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -15,6 +15,7 @@ const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   'grafana-assistant-app',
   'grafana-dash-app',
   'grafana-grafanadocsplugin-app',
+  'grafana-pathfinder',
 ];
 
 export type ExtensionSidebarContextType = {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -16,6 +16,8 @@ function getPluginIcon(pluginId?: string): string {
   switch (pluginId) {
     case 'grafana-grafanadocsplugin-app':
       return 'book';
+    case 'grafana-pathfinder':
+      return 'book';
     case 'grafana-investigations-app':
       return 'eye';
     default:


### PR DESCRIPTION
We are currently renaming the docs plugin to Grafana Pathfinder. In this PR, I have added the new plugin-id to this list rather than replaced the old plugin due to backwards compatability. Will remove in a later PR after release. 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
