### PR TITLE
Navigation: Expose runtime hook for controlling mega menu

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -600,6 +600,7 @@
 /packages/grafana-runtime/src/utils/DataSourceWithBackend* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/licensing.ts @grafana/grafana-operator-experience-squad
 /packages/grafana-runtime/src/utils/logging.ts @grafana/grafana-frontend-platform
+/packages/grafana-runtime/src/utils/megaMenuOpen.ts @grafana/grafana-search-navigate-organise
 /packages/grafana-runtime/src/utils/migrationHandler* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /packages/grafana-runtime/src/utils/plugin.ts @grafana/plugins-platform-frontend
 /packages/grafana-runtime/src/utils/publicDashboardQueryHandler.ts @grafana/grafana-operator-experience-squad

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -51,6 +51,7 @@ export {
 } from './analytics/plugins/eventProperties';
 export { usePluginInteractionReporter } from './analytics/plugins/usePluginInteractionReporter';
 export { setReturnToPreviousHook, useReturnToPrevious } from './utils/returnToPrevious';
+export { setMegaMenuOpenHook, useMegaMenuOpen } from './utils/megaMenuOpen';
 export { setChromeHeaderHeightHook, useChromeHeaderHeight } from './utils/chromeHeaderHeight';
 export { type EmbeddedDashboardProps, EmbeddedDashboard, setEmbeddedDashboard } from './components/EmbeddedDashboard';
 export { hasPermission, hasPermissionInMetadata, hasAllPermissions, hasAnyPermission } from './utils/rbac';

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,4 +1,4 @@
-type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean) => void]>;
+type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean, persist?: boolean) => void]>;
 
 let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
 

--- a/packages/grafana-runtime/src/utils/megaMenuOpen.ts
+++ b/packages/grafana-runtime/src/utils/megaMenuOpen.ts
@@ -1,0 +1,22 @@
+type MegaMenuOpenHook = () => Readonly<[boolean, (open: boolean) => void]>;
+
+let megaMenuOpenHook: MegaMenuOpenHook | undefined = undefined;
+
+export const setMegaMenuOpenHook = (hook: MegaMenuOpenHook) => {
+  megaMenuOpenHook = hook;
+};
+
+/**
+ * Guidelines:
+ * - Should only be used in very specific circumstances where the mega menu needs to be opened or closed programmatically.
+ */
+export const useMegaMenuOpen: MegaMenuOpenHook = () => {
+  if (!megaMenuOpenHook) {
+    if (process.env.NODE_ENV !== 'production') {
+      throw new Error('useMegaMenuOpen hook not found in @grafana/runtime');
+    }
+    return [false, () => console.error('MegaMenuOpen hook not found')];
+  }
+
+  return megaMenuOpenHook();
+};

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -42,6 +42,7 @@ import {
   setFolderPicker,
   setCorrelationsService,
   setPluginFunctionsHook,
+  setMegaMenuOpenHook,
 } from '@grafana/runtime';
 import {
   setGetObservablePluginComponents,
@@ -63,7 +64,11 @@ import { useChromeHeaderHeight } from './core/components/AppChrome/TopBar/useChr
 import { LazyFolderPicker } from './core/components/NestedFolderPicker/LazyFolderPicker';
 import { getAllOptionEditors, getAllStandardFieldConfigs } from './core/components/OptionsUI/registry';
 import { PluginPage } from './core/components/Page/PluginPage';
-import { GrafanaContextType, useReturnToPreviousInternal } from './core/context/GrafanaContext';
+import {
+  GrafanaContextType,
+  useMegaMenuOpenInternal,
+  useReturnToPreviousInternal,
+} from './core/context/GrafanaContext';
 import { initializeCrashDetection } from './core/crash';
 import { NAMESPACES, GRAFANA_NAMESPACE } from './core/internationalization/constants';
 import { loadTranslations } from './core/internationalization/loadTranslations';
@@ -279,6 +284,7 @@ export class GrafanaApp {
       };
 
       setReturnToPreviousHook(useReturnToPreviousInternal);
+      setMegaMenuOpenHook(useMegaMenuOpenInternal);
       setChromeHeaderHeightHook(useChromeHeaderHeight);
 
       if (config.featureToggles.crashDetection) {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -177,9 +177,9 @@ export class AppChromeService {
     return useObservable(this.state, this.state.getValue());
   }
 
-  public setMegaMenuOpen = (newOpenState: boolean) => {
+  public setMegaMenuOpen = (newOpenState: boolean, updatePersistedState = true) => {
     const { megaMenuDocked } = this.state.getValue();
-    if (megaMenuDocked) {
+    if (megaMenuDocked && updatePersistedState) {
       store.set(DOCKED_MENU_OPEN_LOCAL_STORAGE_KEY, newOpenState);
     }
     reportInteraction('grafana_mega_menu_open', {

--- a/public/app/core/context/GrafanaContext.ts
+++ b/public/app/core/context/GrafanaContext.ts
@@ -40,3 +40,11 @@ export function useReturnToPreviousInternal() {
     [chrome]
   );
 }
+
+// Implementation of useMegaMenuOpen that's made available through
+// @grafana/runtime
+export function useMegaMenuOpenInternal() {
+  const { chrome } = useGrafana();
+  const state = chrome.useState();
+  return [state.megaMenuOpen, chrome.setMegaMenuOpen] as const;
+}


### PR DESCRIPTION
**What is this feature?**

Exposing a new hook in `@grafana/runtime` to allow plugins to control whether the mega menu is collapsed or not.

**Why do we need this feature?**

To allow for the onboarding flow in Grafana Cloud to collapse the mega menu when the flow is accessed, to focus the user on the onboarding content itself.

**Who is this feature for?**

Plugin developers.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/OGPM/issues/305 🔐 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
