### PR TITLE
CloudWatch: Fix logs query requestId to prevent setting undefined-logs as a requestId

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -76,6 +76,17 @@ describe('CloudWatchLogsQueryRunner', () => {
       });
     });
 
+    it('does not append -logs to the requestId if requestId is not provided', async () => {
+      const { runner, queryMock } = setupMockedLogsQueryRunner();
+
+      const request = {
+        ...LogsRequestMock,
+      };
+      await expect(runner.handleLogQueries(LogsRequestMock.targets, request, queryMock)).toEmitValuesWith(() => {
+        expect(queryMock.mock.calls[0][0].requestId).toEqual('');
+      });
+    });
+
     it('should request to start each query and then request to get the query results', async () => {
       const { runner } = setupMockedLogsQueryRunner();
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -415,12 +415,14 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
     options?: DataQueryRequest<CloudWatchQuery>
   ): Observable<DataQueryResponse> {
     const range = options?.range || getDefaultTimeRange();
+    // append -logs to prevent requestId from matching metric queries from the same panel
+    const requestId = options?.requestId ? `${options?.requestId}-logs` : '';
 
     const requestParams: DataQueryRequest<CloudWatchLogsQuery> = {
       ...options,
       range,
       skipQueryCache: true,
-      requestId: options?.requestId + '-logs' || '', // adding -logs to prevent requestId from matching metric queries from the same panel
+      requestId,
       interval: options?.interval || '', // dummy
       intervalMs: options?.intervalMs || 1, // dummy
       scopedVars: options?.scopedVars || {}, // dummy


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue where CloudWatch logs request would set a `requestId` that ended up being `undefined-logs`. This can happen because CloudWatch logs queries poll for the query results after it starts the initial request. The queries to poll for data don't have a `requestId` assigned because we are manually kicking off the query ourselves instead of being initiated from the dashboard runner. The result of this is if there are multiple logs query panels on a dashboard, the `requestId` is being set to `undefined-logs` for the polling queries, which causes earlier polling queries to be cancelled because they have the same `requestId` set. This results in those panels showing no data. If the requestId isn't set, then this cancellation of inflight requests doesn't happen.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
