### PR TITLE
Folders: Fix folder parents error handling

### DIFF
--- a/pkg/registry/apis/folders/sub_parents.go
+++ b/pkg/registry/apis/folders/sub_parents.go
@@ -58,14 +58,17 @@ func (r *subParentsREST) Connect(ctx context.Context, name string, opts runtime.
 		obj, err := r.getter.Get(ctx, name, &metav1.GetOptions{})
 		if storage.IsNotFound(err) {
 			responder.Object(http.StatusNotFound, nil)
+			return
 		}
 		if err != nil {
 			responder.Error(err)
+			return
 		}
 
 		folderObj, ok := obj.(*folders.Folder)
 		if !ok {
 			responder.Error(fmt.Errorf("expecting folder, found: %T", folderObj))
+			return
 		}
 
 		info := r.parents(ctx, folderObj)


### PR DESCRIPTION
**What is this feature?**
Fixes response from the `parents` folder API when there is an error

**Why do we need this feature?**
Without this, we get this response when an error occurs (malformed JSON as all errors are returned)

```json
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "folder not found",
  "code": 404
}{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {},
  "status": "Failure",
  "message": "expecting folder, found: *v1beta1.Folder",
  "code": 500
}{
  "kind": "FolderInfoList",
  "apiVersion": "folder.grafana.app/v1beta1",
  "metadata": {},
  "items": []
}
```
