### PR TITLE
tests(integration): Verify test user can authenticate before proceeding

### DIFF
--- a/pkg/tests/api/annotations/annotations_test.go
+++ b/pkg/tests/api/annotations/annotations_test.go
@@ -43,7 +43,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		Password:       "noneuser",
 		IsAdmin:        false,
 		OrgID:          1,
-	})
+	}, grafanaListedAddr)
 
 	tests.CreateUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleEditor),
@@ -51,7 +51,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		Password:       "editor",
 		IsAdmin:        false,
 		OrgID:          1,
-	})
+	}, grafanaListedAddr)
 
 	tests.CreateUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
@@ -59,7 +59,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 		Password:       "viewer",
 		IsAdmin:        false,
 		OrgID:          1,
-	})
+	}, grafanaListedAddr)
 	savedFolder := createFolder(t, grafanaListedAddr, "Test Folder")
 	dash1 := createDashboard(t, grafanaListedAddr, "Dashboard 1", savedFolder.ID, savedFolder.UID) // nolint:staticcheck
 	dash2 := createDashboard(t, grafanaListedAddr, "Dashboard 2", savedFolder.ID, savedFolder.UID) // nolint:staticcheck

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -63,7 +63,7 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 		Password:       "admin",
 		IsAdmin:        true,
 		OrgID:          2,
-	})
+	}, grafanaListedAddr)
 
 	savedFolder := createFolder(t, grafanaListedAddr, "Saved folder")
 	savedDashInFolder := createDashboard(t, grafanaListedAddr, "Saved dash in folder", savedFolder.ID, savedFolder.UID) // nolint:staticcheck
@@ -753,7 +753,7 @@ func TestIntegrationImportDashboardWithLibraryPanels(t *testing.T) {
 				},
 				{
 					"id": 2,
-					"title": "Library Panel 2", 
+					"title": "Library Panel 2",
 					"type": "stat",
 					"gridPos": {"h": 8, "w": 12, "x": 12, "y": 0},
 					"libraryPanel": {
@@ -777,7 +777,7 @@ func TestIntegrationImportDashboardWithLibraryPanels(t *testing.T) {
 					}
 				},
 				"test-lib-panel-2": {
-					"uid": "test-lib-panel-2", 
+					"uid": "test-lib-panel-2",
 					"name": "Test Library Panel 2",
 					"kind": 1,
 					"type": "stat",
@@ -997,13 +997,13 @@ func TestIntegrationDashboardServicePermissions(t *testing.T) {
 		Login:          "editor",
 		Password:       "editor",
 		IsAdmin:        false,
-	})
+	}, grafanaListedAddr)
 	tests.CreateUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
 		DefaultOrgRole: string(org.RoleViewer),
 		Login:          "viewer",
 		Password:       "viewer",
 		IsAdmin:        false,
-	})
+	}, grafanaListedAddr)
 	savedFolder := createFolder(t, grafanaListedAddr, "Saved folder")
 	otherSavedFolder := createFolder(t, grafanaListedAddr, "Other saved folder")
 	savedDashInFolder := createDashboard(t, grafanaListedAddr, "Saved dash in folder", savedFolder.ID, savedFolder.UID) // nolint:staticcheck
@@ -1166,7 +1166,7 @@ func TestIntegrationDashboardServicePermissions(t *testing.T) {
 			Login:          "noneuser",
 			Password:       "noneuser",
 			IsAdmin:        false,
-		})
+		}, grafanaListedAddr)
 		parentFolder := createFolder(t, grafanaListedAddr, "parent")
 		childFolder := createFolder(t, grafanaListedAddr, "child")
 		createDashboard(t, grafanaListedAddr, "dashboard in root", 0, "")

--- a/pkg/tests/api/folders/api_folder_test.go
+++ b/pkg/tests/api/folders/api_folder_test.go
@@ -291,7 +291,7 @@ func TestIntegrationNestedFolders(t *testing.T) {
 					OrgID:          orgID,
 					Password:       "editor",
 					Login:          "editor",
-				})
+				}, grafanaListedAddr)
 				editorClient := tests.GetClient(grafanaListedAddr, "editor", "editor")
 
 				sourceResp, err := adminClient.Folders.CreateFolder(&models.CreateFolderCommand{
@@ -367,7 +367,7 @@ func TestIntegrationSharedWithMe(t *testing.T) {
 		OrgID:          orgID,
 		Password:       "none",
 		Login:          "none",
-	})
+	}, grafanaListedAddr)
 	adminClient := tests.GetClient(grafanaListedAddr, "admin", "admin")
 	noneClient := tests.GetClient(grafanaListedAddr, "none", "none")
 
@@ -422,13 +422,13 @@ func TestIntegrationBasicRoles(t *testing.T) {
 		OrgID:          orgID,
 		Password:       "viewer",
 		Login:          "viewer",
-	})
+	}, grafanaListedAddr)
 	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		OrgID:          orgID,
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
-	})
+	}, grafanaListedAddr)
 
 	adminClient := tests.GetClient(grafanaListedAddr, "admin", "admin")
 	viewerClient := tests.GetClient(grafanaListedAddr, "viewer", "viewer")
@@ -558,7 +558,7 @@ func TestIntegrationFineGrainedPermissions(t *testing.T) {
 		OrgID:          orgID,
 		Password:       "none",
 		Login:          "none",
-	})
+	}, grafanaListedAddr)
 
 	adminClient := tests.GetClient(grafanaListedAddr, "admin", "admin")
 	noneClient := tests.GetClient(grafanaListedAddr, "none", "none")

--- a/pkg/tests/api/folders/api_folders_test.go
+++ b/pkg/tests/api/folders/api_folders_test.go
@@ -48,19 +48,19 @@ func TestGetFolders(t *testing.T) {
 		OrgID:          orgID,
 		Password:       "viewer",
 		Login:          "viewer",
-	})
+	}, grafanaListedAddr)
 	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		OrgID:          orgID,
 		DefaultOrgRole: string(org.RoleEditor),
 		Password:       "editor",
 		Login:          "editor",
-	})
+	}, grafanaListedAddr)
 	tests.CreateUser(t, store, cfg, user.CreateUserCommand{
 		OrgID:          orgID,
 		DefaultOrgRole: string(org.RoleAdmin),
 		Password:       "admin",
 		Login:          "admin2",
-	})
+	}, grafanaListedAddr)
 
 	adminClient := tests.GetClient(grafanaListedAddr, "admin2", "admin")
 	editorClient := tests.GetClient(grafanaListedAddr, "editor", "editor")

--- a/pkg/tests/api/publicdashboards/public_dashboard_query_test.go
+++ b/pkg/tests/api/publicdashboards/public_dashboard_query_test.go
@@ -32,7 +32,7 @@ func TestPublicDashboardQueryAPI(t *testing.T) {
 		Login:          adminUsername,
 		Password:       "admin",
 		IsAdmin:        true,
-	})
+	}, grafanaListedAddr)
 	adminClient := createHTTPClient(grafanaListedAddr, adminUsername, "admin")
 
 	datasourcePayload := map[string]interface{}{

--- a/pkg/tests/api/publicdashboards/public_dashboards_api_test.go
+++ b/pkg/tests/api/publicdashboards/public_dashboards_api_test.go
@@ -39,7 +39,7 @@ func TestPublicDashboardsAPI(t *testing.T) {
 		Login:          adminUsername,
 		Password:       "admin",
 		IsAdmin:        true,
-	})
+	}, grafanaListedAddr)
 	adminClient := createHTTPClient(grafanaListedAddr, adminUsername, "admin")
 
 	t.Run("should create, get, update, and delete public dashboard", func(t *testing.T) {
@@ -341,7 +341,7 @@ func TestPublicDashboardsAPI(t *testing.T) {
 				Login:          limitedUserUsername,
 				Password:       "password",
 				IsAdmin:        false,
-			})
+			}, grafanaListedAddr)
 			limitedUserClient := createHTTPClient(grafanaListedAddr, limitedUserUsername, "password")
 			permissionPayload := map[string]interface{}{
 				"permission": "View",


### PR DESCRIPTION
**What is this feature?**

These changes should help with integration tests stability. A race condition may occur when test users' permissions and roles aren't fully initialized before tests make API calls that require specific access control checks. This ensures that test users' permissions and roles are in place before the test attempts to perform authorized actions.

**Why do we need this feature?**

Integration tests stability improvements

**Who is this feature for?**

developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
