### PR TITLE
Grafana UI: Tabs - add missing style for disabled tabs

### DIFF
--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -27,11 +27,26 @@ export interface TabProps extends HTMLProps<HTMLElement> {
   suffix?: NavModelItem['tabSuffix'];
   truncate?: boolean;
   tooltip?: string;
+  /** When true, the tab will be disabled and not clickable */
+  disabled?: boolean;
 }
 
 export const Tab = React.forwardRef<HTMLElement, TabProps>(
   (
-    { label, active, icon, onChangeTab, counter, suffix: Suffix, className, href, truncate, tooltip, ...otherProps },
+    {
+      label,
+      active,
+      icon,
+      onChangeTab,
+      counter,
+      suffix: Suffix,
+      className,
+      href,
+      truncate,
+      tooltip,
+      disabled,
+      ...otherProps
+    },
     ref
   ) => {
     const tabsStyles = useStyles2(getStyles);
@@ -50,16 +65,18 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
       clearStyles,
       tabsStyles.link,
       active ? tabsStyles.activeStyle : tabsStyles.notActive,
-      truncate && tabsStyles.linkTruncate
+      truncate && tabsStyles.linkTruncate,
+      disabled && tabsStyles.disabled
     );
 
     const commonProps = {
       className: linkClass,
       'data-testid': selectors.components.Tab.title(label),
       ...otherProps,
-      onClick: onChangeTab,
+      onClick: disabled ? undefined : onChangeTab,
       role: 'tab',
       'aria-selected': active,
+      'aria-disabled': disabled,
       title: !!tooltip ? undefined : otherProps.title, // If tooltip is provided, don't set the title on the link or button, it looks weird
     };
 
@@ -168,6 +185,24 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     suffix: css({
       marginLeft: theme.spacing(1),
+    }),
+    disabled: css({
+      color: theme.colors.text.disabled,
+      cursor: 'not-allowed',
+      boxShadow: 'none',
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: 'none',
+      },
+
+      '&:hover, &:focus': {
+        color: theme.colors.text.disabled,
+        cursor: 'not-allowed',
+        boxShadow: 'none',
+
+        '&::before': {
+          backgroundColor: 'transparent',
+        },
+      },
     }),
   };
 };

--- a/packages/grafana-ui/src/components/Tabs/Tab.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tab.tsx
@@ -77,6 +77,7 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
       role: 'tab',
       'aria-selected': active,
       'aria-disabled': disabled,
+      tabIndex: disabled ? -1 : undefined,
       title: !!tooltip ? undefined : otherProps.title, // If tooltip is provided, don't set the title on the link or button, it looks weird
     };
 
@@ -87,7 +88,7 @@ export const Tab = React.forwardRef<HTMLElement, TabProps>(
         <div className={cx(tabsStyles.item, truncate && tabsStyles.itemTruncate, className)}>
           <a
             {...commonProps}
-            href={href}
+            href={disabled ? undefined : href}
             // don't think we can avoid the type assertion here :(
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             ref={ref as React.ForwardedRef<HTMLAnchorElement>}
@@ -189,15 +190,9 @@ const getStyles = (theme: GrafanaTheme2) => {
     disabled: css({
       color: theme.colors.text.disabled,
       cursor: 'not-allowed',
-      boxShadow: 'none',
-      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
-        transition: 'none',
-      },
 
       '&:hover, &:focus': {
         color: theme.colors.text.disabled,
-        cursor: 'not-allowed',
-        boxShadow: 'none',
 
         '&::before': {
           backgroundColor: 'transparent',

--- a/packages/grafana-ui/src/components/Tabs/Tabs.story.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tabs.story.tsx
@@ -58,4 +58,37 @@ Counter.args = {
   value: 10,
 };
 
+export const WithDisabled: StoryFn = () => {
+  const [state, updateState] = useState([
+    { label: 'Enabled Tab', key: 'first', active: true },
+    { label: 'Disabled Tab', key: 'second', active: false, disabled: true },
+    { label: 'Another Tab', key: 'third', active: false },
+  ]);
+
+  return (
+    <DashboardStoryCanvas>
+      <TabsBar>
+        {state.map((tab, index) => {
+          return (
+            <Tab
+              key={index}
+              label={tab.label}
+              active={tab.active}
+              disabled={tab.disabled}
+              onChangeTab={() =>
+                !tab.disabled && updateState(state.map((tab, idx) => ({ ...tab, active: idx === index })))
+              }
+            />
+          );
+        })}
+      </TabsBar>
+      <TabContent>
+        {state[0].active && <div>First tab content</div>}
+        {state[1].active && <div>Second tab content (disabled)</div>}
+        {state[2].active && <div>Third tab content</div>}
+      </TabContent>
+    </DashboardStoryCanvas>
+  );
+};
+
 export default meta;

--- a/packages/grafana-ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tabs.test.tsx
@@ -14,6 +14,9 @@ const setup = (jsx: JSX.Element) => {
 const onChangeTab = jest.fn();
 
 describe('Tabs', () => {
+  beforeEach(() => {
+    onChangeTab.mockClear();
+  });
   it('should call onChangeTab when clicking a tab', async () => {
     const { user } = setup(
       <TabsBar>
@@ -95,5 +98,29 @@ describe('Tabs', () => {
     );
 
     expect(screen.getByTestId('tab-suffix')).toBeInTheDocument();
+  });
+
+  it('should render disabled tab correctly', () => {
+    render(
+      <TabsBar>
+        <Tab label="Disabled Tab" active={false} onChangeTab={onChangeTab} disabled={true} />
+      </TabsBar>
+    );
+
+    const disabledTab = screen.getByRole('tab', { name: 'Disabled Tab' });
+    expect(disabledTab).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should not call onChangeTab when disabled tab is clicked', async () => {
+    const { user } = setup(
+      <TabsBar>
+        <Tab label="Disabled Tab" active={false} onChangeTab={onChangeTab} disabled={true} />
+      </TabsBar>
+    );
+
+    const disabledTab = screen.getByRole('tab', { name: 'Disabled Tab' });
+    await user.click(disabledTab);
+
+    expect(onChangeTab).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

For "Saved Queries" (formerly known as Query Library), we need to support the use case of showing a disabled tab. The `Tab` component was missing disabled styles for the cursor, making it misleading

https://github.com/user-attachments/assets/8cc3d8c6-e3e2-48d1-b44f-d0b18308569e




**Why do we need this feature?**

For "saved queries" public preview ([slack](https://raintank-corp.slack.com/archives/C05Q76JHQG0/p1755602440293039))


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
