### PR TITLE
Alerting: Use db pagination for prometheus api

### DIFF
--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -30,7 +30,7 @@ import (
 
 type RuleStoreReader interface {
 	GetUserVisibleNamespaces(context.Context, int64, identity.Requester) (map[string]*folder.Folder, error)
-	ListAlertRulesStore
+	ListAlertRulesStoreV2
 }
 
 type RuleGroupAccessControlService interface {
@@ -292,7 +292,7 @@ func (srv PrometheusSrv) RouteGetRuleStatuses(c *contextmodel.ReqContext) respon
 		return response.JSON(ruleResponse.HTTPStatusCode(), ruleResponse)
 	}
 
-	ruleResponse = PrepareRuleGroupStatuses(
+	ruleResponse = PrepareRuleGroupStatusesV2(
 		srv.log,
 		srv.store,
 		RuleGroupStatusesOptions{


### PR DESCRIPTION
This reintroduces database pagination for the Prometheus API for rules.

Follow up for #109558 to use the new pagination format.

Note: This changes the sort-order to use `NamespaceUID` instead of the fully qualified Folder path. This also changes the cursor format to use the `NamespaceUID` instead of the Folder path and to be in a reverisble format.
