### PR TITLE
FS: Fix missing SSL certs in docker image

### DIFF
--- a/devenv/frontend-service/grafana-fs-dev.dockerfile
+++ b/devenv/frontend-service/grafana-fs-dev.dockerfile
@@ -1,5 +1,12 @@
 FROM ubuntu:24.04
 
+RUN --mount=type=cache,target=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/cache/apt \
+    set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends ca-certificates; \
+    update-ca-certificates
+
 WORKDIR /grafana
 
 RUN mkdir -p "conf/provisioning/datasources" \


### PR DESCRIPTION
The frontend-service dev stack had a issue where it couldn't make HTTPS requests because the CA certificates weren't updated in the docker image.

This fixes that!

Part of https://github.com/grafana/grafana/issues/104503