### PR TITLE
Plugins: adds plugin version to log output

### DIFF
--- a/public/app/features/datasources/components/DataSourcePluginSettings.tsx
+++ b/public/app/features/datasources/components/DataSourcePluginSettings.tsx
@@ -34,7 +34,11 @@ export class DataSourcePluginSettings extends PureComponent<Props> {
       <div>
         {plugin.components.ConfigEditor &&
           createElement(plugin.components.ConfigEditor, {
-            options: writableProxy(dataSource, { source: 'datasource', pluginId: plugin.meta?.id }),
+            options: writableProxy(dataSource, {
+              source: 'datasource',
+              pluginId: plugin.meta?.id,
+              pluginVersion: plugin.meta?.info?.version,
+            }),
             onOptionsChange: this.onModelChanged,
           })}
       </div>

--- a/public/app/features/plugins/extensions/utils.test.tsx
+++ b/public/app/features/plugins/extensions/utils.test.tsx
@@ -903,7 +903,7 @@ describe('Plugin Extensions / Utils', () => {
       // Logs a warning
       expect(log.error).toHaveBeenCalledTimes(1);
       expect(log.error).toHaveBeenCalledWith(
-        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version unknown`,
+        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version 1.0.0`,
         {
           stack: expect.any(String),
         }
@@ -931,7 +931,7 @@ describe('Plugin Extensions / Utils', () => {
       // Logs a warning
       expect(log.warning).toHaveBeenCalledTimes(1);
       expect(log.warning).toHaveBeenCalledWith(
-        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version unknown`,
+        `Attempted to mutate object property "c" from extension with id grafana-worldmap-panel and version 1.0.0`,
         {
           stack: expect.any(String),
         }

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -98,7 +98,9 @@ export const wrapWithPluginContext = <T,>({
     return (
       <PluginContextProvider meta={pluginMeta}>
         <ExtensionErrorBoundary pluginId={pluginId} extensionTitle={extensionTitle} log={log}>
-          <Component {...writableProxy(props, { log, source: 'extension', pluginId })} />
+          <Component
+            {...writableProxy(props, { log, source: 'extension', pluginId, pluginVersion: pluginMeta.info?.version })}
+          />
         </ExtensionErrorBoundary>
       </PluginContextProvider>
     );


### PR DESCRIPTION
**What is this feature?**

This adds the plugin version to the Mutation Observer log output that was forgotten in #108057 🙈 

**Why do we need this feature?**

So we can identify mutations more easily

**Who is this feature for?**

Plugins platform maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
