### PR TITLE
[release-11.6.6] Geomap: Tooltip for multiple features same coord

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -7467,7 +7467,8 @@ exports[`better eslint`] = {
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
     "public/app/plugins/panel/geomap/utils/tooltip.ts:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
+      [0, 0, 0, "Do not use any type assertions.", "0"],
+      [0, 0, 0, "Do not use any type assertions.", "1"]
     ],
     "public/app/plugins/panel/heatmap/HeatmapPanel.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/components/uPlot/plugins/TooltipPlugin2\' import is restricted from being used by a pattern. Import from the public export instead.", "0"],

--- a/public/app/plugins/panel/geomap/utils/tooltip.test.ts
+++ b/public/app/plugins/panel/geomap/utils/tooltip.test.ts
@@ -1,0 +1,220 @@
+import { Feature, MapBrowserEvent } from 'ol';
+import { Point } from 'ol/geom';
+import WebGLPointsLayer from 'ol/layer/WebGLPoints';
+import VectorSource from 'ol/source/Vector';
+
+import { DataFrame, PanelProps } from '@grafana/data';
+
+import { GeomapPanel } from '../GeomapPanel';
+import { GeomapHoverPayload, GeomapLayerHover } from '../event';
+import { Options } from '../types';
+
+import { pointerMoveListener } from './tooltip';
+
+// Mock the GeomapPanel class
+jest.mock('../GeomapPanel', () => {
+  return {
+    GeomapPanel: jest.fn().mockImplementation(() => {
+      return {
+        map: {
+          getEventPixel: jest.fn().mockReturnValue([100, 100]),
+          getCoordinateFromPixel: jest.fn().mockReturnValue([0, 0]),
+          forEachFeatureAtPixel: jest.fn(),
+        },
+        mapDiv: {
+          style: { cursor: 'auto' },
+        },
+        state: {
+          measureMenuActive: false,
+          ttipOpen: false,
+          ttip: undefined,
+        },
+        hoverPayload: {} as GeomapHoverPayload,
+        hoverEvent: {},
+        props: {
+          eventBus: {
+            publish: jest.fn(),
+          },
+        },
+        setState: jest.fn(),
+        layers: [],
+      };
+    }),
+  };
+});
+
+// Mock the getMapLayerState function
+jest.mock('./layers', () => {
+  return {
+    getMapLayerState: jest.fn().mockReturnValue({
+      options: { tooltip: true },
+      mouseEvents: { next: jest.fn() },
+    }),
+  };
+});
+
+describe('tooltip utils', () => {
+  let panel: GeomapPanel;
+  let mockEvent: MapBrowserEvent<MouseEvent>;
+  let mockWebGLLayer: WebGLPointsLayer<VectorSource<Point>>;
+  let mockVectorSource: VectorSource<Point>;
+
+  // Consolidated feature constants
+  let feature1: Feature;
+  let feature2: Feature;
+  let feature3: Feature;
+  let feature4: Feature;
+  let differentFeature: Feature;
+
+  beforeEach(() => {
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Create mock objects
+    panel = new GeomapPanel({} as PanelProps<Options>);
+    mockEvent = {
+      originalEvent: {
+        pageX: 100,
+        pageY: 100,
+      },
+    } as MapBrowserEvent<MouseEvent>;
+
+    // Create features for testing
+    feature1 = new Feature({
+      geometry: new Point([0, 0]),
+      rowIndex: 1,
+      frame: {} as DataFrame,
+    });
+
+    feature2 = new Feature({
+      geometry: new Point([0, 0]),
+      rowIndex: 2,
+      frame: {} as DataFrame,
+    });
+
+    feature3 = new Feature({
+      geometry: new Point([0, 0]),
+      rowIndex: 3,
+      frame: {} as DataFrame,
+    });
+
+    feature4 = new Feature({
+      geometry: new Point([0, 0]),
+      // No rowIndex
+      frame: {} as DataFrame,
+    });
+
+    differentFeature = new Feature({
+      geometry: new Point([1, 1]),
+      rowIndex: 4,
+      frame: {} as DataFrame,
+    });
+
+    // Create mock vector source
+    mockVectorSource = new VectorSource<Point>();
+    mockVectorSource.forEachFeature = jest.fn();
+
+    // Create mock WebGL layer
+    mockWebGLLayer = new WebGLPointsLayer({
+      source: mockVectorSource,
+      style: {
+        symbol: {
+          symbolType: 'circle',
+          size: 8,
+          color: '#000000',
+          opacity: 1,
+        },
+      },
+    });
+    mockWebGLLayer.getSource = jest.fn().mockReturnValue(mockVectorSource);
+
+    // Setup the forEachFeatureAtPixel mock
+    if (panel.map) {
+      (panel.map.forEachFeatureAtPixel as jest.Mock).mockImplementation((pixel, callback) => {
+        callback(feature1, mockWebGLLayer, null);
+      });
+    }
+  });
+
+  describe('WebGLPointsLayer condition', () => {
+    it('should add additional features at the same coordinates for WebGLPointsLayer', () => {
+      // Setup the mock vector source to return multiple features at the same coordinates
+      (mockVectorSource.forEachFeature as jest.Mock).mockImplementation((callback) => {
+        callback(feature2);
+      });
+
+      // Call the function
+      pointerMoveListener(mockEvent, panel);
+
+      // Verify that forEachFeatureAtPixel was called
+      if (panel.map) {
+        expect(panel.map.forEachFeatureAtPixel).toHaveBeenCalled();
+      }
+
+      // Verify that the layer was added to hoverPayload
+      expect(panel.hoverPayload.layers).toBeDefined();
+      expect(panel.hoverPayload.layers?.length).toBe(1);
+
+      // Verify that both features were added to the layer
+      const layerHover = panel.hoverPayload.layers?.[0] as GeomapLayerHover;
+      expect(layerHover.features.length).toBe(2);
+      expect(layerHover.features).toContain(feature1);
+      expect(layerHover.features).toContain(feature2);
+    });
+
+    it('should not add features with different coordinates', () => {
+      // Setup the mock vector source to return a feature with different coordinates
+      (mockVectorSource.forEachFeature as jest.Mock).mockImplementation((callback) => {
+        callback(differentFeature);
+      });
+
+      // Call the function
+      pointerMoveListener(mockEvent, panel);
+
+      // Verify that only the original feature was added
+      const layerHover = panel.hoverPayload.layers?.[0] as GeomapLayerHover;
+      expect(layerHover.features.length).toBe(1);
+      expect(layerHover.features).toContain(feature1);
+      expect(layerHover.features).not.toContain(differentFeature);
+    });
+
+    it('should not add the same feature twice', () => {
+      // Setup the mock vector source to return the same feature
+      (mockVectorSource.forEachFeature as jest.Mock).mockImplementation((callback) => {
+        callback(feature1);
+      });
+
+      // Call the function
+      pointerMoveListener(mockEvent, panel);
+
+      // Verify that the feature was only added once
+      const layerHover = panel.hoverPayload.layers?.[0] as GeomapLayerHover;
+      expect(layerHover.features.length).toBe(1);
+      expect(layerHover.features).toContain(feature1);
+    });
+
+    it('should sort features by rowIndex when multiple features are at the same coordinates', () => {
+      // Setup the mock vector source to return multiple features
+      (mockVectorSource.forEachFeature as jest.Mock).mockImplementation((callback) => {
+        callback(feature2);
+        callback(feature3);
+        callback(feature4);
+      });
+
+      // Call the function
+      pointerMoveListener(mockEvent, panel);
+
+      // Verify that the features were added and sorted by rowIndex
+      const layerHover = panel.hoverPayload.layers?.[0] as GeomapLayerHover;
+      expect(layerHover.features.length).toBe(4); // feature1 + 3 new features
+
+      // Check that features are sorted by rowIndex (1, 2, 3, MAX_SAFE_INTEGER)
+      // Since rowIndex is unique, we can check the exact order
+      expect(layerHover.features[0].getProperties()['rowIndex']).toBe(1); // feature1
+      expect(layerHover.features[1].getProperties()['rowIndex']).toBe(2); // feature2
+      expect(layerHover.features[2].getProperties()['rowIndex']).toBe(3); // feature3
+      // The last feature (feature4) has no rowIndex, so it should be at the end
+      expect(layerHover.features[3].getProperties()['rowIndex']).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
Backport b694857e00091e88cfd797e8adcc5d6bd9f063e6 from #103163

---

With the [switch to WebGL](https://github.com/grafana/grafana/pull/95457), multiple points at the same coordinate are stacked on top of each other and rasterized into a single flat image for efficiency. That is why only the last point is being detected for the tooltip. To get around this limitation, we need to check all other features for a given `VectorSource` when the layer is a `WebGLPointsLayer`.

- [x] Fix bug
- [x] Add Test Coverage
- [ ] ~~Explore alternatives to `source.forEachFeature`~~ tested to be <100ms for 100,000 points, can revisit in the future if needed
- [x] Verify sorting is working with `rowIndex` properly

[Multiple Feature at Single Location Testing-1744056672580.json](https://github.com/user-attachments/files/19638598/Multiple.Feature.at.Single.Location.Testing-1744056672580.json) with 3 points at the same coordinate.

Before (only last point is found):
![Apr-07-2025 13-08-55](https://github.com/user-attachments/assets/11a94d2c-af5b-4351-bab7-af66b14f9f57)

After (all 3 points at same coordinate are found):
![Apr-07-2025 13-09-16](https://github.com/user-attachments/assets/ffc4c3b5-8a81-4ef9-b1b7-40394d342ebd)




Fixes https://github.com/grafana/support-escalations/issues/15474 
