### PR TITLE
Chore: fix flakey secure value test

### DIFF
--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -48,6 +49,7 @@ func TestSecureLifecycle(t *testing.T) {
 		err := prepareSecureValues(context.Background(), secureStore, obj, nil, info)
 		require.NoError(t, err)
 		require.True(t, info.hasChanged)
+		slices.Sort(info.createdSecureValues) // keep a predictable order
 		require.Equal(t, []string{"NameForA", "NameForB"}, info.createdSecureValues)
 		secure, err := obj.GetSecureValues()
 		require.NoError(t, err)


### PR DESCRIPTION
Avoid testing the results of map keys order

eg https://github.com/grafana/grafana/actions/runs/16972549708/job/48113069456?pr=109582
```
--- FAIL: TestSecureLifecycle (0.00s)
    --- FAIL: TestSecureLifecycle/create_secure_values (0.00s)
        secure_test.go:51:
            	Error Trace:	/home/runner/work/grafana/grafana/pkg/storage/unified/apistore/secure_test.go:51
            	Error:      	Not equal:
            	            	expected: []string{"NameForA", "NameForB"}
            	            	actual  : []string{"NameForB", "NameForA"}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -1,4 +1,4 @@
            	            	 ([]string) (len=2) {
            	            	- (string) (len=8) "NameForA",
            	            	- (string) (len=8) "NameForB"
            	            	+ (string) (len=8) "NameForB",
            	            	+ (string) (len=8) "NameForA"
            	            	 }
            	Test:       	TestSecureLifecycle/create_secure_values
```