### PR TITLE
apiserver: openapi: only log errors when an error happened

### DIFF
--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -34,7 +34,9 @@ func GetOpenAPIDefinitions(builders []APIGroupBuilder, additionalGetters ...open
 				return bytes.Equal(aa, bb)
 			},
 		)
-		logging.DefaultLogger.Error("error initializing DataQuery apiequality", "err", err)
+		if err != nil {
+			logging.DefaultLogger.Error("error initializing DataQuery apiequality", "err", err)
+		}
 	})
 
 	return func(ref openapi.ReferenceCallback) map[string]openapi.OpenAPIDefinition {


### PR DESCRIPTION
the current code always emits an error-log entry, i think it should only do it when the error is not-nil.