### PR TITLE
PieChart: Add panel options for ascending/descending sort, and no sorting

### DIFF
--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -136,6 +136,16 @@ Select the pie chart display style. Choose from **Pie** or **Donut**.
 
 ![Pie chart types](/media/docs/grafana/panels-visualizations/screenshot-pie-chart-types.png)
 
+
+#### Pie chart sorting
+
+By default, the pie chart is sorted so that the slices decrease **clockwise** in size.
+You can configure the sorting of the slices and the legend in three options:
+
+- **Clockwise** - The slices decrease clockwise in size (default).
+- **Counterclockwise** - The slices increase clockwise in size.
+- **None** - No sorting is applied. The original order of the data is maintained.
+
 #### Labels
 
 Select labels to display on the pie chart. You can select more than one.

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -136,10 +136,10 @@ Select the pie chart display style. Choose from **Pie** or **Donut**.
 
 ![Pie chart types](/media/docs/grafana/panels-visualizations/screenshot-pie-chart-types.png)
 
-#### Pie chart sorting
+#### Slice sorting
 
 By default, the pie chart is sorted so that the slices decrease in size clockwise around the circle.
-You can configure the sorting of the slices and the legend, and by extension the legend, with the following options:
+You can configure the sorting of the slices, and by extension the legend, with the following options:
 
 - **Descending** - The slices decrease in size, clockwise (default).
 - **Ascending** - The slices increase in size, clockwise.

--- a/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/panels-visualizations/visualizations/pie-chart/index.md
@@ -136,14 +136,13 @@ Select the pie chart display style. Choose from **Pie** or **Donut**.
 
 ![Pie chart types](/media/docs/grafana/panels-visualizations/screenshot-pie-chart-types.png)
 
-
 #### Pie chart sorting
 
-By default, the pie chart is sorted so that the slices decrease **clockwise** in size.
-You can configure the sorting of the slices and the legend in three options:
+By default, the pie chart is sorted so that the slices decrease in size clockwise around the circle.
+You can configure the sorting of the slices and the legend, and by extension the legend, with the following options:
 
-- **Clockwise** - The slices decrease clockwise in size (default).
-- **Counterclockwise** - The slices increase clockwise in size.
+- **Descending** - The slices decrease in size, clockwise (default).
+- **Ascending** - The slices increase in size, clockwise.
 - **None** - No sorting is applied. The original order of the data is maintained.
 
 #### Labels

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -21,18 +21,6 @@ export enum PieChartType {
 }
 
 /**
- * Select how to sort the pie slices.
- *  - Descending - The slices are sorted in descending value going clockwise (default).
- *  - Ascending - The slices are sorted in ascending value going clockwise.
- *  - None - The slices are not sorted and the order of the query/transform is maintained.
- */
-export enum PieChartSortOptions {
-  Ascending = 'ascending',
-  Descending = 'descending',
-  None = 'none',
-}
-
-/**
  * Select labels to display on the pie chart.
  *  - Name - The series or field name.
  *  - Percent - The percentage of the whole.
@@ -65,8 +53,8 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
-  pieSorting: PieChartSortOptions;
   pieType: PieChartType;
+  sort: common.SortOrder;
 }
 
 export const defaultOptions: Partial<Options> = {

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -65,6 +65,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
+  pieSorting: PieSortOption;
   pieType: PieChartType;
 }
 

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -21,12 +21,12 @@ export enum PieChartType {
 }
 
 /**
- * Select the sorting of the pie slices.
- *  - Clockwise - The slices are sorted descending by value in the clockwise direction.
- *  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+ * Select how to sort the pie slices.
+ *  - Descending - The slices are sorted in descending value going clockwise (default).
+ *  - Ascending - The slices are sorted in ascending value going clockwise.
  *  - None - The slices are not sorted and the order of the query/transform is maintained.
  */
-export enum PieSortOption {
+export enum PieChartSortOptions {
   Clockwise = 'clockwise',
   Counterclockwise = 'counterclockwise',
   None = 'none',
@@ -65,7 +65,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
-  pieSorting: PieSortOption;
+  pieSorting: PieChartSortOptions;
   pieType: PieChartType;
 }
 

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -21,6 +21,18 @@ export enum PieChartType {
 }
 
 /**
+ * Select the sorting of the pie slices.
+ *  - Clockwise - The slices are sorted descending by value in the clockwise direction.
+ *  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+ *  - None - The slices are not sorted and the order of the query/transform is maintained.
+ */
+export enum PieSortOption {
+  Clockwise = 'clockwise',
+  Counterclockwise = 'counterclockwise',
+  None = 'none',
+}
+
+/**
  * Select labels to display on the pie chart.
  *  - Name - The series or field name.
  *  - Percent - The percentage of the whole.

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -27,8 +27,8 @@ export enum PieChartType {
  *  - None - The slices are not sorted and the order of the query/transform is maintained.
  */
 export enum PieChartSortOptions {
-  Clockwise = 'clockwise',
-  Counterclockwise = 'counterclockwise',
+  Ascending = 'ascending',
+  Descending = 'descending',
   None = 'none',
 }
 

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -29,7 +29,7 @@ import {
 } from '@grafana/ui';
 import { getTooltipContainerStyles, useComponentInstanceId } from '@grafana/ui/internal';
 
-import { PieChartType, PieChartLabels } from './panelcfg.gen';
+import { PieChartType, PieSortOption, PieChartLabels } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 /**
@@ -40,6 +40,7 @@ interface PieChartProps {
   width: number;
   fieldDisplayValues: FieldDisplay[];
   pieType: PieChartType;
+  pieSorting: PieSortOption;
   highlightedTitle?: string;
   displayLabels?: PieChartLabels[];
   useGradients?: boolean; // not used?
@@ -49,6 +50,7 @@ interface PieChartProps {
 export const PieChart = ({
   fieldDisplayValues,
   pieType,
+  pieSorting,
   width,
   height,
   highlightedTitle,
@@ -105,6 +107,15 @@ export const PieChart = ({
           <Pie
             data={filteredFieldDisplayValues}
             pieValue={getValue}
+	    pieSortValues={(a, b) => {
+	      if(pieSorting === PieSortOption.Clockwise){
+		return a-b;
+	      } else if (pieSorting === PieSortOption.Counterclockwise){
+		return b-a;
+	      } else {
+	      	return -1;
+	      }
+	    }}
             outerRadius={layout.outerRadius}
             innerRadius={layout.innerRadius}
             cornerRadius={3}

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -18,7 +18,7 @@ import {
   DataHoverEvent,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { VizTooltipOptions } from '@grafana/schema';
+import { SortOrder, VizTooltipOptions } from '@grafana/schema';
 import {
   useTheme2,
   useStyles2,
@@ -29,7 +29,7 @@ import {
 } from '@grafana/ui';
 import { getTooltipContainerStyles, useComponentInstanceId } from '@grafana/ui/internal';
 
-import { PieChartType, PieChartSortOptions, PieChartLabels } from './panelcfg.gen';
+import { PieChartType, PieChartLabels } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 /**
@@ -40,7 +40,7 @@ interface PieChartProps {
   width: number;
   fieldDisplayValues: FieldDisplay[];
   pieType: PieChartType;
-  pieSorting: PieChartSortOptions;
+  sort: SortOrder;
   highlightedTitle?: string;
   displayLabels?: PieChartLabels[];
   useGradients?: boolean; // not used?
@@ -50,7 +50,7 @@ interface PieChartProps {
 export const PieChart = ({
   fieldDisplayValues,
   pieType,
-  pieSorting,
+  sort,
   width,
   height,
   highlightedTitle,

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -29,7 +29,7 @@ import {
 } from '@grafana/ui';
 import { getTooltipContainerStyles, useComponentInstanceId } from '@grafana/ui/internal';
 
-import { PieChartType, PieSortOption, PieChartLabels } from './panelcfg.gen';
+import { PieChartType, PieChartSortOptions, PieChartLabels } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 /**
@@ -40,7 +40,7 @@ interface PieChartProps {
   width: number;
   fieldDisplayValues: FieldDisplay[];
   pieType: PieChartType;
-  pieSorting: PieSortOption;
+  pieSorting: PieChartSortOptions;
   highlightedTitle?: string;
   displayLabels?: PieChartLabels[];
   useGradients?: boolean; // not used?
@@ -107,15 +107,13 @@ export const PieChart = ({
           <Pie
             data={filteredFieldDisplayValues}
             pieValue={getValue}
-	    pieSortValues={(a, b) => {
-	      if(pieSorting === PieSortOption.Clockwise){
-		return b-a;
-	      } else if (pieSorting === PieSortOption.Counterclockwise){
-		return a-b;
-	      } else {
-	      	return -1;
-	      }
-	    }}
+            pieSortValues={(a, b) =>
+              pieSorting === PieChartSortOptions.Descending
+                ? b - a
+                : pieSorting === PieChartSortOptions.Ascending
+                  ? a - b
+                  : 0
+            }
             outerRadius={layout.outerRadius}
             innerRadius={layout.innerRadius}
             cornerRadius={3}

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -107,13 +107,7 @@ export const PieChart = ({
           <Pie
             data={filteredFieldDisplayValues}
             pieValue={getValue}
-            pieSortValues={(a, b) =>
-              pieSorting === PieChartSortOptions.Descending
-                ? b - a
-                : pieSorting === PieChartSortOptions.Ascending
-                  ? a - b
-                  : 0
-            }
+            pieSortValues={() => 0}
             outerRadius={layout.outerRadius}
             innerRadius={layout.innerRadius}
             cornerRadius={3}

--- a/public/app/plugins/panel/piechart/PieChart.tsx
+++ b/public/app/plugins/panel/piechart/PieChart.tsx
@@ -109,9 +109,9 @@ export const PieChart = ({
             pieValue={getValue}
 	    pieSortValues={(a, b) => {
 	      if(pieSorting === PieSortOption.Clockwise){
-		return a-b;
-	      } else if (pieSorting === PieSortOption.Counterclockwise){
 		return b-a;
+	      } else if (pieSorting === PieSortOption.Counterclockwise){
+		return a-b;
 	      } else {
 	      	return -1;
 	      }

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -14,7 +14,7 @@ import {
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel } from './PieChartPanel';
-import { Options, PieChartType, PieSortOption, PieChartLegendValues } from './panelcfg.gen';
+import { Options, PieChartType, PieChartSortOptions, PieChartLegendValues } from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -173,7 +173,7 @@ const setup = (propsOverrides?: {}) => {
 
   const options: Options = {
     pieType: PieChartType.Pie,
-    pieSorting: PieSortOption.Clockwise,
+    pieSorting: PieChartSortOptions.Descending,
     displayLabels: [],
     legend: {
       displayMode: LegendDisplayMode.List,

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -14,7 +14,7 @@ import {
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel, comparePieChartItemsByValue } from './PieChartPanel';
-import { Options, PieChartType, PieChartSortOptions, PieChartLegendValues } from './panelcfg.gen';
+import { Options, PieChartType, PieChartLegendValues } from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -172,35 +172,35 @@ describe('comparePieChartItemsByValue', () => {
   it.each([
     {
       name: 'always: NaN a sorts after 1',
-      sort: PieChartSortOptions.Descending,
+      sort: SortOrder.Descending,
       a: makeFieldDisplay(NaN),
       b: makeFieldDisplay(1),
       expected: 1,
     },
     {
       name: 'always: NaN b sorts before 1',
-      sort: PieChartSortOptions.Descending,
+      sort: SortOrder.Descending,
       a: makeFieldDisplay(1),
       b: makeFieldDisplay(NaN),
       expected: -1,
     },
     {
       name: 'descending: larger a sorts before smaller b (negative)',
-      sort: PieChartSortOptions.Descending,
+      sort: SortOrder.Descending,
       a: makeFieldDisplay(10),
       b: makeFieldDisplay(5),
       expected: -5,
     },
     {
       name: 'ascending: smaller a sorts before larger b (negative)',
-      sort: PieChartSortOptions.Ascending,
+      sort: SortOrder.Ascending,
       a: makeFieldDisplay(5),
       b: makeFieldDisplay(10),
       expected: -5,
     },
     {
       name: 'none: comparator returns 0 regardless of values',
-      sort: PieChartSortOptions.None,
+      sort: SortOrder.None,
       a: makeFieldDisplay(5),
       b: makeFieldDisplay(10),
       expected: 0,
@@ -219,7 +219,7 @@ const setup = (propsOverrides?: {}) => {
 
   const options: Options = {
     pieType: PieChartType.Pie,
-    pieSorting: PieChartSortOptions.Descending,
+    sort: SortOrder.Descending,
     displayLabels: [],
     legend: {
       displayMode: LegendDisplayMode.List,

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -14,7 +14,7 @@ import {
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel } from './PieChartPanel';
-import { Options, PieChartType, PieChartLegendValues } from './panelcfg.gen';
+import { Options, PieChartType, PieSortOption, PieChartLegendValues } from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -173,6 +173,7 @@ const setup = (propsOverrides?: {}) => {
 
   const options: Options = {
     pieType: PieChartType.Pie,
+    pieSorting: PieSortOption.Clockwise,
     displayLabels: [],
     legend: {
       displayMode: LegendDisplayMode.List,

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -85,25 +85,21 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   const total = displayValues.filter(filterDisplayItems).reduce(sumDisplayItemsReducer, 0);
 
   const legendItems: VizLegendItem[] = displayValues
-    // Sort the legend according to the pie slice sorting.
     .sort((a, b) => {
-      if (props.options.pieSorting === PieChartSortOptions.None) {
-        return 1;
-      } else if (props.options.pieSorting === PieChartSortOptions.Ascending) {
-        // Reverse compared objects so that the clockwise sorting (default)
-        // is inverted.
-        let tmp = a;
-        a = b;
-        b = tmp;
-      }
-
       if (isNaN(a.display.numeric)) {
         return 1;
-      } else if (isNaN(b.display.numeric)) {
+      }
+      if (isNaN(b.display.numeric)) {
         return -1;
-      } else {
+      }
+
+      if (props.options.pieSorting === PieChartSortOptions.Descending) {
         return b.display.numeric - a.display.numeric;
       }
+      if (props.options.pieSorting === PieChartSortOptions.Ascending) {
+        return a.display.numeric - b.display.numeric;
+      }
+      return 0;
     })
     .map<VizLegendItem | undefined>((value: FieldDisplay, idx: number) => {
       const hideFrom: HideSeriesConfig = value.field.custom?.hideFrom ?? {};

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -82,25 +82,12 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   if (legendOptions.showLegend === false) {
     return undefined;
   }
+
+  const sortedDisplayValues = displayValues.sort(comparePieChartItemsByValue(props.options.pieSorting));
+
   const total = displayValues.filter(filterDisplayItems).reduce(sumDisplayItemsReducer, 0);
 
-  const legendItems: VizLegendItem[] = displayValues
-    .sort((a, b) => {
-      if (isNaN(a.display.numeric)) {
-        return 1;
-      }
-      if (isNaN(b.display.numeric)) {
-        return -1;
-      }
-
-      if (props.options.pieSorting === PieChartSortOptions.Descending) {
-        return b.display.numeric - a.display.numeric;
-      }
-      if (props.options.pieSorting === PieChartSortOptions.Ascending) {
-        return a.display.numeric - b.display.numeric;
-      }
-      return 0;
-    })
+  const legendItems: VizLegendItem[] = sortedDisplayValues
     .map<VizLegendItem | undefined>((value: FieldDisplay, idx: number) => {
       const hideFrom: HideSeriesConfig = value.field.custom?.hideFrom ?? {};
 
@@ -156,6 +143,28 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
       />
     </VizLayout.Legend>
   );
+}
+
+export function comparePieChartItemsByValue(
+  pieSorting: PieChartSortOptions
+): (a: FieldDisplay, b: FieldDisplay) => number {
+  return function (a: FieldDisplay, b: FieldDisplay) {
+    if (isNaN(a.display.numeric)) {
+      return 1;
+    }
+    if (isNaN(b.display.numeric)) {
+      return -1;
+    }
+
+    if (pieSorting === PieChartSortOptions.Descending) {
+      return b.display.numeric - a.display.numeric;
+    }
+    if (pieSorting === PieChartSortOptions.Ascending) {
+      return a.display.numeric - b.display.numeric;
+    }
+
+    return 0;
+  };
 }
 
 function hasFrames(fieldDisplayValues: FieldDisplay[]) {

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -11,7 +11,7 @@ import {
   PanelProps,
 } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
-import { HideSeriesConfig, LegendDisplayMode } from '@grafana/schema';
+import { HideSeriesConfig, SortOrder, LegendDisplayMode } from '@grafana/schema';
 import {
   SeriesVisibilityChangeBehavior,
   usePanelContext,
@@ -22,7 +22,7 @@ import {
 } from '@grafana/ui';
 
 import { PieChart } from './PieChart';
-import { PieChartLegendOptions, PieChartSortOptions, PieChartLegendValues, Options } from './panelcfg.gen';
+import { PieChartLegendOptions, PieChartLegendValues, Options } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 const defaultLegendOptions: PieChartLegendOptions = {
@@ -67,7 +67,7 @@ export function PieChartPanel(props: Props) {
             fieldDisplayValues={fieldDisplayValues}
             tooltipOptions={options.tooltip}
             pieType={options.pieType}
-            pieSorting={options.pieSorting}
+            sort={options.sort}
             displayLabels={options.displayLabels}
           />
         );
@@ -83,7 +83,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
     return undefined;
   }
 
-  const sortedDisplayValues = displayValues.sort(comparePieChartItemsByValue(props.options.pieSorting));
+  const sortedDisplayValues = displayValues.sort(comparePieChartItemsByValue(props.options.sort));
 
   const total = displayValues.filter(filterDisplayItems).reduce(sumDisplayItemsReducer, 0);
 
@@ -145,9 +145,7 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   );
 }
 
-export function comparePieChartItemsByValue(
-  pieSorting: PieChartSortOptions
-): (a: FieldDisplay, b: FieldDisplay) => number {
+export function comparePieChartItemsByValue(sort: SortOrder): (a: FieldDisplay, b: FieldDisplay) => number {
   return function (a: FieldDisplay, b: FieldDisplay) {
     if (isNaN(a.display.numeric)) {
       return 1;
@@ -156,10 +154,10 @@ export function comparePieChartItemsByValue(
       return -1;
     }
 
-    if (pieSorting === PieChartSortOptions.Descending) {
+    if (sort === SortOrder.Descending) {
       return b.display.numeric - a.display.numeric;
     }
-    if (pieSorting === PieChartSortOptions.Ascending) {
+    if (sort === SortOrder.Ascending) {
       return a.display.numeric - b.display.numeric;
     }
 

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -22,7 +22,7 @@ import {
 } from '@grafana/ui';
 
 import { PieChart } from './PieChart';
-import { PieChartLegendOptions, PieSortOption, PieChartLegendValues, Options } from './panelcfg.gen';
+import { PieChartLegendOptions, PieChartSortOptions, PieChartLegendValues, Options } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 const defaultLegendOptions: PieChartLegendOptions = {
@@ -68,7 +68,7 @@ export function PieChartPanel(props: Props) {
             tooltipOptions={options.tooltip}
             pieType={options.pieType}
             pieSorting={options.pieSorting}
-	    displayLabels={options.displayLabels}
+            displayLabels={options.displayLabels}
           />
         );
       }}
@@ -87,14 +87,14 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   const legendItems: VizLegendItem[] = displayValues
     // Sort the legend according to the pie slice sorting.
     .sort((a, b) => {
-      if(props.options.pieSorting === PieSortOption.None){
-	return 1;
-      } else if (props.options.pieSorting === PieSortOption.Counterclockwise){
-	// Reverse compared objects so that the clockwise sorting (default)
-	// is inverted.
-	let tmp = a;
-	a = b;
-	b = tmp;
+      if (props.options.pieSorting === PieChartSortOptions.None) {
+        return 1;
+      } else if (props.options.pieSorting === PieChartSortOptions.Ascending) {
+        // Reverse compared objects so that the clockwise sorting (default)
+        // is inverted.
+        let tmp = a;
+        a = b;
+        b = tmp;
       }
 
       if (isNaN(a.display.numeric)) {

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -22,7 +22,7 @@ import {
 } from '@grafana/ui';
 
 import { PieChart } from './PieChart';
-import { PieChartLegendOptions, PieChartLegendValues, Options } from './panelcfg.gen';
+import { PieChartLegendOptions, PieSortOption, PieChartLegendValues, Options } from './panelcfg.gen';
 import { filterDisplayItems, sumDisplayItemsReducer } from './utils';
 
 const defaultLegendOptions: PieChartLegendOptions = {
@@ -67,7 +67,8 @@ export function PieChartPanel(props: Props) {
             fieldDisplayValues={fieldDisplayValues}
             tooltipOptions={options.tooltip}
             pieType={options.pieType}
-            displayLabels={options.displayLabels}
+            pieSorting={options.pieSorting}
+	    displayLabels={options.displayLabels}
           />
         );
       }}
@@ -84,8 +85,18 @@ function getLegend(props: Props, displayValues: FieldDisplay[]) {
   const total = displayValues.filter(filterDisplayItems).reduce(sumDisplayItemsReducer, 0);
 
   const legendItems: VizLegendItem[] = displayValues
-    // Since the pie chart is always sorted, let's sort the legend as well.
+    // Sort the legend according to the pie slice sorting.
     .sort((a, b) => {
+      if(props.options.pieSorting === PieSortOption.None){
+	return 1;
+      } else if (props.options.pieSorting === PieSortOption.Counterclockwise){
+	// Reverse compared objects so that the clockwise sorting (default)
+	// is inverted.
+	let tmp = a;
+	a = b;
+	b = tmp;
+      }
+
       if (isNaN(a.display.numeric)) {
         return 1;
       } else if (isNaN(b.display.numeric)) {

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -57,7 +57,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
       })
       .addSelect({
         name: 'Slice sorting',
-        description: 'Select how to sort the pie slices.',
+        description: 'Select how to sort the pie slices',
         path: 'pieSorting',
         settings: {
           options: [

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -57,9 +57,10 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
 		  {value: PieSortOption.Clockwise, label: 'Clockwise'},
 		  {value: PieSortOption.Counterclockwise, label: 'Counterclockwise'},
 		  {value: PieSortOption.None, label:'None'}
-	  ]
-	}
-})
+	  ],
+	},
+	defaultValue: PieSortOption.Clockwise,
+      })
       .addMultiSelect({
         name: t('piechart.name-labels', 'Labels'),
         category,

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -7,7 +7,7 @@ import { addStandardDataReduceOptions } from '../stat/common';
 
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartPanelChangedHandler } from './migrations';
-import { Options, FieldConfig, PieChartType, PieChartLabels, PieChartLegendValues } from './panelcfg.gen';
+import { Options, FieldConfig, PieChartType, PieSortOption, PieChartLabels, PieChartLegendValues } from './panelcfg.gen';
 import { PieChartSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
@@ -48,6 +48,18 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
         },
         defaultValue: PieChartType.Pie,
       })
+      .addSelect({
+        name: 'Piechart sorting',
+	description: 'How shall the slices be sorted',
+	path: 'pieSorting',
+	settings: {
+	  options: [
+		  {value: PieSortOption.Clockwise, label: 'Clockwise'},
+		  {value: PieSortOption.Counterclockwise, label: 'Counterclockwise'},
+		  {value: PieSortOption.None, label:'None'}
+	  ]
+	}
+})
       .addMultiSelect({
         name: t('piechart.name-labels', 'Labels'),
         category,

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -1,5 +1,6 @@
 import { FieldColorModeId, FieldConfigProperty, PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { SortOrder } from '@grafana/schema/dist/esm/index';
 import { commonOptionsBuilder } from '@grafana/ui';
 import { optsWithHideZeros } from '@grafana/ui/internal';
 
@@ -7,14 +8,7 @@ import { addStandardDataReduceOptions } from '../stat/common';
 
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartPanelChangedHandler } from './migrations';
-import {
-  Options,
-  FieldConfig,
-  PieChartType,
-  PieChartSortOptions,
-  PieChartLabels,
-  PieChartLegendValues,
-} from './panelcfg.gen';
+import { Options, FieldConfig, PieChartType, PieChartLabels, PieChartLegendValues } from './panelcfg.gen';
 import { PieChartSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
@@ -58,15 +52,15 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
       .addSelect({
         name: 'Slice sorting',
         description: 'Select how to sort the pie slices',
-        path: 'pieSorting',
+        path: 'sort',
         settings: {
           options: [
-            { value: PieChartSortOptions.Descending, label: 'Descending' },
-            { value: PieChartSortOptions.Ascending, label: 'Ascending' },
-            { value: PieChartSortOptions.None, label: 'None' },
+            { value: SortOrder.Descending, label: 'Descending' },
+            { value: SortOrder.Ascending, label: 'Ascending' },
+            { value: SortOrder.None, label: 'None' },
           ],
         },
-        defaultValue: PieChartSortOptions.Descending,
+        defaultValue: SortOrder.Descending,
       })
       .addMultiSelect({
         name: t('piechart.name-labels', 'Labels'),

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -7,7 +7,14 @@ import { addStandardDataReduceOptions } from '../stat/common';
 
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartPanelChangedHandler } from './migrations';
-import { Options, FieldConfig, PieChartType, PieSortOption, PieChartLabels, PieChartLegendValues } from './panelcfg.gen';
+import {
+  Options,
+  FieldConfig,
+  PieChartType,
+  PieChartSortOptions,
+  PieChartLabels,
+  PieChartLegendValues,
+} from './panelcfg.gen';
 import { PieChartSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
@@ -49,17 +56,17 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
         defaultValue: PieChartType.Pie,
       })
       .addSelect({
-        name: 'Piechart sorting',
-	description: 'How shall the slices be sorted',
-	path: 'pieSorting',
-	settings: {
-	  options: [
-		  {value: PieSortOption.Clockwise, label: 'Clockwise'},
-		  {value: PieSortOption.Counterclockwise, label: 'Counterclockwise'},
-		  {value: PieSortOption.None, label:'None'}
-	  ],
-	},
-	defaultValue: PieSortOption.Clockwise,
+        name: 'Slice sorting',
+        description: 'Select how to sort the pie slices.',
+        path: 'pieSorting',
+        settings: {
+          options: [
+            { value: PieChartSortOptions.Descending, label: 'Descending' },
+            { value: PieChartSortOptions.Ascending, label: 'Ascending' },
+            { value: PieChartSortOptions.None, label: 'None' },
+          ],
+        },
+        defaultValue: PieChartSortOptions.Descending,
       })
       .addMultiSelect({
         name: t('piechart.name-labels', 'Labels'),

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -51,6 +51,7 @@ composableKinds: PanelCfg: {
 					common.OptionsWithTooltip
 					common.SingleStatBaseOptions
 					pieType: PieChartType
+					pieSorting: PieSortOption
 					displayLabels: [...PieChartLabels]
 					legend: PieChartLegendOptions
 				} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -29,11 +29,6 @@ composableKinds: PanelCfg: {
 			{
 				// Select the pie chart display style.
 				PieChartType: "pie" | "donut" @cuetsy(kind="enum")
-				// Select how to sort the pie slices.
-				//  - Descending - The slices are sorted in descending value going clockwise (default).
-				//  - Ascending - The slices are sorted in ascending value going clockwise.
-				//  - None - The slices are not sorted and the order of the query/transform is maintained.
-				PieChartSortOptions: "descending" | "ascending" | "none" @cuetsy(kind="enum")
 				// Select labels to display on the pie chart.
 				//  - Name - The series or field name.
 				//  - Percent - The percentage of the whole.
@@ -51,7 +46,7 @@ composableKinds: PanelCfg: {
 					common.OptionsWithTooltip
 					common.SingleStatBaseOptions
 					pieType: PieChartType
-					pieSorting: PieChartSortOptions
+				sort: common.SortOrder
 					displayLabels: [...PieChartLabels]
 					legend: PieChartLegendOptions
 				} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -29,6 +29,11 @@ composableKinds: PanelCfg: {
 			{
 				// Select the pie chart display style.
 				PieChartType: "pie" | "donut" @cuetsy(kind="enum")
+				// Select the sorting of the pie slices.
+				//  - Clockwise - The slices are sorted descending by value in the clockwise direction.
+				//  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+				//  - None - The slices are not sorted and the order of the query/transform is maintained.
+				PieSortOption: "clockwise" | "counterclockwise" | "none" @cuetsy(kind="enum")
 				// Select labels to display on the pie chart.
 				//  - Name - The series or field name.
 				//  - Percent - The percentage of the whole.

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -29,11 +29,11 @@ composableKinds: PanelCfg: {
 			{
 				// Select the pie chart display style.
 				PieChartType: "pie" | "donut" @cuetsy(kind="enum")
-				// Select the sorting of the pie slices.
-				//  - Clockwise - The slices are sorted descending by value in the clockwise direction.
-				//  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+				// Select how to sort the pie slices.
+				//  - Descending - The slices are sorted in descending value going clockwise (default).
+				//  - Ascending - The slices are sorted in ascending value going clockwise.
 				//  - None - The slices are not sorted and the order of the query/transform is maintained.
-				PieSortOption: "clockwise" | "counterclockwise" | "none" @cuetsy(kind="enum")
+				PieChartSortOptions: "descending" | "ascending" | "none" @cuetsy(kind="enum")
 				// Select labels to display on the pie chart.
 				//  - Name - The series or field name.
 				//  - Percent - The percentage of the whole.
@@ -51,7 +51,7 @@ composableKinds: PanelCfg: {
 					common.OptionsWithTooltip
 					common.SingleStatBaseOptions
 					pieType: PieChartType
-					pieSorting: PieSortOption
+					pieSorting: PieChartSortOptions
 					displayLabels: [...PieChartLabels]
 					legend: PieChartLegendOptions
 				} @cuetsy(kind="interface")

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -19,6 +19,18 @@ export enum PieChartType {
 }
 
 /**
+ * Select the sorting of the pie slices.
+ *  - Clockwise - The slices are sorted descending by value in the clockwise direction.
+ *  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+ *  - None - The slices are not sorted and the order of the query/transform is maintained.
+ */
+export enum PieSortOption {
+  Clockwise = 'clockwise',
+  Counterclockwise = 'counterclockwise',
+  None = 'none',
+}
+
+/**
  * Select labels to display on the pie chart.
  *  - Name - The series or field name.
  *  - Percent - The percentage of the whole.

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -25,8 +25,8 @@ export enum PieChartType {
  *  - None - The slices are not sorted and the order of the query/transform is maintained.
  */
 export enum PieChartSortOptions {
-  Descending = 'descending',
   Ascending = 'ascending',
+  Descending = 'descending',
   None = 'none',
 }
 

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -19,18 +19,6 @@ export enum PieChartType {
 }
 
 /**
- * Select how to sort the pie slices.
- *  - Descending - The slices are sorted in descending value going clockwise (default).
- *  - Ascending - The slices are sorted in ascending value going clockwise.
- *  - None - The slices are not sorted and the order of the query/transform is maintained.
- */
-export enum PieChartSortOptions {
-  Ascending = 'ascending',
-  Descending = 'descending',
-  None = 'none',
-}
-
-/**
  * Select labels to display on the pie chart.
  *  - Name - The series or field name.
  *  - Percent - The percentage of the whole.
@@ -63,8 +51,8 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
-  pieSorting: PieChartSortOptions;
   pieType: PieChartType;
+  sort: common.SortOrder;
 }
 
 export const defaultOptions: Partial<Options> = {

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -63,6 +63,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
+  pieSorting: PieSortOption;
   pieType: PieChartType;
 }
 

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -19,14 +19,14 @@ export enum PieChartType {
 }
 
 /**
- * Select the sorting of the pie slices.
- *  - Clockwise - The slices are sorted descending by value in the clockwise direction.
- *  - Counterclockwise - The slices are sorted ascending by value in the clockwise direction.
+ * Select how to sort the pie slices.
+ *  - Descending - The slices are sorted in descending value going clockwise (default).
+ *  - Ascending - The slices are sorted in ascending value going clockwise.
  *  - None - The slices are not sorted and the order of the query/transform is maintained.
  */
-export enum PieSortOption {
-  Clockwise = 'clockwise',
-  Counterclockwise = 'counterclockwise',
+export enum PieChartSortOptions {
+  Descending = 'descending',
+  Ascending = 'ascending',
   None = 'none',
 }
 
@@ -63,7 +63,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
-  pieSorting: PieSortOption;
+  pieSorting: PieChartSortOptions;
   pieType: PieChartType;
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

> [!NOTE]
> This PR builds on a community contribution: https://github.com/grafana/grafana/pull/106342. 🏆 Thank you @cglukas !!!

🆕 This change adds options to configure sorting of pie chart slices.
- Options have been added for `Ascending` or `Descending` _(default)_ order going clockwise.
- Additionally the option `None` maintains the ordering as it comes from the datasource -- this will allow user defined arbitrary ordering through queries and transformations.
- Legend items are now always sorted in the same way as the data.

⏪ Before this change, an ascending sort order was always applied to pie slices. _(This behaviour has been retained as the default option to keep backwards compatibility with existing panels.)_

https://github.com/user-attachments/assets/f1584b74-99cd-46ea-a31a-b2757cfa9509

**Why do we need this feature?**

This feature was requested by the Grafana user community.

**Who is this feature for?**

All users of Grafana, there is no feature toggle required to benefit from this change.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes: https://github.com/grafana/grafana/issues/82972

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
