### PR TITLE
Query Library: Rename "Query Library" user-facing text to "Saved Queries"

### DIFF
--- a/public/app/features/explore/Explore.test.tsx
+++ b/public/app/features/explore/Explore.test.tsx
@@ -289,7 +289,7 @@ describe('Explore', () => {
       await screen.findByTestId(selectors.components.DataSourcePicker.container);
 
       const addQueryButton = screen.getByRole('button', { name: /Add query$/i });
-      const addFromLibraryButton = screen.getByRole('button', { name: /Add query from library/i });
+      const addFromLibraryButton = screen.getByRole('button', { name: /Add saved query/i });
 
       expect(addQueryButton).toBeDisabled();
       expect(addFromLibraryButton).toBeDisabled();

--- a/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.tsx
@@ -28,7 +28,7 @@ export const RichHistoryAddToLibrary = ({ query }: Props) => {
     }
   };
 
-  const buttonLabel = t('explore.rich-history-card.add-to-library', 'Add to library');
+  const buttonLabel = t('explore.rich-history-card.add-to-library', 'Save query');
 
   return queryLibraryEnabled && !hasBeenSaved ? (
     <>

--- a/public/app/features/explore/SecondaryActions.test.tsx
+++ b/public/app/features/explore/SecondaryActions.test.tsx
@@ -77,7 +77,7 @@ describe('SecondaryActions', () => {
     );
 
     expect(screen.getByRole('button', { name: /Add query$/i })).toBeDisabled();
-    expect(screen.getByRole('button', { name: /Add query from library/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /Add saved query/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /Query inspector/i })).toBeInTheDocument();
   });
 

--- a/public/app/features/explore/SecondaryActions.tsx
+++ b/public/app/features/explore/SecondaryActions.tsx
@@ -74,7 +74,7 @@ export function SecondaryActions({
           {queryLibraryEnabled && (
             <ToolbarButton
               data-testid={selectors.pages.Explore.General.addFromQueryLibrary}
-              aria-label={t('explore.secondary-actions.add-from-query-library', 'Add query from library')}
+              aria-label={t('explore.secondary-actions.add-from-query-library', 'Add saved query')}
               variant="canvas"
               onClick={() =>
                 openQueryLibraryDrawer({
@@ -86,7 +86,7 @@ export function SecondaryActions({
               icon="plus"
               disabled={addQueryRowButtonDisabled}
             >
-              <Trans i18nKey="explore.secondary-actions.add-from-query-library">Add query from library</Trans>
+              <Trans i18nKey="explore.secondary-actions.add-from-query-library">Add saved query</Trans>
             </ToolbarButton>
           )}
         </>

--- a/public/app/features/explore/spec/helper/assert.ts
+++ b/public/app/features/explore/spec/helper/assert.ts
@@ -50,9 +50,9 @@ export const assertAddToQueryLibraryButtonExists = async (value = true) => {
     expect(withinQueryHistory().getByRole('button', { name: /run query/i })).toBeInTheDocument();
 
     if (value) {
-      expect(withinQueryHistory().queryByRole('button', { name: /add to library/i })).toBeInTheDocument();
+      expect(withinQueryHistory().queryByRole('button', { name: /save query/i })).toBeInTheDocument();
     } else {
-      expect(withinQueryHistory().queryByRole('button', { name: /add to library/i })).not.toBeInTheDocument();
+      expect(withinQueryHistory().queryByRole('button', { name: /save query/i })).not.toBeInTheDocument();
     }
   });
 };

--- a/public/app/features/explore/spec/helper/interactions.ts
+++ b/public/app/features/explore/spec/helper/interactions.ts
@@ -40,7 +40,7 @@ export const openQueryHistory = async () => {
 };
 
 export const openQueryLibrary = async () => {
-  const button = screen.getByRole('button', { name: 'Add query from library' });
+  const button = screen.getByRole('button', { name: 'save query' });
   await userEvent.click(button);
   await waitFor(async () => {
     const container = screen.getByRole('dialog', {
@@ -51,7 +51,7 @@ export const openQueryLibrary = async () => {
 };
 
 export const addQueryHistoryToQueryLibrary = async () => {
-  const button = withinQueryHistory().getByRole('button', { name: /add to library/i });
+  const button = withinQueryHistory().getByRole('button', { name: /save query/i });
   await userEvent.click(button);
 };
 

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -634,7 +634,7 @@ function ReplaceQueryFromLibrary<TQuery extends DataQuery>({
 
   return queryLibraryEnabled ? (
     <QueryOperationAction
-      title={t('query-operation.header.replace-query-from-library', 'Replace with query from library')}
+      title={t('query-operation.header.replace-query-from-library', 'Replace with saved query')}
       icon="book"
       onClick={onReplaceQueryFromLibrary}
       isGroupEnd

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7241,7 +7241,7 @@
       }
     },
     "secondary-actions": {
-      "add-from-query-library": "Add query from library",
+      "add-from-query-library": "Add saved query",
       "query-add-button": "Add query",
       "query-add-button-aria-label": "Add query",
       "query-history-button": "Query history",
@@ -11892,7 +11892,7 @@
       "expand-row": "Expand query row",
       "hide-response": "Hide response",
       "remove-query": "Remove query",
-      "replace-query-from-library": "Replace with query from library",
+      "replace-query-from-library": "Replace with saved query",
       "show-response": "Show response"
     },
     "query-editor-not-exported": "Data source plugin does not export any Query Editor component",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7129,7 +7129,7 @@
     "rich-history-card": {
       "add-comment-form": "Add comment form",
       "add-comment-tooltip": "Add comment",
-      "add-to-library": "Add to library",
+      "add-to-library": "Save query",
       "cancel": "Cancel",
       "confirm-delete": "Delete",
       "copy-query-tooltip": "Copy query to clipboard",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Renaming user facing text to be aligned with industry standards

Enterprise PR: https://github.com/grafana/grafana-enterprise/pull/9408

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related https://github.com/grafana/grafana-enterprise/issues/9384

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
