### PR TITLE
Provisioning: Fix rendering loop in FinishedJobStatus component

### DIFF
--- a/public/app/features/provisioning/Job/FinishedJobStatus.tsx
+++ b/public/app/features/provisioning/Job/FinishedJobStatus.tsx
@@ -36,6 +36,20 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
       }, 1000);
     }
 
+    if (retryFailed) {
+      onStatusChange?.({
+        status: 'error',
+        error: {
+          title: t('provisioning.job-status.no-job-found', 'No job found'),
+          message: t(
+            'provisioning.job-status.no-job-found-message',
+            'The job may have been deleted or could not be retrieved. Cancel the current process and start again.'
+          ),
+        },
+      });
+      return;
+    }
+
     if (finishedQuery.isSuccess && job?.status) {
       const { state, message, errors } = job.status;
 
@@ -70,21 +84,7 @@ export function FinishedJobStatus({ jobUid, repositoryName, jobType, onStatusCha
         clearTimeout(timeoutId);
       }
     };
-  }, [finishedQuery, job, onStatusChange]);
-
-  if (retryFailed) {
-    onStatusChange?.({
-      status: 'error',
-      error: {
-        title: t('provisioning.job-status.no-job-found', 'No job found'),
-        message: t(
-          'provisioning.job-status.no-job-found-message',
-          'The job may have been deleted or could not be retrieved. Cancel the current process and start again.'
-        ),
-      },
-    });
-    return null;
-  }
+  }, [finishedQuery, job, onStatusChange, retryFailed]);
 
   if (!job || finishedQuery.isLoading || finishedQuery.isFetching) {
     return (

--- a/public/app/features/provisioning/Job/JobContent.tsx
+++ b/public/app/features/provisioning/Job/JobContent.tsx
@@ -76,15 +76,13 @@ export function JobContent({ jobType, job, isFinishedJob = false, onStatusChange
     <Stack direction="column" gap={2}>
       <Stack direction="column" gap={2}>
         {['working', 'pending'].includes(state ?? '') && (
-          <Stack direction="row" alignItems="center" justifyContent="center" gap={2}>
-            <Spinner size={24} />
-            <Text element="h5" color="secondary">
-              {message ?? state ?? t('provisioning.job-status.starting', 'Starting...')}
-            </Text>
-          </Stack>
-        )}
-        {state && !['success', 'error'].includes(state) && (
-          <Stack direction="row" alignItems="center" justifyContent="center" gap={2}>
+          <Stack direction="column" alignItems="center">
+            <Stack direction="row" alignItems="center" justifyContent="center" gap={2}>
+              <Spinner size={24} />
+              <Text element="h5" color="secondary">
+                {message ?? state ?? t('provisioning.job-status.starting', 'Starting...')}
+              </Text>
+            </Stack>
             <ProgressBar progress={progress ?? 0} />
           </Stack>
         )}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes a React rendering violation in the `FinishedJobStatus` component that was causing console warnings and infinite loops when a sync job fails. The fix moves state update calls from the render phase to `useEffect`.

**Why do we need this feature?**

The component was calling `onStatusChange` during the render phase when retry failed, which violates React's rule against updating components while rendering. This caused the React warning "Cannot update a component while rendering a different component" and could lead to infinite re-renders.
