### PR TITLE
Prometheus: Export interpolateQueryExpr for metrics drilldown links

### DIFF
--- a/packages/grafana-prometheus/src/datasource.ts
+++ b/packages/grafana-prometheus/src/datasource.ts
@@ -47,7 +47,7 @@ import {
   InstantQueryRefIdIndex,
   SUGGESTIONS_LIMIT,
 } from './constants';
-import { prometheusRegularEscape, prometheusSpecialRegexEscape } from './escaping';
+import { interpolateQueryExpr, prometheusRegularEscape } from './escaping';
 import {
   exportToAbstractQuery,
   importFromAbstractQuery,
@@ -379,22 +379,7 @@ export class PrometheusDatasource
   }
 
   interpolateQueryExpr(value: string | string[] = [], variable: QueryVariableModel | CustomVariableModel) {
-    // if no multi or include all do not regexEscape
-    if (!variable.multi && !variable.includeAll) {
-      return prometheusRegularEscape(value);
-    }
-
-    if (typeof value === 'string') {
-      return prometheusSpecialRegexEscape(value);
-    }
-
-    const escapedValues = value.map((val) => prometheusSpecialRegexEscape(val));
-
-    if (escapedValues.length === 1) {
-      return escapedValues[0];
-    }
-
-    return '(' + escapedValues.join('|') + ')';
+    return interpolateQueryExpr(value, variable);
   }
 
   targetContainsTemplate(target: PromQuery) {

--- a/packages/grafana-prometheus/src/escaping.ts
+++ b/packages/grafana-prometheus/src/escaping.ts
@@ -1,7 +1,30 @@
 // NOTE: these two functions are similar to the escapeLabelValueIn* functions
 // in language_utils.ts, but they are not exactly the same algorithm, and we found
 
+import { QueryVariableModel, CustomVariableModel } from '@grafana/data';
 import { config } from '@grafana/runtime';
+
+export function interpolateQueryExpr(
+  value: string | string[] = [],
+  variable: QueryVariableModel | CustomVariableModel
+) {
+  // if no multi or include all do not regexEscape
+  if (!variable.multi && !variable.includeAll) {
+    return prometheusRegularEscape(value);
+  }
+
+  if (typeof value === 'string') {
+    return prometheusSpecialRegexEscape(value);
+  }
+
+  const escapedValues = value.map((val) => prometheusSpecialRegexEscape(val));
+
+  if (escapedValues.length === 1) {
+    return escapedValues[0];
+  }
+
+  return '(' + escapedValues.join('|') + ')';
+}
 
 // no way to reuse one in the another or vice versa.
 export function prometheusRegularEscape<T>(value: T) {

--- a/packages/grafana-prometheus/src/index.ts
+++ b/packages/grafana-prometheus/src/index.ts
@@ -58,6 +58,7 @@ export { PrometheusDatasource } from './datasource';
 // The parts
 export { addLabelToQuery } from './add_label_to_query';
 export { type QueryEditorMode, type PromQueryFormat, type Prometheus } from './dataquery';
+export { interpolateQueryExpr } from './escaping';
 export { loadResources } from './loadResources';
 export { PrometheusMetricFindQuery } from './metric_find_query';
 export { promqlGrammar } from './promql';


### PR DESCRIPTION
**What is this feature?**

In metrics drilldown, we want to interpolate variables in a query expr when a user opens metrics drilldown from a dashboard. The dashboards can have variables so we want to interpolate the query from our app's link. 

Currently we are copying and pasting this function. We would like to just import it :) 

**Why do we need this feature?**

To ease developers lives, for metrics drilldown links from queries with variables.

**Who is this feature for?**

This is for users of the prometheus frontend library and for metrics drilldown developers.

**Special notes for your reviewer:**
The function is exported.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
