### PR TITLE
NewProvisionedFolderForm: When creating a new folder, support empty space in folder name

### DIFF
--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.test.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.test.tsx
@@ -297,7 +297,7 @@ describe('NewProvisionedFolderForm', () => {
         expect.objectContaining({
           ref: undefined, // write workflow uses undefined ref
           name: 'test-repo',
-          path: '/dashboards/new-test-folder/',
+          path: '/dashboards/new test folder/',
           message: 'Creating a new test folder',
           body: {
             title: 'New Test Folder',
@@ -350,7 +350,7 @@ describe('NewProvisionedFolderForm', () => {
         expect.objectContaining({
           ref: 'feature/new-folder',
           name: 'test-repo',
-          path: '/dashboards/branch-folder/',
+          path: '/dashboards/branch folder/',
           message: 'Create folder: Branch Folder',
           body: {
             title: 'Branch Folder',

--- a/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
+++ b/public/app/features/browse-dashboards/components/NewProvisionedFolderForm.tsx
@@ -1,11 +1,10 @@
-import { css } from '@emotion/css';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
-import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { AppEvents } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { getAppEvents } from '@grafana/runtime';
-import { Alert, Text, Button, Field, Icon, Input, Stack, useStyles2 } from '@grafana/ui';
+import { Alert, Button, Field, Input, Stack } from '@grafana/ui';
 import { Folder } from 'app/api/clients/folder/v1beta1';
 import { RepositoryView, useCreateRepositoryFilesWithPathMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath, Resource } from 'app/features/apiserver/types';
@@ -24,7 +23,7 @@ import { useProvisionedFolderFormData } from '../hooks/useProvisionedFolderFormD
 
 import { RepoInvalidStateBanner } from './BulkActions/RepoInvalidStateBanner';
 import { validateFolderName } from './NewFolderForm';
-import { formatFolderName, hasFolderNameCharactersToReplace } from './utils';
+import { formatFolderName } from './utils';
 
 interface FormProps extends Props {
   initialValues: BaseProvisionedFormData;
@@ -48,7 +47,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
   });
   const { handleSubmit, watch, register, formState } = methods;
 
-  const [workflow, title] = watch(['workflow', 'title']);
+  const [workflow] = watch(['workflow']);
 
   const onBranchSuccess = ({ urls }: { urls?: Record<string, string> }, info: ProvisionedOperationInfo) => {
     const prUrl = urls?.newPullRequestURL;
@@ -111,7 +110,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     const basePath = folder?.metadata?.annotations?.[AnnoKeySourcePath] ?? '';
 
     // Convert folder title to filename format (lowercase, replace spaces with hyphens)
-    const titleInFilenameFormat = formatFolderName(title); // TODO: this is currently not working, issue created https://github.com/grafana/git-ui-sync-project/issues/314
+    const titleInFilenameFormat = formatFolderName(title); // TODO: folder name validation is currently not working, issue created https://github.com/grafana/git-ui-sync-project/issues/314
 
     const prefix = basePath ? `${basePath}/` : '';
     const path = `${prefix}${titleInFilenameFormat}/`;
@@ -169,7 +168,6 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
               id="folder-name-input"
             />
           </Field>
-          <FolderNamePreviewMessage folderName={title} />
 
           <ResourceEditFormSharedFields
             resourceType="folder"
@@ -244,39 +242,3 @@ export function NewProvisionedFolderForm({ parentFolder, onDismiss }: Props) {
     />
   );
 }
-
-function FolderNamePreviewMessage({ folderName }: { folderName: string }) {
-  const styles = useStyles2(getStyles);
-  const isValidFolderName =
-    folderName.length && hasFolderNameCharactersToReplace(folderName) && validateFolderName(folderName);
-
-  if (!isValidFolderName) {
-    return null;
-  }
-
-  return (
-    <div className={styles.folderNameMessage}>
-      <Icon name="check-circle" type="solid" />
-      <Text color="success">
-        {t(
-          'browse-dashboards.new-provisioned-folder-form.text-your-folder-will-be-created-as',
-          'Your folder will be created as {{folderName}}',
-          {
-            folderName: formatFolderName(folderName),
-          }
-        )}
-      </Text>
-    </div>
-  );
-}
-
-const getStyles = (theme: GrafanaTheme2) => {
-  return {
-    folderNameMessage: css({
-      display: 'flex',
-      alignItems: 'center',
-      fontSize: theme.typography.bodySmall.fontSize,
-      color: theme.colors.success.text,
-    }),
-  };
-};

--- a/public/app/features/browse-dashboards/components/utils.test.ts
+++ b/public/app/features/browse-dashboards/components/utils.test.ts
@@ -1,4 +1,4 @@
-import { formatFolderName, hasFolderNameCharactersToReplace } from './utils';
+import { formatFolderName } from './utils';
 
 describe('formatFolderName', () => {
   it('should handle empty string', () => {
@@ -56,69 +56,5 @@ describe('formatFolderName', () => {
     expect(formatFolderName('already-formatted')).toBe('already-formatted');
     expect(formatFolderName('folder123')).toBe('folder123');
     expect(formatFolderName('test-folder-name-123')).toBe('test-folder-name-123');
-  });
-});
-
-describe('hasFolderNameCharactersToReplace', () => {
-  it('should return false for non-string inputs', () => {
-    // @ts-expect-error
-    expect(hasFolderNameCharactersToReplace(null)).toBe(false);
-    // @ts-expect-error
-    expect(hasFolderNameCharactersToReplace(undefined)).toBe(false);
-    // @ts-expect-error
-    expect(hasFolderNameCharactersToReplace(123)).toBe(false);
-    // @ts-expect-error
-    expect(hasFolderNameCharactersToReplace({})).toBe(false);
-    // @ts-expect-error
-    expect(hasFolderNameCharactersToReplace([])).toBe(false);
-  });
-
-  it('should return false for empty string', () => {
-    expect(hasFolderNameCharactersToReplace('')).toBe(false);
-  });
-
-  it('should return false for valid folder names', () => {
-    expect(hasFolderNameCharactersToReplace('validname')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('folder123')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('test-folder-name')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('folder-123')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('123-folder')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('a')).toBe(false);
-    expect(hasFolderNameCharactersToReplace('1')).toBe(false);
-  });
-
-  it('should return true for names with whitespace', () => {
-    expect(hasFolderNameCharactersToReplace('folder name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder  name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder\tname')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder\nname')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('  folder')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder  ')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('   ')).toBe(true);
-  });
-
-  it('should return true for names with uppercase letters', () => {
-    expect(hasFolderNameCharactersToReplace('FolderName')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('UPPERCASE')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('MiXeD')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder-Name')).toBe(true);
-  });
-
-  it('should return true for names with special characters', () => {
-    expect(hasFolderNameCharactersToReplace('folder@name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder!name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder_name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder.name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder/name')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('folder#name')).toBe(true);
-  });
-
-  it('should return true for mixed cases with multiple issues', () => {
-    expect(hasFolderNameCharactersToReplace('Test@Folder#Name$123')).toBe(true);
-    expect(hasFolderNameCharactersToReplace('Multiple   Spaces   Between')).toBe(true);
-  });
-
-  it('should return true for strings with only special characters', () => {
-    expect(hasFolderNameCharactersToReplace('!@#$%^&*()')).toBe(true);
   });
 });

--- a/public/app/features/browse-dashboards/components/utils.ts
+++ b/public/app/features/browse-dashboards/components/utils.ts
@@ -33,20 +33,6 @@ export function getFolderURL(uid: string) {
   return url;
 }
 
-export function hasFolderNameCharactersToReplace(folderName: string): boolean {
-  if (typeof folderName !== 'string') {
-    return false;
-  }
-
-  // whitespace that needs to be replaced with hyphens
-  const hasWhitespace = /\s+/.test(folderName);
-
-  // characters that are not lowercase letters, numbers, or hyphens
-  const hasInvalidCharacters = /[^a-z0-9-]/.test(folderName);
-
-  return hasWhitespace || hasInvalidCharacters;
-}
-
 export function formatFolderName(folderName?: string): string {
   if (typeof folderName !== 'string') {
     console.error('Invalid folder name type:', typeof folderName);
@@ -55,10 +41,7 @@ export function formatFolderName(folderName?: string): string {
 
   const result = folderName
     .trim() // Remove leading/trailing whitespace first
-    .toLowerCase()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9-]/g, '')
-    .replace(/^-+|-+$/g, ''); // Remove leading/trailing hyphens
+    .toLowerCase();
 
   // If the result is empty, return empty string
   if (result === '') {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3629,7 +3629,6 @@
       "folder-name-input-placeholder-enter-folder-name": "Enter folder name",
       "label-folder-name": "Folder name",
       "text-pull-request-created": "A pull request has been created with changes to this folder:",
-      "text-your-folder-will-be-created-as": "Your folder will be created as {{folderName}}",
       "title-pull-request-created": "Pull request created",
       "title-this-repository-is-read-only": "This repository is read only"
     },


### PR DESCRIPTION
**What is this feature?**

- In provisioned folder, while creating new folder, support folder name with space. 
- Removed `hasFolderNameCharactersToReplace` util as it was created when we require no space in folder name

https://github.com/user-attachments/assets/13e288e2-952c-4a59-8ce7-3ac9f6f2d739



**Why do we need this feature?**

Better user experience, less strict folder naming rules. 

**Who is this feature for?**

git user. 


**Which issue(s) does this PR fix?**:

Fixes  https://github.com/grafana/git-ui-sync-project/issues/222

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
