### PR TITLE
Chore: Skip more GHA jobs if backend files are not changed

### DIFF
--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -14,10 +14,6 @@ on:
       - 'docs/**'
       - 'latest.json'
 
-permissions:
-  contents: read
-  id-token: write
-
 jobs:
   detect-changes:
     name: Detect whether code changed
@@ -38,6 +34,9 @@ jobs:
           self: .github/workflows/backend-code-checks.yml
 
   validate-configs:
+    permissions:
+      contents: read
+      id-token: write
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     name: Validate Backend Configs

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -19,7 +19,27 @@ permissions:
   id-token: write
 
 jobs:
+  detect-changes:
+    name: Detect whether code changed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # required to get more history in the changed-files action
+          fetch-depth: 2
+      - name: Detect changes
+        id: detect-changes
+        uses: ./.github/actions/change-detection
+        with:
+          self: .github/workflows/backend-code-checks.yml
+
   validate-configs:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     name: Validate Backend Configs
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -13,7 +13,27 @@ permissions:
   contents: read
 
 jobs:
+  detect-changes:
+    name: Detect whether code changed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # required to get more history in the changed-files action
+          fetch-depth: 2
+      - name: Detect changes
+        id: detect-changes
+        uses: ./.github/actions/change-detection
+        with:
+          self: .github/workflows/go-lint.yml
+
   lint-go:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -14,10 +14,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  detect-changes:
+    name: Detect whether code changed
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.detect-changes.outputs.backend }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: true # required to get more history in the changed-files action
+          fetch-depth: 2
+      - name: Detect changes
+        id: detect-changes
+        uses: ./.github/actions/change-detection
+        with:
+          self: .github/workflows/swagger-gen.yml
+
   verify:
     name: Verify committed API specs match
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'grafana/grafana' }}
+    needs: detect-changes
+    if: github.repository == 'grafana/grafana' && needs.detect-changes.outputs.changed == 'true'
     permissions:
       contents: read # clone the repository
       id-token: write # required for Vault access


### PR DESCRIPTION
**What is this feature?**
Skips more jobs if only backend files were changed.

**Why do we need this feature?**
Save CI time and resources if no backend files were changed

**Who is this feature for?**
All devs opening PRs!