### PR TITLE
datasources: querier: add user to query

### DIFF
--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -234,7 +234,13 @@ func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheSer
 		headers:                    headers,
 		concurrentQueryLimit:       16, // TODO: make it configurable
 	}
-	return s.QueryDataNew(ctx, nil, false, reqDTO)
+
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.QueryDataNew(ctx, user, false, reqDTO)
 }
 
 // handleExpressions handles queries when there is an expression.


### PR DESCRIPTION
(fixes https://github.com/grafana/grafana/issues/109916)

currently, when we go through the query-service flow (single-tenant or multi-tenant) we set `user` to `nil`. unfortunately we hit a code-path that calls `user.GetOrgId()`, which panics, because `user` is `nil`. (for details see the linked issue).

we extract the user from the context, and use it.