### PR TITLE
Alerting: Disable group consistency check for GMA rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -48,6 +48,7 @@ import {
   RulePluginOrigin,
   getRulePluginOrigin,
   isFederatedRuleGroup,
+  isGrafanaRuleIdentifier,
   isPausedRule,
   prometheusRuleType,
   rulerRuleType,
@@ -83,11 +84,14 @@ export enum ActiveTab {
 const prometheusRulesPrimary = shouldUsePrometheusRulesPrimary();
 const alertingListViewV2 = shouldUseAlertingListViewV2();
 
-const shouldUseConsistencyCheck = prometheusRulesPrimary || alertingListViewV2;
-
 const RuleViewer = () => {
   const { rule, identifier } = useAlertRule();
   const { pageNav, activeTab } = usePageNav(rule);
+
+  // GMA /api/v1/rules endpoint is strongly consistent, so we don't need to check for consistency
+  const shouldUseConsistencyCheck = isGrafanaRuleIdentifier(identifier)
+    ? false
+    : prometheusRulesPrimary || alertingListViewV2;
 
   // this will be used to track if we are in the process of cloning a rule
   // we want to be able to show a modal if the rule has been provisioned explain the limitations


### PR DESCRIPTION
This pull request updates the logic for determining when to use the consistency check in the `RuleViewer` component. The main change is that the consistency check is now disabled for Grafana-managed rules, reflecting that the `/api/v1/rules` endpoint is strongly consistent and does not require additional checks.

Logic update for consistency check:

* Added the `isGrafanaRuleIdentifier` import to support the new logic for identifying Grafana-managed rules (`public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx`).
* Updated the `shouldUseConsistencyCheck` assignment to disable the check for Grafana rule identifiers, ensuring consistency checks are only performed when necessary (`public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx`).