### PR TITLE
App Installer: Revert #109267 and skip ShortURL integration tests

### DIFF
--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -11,7 +11,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericapiserver "k8s.io/apiserver/pkg/server"
@@ -59,31 +58,27 @@ func AddToScheme(
 	return additionalGroupVersions, nil
 }
 
-// RegisterAdmission combines the existing admission control from builders.
-func RegisterAdmission(
-	existingAdmission admission.Interface,
+// RegisterAdmissionPlugins registers admission plugins for app installers
+func RegisterAdmissionPlugins(
+	ctx context.Context,
 	appInstallers []appsdkapiserver.AppInstaller,
-) (admission.Interface, error) {
-	controllers := []admission.Interface{}
+	options *grafanaapiserveroptions.Options,
+) error {
+	logger := logging.FromContext(ctx)
 
 	for _, installer := range appInstallers {
-		factory := installer.AdmissionPlugin()
-		if factory == nil {
-			continue
+		plugin := installer.AdmissionPlugin()
+		if plugin != nil {
+			md := installer.ManifestData()
+			if md == nil {
+				return fmt.Errorf("manifest is not initialized for installer for GroupVersions %v", installer.GroupVersions())
+			}
+			pluginName := md.AppName + " admission"
+			options.RecommendedOptions.Admission.Plugins.Register(pluginName, plugin)
+			logger.Info("Registered admission plugin", "app", md.AppName)
 		}
-
-		admissionInterface, err := factory(nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create admission plugin: %w", err)
-		}
-		controllers = append(controllers, admissionInterface)
 	}
-
-	if existingAdmission != nil {
-		controllers = append(controllers, existingAdmission)
-	}
-
-	return admission.NewChainHandler(controllers...), nil
+	return nil
 }
 
 type AuthorizerRegistrar interface {

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -291,6 +291,11 @@ func (s *service) start(ctx context.Context) error {
 
 	o := grafanaapiserveroptions.NewOptions(s.codecs.LegacyCodec(groupVersions...))
 
+	// Register admission plugins from app installers after options are created
+	if err := appinstaller.RegisterAdmissionPlugins(ctx, s.appInstallers, o); err != nil {
+		return err
+	}
+
 	// Register authorizers from app installers
 	appinstaller.RegisterAuthorizers(ctx, s.appInstallers, s.authorizer)
 
@@ -357,14 +362,6 @@ func (s *service) start(ctx context.Context) error {
 		s.buildHandlerChainFuncFromBuilders,
 		groupVersions,
 		defGetters,
-	)
-	if err != nil {
-		return err
-	}
-
-	serverConfig.AdmissionControl, err = appinstaller.RegisterAdmission(
-		serverConfig.AdmissionControl,
-		s.appInstallers,
 	)
 	if err != nil {
 		return err

--- a/pkg/tests/apis/shorturl/shorturl_test.go
+++ b/pkg/tests/apis/shorturl/shorturl_test.go
@@ -36,6 +36,8 @@ var gvr = schema.GroupVersionResource{
 var RESOURCEGROUP = gvr.GroupResource().String()
 
 func TestIntegrationShortURL(t *testing.T) {
+	t.Skip("Skipping due to issue with https://github.com/grafana/grafana/pull/109267")
+
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}


### PR DESCRIPTION
PR #109267 is causing a lot of flakiness in integration tests, so reverting that.

Unfortunately ShortURL integration tests depend on that change, so we skip those tests for now as well.