### PR TITLE
Sparkline: Properly handle flat data (min === max)

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -121,8 +121,8 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
       if (min === 0) {
         max = 100;
       } else {
-        min = Math.min(min - 10, 0);
-        max! *= 2;
+        min = 0;
+        max *= 2;
       }
     }
 

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -103,25 +103,30 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
 
   getYRange(field: Field): Range.MinMax {
     let { min, max } = this.state.alignedDataFrame.fields[1].state?.range!;
-    const noValue = +this.state.alignedDataFrame.fields[1].config?.noValue!;
 
+    // enure that the min/max from the field config are respected
+    min = Math.max(min!, field.config.min ?? -Infinity);
+    max = Math.min(max!, field.config.max ?? Infinity);
+
+    // if noValue is set, ensure that it is included in the range as well
+    const noValue = +this.state.alignedDataFrame.fields[1].config?.noValue!;
     if (!Number.isNaN(noValue)) {
-      min = Math.min(min!, +noValue);
-      max = Math.max(max!, +noValue);
+      min = Math.min(min, +noValue);
+      max = Math.max(max, +noValue);
     }
 
+    // if min and max are equal after all of that, create a range
+    // that allows the sparkline to be visible in the center of the viz
     if (min === max) {
       if (min === 0) {
         max = 100;
       } else {
-        min = 0;
+        min = Math.min(min - 10, 0);
         max! *= 2;
       }
-
-      return [min, max!];
     }
 
-    return [Math.max(min!, field.config.min ?? -Infinity), Math.min(max!, field.config.max ?? Infinity)];
+    return [min, max];
   }
 
   prepareConfig(data: DataFrame) {

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -26,7 +26,7 @@ import { UPlotChart } from '../uPlot/Plot';
 import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 import { preparePlotData2, getStackingGroups } from '../uPlot/utils';
 
-import { preparePlotFrame } from './utils';
+import { getYRange, preparePlotFrame } from './utils';
 
 export interface SparklineProps extends Themeable2 {
   width: number;
@@ -102,31 +102,7 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
   }
 
   getYRange(field: Field): Range.MinMax {
-    let { min, max } = this.state.alignedDataFrame.fields[1].state?.range!;
-
-    // enure that the min/max from the field config are respected
-    min = Math.max(min!, field.config.min ?? -Infinity);
-    max = Math.min(max!, field.config.max ?? Infinity);
-
-    // if noValue is set, ensure that it is included in the range as well
-    const noValue = +this.state.alignedDataFrame.fields[1].config?.noValue!;
-    if (!Number.isNaN(noValue)) {
-      min = Math.min(min, noValue);
-      max = Math.max(max, noValue);
-    }
-
-    // if min and max are equal after all of that, create a range
-    // that allows the sparkline to be visible in the center of the viz
-    if (min === max) {
-      if (min === 0) {
-        max = 100;
-      } else {
-        min = 0;
-        max *= 2;
-      }
-    }
-
-    return [min, max];
+    return getYRange(field, this.state.alignedDataFrame);
   }
 
   prepareConfig(data: DataFrame) {

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -111,8 +111,8 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
     // if noValue is set, ensure that it is included in the range as well
     const noValue = +this.state.alignedDataFrame.fields[1].config?.noValue!;
     if (!Number.isNaN(noValue)) {
-      min = Math.min(min, +noValue);
-      max = Math.max(max, +noValue);
+      min = Math.min(min, noValue);
+      max = Math.max(max, noValue);
     }
 
     // if min and max are equal after all of that, create a range

--- a/packages/grafana-ui/src/components/Sparkline/utils.test.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.test.ts
@@ -172,6 +172,8 @@ describe('Get y range', () => {
       expected: [0, 2],
     },
   ])(`should return correct range for $description`, ({ field, expected }) => {
-    expect(getYRange(field, getAlignedFrame(field))).toEqual(expected);
+    const actual = getYRange(field, getAlignedFrame(field));
+    expect(actual).toEqual(expected);
+    expect(actual[0]).toBeLessThan(actual[1]!);
   });
 });

--- a/packages/grafana-ui/src/components/Sparkline/utils.test.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.test.ts
@@ -93,7 +93,7 @@ describe('Prepare Sparkline plot frame', () => {
 });
 
 describe('Get y range', () => {
-  const yField: Field = {
+  const defaultYField: Field = {
     name: 'y',
     values: [1, 2, 3, 4, 5],
     type: FieldType.number,
@@ -120,101 +120,58 @@ describe('Get y range', () => {
     type: FieldType.time,
     config: {},
   };
+  const getAlignedFrame = (yField: Field) => ({
+    refId: 'sparkline',
+    fields: [xField, yField],
+    length: yField.values.length,
+  });
   it.each([
     {
       description: 'inferred min and max',
-      field: yField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, yField],
-        length: yField.values.length,
-      },
+      field: defaultYField,
       expected: [1, 5],
     },
     {
       description: 'min from config',
-      field: yField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, { ...yField, config: { min: 3 }, state: { range: { min: 3, max: 5, delta: 2 } } }],
-        length: yField.values.length,
-      },
+      field: { ...defaultYField, config: { min: 3 }, state: { range: { min: 3, max: 5, delta: 2 } } },
       expected: [3, 5],
     },
     {
       description: 'max from config',
-      field: yField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, { ...yField, config: { max: 30 }, state: { range: { min: 1, max: 30, delta: 29 } } }],
-        length: yField.values.length,
-      },
+      field: { ...defaultYField, config: { max: 30 }, state: { range: { min: 1, max: 30, delta: 29 } } },
       expected: [1, 30],
     },
     {
       description: 'no value is set',
-      field: yField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, { ...yField, config: { noValue: '0' } }],
-        length: yField.values.length,
-      },
+      field: { ...defaultYField, config: { noValue: '0' } },
       expected: [0, 5],
     },
     {
       description: 'NaN no value is set',
-      field: yField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, { ...yField, config: { noValue: 'foo' } }],
-        length: yField.values.length,
-      },
+      field: { ...defaultYField, config: { noValue: 'foo' } },
       expected: [1, 5],
     },
     {
       description: 'straight line',
       field: straightLineYField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, straightLineYField],
-        length: straightLineYField.values.length,
-      },
       expected: [0, 4],
     },
     {
       description: 'straight line, negative values',
-      field: straightLineYField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, straightLineNegYField],
-        length: straightLineYField.values.length,
-      },
+      field: straightLineNegYField,
       expected: [-4, 0],
     },
     {
       description: 'straight line with config min and max',
-      field: straightLineYField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [
-          xField,
-          { ...straightLineYField, config: { min: 1, max: 3 }, state: { range: { min: 1, max: 3, delta: 2 } } },
-        ],
-        length: straightLineYField.values.length,
-      },
+      field: { ...straightLineYField, config: { min: 1, max: 3 }, state: { range: { min: 1, max: 3, delta: 2 } } },
       expected: [1, 3],
     },
     {
       description: 'straight line with config no value',
-      field: straightLineYField,
-      alignedFrame: {
-        refId: 'sparkline',
-        fields: [xField, { ...straightLineYField, config: { noValue: '0' } }],
-        length: straightLineYField.values.length,
-      },
+      field: { ...straightLineYField, config: { noValue: '0' } },
       expected: [0, 2],
     },
-  ])(`should return correct range for $description`, ({ field, alignedFrame, expected }) => {
-    expect(getYRange(field, alignedFrame)).toEqual(expected);
+  ])(`should return correct range for $description`, ({ field, expected }) => {
+    expect(getYRange(field, getAlignedFrame(field))).toEqual(expected);
   });
 });

--- a/packages/grafana-ui/src/components/Sparkline/utils.test.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.test.ts
@@ -1,6 +1,6 @@
-import { FieldSparkline, FieldType } from '@grafana/data';
+import { Field, FieldSparkline, FieldType } from '@grafana/data';
 
-import { preparePlotFrame } from './utils';
+import { getYRange, preparePlotFrame } from './utils';
 
 describe('Prepare Sparkline plot frame', () => {
   it('should return sorted array if x-axis numeric', () => {
@@ -89,5 +89,132 @@ describe('Prepare Sparkline plot frame', () => {
 
     expect(frame.fields[0].values).toEqual([2, 3, 4, 5, 6, 7]);
     expect(frame.fields[1].values).toEqual([2, null, 3, null, null, 1]);
+  });
+});
+
+describe('Get y range', () => {
+  const yField: Field = {
+    name: 'y',
+    values: [1, 2, 3, 4, 5],
+    type: FieldType.number,
+    config: {},
+    state: { range: { min: 1, max: 5, delta: 4 } },
+  };
+  const straightLineYField: Field = {
+    name: 'y',
+    values: [2, 2, 2, 2, 2],
+    type: FieldType.number,
+    config: {},
+    state: { range: { min: 2, max: 2, delta: 0 } },
+  };
+  const straightLineNegYField: Field = {
+    name: 'y',
+    values: [-2, -2, -2, -2, -2],
+    type: FieldType.number,
+    config: {},
+    state: { range: { min: -2, max: -2, delta: 0 } },
+  };
+  const xField: Field = {
+    name: 'x',
+    values: [1000, 2000, 3000, 4000, 5000],
+    type: FieldType.time,
+    config: {},
+  };
+  it.each([
+    {
+      description: 'inferred min and max',
+      field: yField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, yField],
+        length: yField.values.length,
+      },
+      expected: [1, 5],
+    },
+    {
+      description: 'min from config',
+      field: yField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, { ...yField, config: { min: 3 }, state: { range: { min: 3, max: 5, delta: 2 } } }],
+        length: yField.values.length,
+      },
+      expected: [3, 5],
+    },
+    {
+      description: 'max from config',
+      field: yField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, { ...yField, config: { max: 30 }, state: { range: { min: 1, max: 30, delta: 29 } } }],
+        length: yField.values.length,
+      },
+      expected: [1, 30],
+    },
+    {
+      description: 'no value is set',
+      field: yField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, { ...yField, config: { noValue: '0' } }],
+        length: yField.values.length,
+      },
+      expected: [0, 5],
+    },
+    {
+      description: 'NaN no value is set',
+      field: yField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, { ...yField, config: { noValue: 'foo' } }],
+        length: yField.values.length,
+      },
+      expected: [1, 5],
+    },
+    {
+      description: 'straight line',
+      field: straightLineYField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, straightLineYField],
+        length: straightLineYField.values.length,
+      },
+      expected: [0, 4],
+    },
+    {
+      description: 'straight line, negative values',
+      field: straightLineYField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, straightLineNegYField],
+        length: straightLineYField.values.length,
+      },
+      expected: [-4, 0],
+    },
+    {
+      description: 'straight line with config min and max',
+      field: straightLineYField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [
+          xField,
+          { ...straightLineYField, config: { min: 1, max: 3 }, state: { range: { min: 1, max: 3, delta: 2 } } },
+        ],
+        length: straightLineYField.values.length,
+      },
+      expected: [1, 3],
+    },
+    {
+      description: 'straight line with config no value',
+      field: straightLineYField,
+      alignedFrame: {
+        refId: 'sparkline',
+        fields: [xField, { ...straightLineYField, config: { noValue: '0' } }],
+        length: straightLineYField.values.length,
+      },
+      expected: [0, 2],
+    },
+  ])(`should return correct range for $description`, ({ field, alignedFrame, expected }) => {
+    expect(getYRange(field, alignedFrame)).toEqual(expected);
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -97,6 +97,7 @@ export function TableNG(props: TableNGProps) {
     onSortByChange,
     showTypeIcons,
     structureRev,
+    timeRange,
     transparent,
     width,
   } = props;
@@ -461,6 +462,7 @@ export function TableNG(props: TableNGProps) {
                 theme,
                 value,
                 width,
+                timeRange,
                 cellInspect,
                 showFilters,
                 getActions: getCellActions,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -648,6 +648,7 @@ export function TableNG(props: TableNGProps) {
     showTypeIcons,
     sortColumns,
     styles,
+    timeRange,
     theme,
     visibleFields,
     widths,


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/17903

This appears to have flared up as a result of [honoring the min and max in the config](https://github.com/grafana/grafana/pull/107991), particularly if some other complication comes up like if you have a `noValue` config set at the same time.

This fix is one possible path, the other would be to add logic to SparklineCell to prevent passing identical min and max in.