### PR TITLE
Plugins: adds languages to the plugin schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -685,6 +685,13 @@
           }
         }
       }
+    },
+    "languages": {
+      "type": "array",
+      "description": "The list of languages supported by the plugin. Each entry should be a locale identifier in the format `language-COUNTRY` (e.g., `en-US`, `fr-FR`, `es-ES`).",
+      "items": {
+        "type": "string"
+      }
     }
   }
 }


### PR DESCRIPTION
**What is this feature?**

Adds the `languages` property to the json schema for `plugin.json`

**Why do we need this feature?**

So the schema is up to date with implementation

**Who is this feature for?**

Plugin authors

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates https://github.com/grafana/plugin-tools/issues/1976

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
