### PR TITLE
[release-12.1.2] Azure: Fix logs editor rendering

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryBuilder/LogsQueryBuilder.tsx
@@ -36,7 +36,7 @@ interface LogsQueryBuilderProps {
   query: AzureMonitorQuery;
   basicLogsEnabled: boolean;
   onQueryChange: (newQuery: AzureMonitorQuery) => void;
-  schema: EngineSchema;
+  schema?: EngineSchema;
   templateVariableOptions: SelectableValue<string>;
   datasource: Datasource;
   timeRange?: TimeRange;

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -6,6 +6,7 @@ import { dateTime, LoadingState } from '@grafana/data';
 import { ResultFormat } from '../../dataquery.gen';
 import createMockDatasource from '../../mocks/datasource';
 import createMockQuery from '../../mocks/query';
+import { EngineSchema } from '../../types/types';
 
 import LogsQueryEditor from './LogsQueryEditor';
 import { createMockResourcePickerData } from './mocks';
@@ -626,6 +627,129 @@ describe('LogsQueryEditor', () => {
         azureLogAnalytics: { resultFormat: ResultFormat.Logs },
       };
       expect(onChange).toHaveBeenCalledWith(newQuery);
+    });
+  });
+
+  describe('schema loading and auto-completion', () => {
+    it('loads schema and table plans when resources change and builder mode is set', async () => {
+      const mockSchema: EngineSchema = {
+        clusterType: 'Engine',
+        cluster: {
+          connectionString:
+            '/subscriptions/subscriptionId/resourceGroups/resourceGroup/providers/Microsoft.OperationalInsights/workspaces/la-workspace',
+          databases: [
+            {
+              name: '/subscriptions/subscriptionId/resourceGroups/resourceGroup/providers/Microsoft.OperationalInsights/workspaces/la-workspace',
+              tables: [
+                {
+                  columns: [
+                    {
+                      description: '',
+                      isPreferredFacet: false,
+                      name: 'TenantId',
+                      type: 'string',
+                    },
+                    {
+                      description: 'Date and time when dependency call was recorded.',
+                      isPreferredFacet: false,
+                      name: 'TimeGenerated',
+                      type: 'datetime',
+                    },
+                  ],
+                  description: 'Application Insights dependencies.',
+                  id: 'AppDependencies',
+                  name: 'AppDependencies',
+                  timespanColumn: 'TimeGenerated',
+                  hasData: true,
+                  related: {
+                    solutions: [],
+                    functions: [],
+                    categories: [],
+                  },
+                },
+              ],
+              functions: [],
+              majorVersion: 0,
+              minorVersion: 0,
+              entityGroups: [],
+            },
+          ],
+        },
+        database: {
+          name: '/subscriptions/subscriptionId/resourceGroups/resourceGroup/providers/Microsoft.OperationalInsights/workspaces/la-workspace',
+          tables: [
+            {
+              columns: [
+                {
+                  description: '',
+                  isPreferredFacet: false,
+                  name: 'TenantId',
+                  type: 'string',
+                },
+                {
+                  description: 'Date and time when dependency call was recorded.',
+                  isPreferredFacet: false,
+                  name: 'TimeGenerated',
+                  type: 'datetime',
+                },
+              ],
+              description: 'Application Insights dependencies.',
+              id: 'AppDependencies',
+              name: 'AppDependencies',
+              timespanColumn: 'TimeGenerated',
+              hasData: true,
+              related: {
+                solutions: [],
+                functions: [],
+                categories: [],
+              },
+            },
+          ],
+          functions: [],
+          majorVersion: 0,
+          minorVersion: 0,
+          entityGroups: [],
+        },
+      };
+      const mockDatasource = createMockDatasource();
+      mockDatasource.azureLogAnalyticsDatasource.getKustoSchema = jest.fn().mockResolvedValue(mockSchema);
+      // @ts-ignore: forcibly attach for test
+      mockDatasource.azureMonitorDatasource.getWorkspaceTablePlan = jest.fn().mockResolvedValue('plan');
+      const query = createMockQuery({
+        azureLogAnalytics: {
+          resources: [
+            '/subscriptions/def-456/resourceGroups/dev-3/providers/microsoft.operationalinsights/workspaces/la-workspace',
+          ],
+          mode: require('../../dataquery.gen').LogsEditorMode.Builder,
+        },
+      });
+      const onChange = jest.fn();
+      const onQueryChange = jest.fn();
+
+      await act(async () => {
+        render(
+          <LogsQueryEditor
+            query={query}
+            datasource={mockDatasource}
+            variableOptionGroup={variableOptionGroup}
+            onChange={onChange}
+            onQueryChange={onQueryChange}
+            setError={() => {}}
+            basicLogsEnabled={true}
+          />
+        );
+      });
+
+      await waitFor(() => {
+        expect(mockDatasource.azureLogAnalyticsDatasource.getKustoSchema).toHaveBeenCalledWith(
+          query.azureLogAnalytics?.resources?.[0]
+        );
+      });
+      expect(mockDatasource.azureMonitorDatasource.getWorkspaceTablePlan).toHaveBeenCalledTimes(1);
+      expect(mockDatasource.azureMonitorDatasource.getWorkspaceTablePlan).toHaveBeenCalledWith(
+        query.azureLogAnalytics?.resources,
+        'AppDependencies'
+      );
     });
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.test.tsx
@@ -632,6 +632,9 @@ describe('LogsQueryEditor', () => {
 
   describe('schema loading and auto-completion', () => {
     it('loads schema and table plans when resources change and builder mode is set', async () => {
+      // Mock these as we expect Kusto to complain about workers
+      jest.spyOn(console, 'warn').mockImplementation();
+      jest.spyOn(console, 'error').mockImplementation();
       const mockSchema: EngineSchema = {
         clusterType: 'Engine',
         cluster: {

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsQueryEditor.tsx
@@ -108,11 +108,9 @@ const LogsQueryEditor = ({
             if (schema.database?.tables) {
               schema.database.tables = t;
             }
-            setSchema(schema);
           });
-        } else {
-          setSchema(schema);
         }
+        setSchema(schema);
         setIsLoadingSchema(false);
       });
     }
@@ -281,7 +279,7 @@ const LogsQueryEditor = ({
         !!config.featureToggles.azureMonitorLogsBuilderEditor ? (
           <LogsQueryBuilder
             query={query}
-            schema={schema!}
+            schema={schema}
             basicLogsEnabled={basicLogsEnabled}
             onQueryChange={onQueryChange}
             templateVariableOptions={templateVariableOptions}

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.test.tsx
@@ -60,6 +60,25 @@ describe('LogsQueryEditor.TimeManagement', () => {
     );
   });
 
+  it('should render correctly even if no tables are in the schema', async () => {
+    const mockDatasource = createMockDatasource();
+    const query = createMockQuery({ azureLogAnalytics: { timeColumn: undefined } });
+    const onChange = jest.fn();
+
+    render(
+      <TimeManagement
+        query={query}
+        datasource={mockDatasource}
+        variableOptionGroup={variableOptionGroup}
+        onQueryChange={onChange}
+        setError={() => {}}
+        schema={FakeSchemaData.getLogAnalyticsFakeEngineSchema([])}
+      />
+    );
+
+    expect(screen.getByText('Time-range')).toBeInTheDocument();
+  });
+
   it('should render the default value if no time columns exist', async () => {
     const mockDatasource = createMockDatasource();
     const query = createMockQuery();

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/TimeManagement.tsx
@@ -21,7 +21,7 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
       const timeColumnsSet: Set<string> = new Set();
       const defaultColumnsMap: Map<string, SelectableValue> = new Map();
       const db = schema.database;
-      if (db) {
+      if (db && db?.tables?.length > 0) {
         for (const table of db.tables) {
           const cols = table.columns.reduce<SelectableValue[]>((prev, curr, i) => {
             if (curr.type === 'datetime') {
@@ -40,28 +40,27 @@ export function TimeManagement({ query, onQueryChange: onChange, schema }: Azure
             });
           }
         }
-      }
-      setTimeColumns(timeColumnOptions);
-      const defaultColumns = Array.from(defaultColumnsMap.values());
-      setDefaultTimeColumns(defaultColumns);
-
-      // Set default value
-      if (
-        !query.azureLogAnalytics.timeColumn ||
-        (query.azureLogAnalytics.timeColumn &&
-          !timeColumnsSet.has(query.azureLogAnalytics.timeColumn) &&
-          !defaultColumnsMap.has(query.azureLogAnalytics.timeColumn))
-      ) {
-        if (defaultColumns && defaultColumns.length) {
-          setDefaultColumn(defaultColumns[0].value);
-          setDefaultColumn(defaultColumns[0].value);
-          return;
-        } else if (timeColumnOptions && timeColumnOptions.length) {
-          setDefaultColumn(timeColumnOptions[0].value);
-          return;
-        } else {
-          setDefaultColumn('TimeGenerated');
-          return;
+        setTimeColumns(timeColumnOptions);
+        const defaultColumns = Array.from(defaultColumnsMap.values());
+        setDefaultTimeColumns(defaultColumns);
+        // Set default value
+        if (
+          !query.azureLogAnalytics.timeColumn ||
+          (query.azureLogAnalytics.timeColumn &&
+            !timeColumnsSet.has(query.azureLogAnalytics.timeColumn) &&
+            !defaultColumnsMap.has(query.azureLogAnalytics.timeColumn))
+        ) {
+          if (defaultColumns && defaultColumns.length) {
+            setDefaultColumn(defaultColumns[0].value);
+            setDefaultColumn(defaultColumns[0].value);
+            return;
+          } else if (timeColumnOptions && timeColumnOptions.length) {
+            setDefaultColumn(timeColumnOptions[0].value);
+            return;
+          } else {
+            setDefaultColumn('TimeGenerated');
+            return;
+          }
         }
       }
     }


### PR DESCRIPTION
Backport b34642b1880a496c51b6fa826aa52ac5612f3165 from #109491

---

The Logs query editor has a re-rendering issue when the schema provided has no tables.

This PR rectifies the problem and prevents the infinite re-render. Also, I've added a test for the schema loading. An additional test has been added to the time management component for a schema without tables.

This can be tested by building and running Grafana and connecting to Azure Monitor. Choosing the resource `azmonlogstest` with this branch will succeed. Testing without this branch will lead to the editor crashing.

Fixes #109613 
