### PR TITLE
WIP Dashboard Migrations: V17 - minSpan to maxPerRow conversion

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/migrations.go
+++ b/apps/dashboard/pkg/migration/schemaversion/migrations.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	MIN_VERSION    = 17
+	MIN_VERSION    = 16
 	LATEST_VERSION = 41
 )
 
@@ -38,6 +38,7 @@ type PanelPluginInfoProvider interface {
 
 func GetMigrations(dsInfoProvider DataSourceInfoProvider, panelProvider PanelPluginInfoProvider) map[int]SchemaVersionMigrationFunc {
 	return map[int]SchemaVersionMigrationFunc{
+		17: V17,
 		18: V18,
 		19: V19,
 		20: V20,

--- a/apps/dashboard/pkg/migration/schemaversion/v17.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v17.go
@@ -1,0 +1,98 @@
+package schemaversion
+
+// V17 migrates panel minSpan to maxPerRow property.
+// For panels with minSpan property, it calculates maxPerRow based on grid column count factors
+// and removes the minSpan property.
+//
+// Example before migration:
+//
+//	{
+//	  "panels": [
+//	    {
+//	      "id": 1,
+//	      "minSpan": 6,
+//	      "type": "graph"
+//	    }
+//	  ]
+//	}
+//
+// Example after migration:
+//
+//	{
+//	  "panels": [
+//	    {
+//	      "id": 1,
+//	      "maxPerRow": 4,
+//	      "type": "graph"
+//	    }
+//	  ]
+//	}
+func V17(dashboard map[string]interface{}) error {
+	dashboard["schemaVersion"] = 17
+
+	panels, ok := dashboard["panels"].([]interface{})
+	if !ok {
+		return nil
+	}
+
+	const gridColumnCount = 24
+
+	for _, p := range panels {
+		panel, ok := p.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		minSpan, hasMinSpan := panel["minSpan"]
+		if !hasMinSpan {
+			continue
+		}
+
+		// Extract minSpan value
+		var minSpanValue float64
+		switch v := minSpan.(type) {
+		case int:
+			minSpanValue = float64(v)
+		case float64:
+			minSpanValue = v
+		default:
+			continue
+		}
+
+		if minSpanValue > 0 {
+			max := gridColumnCount / minSpanValue
+			factors := getFactors(gridColumnCount)
+
+			// Find the best match compared to factors
+			maxPerRow := 1 // default value
+			for i, factor := range factors {
+				if float64(factor) > max {
+					if i > 0 {
+						maxPerRow = factors[i-1]
+					}
+					break
+				}
+				maxPerRow = factor
+			}
+
+			panel["maxPerRow"] = maxPerRow
+		}
+
+		// Remove the minSpan property
+		delete(panel, "minSpan")
+	}
+
+	return nil
+}
+
+// getFactors returns the factors of a number
+// Example getFactors(24) -> [1, 2, 3, 4, 6, 8, 12, 24]
+func getFactors(num int) []int {
+	var factors []int
+	for i := 1; i <= num; i++ {
+		if num%i == 0 {
+			factors = append(factors, i)
+		}
+	}
+	return factors
+}

--- a/apps/dashboard/pkg/migration/schemaversion/v17_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v17_test.go
@@ -1,0 +1,218 @@
+package schemaversion
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV17(t *testing.T) {
+	tests := []struct {
+		name           string
+		input          map[string]interface{}
+		expectedOutput map[string]interface{}
+	}{
+		{
+			name: "panels with minSpan should be converted to maxPerRow",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":      1,
+						"minSpan": 6,
+						"type":    "graph",
+					},
+					map[string]interface{}{
+						"id":      2,
+						"minSpan": 4,
+						"type":    "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":        1,
+						"maxPerRow": 4,
+						"type":      "graph",
+					},
+					map[string]interface{}{
+						"id":        2,
+						"maxPerRow": 6,
+						"type":      "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "panels without minSpan should not be changed",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":   1,
+						"type": "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":   1,
+						"type": "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "minSpan of 12 should result in maxPerRow of 2",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":      1,
+						"minSpan": 12,
+						"type":    "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":        1,
+						"maxPerRow": 2,
+						"type":      "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "minSpan of 8 should result in maxPerRow of 3",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":      1,
+						"minSpan": 8,
+						"type":    "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":        1,
+						"maxPerRow": 3,
+						"type":      "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "minSpan of 2 should result in maxPerRow of 12",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":      1,
+						"minSpan": 2,
+						"type":    "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":        1,
+						"maxPerRow": 12,
+						"type":      "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "minSpan as float64 should work",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":      1,
+						"minSpan": 6.0,
+						"type":    "graph",
+					},
+				},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id":        1,
+						"maxPerRow": 4,
+						"type":      "graph",
+					},
+				},
+			},
+		},
+		{
+			name: "dashboard without panels should not error",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+			},
+		},
+		{
+			name: "empty panels array should not error",
+			input: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels":        []interface{}{},
+			},
+			expectedOutput: map[string]interface{}{
+				"schemaVersion": 17,
+				"panels":        []interface{}{},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := V17(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedOutput, tt.input)
+		})
+	}
+}
+
+func TestGetFactors(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected []int
+	}{
+		{
+			input:    24,
+			expected: []int{1, 2, 3, 4, 6, 8, 12, 24},
+		},
+		{
+			input:    12,
+			expected: []int{1, 2, 3, 4, 6, 12},
+		},
+		{
+			input:    1,
+			expected: []int{1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run("factors", func(t *testing.T) {
+			result := getFactors(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/apps/dashboard/pkg/migration/testdata/input/v17.minspan_to_maxperrow.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v17.minspan_to_maxperrow.json
@@ -1,0 +1,84 @@
+{
+  "title": "V17 MinSpan to MaxPerRow Migration Test Dashboard",
+  "schemaVersion": 16,
+  "panels": [
+    {
+      "id": 1,
+      "type": "graph",
+      "title": "Panel with minSpan 6",
+      "minSpan": 6,
+      "gridPos": {
+        "x": 0,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 2,
+      "type": "singlestat",
+      "title": "Panel with minSpan 4", 
+      "minSpan": 4,
+      "gridPos": {
+        "x": 12,
+        "y": 0,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 3,
+      "type": "graph",
+      "title": "Panel with minSpan 12",
+      "minSpan": 12,
+      "gridPos": {
+        "x": 0,
+        "y": 8,
+        "w": 24,
+        "h": 8
+      }
+    },
+    {
+      "id": 4,
+      "type": "graph", 
+      "title": "Panel with minSpan 8",
+      "minSpan": 8,
+      "gridPos": {
+        "x": 0,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 5,
+      "type": "graph",
+      "title": "Panel with minSpan 2",
+      "minSpan": 2,
+      "gridPos": {
+        "x": 12,
+        "y": 16,
+        "w": 12,
+        "h": 8
+      }
+    },
+    {
+      "id": 6,
+      "type": "graph",
+      "title": "Panel without minSpan",
+      "gridPos": {
+        "x": 0,
+        "y": 24,
+        "w": 24,
+        "h": 8
+      }
+    }
+  ],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
+  }
+}


### PR DESCRIPTION
## Dashboard Migrations: V17 - minSpan to maxPerRow conversion

### Problem

Panel `minSpan` property needs to be migrated to `maxPerRow` property as part of moving dashboard schema migrations from frontend to backend. The `minSpan` property was used to control minimum panel width, but needs to be converted to `maxPerRow` which controls how many panels can be displayed per row.

### Solution

This migration converts panel `minSpan` values to appropriate `maxPerRow` values by:
1. Calculating the maximum number of panels per row based on grid column count (24) divided by minSpan
2. Finding the best factor match from available grid factors [1, 2, 3, 4, 6, 8, 12, 24]
3. Setting the `maxPerRow` property and removing the `minSpan` property

Examples:
- `minSpan: 6` → `maxPerRow: 4` (24/6 = 4)
- `minSpan: 8` → `maxPerRow: 3` (24/8 = 3, closest factor)
- `minSpan: 12` → `maxPerRow: 2` (24/12 = 2)

## How to test

1. Run backend tests: `go test ./apps/dashboard/pkg/migration/schemaversion -v -run TestV17`
2. Run snapshot testing: `go test ./apps/dashboard/pkg/migration`
3. Verify output matches expected conversion in test data