### PR TITLE
Unified storage bugfix legacy folders getting first page

### DIFF
--- a/pkg/registry/apis/folders/continue.go
+++ b/pkg/registry/apis/folders/continue.go
@@ -14,9 +14,13 @@ type continueToken struct {
 	limit int64
 }
 
+const defaultPageLimit = 100
+const defaultPageNumber = 1
+
 func readContinueToken(options *internalversion.ListOptions) (*continueToken, error) {
 	t := &continueToken{
-		limit: 100, // default page size
+		limit: defaultPageLimit,  // default page size
+		page:  defaultPageNumber, // default page number
 	}
 	if options.Continue == "" {
 		if options.Limit > 0 {

--- a/pkg/registry/apis/folders/continue_test.go
+++ b/pkg/registry/apis/folders/continue_test.go
@@ -10,15 +10,15 @@ import (
 func TestContinueToken(t *testing.T) {
 	token, err := readContinueToken(&internalversion.ListOptions{})
 	require.NoError(t, err)
-	require.Equal(t, int64(100), token.limit)
-	require.Equal(t, int64(0), token.page)
+	require.Equal(t, int64(defaultPageLimit), token.limit)
+	require.Equal(t, int64(defaultPageNumber), token.page)
 
 	next := token.GetNextPageToken()
-	require.Equal(t, "MTAwfDE=", next)
+	require.Equal(t, "MTAwfDI=", next)
 	token, err = readContinueToken(&internalversion.ListOptions{Continue: next})
 	require.NoError(t, err)
-	require.Equal(t, int64(100), token.limit)
-	require.Equal(t, int64(1), token.page) // <<< +1
+	require.Equal(t, int64(defaultPageLimit), token.limit)
+	require.Equal(t, int64(defaultPageNumber+1), token.page) // <<< +1
 
 	// Error if the limit has changed
 	_, err = readContinueToken(&internalversion.ListOptions{Continue: next, Limit: 50})

--- a/pkg/registry/apis/folders/legacy_storage.go
+++ b/pkg/registry/apis/folders/legacy_storage.go
@@ -95,16 +95,10 @@ func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListO
 		SignedInUser: user,
 		OrgID:        orgId,
 	}
-	if options.Continue != "" {
-		query.Page = paging.page
-		query.Limit = paging.limit
-	} else if options.Limit > 0 {
-		query.Limit = options.Limit
-		query.Page = 1
-		// also need to update the paging token so the continue token is correct
-		paging.limit = options.Limit
-		paging.page = 1
-	}
+
+	// paging is always retrieved from the continue token
+	query.Limit = paging.limit
+	query.Page = paging.page
 
 	if options.LabelSelector != nil && options.LabelSelector.Matches(labels.Set{utils.LabelGetFullpath: "true"}) {
 		query.WithFullpath = true

--- a/pkg/registry/apis/folders/legacy_storage_test.go
+++ b/pkg/registry/apis/folders/legacy_storage_test.go
@@ -121,6 +121,32 @@ func TestLegacyStorage_List_Pagination(t *testing.T) {
 		require.Equal(t, int64(2), folderService.LastQuery.Limit)
 		require.Equal(t, int64(1), folderService.LastQuery.Page)
 	})
+
+	t.Run("should set page limit to default when no limit is specified in options", func(t *testing.T) {
+		options := &metainternalversion.ListOptions{}
+		folders := make([]*folder.Folder, defaultPageLimit)
+		for i := range folders {
+			folders[i] = &folder.Folder{
+				UID:   fmt.Sprintf("folder-%d", i),
+				Title: fmt.Sprintf("Folder %d", i),
+			}
+		}
+		folderService.ExpectedFolders = folders
+
+		result, err := storage.List(ctx, options)
+		require.NoError(t, err)
+
+		// assert we return the default page limit for the first page
+		list, ok := result.(*folderv1.FolderList)
+		require.True(t, ok)
+
+		// assert returned continue token is correct and previous paging was correct
+		token, err := base64.StdEncoding.DecodeString(list.Continue)
+		require.NoError(t, err)
+		require.Equal(t, "100|2", string(token))
+		require.Equal(t, int64(defaultPageLimit), folderService.LastQuery.Limit)
+		require.Equal(t, int64(1), folderService.LastQuery.Page)
+	})
 }
 
 func TestLegacyStorage_List_LabelSelector(t *testing.T) {

--- a/pkg/registry/apis/folders/legacy_storage_test.go
+++ b/pkg/registry/apis/folders/legacy_storage_test.go
@@ -136,7 +136,6 @@ func TestLegacyStorage_List_Pagination(t *testing.T) {
 		result, err := storage.List(ctx, options)
 		require.NoError(t, err)
 
-		// assert we return the default page limit for the first page
 		list, ok := result.(*folderv1.FolderList)
 		require.True(t, ok)
 


### PR DESCRIPTION
fixes https://github.com/grafana/support-escalations/issues/17690

This fixes a couple things:
1. When a limit wasn't specified, it would be zero, which caused this block to be skipped:
```go
else if options.Limit > 0 {
		query.Limit = options.Limit
		query.Page = 1
		// also need to update the paging token so the continue token is correct
		paging.limit = options.Limit
		paging.page = 1
	}
```
This is why the first page returned everything.

2. Simplifies the paging logic by making the continue token (new or existing) responsible for holding the paging info.