### PR TITLE
Chore: Remove deprecated `HorizontalGroup` in plugins/panel

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -3675,9 +3675,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/annolist/AnnotationListItem.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Card components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],
-    "public/app/plugins/panel/barchart/TickSpacingEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/plugins/panel/barchart/bars.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
@@ -3740,7 +3737,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
     "public/app/plugins/panel/geomap/editor/StyleEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
+      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "1"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "2"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "3"],
@@ -3754,7 +3751,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "11"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "12"],
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "13"],
-      [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "14"],
+      [0, 0, 0, "Do not use any type assertions.", "14"],
       [0, 0, 0, "Do not use any type assertions.", "15"],
       [0, 0, 0, "Do not use any type assertions.", "16"],
       [0, 0, 0, "Do not use any type assertions.", "17"],
@@ -3765,8 +3762,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Do not use any type assertions.", "22"],
       [0, 0, 0, "Do not use any type assertions.", "23"],
       [0, 0, 0, "Do not use any type assertions.", "24"],
-      [0, 0, 0, "Do not use any type assertions.", "25"],
-      [0, 0, 0, "Do not use any type assertions.", "26"]
+      [0, 0, 0, "Do not use any type assertions.", "25"]
     ],
     "public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
@@ -3935,15 +3931,6 @@ exports[`better eslint`] = {
     "public/app/plugins/panel/text/textPanelMigrationHandler.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/plugins/panel/timeseries/InsertNullsEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "public/app/plugins/panel/timeseries/LineStyleEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
-    "public/app/plugins/panel/timeseries/SpanNullsEditor.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"]
-    ],
     "public/app/plugins/panel/timeseries/migrations.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"],
       [0, 0, 0, "Do not use any type assertions.", "1"],
@@ -3968,8 +3955,7 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx:5381": [
-      [0, 0, 0, "\'HorizontalGroup\' import from \'@grafana/ui\' is restricted from being used by a pattern. Use Stack component instead.", "0"],
-      [0, 0, 0, "Unexpected any. Specify a different type.", "1"]
+      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/xychart/SeriesEditor.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"],

--- a/public/app/plugins/panel/barchart/TickSpacingEditor.tsx
+++ b/public/app/plugins/panel/barchart/TickSpacingEditor.tsx
@@ -1,6 +1,6 @@
 import { SelectableValue, StandardEditorProps } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Checkbox, HorizontalGroup, RadioButtonGroup, Tooltip } from '@grafana/ui';
+import { Checkbox, Stack, RadioButtonGroup, Tooltip } from '@grafana/ui';
 
 export const TickSpacingEditor = (props: StandardEditorProps<number>) => {
   const GAPS_OPTIONS: Array<SelectableValue<number>> = [
@@ -53,7 +53,7 @@ export const TickSpacingEditor = (props: StandardEditorProps<number>) => {
   };
 
   return (
-    <HorizontalGroup>
+    <Stack>
       <RadioButtonGroup value={gap.value} options={GAPS_OPTIONS} onChange={onSpacingChange} />
       {value !== 0 && (
         <Tooltip
@@ -68,6 +68,6 @@ export const TickSpacingEditor = (props: StandardEditorProps<number>) => {
           </div>
         </Tooltip>
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };

--- a/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
@@ -12,15 +12,7 @@ import {
   TextDimensionConfig,
   ScalarDimensionConfig,
 } from '@grafana/schema';
-import {
-  ColorPicker,
-  Field,
-  HorizontalGroup,
-  InlineField,
-  InlineFieldRow,
-  InlineLabel,
-  RadioButtonGroup,
-} from '@grafana/ui';
+import { ColorPicker, Field, Stack, InlineField, InlineFieldRow, InlineLabel, RadioButtonGroup } from '@grafana/ui';
 import { NumberValueEditor } from 'app/core/components/OptionsUI/number';
 import { SliderValueEditor } from 'app/core/components/OptionsUI/slider';
 import { ColorDimensionEditor } from 'app/features/dimensions/editors/ColorDimensionEditor';
@@ -338,7 +330,7 @@ export const StyleEditor = (props: Props) => {
 
       {hasTextLabel && (
         <>
-          <HorizontalGroup>
+          <Stack>
             <Field label={t('geomap.style-editor.label-font-size', 'Font size')}>
               <NumberValueEditor
                 value={value?.textConfig?.fontSize ?? defaultStyleConfig.textConfig.fontSize}
@@ -363,7 +355,7 @@ export const StyleEditor = (props: Props) => {
                 item={{} as FieldConfigPropertyItem}
               />
             </Field>
-          </HorizontalGroup>
+          </Stack>
           <Field label={t('geomap.style-editor.label-align', 'Align')}>
             <RadioButtonGroup
               value={value?.textConfig?.textAlign ?? defaultStyleConfig.textConfig.textAlign}

--- a/public/app/plugins/panel/timeseries/InsertNullsEditor.tsx
+++ b/public/app/plugins/panel/timeseries/InsertNullsEditor.tsx
@@ -1,6 +1,6 @@
 import { StandardEditorProps, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { HorizontalGroup, RadioButtonGroup } from '@grafana/ui';
+import { Stack, RadioButtonGroup } from '@grafana/ui';
 
 import { InputPrefix, NullsThresholdInput } from './NullsThresholdInput';
 
@@ -21,7 +21,7 @@ export const InsertNullsEditor = ({ value, onChange, item }: Props) => {
   DISCONNECT_OPTIONS[1].value = isThreshold ? value : 3600000; // 1h
 
   return (
-    <HorizontalGroup>
+    <Stack>
       <RadioButtonGroup value={value} options={DISCONNECT_OPTIONS} onChange={onChange} />
       {isThreshold && (
         <NullsThresholdInput
@@ -31,6 +31,6 @@ export const InsertNullsEditor = ({ value, onChange, item }: Props) => {
           isTime={item.settings?.isTime ?? false}
         />
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };

--- a/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
+++ b/public/app/plugins/panel/timeseries/LineStyleEditor.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 import { StandardEditorProps, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { LineStyle } from '@grafana/schema';
-import { HorizontalGroup, IconButton, RadioButtonGroup, Select } from '@grafana/ui';
+import { IconButton, RadioButtonGroup, Select, Stack } from '@grafana/ui';
 
 type LineFill = 'solid' | 'dash' | 'dot';
 
@@ -72,7 +72,7 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
   }, [value, options]);
 
   return (
-    <HorizontalGroup>
+    <Stack wrap={true} alignItems="flex-end">
       <RadioButtonGroup
         value={value?.fill || 'solid'}
         options={lineFillOptions}
@@ -121,7 +121,7 @@ export const LineStyleEditor = ({ value, onChange }: Props) => {
           </div>
         </>
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };
 

--- a/public/app/plugins/panel/timeseries/SpanNullsEditor.tsx
+++ b/public/app/plugins/panel/timeseries/SpanNullsEditor.tsx
@@ -1,6 +1,6 @@
 import { StandardEditorProps, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { HorizontalGroup, RadioButtonGroup } from '@grafana/ui';
+import { Stack, RadioButtonGroup } from '@grafana/ui';
 
 import { InputPrefix, NullsThresholdInput } from './NullsThresholdInput';
 
@@ -25,7 +25,7 @@ export const SpanNullsEditor = ({ value, onChange, item }: Props) => {
   GAPS_OPTIONS[2].value = isThreshold ? value : 3600000; // 1h
 
   return (
-    <HorizontalGroup>
+    <Stack wrap={true}>
       <RadioButtonGroup value={value} options={GAPS_OPTIONS} onChange={onChange} />
       {isThreshold && (
         <NullsThresholdInput
@@ -35,6 +35,6 @@ export const SpanNullsEditor = ({ value, onChange, item }: Props) => {
           isTime={item.settings?.isTime ?? false}
         />
       )}
-    </HorizontalGroup>
+    </Stack>
   );
 };

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -123,7 +123,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   header: css({
     padding: theme.spacing(0.5, 1),
-    borderBottom: `1px solid ${theme.colors.border.medium}`,
+    borderBottom: `1px solid ${theme.colors.border.weak}`,
     fontWeight: theme.typography.fontWeightBold,
     fontSize: theme.typography.fontSize,
     color: theme.colors.text.primary,

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -65,7 +65,7 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
   return (
     <div className={styles.wrapper}>
       <div className={styles.header}>
-        <Stack gap={2} basis="100%">
+        <Stack gap={2} basis="100%" justifyContent="space-between" alignItems="center">
           <div className={styles.meta}>
             <span>
               {avatar}
@@ -131,15 +131,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   meta: css({
     display: 'flex',
-    flexGrow: 1,
-    justifyContent: 'flex-start',
     color: theme.colors.text.primary,
     fontWeight: 400,
   }),
   editControls: css({
     display: 'flex',
-    flexGrow: 1,
-    justifyContent: 'flex-end',
     '> :last-child': {
       marginLeft: 0,
     },

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -65,8 +65,7 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
   return (
     <div className={styles.wrapper}>
       <div className={styles.header}>
-        {/* TODO check alignment: space-between */}
-        <Stack gap={2}>
+        <Stack gap={2} basis="100%">
           <div className={styles.meta}>
             <span>
               {avatar}
@@ -132,13 +131,15 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   meta: css({
     display: 'flex',
-    justifyContent: 'space-between',
+    flexGrow: 1,
+    justifyContent: 'flex-start',
     color: theme.colors.text.primary,
     fontWeight: 400,
   }),
   editControls: css({
     display: 'flex',
-    alignItems: 'center',
+    flexGrow: 1,
+    justifyContent: 'flex-end',
     '> :last-child': {
       marginLeft: 0,
     },

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { GrafanaTheme2, dateTimeFormat, systemDateFormats, textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { HorizontalGroup, IconButton, Tag, usePanelContext, useStyles2 } from '@grafana/ui';
+import { Stack, IconButton, Tag, usePanelContext, useStyles2 } from '@grafana/ui';
 import alertDef from 'app/features/alerting/state/alertDef';
 
 interface Props {
@@ -65,7 +65,8 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
   return (
     <div className={styles.wrapper}>
       <div className={styles.header}>
-        <HorizontalGroup justify={'space-between'} align={'center'} spacing={'md'}>
+        {/* TODO check alignment: space-between */}
+        <Stack gap={2}>
           <div className={styles.meta}>
             <span>
               {avatar}
@@ -93,18 +94,18 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit }: Prop
               )}
             </div>
           )}
-        </HorizontalGroup>
+        </Stack>
       </div>
 
       <div className={styles.body}>
         {text && <div className={styles.text} dangerouslySetInnerHTML={{ __html: textUtil.sanitize(text) }} />}
         {alertText}
         <div>
-          <HorizontalGroup spacing="xs" wrap>
+          <Stack gap={0.5} wrap={true}>
             {annoVals.tags?.[annoIdx]?.map((t: string, i: number) => (
               <Tag name={t} key={`${t}-${i}`} />
             ))}
-          </HorizontalGroup>
+          </Stack>
         </div>
       </div>
     </div>
@@ -123,7 +124,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   header: css({
     padding: theme.spacing(0.5, 1),
-    borderBottom: `1px solid ${theme.colors.border.weak}`,
+    borderBottom: `1px solid ${theme.colors.border.medium}`,
     fontWeight: theme.typography.fontWeightBold,
     fontSize: theme.typography.fontSize,
     color: theme.colors.text.primary,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Remove deprecated layout components in:
- public/app/plugins/panel/barchart/TickSpacingEditor.tsx
- public/app/plugins/panel/geomap/editor/StyleEditor.tsx
- public/app/plugins/panel/timeseries/InsertNullsEditor.tsx
- public/app/plugins/panel/timeseries/LineStyleEditor.tsx
- public/app/plugins/panel/timeseries/SpanNullsEditor.tsx
- public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx

**Why do we need this feature?**
To get rid of deprecated layout components.

**Who is this feature for?**
Everybody

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
Related to #86844

**Special notes for your reviewer:**

There have been some changes, but I think they are for the better:

**SpanNullsEditor**
| Without changes | With changes |
|--|--|
|<img width="336" height="139" alt="Captura de pantalla 2025-08-13 a las 16 56 44" src="https://github.com/user-attachments/assets/2236b485-adf6-486e-831c-889d22a25410" />|<img width="335" height="179" alt="Captura de pantalla 2025-08-13 a las 16 56 31" src="https://github.com/user-attachments/assets/69a0b7cd-dfd7-4b5a-9a63-df2df65a1e13" />|

**LineStyleEditor**
| Without changes | With changes |
|--|--|
|<img width="316" height="147" alt="Captura de pantalla 2025-08-13 a las 16 47 28" src="https://github.com/user-attachments/assets/d4747d8a-c6bf-40b4-853b-e5b2ca7a1b44" />|<img width="310" height="177" alt="Captura de pantalla 2025-08-13 a las 16 47 40" src="https://github.com/user-attachments/assets/9190faa6-55ee-49a5-ab8f-39fcb8964c09" />|


Regarding **AnnotationTooltip2**, it needed a few more adjustments to align its elements correctly:
| Without changes | With changes |
|--|--|
| <img width="377" height="198" alt="Captura de pantalla 2025-08-14 a las 10 56 05" src="https://github.com/user-attachments/assets/47e31d14-807c-4078-8a69-17d87a34fe78" /> | <img width="388" height="179" alt="Captura de pantalla 2025-08-14 a las 10 55 51" src="https://github.com/user-attachments/assets/e6e74f62-4b54-4c0d-9dd1-e3070be66ded" /> |

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
