### PR TITLE
Alerting: Fix duplication of imported Prometheus alert rules

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/reducer.ts
@@ -247,8 +247,9 @@ export const queriesAndExpressionsReducer = createReducer(initialState, (builder
 
       const dataQuery = updatedQueries.at(0);
       const isInstantDataQuery = dataQuery ? getInstantFromDataQuery(dataQuery) : false;
+      const hasReducer = expressionQueries.some((q) => isReducerExpression(q.model));
+      const shouldRemoveReducer = isInstantDataQuery && expressionQueries.length === 2 && hasReducer;
 
-      const shouldRemoveReducer = isInstantDataQuery && expressionQueries.length === 2;
       if (shouldRemoveReducer) {
         const reduceExpressionIndex = state.queries.findIndex(
           (query) =>


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where duplicating (clicking on the "Duplicate" button in the UI) imported Prometheus alert rules fails with the error:

```
Failed to build evaluator for queries and expressions: failed to parse expression 'prometheus_math': invalid math command type: expr: non existent function query
```

Imported Prometheus rules have a specific structure with three nodes: `query`, `prometheus_math` and `threshold`. The math expression contains `is_number($query) || is_nan($query) || is_inf($query)`. The reducer optimization logic was incorrectly modifying this math expression, changing it to just `query` because it assumed this was a reduce node.

**Special notes for your reviewer:**

You can check that it's working on the ephemeral instance, I've created a couple of alert rules there: https://ephemeral15111821109770alexan.grafana-dev.net/alerting/list

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
