### PR TITLE
apiserver: enable support for Streaming lists  

### DIFF
--- a/pkg/services/apiserver/options/extra.go
+++ b/pkg/services/apiserver/options/extra.go
@@ -45,6 +45,7 @@ func (o *ExtraOptions) ApplyTo(c *genericapiserver.RecommendedConfig) error {
 	logger := slog.New(handler)
 	if err := utilfeature.DefaultMutableFeatureGate.SetFromMap(map[string]bool{
 		string(genericfeatures.APIServerTracing): false,
+		string(genericfeatures.WatchList):        true,
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Enable support for watchlist feature gate by enabling the WatchList feature gate.

See https://kubernetes.io/docs/reference/using-api/api-concepts/#streaming-lists
initial [thread](https://raintank-corp.slack.com/archives/C06JFJ7H3GC/p1755181091964109)