### PR TITLE
Alerting: Fix permission checks for the Import to GMA

### DIFF
--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -226,7 +226,10 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     },
     {
       path: '/alerting/import-datasource-managed-rules',
-      roles: () => ['Admin'],
+      roles: evaluateAccess([
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+      ]),
       component: config.featureToggles.alertingMigrationUI
         ? importAlertingComponent(
             () =>

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -6,6 +6,8 @@ import { GrafanaTheme2, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Badge, LinkButton, LoadingPlaceholder, Pagination, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 import { CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
@@ -14,7 +16,6 @@ import { usePagination } from '../../hooks/usePagination';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { getPaginationStyles } from '../../styles/pagination';
 import { getRulesDataSources, getRulesSourceUid } from '../../utils/datasource';
-import { isAdmin } from '../../utils/misc';
 import { isAsyncRequestStatePending } from '../../utils/redux';
 import { createRelativeUrl } from '../../utils/url';
 
@@ -49,7 +50,11 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
     DEFAULT_PER_PAGE_PAGINATION
   );
 
-  const canMigrateToGMA = hasDataSourcesConfigured && isAdmin() && config.featureToggles.alertingMigrationUI;
+  const canMigrateToGMA =
+    hasDataSourcesConfigured &&
+    config.featureToggles.alertingMigrationUI &&
+    contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
+    contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 
   return (
     <section className={styles.wrapper}>

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -255,9 +255,12 @@ describe('RuleListActions', () => {
   describe('Import Alert Rules', () => {
     testWithFeatureToggles(['alertingMigrationUI']);
 
-    it('should show "Import alert rules" option when user is admin and feature toggle is enabled', async () => {
-      grantUserRole(OrgRole.Admin);
-      grantUserPermissions([AccessControlAction.AlertingRuleRead]);
+    it('should show "Import alert rules" option when user has required permissions and feature toggle is enabled', async () => {
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+      ]);
 
       const { user } = render(<RuleListActions />);
 
@@ -267,8 +270,8 @@ describe('RuleListActions', () => {
       expect(ui.menuOptions.importAlertRules.query(menu)).toBeInTheDocument();
     });
 
-    it('should not show "Import alert rules" option when user is not admin', async () => {
-      // Keep default Viewer role
+    it('should not show "Import alert rules" option when user lacks required permissions', async () => {
+      // Keep default Viewer role and only read permissions
       grantUserPermissions([AccessControlAction.AlertingRuleRead]);
 
       const { user } = render(<RuleListActions />);
@@ -280,8 +283,11 @@ describe('RuleListActions', () => {
     });
 
     it('should have correct URL for "Import alert rules" menu item', async () => {
-      grantUserRole(OrgRole.Admin);
-      grantUserPermissions([AccessControlAction.AlertingRuleRead]);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+      ]);
 
       const { user } = render(<RuleListActions />);
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -4,6 +4,8 @@ import { useToggle } from 'react-use';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Dropdown, Icon, LinkButton, Menu, Stack } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
@@ -12,7 +14,6 @@ import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelecto
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
-import { isAdmin } from '../utils/misc';
 
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
@@ -44,7 +45,11 @@ export function RuleListActions() {
   const canExportRules = exportRulesSupported && exportRulesAllowed;
 
   const canCreateRules = canCreateGrafanaRules || canCreateCloudRules;
-  const canImportRulesToGMA = isAdmin() && config.featureToggles.alertingMigrationUI;
+  // Align import UI permission with convert endpoint requirements: rule create + provisioning set status
+  const canImportRulesToGMA =
+    config.featureToggles.alertingMigrationUI &&
+    contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
+    contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
 

--- a/public/app/types/accessControl.ts
+++ b/public/app/types/accessControl.ts
@@ -129,6 +129,11 @@ export enum AccessControlAction {
   AlertingProvisioningReadSecrets = 'alert.provisioning.secrets:read',
   AlertingProvisioningRead = 'alert.provisioning:read',
   AlertingProvisioningWrite = 'alert.provisioning:write',
+  AlertingRulesProvisioningRead = 'alert.rules.provisioning:read',
+  AlertingRulesProvisioningWrite = 'alert.rules.provisioning:write',
+  AlertingNotificationsProvisioningRead = 'alert.notifications.provisioning:read',
+  AlertingNotificationsProvisioningWrite = 'alert.notifications.provisioning:write',
+  AlertingProvisioningSetStatus = 'alert.provisioning.provenance:write',
 
   // Alerting receivers actions
   AlertingReceiversPermissionsRead = 'receivers.permissions:read',


### PR DESCRIPTION
Fix: Align Import Alert Rules UI permissions with convert endpoint

This changes the Import rules button gating and route access to match backend convert API requirements:
- Gate visibility/enabled state by AlertingRuleCreate + AlertingProvisioningSetStatus (instead of Admin role).
- Apply the same logic in RuleList v1 (CloudRules) and v2 actions menu.
- Update the /alerting/import-datasource-managed-rules route to use evaluateAccess with the same actions.
- Add missing AccessControlAction constants for provisioning parity with backend.
- Adjust unit tests accordingly.

Why: Users with correct RBAC (per docs) couldn’t see the Import button, while the backend allowed them via /api/convert. This aligns FE with BE.

Refs: grafana/support-escalations#18027
