### PR TITLE
Dashboard: Resume tracking changes after save from JSON model page

### DIFF
--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -73,7 +73,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
       // FIXME: We could avoid this call by storing the entire dashboard DTO as initial dashboard scene instead of only the spec and metadata
       const dto = await getDashboardAPI('v2').getDashboardDTO(result.uid);
       newDashboardScene = transformSaveModelSchemaV2ToScene(dto);
-      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state);
+      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state, { key: dashboard.state.key });
 
       dashboard.pauseTrackingChanges();
       dashboard.setInitialSaveModel(dto.spec, dto.metadata);
@@ -84,7 +84,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
         dashboard: jsonModel,
         meta: dashboard.state.meta,
       });
-      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state);
+      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state, { key: dashboard.state.key });
 
       dashboard.pauseTrackingChanges();
       dashboard.setInitialSaveModel(jsonModel, dashboard.state.meta);
@@ -93,12 +93,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
 
     this.setState({ jsonText: this.getJsonText() });
 
-    // Given we clone the state of the new dashboard scene, new objects from the state are not activated
-    // We need to force a dashboard deactivation otherwise we lost the URL sync, and there are probably
-    // Other silent errors we didn't notice yet
-    dashboard.activate();
-
-    // We also need to resume tracking changes since any subsequent edit won't be seen by the change handler
+    // We also need to resume tracking changes since the change handler won't see any later edit
     dashboard.resumeTrackingChanges();
   };
 

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -92,6 +92,14 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
     }
 
     this.setState({ jsonText: this.getJsonText() });
+
+    // Given we clone the state of the new dashboard scene, new objects from the state are not activated
+    // We need to force a dashboard deactivation otherwise we lost the URL sync, and there are probably
+    // Other silent errors we didn't notice yet
+    dashboard.activate();
+
+    // We also need to resume tracking changes since any subsequent edit won't be seen by the change handler
+    dashboard.resumeTrackingChanges();
   };
 
   static Component = ({ model }: SceneComponentProps<JsonModelEditView>) => {


### PR DESCRIPTION
**What is this feature?**

Resume tracking changes after doing a dashboard save from the JSON model page.

Another problem was that after doing a save from the same page, we would lose the URL sync given

**Why do we need this feature?**

Fix bugs.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

GJ @Sergej-Vlasov and @oscarkilhed for helping debugging this.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
