### PR TITLE
i18n: fixes translations for plugins before v12.1.0

### DIFF
--- a/packages/grafana-i18n/src/i18n.tsx
+++ b/packages/grafana-i18n/src/i18n.tsx
@@ -89,8 +89,15 @@ export async function initPluginTranslations(id: string, loaders?: ResourceLoade
   return { language };
 }
 
-export function getI18nInstance() {
-  return i18n;
+export function getI18nInstance(): typeof i18n {
+  // in Grafana versions < 12.1.0 the i18n instance is exposed through the default export
+  // used by plugins that support translations from Grafana >= 11.0.0
+  const instance: typeof i18n & { default?: typeof i18n } = i18n;
+  if (instance && instance.default) {
+    return instance.default;
+  }
+
+  return instance;
 }
 
 interface Module {


### PR DESCRIPTION
**What is this feature?**

For plugins that want to support translations starting from Grafana 11.0.0 this isn't currently possible because the externalized `i18n` has a default export.

**Why do we need this feature?**

So that plugins that want to support translations before Grafana 12.1.0 can work.

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
