### PR TITLE
Provisioning: Remove clonedir (not used by nanogit)

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -95,7 +94,6 @@ type APIBuilder struct {
 	repositoryResources resources.RepositoryResourcesFactory
 	clients             resources.ClientFactory
 	ghFactory           *github.Factory
-	clonedir            string // where repo clones are managed
 	jobs                interface {
 		jobs.Queue
 		jobs.Store
@@ -126,7 +124,6 @@ func NewAPIBuilder(
 	local *local.LocalFolderResolver,
 	features featuremgmt.FeatureToggles,
 	unified resource.ResourceClient,
-	clonedir string, // where repo clones are managed
 	configProvider apiserver.RestConfigProvider,
 	ghFactory *github.Factory,
 	legacyMigrator legacy.LegacyMigrator,
@@ -158,7 +155,6 @@ func NewAPIBuilder(
 		clients:             clients,
 		parsers:             parsers,
 		repositoryResources: resources.NewRepositoryResourcesFactory(parsers, clients, resourceLister),
-		clonedir:            clonedir,
 		resourceLister:      resourceLister,
 		legacyMigrator:      legacyMigrator,
 		storageStatus:       storageStatus,
@@ -251,7 +247,6 @@ func RegisterAPIService(
 	}
 	builder := NewAPIBuilder(folderResolver, features,
 		client,
-		filepath.Join(cfg.DataPath, "clone"), // where repositories are cloned (temporarialy for now)
 		configProvider, ghFactory,
 		legacyMigrator, storageStatus,
 		usageStats,

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -3,8 +3,11 @@ package webhooks
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
+
+	"k8s.io/apiserver/pkg/authorization/authorizer"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/kube-openapi/pkg/spec3"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -22,9 +25,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/rendering"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"k8s.io/apiserver/pkg/authorization/authorizer"
-	"k8s.io/apiserver/pkg/registry/rest"
-	"k8s.io/kube-openapi/pkg/spec3"
 )
 
 // WebhookExtraBuilder is a function that returns an ExtraBuilder.
@@ -81,7 +81,6 @@ func ProvideWebhooks(
 				urlProvider,
 				repositorySecrets,
 				ghFactory,
-				filepath.Join(cfg.DataPath, "clone"),
 				parsers,
 				[]jobs.Worker{pullRequestWorker},
 				isPublic, // Pass the public URL flag
@@ -98,7 +97,6 @@ type WebhookExtra struct {
 	urlProvider func(namespace string) string
 	secrets     secrets.RepositorySecrets
 	ghFactory   *github.Factory
-	clonedir    string
 	parsers     resources.ParserFactory
 	workers     []jobs.Worker
 	isPublic    bool // Flag to determine if webhook-enhanced repositories should be created
@@ -110,7 +108,6 @@ func NewWebhookExtra(
 	urlProvider func(namespace string) string,
 	secrets secrets.RepositorySecrets,
 	ghFactory *github.Factory,
-	clonedir string,
 	parsers resources.ParserFactory,
 	workers []jobs.Worker,
 	isPublic bool,
@@ -121,7 +118,6 @@ func NewWebhookExtra(
 		urlProvider: urlProvider,
 		secrets:     secrets,
 		ghFactory:   ghFactory,
-		clonedir:    clonedir,
 		parsers:     parsers,
 		workers:     workers,
 		isPublic:    isPublic,


### PR DESCRIPTION
Remove the clonedir argument -- it is not used by nanogit