### PR TITLE
Secret/Keepers: Return already exists error from DB when creating keeper

### DIFF
--- a/pkg/registry/apis/secret/contracts/keeper.go
+++ b/pkg/registry/apis/secret/contracts/keeper.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	ErrKeeperNotFound = errors.New("keeper not found")
+	ErrKeeperNotFound      = errors.New("keeper not found")
+	ErrKeeperAlreadyExists = errors.New("keeper already exists")
 )
 
 // KeeperMetadataStorage is the interface for wiring and dependency injection.


### PR DESCRIPTION
**What is this feature?**

Adds a new domain error when a Keeper already exists in the DB, so it can be handled by the REST storage.

**Why do we need this feature?**

More descriptive error codes!

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
