### PR TITLE
Auth: Add subtitle for cloud access policy page

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -104,6 +104,10 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 					link.Id = "standalone-plugin-page-" + include.Path
 					link.SortWeight = pathConfig.SortWeight
 
+					if len(pathConfig.SubTitle) > 0 {
+						link.SubTitle = pathConfig.SubTitle
+					}
+
 					// Check if the section already has a page with the same URL, and in that case override it
 					// (This only happens if it is explicitly set by `navigation.app_standalone_pages` in the INI config)
 					isOverridingCorePage := false
@@ -348,7 +352,11 @@ func (s *ServiceImpl) readNavigationSettings() {
 	}
 
 	s.navigationAppPathConfig = map[string]NavigationAppConfig{
-		"/a/grafana-auth-app": {SectionID: navtree.NavIDCfgAccess, SortWeight: 2},
+		"/a/grafana-auth-app": {
+			SectionID:  navtree.NavIDCfgAccess,
+			SortWeight: 2,
+			SubTitle:   "Use policies to control automated access to metrics, logs, traces, and other Grafana Cloud services",
+		},
 	}
 
 	appSections := s.cfg.Raw.Section("navigation.app_sections")


### PR DESCRIPTION
Relates to https://github.com/grafana/grafana-enterprise/pull/9304, https://github.com/grafana/grafana-enterprise/pull/9314, and possibly https://github.com/grafana/grafana/pull/109445.

---

**What is this feature?**

This PR adds a subtitle to the Cloud Access Policy plugin to provide users with more context.

**Why do we need this feature?**

This feature aims to improve user experience.

**Who is this feature for?**

Users of the Cloud Access Policy UI.

**Sneak peek**

<img width="1584" height="277" alt="Screenshot 2025-08-11 at 8 18 16 PM" src="https://github.com/user-attachments/assets/1768e6a5-86d6-4bdb-96eb-67c78432b347" />

