### PR TITLE
Provisioning: Fix migration behavior for folder-type repositories

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/clean_test.go
@@ -139,8 +139,8 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 		progress.AssertExpectations(t)
 	})
 
-	t.Run("should successfully clean namespace", func(t *testing.T) {
-		// Create a mock dynamic client that returns a list with multiple items
+	t.Run("should only delete unprovisioned resources", func(t *testing.T) {
+		// Create a mock dynamic client that returns a list with mixed provisioned and unprovisioned items
 		mockDynamicClient := &mockDynamicInterface{
 			items: []unstructured.Unstructured{
 				{
@@ -148,7 +148,8 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 						"apiVersion": "folder.grafana.app/v1alpha1",
 						"kind":       "Folder",
 						"metadata": map[string]interface{}{
-							"name": "folder-1",
+							"name": "unprovisioned-folder",
+							// No manager annotations - this is unprovisioned
 						},
 					},
 				},
@@ -157,7 +158,21 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 						"apiVersion": "dashboard.grafana.app/v1alpha1",
 						"kind":       "Dashboard",
 						"metadata": map[string]interface{}{
-							"name": "dashboard-1",
+							"name": "provisioned-dashboard",
+							"annotations": map[string]interface{}{
+								"grafana.app/managerKind": "repo",
+								"grafana.app/managerId":   "test-repo",
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "dashboard.grafana.app/v1alpha1",
+						"kind":       "Dashboard",
+						"metadata": map[string]interface{}{
+							"name": "unprovisioned-dashboard",
+							// No manager annotations - this is unprovisioned
 						},
 					},
 				},
@@ -177,15 +192,88 @@ func TestNamespaceCleaner_Clean(t *testing.T) {
 		progress.On("SetMessage", mock.Anything, "remove unprovisioned folders").Return()
 		progress.On("SetMessage", mock.Anything, "remove unprovisioned dashboards").Return()
 
-		// Expect two successful deletions
+		// Expect only unprovisioned resources to be deleted (2 deletions)
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action == repository.FileActionDeleted &&
-				result.Name == "dashboard-1" &&
+				result.Name == "unprovisioned-folder" &&
 				result.Error == nil
 		})).Return()
 		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
 			return result.Action == repository.FileActionDeleted &&
-				result.Name == "folder-1" &&
+				result.Name == "unprovisioned-dashboard" &&
+				result.Error == nil
+		})).Return()
+
+		// Expect provisioned resource to be ignored (1 ignore)
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action == repository.FileActionIgnored &&
+				result.Name == "provisioned-dashboard" &&
+				result.Error == nil
+		})).Return()
+
+		err := cleaner.Clean(context.Background(), "test-namespace", progress)
+		require.NoError(t, err)
+
+		mockClientFactory.AssertExpectations(t)
+		clients.AssertExpectations(t)
+		progress.AssertExpectations(t)
+	})
+
+	t.Run("should skip all provisioned resources", func(t *testing.T) {
+		// Create a mock dynamic client with only provisioned resources
+		mockDynamicClient := &mockDynamicInterface{
+			items: []unstructured.Unstructured{
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "dashboard.grafana.app/v1alpha1",
+						"kind":       "Dashboard",
+						"metadata": map[string]interface{}{
+							"name": "repo-managed-dashboard",
+							"annotations": map[string]interface{}{
+								"grafana.app/managerKind": "repo",
+								"grafana.app/managerId":   "my-repo",
+							},
+						},
+					},
+				},
+				{
+					Object: map[string]interface{}{
+						"apiVersion": "folder.grafana.app/v1alpha1",
+						"kind":       "Folder",
+						"metadata": map[string]interface{}{
+							"name": "file-provisioned-folder",
+							"annotations": map[string]interface{}{
+								"grafana.app/managerKind": "classic-file-provisioning",
+								"grafana.app/managerId":   "file-provisioner",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		clients := &mockClients{}
+		clients.On("ForResource", mock.Anything).
+			Return(mockDynamicClient, schema.GroupVersionKind{}, nil)
+
+		mockClientFactory := resources.NewMockClientFactory(t)
+		mockClientFactory.On("Clients", mock.Anything, "test-namespace").
+			Return(clients, nil)
+
+		cleaner := NewNamespaceCleaner(mockClientFactory)
+		progress := jobs.NewMockJobProgressRecorder(t)
+		progress.On("SetMessage", mock.Anything, "remove unprovisioned folders").Return()
+		progress.On("SetMessage", mock.Anything, "remove unprovisioned dashboards").Return()
+
+		// Expect both resources to be ignored (no deletions)
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action == repository.FileActionIgnored &&
+				result.Name == "repo-managed-dashboard" &&
+				result.Error == nil
+		})).Return()
+		progress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+			return result.Action == repository.FileActionIgnored &&
+				result.Name == "file-provisioned-folder" &&
 				result.Error == nil
 		})).Return()
 

--- a/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/unifiedstorage_test.go
@@ -28,6 +28,11 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 						Name:      "test-repo",
 						Namespace: "test-namespace",
 					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
 				})
 				pr.On("SetMessage", mock.Anything, "export resources").Return()
 				pr.On("StrictMaxErrors", 1).Return()
@@ -44,6 +49,11 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
 						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
 					},
 				})
 				pr.On("SetMessage", mock.Anything, "export resources").Return()
@@ -66,6 +76,11 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-repo",
 						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
 					},
 				})
 				pr.On("SetMessage", mock.Anything, "export resources").Return()
@@ -93,6 +108,11 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 						Name:      "test-repo",
 						Namespace: "test-namespace",
 					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
 				})
 				pr.On("SetMessage", mock.Anything, "export resources").Return()
 				pr.On("StrictMaxErrors", 1).Return()
@@ -113,6 +133,144 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 			},
 			expectedError: "",
 		},
+		{
+			name: "should only run sync for folder-type repositories",
+			setupMocks: func(nc *MockNamespaceCleaner, ew *jobs.MockWorker, sw *jobs.MockWorker, pr *jobs.MockJobProgressRecorder, rw *repository.MockRepository) {
+				rw.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeFolder,
+						},
+					},
+				})
+				// Export should be skipped - no export-related mocks
+				// Cleaner should also be skipped - no cleaner-related mocks
+				// Only sync job should run
+				pr.On("SetMessage", mock.Anything, "pull resources").Return()
+				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
+				}), pr).Return(nil)
+			},
+			expectedError: "",
+		},
+		{
+			name: "should fail when sync job fails for folder-type repositories",
+			setupMocks: func(nc *MockNamespaceCleaner, ew *jobs.MockWorker, sw *jobs.MockWorker, pr *jobs.MockJobProgressRecorder, rw *repository.MockRepository) {
+				rw.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeFolder,
+						},
+					},
+				})
+				// Only sync job should run and fail
+				pr.On("SetMessage", mock.Anything, "pull resources").Return()
+				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
+				}), pr).Return(errors.New("folder sync failed"))
+			},
+			expectedError: "pull resources: folder sync failed",
+		},
+		{
+			name: "should run complete workflow for instance-type repositories",
+			setupMocks: func(nc *MockNamespaceCleaner, ew *jobs.MockWorker, sw *jobs.MockWorker, pr *jobs.MockJobProgressRecorder, rw *repository.MockRepository) {
+				rw.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
+				// Export should run for instance repositories
+				pr.On("SetMessage", mock.Anything, "export resources").Return()
+				pr.On("StrictMaxErrors", 1).Return()
+				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Push != nil
+				}), pr).Return(nil)
+				pr.On("ResetResults").Return()
+
+				// Sync job and cleanup should also run
+				pr.On("SetMessage", mock.Anything, "pull resources").Return()
+				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
+				}), pr).Return(nil)
+				pr.On("SetMessage", mock.Anything, "clean namespace").Return()
+				nc.On("Clean", mock.Anything, "test-namespace", pr).Return(nil)
+			},
+			expectedError: "",
+		},
+		{
+			name: "should handle empty target type as instance",
+			setupMocks: func(nc *MockNamespaceCleaner, ew *jobs.MockWorker, sw *jobs.MockWorker, pr *jobs.MockJobProgressRecorder, rw *repository.MockRepository) {
+				rw.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: "", // Empty target should default to instance behavior
+						},
+					},
+				})
+				// Should run full workflow like instance type
+				pr.On("SetMessage", mock.Anything, "export resources").Return()
+				pr.On("StrictMaxErrors", 1).Return()
+				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Push != nil
+				}), pr).Return(nil)
+				pr.On("ResetResults").Return()
+				pr.On("SetMessage", mock.Anything, "pull resources").Return()
+				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
+				}), pr).Return(nil)
+				pr.On("SetMessage", mock.Anything, "clean namespace").Return()
+				nc.On("Clean", mock.Anything, "test-namespace", pr).Return(nil)
+			},
+			expectedError: "",
+		},
+		{
+			name: "should pass migrate options to export job",
+			setupMocks: func(nc *MockNamespaceCleaner, ew *jobs.MockWorker, sw *jobs.MockWorker, pr *jobs.MockJobProgressRecorder, rw *repository.MockRepository) {
+				rw.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "test-namespace",
+					},
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
+				pr.On("SetMessage", mock.Anything, "export resources").Return()
+				pr.On("StrictMaxErrors", 1).Return()
+				// Verify that the export job receives the migrate message
+				ew.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Push != nil && job.Spec.Push.Message == "test migration message"
+				}), pr).Return(nil)
+				pr.On("ResetResults").Return()
+				pr.On("SetMessage", mock.Anything, "pull resources").Return()
+				sw.On("Process", mock.Anything, rw, mock.MatchedBy(func(job provisioning.Job) bool {
+					return job.Spec.Pull != nil && !job.Spec.Pull.Incremental
+				}), pr).Return(nil)
+				pr.On("SetMessage", mock.Anything, "clean namespace").Return()
+				nc.On("Clean", mock.Anything, "test-namespace", pr).Return(nil)
+			},
+			expectedError: "",
+		},
 	}
 
 	for _, tt := range tests {
@@ -129,7 +287,14 @@ func TestUnifiedStorageMigrator_Migrate(t *testing.T) {
 
 			migrator := NewUnifiedStorageMigrator(mockNamespaceCleaner, exportWorker, syncWorker)
 
-			err := migrator.Migrate(context.Background(), readerWriter, provisioning.MigrateJobOptions{}, progressRecorder)
+			var migrateOptions provisioning.MigrateJobOptions
+			if tt.name == "should pass migrate options to export job" {
+				migrateOptions = provisioning.MigrateJobOptions{
+					Message: "test migration message",
+				}
+			}
+
+			err := migrator.Migrate(context.Background(), readerWriter, migrateOptions, progressRecorder)
 
 			if tt.expectedError != "" {
 				require.Error(t, err)

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker.go
@@ -55,6 +55,13 @@ func (w *MigrationWorker) Process(ctx context.Context, repo repository.Repositor
 		}
 	}
 
+	// Block migrate for legacy resources if repository type is folder
+	if repo.Config().Spec.Sync.Target == provisioning.SyncTargetTypeFolder {
+		if dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, w.storageStatus) {
+			return errors.New("migration of legacy resources is not supported for folder-type repositories")
+		}
+	}
+
 	if dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, w.storageStatus) {
 		return w.legacyMigrator.Migrate(ctx, rw, *options, progress)
 	}

--- a/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/migrate/worker_test.go
@@ -114,6 +114,7 @@ func TestMigrationWorker_Process(t *testing.T) {
 	tests := []struct {
 		name           string
 		setupMocks     func(*MockMigrator, *MockMigrator, *dualwrite.MockService, *jobs.MockJobProgressRecorder)
+		setupRepo      func(*repository.MockRepository)
 		job            provisioning.Job
 		expectedError  string
 		isLegacyActive bool
@@ -127,6 +128,9 @@ func TestMigrationWorker_Process(t *testing.T) {
 				},
 			},
 			setupMocks: func(lm *MockMigrator, um *MockMigrator, ds *dualwrite.MockService, pr *jobs.MockJobProgressRecorder) {
+			},
+			setupRepo: func(repo *repository.MockRepository) {
+				// No Config() call expected since we fail before that
 			},
 			expectedError: "missing migrate settings",
 		},
@@ -144,6 +148,15 @@ func TestMigrationWorker_Process(t *testing.T) {
 				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(false, nil)
 				lm.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
+			},
 		},
 		{
 			name: "should use unified storage migrator when legacy storage is not active",
@@ -158,6 +171,15 @@ func TestMigrationWorker_Process(t *testing.T) {
 				pr.On("SetTotal", mock.Anything, 10).Return()
 				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(true, nil)
 				um.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
 			},
 		},
 		{
@@ -174,7 +196,91 @@ func TestMigrationWorker_Process(t *testing.T) {
 				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(false, nil)
 				lm.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("migration failed"))
 			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
+			},
 			expectedError: "migration failed",
+		},
+		{
+			name: "should block migration of legacy resources for folder-type repositories",
+			job: provisioning.Job{
+				Spec: provisioning.JobSpec{
+					Action:  provisioning.JobActionMigrate,
+					Migrate: &provisioning.MigrateJobOptions{},
+				},
+			},
+			isLegacyActive: true,
+			setupMocks: func(lm *MockMigrator, um *MockMigrator, ds *dualwrite.MockService, pr *jobs.MockJobProgressRecorder) {
+				pr.On("SetTotal", mock.Anything, 10).Return()
+				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(false, nil)
+				// legacyMigrator should not be called as we block before reaching it
+			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeFolder,
+						},
+					},
+				})
+			},
+			expectedError: "migration of legacy resources is not supported for folder-type repositories",
+		},
+		{
+			name: "should allow migration of legacy resources for instance-type repositories",
+			job: provisioning.Job{
+				Spec: provisioning.JobSpec{
+					Action:  provisioning.JobActionMigrate,
+					Migrate: &provisioning.MigrateJobOptions{},
+				},
+			},
+			isLegacyActive: true,
+			setupMocks: func(lm *MockMigrator, um *MockMigrator, ds *dualwrite.MockService, pr *jobs.MockJobProgressRecorder) {
+				pr.On("SetTotal", mock.Anything, 10).Return()
+				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(false, nil)
+				lm.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeInstance,
+						},
+					},
+				})
+			},
+			expectedError: "",
+		},
+		{
+			name: "should allow migration for folder-type repositories when legacy storage is not active",
+			job: provisioning.Job{
+				Spec: provisioning.JobSpec{
+					Action:  provisioning.JobActionMigrate,
+					Migrate: &provisioning.MigrateJobOptions{},
+				},
+			},
+			isLegacyActive: false,
+			setupMocks: func(lm *MockMigrator, um *MockMigrator, ds *dualwrite.MockService, pr *jobs.MockJobProgressRecorder) {
+				pr.On("SetTotal", mock.Anything, 10).Return()
+				ds.On("ReadFromUnified", mock.Anything, mock.Anything).Return(true, nil)
+				um.On("Migrate", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			setupRepo: func(repo *repository.MockRepository) {
+				repo.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Sync: provisioning.SyncOptions{
+							Target: provisioning.SyncTargetTypeFolder,
+						},
+					},
+				})
+			},
+			expectedError: "",
 		},
 	}
 
@@ -192,6 +298,9 @@ func TestMigrationWorker_Process(t *testing.T) {
 			}
 
 			rw := repository.NewMockRepository(t)
+			if tt.setupRepo != nil {
+				tt.setupRepo(rw)
+			}
 			err := worker.Process(context.Background(), rw, tt.job, progressRecorder)
 
 			if tt.expectedError != "" {


### PR DESCRIPTION
## What is this feature?

Fix migration behavior for folder-type repositories to prevent issues with legacy resource migration and namespace cleaning.

## Why do we need this feature?

- Legacy resource migration to folder-type repositories is not supported and should be blocked. (we either migrate everything into a repository or not).
- Folder-type repositories should only perform sync operations, not export or cleaning (because it doesn't make sense to export remaining unprovisioned resources into a folder)
- The namespace cleaner was incorrectly removing all resources instead of only unprovisioned ones. 

## Who is this feature for?

Users utilizing folder-type repositories in the provisioning system.

## Which issue(s) does this PR fix?

Fixes grafana/git-ui-sync-project#440
Fixes grafana/git-ui-sync-project#414

## How to test this PR

1. Set up a folder-type repository configuration
2. Attempt to migrate with legacy resources active - should be blocked
3. Run migration with unified storage - should only perform sync, skip export/cleaner
4. Verify namespace cleaner only removes unprovisioned resources

## What are the changes

- **Migration Worker**: Added blocking logic to prevent migration of legacy resources when repository type is folder
- **Unified Storage Migrator**: Refactored with early return pattern for folder repositories - only runs sync, skips export and cleaner
- **Namespace Cleaner**: Fixed critical bug where all resources were being deleted instead of only unprovisioned ones

🤖 Generated with [Claude Code](https://claude.ai/code)