### PR TITLE
Security: Fix actor spoofing vulnerability in Dependabot workflow

### DIFF
--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   update:
     runs-on: "ubuntu-latest"
-    if: ${{ github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     continue-on-error: true
     steps:
     - name: Retrieve GitHub App secrets


### PR DESCRIPTION
## What is this feature?

This PR fixes a security vulnerability identified by zizmor in the Dependabot workspace update workflow. The issue was that `github.actor` can be spoofed in pull requests from forks, making the security check insufficient.

## Why do we need this feature?

The current implementation uses `github.actor == 'dependabot[bot]'` which can be spoofed by malicious actors in pull requests from forks. This creates a potential security risk where unauthorized users could trigger the workflow.

## Who is this feature for?

This is a security fix that protects the Grafana repository from potential actor spoofing attacks in GitHub workflows.

## Which issue(s) does this PR fix?

Fixes zizmor security finding: `./.github/workflows/pr-dependabot-update-go-workspace.yml:18:3` - actor context may be spoofable

Reference: [zizmor documentation on actor spoofing](https://woodruffw.github.io/zizmor/audits/#actor-spoofing)

## Notes to the reviewer

- The fix replaces `github.actor` with `github.event.pull_request.user.login` which cannot be spoofed in pull requests from forks
- This maintains the same functionality while closing the security vulnerability
- The change is minimal and only affects the conditional check for Dependabot PRs

🤖 Generated with [Claude Code](https://claude.ai/code)