### PR TITLE
New Logs Context: Add time window option

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -137,7 +137,7 @@ export interface LogRowContextOptions {
   direction?: LogRowContextQueryDirection;
   limit?: number;
   scopedVars?: ScopedVars;
-  // Size of the time window to get logs before of after the referenced entry. Defaults to 2h.
+  // Optional. Size of the time window to get logs before of after the referenced entry.
   timeWindowMs?: number;
 }
 

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -137,6 +137,8 @@ export interface LogRowContextOptions {
   direction?: LogRowContextQueryDirection;
   limit?: number;
   scopedVars?: ScopedVars;
+  // Size of the time window to get logs before of after the referenced entry. Defaults to 2h.
+  timeWindowMs?: number;
 }
 
 export enum LogRowContextQueryDirection {

--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -183,6 +183,9 @@ export interface DataSourceWithLogsContextSupport<TQuery extends DataQuery = Dat
     origQuery?: TQuery,
     scopedVars?: ScopedVars
   ): React.ReactNode;
+
+  // Does the datasource support the user adjusting the time range in the logs context window? https://github.com/grafana/grafana/pull/109901
+  supportsAdjustableWindow?: boolean;
 }
 
 export const hasLogsContextSupport = (datasource: unknown): datasource is DataSourceWithLogsContextSupport => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -581,10 +581,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   let onCloseContext = useCallback(() => {
     setContextOpen(false);
     setContextRow(undefined);
-    reportInteraction('grafana_explore_logs_log_context_closed', {
-      datasourceType: contextRow?.datasourceType,
-      logRowUid: contextRow?.uid,
-    });
+    if (!config.featureToggles.newLogContext) {
+      reportInteraction('grafana_explore_logs_log_context_closed', {
+        datasourceType: contextRow?.datasourceType,
+        logRowUid: contextRow?.uid,
+      });
+    }
     onCloseCallbackRef?.current();
   }, [contextRow?.datasourceType, contextRow?.uid, onCloseCallbackRef]);
 
@@ -592,10 +594,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     // we are setting the `contextOpen` open state and passing it down to the `LogRow` in order to highlight the row when a LogContext is open
     setContextOpen(true);
     setContextRow(row);
-    reportInteraction('grafana_explore_logs_log_context_opened', {
-      datasourceType: row.datasourceType,
-      logRowUid: row.uid,
-    });
+    if (!config.featureToggles.newLogContext) {
+      reportInteraction('grafana_explore_logs_log_context_opened', {
+        datasourceType: row.datasourceType,
+        logRowUid: row.uid,
+      });
+    }
     onCloseCallbackRef.current = onClose;
   }, []);
 

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -26,6 +26,7 @@ export interface Props {
   displayedFields: string[];
   handleOverflow: (index: number, id: string, height?: number) => void;
   infiniteScrollMode: InfiniteScrollMode;
+  loading?: boolean;
   loadMore?: LoadMoreLogsType;
   logs: LogListModel[];
   onClick: (e: MouseEvent<HTMLElement>, log: LogListModel) => void;
@@ -50,6 +51,7 @@ export const InfiniteScroll = ({
   displayedFields,
   handleOverflow,
   infiniteScrollMode,
+  loading,
   loadMore,
   logs,
   onClick,
@@ -102,12 +104,12 @@ export const InfiniteScroll = ({
   }, [prevSortOrder, sortOrder]);
 
   useEffect(() => {
-    if (autoScroll) {
+    if (autoScroll && !loading) {
       setInitialScrollPosition(scrollToLogLineRef.current);
       scrollToLogLineRef.current = undefined;
       setAutoScroll(false);
     }
-  }, [autoScroll, setInitialScrollPosition]);
+  }, [autoScroll, loading, setInitialScrollPosition]);
 
   const onLoadMore = useCallback(
     (scrollDirection: ScrollDirection) => {

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -10,7 +10,7 @@ import {
 
 import { dataFrameToLogsModel } from '../../logsModel';
 
-import { LogLineContext } from './LogLineContext';
+import { DEFAULT_TIME_WINDOW, LogLineContext, PAGE_SIZE } from './LogLineContext';
 
 jest.mock('@grafana/assistant', () => ({
   ...jest.requireActual('@grafana/assistant'),
@@ -541,5 +541,30 @@ describe('LogLineContext', () => {
     await userEvent.click(splitViewButton);
 
     await waitFor(() => expect(dispatchMock).toHaveBeenCalledWith(splitOpenSym));
+  });
+
+  test('Allows to change the time window surrounding the log', async () => {
+    row.datasourceType = 'loki';
+    
+    render(
+      <LogLineContext
+        log={row}
+        open={true}
+        onClose={() => {}}
+        getRowContext={getRowContext}
+        timeZone={timeZone}
+        sortOrder={LogsSortOrder.Descending}
+      />
+    );
+    await waitFor(() => expect(getRowContext).toHaveBeenCalledWith(expect.anything(), {
+      limit: PAGE_SIZE,
+      direction: LogRowContextQueryDirection.Forward,
+      timeWindowMs: DEFAULT_TIME_WINDOW,
+    }));
+    expect(getRowContext).toHaveBeenCalledWith(expect.anything(), {
+      limit: PAGE_SIZE,
+      direction: LogRowContextQueryDirection.Backward,
+      timeWindowMs: DEFAULT_TIME_WINDOW,
+    });
   });
 });

--- a/public/app/features/logs/components/panel/LogLineContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.test.tsx
@@ -545,7 +545,7 @@ describe('LogLineContext', () => {
 
   test('Allows to change the time window surrounding the log', async () => {
     row.datasourceType = 'loki';
-    
+
     render(
       <LogLineContext
         log={row}
@@ -556,11 +556,13 @@ describe('LogLineContext', () => {
         sortOrder={LogsSortOrder.Descending}
       />
     );
-    await waitFor(() => expect(getRowContext).toHaveBeenCalledWith(expect.anything(), {
-      limit: PAGE_SIZE,
-      direction: LogRowContextQueryDirection.Forward,
-      timeWindowMs: DEFAULT_TIME_WINDOW,
-    }));
+    await waitFor(() =>
+      expect(getRowContext).toHaveBeenCalledWith(expect.anything(), {
+        limit: PAGE_SIZE,
+        direction: LogRowContextQueryDirection.Forward,
+        timeWindowMs: DEFAULT_TIME_WINDOW,
+      })
+    );
     expect(getRowContext).toHaveBeenCalledWith(expect.anything(), {
       limit: PAGE_SIZE,
       direction: LogRowContextQueryDirection.Backward,

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -58,8 +58,8 @@ interface LogLineContextProps {
   onClickHideField?: (key: string) => void;
 }
 
-const PAGE_SIZE = 100;
-const DEFAULT_TIME_WINDOW = 7200000;
+export const PAGE_SIZE = 100;
+export const DEFAULT_TIME_WINDOW = 7200000;
 
 export const LogLineContext = memo(
   ({

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -125,13 +125,6 @@ export const LogLineContext = memo(
       setContextQuery(contextQuery);
     }, [log, getRowContextQuery]);
 
-    const updateResults = useCallback(async () => {
-      setAboveLogs([]);
-      setBelowLogs([]);
-      await updateContextQuery();
-      setInitialized(false);
-    }, [updateContextQuery]);
-
     useEffect(() => {
       if (open) {
         updateContextQuery();
@@ -275,6 +268,13 @@ export const LogLineContext = memo(
       });
       onClose();
     }, [log.datasourceType, log.uid, onClose]);
+
+    const updateResults = useCallback(async () => {
+      setAboveLogs([]);
+      setBelowLogs([]);
+      await updateContextQuery();
+      setInitialized(false);
+    }, [updateContextQuery]);
 
     const wrapLogMessage = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.wrapLogMessage`, true) : true;
     const syntaxHighlighting = logOptionsStorageKey

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -303,7 +303,7 @@ export const LogLineContext = memo(
         onDismiss={handleClose}
       >
         {config.featureToggles.logsContextDatasourceUi && getLogRowContextUi && (
-          <div className={styles.datasourceUi}>{getLogRowContextUi(log, updateResults)}</div>
+          <div>{getLogRowContextUi(log, updateResults)}</div>
         )}
         <Collapse
           collapsible={true}
@@ -421,10 +421,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       top: '50%',
       left: '50%',
       transform: 'translate(-50%, -50%)',
-    }),
-    datasourceUi: css({
-      display: 'flex',
-      alignItems: 'center',
     }),
     loadingIndicator: css({
       height: theme.spacing(3),

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -433,8 +433,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     wrapper: css({
       border: `1px solid ${theme.colors.border.weak}`,
       padding: theme.spacing(0, 1, 1, 0),
-      flex: 1,
-      height: '100%',
+      flex: '1 1 auto',
+      minHeight: 0,
     }),
     logsContainer: css({
       height: '100%',

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -102,8 +102,7 @@ export const LogLineContext = memo(
         sortOrder === LogsSortOrder.Ascending ? allLogs[0].timeEpochMs : allLogs[allLogs.length - 1].timeEpochMs;
       let toMs =
         sortOrder === LogsSortOrder.Ascending ? allLogs[allLogs.length - 1].timeEpochMs : allLogs[0].timeEpochMs;
-      // In case we have a lot of logs and from and to have same millisecond
-      // we add 1 millisecond to toMs to make sure we have a range
+      // Add one second to get a range when from and to are equal.
       if (fromMs === toMs) {
         toMs += 1;
       }

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -59,6 +59,7 @@ interface LogLineContextProps {
 }
 
 const PAGE_SIZE = 100;
+const DEFAULT_TIME_WINDOW = 7200000;
 
 export const LogLineContext = memo(
   ({
@@ -87,8 +88,8 @@ export const LogLineContext = memo(
     const [belowState, setBelowState] = useState(LoadingState.NotStarted);
     const [showLog, setShowLog] = useState(false);
     const defaultTimeWindow = logOptionsStorageKey
-      ? (store.get(`${logOptionsStorageKey}.contextTimeWindow`) ?? '7200000')
-      : '7200000';
+      ? (store.get(`${logOptionsStorageKey}.contextTimeWindow`) ?? DEFAULT_TIME_WINDOW.toString())
+      : DEFAULT_TIME_WINDOW.toString();
     const [timeWindow, setTimeWindow] = useState(parseInt(defaultTimeWindow, 10));
 
     const eventBusRef = useRef(new EventBusSrv());
@@ -509,7 +510,7 @@ const containsRow = (rows: LogRowModel[], row: LogRowModel) => {
 };
 
 function getTimeWindowOptions() {
-  const intervals = [100, 500, 1000, 5000, 30000, 60000, 300000, 1800000, 3600000, 7200000];
+  const intervals = [100, 500, 1000, 5000, 30000, 60000, 300000, 1800000, 3600000, DEFAULT_TIME_WINDOW];
   return intervals.map((interval) => ({
     label: formattedValueToString(getValueFormat('ms')(interval)),
     value: interval.toString(),

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -102,7 +102,7 @@ export const LogLineContext = memo(
         sortOrder === LogsSortOrder.Ascending ? allLogs[0].timeEpochMs : allLogs[allLogs.length - 1].timeEpochMs;
       let toMs =
         sortOrder === LogsSortOrder.Ascending ? allLogs[allLogs.length - 1].timeEpochMs : allLogs[0].timeEpochMs;
-      // Add one second to get a range when from and to are equal.
+      // Add one millisecond to get a range when from and to are equal.
       if (fromMs === toMs) {
         toMs += 1;
       }

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -84,7 +84,7 @@ export const LogLineContext = memo(
     const [aboveState, setAboveState] = useState(LoadingState.NotStarted);
     const [belowState, setBelowState] = useState(LoadingState.NotStarted);
     const [showLog, setShowLog] = useState(false);
-    const [interval, setInterval] = useState(0);
+    const [timeWindow, setTimeWindow] = useState(100);
     const eventBusRef = useRef(new EventBusSrv());
 
     const dispatch = useDispatch();
@@ -142,6 +142,7 @@ export const LogLineContext = memo(
         const result = await getRowContext(normalizeLogRefId(refLog), {
           limit: PAGE_SIZE,
           direction: getLoadMoreDirection(place, sortOrder),
+          timeWindowMs: timeWindow,
         });
 
         const newLogs = dataFrameToLogsModel(result.data).rows;
@@ -150,7 +151,7 @@ export const LogLineContext = memo(
         }
         return newLogs.filter((r) => !containsRow(allLogs, r));
       },
-      [allLogs, getRowContext, sortOrder]
+      [allLogs, getRowContext, sortOrder, timeWindow]
     );
 
     const loadMore = useCallback(
@@ -245,8 +246,8 @@ export const LogLineContext = memo(
       });
     }, [contextQuery, dispatch, log.dataFrame.refId, log.datasourceType, log.uid, onClose, timeRange]);
 
-    const handleIntervalChange = useCallback((newInterval: string) => {
-      setInterval(parseInt(newInterval, 10));
+    const handleIntervalChange = useCallback((windowSize: string) => {
+      setTimeWindow(parseInt(windowSize, 10));
       setAboveLogs([]);
       setBelowLogs([]);
       setInitialized(false);
@@ -301,7 +302,7 @@ export const LogLineContext = memo(
         <div className={styles.controls}>
           <RadioButtonGroup
             options={getIntervalOptions()}
-            value={interval.toString()}
+            value={timeWindow.toString()}
             onChange={handleIntervalChange}
           />
           <Button variant="secondary" onClick={onScrollCenterClick}>
@@ -480,19 +481,9 @@ const containsRow = (rows: LogRowModel[], row: LogRowModel) => {
 };
 
 function getIntervalOptions() {
-  const options = [
-    {
-      label: t('logs.log-line-context.interval-auto', 'Auto'),
-      value: '0',
-    },
-  ];
-  const intervals = [100, 500, 1000, 5000, 30000, 60000, 90000];
-  intervals.forEach((interval) => {
-    options.push({
-      label: interval.toString(),
-      value: interval.toString(),
-    });
-  });
-
-  return options;
+  const intervals = [100, 500, 1000, 5000, 30000, 60000, 90000, 1800000, 3600000, 10800000];
+  return intervals.map((interval) => ({
+    label: interval.toString(),
+    value: interval.toString(),
+  }));
 }

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -96,7 +96,6 @@ type LogListComponentProps = Omit<
   | 'dedupStrategy'
   | 'displayedFields'
   | 'enableLogDetails'
-  | 'loading'
   | 'logOptionsStorageKey'
   | 'permalinkedLogId'
   | 'showTime'
@@ -203,6 +202,7 @@ export const LogList = ({
           grammar={grammar}
           initialScrollPosition={initialScrollPosition}
           infiniteScrollMode={infiniteScrollMode}
+          loading={loading}
           loadMore={loadMore}
           logs={logs}
           showControls={showControls}
@@ -221,6 +221,7 @@ const LogListComponent = ({
   grammar,
   initialScrollPosition = 'top',
   infiniteScrollMode = 'interval',
+  loading,
   loadMore,
   logs,
   showControls,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -452,6 +452,7 @@ const LogListComponent = ({
           displayedFields={displayedFields}
           handleOverflow={handleOverflow}
           infiniteScrollMode={infiniteScrollMode}
+          loading={loading}
           logs={filteredLogs}
           loadMore={loadMore}
           onClick={handleLogLineClick}

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -181,8 +181,6 @@ export class LogContextProvider {
             to: timestamp,
           };
 
-    console.log(queryDirection, range.from, range.to);
-
     return {
       query,
       range: {

--- a/public/app/plugins/datasource/loki/LogContextProvider.ts
+++ b/public/app/plugins/datasource/loki/LogContextProvider.ts
@@ -71,7 +71,7 @@ export class LogContextProvider {
       this.cachedContextFilters = filters;
     }
 
-    return await this.prepareLogRowContextQueryTarget(row, limit, direction, origQuery);
+    return await this.prepareLogRowContextQueryTarget(row, limit, direction, origQuery, options?.timeWindowMs);
   }
 
   getLogRowContextQuery = async (
@@ -136,11 +136,10 @@ export class LogContextProvider {
     row: LogRowModel,
     limit: number,
     direction: LogRowContextQueryDirection,
-    origQuery?: LokiQuery
+    origQuery?: LokiQuery,
+    timeWindowMs = 2 * 60 * 60 * 1000
   ): Promise<{ query: LokiQuery; range: TimeRange }> {
     const expr = this.prepareExpression(this.cachedContextFilters, origQuery);
-
-    const contextTimeBuffer = 2 * 60 * 60 * 1000; // 2h buffer
 
     const queryDirection =
       direction === LogRowContextQueryDirection.Forward ? LokiQueryDirection.Forward : LokiQueryDirection.Backward;
@@ -174,13 +173,15 @@ export class LogContextProvider {
             // because the are before but came it he response that should return only rows after.
             from: timestamp,
             // convert to ns, we lose some precision here but it is not that important at the far points of the context
-            to: toUtc(row.timeEpochMs + contextTimeBuffer),
+            to: toUtc(row.timeEpochMs + timeWindowMs),
           }
         : {
             // convert to ns, we lose some precision here but it is not that important at the far points of the context
-            from: toUtc(row.timeEpochMs - contextTimeBuffer),
+            from: toUtc(row.timeEpochMs - timeWindowMs),
             to: timestamp,
           };
+
+    console.log(queryDirection, range.from, range.to);
 
     return {
       query,

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -162,7 +162,11 @@ export class LokiDatasource
     };
     this.variables = new LokiVariableSupport(this);
     this.logContextProvider = new LogContextProvider(this);
+    this.supportsAdjustableWindow = true;
   }
+
+  // Flag marking datasource as supporting adjusting the time range window in the logs context window: https://github.com/grafana/grafana/pull/109901
+  public supportsAdjustableWindow;
 
   /**
    * Implemented for DataSourceWithSupplementaryQueriesSupport.

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9476,6 +9476,8 @@
       "no-more-logs-available": "No more logs available.",
       "older-logs": "older",
       "open-in-split-view": "Open in split view",
+      "time-window-label": "Context time window",
+      "time-window-tooltip": "Amount of time before and after the referenced log",
       "title-log-context": "Log context",
       "title-log-line": "Referenced log line"
     },


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/99075

This PR adds a new option to Log Context to select the surrounding time around the referenced log line to request.

<img width="302" height="401" alt="imagen" src="https://github.com/user-attachments/assets/0a0af5f4-880a-4047-a3e3-df8dc878eabe" />

It defaults to 2 hours, which is what was used by the current implementation: https://github.com/grafana/grafana/blob/main/public/app/plugins/datasource/loki/LogContextProvider.ts#L143

https://github.com/user-attachments/assets/6f6ccebb-80c7-4d45-afaf-e99ca8425031

Additionally, the Log Context layout has been improved.