### PR TITLE
Secrets: Fix OpenAPI definition for create resource

### DIFF
--- a/apps/secret/kinds/v1beta1/securevalue.cue
+++ b/apps/secret/kinds/v1beta1/securevalue.cue
@@ -19,7 +19,7 @@ SecureValueSpec: {
 	// Minimum and maximum lengths in bytes.
 	// +k8s:validation:minLength=1
 	// +k8s:validation:maxLength=24576
-	// +optional 
+	// +optional
 	value?: #ExposedSecureValue
 
 	// When using a third-party keeper, the `ref` is used to reference a value inside the remote storage.
@@ -41,13 +41,16 @@ SecureValueSpec: {
 	// +k8s:validation:maxItems=64
 	// +k8s:validation:uniqueItems=true
 	// +listType=atomic
-	// +optional 
+	// +optional
 	decrypters?: [...string] & list.UniqueItems() & list.MaxItems(64)
 }
 
 SecureValueStatus: {
+	// Version of the secure value. Cannot be set.
+	// +optional
 	version: int64 & >=0
 
+	// External ID where the secret is stored. Cannot be set.
 	// +optional
 	externalID: string
 }

--- a/apps/secret/pkg/apis/secret/v1beta1/securevalue_status_gen.go
+++ b/apps/secret/pkg/apis/secret/v1beta1/securevalue_status_gen.go
@@ -22,10 +22,13 @@ func NewSecureValuestatusOperatorState() *SecureValuestatusOperatorState {
 
 // +k8s:openapi-gen=true
 type SecureValueStatus struct {
+	// Version of the secure value. Cannot be set.
+	// +optional
 	Version int64 `json:"version"`
 	// operatorStates is a map of operator ID to operator state evaluations.
 	// Any operator which consumes this kind SHOULD add its state evaluation information to this field.
 	OperatorStates map[string]SecureValuestatusOperatorState `json:"operatorStates,omitempty"`
+	// External ID where the secret is stored. Cannot be set.
 	// +optional
 	ExternalID string `json:"externalID"`
 	// additionalFields is reserved for future use

--- a/apps/secret/pkg/apis/secret/v1beta1/zz_openapi_gen.go
+++ b/apps/secret/pkg/apis/secret/v1beta1/zz_openapi_gen.go
@@ -633,9 +633,10 @@ func schema_pkg_apis_secret_v1beta1_SecureValueStatus(ref common.ReferenceCallba
 				Properties: map[string]spec.Schema{
 					"version": {
 						SchemaProps: spec.SchemaProps{
-							Default: 0,
-							Type:    []string{"integer"},
-							Format:  "int64",
+							Description: "Version of the secure value. Cannot be set.",
+							Default:     0,
+							Type:        []string{"integer"},
+							Format:      "int64",
 						},
 					},
 					"operatorStates": {
@@ -655,9 +656,10 @@ func schema_pkg_apis_secret_v1beta1_SecureValueStatus(ref common.ReferenceCallba
 					},
 					"externalID": {
 						SchemaProps: spec.SchemaProps{
-							Default: "",
-							Type:    []string{"string"},
-							Format:  "",
+							Description: "External ID where the secret is stored. Cannot be set.",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
 						},
 					},
 					"additionalFields": {
@@ -676,7 +678,6 @@ func schema_pkg_apis_secret_v1beta1_SecureValueStatus(ref common.ReferenceCallba
 						},
 					},
 				},
-				Required: []string{"version"},
 			},
 		},
 		Dependencies: []string{


### PR DESCRIPTION
**What is this feature?**

The `status.version` shouldn't be required as it forces the API client to pass a version.

**Why do we need this feature?**

More correct client API generation.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
