### PR TITLE
Secrets: Refactor setting additional decrypter

### DIFF
--- a/pkg/registry/apis/provisioning/secrets/repository.go
+++ b/pkg/registry/apis/provisioning/secrets/repository.go
@@ -21,7 +21,7 @@ func ProvideRepositorySecrets(
 	decryptSvc secret.DecryptService,
 	cfg *setting.Cfg,
 ) RepositorySecrets {
-	return NewRepositorySecrets(features, NewSecretsService(secretsSvc, decryptSvc, cfg), NewSingleTenant(legacySecretsSvc))
+	return NewRepositorySecrets(features, NewSecretsService(secretsSvc, decryptSvc, cfg.SecretsManagement.GrpcGrafanaServiceName), NewSingleTenant(legacySecretsSvc))
 }
 
 //go:generate mockery --name RepositorySecrets --structname MockRepositorySecrets --inpackage --filename repository_secrets_mock.go --with-expecter

--- a/pkg/registry/apis/provisioning/secrets/secret.go
+++ b/pkg/registry/apis/provisioning/secrets/secret.go
@@ -11,7 +11,6 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 const svcName = provisioning.GROUP
@@ -30,16 +29,16 @@ var _ Service = (*secretsService)(nil)
 
 //go:generate mockery --name DecryptService --structname MockDecryptService --srcpkg=github.com/grafana/grafana/pkg/registry/apis/secret --filename decrypt_service_mock.go --with-expecter
 type secretsService struct {
-	secureValues SecureValueClient
-	decryptSvc   secret.DecryptService
-	cfg          *setting.Cfg
+	secureValues         SecureValueClient
+	decryptSvc           secret.DecryptService
+	decrypterServiceName string
 }
 
-func NewSecretsService(secretsSvc SecureValueClient, decryptSvc secret.DecryptService, cfg *setting.Cfg) Service {
+func NewSecretsService(secretsSvc SecureValueClient, decryptSvc secret.DecryptService, grpcGrafanaServiceName string) Service {
 	return &secretsService{
-		secureValues: secretsSvc,
-		decryptSvc:   decryptSvc,
-		cfg:          cfg,
+		secureValues:         secretsSvc,
+		decryptSvc:           decryptSvc,
+		decrypterServiceName: grpcGrafanaServiceName,
 	}
 }
 
@@ -78,8 +77,8 @@ func (s *secretsService) Encrypt(ctx context.Context, namespace, name string, da
 	}
 
 	decrypters := []string{svcName}
-	if s.cfg.SecretsManagement.GrpcGrafanaServiceName != "" {
-		decrypters = append(decrypters, s.cfg.SecretsManagement.GrpcGrafanaServiceName)
+	if s.decrypterServiceName != "" {
+		decrypters = append(decrypters, s.decrypterServiceName)
 	}
 
 	// Create the secret directly as unstructured

--- a/pkg/registry/apis/provisioning/secrets/secret_test.go
+++ b/pkg/registry/apis/provisioning/secrets/secret_test.go
@@ -16,7 +16,6 @@ import (
 	secretv1beta1 "github.com/grafana/grafana/apps/secret/pkg/apis/secret/v1beta1"
 	"github.com/grafana/grafana/pkg/registry/apis/secret"
 	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 // mockDynamicInterface implements a simplified version of the dynamic.ResourceInterface
@@ -51,7 +50,7 @@ func TestNewSecretsService(t *testing.T) {
 	mockSecretsSvc := NewMockSecureValueClient(t)
 	mockDecryptSvc := &secret.MockDecryptService{}
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 
 	assert.NotNil(t, svc)
 	assert.IsType(t, &secretsService{}, svc)
@@ -209,7 +208,7 @@ func TestSecretsService_Encrypt(t *testing.T) {
 
 			tt.setupMocks(mockSecretsSvc, mockDecryptSvc, mockResourceInterface)
 
-			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 
 			ctx := context.Background()
 
@@ -233,7 +232,7 @@ func TestSecretsService_Encrypt_ClientError(t *testing.T) {
 	// Setup client to return error
 	mockSecretsSvc.EXPECT().Client(mock.Anything, "test-namespace").Return(nil, errors.New("client error"))
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 
 	ctx := context.Background()
 
@@ -336,7 +335,7 @@ func TestSecretsService_Decrypt(t *testing.T) {
 
 			tt.setupMocks(mockSecretsSvc, mockDecryptSvc)
 
-			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 
 			ctx := context.Background()
 
@@ -374,7 +373,7 @@ func TestSecretsService_Decrypt_ServiceIdentityContext(t *testing.T) {
 		"test-secret": mockResult,
 	}, nil)
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 
 	ctx := context.Background()
 	result, err := svc.Decrypt(ctx, "test-namespace", "test-secret")
@@ -436,7 +435,7 @@ func TestSecretsService_Delete(t *testing.T) {
 
 			tt.setupMocks(mockSecretsSvc, mockDecryptSvc, mockResourceInterface)
 
-			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+			svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 			ctx := context.Background()
 
 			err := svc.Delete(ctx, tt.namespace, tt.secretName)
@@ -521,7 +520,7 @@ func TestSecretsService_Encrypt_WithK8sNotFoundError(t *testing.T) {
 	}
 	mockResourceInterface.createErr = nil
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 	ctx := context.Background()
 
 	result, err := svc.Encrypt(ctx, "test-namespace", "test-secret", "secret-data")
@@ -542,7 +541,7 @@ func TestSecretsService_Delete_WithK8sNotFoundError(t *testing.T) {
 	k8sNotFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "secret.grafana.app", Resource: "securevalues"}, "test-secret")
 	mockResourceInterface.deleteErr = k8sNotFoundErr
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 	ctx := context.Background()
 
 	err := svc.Delete(ctx, "test-namespace", "test-secret")
@@ -563,7 +562,7 @@ func TestSecretsService_Delete_WithGrafanaNotFoundError(t *testing.T) {
 	// Mock Delete call to return Grafana not found error
 	mockResourceInterface.deleteErr = contracts.ErrSecureValueNotFound
 
-	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, &setting.Cfg{})
+	svc := NewSecretsService(mockSecretsSvc, mockDecryptSvc, "")
 	ctx := context.Background()
 
 	err := svc.Delete(ctx, "test-namespace", "test-secret")


### PR DESCRIPTION
**What is this feature?**

This PR refactors the `NewSecretsService` function, to take the decrypter value directly, so we do not have to depend on the settings.Cfg

Required for https://github.com/grafana/grafana-enterprise/pull/9325/files