### PR TITLE
Logs: fix running condition causing LogList to not be rendered

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1125,9 +1125,9 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
                 />
               </>
             )}
-          {config.featureToggles.newLogsPanel && visualisationType === 'logs' && hasData && (
+          {config.featureToggles.newLogsPanel && visualisationType === 'logs' && (
             <div data-testid="logRows" ref={logsContainerRef} className={styles.logRowsWrapper}>
-              {logsContainerRef.current && (
+              {logsContainerRef.current && hasData && (
                 <LogList
                   app={CoreApp.Explore}
                   containerElement={logsContainerRef.current}


### PR DESCRIPTION
Fixes a running condition in Explore where the logs panel would not display logs. This was caused by `logsContainerRef.current` getting a reference without a state update triggering the panel to be rendered.

How to reproduce:
- Generate a query that returns 1 log line, 2 or 3 days into the past
- Query last 24 hours, last 2 days, last 3 days
- Expectation: query splitting will run, the panel will receive updates with partial responses, eventually displaying the single log
- Bug: query splitting runs, no results on the first day, continues until it finds it, but it's never displayed. Switching to table and back to logs shows it.

