### PR TITLE
GHA: Switch some BE workflows to self-hosted runners

### DIFF
--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
 
     name: Grafana (${{ matrix.shard }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -81,7 +81,7 @@ jobs:
       fail-fast: false
 
     name: Grafana Enterprise (${{ matrix.shard }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -12,7 +12,7 @@ jobs:
   handle-ephemeral-instances:
     if: ${{ github.event.issue.pull_request && (startsWith(github.event.comment.body, '/deploy-to-hg') || github.event.action == 'closed') && github.repository_owner == 'grafana' }}
     runs-on:
-      labels: ubuntu-latest-16-cores
+      labels: ubuntu-x64-xlarge
     continue-on-error: true
     permissions:
       # For commenting.

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -41,14 +41,14 @@ jobs:
     if: needs.detect-changes.outputs.changed == 'true'
     strategy:
       matrix:
+        # We don't need more than this since it has to wait for the other tests.
         shard: [
-          1/8, 2/8, 3/8, 4/8,
-          5/8, 6/8, 7/8, 8/8,
+          1/4, 2/4, 3/4, 4/4,
         ]
       fail-fast: false
 
     name: Sqlite (${{ matrix.shard }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
     steps:
@@ -74,13 +74,15 @@ jobs:
     strategy:
       matrix:
         shard: [
-          1/8, 2/8, 3/8, 4/8,
-          5/8, 6/8, 7/8, 8/8,
+           1/16,  2/16,  3/16,  4/16,
+           5/16,  6/16,  7/16,  8/16,
+           9/16, 10/16, 11/16, 12/16,
+          13/16, 14/16, 15/16, 16/16,
         ]
       fail-fast: false
 
     name: MySQL (${{ matrix.shard }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
     env:
@@ -122,13 +124,15 @@ jobs:
     strategy:
       matrix:
         shard: [
-          1/8, 2/8, 3/8, 4/8,
-          5/8, 6/8, 7/8, 8/8,
+           1/16,  2/16,  3/16,  4/16,
+           5/16,  6/16,  7/16,  8/16,
+           9/16, 10/16, 11/16, 12/16,
+          13/16, 14/16, 15/16, 16/16,
         ]
       fail-fast: false
 
     name: Postgres (${{ matrix.shard }})
-    runs-on: ubuntu-latest-8-cores
+    runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
     env:

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -141,7 +141,7 @@ jobs:
       POSTGRES_HOST: 127.0.0.1
     services:
       postgres:
-        image: postgres:12.3-alpine
+        image: postgres:17.6
         env:
           POSTGRES_USER: grafanatest
           POSTGRES_PASSWORD: grafanatest

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -90,7 +90,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
     services:
       mysql:
-        image: mysql:8.0.32
+        image: mysql:8.0.43
         env:
           MYSQL_ROOT_PASSWORD: rootpass
           MYSQL_DATABASE: grafana_tests


### PR DESCRIPTION
Instead of using GitHub provided runners for these workflows that are more "beefy", we use our own self-hosted runners instead.

I've done a bunch of testing here https://github.com/grafana/grafana/pull/109783 to find a good balance of runner size and shards.

