### PR TITLE
feat(UserStorage): Expose getUserStorage

### DIFF
--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -56,7 +56,7 @@ export { type EmbeddedDashboardProps, EmbeddedDashboard, setEmbeddedDashboard } 
 export { hasPermission, hasPermissionInMetadata, hasAllPermissions, hasAnyPermission } from './utils/rbac';
 export { QueryEditorWithMigration } from './components/QueryEditorWithMigration';
 export { type MigrationHandler, isMigrationHandler, migrateQuery, migrateRequest } from './utils/migrationHandler';
-export { usePluginUserStorage } from './utils/userStorage';
+export { usePluginUserStorage, getPluginUserStorage } from './utils/userStorage';
 export { useFavoriteDatasources, type FavoriteDatasources } from './utils/useFavoriteDatasources';
 export { FolderPicker, setFolderPicker } from './components/FolderPicker';
 export {

--- a/packages/grafana-runtime/src/utils/userStorage.tsx
+++ b/packages/grafana-runtime/src/utils/userStorage.tsx
@@ -156,3 +156,26 @@ export function usePluginUserStorage(): PluginUserStorage {
   }
   return new UserStorage(context?.meta.id);
 }
+
+/**
+ * A function for interacting with the backend user storage (or local storage if not enabled).
+ * @returns An scoped object for a plugin and a user with getItem and setItem functions.
+ * @alpha Experimental
+ */
+export function getPluginUserStorage(): UserStorage {
+  const pluginId = getPluginIdFromUrl();
+  if (!pluginId) {
+    throw new Error(
+      'getUserStorage() could not determine the current plugin ID from URL. ' +
+        'This function must be called from within an app plugin context (URL pattern: /a/plugin-id). ' +
+        'For React components, use usePluginUserStorage() hook instead.'
+    );
+  }
+  return new UserStorage(pluginId);
+}
+
+function getPluginIdFromUrl(): string | null {
+  // App plugin URL pattern: /a/{pluginId}/... or /a/{pluginId}
+  const [, appPluginId] = window.location.pathname.match(/\/a\/([^\/\?]+)/) || [];
+  return appPluginId || null;
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A follow-up of https://github.com/grafana/grafana/pull/95834 to expose a new `getPluginUserStorage` function. This function enables app plugin developers to programmatically [store user information](https://grafana.com/developers/plugin-tools/how-to-guides/add-user-storage).

**Why do we need this feature?**

The only function exposed before this PR is the `usePluginUserStorage` React hook, which returns a `UserStorage` instance scoped to the current plugin. But being a React hook, plugin developers can only call it from a React component.

What if the plugin code is designed in a way that infrastructure calls (like retrieving user preferences from an API to perform some business logic) do not live in a React component?

We would force them to get the `UserStorage` instance in a React component and to pass around to the functions responsible for performing the business logic.

This PR is an attempt at removing this limitation in order to help fostering the adoption of the new backend storage.

**Who is this feature for?**

All app plugin developers.

**Which issue(s) does this PR fix?**:

`-`

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
