### PR TITLE
DS-Querier: support group queries

### DIFF
--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -274,31 +274,23 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 		func() {
 			ctx, span := s.tracer.Start(ctx, "SSE.ExecuteDatasourceQuery")
 			defer span.End()
-			firstNode := nodeGroup[0]
-			pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, firstNode.datasource.Type, firstNode.request.User, firstNode.datasource)
-			if err != nil {
-				for _, dn := range nodeGroup {
-					vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
-				}
-				return
-			}
 
+			firstNode := nodeGroup[0]
 			logger := logger.FromContext(ctx).New("datasourceType", firstNode.datasource.Type,
 				"queryRefId", firstNode.refID,
 				"datasourceUid", firstNode.datasource.UID,
 				"datasourceVersion", firstNode.datasource.Version,
 			)
-
 			span.SetAttributes(
 				attribute.String("datasource.type", firstNode.datasource.Type),
 				attribute.String("datasource.uid", firstNode.datasource.UID),
 			)
 
 			req := &backend.QueryDataRequest{
-				PluginContext: pCtx,
-				Headers:       firstNode.request.Headers,
+				Headers: firstNode.request.Headers,
 			}
 
+			// add all the queries from the node group to the request
 			for _, dn := range nodeGroup {
 				req.Queries = append(req.Queries, backend.DataQuery{
 					RefID:         dn.refID,
@@ -324,15 +316,48 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 				s.metrics.DSRequests.WithLabelValues(respStatus, fmt.Sprintf("%t", useDataplane), firstNode.datasource.Type).Inc()
 			}
 
-			resp, err := s.dataService.QueryData(ctx, req)
+			var resp *backend.QueryDataResponse
+
+			// get the new client if it exists
+			mtDSClient, ok, err := s.mtDatasourceClientBuilder.BuildClient(firstNode.datasource.Type, firstNode.datasource.UID)
 			if err != nil {
 				for _, dn := range nodeGroup {
-					vars[dn.refID] = mathexp.Results{Error: MakeQueryError(firstNode.refID, firstNode.datasource.UID, err)}
+					vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
 				}
 				instrument(err, "")
 				return
 			}
 
+			var queryErr error
+			if !ok { // legacy flow
+				pCtx, err := s.pCtxProvider.GetWithDataSource(ctx, firstNode.datasource.Type, firstNode.request.User, firstNode.datasource)
+				if err != nil {
+					for _, dn := range nodeGroup {
+						vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
+					}
+					return
+				}
+				req.PluginContext = pCtx
+				resp, queryErr = s.dataService.QueryData(ctx, req)
+			} else { // new query service flow
+				k8sReq, err := ConvertBackendRequestToDataRequest(req)
+				if err != nil {
+					for _, dn := range nodeGroup {
+						vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
+					}
+					return
+				}
+
+				resp, queryErr = mtDSClient.QueryData(ctx, *k8sReq)
+			}
+
+			if queryErr != nil {
+				for _, dn := range nodeGroup {
+					vars[dn.refID] = mathexp.Results{Error: MakeQueryError(firstNode.refID, firstNode.datasource.UID, queryErr)}
+				}
+				instrument(queryErr, "")
+				return
+			}
 			for _, dn := range nodeGroup {
 				dataFrames, err := getResponseFrame(logger, resp, dn.refID)
 				if err != nil {

--- a/pkg/expr/nodes.go
+++ b/pkg/expr/nodes.go
@@ -319,7 +319,7 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 			var resp *backend.QueryDataResponse
 
 			// get the new client if it exists
-			mtDSClient, ok, err := s.mtDatasourceClientBuilder.BuildClient(firstNode.datasource.Type, firstNode.datasource.UID)
+			qsDSClient, ok, err := s.qsDatasourceClientBuilder.BuildClient(firstNode.datasource.Type, firstNode.datasource.UID)
 			if err != nil {
 				for _, dn := range nodeGroup {
 					vars[dn.refID] = mathexp.Results{Error: datasources.ErrDataSourceNotFound}
@@ -348,7 +348,7 @@ func executeDSNodesGrouped(ctx context.Context, now time.Time, vars mathexp.Vars
 					return
 				}
 
-				resp, queryErr = mtDSClient.QueryData(ctx, *k8sReq)
+				resp, queryErr = qsDSClient.QueryData(ctx, *k8sReq)
 			}
 
 			if queryErr != nil {


### PR DESCRIPTION
An alert rule can contain multiple queries for example: 
```
{
    "from": "1755541814692",
    "to": "1755545414692",
    "queries": [
        {
            "refId": "A",
            "datasource": {
                "type": "cloudwatch",
                "uid": "000000044"
            },
            //...
        },
        {
            "refId": "B",
            "datasource": {
                "type": "cloudwatch",
                "uid": "000000044"
            },
            //...
        },
        {
            "refId": "C",
            "datasource": {
                "type": "__expr__",
                "uid": "__expr__"
            },
            "type": "math",
            "expression": "$B * 3",
            "timeRange": {
                "from": "1755100555074",
                "to": "1755100855074"
            }
        }
    ]
}
```
By default each of these queries is made individually, even if they share the same datasource and share the same timerange.

However, it is possible to have some of these queries referencing each other. Often this is done with serverside expressions (for example you see here an expression `$B * 3`) but it is also possible in some datasources to do this in the datasource itself. For example, cloudwatch has a very similar concept to server side expressions called metric math where you can do this sort of multiplication but it is done within AWS. In such cases we need to send the queries together as a group in the same http request.

This has already been implemented under the featureflags `CloudWatchBatchQueries` and `sseGroupByDatasource`, however in our new query service we have not yet added support for this, and it throws a panic in our query service flow doesn't implement "pluginContext". This pr adds support for this functionality in the query service.

Fixes: https://github.com/grafana/grafana-enterprise/issues/9404