### PR TITLE
Loki Datasource: /config endpoint

### DIFF
--- a/public/app/plugins/datasource/loki/types.ts
+++ b/public/app/plugins/datasource/loki/types.ts
@@ -108,4 +108,7 @@ export interface DetectedFieldsResult {
   limit: number;
 }
 
+export interface LokiGlobalConfig {}
+export interface LokiTenantConfig {}
+
 export type LokiGroupedRequest = { request: DataQueryRequest<LokiQuery>; partition: TimeRange[] };


### PR DESCRIPTION
PoC/WIP

**What is this feature?**
Allowing the frontend to request loki config

**Why do we need this feature?**
So Loki datasource and plugins can modify the UI behavior based on Loki configuration.
e.g. Respecting max query limits despite time splitting/ query sharding

**Who is this feature for?**
Users of Loki datasource

**Special notes for your reviewer:**
WIP/PoC

Need to pull tenant config additionally or as a seperate API call in the frontend.
Someone will need to take a closer look at the backend changes, no LLMs used but still slop :P 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
