### PR TITLE
Remote Alertmanager: Ignore tenant ID when merging remote state

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -381,11 +381,13 @@ func (am *Alertmanager) GetRemoteState(ctx context.Context) (notifier.ExternalSt
 	// Mimir state has two parts:
 	// - "sil:<tenantID>": silences
 	// - "nfl:<tenantID>": notification log entries
+	// The tenant ID can be different in the remote AM, so we consider only the part before the ':'.
 	for _, p := range protoState.Parts {
-		switch p.Key {
-		case "sil:" + am.tenantID:
+		k := strings.Split(p.Key, ":")
+		switch k[0] {
+		case "sil":
 			rs.Silences = p.Data
-		case "nfl:" + am.tenantID:
+		case "nfl":
 			rs.Nflog = p.Data
 		default:
 			return rs, fmt.Errorf("unknown part key %q", p.Key)

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -182,8 +182,8 @@ func TestGetRemoteState(t *testing.T) {
 
 	state := alertingClusterPB.FullState{
 		Parts: []alertingClusterPB.Part{
-			{Key: "nfl:test", Data: []byte("test-nflog")},
-			{Key: "sil:test", Data: []byte("test-silences")},
+			{Key: "nfl:otherID", Data: []byte("test-nflog")},
+			{Key: "sil:otherID", Data: []byte("test-silences")},
 		},
 	}
 	rawState, err := state.Marshal()


### PR DESCRIPTION
The tenant ID can be different on the remote Alertmanager's side. We should ignore it when merging remote state, only considering the substring before the `:`.