### PR TITLE
Provisioning: Fix Bug Blocking Changing Pull Target During Onboarding

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -286,7 +286,6 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					Namespace:   a.GetNamespace(),
 					Subresource: a.GetSubresource(),
 				})
-
 				if err != nil {
 					return authorizer.DecisionDeny, "failed to perform authorization", err
 				}
@@ -622,7 +621,7 @@ func (b *APIBuilder) verifyAgaintsExistingRepositories(cfg *provisioning.Reposit
 	} else {
 		// Folder sync cannot be created if an instance repository exists
 		for _, v := range all {
-			if v.Spec.Sync.Target == provisioning.SyncTargetTypeInstance {
+			if v.Spec.Sync.Target == provisioning.SyncTargetTypeInstance && v.Name != cfg.Name {
 				return field.Forbidden(field.NewPath("spec", "sync", "target"),
 					"Cannot create folder repository when instance repository exists: "+v.Name)
 			}

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -485,14 +485,9 @@ func (h *provisioningTestHelper) CreateRepo(t *testing.T, repo TestRepo) {
 		require.NoError(t, err, "should be able to create repository path")
 	}
 
-	syncEnabled := true
-	if repo.SkipSync {
-		syncEnabled = false
-	}
-
 	templateVars := map[string]any{
 		"Name":        repo.Name,
-		"SyncEnabled": syncEnabled,
+		"SyncEnabled": !repo.SkipSync,
 		"SyncTarget":  repo.Target,
 	}
 	if repo.Path != "" {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix the issue where users are blocked from creating repositories with folder sync enabled.

**Why do we need this feature?**

The system blocks users from creating repositories with folder sync.

**Who is this feature for?**

Users of Git Sync / Provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/457>
Introduced by https://github.com/grafana/grafana/pull/109512

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
