### PR TITLE
Docs: Fix broken links

### DIFF
--- a/docs/sources/dashboards/_index.md
+++ b/docs/sources/dashboards/_index.md
@@ -1,7 +1,7 @@
 ---
 aliases:
   - features/dashboard/dashboards/ # /docs/grafana/latest/features/dashboard/dashboards/
-  - dashboards/previews/ # /docs/grafana/latest/dashboards/previews/
+  - ./dashboards/previews/ # /docs/grafana/latest/dashboards/previews/
 labels:
   products:
     - cloud

--- a/docs/sources/panels-visualizations/visualizations/table/index.md
+++ b/docs/sources/panels-visualizations/visualizations/table/index.md
@@ -411,7 +411,7 @@ also toggle on **Pagination** to avoid performance issues in larger tables, sinc
 Dynamic height disables table {{< term "virtualization" >}}virtualization{{< /term >}}.
 
 By default, the HTML rendered is sanitized, and un-sanitized HTML can only be rendered
-in these cells if the [`disable_sanitize_html`](../../../setup-grafana/configure-grafana/_index.md#disable_sanitize_html) option is set to true for your Grafana instance.
+in these cells if the [`disable_sanitize_html`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#disable_sanitize_html) option is set to true for your Grafana instance.
 
 #### Image
 


### PR DESCRIPTION
Fixes link with typo and incorrect alias (whoops!).