### PR TITLE
[release-12.0.5] Azure: Fix logs editor rendering

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
@@ -38,7 +38,7 @@ interface LogsQueryBuilderProps {
   query: AzureMonitorQuery;
   basicLogsEnabled: boolean;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
-  schema: EngineSchema;
+  schema?: EngineSchema;
   templateVariableOptions: SelectableValue<string>;
   datasource: Datasource;
   timeRange?: TimeRange;

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -632,6 +632,9 @@ describe('LogsQueryEditor', () => {
 
   describe('schema loading and auto-completion', () => {
     it('loads schema and table plans when resources change and builder mode is set', async () => {
+      // Mock these as we expect Kusto to complain about workers
+      jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'error').mockImplementation();
       const mockSchema: EngineSchema = {
         clusterType: 'Engine',
         cluster: {

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -112,11 +112,9 @@ const LogsQueryEditor = ({
             if (schema.database?.tables) {
               schema.database.tables = t;
             }
-            setSchema(schema);
           });
-        } else {
-          setSchema(schema);
         }
+        setSchema(schema);
         setIsLoadingSchema(false);
       });
     }
@@ -285,7 +283,7 @@ const LogsQueryEditor = ({
         !!config.featureToggles.azureMonitorLogsBuilderEditor ? (
           <LogsQueryBuilder
             query={query}
-            schema={schema!}
+            schema={schema}
             basicLogsEnabled={basicLogsEnabled}
             onQueryChange={onQueryChange}
             templateVariableOptions={templateVariableOptions}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
@@ -60,6 +60,25 @@ describe('LogsQueryEditor.TimeManagement', () => {
     );
   });
 
+  it('should render correctly even if no tables are in the schema', async () => {
+    const mockDatasource = createMockDatasource();
+    const query = createMockQuery({ azureLogAnalytics: { timeColumn: undefined } });
+    const onChange = jest.fn();
+
+    render(
+      <TimeManagement
+        query={query}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onQueryChange={onChange}
+        setError={() => {}}
+        schema={FakeSchemaData.getLogAnalyticsFakeEngineSchema([])}
+      />
+    );
+
+    expect(screen.getByText('Time-range')).toBeInTheDocument();
+  });
+
   it('should render the default value if no time columns exist', async () => {
     const mockDatasource = createMockDatasource();
     const query = createMockQuery();

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
@@ -20,7 +20,7 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
       const timeColumnsSet: Set<string> = new Set();
       const defaultColumnsMap: Map<string, SelectableValue> = new Map();
       const db = schema.database;
-      if (db) {
+      if (db && db?.tables?.length > 0) {
         for (const table of db.tables) {
           const cols = table.columns.reduce<SelectableValue[]>((prev, curr, i) => {
             if (curr.type === 'datetime') {
@@ -39,28 +39,27 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
             });
           }
         }
-      }
-      setTimeColumns(timeColumnOptions);
-      const defaultColumns = Array.from(defaultColumnsMap.values());
-      setDefaultTimeColumns(defaultColumns);
-
-      // Set default value
-      if (
-        !query.azureLogAnalytics.timeColumn ||
-        (query.azureLogAnalytics.timeColumn &&
-          !timeColumnsSet.has(query.azureLogAnalytics.timeColumn) &&
-          !defaultColumnsMap.has(query.azureLogAnalytics.timeColumn))
-      ) {
-        if (defaultColumns && defaultColumns.length) {
-          setDefaultColumn(defaultColumns[0].value);
-          setDefaultColumn(defaultColumns[0].value);
-          return;
-        } else if (timeColumnOptions && timeColumnOptions.length) {
-          setDefaultColumn(timeColumnOptions[0].value);
-          return;
-        } else {
-          setDefaultColumn('TimeGenerated');
-          return;
+        setTimeColumns(timeColumnOptions);
+        const defaultColumns = Array.from(defaultColumnsMap.values());
+        setDefaultTimeColumns(defaultColumns);
+        // Set default value
+        if (
+          !query.azureLogAnalytics.timeColumn ||
+          (query.azureLogAnalytics.timeColumn &&
+            !timeColumnsSet.has(query.azureLogAnalytics.timeColumn) &&
+            !defaultColumnsMap.has(query.azureLogAnalytics.timeColumn))
+        ) {
+          if (defaultColumns && defaultColumns.length) {
+            setDefaultColumn(defaultColumns[0].value);
+            setDefaultColumn(defaultColumns[0].value);
+            return;
+          } else if (timeColumnOptions && timeColumnOptions.length) {
+            setDefaultColumn(timeColumnOptions[0].value);
+            return;
+          } else {
+            setDefaultColumn('TimeGenerated');
+            return;
+          }
         }
       }
     }


### PR DESCRIPTION
Backport b34642b1880a496c51b6fa826aa52ac5612f3165 from #109491

---

The Logs query editor has a re-rendering issue when the schema provided has no tables.

This PR rectifies the problem and prevents the infinite re-render. Also, I've added a test for the schema loading. An additional test has been added to the time management component for a schema without tables.

This can be tested by building and running Grafana and connecting to Azure Monitor. Choosing the resource `azmonlogstest` with this branch will succeed. Testing without this branch will lead to the editor crashing.

Fixes #109613 
