### PR TITLE
Tooltip: Remove hideFrom.tooltip check for tooltip headers

### DIFF
--- a/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
+++ b/public/app/plugins/panel/canvas/components/CanvasTooltip.tsx
@@ -57,7 +57,7 @@ export const CanvasTooltip = ({ scene }: Props) => {
   const shouldDisplayTimeContentItem =
     timeField && lastTimeValue && element.data.field && getFieldDisplayName(timeField) !== element.data.field;
 
-  const headerItem: VizTooltipItem | null = {
+  const headerItem: VizTooltipItem = {
     label: element.getName(),
     value: '',
   };

--- a/public/app/plugins/panel/histogram/HistogramTooltip.tsx
+++ b/public/app/plugins/panel/histogram/HistogramTooltip.tsx
@@ -50,12 +50,10 @@ export const HistogramTooltip = ({
   const xMinVal = formattedValueToString(xMinDisp!(xMinField.values[dataIdxs[0]!]));
   const xMaxVal = formattedValueToString(xMaxDisp!(xMaxField.values[dataIdxs[1]!]));
 
-  const headerItem: VizTooltipItem | null = xMinField.config.custom?.hideFrom?.tooltip
-    ? null
-    : {
-        label: 'Bucket',
-        value: `${xMinVal} - ${xMaxVal}`,
-      };
+  const headerItem: VizTooltipItem = {
+    label: 'Bucket',
+    value: `${xMinVal} - ${xMaxVal}`,
+  };
 
   const contentItems = useMemo(
     () => getContentItems(xMinOnlyFrame.fields, xMinField, dataIdxs, seriesIdx, mode, sortOrder),

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -90,12 +90,10 @@ export const TimeSeriesTooltip = ({
     }
   }
 
-  const headerItem: VizTooltipItem | null = xField.config.custom?.hideFrom?.tooltip
-    ? null
-    : {
-        label: xField.type === FieldType.time ? '' : (xField.state?.displayName ?? xField.name),
-        value: xVal,
-      };
+  const headerItem: VizTooltipItem | null = {
+    label: xField.type === FieldType.time ? '' : (xField.state?.displayName ?? xField.name),
+    value: xVal,
+  };
 
   return (
     <VizTooltipWrapper>

--- a/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesTooltip.tsx
@@ -90,7 +90,7 @@ export const TimeSeriesTooltip = ({
     }
   }
 
-  const headerItem: VizTooltipItem | null = {
+  const headerItem: VizTooltipItem = {
     label: xField.type === FieldType.time ? '' : (xField.state?.displayName ?? xField.name),
     value: xVal,
   };


### PR DESCRIPTION
The tooltip header should not account for `hideFrom.tooltip`.

Before
<img width="900" height="335" alt="Screenshot 2025-08-20 at 10 25 56 AM" src="https://github.com/user-attachments/assets/2d0315ea-d52e-4027-b515-f22e8174d736" />


After
<img width="915" height="371" alt="Screenshot 2025-08-20 at 10 24 20 AM" src="https://github.com/user-attachments/assets/0a3a112d-38b6-4e6c-b0ce-1af2dba3c916" />



Fixes https://github.com/grafana/support-escalations/issues/18004


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
