### PR TITLE
RepositoryResources: hide history button when repo type is pure git

### DIFF
--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -1,12 +1,14 @@
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useParams } from 'react-router-dom-v5-compat';
 
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { Card, EmptyState, Spinner, Stack, Text, TextLink, UserIcon } from '@grafana/ui';
 import {
   useGetRepositoryHistoryWithPathQuery,
   useGetRepositoryStatusQuery,
 } from 'app/api/clients/provisioning/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
+import { useUrlParams } from 'app/core/navigation/hooks';
 import { isNotFoundError } from 'app/features/alerting/unified/api/util';
 
 import { PROVISIONING_URL } from '../constants';
@@ -17,9 +19,16 @@ export default function FileHistoryPage() {
   const params = useParams();
   const name = params['name'] ?? '';
   const path = params['*'] ?? '';
+  const [urlParams] = useUrlParams();
+  const repoType = urlParams.get('repo_type');
+  const isPureGit = repoType === 'git';
   const query = useGetRepositoryStatusQuery({ name });
-  const history = useGetRepositoryHistoryWithPathQuery({ name, path });
-  const notFound = query.isError && isNotFoundError(query.error);
+  const history = useGetRepositoryHistoryWithPathQuery(isPureGit ? skipToken : { name, path });
+  const notFound = (query.isError && isNotFoundError(query.error)) || isPureGit;
+
+  const notFoundErrorMsg = isPureGit
+    ? t('', 'File history is not supported for pure git')
+    : t('', 'Repository not found');
 
   return (
     <Page
@@ -31,11 +40,14 @@ export default function FileHistoryPage() {
     >
       <Page.Contents isLoading={false}>
         {notFound ? (
-          <EmptyState message={`Repository not found`} variant="not-found">
+          <EmptyState message={notFoundErrorMsg} variant="not-found">
             <Text element={'p'}>
-              <Trans i18nKey="provisioning.file-history-page.repository-config-exists-configuration">
-                Make sure the repository config exists in the configuration file.
-              </Trans>
+              {/* only show detail message if repoType is not git */}
+              {repoType !== 'git' && (
+                <Trans i18nKey="provisioning.file-history-page.repository-config-exists-configuration">
+                  Make sure the repository config exists in the configuration file.
+                </Trans>
+              )}
             </Text>
             <TextLink href={PROVISIONING_URL}>
               <Trans i18nKey="provisioning.file-history-page.back-to-repositories">Back to repositories</Trans>

--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -27,8 +27,8 @@ export default function FileHistoryPage() {
   const notFound = (query.isError && isNotFoundError(query.error)) || isPureGit;
 
   const notFoundErrorMsg = isPureGit
-    ? t('', 'File history is not supported for pure git')
-    : t('', 'Repository not found');
+    ? t('i18n.provisioning.file-history-page.pure-git-not-support', 'File history is not supported for pure git')
+    : t('i18n.provisioning.file-history-page.repository-not-found', 'Repository not found');
 
   return (
     <Page

--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -27,8 +27,8 @@ export default function FileHistoryPage() {
   const notFound = (query.isError && isNotFoundError(query.error)) || isPureGit;
 
   const notFoundErrorMsg = isPureGit
-    ? t('i18n.provisioning.file-history-page.pure-git-not-support', 'File history is not supported for pure git')
-    : t('i18n.provisioning.file-history-page.repository-not-found', 'Repository not found');
+    ? t('provisioning.file-history-page.pure-git-not-support', 'File history is not supported for pure git')
+    : t('provisioning.file-history-page.repository-not-found', 'Repository not found');
 
   return (
     <Page

--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -15,19 +15,21 @@ import { PROVISIONING_URL } from '../constants';
 import { HistoryListResponse } from '../types';
 import { formatTimestamp } from '../utils/time';
 
+import { isFileHistorySupported } from './utils';
+
 export default function FileHistoryPage() {
   const params = useParams();
   const name = params['name'] ?? '';
   const path = params['*'] ?? '';
   const [urlParams] = useUrlParams();
   const repoType = urlParams.get('repo_type');
-  const isPureGit = repoType === 'git';
+  const historyNotSupported = !isFileHistorySupported(repoType);
   const query = useGetRepositoryStatusQuery({ name });
-  const history = useGetRepositoryHistoryWithPathQuery(isPureGit ? skipToken : { name, path });
-  const notFound = (query.isError && isNotFoundError(query.error)) || isPureGit;
+  const history = useGetRepositoryHistoryWithPathQuery(historyNotSupported ? skipToken : { name, path });
+  const notFound = (query.isError && isNotFoundError(query.error)) || historyNotSupported;
 
-  const notFoundErrorMsg = isPureGit
-    ? t('provisioning.file-history-page.pure-git-not-support', 'File history is not supported for pure git')
+  const notFoundErrorMsg = historyNotSupported
+    ? t('provisioning.file-history-page.history-not-supported', 'File history is not supported for this repository')
     : t('provisioning.file-history-page.repository-not-found', 'Repository not found');
 
   return (

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -59,7 +59,7 @@ export function FilesView({ repo }: FilesViewProps) {
               </LinkButton>
             )}
             {showHistoryBtn && (
-              <LinkButton href={`${PROVISIONING_URL}/${name}/history/${path}`}>
+              <LinkButton href={`${PROVISIONING_URL}/${name}/history/${path}?repo_type=${repo.spec?.type}`}>
                 <Trans i18nKey="provisioning.files-view.columns.history">History</Trans>
               </LinkButton>
             )}

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -7,6 +7,8 @@ import { Repository, useGetRepositoryFilesQuery } from 'app/api/clients/provisio
 import { PROVISIONING_URL } from '../constants';
 import { FileDetails } from '../types';
 
+import { isFileHistorySupported } from './utils';
+
 interface FilesViewProps {
   repo: Repository;
 }
@@ -20,7 +22,7 @@ export function FilesView({ repo }: FilesViewProps) {
   const data = [...(query.data?.items ?? [])].filter((file) =>
     file.path.toLowerCase().includes(searchQuery.toLowerCase())
   );
-  const showHistoryBtn = repo.spec?.type !== 'git';
+  const showHistoryBtn = isFileHistorySupported(repo.spec?.type);
 
   const columns: Array<Column<FileDetails>> = [
     {

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -20,6 +20,7 @@ export function FilesView({ repo }: FilesViewProps) {
   const data = [...(query.data?.items ?? [])].filter((file) =>
     file.path.toLowerCase().includes(searchQuery.toLowerCase())
   );
+  const showHistoryBtn = repo.spec?.type !== 'git';
 
   const columns: Array<Column<FileDetails>> = [
     {
@@ -57,9 +58,11 @@ export function FilesView({ repo }: FilesViewProps) {
                 <Trans i18nKey="provisioning.files-view.columns.view">View</Trans>
               </LinkButton>
             )}
-            <LinkButton href={`${PROVISIONING_URL}/${name}/history/${path}`}>
-              <Trans i18nKey="provisioning.files-view.columns.history">History</Trans>
-            </LinkButton>
+            {showHistoryBtn && (
+              <LinkButton href={`${PROVISIONING_URL}/${name}/history/${path}`}>
+                <Trans i18nKey="provisioning.files-view.columns.history">History</Trans>
+              </LinkButton>
+            )}
           </Stack>
         );
       },

--- a/public/app/features/provisioning/File/utils.ts
+++ b/public/app/features/provisioning/File/utils.ts
@@ -1,6 +1,4 @@
-import { RepoType } from '../Wizard/types';
-
-export function isFileHistorySupported(repoType?: string) {
-  const supportedRepoTypes: RepoType[] = ['github', 'gitlab', 'bitbucket'];
-  return repoType && repoType in supportedRepoTypes;
+export function isFileHistorySupported(repoType?: string | null): boolean {
+  const supportedRepoTypes = new Set(['github', 'gitlab', 'bitbucket']);
+  return !!repoType && supportedRepoTypes.has(repoType);
 }

--- a/public/app/features/provisioning/File/utils.ts
+++ b/public/app/features/provisioning/File/utils.ts
@@ -1,0 +1,6 @@
+import { RepoType } from '../Wizard/types';
+
+export function isFileHistorySupported(repoType?: string) {
+  const supportedRepoTypes: RepoType[] = ['github', 'gitlab', 'bitbucket'];
+  return repoType && repoType in supportedRepoTypes;
+}

--- a/public/app/features/provisioning/Repository/RepositoryResources.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryResources.tsx
@@ -4,6 +4,7 @@ import { Trans, t } from '@grafana/i18n';
 import { CellProps, Column, FilterInput, InteractiveTable, Link, LinkButton, Spinner, Stack } from '@grafana/ui';
 import { Repository, ResourceListItem, useGetRepositoryResourcesQuery } from 'app/api/clients/provisioning/v0alpha1';
 
+import { isFileHistorySupported } from '../File/utils';
 import { PROVISIONING_URL } from '../constants';
 
 interface RepoProps {
@@ -24,7 +25,7 @@ export function RepositoryResources({ repo }: RepoProps) {
   );
 
   // hide history button when repo type is pure git as it won't be implemented.
-  const showHistoryBtn = repo.spec?.type !== 'git';
+  const historySupported = isFileHistorySupported(repo.spec?.type);
 
   const columns: Array<Column<ResourceListItem>> = useMemo(
     () => [
@@ -101,7 +102,7 @@ export function RepositoryResources({ repo }: RepoProps) {
                   <Trans i18nKey="provisioning.repository-resources.columns.view-folder">View</Trans>
                 </LinkButton>
               )}
-              {showHistoryBtn && (
+              {historySupported && (
                 <LinkButton
                   href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}?repo_type=${repo.spec?.type}`}
                 >
@@ -113,7 +114,7 @@ export function RepositoryResources({ repo }: RepoProps) {
         },
       },
     ],
-    [repo.metadata?.name, showHistoryBtn, repo.spec?.type]
+    [repo.metadata?.name, historySupported, repo.spec?.type]
   );
 
   if (query.isLoading) {

--- a/public/app/features/provisioning/Repository/RepositoryResources.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryResources.tsx
@@ -23,6 +23,9 @@ export function RepositoryResources({ repo }: RepoProps) {
     Resource.path.toLowerCase().includes(searchQuery.toLowerCase())
   );
 
+  // hide history button when repo type is pure git as it won't be implemented.
+  const showHistoryBtn = repo.spec?.type !== 'git';
+
   const columns: Array<Column<ResourceListItem>> = useMemo(
     () => [
       {
@@ -98,15 +101,17 @@ export function RepositoryResources({ repo }: RepoProps) {
                   <Trans i18nKey="provisioning.repository-resources.columns.view-folder">View</Trans>
                 </LinkButton>
               )}
-              <LinkButton href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}`}>
-                <Trans i18nKey="provisioning.repository-resources.columns.history">History</Trans>
-              </LinkButton>
+              {showHistoryBtn && (
+                <LinkButton href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}`}>
+                  <Trans i18nKey="provisioning.repository-resources.columns.history">History</Trans>
+                </LinkButton>
+              )}
             </Stack>
           );
         },
       },
     ],
-    [repo.metadata?.name]
+    [repo.metadata?.name, showHistoryBtn]
   );
 
   if (query.isLoading) {

--- a/public/app/features/provisioning/Repository/RepositoryResources.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryResources.tsx
@@ -102,7 +102,9 @@ export function RepositoryResources({ repo }: RepoProps) {
                 </LinkButton>
               )}
               {showHistoryBtn && (
-                <LinkButton href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}`}>
+                <LinkButton
+                  href={`${PROVISIONING_URL}/${repo.metadata?.name}/history/${path}?repo_type=${repo.spec?.type}`}
+                >
                   <Trans i18nKey="provisioning.repository-resources.columns.history">History</Trans>
                 </LinkButton>
               )}
@@ -111,7 +113,7 @@ export function RepositoryResources({ repo }: RepoProps) {
         },
       },
     ],
-    [repo.metadata?.name, showHistoryBtn]
+    [repo.metadata?.name, showHistoryBtn, repo.spec?.type]
   );
 
   if (query.isLoading) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8993,6 +8993,14 @@
     "name-line-width": "Line width",
     "name-stacking": "Stacking"
   },
+  "i18n": {
+    "provisioning": {
+      "file-history-page": {
+        "pure-git-not-support": "File history is not supported for pure git",
+        "repository-not-found": "Repository not found"
+      }
+    }
+  },
   "inspector": {
     "inspect-data-tab": {
       "loading": "Loading",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11251,7 +11251,7 @@
     },
     "file-history-page": {
       "back-to-repositories": "Back to repositories",
-      "pure-git-not-support": "File history is not supported for pure git",
+      "history-not-supported": "File history is not supported for this repository",
       "repository-config-exists-configuration": "Make sure the repository config exists in the configuration file.",
       "repository-not-found": "Repository not found"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8993,14 +8993,6 @@
     "name-line-width": "Line width",
     "name-stacking": "Stacking"
   },
-  "i18n": {
-    "provisioning": {
-      "file-history-page": {
-        "pure-git-not-support": "File history is not supported for pure git",
-        "repository-not-found": "Repository not found"
-      }
-    }
-  },
   "inspector": {
     "inspect-data-tab": {
       "loading": "Loading",
@@ -11259,7 +11251,9 @@
     },
     "file-history-page": {
       "back-to-repositories": "Back to repositories",
-      "repository-config-exists-configuration": "Make sure the repository config exists in the configuration file."
+      "pure-git-not-support": "File history is not supported for pure git",
+      "repository-config-exists-configuration": "Make sure the repository config exists in the configuration file.",
+      "repository-not-found": "Repository not found"
     },
     "file-status-page": {
       "save": "Save",


### PR DESCRIPTION
**What is this feature?**

In Provisioning -> Repo -> Resources (tab), hide history button when repo type is pure git. 
- Both `local` and `pure git` repo type should not display history button 
<img width="1051" height="402" alt="image" src="https://github.com/user-attachments/assets/aff2236c-4c4b-4b9d-943b-c955522b7d5c" />
Files page:  
<img width="1444" height="546" alt="image" src="https://github.com/user-attachments/assets/3d6b5a4f-d715-4fbb-93bc-cd99dc72df59" />. 

History page:  
<img width="1095" height="643" alt="image" src="https://github.com/user-attachments/assets/2e8d9603-0ca3-41ff-93d3-922f3b132b04" />




**Why do we need this feature?**

 Pure git repository history is not supported.

**Who is this feature for?**

Pure git repo users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/439

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
