### PR TITLE
feat(@grafana/assistant): bump assistant sdk

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,7 @@
     "@formatjs/intl-durationformat": "^0.7.0",
     "@glideapps/glide-data-grid": "^6.0.0",
     "@grafana/alerting": "workspace:*",
-    "@grafana/assistant": "0.0.14",
+    "@grafana/assistant": "0.0.16",
     "@grafana/aws-sdk": "0.7.1",
     "@grafana/azure-sdk": "0.0.7",
     "@grafana/data": "workspace:*",

--- a/packages/grafana-flamegraph/src/AnalyzeFlameGraphButton.tsx
+++ b/packages/grafana-flamegraph/src/AnalyzeFlameGraphButton.tsx
@@ -19,6 +19,7 @@ export function AnalyzeFlameGraphButton(props: Props) {
       className={className}
       onClick={() =>
         openAssistant({
+          origin: 'grafana-flamegraph',
           prompt: 'Analyze Flame Graph',
           context: assistantContext,
         })

--- a/packages/grafana-flamegraph/src/AnalyzeFlameGraphButton.tsx
+++ b/packages/grafana-flamegraph/src/AnalyzeFlameGraphButton.tsx
@@ -19,7 +19,7 @@ export function AnalyzeFlameGraphButton(props: Props) {
       className={className}
       onClick={() =>
         openAssistant({
-          origin: 'grafana-flamegraph',
+          origin: 'analyze-flame-graph',
           prompt: 'Analyze Flame Graph',
           context: assistantContext,
         })

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -732,7 +732,7 @@ async function handleOpenAssistant(openAssistant: (props: OpenAssistantProps) =>
     ${log.entry.replaceAll('`', '\\`')}
     \`\`\`
     `,
-    origin: 'Logs',
+    origin: 'grafana-logs',
     context: [
       ...context,
       createAssistantContextItem('structured', {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -732,7 +732,7 @@ async function handleOpenAssistant(openAssistant: (props: OpenAssistantProps) =>
     ${log.entry.replaceAll('`', '\\`')}
     \`\`\`
     `,
-    origin: 'grafana-logs',
+    origin: 'explain-log-line',
     context: [
       ...context,
       createAssistantContextItem('structured', {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -11,11 +11,7 @@ import {
   useState,
 } from 'react';
 
-import { 
-  createAssistantContextItem, 
-  OpenAssistantProps, 
-  useAssistant 
-} from '@grafana/assistant';
+import { createAssistantContextItem, OpenAssistantProps, useAssistant } from '@grafana/assistant';
 import {
   CoreApp,
   DataFrame,
@@ -744,7 +740,7 @@ async function handleOpenAssistant(openAssistant: (props: OpenAssistantProps) =>
         data: {
           labels: log.labels,
           value: log.entry,
-          timestamp: log.timestamp
+          timestamp: log.timestamp,
         },
       }),
     ],

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -11,11 +11,10 @@ import {
   useState,
 } from 'react';
 
-import {
-  createContext as createAssistantContext,
-  ItemDataType,
-  OpenAssistantProps,
-  useAssistant,
+import { 
+  createAssistantContextItem, 
+  OpenAssistantProps, 
+  useAssistant 
 } from '@grafana/assistant';
 import {
   CoreApp,
@@ -728,30 +727,24 @@ async function handleOpenAssistant(openAssistant: (props: OpenAssistantProps) =>
   const datasource = await getDataSourceSrv().get(log.datasourceUid);
   const context = [];
   if (datasource) {
-    context.push(
-      createAssistantContext(ItemDataType.Datasource, {
-        datasourceUid: datasource.uid,
-        datasourceName: datasource.name,
-        datasourceType: datasource.type,
-        img: datasource.meta?.info?.logos?.small,
-      })
-    );
+    context.push(createAssistantContextItem('datasource', { datasourceUid: datasource.uid }));
   }
   openAssistant({
     prompt: `${t('logs.log-line-menu.log-line-explainer', 'Explain this log line in a concise way')}:
-
-      \`\`\`
-${log.entry.replaceAll('`', '\\`')}
-      \`\`\`
-      `,
+    
+    \`\`\`
+    ${log.entry.replaceAll('`', '\\`')}
+    \`\`\`
+    `,
+    origin: 'Logs',
     context: [
       ...context,
-      createAssistantContext(ItemDataType.Structured, {
+      createAssistantContextItem('structured', {
         title: t('logs.log-line-menu.log-line', 'Log line'),
         data: {
           labels: log.labels,
           value: log.entry,
-          timestamp: log.timestamp,
+          timestamp: log.timestamp
         },
       }),
     ],

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
@@ -1,4 +1,4 @@
-import { createContext, ItemDataType } from '@grafana/assistant';
+import { createAssistantContextItem } from '@grafana/assistant';
 import {
   DataFrame,
   DataQueryResponse,
@@ -21,7 +21,7 @@ jest.mock('@grafana/assistant', () => ({
   },
 }));
 
-const mockCreateContext = createContext as jest.MockedFunction<typeof createContext>;
+const mockCreateContext = createAssistantContextItem as jest.MockedFunction<typeof createAssistantContextItem>;
 
 describe('enrichDataFrameWithAssistantContentMapper', () => {
   beforeEach(() => {
@@ -113,14 +113,14 @@ describe('enrichDataFrameWithAssistantContentMapper', () => {
       expect(mockCreateContext).toHaveBeenCalledTimes(2);
 
       // Verify datasource context
-      expect(mockCreateContext).toHaveBeenCalledWith(ItemDataType.Datasource, {
+      expect(mockCreateContext).toHaveBeenCalledWith('datasource', {
         datasourceName: 'PyroscopeDatasource',
         datasourceUid: 'test-uid',
         datasourceType: 'grafana-pyroscope-datasource',
       });
 
       // Verify structured context
-      expect(mockCreateContext).toHaveBeenCalledWith(ItemDataType.Structured, {
+      expect(mockCreateContext).toHaveBeenCalledWith('structured', {
         title: 'Analyze Flame Graph',
         data: {
           start: request.range.from.valueOf(),
@@ -327,7 +327,7 @@ describe('enrichDataFrameWithAssistantContentMapper', () => {
       const mapper = enrichDataFrameWithAssistantContentMapper(request, 'TestDatasource');
       mapper(response);
 
-      expect(mockCreateContext).toHaveBeenCalledWith(ItemDataType.Structured, {
+      expect(mockCreateContext).toHaveBeenCalledWith('structured', {
         title: 'Analyze Flame Graph',
         data: {
           start: fromTime.valueOf(),

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.test.ts
@@ -14,11 +14,7 @@ import { enrichDataFrameWithAssistantContentMapper } from './utils';
 
 // Mock the createContext function
 jest.mock('@grafana/assistant', () => ({
-  createContext: jest.fn(),
-  ItemDataType: {
-    Datasource: 'datasource',
-    Structured: 'structured',
-  },
+  createAssistantContextItem: jest.fn(),
 }));
 
 const mockCreateContext = createAssistantContextItem as jest.MockedFunction<typeof createAssistantContextItem>;
@@ -114,9 +110,7 @@ describe('enrichDataFrameWithAssistantContentMapper', () => {
 
       // Verify datasource context
       expect(mockCreateContext).toHaveBeenCalledWith('datasource', {
-        datasourceName: 'PyroscopeDatasource',
         datasourceUid: 'test-uid',
-        datasourceType: 'grafana-pyroscope-datasource',
       });
 
       // Verify structured context

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/utils.ts
@@ -1,7 +1,7 @@
 import { invert } from 'lodash';
 import Prism, { Grammar, Token } from 'prismjs';
 
-import { createContext, ItemDataType } from '@grafana/assistant';
+import { createAssistantContextItem } from '@grafana/assistant';
 import {
   AbstractLabelMatcher,
   AbstractLabelOperator,
@@ -158,12 +158,10 @@ export function enrichDataFrameWithAssistantContentMapper(
       }
 
       const context = [
-        createContext(ItemDataType.Datasource, {
-          datasourceName: datasourceName,
+        createAssistantContextItem('datasource', {
           datasourceUid: query.datasource.uid,
-          datasourceType: query.datasource.type,
         }),
-        createContext(ItemDataType.Structured, {
+        createAssistantContextItem('structured', {
           title: 'Analyze Flame Graph',
           data: {
             start: request.range.from.valueOf(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3056,9 +3056,9 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@grafana/assistant@npm:0.0.14":
-  version: 0.0.14
-  resolution: "@grafana/assistant@npm:0.0.14"
+"@grafana/assistant@npm:0.0.16":
+  version: 0.0.16
+  resolution: "@grafana/assistant@npm:0.0.16"
   peerDependencies:
     "@grafana/data": ">=12.1.0"
     "@grafana/runtime": ">=12.1.0"
@@ -3066,7 +3066,7 @@ __metadata:
     "@grafana/ui": ">=12.1.0"
     react: ">=18.0.0"
     rxjs: ">=7.0.0"
-  checksum: 10/3e85effd69494b023d395940f5f926da1d2868850db613581d7b2f398e8f00fe07339fdb6fa12b3029603cd394d012104f187f2fd2fcb85196dac72cd6e072df
+  checksum: 10/8482e09d3e86a865a8cf90908ae1438317b994798b5bf5d1a2369154b786e1ba20f30e208d48bed249c8427f11f87307b338c5307a8cb5143cffb2ef02050847
   languageName: node
   linkType: hard
 
@@ -18292,7 +18292,7 @@ __metadata:
     "@formatjs/intl-durationformat": "npm:^0.7.0"
     "@glideapps/glide-data-grid": "npm:^6.0.0"
     "@grafana/alerting": "workspace:*"
-    "@grafana/assistant": "npm:0.0.14"
+    "@grafana/assistant": "npm:0.0.16"
     "@grafana/aws-sdk": "npm:0.7.1"
     "@grafana/azure-sdk": "npm:0.0.7"
     "@grafana/data": "workspace:*"


### PR DESCRIPTION
**What is this feature?**

This PR updates the `@grafana/assistant` SDK to it's latest version and updates breaking changes.

**Why do we need this feature?**

The new SDK version provides a few improvements:
- the interface for ContextItems was simpliefied such that `datasource` items will infer their `type`, `img` etc. from the datasources `uid`
- the function `createContext` was renamed into `createAssistantContextItems` because it's more precise and does not collide with Reacts naming
- it exposes an `OpenAssistantButton` which can be used to integrate the Assistant in different plugins and apps across grafana

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
