### PR TITLE
Dynamic dashboards: Fix height of disabled margin option pane categories

### DIFF
--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneCategory.tsx
@@ -214,7 +214,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   disabledIcon: css({
     color: theme.colors.text.disabled,
-    marginRight: theme.spacing(1),
+    margin: theme.spacing(1, 1, 1, 0),
   }),
   bodyNested: css({
     position: 'relative',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disabled option pane categories are not as tall as collapsed enabled categories.
This sets the disabled icon to be as big as the toggle button, making the heights match.

before:
<img width="988" height="1034" alt="image" src="https://github.com/user-attachments/assets/0b7c5ef4-8efe-4581-8bae-9d540407f2e2" />

after:
<img width="296" height="481" alt="image" src="https://github.com/user-attachments/assets/68dde402-ca91-41f6-b35d-3432bad2dcb4" />
