### PR TITLE
Transformations: POC of frame alias, non global

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/joinByField.ts
+++ b/packages/grafana-data/src/transformations/transformers/joinByField.ts
@@ -17,6 +17,7 @@ export enum JoinMode {
 export interface JoinByFieldOptions {
   byField?: string; // empty will pick the field automatically
   mode?: JoinMode;
+  frameAlias?: string;
 }
 
 export const joinByFieldTransformer: SynchronousDataTransformerInfo<JoinByFieldOptions> = {
@@ -42,7 +43,9 @@ export const joinByFieldTransformer: SynchronousDataTransformerInfo<JoinByFieldO
         }
         const joined = joinDataFrames({ frames: data, joinBy, mode: options.mode });
         if (joined) {
-          joined.refId = `${DataTransformerID.joinByField}-${data.map((frame) => frame.refId).join('-')}`;
+          const newRefId =
+            options.frameAlias ?? `${DataTransformerID.joinByField}-${data.map((frame) => frame.refId).join('-')}`;
+          joined.refId = newRefId;
           return [joined];
         }
       }

--- a/packages/grafana-data/src/transformations/transformers/merge.ts
+++ b/packages/grafana-data/src/transformations/transformers/merge.ts
@@ -12,7 +12,9 @@ interface ValuePointer {
   index: number;
 }
 
-export interface MergeTransformerOptions {}
+export interface MergeTransformerOptions {
+  frameAlias?: string;
+}
 
 export const mergeTransformer: DataTransformerInfo<MergeTransformerOptions> = {
   id: DataTransformerID.merge,
@@ -43,8 +45,10 @@ export const mergeTransformer: DataTransformerInfo<MergeTransformerOptions> = {
         const fieldNames = new Set<string>();
         const fieldIndexByName: Record<string, Record<number, number>> = {};
         const fieldNamesForKey: string[] = [];
+        const newRefId =
+          options.frameAlias ?? `${DataTransformerID.merge}-${data.map((frame) => frame.refId).join('-')}`;
         const dataFrame = new MutableDataFrame({
-          refId: `${DataTransformerID.merge}-${data.map((frame) => frame.refId).join('-')}`,
+          refId: newRefId,
           fields: [],
         });
 

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -22,6 +22,7 @@ export interface ReduceTransformerOptions {
   mode?: ReduceTransformerMode;
   includeTimeField?: boolean;
   labelsToFields?: boolean;
+  frameAlias?: string;
 }
 
 export const reduceTransformer: DataTransformerInfo<ReduceTransformerOptions> = {
@@ -56,9 +57,9 @@ export const reduceTransformer: DataTransformerInfo<ReduceTransformerOptions> = 
 
         // Add a row for each series
         const res = reduceSeriesToRows(data, matcher, options.reducers, options.labelsToFields);
-        return res
-          ? [{ ...res, refId: `${DataTransformerID.reduce}-${data.map((frame) => frame.refId).join('-')}` }]
-          : [];
+        const newRefId =
+          options.frameAlias ?? `${DataTransformerID.reduce}-${data.map((frame) => frame.refId).join('-')}`;
+        return res ? [{ ...res, refId: newRefId }] : [];
       })
     ),
 };

--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -117,7 +117,7 @@ export function SeriesToFieldsTransformerEditor({ input, options, onChange }: Tr
           labelWidth={16}
           label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
         >
-          <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
+          <Input id="frame-alias" value={options.frameAlias} onChange={onChangeFrameAlias} />
         </InlineField>
       </InlineFieldRow>
     </>

--- a/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/JoinByFieldTransformerEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { ChangeEvent, useCallback } from 'react';
 
 import {
   DataTransformerID,
@@ -11,7 +11,7 @@ import {
 import { JoinByFieldOptions, JoinMode } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
-import { Select, InlineFieldRow, InlineField } from '@grafana/ui';
+import { Select, InlineFieldRow, InlineField, Input } from '@grafana/ui';
 import { useFieldDisplayNames, useSelectOptions } from '@grafana/ui/internal';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
@@ -75,6 +75,16 @@ export function SeriesToFieldsTransformerEditor({ input, options, onChange }: Tr
     [onChange, options]
   );
 
+  const onChangeFrameAlias = useCallback(
+    (evt: ChangeEvent<HTMLInputElement>) => {
+      onChange({
+        ...options,
+        frameAlias: evt.target.value,
+      });
+    },
+    [onChange, options]
+  );
+
   return (
     <>
       <InlineFieldRow>
@@ -101,6 +111,13 @@ export function SeriesToFieldsTransformerEditor({ input, options, onChange }: Tr
             placeholder="time"
             isClearable
           />
+        </InlineField>
+        <InlineField
+          htmlFor="frame-alias"
+          labelWidth={16}
+          label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
+        >
+          <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
         </InlineField>
       </InlineFieldRow>
     </>

--- a/public/app/features/transformers/editors/MergeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/MergeTransformerEditor.tsx
@@ -1,3 +1,5 @@
+import { useCallback, ChangeEvent } from 'react';
+
 import {
   DataTransformerID,
   standardTransformers,
@@ -7,13 +9,23 @@ import {
 } from '@grafana/data';
 import { MergeTransformerOptions } from '@grafana/data/internal';
 import { Trans, t } from '@grafana/i18n';
-import { FieldValidationMessage } from '@grafana/ui';
+import { FieldValidationMessage, InlineField, Input } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
 import darkImage from '../images/dark/merge.svg';
 import lightImage from '../images/light/merge.svg';
 
 export const MergeTransformerEditor = ({ input, options, onChange }: TransformerUIProps<MergeTransformerOptions>) => {
+  const onChangeFrameAlias = useCallback(
+    (evt: ChangeEvent<HTMLInputElement>) => {
+      onChange({
+        ...options,
+        frameAlias: evt.target.value,
+      });
+    },
+    [onChange, options]
+  );
+
   if (input.length <= 1) {
     // Show warning that merge is useless only apply on a single frame
     return (
@@ -24,7 +36,15 @@ export const MergeTransformerEditor = ({ input, options, onChange }: Transformer
       </FieldValidationMessage>
     );
   }
-  return null;
+  return (
+    <InlineField
+      htmlFor="frame-alias"
+      labelWidth={16}
+      label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
+    >
+      <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
+    </InlineField>
+  );
 };
 
 export const getMergeTransformerRegistryItem: () => TransformerRegistryItem<MergeTransformerOptions> = () => ({

--- a/public/app/features/transformers/editors/MergeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/MergeTransformerEditor.tsx
@@ -42,7 +42,7 @@ export const MergeTransformerEditor = ({ input, options, onChange }: Transformer
       labelWidth={16}
       label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
     >
-      <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
+      <Input id="frame-alias" value={options.frameAlias} onChange={onChangeFrameAlias} />
     </InlineField>
   );
 };

--- a/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
@@ -130,7 +130,7 @@ export const ReduceTransformerEditor = ({ options, onChange }: TransformerUIProp
             labelWidth={16}
             label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
           >
-            <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
+            <Input id="frame-alias" value={options.frameAlias} onChange={onChangeFrameAlias} />
           </InlineField>
         </>
       )}

--- a/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ReduceTransformerEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { ChangeEvent, useCallback } from 'react';
 
 import {
   DataTransformerID,
@@ -12,7 +12,7 @@ import {
 import { ReduceTransformerMode, ReduceTransformerOptions } from '@grafana/data/internal';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { InlineField, Select, StatsPicker, InlineSwitch } from '@grafana/ui';
+import { InlineField, Select, StatsPicker, InlineSwitch, Input } from '@grafana/ui';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
 import darkImage from '../images/dark/reduce.svg';
@@ -65,6 +65,16 @@ export const ReduceTransformerEditor = ({ options, onChange }: TransformerUIProp
     });
   }, [onChange, options]);
 
+  const onChangeFrameAlias = useCallback(
+    (evt: ChangeEvent<HTMLInputElement>) => {
+      onChange({
+        ...options,
+        frameAlias: evt.target.value,
+      });
+    },
+    [onChange, options]
+  );
+
   return (
     <>
       <InlineField
@@ -107,13 +117,22 @@ export const ReduceTransformerEditor = ({ options, onChange }: TransformerUIProp
         </InlineField>
       )}
       {options.mode !== ReduceTransformerMode.ReduceFields && (
-        <InlineField
-          htmlFor="labels-to-fields"
-          labelWidth={16}
-          label={t('transformers.reduce-transformer-editor.label-labels-to-fields', 'Labels to fields')}
-        >
-          <InlineSwitch id="labels-to-fields" value={!!options.labelsToFields} onChange={onToggleLabels} />
-        </InlineField>
+        <>
+          <InlineField
+            htmlFor="labels-to-fields"
+            labelWidth={16}
+            label={t('transformers.reduce-transformer-editor.label-labels-to-fields', 'Labels to fields')}
+          >
+            <InlineSwitch id="labels-to-fields" value={!!options.labelsToFields} onChange={onToggleLabels} />
+          </InlineField>
+          <InlineField
+            htmlFor="frame-alias"
+            labelWidth={16}
+            label={t('transformers.reduce-transformer-editor.label-frame-alias', 'Frame Alias')}
+          >
+            <Input id="frame-alias" value={options.frameAlias ?? ''} onChange={onChangeFrameAlias} />
+          </InlineField>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
This is a WIP/POC so we can discuss a pressing problem we're seeing more issues with. This did not run the i18n script to keep the changeset minimal. I am not interested in nit type feedback while this is in draft. This is to facilitate a design discussion until this description is edited and the PR is taken out of draft.

### Problem:
Several transformations result in a merged data frame, that is named something like `<operation>-<refId1>-<refId2>...` and so on. This can break filters when a user action causes the number of frames merged to change, as it results in a changed refID. Things dependent on that refID, such as transformation filters, will break. 

On a superficial level, this can cause confusion when filters would disappear. This was fixed in https://github.com/grafana/grafana/pull/109008 . However, in some cases, the disappearing filters will break panels. Internal folk, please see https://github.com/grafana/support-escalations/issues/17303

This is also written up here https://github.com/grafana/grafana/issues/103955 

Since we use the same naming pattern, its easy to see what transformations are directly affected

- Join by field ([src](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/joinByField.ts#L45))
- Merge ([src](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/merge.ts#L47))
- Reduce ([src](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/reduce.ts#L60))
- Series to Rows ([src](https://github.com/grafana/grafana/blob/main/packages/grafana-data/src/transformations/transformers/seriesToRows.ts#L41))
- Join by labels ([src](https://github.com/grafana/grafana/blob/main/public/app/features/transformers/joinByLabels/joinByLabels.ts#L114))

#### Demonstrations of problem

In this video, I go through the three transformations in this PR, demonstrate how changing the variable can alter the results and break refIDs. I did not do a good job of showing this, but the variable list will change the prometheus query to filter by the selected servers. There is one dataframe returned per server.

On the last demo, I demonstrate how adding the frame alias of "test" using the code change in the PR can make the refID stable, and thus not break when the results change.

https://github.com/user-attachments/assets/78efcfec-4473-4238-856a-b74ebe0e99bc

The following dashboard requires `gdev-prometheus` to be running from devenv. Due to the structure of the data, it is best repro'd using prometheus that can expect dynamic queries from a variable.
<details><summary>Example dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 23064,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "prometheus",
        "uid": "gdev-prometheus"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "editorMode": "builder",
          "expr": "counters_logins{job=\"fake-data-gen\", server=~\"$query0\"}",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        }
      ],
      "title": "Reduce Example",
      "transformations": [
        {
          "id": "reduce",
          "options": {
            "includeTimeField": false,
            "mode": "seriesToRows",
            "reducers": [
              "max"
            ]
          }
        },
        {
          "filter": {
            "id": "byRefId",
            "options": ""
          },
          "id": "calculateField",
          "options": {}
        }
      ],
      "type": "table"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "gdev-prometheus"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 8
      },
      "id": 2,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "editorMode": "builder",
          "expr": "counters_logins{job=\"fake-data-gen\", server=~\"$query0\"}",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        }
      ],
      "title": "Merge Example",
      "transformations": [
        {
          "id": "merge",
          "options": {}
        },
        {
          "id": "calculateField",
          "options": {}
        }
      ],
      "type": "table"
    },
    {
      "datasource": {
        "type": "prometheus",
        "uid": "gdev-prometheus"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 16
      },
      "id": 3,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "editorMode": "builder",
          "expr": "counters_logins{job=\"fake-data-gen\", server=~\"$query0\"}",
          "instant": false,
          "legendFormat": "__auto",
          "range": true,
          "refId": "A"
        }
      ],
      "title": "Join by Example",
      "transformations": [
        {
          "id": "joinByField",
          "options": {
            "byField": "Time",
            "mode": "outer"
          }
        },
        {
          "id": "calculateField",
          "options": {}
        }
      ],
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": [
      {
        "allValue": "*",
        "allowCustomValue": false,
        "current": {
          "text": [
            "backend-01",
            "webserver-01"
          ],
          "value": [
            "backend-01",
            "webserver-01"
          ]
        },
        "datasource": {
          "type": "prometheus",
          "uid": "gdev-prometheus"
        },
        "definition": "label_values(counters_requests,server)",
        "includeAll": false,
        "multi": true,
        "name": "query0",
        "options": [],
        "query": {
          "qryType": 1,
          "query": "label_values(counters_requests,server)",
          "refId": "PrometheusVariableQueryEditor-VariableQuery"
        },
        "refresh": 1,
        "regex": "",
        "type": "query"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Frame alias Examples",
  "uid": "25df3d23-872c-44fc-8d35-1cfdbeb2e962",
  "version": 14
}
```
</details>

### Seeking feedback
I have done three transformations out of this as part of this PR to demonstrate what kind of code impact this change has. The question I have is **should we limit this to just the 5 above, or consider making it a part of the global transformation UI and bring it into the code for every transformation?** Although the five above emit a new frame, all transformations end up emiting one or more dataframe(s). We could conceivably have an override for all of them (although with some that emit more than one dataframe, like partition by values, this might not make sense directly).

If we decide to do this globally, it would be best implemented as an action along with hide/remove/debug/etc in the transformation row.

If we decide to just implement this in the transformations impacted by the bug, I will be sure to follow proper code standards that were not followed in this PR as a PoC.