### PR TITLE
fix: dashboard version history duplicating entries sometimes

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -1,4 +1,12 @@
-import { CoreApp, GrafanaConfig, LoadingState, getDefaultTimeRange, locationUtil, store } from '@grafana/data';
+import {
+  CoreApp,
+  GrafanaConfig,
+  LiveChannelEventType,
+  LoadingState,
+  getDefaultTimeRange,
+  locationUtil,
+  store,
+} from '@grafana/data';
 import { config, locationService, RefreshEvent } from '@grafana/runtime';
 import {
   sceneGraph,
@@ -17,6 +25,8 @@ import appEvents from 'app/core/app_events';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';
 import { AnnoKeyManagerKind, ManagerKind } from 'app/features/apiserver/types';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
+import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
+import { DashboardEventAction } from 'app/features/live/dashboard/types';
 import { VariablesChanged } from 'app/features/variables/types';
 
 import { buildPanelEditScene } from '../panel-edit/PanelEditor';
@@ -764,10 +774,44 @@ describe('DashboardScene', () => {
 
       return scene.onRestore(getVersionMock()).then((res) => {
         expect(res).toBe(true);
-
         expect(scene.state.version).toBe(newVersion);
         expect(scene.state.isEditing).toBe(false);
       });
+    });
+
+    it('should call dashboardWatcher.reloadPage even if dashboard is in editing mode', async () => {
+      // sometimes a dashboard can be in editing mode after user has already restored to a previous version
+
+      const newVersion = 3;
+      const mockScene = new DashboardScene({
+        title: 'new name',
+        uid: 'dash-1',
+        version: 4,
+      });
+      jest.mocked(historySrv.restoreDashboard).mockResolvedValue({ version: newVersion });
+      jest.mocked(transformSaveModelToScene).mockReturnValue(mockScene);
+
+      const reloadSpy = jest.spyOn(dashboardWatcher, 'reloadPage').mockImplementation(() => {});
+
+      dashboardWatcher.editing = false;
+      const dash = { uid: 'dash-1', hasUnsavedChanges: () => true };
+      jest
+        .spyOn(require('app/features/dashboard/services/DashboardSrv'), 'getDashboardSrv')
+        .mockReturnValue({ getCurrent: () => dash });
+
+      dashboardWatcher.observer.next({
+        type: LiveChannelEventType.Message,
+        message: {
+          sessionId: 'other',
+          message: 'Restored from version 3',
+          uid: 'dash-1',
+          action: DashboardEventAction.Saved,
+          timestamp: Date.now(),
+        },
+      });
+
+      expect(reloadSpy).toHaveBeenCalled();
+      reloadSpy.mockRestore();
     });
 
     it('should return early if historySrv does not return a valid version number', () => {

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -113,7 +113,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       .then((result) => {
         this.setState({
           isLoading: false,
-          versions: [...(this.state.versions ?? []), ...this.decorateVersions(result.versions)],
+          versions: [...(append ? this.state.versions ?? [] : []), ...this.decorateVersions(result.versions)],
         });
         this._start += this._limit;
         // Update the continueToken for the next request, if available

--- a/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VersionsEditView.tsx
@@ -113,7 +113,7 @@ export class VersionsEditView extends SceneObjectBase<VersionsEditViewState> imp
       .then((result) => {
         this.setState({
           isLoading: false,
-          versions: [...(append ? this.state.versions ?? [] : []), ...this.decorateVersions(result.versions)],
+          versions: [...(append ? (this.state.versions ?? []) : []), ...this.decorateVersions(result.versions)],
         });
         this._start += this._limit;
         // Update the continueToken for the next request, if available

--- a/public/app/features/live/dashboard/dashboardWatcher.ts
+++ b/public/app/features/live/dashboard/dashboardWatcher.ts
@@ -109,7 +109,7 @@ class DashboardWatcher {
           return; // skip internal messages
         }
 
-        const { action } = event.message;
+        const { action, message } = event.message;
         switch (action) {
           case DashboardEventAction.EditingStarted:
           case DashboardEventAction.Saved: {
@@ -124,7 +124,13 @@ class DashboardWatcher {
               return;
             }
 
-            const showPopup = this.editing || dash.hasUnsavedChanges();
+            let showPopup = this.editing || dash.hasUnsavedChanges();
+
+            // Dashboard could have unsaved changes but if user has already restored from a version
+            // the reloadPage should be called below
+            if (message?.includes('Restored from version')) {
+              showPopup = false;
+            }
 
             if (action === DashboardEventAction.Saved) {
               if (showPopup) {


### PR DESCRIPTION
closes https://github.com/grafana/search-and-storage-team/issues/416

when the kubernetes API is enabled, the dashboard version history sometimes fails to navigate back to the dashboard and the component re-fetches the version history, duplicating all entries.

One way I can replicate fairly reliably is:

1. go to `/dashboards`
2. visit dashboard
3. click edit
4. add row/visualization, and save
5. go to settings
6. go to version history
7. restore to previous version
8. navigation fails and history is re-fetched

It's not necessary to make an edit for the navigation to fail. I've seen that happen without editting the dashboard, but this is one of the ways that I found to reproduce this bug reliably.

Screencast reproducing the bug:


https://github.com/user-attachments/assets/2ba49131-9a79-4444-a24f-b223e6e3d68e