### PR TITLE
datasources: querier: better error handling

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -395,7 +395,11 @@ func (dn *DSNode) Execute(ctx context.Context, now time.Time, _ mathexp.Vars, s 
 	}()
 
 	var resp *backend.QueryDataResponse
-	mtDSClient, ok := s.mtDatasourceClientBuilder.BuildClient(dn.datasource.Type, dn.datasource.UID)
+	mtDSClient, ok, err := s.mtDatasourceClientBuilder.BuildClient(dn.datasource.Type, dn.datasource.UID)
+	if err != nil {
+		return mathexp.Results{}, MakeQueryError(dn.refID, dn.datasource.UID, err)
+	}
+
 	if !ok { // use single tenant client
 		pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, dn.datasource.Type, dn.request.User, dn.datasource)
 		if err != nil {

--- a/pkg/services/mtdsclient/mt_datasource_client_builder.go
+++ b/pkg/services/mtdsclient/mt_datasource_client_builder.go
@@ -9,13 +9,13 @@ import (
 )
 
 type MTDatasourceClientBuilder interface {
-	BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool)
+	BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool, error)
 }
 
 type nullBuilder struct{}
 
-func (m *nullBuilder) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool) {
-	return nil, false
+func (m *nullBuilder) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool, error) {
+	return nil, false, nil
 }
 
 // we use this noop for st flows
@@ -29,7 +29,7 @@ type MtDatasourceClientBuilderWithInstance struct {
 	logger   log.Logger
 }
 
-func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool) {
+func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool, error) {
 	dsClient, err := b.instance.GetDataSourceClient(
 		b.ctx,
 		v0alpha1.DataSourceRef{
@@ -38,10 +38,9 @@ func (b *MtDatasourceClientBuilderWithInstance) BuildClient(pluginId string, uid
 		},
 	)
 	if err != nil {
-		b.logger.Debug("failed to get mt ds client", "error", err)
-		return nil, false
+		return nil, true, err
 	}
-	return dsClient, true
+	return dsClient, true, nil
 }
 
 // TODO: I think we might be able to refactor this to just use the instance
@@ -69,10 +68,10 @@ type testBuilder struct {
 	isMultitenant bool
 }
 
-func (b *testBuilder) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool) {
+func (b *testBuilder) BuildClient(pluginId string, uid string) (clientapi.QueryDataClient, bool, error) {
 	if !b.isMultitenant {
-		return nil, false
+		return nil, false, nil
 	}
 
-	return b.mockClient, true
+	return b.mockClient, true, nil
 }

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -302,7 +302,11 @@ func (s *ServiceImpl) handleQuerySingleDatasource(ctx context.Context, user iden
 		req.Queries = append(req.Queries, q.query)
 	}
 
-	mtDsClient, ok := s.mtDatasourceClientBuilder.BuildClient(ds.Type, ds.UID)
+	mtDsClient, ok, err := s.mtDatasourceClientBuilder.BuildClient(ds.Type, ds.UID)
+	if err != nil {
+		return nil, err
+	}
+
 	if !ok { // single tenant flow
 		pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, ds.Type, user, ds)
 		if err != nil {


### PR DESCRIPTION
we have this code currently:
https://github.com/grafana/grafana/blob/3dccd29f89962f77bbfc438b9f73e656502da483/pkg/services/mtdsclient/mt_datasource_client_builder.go#L32-L43

the important part is "if an error happens, return `false`".

if we look at the place that consumes this:
https://github.com/grafana/grafana/blob/3dccd29f89962f77bbfc438b9f73e656502da483/pkg/services/query/query.go#L305-L307

so, if `GetDataSourceClient() returns an error, `BuildClient()` will return `false`, and `services/query/query.go` will decide to do the single-tenant flow.

this is not what we want, because if we are doing the query-service flow, we do not want to fall back to the non-query-service-flow.