### PR TITLE
Unified Storage: Search after write get event delta

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -79,6 +79,10 @@ type ResourceIndex interface {
 
 	// Get the number of documents in the index
 	DocCount(ctx context.Context, folder string) (int64, error)
+
+	GetLatestResourceVersion(ctx context.Context) (int64, error)
+
+	SetLatestResourceVersion(ctx context.Context, rv int64) error
 }
 
 // SearchBackend contains the technology specific logic to support search
@@ -640,6 +644,19 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 	}
 
 	if idx != nil {
+		// what is rv of the index?
+		indexRv, _ := idx.GetLatestResourceVersion(ctx)
+		// what is the latest rv?
+		latestRv, _ := s.storage.GetResourceMaxHistoryRv(ctx, &resourcepb.ResourceKey{
+			Namespace: key.Namespace,
+			Group:     key.Group,
+			Resource:  key.Resource,
+		})
+		// If they are different, we need to index the delta
+		if indexRv < latestRv {
+			// TODO - get the delta of events
+		}
+
 		return idx, nil
 	}
 

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -120,6 +120,8 @@ type StorageBackend interface {
 
 	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
 	GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error)
+
+	GetResourceMaxHistoryRv(ctx context.Context, key *resourcepb.ResourceKey) (int64, error)
 }
 
 type ResourceStats struct {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -563,6 +563,21 @@ type bleveIndex struct {
 	allFields []*resourcepb.ResourceTableColumnDefinition
 	features  featuremgmt.FeatureToggles
 	tracing   trace.Tracer
+
+	latestRv int64 // The latest resource version that was used to build this index.
+}
+
+func (b *bleveIndex) GetLatestResourceVersion(ctx context.Context) (int64, error) {
+	return b.latestRv, nil
+}
+
+func (b *bleveIndex) SetLatestResourceVersion(ctx context.Context, rv int64) error {
+	if rv > b.latestRv {
+		b.latestRv = rv
+		return nil
+	}
+
+	return fmt.Errorf("cannot set latest resource version to less than the current one: %d < %d", rv, b.latestRv)
 }
 
 // BulkIndex implements resource.ResourceIndex.

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -310,6 +310,22 @@ func (b *backend) GetResourceStats(ctx context.Context, namespace string, minCou
 	return res, err
 }
 
+// GetResourceMaxHistoryRv( ctx context.Context, key *resourcepb.ResourceKey) (int64, error)
+func (b *backend) GetResourceMaxHistoryRv(ctx context.Context, key *resourcepb.ResourceKey) (int64, error) {
+	ctx, span := b.tracer.Start(ctx, tracePrefix+"GetResourceMaxHistoryRv")
+	defer span.End()
+
+	if key == nil {
+		return 0, fmt.Errorf("key cannot be nil")
+	}
+
+	rv, err := b.fetchLatestHistoryRV(ctx, b.db, b.dialect, key, -1) // pass -1 to consider all event types
+	if err != nil {
+		return 0, fmt.Errorf("failed to get max history RV for %s: %w", key.String(), err)
+	}
+	return rv, nil
+}
+
 func (b *backend) WriteEvent(ctx context.Context, event resource.WriteEvent) (int64, error) {
 	_, span := b.tracer.Start(ctx, tracePrefix+"WriteEvent")
 	defer span.End()

--- a/pkg/storage/unified/sql/data/resource_history_list_delta.sql
+++ b/pkg/storage/unified/sql/data/resource_history_list_delta.sql
@@ -1,0 +1,15 @@
+SELECT
+  {{ .Ident "guid" }},
+  {{ .Ident "resource_version" }},
+  {{ .Ident "namespace" }},
+  {{ .Ident "group" }},
+  {{ .Ident "resource" }},
+  {{ .Ident "name" }},
+  {{ .Ident "folder" }},
+  {{ .Ident "value" }}
+FROM {{ .Ident "resource_history" }} as rh
+WHERE {{ .Ident "resource_version" }} > {{ .Arg .Request.SinceVersion }} -- list all new events since the given RV for the namespaced resource
+AND {{ .Ident "namespace" }} = {{ .Arg .Request.Options.Key.Namespace }}
+AND {{ .Ident "group" }}     = {{ .Arg .Request.Options.Key.Group }}
+AND {{ .Ident "resource" }}  = {{ .Arg .Request.Options.Key.Resource }}
+ORDER BY {{ .Ident "resource_version" }} ASC

--- a/pkg/storage/unified/sql/data/resource_history_read_latest_rv.sql
+++ b/pkg/storage/unified/sql/data/resource_history_read_latest_rv.sql
@@ -6,7 +6,9 @@ SELECT
     WHERE {{ .Ident "namespace" }}   = {{ .Arg .Request.Key.Namespace }}
         AND {{ .Ident "group" }}     = {{ .Arg .Request.Key.Group }}
         AND {{ .Ident "resource" }}  = {{ .Arg .Request.Key.Resource }}
+        {{ if .name }} -- idk what the syntax is for these templates. We want resource name to be optional.
         AND {{ .Ident "name" }}      = {{ .Arg .Request.Key.Name }}
+        {{ end }}
         {{ if gt .Request.EventType 0 }}
             AND {{ .Ident "action" }} = {{ .Arg .Request.EventType }}
         {{ end }}


### PR DESCRIPTION
Starting poking around at how we can check if there are new events that need to be indexed (the delta).

Notes:
- Added a query for getting the delta of events for a namespaced resource from `resource_history`.

Todo:
- Need to add a method on the storage backend that gets the delta of events.