### PR TITLE
Devenv: Add tempo and pyroscope to the provisioned data sources

### DIFF
--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -171,6 +171,51 @@ datasources:
 
   - name: gdev-loki
     type: loki
+    uid: gdev-loki
     access: proxy
     url: http://loki:3100
     editable: false
+
+  - name: gdev-pyroscope
+    type: grafana-pyroscope-datasource
+    uid: gdev-pyroscope
+    access: proxy
+    url: http://pyroscope:4040
+    editable: false
+
+  - name: gdev-tempo
+    type: tempo
+    uid: gdev-tempo
+    access: proxy
+    url: http://tempo:3200
+    editable: false
+    correlations:
+      - targetUID: gdev-loki
+        label: 'Logs (correlation)'
+        description: 'Correlation to logs stored in Loki'
+        config:
+          type: query
+          target:
+            expr: '{ job="job" }'
+          field: 'traceID'
+    jsonData:
+      tracesToLogsV2:
+        datasourceUid: gdev-loki
+        spanStartTimeShift: '5m'
+        spanEndTimeShift: '-5m'
+        customQuery: true
+        query: '{filename="/var/log/grafana/grafana.log"} |="$${__span.traceId}"'
+      tracesToProfiles:
+        datasourceUid: gdev-pyroscope
+        profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'
+      tracesToMetrics:
+        datasourceUid: gdev-prometheus
+        spanStartTimeShift: '1h'
+        spanEndTimeShift: '-1h'
+        tags: [{ key: 'job' }]
+        queries:
+          - name: 'Metrics'
+            query: 'sum(rate({$$__tags}[5m]))'
+      serviceMap:
+        datasourceUid: 'gdev-prometheus'
+        histogramType: 'both' # 'classic' or 'native' or 'both'


### PR DESCRIPTION
**What is this feature?**

Add tempo and pyroscope to the provisioned data sources.

**Why do we need this feature?**

It's convenient to have tempo pre-configured when you run grafana in docker to catch some performance metrics.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
