### PR TITLE
FS: Replace frontend-service-up with command that auto shuts down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,13 +283,9 @@ run-bra: ## [Deprecated] Build and run web server on filesystem changes. See /.b
 frontend-service-check:
 	./devenv/frontend-service/local-init.sh
 
-.PHONY: frontend-service-up
-frontend-service-up: frontend-service-check
-	tilt up -f devenv/frontend-service/Tiltfile
-
-.PHONY: frontend-service-down
-frontend-service-down: frontend-service-check
-	tilt down -f devenv/frontend-service/Tiltfile
+.PHONY: frontend-service
+frontend-service: frontend-service-check
+	bash ./devenv/frontend-service/run.sh
 
 ##@ Testing
 

--- a/devenv/frontend-service/run.sh
+++ b/devenv/frontend-service/run.sh
@@ -1,0 +1,13 @@
+# Script called from makefile to auto down the tilt environment on ctrl + c.
+# Paths are relative to the makefile
+
+function tilt_down()
+{
+    echo "Tearing down Tilt environment... (this might take a little while)"
+    tilt down -f devenv/frontend-service/Tiltfile
+}
+
+
+trap tilt_down SIGINT
+
+tilt up -f devenv/frontend-service/Tiltfile


### PR DESCRIPTION
@ashharrison90 shared minor feedback on the `make frontend-service-up` development flow, that it's annoying that it doesn't auto-quit when you ctrl+c. I agree, and I've been thinking about this.

While tilt doesn't support this directly https://github.com/tilt-dev/tilt/issues/2427, we can instead have a `make frontend-service` command that runs a bash script that uses a trap to automatically run `tilt down` on ctrl + c.

This PR removes the `frontend-service-up` / `frontend-service-down` make targets, replacing them with a single `make frontend-service` command. This'll break workflows, but I'm pretty sure no one else is using this at the moment so I think it's fine.