### PR TITLE
Chore: Remove deprecated `HorizontalGroup` in geo and transformers editors

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2860,14 +2860,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "3"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "4"]
     ],
-    "public/app/features/transformers/joinByLabels/JoinByLabelsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/transformers/lookupGazetteer/FieldLookupTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
-    "public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
     ],
     "public/app/features/transformers/spatial/optionsHelper.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],

--- a/.betterer.results
+++ b/.betterer.results
@@ -2404,9 +2404,6 @@ exports[`better eslint`] = {
     "public/app/features/expressions/guards.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "public/app/features/geo/editor/locationModeEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/geo/gazetteer/gazetteer.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Unexpected any. Specify a different type.", "1"]

--- a/.betterer.results
+++ b/.betterer.results
@@ -2802,9 +2802,6 @@ exports[`better eslint`] = {
     "public/app/features/transformers/FilterByValueTransformer/ValueMatchers/valueMatchersUI.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/transformers/calculateHeatmap/editor/AxisEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/features/transformers/calculateHeatmap/editor/helper.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/public/app/features/geo/editor/locationModeEditor.tsx
+++ b/public/app/features/geo/editor/locationModeEditor.tsx
@@ -5,7 +5,7 @@ import { StandardEditorProps, DataFrame, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { FrameGeometrySource, FrameGeometrySourceMode } from '@grafana/schema';
-import { Alert, HorizontalGroup, Icon, Select, useStyles2 } from '@grafana/ui';
+import { Alert, Icon, Select, useStyles2 } from '@grafana/ui';
 
 import { FrameGeometryField, getGeometryField, getLocationMatchers } from '../utils/location';
 
@@ -103,7 +103,7 @@ export const LocationModeEditor = ({
           onChange(v.value);
         }}
       />
-      <HorizontalGroup className={styles.hGroup}>{dataValidation()}</HorizontalGroup>
+      {dataValidation()}
     </>
   );
 };

--- a/public/app/features/transformers/calculateHeatmap/editor/AxisEditor.tsx
+++ b/public/app/features/transformers/calculateHeatmap/editor/AxisEditor.tsx
@@ -4,7 +4,7 @@ import { SelectableValue, StandardEditorProps, VariableOrigin } from '@grafana/d
 import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
 import { HeatmapCalculationBucketConfig, HeatmapCalculationMode } from '@grafana/schema';
-import { HorizontalGroup, RadioButtonGroup, ScaleDistribution } from '@grafana/ui';
+import { RadioButtonGroup, ScaleDistribution, Stack } from '@grafana/ui';
 
 import { SuggestionsInput } from '../../suggestionsInput/SuggestionsInput';
 import { numberOrVariableValidator } from '../../utils';
@@ -71,7 +71,7 @@ export const AxisEditor = ({ value, onChange, item }: StandardEditorProps<Heatma
   });
 
   return (
-    <HorizontalGroup>
+    <Stack>
       <RadioButtonGroup
         value={value?.mode || HeatmapCalculationMode.Size}
         options={value?.scale?.type === ScaleDistribution.Log ? logModeOptions : modeOptions}
@@ -98,6 +98,6 @@ export const AxisEditor = ({ value, onChange, item }: StandardEditorProps<Heatma
         }}
         suggestions={variables}
       />
-    </HorizontalGroup>
+    </Stack>
   );
 };

--- a/public/app/features/transformers/joinByLabels/JoinByLabelsTransformerEditor.tsx
+++ b/public/app/features/transformers/joinByLabels/JoinByLabelsTransformerEditor.tsx
@@ -9,7 +9,7 @@ import {
   TransformerCategory,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, HorizontalGroup, InlineField, InlineFieldRow, Select, ValuePicker } from '@grafana/ui';
+import { Alert, Stack, InlineField, InlineFieldRow, Select, ValuePicker } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
 import darkImage from '../images/dark/joinByLabels.svg';
@@ -136,7 +136,7 @@ export function JoinByLabelsTransformerEditor({ input, options, onChange }: Prop
               error="Unable to join by the value label"
               invalid={v === options.value}
             >
-              <HorizontalGroup>
+              <Stack>
                 <Select
                   options={info.joinOptions}
                   value={info.joinOptions.find((o) => o.value === v)}
@@ -153,7 +153,7 @@ export function JoinByLabelsTransformerEditor({ input, options, onChange }: Prop
                     variant="secondary"
                   />
                 )}
-              </HorizontalGroup>
+              </Stack>
             </InlineField>
           </InlineFieldRow>
         ))

--- a/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
+++ b/public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx
@@ -14,7 +14,7 @@ import {
   InlineFieldRow,
   ValuePicker,
   Button,
-  HorizontalGroup,
+  Stack,
   FieldValidationMessage,
   RadioButtonGroup,
 } from '@grafana/ui';
@@ -119,7 +119,7 @@ export function PartitionByValuesEditor({
           labelWidth={10}
           grow={true}
         >
-          <HorizontalGroup>
+          <Stack>
             {fieldNames.map((name) => (
               <Button key={name} icon="times" variant="secondary" size="md" onClick={() => removeField(name)}>
                 {name}
@@ -133,9 +133,10 @@ export function PartitionByValuesEditor({
                 onChange={addField}
                 label={t('transformers.partition-by-values-editor.label-select-field', 'Select field')}
                 icon="plus"
+                isFullWidth={false}
               />
             )}
-          </HorizontalGroup>
+          </Stack>
         </InlineField>
       </InlineFieldRow>
       <InlineFieldRow>


### PR DESCRIPTION
**What is this feature?**
Remove deprecated layout components in:
- public/app/features/geo/editor/locationModeEditor.tsx
- public/app/features/transformers/calculateHeatmap/editor/AxisEditor.tsx
- public/app/features/transformers/joinByLabels/JoinByLabelsTransformerEditor.tsx
- public/app/features/transformers/partitionByValues/PartitionByValuesEditor.tsx

**Why do we need this feature?**
To get rid of deprecated layout components.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?:**

Fixes #
Related to https://github.com/grafana/grafana/issues/86844