### PR TITLE
New Logs Panel: Performance and display updates and fixes

### DIFF
--- a/public/app/features/logs/components/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.test.tsx
@@ -57,10 +57,9 @@ function setup(
   startPosition: number,
   rows: LogRowModel[],
   order: LogsSortOrder,
-  app?: CoreApp
+  app?: CoreApp,
+  { element, events } = getMockElement(startPosition)
 ) {
-  const { element, events } = getMockElement(startPosition);
-
   function scrollTo(position: number, timeStamp?: number) {
     element.scrollTop = position;
 
@@ -69,7 +68,7 @@ function setup(
       if (timeStamp) {
         jest.spyOn(event, 'timeStamp', 'get').mockReturnValue(timeStamp);
       }
-      events['scroll'](event);
+      events['scroll']?.(event);
     });
 
     // When scrolling top, we wait for the user to reach the top, and then for a new scrolling event
@@ -192,11 +191,13 @@ describe('InfiniteScroll', () => {
 
       test('Does not request more logs when there is no scroll', async () => {
         const loadMoreMock = jest.fn();
-        const { scrollTo, element } = setup(loadMoreMock, 0, rows, order);
-
-        expect(await screen.findByTestId('contents')).toBeInTheDocument();
+        const { element, events } = getMockElement(0);
         element.clientHeight = 40;
         element.scrollHeight = element.clientHeight;
+
+        const { scrollTo } = setup(loadMoreMock, 0, rows, order, undefined, { element, events });
+
+        expect(await screen.findByTestId('contents')).toBeInTheDocument();
 
         scrollTo(39, 1);
         scrollTo(40, 600);

--- a/public/app/features/logs/components/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/InfiniteScroll.tsx
@@ -81,6 +81,9 @@ export const InfiniteScroll = ({
     if (!scrollElement || !loadMoreLogs) {
       return;
     }
+    if (scrollElement.scrollHeight <= scrollElement.clientHeight) {
+      return;
+    }
 
     function handleScroll(event: Event | WheelEvent) {
       if (!scrollElement || !loadMoreLogs || !rows.length || loading || !config.featureToggles.logsInfiniteScrolling) {
@@ -227,10 +230,6 @@ export function shouldLoadMore(
   element: HTMLDivElement,
   lastScroll: number
 ): ScrollDirection {
-  // Disable behavior if there is no scroll
-  if (element.scrollHeight <= element.clientHeight) {
-    return ScrollDirection.NoScroll;
-  }
   const delta = event instanceof WheelEvent ? event.deltaY : element.scrollTop - lastScroll;
   if (delta === 0) {
     return ScrollDirection.NoScroll;

--- a/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.test.tsx
@@ -46,10 +46,9 @@ function setup(
   startPosition: number,
   logs: LogListModel[],
   order: LogsSortOrder,
-  infiniteScrollMode: InfiniteScrollMode = 'interval'
+  infiniteScrollMode: InfiniteScrollMode = 'interval',
+  { element, events } = getMockElement(startPosition)
 ) {
-  const { element, events } = getMockElement(startPosition);
-
   function scrollTo(position: number, timeStamp?: number) {
     element.scrollTop = position;
 
@@ -168,11 +167,13 @@ describe('InfiniteScroll', () => {
 
       test('Does not request more logs when there is no scroll', async () => {
         const loadMoreMock = jest.fn();
-        const { scrollTo, element } = setup(loadMoreMock, 0, logs, order);
-
-        expect(await screen.findByText('log line 1')).toBeInTheDocument();
+        const { element, events } = getMockElement(0);
         element.clientHeight = 40;
         element.scrollHeight = element.clientHeight;
+
+        const { scrollTo } = setup(loadMoreMock, 0, logs, order, undefined, { element, events });
+
+        expect(await screen.findByText('log line 1')).toBeInTheDocument();
 
         scrollTo(39, 1);
         scrollTo(40, 600);

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -73,6 +73,7 @@ export const InfiniteScroll = ({
   const styles = useStyles2(getStyles, virtualization);
   const resetStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollToLogLineRef = useRef<LogListModel | undefined>(undefined);
+  const noScrollRef = useRef(false);
 
   useEffect(() => {
     // Logs have not changed, ignore effect
@@ -237,10 +238,13 @@ export const InfiniteScroll = ({
 
   const onItemsRendered = useCallback(
     (props: ListOnItemsRenderedProps) => {
-      if (!scrollElement || infiniteLoaderState === 'loading' || infiniteLoaderState === 'out-of-bounds') {
+      if (!scrollElement) {
         return;
       }
-      if (scrollElement.scrollHeight <= scrollElement.clientHeight) {
+      if (props.visibleStartIndex === 0) {
+        noScrollRef.current = scrollElement.scrollHeight <= scrollElement.clientHeight;
+      }
+      if (noScrollRef.current || infiniteLoaderState === 'loading' || infiniteLoaderState === 'out-of-bounds') {
         return;
       }
       const lastLogIndex = logs.length - 1;

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -110,7 +110,7 @@ const LogLineComponent = memo(
     const permalinked = useLogIsPermalinked(log);
 
     useEffect(() => {
-      if (!onOverflow || !logLineRef.current || !virtualization || !height) {
+      if (!onOverflow || !logLineRef.current || !virtualization || !height || !wrapLogMessage) {
         return;
       }
       const calculatedHeight = typeof height === 'number' ? height : undefined;

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -178,6 +178,7 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
     height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
     paddingBottom: theme.spacing(0.5),
     marginRight: 1,
+    maxWidth: '95vw',
   }),
   container: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -134,7 +134,7 @@ export interface InlineLogLineDetailsProps {
 }
 
 export const InlineLogLineDetails = memo(({ logs, log }: InlineLogLineDetailsProps) => {
-  const { app, noInteractions } = useLogListContext();
+  const { app, detailsWidth, noInteractions } = useLogListContext();
   const styles = useStyles2(getStyles, 'inline');
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -159,7 +159,7 @@ export const InlineLogLineDetails = memo(({ logs, log }: InlineLogLineDetailsPro
   }, [log]);
 
   return (
-    <div className={`${styles.inlineWrapper} log-line-inline-details`}>
+    <div className={`${styles.inlineWrapper} log-line-inline-details`} style={{ maxWidth: detailsWidth }}>
       <div className={styles.container}>
         <div className={styles.scrollContainer} ref={scrollRef} onScroll={saveScroll}>
           <LogLineDetailsComponent log={log} logs={logs} />
@@ -178,7 +178,6 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
     height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
     paddingBottom: theme.spacing(0.5),
     marginRight: 1,
-    maxWidth: '95vw',
   }),
   container: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -312,9 +312,6 @@ const LogListComponent = ({
   }, [eventBus, filteredLogs]);
 
   useEffect(() => {
-    if (loading) {
-      return;
-    }
     setProcessedLogs(
       preProcessLogs(
         logs,
@@ -324,7 +321,7 @@ const LogListComponent = ({
     );
     virtualization.resetLogLineSizes();
     listRef.current?.resetAfterIndex(0);
-  }, [forceEscape, getFieldLinks, grammar, loading, logs, sortOrder, timeZone, virtualization, wrapLogMessage]);
+  }, [forceEscape, getFieldLinks, grammar, logs, sortOrder, timeZone, virtualization, wrapLogMessage]);
 
   useEffect(() => {
     listRef.current?.resetAfterIndex(0);

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -96,6 +96,7 @@ type LogListComponentProps = Omit<
   | 'dedupStrategy'
   | 'displayedFields'
   | 'enableLogDetails'
+  | 'loading'
   | 'logOptionsStorageKey'
   | 'permalinkedLogId'
   | 'showTime'
@@ -202,7 +203,6 @@ export const LogList = ({
           grammar={grammar}
           initialScrollPosition={initialScrollPosition}
           infiniteScrollMode={infiniteScrollMode}
-          loading={loading}
           loadMore={loadMore}
           logs={logs}
           showControls={showControls}
@@ -221,7 +221,6 @@ const LogListComponent = ({
   grammar,
   initialScrollPosition = 'top',
   infiniteScrollMode = 'interval',
-  loading,
   loadMore,
   logs,
   showControls,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -586,8 +586,6 @@ export const LogListContextProvider = ({
   const hasSampledLogs = useMemo(() => logs.some((log) => !!checkLogsSampled(log)), [logs]);
   const hasUnescapedContent = useMemo(() => logs.some((r) => r.hasUnescapedContent), [logs]);
 
-  console.log(detailsWidth);
-
   return (
     <LogListContext.Provider
       value={{

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -13,6 +13,8 @@ export const FIELD_GAP_MULTIPLIER = 1.5;
 
 export const DEFAULT_LINE_HEIGHT = 22;
 
+export const LOG_LIST_CONTROLS_WIDTH = 32;
+
 export class LogLineVirtualization {
   private ctx: CanvasRenderingContext2D | null = null;
   private gridSize;


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

Optimizations:
- Ommit overflow checks when the log line is unwrapped. It's a single line with fixed height, so it was an unnecessary operation to do while log lines are displayed. 4fec7788540b92f0d4748b9939c0aa829f123a7a
- Refactored access to `scrollHeight` because the profiler showed reflows caused by these unnecessary reads, which were only to know if there was a scroll or not. 4db6268224e38b2498171493ef7df0ac04d305d6 and 1a16916c6e894f3c89a4a9f588115749f499d8f5

Improvements:
- Added a maxWidth to inline Log Details to prevent it for being as wide as an unwrapped log line, which can be infinitely wide. ef0738c48546871ed0425b9cef4a65ccfd550b63 . Now taking the container width instead of using a harcoded max width, and using a resize observer to respond to resizes in Dashboards. b80874f99b079e7e444639934e8675ce3b2a0930

Fixes:
- Process logs while loading. Fixes a situation where, while log results are streaming (multi-day query), if the user changed the wrapping settings, it would generate an inconsistent visual state because loading logs weren't being processed. ef0738c48546871ed0425b9cef4a65ccfd550b63
- Fixed a running condition, specially while streaming, where the log results would not be rendered, because of a combination of re-renders and the `logsContainerRef` reference. 569a2482a0ea181c66d3a227e9f2f7f6dc678d72

### How to test

Optimizations: no repro steps. The changes were based on profilling while scrolling logs. There shouldn't be reflows caused by accessing `scrollHeight`

Improvements: inline log details of very log lines should not be wider than the log visualization.

Fixes: with the logs panel streaming (multi-day query receiving less than 1000 lines), changing line wrapping should not produce display errors.