### PR TITLE
Logs Panel: use provided height for the container

### DIFF
--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -172,6 +172,7 @@ export const LogsPanel = ({
     timestampResolution,
     ...options
   },
+  height,
   id,
 }: LogsPanelProps) => {
   const isAscending = sortOrder === LogsSortOrder.Ascending;
@@ -565,6 +566,7 @@ export const LogsPanel = ({
         <div
           onMouseLeave={onLogContainerMouseLeave}
           className={style.logListContainer}
+          style={height ? { minHeight: height } : undefined}
           ref={(element: HTMLDivElement) => setScrollElement(element)}
         >
           {deduplicatedRows.length > 0 && scrollElement && (


### PR DESCRIPTION
The new Logs Panel is a virtualized list, so it needs a defined height to know how many items to render before rendering anything. Until now, it relied on reading the clientHeight of the container element, which usually was 100% of another container with a defined height. When the container element doens't have a defined height, and nor does the container of the container, the computed height was 0.

With this change, the panel will use the provided height.

Reproduced rendering logs in Explore through the `PanelRenderer` component, similar to where the issue was found: https://github.com/grafana/synthetic-monitoring-app/blob/c7af0afa9d69ad5996ddf07ae53f0593176b67db/src/components/CheckTestResult.tsx#L47-L64