### PR TITLE
[release-12.1.1] Alerting: Fix subpath handling in the alerting package

### DIFF
--- a/packages/grafana-alerting/src/grafana/api/util.test.ts
+++ b/packages/grafana-alerting/src/grafana/api/util.test.ts
@@ -1,0 +1,67 @@
+import { config } from '@grafana/runtime';
+
+import { getAPIBaseURL, getAPINamespace, getAPIReducerPath } from './util';
+
+describe('API utilities', () => {
+  const originalAppSubUrl = config.appSubUrl;
+  const originalNamespace = config.namespace;
+
+  afterEach(() => {
+    // Restore original config after each test
+    config.appSubUrl = originalAppSubUrl;
+    config.namespace = originalNamespace;
+  });
+
+  describe('getAPIBaseURL', () => {
+    const group = 'notifications.alerting.grafana.app';
+    const version = 'v0alpha1';
+
+    it('should generate correct API base URL without subpath', () => {
+      config.appSubUrl = '';
+      config.namespace = 'default';
+
+      const result = getAPIBaseURL(group, version);
+
+      expect(result).toBe('/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/default');
+    });
+
+    it('should generate correct API base URL with subpath', () => {
+      config.appSubUrl = '/grafana';
+      config.namespace = 'default';
+
+      const result = getAPIBaseURL(group, version);
+
+      expect(result).toBe('/grafana/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/default');
+    });
+
+    it('should handle different namespace', () => {
+      config.appSubUrl = '/grafana';
+      config.namespace = 'custom-namespace';
+
+      const result = getAPIBaseURL(group, version);
+
+      expect(result).toBe('/grafana/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/custom-namespace');
+    });
+  });
+
+  describe('getAPINamespace', () => {
+    it('should return configured namespace', () => {
+      config.namespace = 'test-namespace';
+
+      const result = getAPINamespace();
+
+      expect(result).toBe('test-namespace');
+    });
+  });
+
+  describe('getAPIReducerPath', () => {
+    it('should generate correct reducer path', () => {
+      const group = 'notifications.alerting.grafana.app';
+      const version = 'v0alpha1';
+
+      const result = getAPIReducerPath(group, version);
+
+      expect(result).toBe('notifications.alerting.grafana.app/v0alpha1');
+    });
+  });
+});

--- a/packages/grafana-alerting/src/grafana/api/util.ts
+++ b/packages/grafana-alerting/src/grafana/api/util.ts
@@ -6,8 +6,10 @@ import { config } from '@grafana/runtime';
 
 export const getAPINamespace = () => config.namespace;
 
-export const getAPIBaseURL = (group: string, version: string) =>
-  `/apis/${group}/${version}/namespaces/${getAPINamespace()}` as const;
+export const getAPIBaseURL = (group: string, version: string) => {
+  const subPath = config.appSubUrl || '';
+  return `${subPath}/apis/${group}/${version}/namespaces/${getAPINamespace()}` as const;
+};
 
 // By including the version in the reducer path we can prevent cache bugs when different versions of the API are used for the same entities
 export const getAPIReducerPath = (group: string, version: string) => `${group}/${version}` as const;


### PR DESCRIPTION
Backport a0cf529465a3c03627f5cbd8af29f7715e42e711 from #109448  

**API URL generation improvements:**
 
 * Updated `getAPIBaseURL` in `util.ts` to prepend the `config.appSubUrl` (if set) to the API base path, ensuring that URLs are correctly formed for deployments with a subpath.
 
 **Testing enhancements:**
 
 * Added a new test suite in `util.test.ts` that covers:
   - Various scenarios for `getAPIBaseURL`, including different subpaths and namespaces.
   - Validation of namespace retrieval with `getAPINamespace`.
   - Correct generation of reducer paths with `getAPIReducerPath`.
