### PR TITLE
FS: Fix theme- class name not being set on body

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -262,18 +262,14 @@
           const theme = window.grafanaBootData.user.theme;
           if (theme === "system") {
             const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
-
-            if (darkQuery.matches) {
-              document.body.classList.add("theme-dark");
-              window.grafanaBootData.user.lightTheme = false;
-            } else {
-              document.body.classList.add("theme-light");
-              window.grafanaBootData.user.lightTheme = true;
-            }
+            window.grafanaBootData.user.lightTheme = !darkQuery.matches;
           }
-          const isLightTheme = window.grafanaBootData.user.lightTheme;
-          cssLink.href = window.grafanaBootData.assets[isLightTheme ? 'light' : 'dark'];
 
+          const isLightTheme = window.grafanaBootData.user.lightTheme;
+
+          document.body.classList.add(isLightTheme ? "theme-light" : "theme-dark");
+
+          cssLink.href = window.grafanaBootData.assets[isLightTheme ? 'light' : 'dark'];
           document.head.appendChild(cssLink);
         }
 


### PR DESCRIPTION
In the refactor of https://github.com/grafana/grafana/pull/108902, we missed setting the `theme-light`/`theme-dark` class on the body.

This caused an issue with a plugin which was relying on this to set some CSS variables.

Part of https://github.com/grafana/grafana/issues/104503