### PR TITLE
Alerting: Fix newly created alert rules not immediately showing up in folder view 

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -246,7 +246,9 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         const { path, params } = rulerUrlBuilder(rulerConfig).namespace(namespace);
         return { url: path, params };
       },
-      providesTags: (_result, _error, { namespace }) => [{ type: 'RuleNamespace', id: namespace }],
+      providesTags: (_result, _error, { namespace, rulerConfig }) => [
+        { type: 'RuleNamespace', id: `${rulerConfig.dataSourceUid}/${namespace}` },
+      ],
     }),
 
     // TODO This should be probably a separate ruler API file


### PR DESCRIPTION
**What is this feature?**
Fixes the case of creating a new alert rule and then checking for it in the dashboards/folder view: https://github.com/grafana/search-and-storage-team/issues/418

**Why do we need this feature?**
The tags provided for `RulerNamespace` were incorrect - they needed to include the datasourceUID as well, so that they provided:
`grafana/{folderUID}` 
rather than
`{folderUID}`

Reproduction steps:
* Check the list of rules in a folder from the dashboards/folder view
* Go straight to alerting and create a new rule in that folder
* Go back to the folder you first looked at and check the alert rules tab again
* The rule should show up without a page refresh


Fixes https://github.com/grafana/search-and-storage-team/issues/418