### PR TITLE
API: (Chore) Update response / Errors.As to pointer to pointer

### DIFF
--- a/pkg/api/response/response.go
+++ b/pkg/api/response/response.go
@@ -286,7 +286,7 @@ func Err(err error) *NormalResponse {
 // If the error provided is not an errutil.Error and is/wraps context.Canceled
 // the function returns an Err(errRequestCanceledBase).
 func ErrOrFallback(status int, message string, err error) *NormalResponse {
-	grafanaErr := errutil.Error{}
+	grafanaErr := &errutil.Error{}
 	if errors.As(err, &grafanaErr) {
 		return Err(err)
 	}


### PR DESCRIPTION
I think it is supposed to be like this, and the linter might have complained if it were new code? (Don't want to divert from current branch and work, so making that as a note to look into).



Fixes #

**Special notes for your reviewer:**

errutil doesn't use pointer recievers, it is like:

```
// Error implements the error interface.
func (e Error) Error() string {
	return fmt.Sprintf("[%s] %s", e.MessageID, e.LogMessage)
}
```

So not sure.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
