### PR TITLE
Unified/APIStore: Fix flaky tests on secure value support inline

### DIFF
--- a/pkg/storage/unified/apistore/secure_test.go
+++ b/pkg/storage/unified/apistore/secure_test.go
@@ -70,7 +70,10 @@ func TestSecureLifecycle(t *testing.T) {
 		expectError := fmt.Errorf("expected error")
 		secureStore := secret.NewMockInlineSecureValueSupport(t)
 		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretAAA")).
-			Return("", expectError).Once()
+			Return("", expectError).Maybe()
+		secureStore.On("CreateInline", mock.Anything, mock.Anything, common.RawSecureValue("SecretBBB")).
+			Return("", expectError).Maybe()
+
 		err := prepareSecureValues(context.Background(), secureStore, obj, nil, info)
 		require.Error(t, err, "should error when secure value creation fails")
 		require.Equal(t, expectError, err, "error should be propagated")


### PR DESCRIPTION
Because the `prepareSecureValues` method takes a map, ordering is not guaranteed so I updated the mock expectation to be either the first or the second secure value to be called.