### PR TITLE
[release-12.1.2] Docs: Remove enterprise product label and add more notes

### DIFF
--- a/docs/sources/dashboards/build-dashboards/create-dynamic-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dynamic-dashboard/index.md
@@ -2,7 +2,6 @@
 labels:
   products:
     - cloud
-    - enterprise
     - oss
   stage:
     - experimental
@@ -161,6 +160,14 @@ To create a dashboard, follow these steps:
 1. When you've saved all the changes you want to make to the dashboard, click **Back to dashboard**.
 1. Toggle off the edit mode switch.
 
+{{< admonition type="caution" >}}
+
+Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
+
+**Do not enable this feature in production environments as it may result in the irreversible loss of data.**
+
+{{< /admonition >}}
+
 ## Group panels
 
 To help create meaningful sections in your dashboard, you can group panels into rows or tabs.
@@ -294,6 +301,14 @@ To configure show/hide rules, follow these steps:
 1. Click **Save**.
 1. Toggle off the edit mode switch.
 
+{{< admonition type="caution" >}}
+
+Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
+
+**Do not enable this feature in production environments as it may result in the irreversible loss of data.**
+
+{{< /admonition >}}
+
 ## Edit dashboards
 
 When the dashboard is in edit mode, the edit pane that opens displays options associated with the part of the dashboard that it's in focus.
@@ -397,3 +412,11 @@ To make a copy of a dashboard, follow these steps:
    By default, the copied dashboard has the same name as the original dashboard with the word "Copy" appended and is in the same folder.
 
 1. Click **Save**.
+
+{{< admonition type="caution" >}}
+
+Dynamic dashboards is an [experimental](https://grafana.com/docs/release-life-cycle/) feature. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
+
+**Do not enable this feature in production environments as it may result in the irreversible loss of data.**
+
+{{< /admonition >}}


### PR DESCRIPTION
Backport 19d2bfba7f881a8a1452e0fddd8377fc8c39c3d8 from #109270

---

Removing Enterprise product label and adding more experimental caution notes to further discourage users from installing DD in on-premise production environments.
