### PR TITLE
[release-12.0.5] Dashboard: Resume tracking changes after save from JSON model page

### DIFF
--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -72,7 +72,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
       // FIXME: We could avoid this call by storing the entire dashboard DTO as initial dashboard scene instead of only the spec and metadata
       const dto = await getDashboardAPI('v2').getDashboardDTO(result.uid);
       newDashboardScene = transformSaveModelSchemaV2ToScene(dto);
-      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state);
+      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state, { key: dashboard.state.key });
 
       dashboard.pauseTrackingChanges();
       dashboard.setInitialSaveModel(dto.spec, dto.metadata);
@@ -83,7 +83,7 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
         dashboard: jsonModel,
         meta: dashboard.state.meta,
       });
-      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state);
+      const newState = sceneUtils.cloneSceneObjectState(newDashboardScene.state, { key: dashboard.state.key });
 
       dashboard.pauseTrackingChanges();
       dashboard.setInitialSaveModel(jsonModel, dashboard.state.meta);
@@ -91,6 +91,9 @@ export class JsonModelEditView extends SceneObjectBase<JsonModelEditViewState> i
     }
 
     this.setState({ jsonText: this.getJsonText() });
+
+    // We also need to resume tracking changes since the change handler won't see any later edit
+    dashboard.resumeTrackingChanges();
   };
 
   static Component = ({ model }: SceneComponentProps<JsonModelEditView>) => {


### PR DESCRIPTION
Backport e285cc2ddcd690b931983c6aa2ac57dd1ada1f5b from #109607

---

**What is this feature?**

Resume tracking changes after doing a dashboard save from the JSON model page.

Another problem was that after doing a save from the same page, we would lose the URL sync given

**Why do we need this feature?**

Fix bugs.

**Who is this feature for?**

Everybody

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

GJ @Sergej-Vlasov and @oscarkilhed for helping debugging this.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
