### PR TITLE
Build: Add -buildvcs=false flag to go build

### DIFF
--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -203,6 +203,10 @@ func doBuild(binaryName, pkg string, opts BuildOpts) error {
 		args = append(args, "-race")
 	}
 
+	// We should not publish Grafana as a Go module, disabling vcs changes the version to (devel)
+	// and works better with SBOM and Vulnerability Scanners.
+	args = append(args, "-buildvcs=false")
+
 	args = append(args, "-o", binary)
 	args = append(args, pkg)
 

--- a/pkg/build/daggerbuild/backend/build.go
+++ b/pkg/build/daggerbuild/backend/build.go
@@ -34,6 +34,9 @@ func GoLDFlags(flags []LDFlag) string {
 // GoBuildCommand returns the arguments for go build to be used in 'WithExec'.
 func GoBuildCommand(output string, ldflags []LDFlag, tags []string, main string) []string {
 	args := []string{"go", "build",
+		// We should not publish Grafana as a Go module, disabling vcs changes the version to (devel)
+		// and works better with SBOM and Vulnerability Scanners.
+		"-buildvcs=false",
 		fmt.Sprintf("-ldflags=\"%s\"", GoLDFlags(ldflags)),
 		fmt.Sprintf("-o=%s", output),
 		"-trimpath",


### PR DESCRIPTION
**What is this feature?**

Builds Grafana binaries with `-buildvcs=false` flag.

Without the flag, tools like `Syft` report the root Go modules as:
```
github.com/grafana/grafana                                                           UNKNOWN                                      go-module  (+2 duplicates)
```
Which is expected, as we don't release or version the root Go module.

Without the change, `Syft` reports it as:
```
github.com/grafana/grafana                                                           v0.0.1-test.0.20250718152410-1fdeca10151e+dirty  go-module
```

Which trips up SBOM generators and Security Scanners which think there's a very old version of Grafana in the artifacts.

**Why do we need this feature?**

Proper SBOM generation and remove false positives from Security Scanners.

**Who is this feature for?**

SBOM generators and Security Scanners

**Which issue(s) does this PR fix?**:

Addresses https://github.com/grafana/grafana/issues/106728

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.