### PR TITLE
Alerting: Set dataSourceName to GRAFANA_RULES_SOURCE_NAME when switch…

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -37,7 +37,7 @@ import {
   isExpressionQueryInAlert,
 } from '../../../rule-editor/formProcessing';
 import { RuleFormType, RuleFormValues } from '../../../types/rule-form';
-import { getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
+import { GRAFANA_RULES_SOURCE_NAME, getDefaultOrFirstCompatibleDataSource } from '../../../utils/datasource';
 import { PromOrLokiQuery, isPromOrLokiQuery } from '../../../utils/rule-form';
 import {
   isCloudAlertingRuleByType,
@@ -422,7 +422,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
     const typeInForm = getValues('type');
     if (typeInForm === RuleFormType.cloudAlerting) {
       setValue('type', RuleFormType.grafana);
-      setValue('dataSourceName', null); // set data source name back to "null"
+      setValue('dataSourceName', GRAFANA_RULES_SOURCE_NAME);
 
       prevExpressions.length > 0 && restoreExpressionsInQueries();
       prevCondition && setValue('condition', prevCondition);


### PR DESCRIPTION
**Which issue(s) does this PR fix?:**
Fixes escalation [#17967](https://github.com/grafana/support-escalations/issues/17967)

**Issue**
Submitting after switching Rule Type from data source‑managed (DMA) to Grafana‑managed (GMA) fails with Uncaught (in promise) Error: no datasource name in form values. This happens when toggling between types in the editor (not only when duplicating a rule).

Context: previous handling discussed in PR grafana/grafana#73854.

**Root cause**
In onClickSwitch (QueryAndExpressionsStep.tsx), when switching to GMA the code sets dataSourceName to null.
Submit logic always requires a non‑null dataSourceName to compute the rule group target, so the form errors on save.

**Reproduction**
Open an alert rule (new or duplicated).
Switch Rule Type to DMA, then back to GMA.
Click Save.
Observe console error: no datasource name in form values.




