### PR TITLE
Alerting: Add keepFiringFor and missing_series_evals_to_resolve to file provisioning

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -273,7 +273,7 @@ type AlertRuleExport struct {
 	NoDataState   *NoDataState         `json:"noDataState,omitempty" yaml:"noDataState,omitempty" hcl:"no_data_state"`
 	ExecErrState  *ExecutionErrorState `json:"execErrState,omitempty" yaml:"execErrState,omitempty" hcl:"exec_err_state"`
 	For           model.Duration       `json:"for,omitempty" yaml:"for,omitempty"`
-	KeepFiringFor model.Duration       `json:"keepFiringFor,omitempty" yaml:"keepFiringFor,omitempty" hcl:"keep_firing_for"`
+	KeepFiringFor model.Duration       `json:"keepFiringFor,omitempty" yaml:"keepFiringFor,omitempty"`
 	// ForString and KeepFiringForString are used to:
 	// - Only export the for field for HCL if it is non-zero.
 	// - Format the Prometheus model.Duration type properly for HCL.

--- a/pkg/services/provisioning/alerting/rules_types.go
+++ b/pkg/services/provisioning/alerting/rules_types.go
@@ -62,21 +62,23 @@ func (ruleGroupV1 *AlertRuleGroupV1) MapToModel() (models.AlertRuleGroupWithFold
 }
 
 type AlertRuleV1 struct {
-	UID                  values.StringValue      `json:"uid" yaml:"uid"`
-	Title                values.StringValue      `json:"title" yaml:"title"`
-	Condition            values.StringValue      `json:"condition" yaml:"condition"`
-	Data                 []QueryV1               `json:"data" yaml:"data"`
-	DasboardUID          values.StringValue      `json:"dasboardUid" yaml:"dasboardUid"` // TODO: Grandfathered typo support. TODO: This should be removed in V2.
-	DashboardUID         values.StringValue      `json:"dashboardUid" yaml:"dashboardUid"`
-	PanelID              values.Int64Value       `json:"panelId" yaml:"panelId"`
-	NoDataState          values.StringValue      `json:"noDataState" yaml:"noDataState"`
-	ExecErrState         values.StringValue      `json:"execErrState" yaml:"execErrState"`
-	For                  values.StringValue      `json:"for" yaml:"for"`
-	Annotations          values.StringMapValue   `json:"annotations" yaml:"annotations"`
-	Labels               values.StringMapValue   `json:"labels" yaml:"labels"`
-	IsPaused             values.BoolValue        `json:"isPaused" yaml:"isPaused"`
-	NotificationSettings *NotificationSettingsV1 `json:"notification_settings" yaml:"notification_settings"`
-	Record               *RecordV1               `json:"record" yaml:"record"`
+	UID                         values.StringValue      `json:"uid" yaml:"uid"`
+	Title                       values.StringValue      `json:"title" yaml:"title"`
+	Condition                   values.StringValue      `json:"condition" yaml:"condition"`
+	Data                        []QueryV1               `json:"data" yaml:"data"`
+	DasboardUID                 values.StringValue      `json:"dasboardUid" yaml:"dasboardUid"` // TODO: Grandfathered typo support. TODO: This should be removed in V2.
+	DashboardUID                values.StringValue      `json:"dashboardUid" yaml:"dashboardUid"`
+	PanelID                     values.Int64Value       `json:"panelId" yaml:"panelId"`
+	NoDataState                 values.StringValue      `json:"noDataState" yaml:"noDataState"`
+	ExecErrState                values.StringValue      `json:"execErrState" yaml:"execErrState"`
+	For                         values.StringValue      `json:"for" yaml:"for"`
+	KeepFiringFor               values.StringValue      `json:"keepFiringFor" yaml:"keepFiringFor"`
+	MissingSeriesEvalsToResolve values.Int64Value       `json:"missing_series_evals_to_resolve" yaml:"missing_series_evals_to_resolve"`
+	Annotations                 values.StringMapValue   `json:"annotations" yaml:"annotations"`
+	Labels                      values.StringMapValue   `json:"labels" yaml:"labels"`
+	IsPaused                    values.BoolValue        `json:"isPaused" yaml:"isPaused"`
+	NotificationSettings        *NotificationSettingsV1 `json:"notification_settings" yaml:"notification_settings"`
+	Record                      *RecordV1               `json:"record" yaml:"record"`
 }
 
 func withFallback(value, fallback string) *string {
@@ -107,6 +109,24 @@ func (rule *AlertRuleV1) mapToModel(orgID int64) (models.AlertRule, error) {
 		}
 	}
 	alertRule.For = time.Duration(duration)
+
+	keepFiringForDuration := model.Duration(0)
+	if rule.KeepFiringFor.Value() != "" {
+		var err error
+		keepFiringForDuration, err = model.ParseDuration(rule.KeepFiringFor.Value())
+		if err != nil {
+			return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse 'keepFiringFor' field: %w", alertRule.Title, err)
+		}
+	}
+	alertRule.KeepFiringFor = time.Duration(keepFiringForDuration)
+
+	if rule.MissingSeriesEvalsToResolve.Raw != "" {
+		missingSeriesEvalsToResolve := rule.MissingSeriesEvalsToResolve.Value()
+		if missingSeriesEvalsToResolve < 0 {
+			return models.AlertRule{}, fmt.Errorf("rule '%s' failed to parse 'missing_series_evals_to_resolve' field: cannot be negative", alertRule.Title)
+		}
+		alertRule.MissingSeriesEvalsToResolve = &missingSeriesEvalsToResolve
+	}
 
 	dasboardUID := rule.DasboardUID.Value()
 	dashboardUID := rule.DashboardUID.Value()

--- a/pkg/tests/api/alerting/api_provisioning_test.go
+++ b/pkg/tests/api/alerting/api_provisioning_test.go
@@ -1028,6 +1028,15 @@ func TestIntegrationExportFileProvision(t *testing.T) {
 		require.Equal(t, http.StatusOK, status)
 		require.Greater(t, len(data), 0)
 
+		t.Run("provisioned alert rules should have proper data", func(t *testing.T) {
+			provisionedRule, status, _ := apiClient.GetProvisioningAlertRule(t, "my_id_1")
+			require.Equal(t, http.StatusOK, status)
+
+			require.Equal(t, model.Duration(time.Second*120), provisionedRule.KeepFiringFor)
+			require.NotNil(t, provisionedRule.MissingSeriesEvalsToResolve)
+			require.Equal(t, int64(3), *provisionedRule.MissingSeriesEvalsToResolve)
+		})
+
 		t.Run("exported alert rules should escape $ characters", func(t *testing.T) {
 			// call export endpoint
 			status, exportRaw := apiClient.ExportRulesWithStatus(t, &definitions.AlertRulesExportParameters{

--- a/pkg/tests/api/alerting/test-data/provisioning-rules.yaml
+++ b/pkg/tests/api/alerting/test-data/provisioning-rules.yaml
@@ -62,6 +62,10 @@ groups:
         execErrState: Alerting
         # <duration, required> for how long should the alert fire before alerting
         for: 60s
+        # <duration> for how long the alert should keep firing after condition stops being true
+        keepFiringFor: 120s
+        # <int> number of evaluation intervals required to resolve alert when data is missing
+        missing_series_evals_to_resolve: 3
         # <map<string, string>> a map of strings to pass around any data
         annotations:
           some_key: some_value

--- a/pkg/tests/api/alerting/testing.go
+++ b/pkg/tests/api/alerting/testing.go
@@ -1487,6 +1487,14 @@ func createUser(t *testing.T, db db.DB, cfg *setting.Cfg, cmd user.CreateUserCom
 	return u.ID
 }
 
+func (a apiClient) GetProvisioningAlertRule(t *testing.T, ruleUID string) (apimodels.ProvisionedAlertRule, int, string) {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("%s/api/v1/provisioning/alert-rules/%s", a.url, ruleUID), nil)
+	require.NoError(t, err)
+
+	return sendRequestJSON[apimodels.ProvisionedAlertRule](t, req, http.StatusOK)
+}
+
 func (a apiClient) GetProvisioningAlertRuleExport(t *testing.T, ruleUID string, params *apimodels.ExportQueryParams) (int, string) {
 	t.Helper()
 	u, err := url.Parse(fmt.Sprintf("%s/api/v1/provisioning/alert-rules/%s/export", a.url, ruleUID))


### PR DESCRIPTION
**What is this feature?**

Added support for `keepFiringFor` and `missing_series_evals_to_resolve` fields in alert rule file provisioning.

**Why do we need this feature?**

These fields were being ignored in file provisioning despite being supported in the API.

**Who is this feature for?**

Users of file provisioning in Grafana Alerting.

**Which issue(s) does this PR fix?**:

Fixes #109367

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
