### PR TITLE
Secrets: Validate name/namespace with standard K8s validator

### DIFF
--- a/pkg/registry/apis/secret/contracts/secure_value.go
+++ b/pkg/registry/apis/secret/contracts/secure_value.go
@@ -11,7 +11,7 @@ import (
 )
 
 // The maximum size of a secure value in bytes when written as raw input.
-const SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES = 24576 // 24 KiB
+const SecureValueRawInputMaxSizeBytes = 24576 // 24 KiB
 
 type DecryptSecureValue struct {
 	Keeper     *string

--- a/pkg/registry/apis/secret/inline/inline_secure_value.go
+++ b/pkg/registry/apis/secret/inline/inline_secure_value.go
@@ -118,10 +118,7 @@ func (s *LocalInlineSecureValueService) isSecureValueOwnedByResource(ctx context
 			return true, nil // The secure value is owned by the same owner reference, pass!
 		}
 
-		return false, fmt.Errorf(
-			"secure value %s is not owned by %s/%s/%s/%s but by %s/%s/%s",
-			name, owner.APIGroup, owner.APIVersion, owner.Kind, owner.Name, actualOwner.APIVersion, actualOwner.Kind, actualOwner.Name,
-		)
+		return false, fmt.Errorf("secure value %s is not owned by %s/%s/%s/%s", name, owner.APIGroup, owner.APIVersion, owner.Kind, owner.Name)
 	}
 
 	// not owned

--- a/pkg/registry/apis/secret/validator/secure_value.go
+++ b/pkg/registry/apis/secret/validator/secure_value.go
@@ -38,17 +38,27 @@ func (v *secureValueValidator) Validate(sv, oldSv *secretv1beta1.SecureValue, op
 	}
 
 	// General validations.
-	if sv.Name == "" {
-		errs = append(errs, field.Required(field.NewPath("metadata", "name"), "a `name` is required"))
-	}
-	if sv.Namespace == "" {
-		errs = append(errs, field.Required(field.NewPath("metadata", "namespace"), "a `namespace` is required"))
-	}
-
-	if sv.Spec.Value != nil && len(*sv.Spec.Value) > contracts.SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES {
+	if err := validation.IsDNS1123Subdomain(sv.Name); len(err) > 0 {
 		errs = append(
 			errs,
-			field.TooLong(field.NewPath("spec", "value"), len(*sv.Spec.Value), contracts.SECURE_VALUE_RAW_INPUT_MAX_SIZE_BYTES),
+			field.Invalid(field.NewPath("metadata", "name"), sv.Name, strings.Join(err, ",")),
+		)
+
+		return errs
+	}
+	if err := validation.IsDNS1123Subdomain(sv.Namespace); len(err) > 0 {
+		errs = append(
+			errs,
+			field.Invalid(field.NewPath("metadata", "namespace"), sv.Name, strings.Join(err, ",")),
+		)
+
+		return errs
+	}
+
+	if sv.Spec.Value != nil && len(*sv.Spec.Value) > contracts.SecureValueRawInputMaxSizeBytes {
+		errs = append(
+			errs,
+			field.TooLong(field.NewPath("spec", "value"), len(*sv.Spec.Value), contracts.SecureValueRawInputMaxSizeBytes),
 		)
 	}
 


### PR DESCRIPTION
Rather than validate name and namespace manually, we can use the `IsDNS1123Subdomain` method which can validate both more correctly. https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names