### PR TITLE
New Logs Panel: Details and JSON adjustments

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -176,7 +176,7 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
   inlineWrapper: css({
     gridColumn: '1 / -1',
     height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
-    paddingBottom: theme.spacing(0.5),
+    padding: theme.spacing(1, 2, 1.5, 2),
     marginRight: 1,
   }),
   container: css({

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -105,7 +105,7 @@ const getFieldsStyles = (theme: GrafanaTheme2) => ({
   fieldsTable: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `${theme.spacing(11.5)} minmax(auto, 50%) 1fr`,
+    gridTemplateColumns: `${theme.spacing(11.5)} minmax(auto, 40%) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -105,7 +105,7 @@ const getFieldsStyles = (theme: GrafanaTheme2) => ({
   fieldsTable: css({
     display: 'grid',
     gap: theme.spacing(1),
-    gridTemplateColumns: `${theme.spacing(11.5)} auto 1fr`,
+    gridTemplateColumns: `${theme.spacing(11.5)} minmax(auto, 50%) 1fr`,
   }),
   fieldsTableNoActions: css({
     display: 'grid',

--- a/public/app/features/logs/components/panel/grammar.test.ts
+++ b/public/app/features/logs/components/panel/grammar.test.ts
@@ -7,6 +7,8 @@ import { generateLogGrammar } from './grammar';
 describe('generateLogGrammar', () => {
   function generateScenario(entry: string) {
     const log = createLogLine({ labels: { place: 'luna', source: 'logs' }, entry });
+    // Access body getter to trigger LogLineModel internals
+    expect(log.body).toBeDefined();
     const grammar = generateLogGrammar(log);
     const tokens = Prism.tokenize(log.entry, grammar);
     return { log, grammar, tokens };
@@ -29,7 +31,7 @@ describe('generateLogGrammar', () => {
       expect(tokens[1].type).toBe('log-token-json-key');
     }
     if (tokens[3] instanceof Token) {
-      expect(tokens[3].content).toBe('"value"');
+      expect(tokens[3].content).toEqual(['"value"']);
       expect(tokens[3].type).toBe('log-token-string');
     }
     if (tokens[5] instanceof Token) {
@@ -37,10 +39,10 @@ describe('generateLogGrammar', () => {
       expect(tokens[5].type).toBe('log-token-json-key');
     }
     if (tokens[7] instanceof Token) {
-      expect(tokens[7].content).toBe('"value2"');
+      expect(tokens[7].content).toEqual(['"value2"']);
       expect(tokens[7].type).toBe('log-token-string');
     }
-    expect.assertions(8);
+    expect.assertions(9);
   });
 
   test('Identifies sizes', () => {
@@ -53,7 +55,7 @@ describe('generateLogGrammar', () => {
       expect(tokens[2].content).toBe('2 KB');
       expect(tokens[2].type).toBe('log-token-size');
     }
-    expect.assertions(4);
+    expect.assertions(5);
   });
 
   test('Identifies durations', () => {
@@ -70,7 +72,7 @@ describe('generateLogGrammar', () => {
       expect(tokens[4].content).toBe('1h');
       expect(tokens[4].type).toBe('log-token-duration');
     }
-    expect.assertions(6);
+    expect.assertions(7);
   });
 
   test.each(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'])(
@@ -81,7 +83,7 @@ describe('generateLogGrammar', () => {
         expect(tokens[1].content).toBe(method);
         expect(tokens[1].type).toBe('log-token-method');
       }
-      expect.assertions(2);
+      expect.assertions(3);
     }
   );
 });

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -30,17 +30,10 @@ const jsonGrammar: Grammar = {
     greedy: true,
     inside: {
       ...tokensGrammar,
-    }
+    },
   },
   'log-token-size': /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
-  'punctuation': /[{}[\],]/,
-  'operator': /:/,
-  'boolean': /\b(?:false|true)\b/,
-  'null': {
-    pattern: /\bnull\b/,
-    alias: 'keyword',
-  },
-}
+};
 
 export const generateLogGrammar = (log: LogListModel) => {
   const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -48,7 +48,6 @@ export const generateLogGrammar = (log: LogListModel) => {
     'log-token-label': new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
   };
   if (log.isJSON) {
-    console.log('yeah')
     return {
       ...logGrammar,
       ...jsonGrammar,

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -6,7 +6,6 @@ import { LogListModel } from './processing';
 
 // The Logs grammar is used for highlight in the logs panel
 const logsGrammar: Grammar = {
-  'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
   'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
 };
@@ -48,8 +47,8 @@ export const generateLogGrammar = (log: LogListModel) => {
   }
   return {
     ...logGrammar,
-    ...logsGrammar,
     ...tokensGrammar,
+    ...logsGrammar,
   };
 };
 

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -5,24 +5,59 @@ import { escapeRegex, parseFlags } from '@grafana/data';
 import { LogListModel } from './processing';
 
 // The Logs grammar is used for highlight in the logs panel
-export const logsGrammar: Grammar = {
-  'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
+const logsGrammar: Grammar = {
   'log-token-json-key': /"(\b|\B)[\w-]+"(?=\s*:)/gi,
   'log-token-key': /(\b|\B)[\w_]+(?=\s*=)/gi,
+  'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
+};
+
+const tokensGrammar: Grammar = {
+  'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
   'log-token-duration': /(?:\b)\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b)/g,
   'log-token-method': /\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)\b/g,
-  'log-token-string': /"(?!:)([^'"])*?"(?!:)/g,
 };
+
+const jsonGrammar: Grammar = {
+  'log-token-json-key': {
+    pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
+    lookbehind: true,
+    greedy: true,
+  },
+  'log-token-string': {
+    pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
+    lookbehind: true,
+    greedy: true,
+    inside: {
+      ...tokensGrammar,
+    }
+  },
+  'log-token-size': /-?\b\d+(?:\.\d+)?(?:e[+-]?\d+)?\b/i,
+  'punctuation': /[{}[\],]/,
+  'operator': /:/,
+  'boolean': /\b(?:false|true)\b/,
+  'null': {
+    pattern: /\bnull\b/,
+    alias: 'keyword',
+  },
+}
 
 export const generateLogGrammar = (log: LogListModel) => {
   const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));
   const logGrammar: Grammar = {
     'log-token-label': new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
   };
+  if (log.isJSON) {
+    console.log('yeah')
+    return {
+      ...logGrammar,
+      ...jsonGrammar,
+    };
+  }
   return {
     ...logGrammar,
     ...logsGrammar,
+    ...tokensGrammar,
   };
 };
 

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -142,7 +142,7 @@ describe('preProcessLogs', () => {
       expect(logListModel.getDisplayedFieldValue(LOG_LINE_BODY_FIELD_NAME, true)).toBe('log message 1');
     });
 
-    test('Prettifies JSON', () => {
+    test('Does not modify unwrapped JSON', () => {
       const entry = '{"key": "value", "otherKey": "otherValue"}';
       const logListModel = createLogLine(
         { entry },
@@ -151,6 +151,21 @@ describe('preProcessLogs', () => {
           order: LogsSortOrder.Descending,
           timeZone: 'browser',
           wrapLogMessage: false, // unwrapped
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).toBe(entry);
+    });
+
+    test('Prettifies wrapped JSON', () => {
+      const entry = '{"key": "value", "otherKey": "otherValue"}';
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: true, // wrapped
         }
       );
       expect(logListModel.entry).toBe(entry);

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -186,6 +186,40 @@ describe('preProcessLogs', () => {
       expect(logListModel.entry).toBe(entry);
       expect(logListModel.body).toContain('90071992547409911');
     });
+
+    test.each([
+      '{"timestamp":"2025-08-19T12:34:56Z","level":"INFO","message":"User logged in","user_id":1234}',
+      '{"time":"2025-08-19T12:35:10Z","level":"ERROR","service":"payment","error":"Insufficient funds","transaction_id":"tx-98765"}',
+      '{"ts":1692444912,"lvl":"WARN","component":"auth","msg":"Token expired","session_id":"abcd1234"}',
+      '{"@timestamp":"2025-08-19T12:36:00Z","severity":"DEBUG","event":"cache_hit","key":"user_profile:1234","duration_ms":3}',
+      '{}',
+    ])('Detects JSON logs', (entry: string) => {
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: false,
+        }
+      );
+      expect(logListModel.body).toBeDefined(); // Triggers parsing
+      expect(logListModel.isJSON).toBe(true);
+    });
+
+    test.each(['1', '"1"', 'true', 'null', 'false', 'not json', '"nope"'])('Detects non-JSON logs', (entry: string) => {
+      const logListModel = createLogLine(
+        { entry },
+        {
+          escape: false,
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: false,
+        }
+      );
+      expect(logListModel.body).toBeDefined(); // Triggers parsing
+      expect(logListModel.isJSON).toBe(false);
+    });
   });
 
   test('Orders logs', () => {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -63,6 +63,7 @@ export class LogListModel implements LogRowModel {
   private _getFieldLinks: GetFieldLinksFn | undefined = undefined;
   private _virtualization?: LogLineVirtualization;
   private _wrapLogMessage: boolean;
+  private _json = false;
 
   constructor(
     log: LogRowModel,
@@ -124,9 +125,13 @@ export class LogListModel implements LogRowModel {
   get body(): string {
     if (this._body === undefined) {
       try {
-        const parsed = stringify(parse(this.raw), undefined, this._wrapLogMessage ? 2 : 1);
-        if (parsed) {
-          this.raw = parsed;
+        const parsed = parse(this.raw);
+        if (typeof parsed === 'object') {
+          this._json = true; 
+        }
+        const reStringified = this._wrapLogMessage ? stringify(parsed, undefined, 2) : this.raw;
+        if (reStringified) {
+          this.raw = reStringified;
         }
       } catch (error) {}
       const raw = config.featureToggles.otelLogsFormatting && this.otelLanguage ? getOtelFormattedBody(this) : this.raw;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -162,11 +162,7 @@ export class LogListModel implements LogRowModel {
       const sanitizedBody = textUtil.sanitize(this.body);
       this._grammar = this._grammar ?? generateLogGrammar(this);
       const extraGrammar = generateTextMatchGrammar(this.searchWords, this._currentSearch);
-      this._highlightedBody = Prism.highlight(
-        sanitizedBody,
-        { ...extraGrammar, ...this._grammar },
-        'lokiql'
-      );
+      this._highlightedBody = Prism.highlight(sanitizedBody, { ...extraGrammar, ...this._grammar }, 'lokiql');
     }
     return this._highlightedBody;
   }


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

Changes:

- Improved the column size of label names in log details, to leave enough space for values when names are long. 08565bd5bb9033c3f4958676aa61a80e4fa4b290

Before:

<img width="804" height="1018" alt="Before" src="https://github.com/user-attachments/assets/44d326f2-26bf-46d0-b625-8259d5825192" />

After:

<img width="826" height="1027" alt="After" src="https://github.com/user-attachments/assets/a7ac0218-030a-486c-b192-e75abb136b0a" />

- When JSON log lines are unwrapped, do not "prettify". This was introducing spaces to the inline JSON, which increased proportionally with the depth of the JSON structure. 2ecd17c159d7f9199ec2983150e5c32d26e01c8d
- When JSON log lines are detected (they don't produce exceptions when parsing and return objects), we now use a custom highlighting [grammar](https://github.com/PrismJS/prism/blob/v2/src/languages/json.js) more appropriate for JSON, further improving readability of wrapped and unwrapped JSON. 2ecd17c159d7f9199ec2983150e5c32d26e01c8d and 40fd0d24bed68859b15c733dafb19b5e151cc104 

Before: extra spaces, incorrect highlighting.

<img width="1638" height="187" alt="JSON before" src="https://github.com/user-attachments/assets/5221e4b6-b3aa-416b-85b6-9e79fc8e761e" />

After:

https://github.com/user-attachments/assets/764b1264-8e72-451d-a0f6-f1161fd34ad5

- Improved margins for inline Log Details to better scope them to the source log line and improve readability.

<img width="1586" height="738" alt="Details after" src="https://github.com/user-attachments/assets/b6b70796-5267-4187-82eb-428d7276374e" />

<img width="1612" height="754" alt="Details dashboards after" src="https://github.com/user-attachments/assets/7dfd5aea-20d6-4f93-b1a2-8f073db7321b" />
