### PR TITLE
SecretsManager: clear unused metrics

### DIFF
--- a/pkg/registry/apis/secret/service/metrics/metrics.go
+++ b/pkg/registry/apis/secret/service/metrics/metrics.go
@@ -14,15 +14,10 @@ const (
 // SecureValueServiceMetrics is a struct that contains all the metrics for SecureValue.
 type SecureValueServiceMetrics struct {
 	SecureValueCreateDuration *prometheus.HistogramVec
-	SecureValueCreateCount    *prometheus.CounterVec
 	SecureValueUpdateDuration *prometheus.HistogramVec
-	SecureValueUpdateCount    *prometheus.CounterVec
 	SecureValueReadDuration   *prometheus.HistogramVec
-	SecureValueReadCount      *prometheus.CounterVec
 	SecureValueListDuration   *prometheus.HistogramVec
-	SecureValueListCount      *prometheus.CounterVec
 	SecureValueDeleteDuration *prometheus.HistogramVec
-	SecureValueDeleteCount    *prometheus.CounterVec
 }
 
 func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
@@ -34,24 +29,12 @@ func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
 			Help:      "Duration of Secure Value create operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"success"}),
-		SecureValueCreateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_create_count",
-			Help:      "Count of Secure Value create operations",
-		}, []string{"success"}),
 		SecureValueReadDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_read_duration_seconds",
 			Help:      "Duration of Secure Value read operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
-		SecureValueReadCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_read_count",
-			Help:      "Count of Secure Value read operations",
 		}, []string{"success"}),
 		SecureValueUpdateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -60,12 +43,6 @@ func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
 			Help:      "Duration of Secure Value update operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"success"}),
-		SecureValueUpdateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_update_count",
-			Help:      "Count of Secure Value update operations",
-		}, []string{"success"}),
 		SecureValueListDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -73,24 +50,12 @@ func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
 			Help:      "Duration of Secure Value list operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"success"}),
-		SecureValueListCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_list_count",
-			Help:      "Count of Secure Value list operations",
-		}, []string{"success"}),
 		SecureValueDeleteDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_delete_duration_seconds",
 			Help:      "Duration of Secure Value delete operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
-		SecureValueDeleteCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_delete_count",
-			Help:      "Count of Secure Value delete operations",
 		}, []string{"success"}),
 	}
 }
@@ -107,15 +72,10 @@ func NewSecureValueServiceMetrics(reg prometheus.Registerer) *SecureValueService
 		if reg != nil {
 			reg.MustRegister(
 				m.SecureValueCreateDuration,
-				m.SecureValueCreateCount,
 				m.SecureValueReadDuration,
-				m.SecureValueReadCount,
 				m.SecureValueUpdateDuration,
-				m.SecureValueUpdateCount,
 				m.SecureValueListDuration,
-				m.SecureValueListCount,
 				m.SecureValueDeleteDuration,
-				m.SecureValueDeleteCount,
 			)
 		}
 		metricsInstance = m

--- a/pkg/registry/apis/secret/service/metrics/metrics.go
+++ b/pkg/registry/apis/secret/service/metrics/metrics.go
@@ -9,6 +9,8 @@ import (
 const (
 	namespace = "grafana_secrets_manager"
 	subsystem = "service"
+	// labels
+	successLabel = "success"
 )
 
 // SecureValueServiceMetrics is a struct that contains all the metrics for SecureValue.
@@ -28,35 +30,35 @@ func newSecureValueServiceMetrics() *SecureValueServiceMetrics {
 			Name:      "secure_value_create_duration_seconds",
 			Help:      "Duration of Secure Value create operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
+		}, []string{successLabel}),
 		SecureValueReadDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_read_duration_seconds",
 			Help:      "Duration of Secure Value read operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
+		}, []string{successLabel}),
 		SecureValueUpdateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_update_duration_seconds",
 			Help:      "Duration of Secure Value update operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
+		}, []string{successLabel}),
 		SecureValueListDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_list_duration_seconds",
 			Help:      "Duration of Secure Value list operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
+		}, []string{successLabel}),
 		SecureValueDeleteDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_delete_duration_seconds",
 			Help:      "Duration of Secure Value delete operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"success"}),
+		}, []string{successLabel}),
 	}
 }
 

--- a/pkg/registry/apis/secret/service/secure_value.go
+++ b/pkg/registry/apis/secret/service/secure_value.go
@@ -90,7 +90,6 @@ func (s *SecureValueService) Create(ctx context.Context, sv *secretv1beta1.Secur
 		logging.FromContext(ctx).Info("SecureValueService.Create finished", args...)
 
 		s.metrics.SecureValueCreateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueCreateCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	return s.createNewVersion(ctx, sv, actorUID)
@@ -126,7 +125,6 @@ func (s *SecureValueService) Update(ctx context.Context, newSecureValue *secretv
 		logging.FromContext(ctx).Info("SecureValueService.Update finished", args...)
 
 		s.metrics.SecureValueUpdateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueUpdateCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	if newSecureValue.Spec.Value == nil {
@@ -245,7 +243,6 @@ func (s *SecureValueService) Read(ctx context.Context, namespace xkube.Namespace
 		logging.FromContext(ctx).Info("SecureValueService.Read finished", args...)
 
 		s.metrics.SecureValueReadDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueReadCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	defer span.End()
@@ -281,7 +278,6 @@ func (s *SecureValueService) List(ctx context.Context, namespace xkube.Namespace
 		logging.FromContext(ctx).Info("SecureValueService.List finished", args...)
 
 		s.metrics.SecureValueListDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueListCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	user, ok := claims.AuthInfoFrom(ctx)
@@ -353,7 +349,6 @@ func (s *SecureValueService) Delete(ctx context.Context, namespace xkube.Namespa
 		logging.FromContext(ctx).Info("SecureValueService.Delete finished", args...)
 
 		s.metrics.SecureValueDeleteDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueDeleteCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	// TODO: does this need to be for update?

--- a/pkg/registry/apis/secret/service/secure_value.go
+++ b/pkg/registry/apis/secret/service/secure_value.go
@@ -229,7 +229,7 @@ func (s *SecureValueService) Read(ctx context.Context, namespace xkube.Namespace
 	defer func() {
 		args := []any{
 			"name", name,
-			"namespace", namespace,
+			"namespace", namespace.String(),
 		}
 
 		success := readErr == nil

--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -95,7 +95,6 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 
 		success := decryptErr == nil
 		s.metrics.DecryptDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.DecryptRequestCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	// Basic authn check before reading a secure value metadata, it is here on purpose.

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -292,13 +292,14 @@ func TestIntegrationDecrypt(t *testing.T) {
 		require.NotEmpty(t, exposed)
 		require.Equal(t, "value", exposed.DangerouslyExposeAndConsumeValue())
 
-		require.Len(t, fakeLogger.InfoMsgs, 2)
+		require.Len(t, fakeLogger.InfoMsgs, 3)
 		require.Equal(t, fakeLogger.InfoMsgs[0], "SecureValueMetadataStorage.Read")
-		require.Equal(t, fakeLogger.InfoMsgs[1], "Secrets Audit Log")
+		require.Equal(t, fakeLogger.InfoMsgs[1], "KeeperMetadataStorage.GetKeeperConfig")
+		require.Equal(t, fakeLogger.InfoMsgs[2], "Secrets Audit Log")
 
-		require.Len(t, fakeLogger.InfoArgs, 2)
+		require.Len(t, fakeLogger.InfoArgs, 3)
 		// we only want to check the audit log args
-		args := fakeLogger.InfoArgs[1]
+		args := fakeLogger.InfoArgs[2]
 		require.Contains(t, args, "grafana_decrypter_identity")
 		require.Contains(t, args, "decrypter_identity")
 		for i, arg := range args {

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -366,7 +366,7 @@ func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namesp
 		success := err == nil
 
 		args := []any{
-			"namespace", namespace,
+			"namespace", namespace.String(),
 			"success", success,
 		}
 

--- a/pkg/storage/secret/metadata/keeper_store.go
+++ b/pkg/storage/secret/metadata/keeper_store.go
@@ -100,7 +100,6 @@ func (s *keeperMetadataStorage) Create(ctx context.Context, keeper *secretv1beta
 	}
 
 	s.metrics.KeeperMetadataCreateDuration.WithLabelValues(string(createdKeeper.Spec.GetType())).Observe(time.Since(start).Seconds())
-	s.metrics.KeeperMetadataCreateCount.WithLabelValues(string(createdKeeper.Spec.GetType())).Inc()
 
 	return createdKeeper, nil
 }
@@ -125,7 +124,6 @@ func (s *keeperMetadataStorage) Read(ctx context.Context, namespace xkube.Namesp
 	}
 
 	s.metrics.KeeperMetadataGetDuration.WithLabelValues(string(keeper.Spec.GetType())).Observe(time.Since(start).Seconds())
-	s.metrics.KeeperMetadataGetCount.WithLabelValues(string(keeper.Spec.GetType())).Inc()
 
 	return keeper, nil
 }
@@ -240,7 +238,6 @@ func (s *keeperMetadataStorage) Update(ctx context.Context, newKeeper *secretv1b
 	}
 
 	s.metrics.KeeperMetadataUpdateDuration.WithLabelValues(string(keeper.Spec.GetType())).Observe(time.Since(start).Seconds())
-	s.metrics.KeeperMetadataUpdateCount.WithLabelValues(string(keeper.Spec.GetType())).Inc()
 
 	return keeper, nil
 }
@@ -280,7 +277,6 @@ func (s *keeperMetadataStorage) Delete(ctx context.Context, namespace xkube.Name
 	}
 
 	s.metrics.KeeperMetadataDeleteDuration.Observe(time.Since(start).Seconds())
-	s.metrics.KeeperMetadataDeleteCount.Inc()
 
 	return nil
 }
@@ -337,7 +333,6 @@ func (s *keeperMetadataStorage) List(ctx context.Context, namespace xkube.Namesp
 	}
 
 	s.metrics.KeeperMetadataListDuration.Observe(time.Since(start).Seconds())
-	s.metrics.KeeperMetadataListCount.Inc()
 
 	return keepers, nil
 }

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -9,22 +9,24 @@ import (
 const (
 	namespace = "grafana_secrets_manager"
 	subsystem = "storage"
+	// labels
+	successLabel = "success"
 )
 
 // StorageMetrics is a struct that contains all the metrics for all operations of secrets storage.
 type StorageMetrics struct {
 	KeeperMetadataCreateDuration          *prometheus.HistogramVec
 	KeeperMetadataUpdateDuration          *prometheus.HistogramVec
-	KeeperMetadataDeleteDuration          prometheus.Histogram
+	KeeperMetadataDeleteDuration          *prometheus.HistogramVec
 	KeeperMetadataGetDuration             *prometheus.HistogramVec
-	KeeperMetadataListDuration            prometheus.Histogram
-	KeeperMetadataGetKeeperConfigDuration prometheus.Histogram
+	KeeperMetadataListDuration            *prometheus.HistogramVec
+	KeeperMetadataGetKeeperConfigDuration *prometheus.HistogramVec
 
 	SecureValueMetadataCreateDuration *prometheus.HistogramVec
-	SecureValueMetadataGetDuration    prometheus.Histogram
-	SecureValueMetadataListDuration   prometheus.Histogram
-	SecureValueSetExternalIDDuration  prometheus.Histogram
-	SecureValueSetStatusDuration      prometheus.Histogram
+	SecureValueMetadataGetDuration    *prometheus.HistogramVec
+	SecureValueMetadataListDuration   *prometheus.HistogramVec
+	SecureValueSetExternalIDDuration  *prometheus.HistogramVec
+	SecureValueSetStatusDuration      *prometheus.HistogramVec
 
 	DecryptDuration *prometheus.HistogramVec
 }
@@ -38,42 +40,42 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "keeper_metadata_create_duration_seconds",
 			Help:      "Duration of keeper metadata create operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"keeper_type"}),
+		}, []string{successLabel}),
 		KeeperMetadataUpdateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_update_duration_seconds",
 			Help:      "Duration of keeper metadata update operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"keeper_type"}),
-		KeeperMetadataDeleteDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		KeeperMetadataDeleteDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_delete_duration_seconds",
 			Help:      "Duration of keeper metadata delete operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
+		}, []string{successLabel}),
 		KeeperMetadataGetDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_get_duration_seconds",
 			Help:      "Duration of keeper metadata get operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"keeper_type"}),
-		KeeperMetadataListDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		KeeperMetadataListDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_list_duration_seconds",
 			Help:      "Duration of keeper metadata list operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		KeeperMetadataGetKeeperConfigDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		KeeperMetadataGetKeeperConfigDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_get_keeper_config_duration_seconds",
 			Help:      "Duration of keeper metadata get keeper config operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
+		}, []string{successLabel}),
 
 		// Secure value metrics
 		SecureValueMetadataCreateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -82,36 +84,35 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "secure_value_metadata_create_duration_seconds",
 			Help:      "Duration of secure value metadata create operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"successful"}),
-		SecureValueMetadataGetDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		SecureValueMetadataGetDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_metadata_get_duration_seconds",
 			Help:      "Duration of secure value metadata get operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-
-		SecureValueMetadataListDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		SecureValueMetadataListDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_metadata_list_duration_seconds",
 			Help:      "Duration of secure value metadata list operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueSetExternalIDDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		SecureValueSetExternalIDDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_set_external_id_duration_seconds",
 			Help:      "Duration of secure value set external id operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueSetStatusDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
+		}, []string{successLabel}),
+		SecureValueSetStatusDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_set_status_duration_seconds",
 			Help:      "Duration of secure value set status operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
+		}, []string{successLabel}),
 
 		// Decrypt metrics
 		DecryptDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
@@ -120,7 +121,7 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "decrypt_duration_seconds",
 			Help:      "Duration of decrypt operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"successful"}),
+		}, []string{successLabel}),
 	}
 }
 

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -14,28 +14,19 @@ const (
 // StorageMetrics is a struct that contains all the metrics for all operations of secrets storage.
 type StorageMetrics struct {
 	KeeperMetadataCreateDuration          *prometheus.HistogramVec
-	KeeperMetadataCreateCount             *prometheus.CounterVec
 	KeeperMetadataUpdateDuration          *prometheus.HistogramVec
-	KeeperMetadataUpdateCount             *prometheus.CounterVec
 	KeeperMetadataDeleteDuration          prometheus.Histogram
-	KeeperMetadataDeleteCount             prometheus.Counter
 	KeeperMetadataGetDuration             *prometheus.HistogramVec
-	KeeperMetadataGetCount                *prometheus.CounterVec
 	KeeperMetadataListDuration            prometheus.Histogram
-	KeeperMetadataListCount               prometheus.Counter
 	KeeperMetadataGetKeeperConfigDuration prometheus.Histogram
 
 	SecureValueMetadataCreateDuration *prometheus.HistogramVec
-	SecureValueMetadataCreateCount    *prometheus.CounterVec
 	SecureValueMetadataGetDuration    prometheus.Histogram
-	SecureValueMetadataGetCount       prometheus.Counter
 	SecureValueMetadataListDuration   prometheus.Histogram
-	SecureValueMetadataListCount      prometheus.Counter
 	SecureValueSetExternalIDDuration  prometheus.Histogram
 	SecureValueSetStatusDuration      prometheus.Histogram
 
-	DecryptDuration     *prometheus.HistogramVec
-	DecryptRequestCount *prometheus.CounterVec
+	DecryptDuration *prometheus.HistogramVec
 }
 
 func newStorageMetrics() *StorageMetrics {
@@ -48,24 +39,12 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of keeper metadata create operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"keeper_type"}),
-		KeeperMetadataCreateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "keeper_metadata_create_count",
-			Help:      "Count of keeper metadata create operations",
-		}, []string{"keeper_type"}),
 		KeeperMetadataUpdateDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_update_duration_seconds",
 			Help:      "Duration of keeper metadata update operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{"keeper_type"}),
-		KeeperMetadataUpdateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "keeper_metadata_update_count",
-			Help:      "Count of keeper metadata update operations",
 		}, []string{"keeper_type"}),
 		KeeperMetadataDeleteDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -74,12 +53,6 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of keeper metadata delete operations",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		KeeperMetadataDeleteCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "keeper_metadata_delete_count",
-			Help:      "Count of keeper metadata delete operations",
-		}),
 		KeeperMetadataGetDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -87,24 +60,12 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of keeper metadata get operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"keeper_type"}),
-		KeeperMetadataGetCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "keeper_metadata_get_count",
-			Help:      "Count of keeper metadata get operations",
-		}, []string{"keeper_type"}),
 		KeeperMetadataListDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "keeper_metadata_list_duration_seconds",
 			Help:      "Duration of keeper metadata list operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		KeeperMetadataListCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "keeper_metadata_list_count",
-			Help:      "Count of keeper metadata list operations",
 		}),
 		KeeperMetadataGetKeeperConfigDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -122,12 +83,6 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of secure value metadata create operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"successful"}),
-		SecureValueMetadataCreateCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_create_count",
-			Help:      "Count of secure value metadata create operations",
-		}, []string{"successful"}),
 		SecureValueMetadataGetDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -135,24 +90,13 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of secure value metadata get operations",
 			Buckets:   prometheus.DefBuckets,
 		}),
-		SecureValueMetadataGetCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_get_count",
-			Help:      "Count of secure value metadata get operations",
-		}),
+
 		SecureValueMetadataListDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
 			Name:      "secure_value_metadata_list_duration_seconds",
 			Help:      "Duration of secure value metadata list operations",
 			Buckets:   prometheus.DefBuckets,
-		}),
-		SecureValueMetadataListCount: prometheus.NewCounter(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "secure_value_metadata_list_count",
-			Help:      "Count of secure value metadata list operations",
 		}),
 		SecureValueSetExternalIDDuration: prometheus.NewHistogram(prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -177,12 +121,6 @@ func newStorageMetrics() *StorageMetrics {
 			Help:      "Duration of decrypt operations",
 			Buckets:   prometheus.DefBuckets,
 		}, []string{"successful"}),
-		DecryptRequestCount: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Namespace: namespace,
-			Subsystem: subsystem,
-			Name:      "decrypt_request_count",
-			Help:      "Count of decrypt operations",
-		}, []string{"successful"}),
 	}
 }
 
@@ -199,26 +137,17 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 		if reg != nil {
 			reg.MustRegister(
 				m.KeeperMetadataCreateDuration,
-				m.KeeperMetadataCreateCount,
 				m.KeeperMetadataUpdateDuration,
-				m.KeeperMetadataUpdateCount,
 				m.KeeperMetadataDeleteDuration,
-				m.KeeperMetadataDeleteCount,
 				m.KeeperMetadataGetDuration,
-				m.KeeperMetadataGetCount,
 				m.KeeperMetadataListDuration,
-				m.KeeperMetadataListCount,
 				m.KeeperMetadataGetKeeperConfigDuration,
 				m.SecureValueMetadataCreateDuration,
-				m.SecureValueMetadataCreateCount,
 				m.SecureValueMetadataGetDuration,
-				m.SecureValueMetadataGetCount,
 				m.SecureValueMetadataListDuration,
-				m.SecureValueMetadataListCount,
 				m.SecureValueSetExternalIDDuration,
 				m.SecureValueSetStatusDuration,
 				m.DecryptDuration,
-				m.DecryptRequestCount,
 			)
 		}
 

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -72,7 +72,6 @@ func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1bet
 		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Create", args...)
 
 		s.metrics.SecureValueMetadataCreateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueMetadataCreateCount.WithLabelValues(strconv.FormatBool(success)).Inc()
 	}()
 
 	// Set inside the transaction callback
@@ -268,7 +267,6 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Read", "namespace", namespace, "name", name, "success", readErr == nil, "error", readErr)
 
 		s.metrics.SecureValueMetadataGetDuration.Observe(time.Since(start).Seconds())
-		s.metrics.SecureValueMetadataGetCount.Inc()
 	}()
 
 	secureValue, err := s.readActiveVersion(ctx, namespace, name, opts)
@@ -345,7 +343,6 @@ func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.N
 	}
 
 	s.metrics.SecureValueMetadataListDuration.Observe(time.Since(start).Seconds())
-	s.metrics.SecureValueMetadataListCount.Inc()
 
 	return secureValues, nil
 }

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -55,13 +55,14 @@ func (s *secureValueMetadataStorage) Create(ctx context.Context, sv *secretv1bet
 	defer span.End()
 
 	defer func() {
+		success := svmCreateErr == nil
+
 		args := []any{
 			"name", name,
 			"namespace", namespace,
 			"actorUID", actorUID,
 		}
 
-		success := svmCreateErr == nil
 		args = append(args, "success", success)
 		if !success {
 			span.SetStatus(codes.Error, "SecureValueMetadataStorage.Create failed")
@@ -264,9 +265,22 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 	defer span.End()
 
 	defer func() {
-		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Read", "namespace", namespace, "name", name, "success", readErr == nil, "error", readErr)
+		success := readErr == nil
 
-		s.metrics.SecureValueMetadataGetDuration.Observe(time.Since(start).Seconds())
+		args := []any{
+			"name", name,
+			"namespace", namespace.String(),
+			"success", success,
+		}
+
+		if !success {
+			span.SetStatus(codes.Error, "KeeperMetadataStorage.List failed")
+			span.RecordError(readErr)
+			args = append(args, "error", readErr)
+		}
+
+		logging.FromContext(ctx).Info("SecureValueMetadataStorage.Read", args...)
+		s.metrics.SecureValueMetadataGetDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
 	}()
 
 	secureValue, err := s.readActiveVersion(ctx, namespace, name, opts)
@@ -282,7 +296,7 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 	return secureValueKub, nil
 }
 
-func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (svList []secretv1beta1.SecureValue, error error) {
+func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.Namespace) (svList []secretv1beta1.SecureValue, listErr error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.List", trace.WithAttributes(
 		attribute.String("namespace", namespace.String()),
@@ -290,7 +304,23 @@ func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.N
 	defer span.End()
 
 	defer func() {
+		success := listErr == nil
 		span.SetAttributes(attribute.Int("returnedList.count", len(svList)))
+
+		args := []any{
+			"namespace", namespace.String(),
+			"success", success,
+		}
+
+		if !success {
+			span.SetStatus(codes.Error, "SecureValueMetadataStorage.List failed")
+			span.RecordError(listErr)
+			args = append(args, "error", listErr)
+		}
+
+		logging.FromContext(ctx).Info("SecureValueMetadataStorage.List", args...)
+
+		s.metrics.SecureValueMetadataListDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
 	}()
 
 	req := listSecureValue{
@@ -341,8 +371,6 @@ func (s *secureValueMetadataStorage) List(ctx context.Context, namespace xkube.N
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("read rows error: %w", err)
 	}
-
-	s.metrics.SecureValueMetadataListDuration.Observe(time.Since(start).Seconds())
 
 	return secureValues, nil
 }
@@ -420,7 +448,7 @@ func (s *secureValueMetadataStorage) SetVersionToInactive(ctx context.Context, n
 	return nil
 }
 
-func (s *secureValueMetadataStorage) SetExternalID(ctx context.Context, namespace xkube.Namespace, name string, version int64, externalID contracts.ExternalID) error {
+func (s *secureValueMetadataStorage) SetExternalID(ctx context.Context, namespace xkube.Namespace, name string, version int64, externalID contracts.ExternalID) (setExtIDErr error) {
 	start := time.Now()
 	ctx, span := s.tracer.Start(ctx, "SecureValueMetadataStorage.SetExternalID", trace.WithAttributes(
 		attribute.String("name", name),
@@ -428,7 +456,28 @@ func (s *secureValueMetadataStorage) SetExternalID(ctx context.Context, namespac
 		attribute.String("externalID", externalID.String()),
 		attribute.Int64("version", version),
 	))
+
 	defer span.End()
+
+	defer func() {
+		success := setExtIDErr == nil
+		args := []any{
+			"name", name,
+			"namespace", namespace.String(),
+			"success", success,
+			"version", strconv.FormatInt(version, 10),
+			"externalID", externalID.String(),
+		}
+
+		if !success {
+			span.SetStatus(codes.Error, "SecureValueMetadataStorage.SetExternalID failed")
+			span.RecordError(setExtIDErr)
+			args = append(args, "error", setExtIDErr)
+		}
+
+		logging.FromContext(ctx).Info("SecureValueMetadataStorage.SetExternalID", args...)
+		s.metrics.SecureValueSetExternalIDDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
+	}()
 
 	req := updateExternalIdSecureValue{
 		SQLTemplate: sqltemplate.New(s.dialect),
@@ -456,7 +505,6 @@ func (s *secureValueMetadataStorage) SetExternalID(ctx context.Context, namespac
 	if modifiedCount > 1 {
 		return fmt.Errorf("secureValueMetadataStorage.SetExternalID: modified more than one secret, this is a bug, check the where condition: modifiedCount=%d", modifiedCount)
 	}
-	s.metrics.SecureValueSetExternalIDDuration.Observe(time.Since(start).Seconds())
 
 	return nil
 }

--- a/pkg/storage/secret/metadata/secure_value_store.go
+++ b/pkg/storage/secret/metadata/secure_value_store.go
@@ -274,7 +274,7 @@ func (s *secureValueMetadataStorage) Read(ctx context.Context, namespace xkube.N
 		}
 
 		if !success {
-			span.SetStatus(codes.Error, "KeeperMetadataStorage.List failed")
+			span.SetStatus(codes.Error, "SecureValueMetadataStorage.Read failed")
 			span.RecordError(readErr)
 			args = append(args, "error", readErr)
 		}


### PR DESCRIPTION
Improvements to Secrets Service metrics:
- Removed all counter metrics (*Count metrics) as they are redundant with histogram _count metrics
- Converted simple histogram metrics to histogram vectors with success labels for better error tracking