### PR TITLE
Chore: Removed unused style definition

### DIFF
--- a/public/app/features/geo/editor/locationModeEditor.tsx
+++ b/public/app/features/geo/editor/locationModeEditor.tsx
@@ -120,11 +120,5 @@ const getStyles = (theme: GrafanaTheme2) => {
       marginTop: '5px',
       padding: theme.spacing(0.25),
     }),
-    // TODO apply styling to horizontal group (currently not working)
-    hGroup: css({
-      '& div': {
-        width: '100%',
-      },
-    }),
   };
 };


### PR DESCRIPTION
From this change: https://github.com/grafana/grafana/pull/109602/files#diff-734f03ac7fa7f38ba0adc4211232806766b2731a5349a19c7fd00a44f4c7b9e1L106

The `hGroup` style is no longer used, and so now removed

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
