### PR TITLE
Alertmanager: add config to set default contact point

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1301,6 +1301,10 @@ alertmanager_max_silences_count =
 # Maximum silence size in bytes. Default: 0 (no limit).
 alertmanager_max_silence_size_bytes =
 
+# Default configuration for the initial contact point. The default is defined in:
+# https://github.com/grafana/grafana/blob/main/pkg/setting/setting_unified_alerting.go
+default_configuration =
+
 # Redis server address or addresses. It can be a single Redis address if using Redis standalone,
 # or a list of comma-separated addresses if using Redis Cluster/Sentinel.
 ha_redis_address =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1278,6 +1278,10 @@
 # Maximum silence size in bytes. Default: 0 (no limit).
 ;alertmanager_max_silence_size_bytes =
 
+# Default configuration for the initial contact point. The default is defined in:
+# https://github.com/grafana/grafana/blob/main/pkg/setting/setting_unified_alerting.go
+;default_configuration =
+
 # Redis server address or addresses. It can be a single Redis address if using Redis standalone,
 # or a list of comma-separated addresses if using Redis Cluster/Sentinel.
 ;ha_redis_address =

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -24,7 +24,6 @@ const (
 	alertmanagerDefaultConfigPollInterval = time.Minute
 	alertmanagerRedisDefaultMaxConns      = 5
 	// To start, the alertmanager needs at least one route defined.
-	// TODO: we should move this to Grafana settings and define this as the default.
 	alertmanagerDefaultConfiguration = `{
 	"alertmanager_config": {
 		"route": {
@@ -334,9 +333,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	uaCfg.HARedisTLSConfig.InsecureSkipVerify = ua.Key("ha_redis_tls_insecure_skip_verify").MustBool(false)
 	uaCfg.HARedisTLSConfig.CipherSuites = ua.Key("ha_redis_tls_cipher_suites").MustString("")
 	uaCfg.HARedisTLSConfig.MinVersion = ua.Key("ha_redis_tls_min_version").MustString("")
-
-	// TODO load from ini file
-	uaCfg.DefaultConfiguration = alertmanagerDefaultConfiguration
+	uaCfg.DefaultConfiguration = valueAsString(ua, "default_configuration", alertmanagerDefaultConfiguration)
 
 	alerting := iniFile.Section("alerting")
 
@@ -557,6 +554,7 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	return nil
 }
 
+// Does not respect custom config
 func GetAlertmanagerDefaultConfiguration() string {
 	return alertmanagerDefaultConfiguration
 }

--- a/pkg/setting/setting_unified_alerting_test.go
+++ b/pkg/setting/setting_unified_alerting_test.go
@@ -419,3 +419,38 @@ func TestHARedisSentinelModeSettings(t *testing.T) {
 		})
 	}
 }
+
+func TestAlertmanagerDefaultConfig(t *testing.T) {
+	f := ini.Empty()
+	section, err := f.NewSection("unified_alerting")
+	require.NoError(t, err)
+
+	snsConfig := `{
+	"alertmanager_config": {
+		"route": {
+			"receiver": "grafana-default-sns",
+			"group_by": ["grafana_folder", "alertname"]
+		},
+		"receivers": [{
+			"name": "grafana-default-sns",
+			"grafana_managed_receiver_configs": [{
+				"uid": "",
+				"name": "sns receiver",
+				"type": "sns",
+				"settings": {
+					"topic_arn": "arn:aws:sns:region:0123456789:SNSTopicName"
+				}
+			}]
+		}]
+	}
+}`
+
+	_, err = section.NewKey("default_configuration", snsConfig)
+	require.NoError(t, err)
+
+	cfg := NewCfg()
+	err = cfg.ReadUnifiedAlertingSettings(f)
+	require.NoError(t, err)
+
+	require.Equal(t, snsConfig, cfg.UnifiedAlerting.DefaultConfiguration)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Introduces a new config `unified_alerting.default_configuration` to set the initial default contact point.

**Why do we need this feature?**

Some workspaces might not want to support email.

**Who is this feature for?**

Workspaces that need to set a different default contact point other than email.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #109773

**Special notes for your reviewer:**

* By design this does not overwrite the initial config if it was already created. Essentially this is only useful for new workspaces.
* I tested this by setting the config to AWS SNS. The default config gets set as expected:
<img width="1579" height="305" alt="image" src="https://github.com/user-attachments/assets/ab9ca7c7-b4b9-429e-a274-79357dd57092" />

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
