### PR TITLE
Table: fix use row height after lines-to-pxs update

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -477,7 +477,7 @@ describe('TableNG hooks', () => {
           }),
           columnWidths: [100, 100, 100],
           enabled: true,
-          typographyCtx: { ...typographyCtx, avgCharWidth: 5, measureHeight: jest.fn(() => 38) },
+          typographyCtx: { ...typographyCtx, avgCharWidth: 5, measureHeight: jest.fn(() => 44) },
           sortColumns: [],
         });
       });
@@ -518,7 +518,7 @@ describe('TableNG hooks', () => {
         });
       });
 
-      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 86, modifiedFields[0], -1, 6);
+      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 86, modifiedFields[0], -1, 22);
 
       modifiedFields = fields.map((field) => {
         if (field.name === 'name') {
@@ -549,7 +549,7 @@ describe('TableNG hooks', () => {
         });
       });
 
-      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 26, modifiedFields[0], -1, 6);
+      expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 26, modifiedFields[0], -1, 22);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -368,7 +368,15 @@ export function useHeaderHeight({
     if (!enabled) {
       return 0;
     }
-    return getRowHeight(fields, -1, columnAvailableWidths, TABLE.HEADER_HEIGHT, measurers, TABLE.CELL_PADDING);
+    return getRowHeight(
+      fields,
+      -1,
+      columnAvailableWidths,
+      TABLE.HEADER_HEIGHT,
+      measurers,
+      TABLE.LINE_HEIGHT,
+      TABLE.CELL_PADDING
+    );
   }, [fields, enabled, columnAvailableWidths, measurers]);
 
   return headerHeight;


### PR DESCRIPTION
_My grudge against long lists of positional args is reinforced yet again..._

#109735 updated the getRowHeight method, but a mistake was made in the integration with `useHeaderHeight` which caused Wrap header text to stop working. This corrects that error.

To test:

1. open a table panel
2. update the display name of a field to a long string
3. set "Wrap header text" to true (either just for that field, or globally)