### PR TITLE
Grafana UI: correct filter selector behavior for All option

### DIFF
--- a/packages/grafana-ui/src/components/Select/SelectBase.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectBase.tsx
@@ -183,10 +183,26 @@ export function SelectBase<T, Rest = {}>({
 
   const onChangeWithEmpty = useCallback(
     (value: SelectableValue<T>, action: ActionMeta) => {
-      if (isMulti && (value === undefined || value === null)) {
+      let newValue = value;
+      // Change 3: Exclusive 'All' selection logic for multi-select
+      if (isMulti && Array.isArray(newValue)) {
+        const hasAll = newValue.some(opt => opt.value === '$__all');
+        if (hasAll) {
+          // If 'All' is selected, deselect all others and keep only 'All'
+          newValue = newValue.filter(opt => opt.value === '$__all');
+        } else {
+          // If 'All' is currently selected but another option is picked, remove 'All'
+          newValue = newValue.filter(opt => opt.value !== '$__all');
+        }
+      }
+      // Change 2: Clear filter input after selection
+      if (typeof setHasInputValue === 'function') {
+        setHasInputValue(false); // Reset filter input
+      }
+      if (isMulti && (newValue === undefined || newValue === null)) {
         return onChange([], action);
       }
-      onChange(value, action);
+      onChange(newValue, action);
     },
     [isMulti, onChange]
   );

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -287,7 +287,8 @@ export const SelectMenuOptions = ({
       {icon && <Icon name={icon} className={styles.optionIcon} />}
       {data.imgUrl && <img className={styles.optionImage} src={data.imgUrl} alt={data.label || String(data.value)} />}
       <div className={styles.optionBody}>
-        <span>{renderOptionLabel ? renderOptionLabel(data) : children}</span>
+  {/* Change 1: Always display 'All' label for '$__all' value */}
+  <span>{renderOptionLabel ? renderOptionLabel(data) : (data.value === '$__all' ? 'All' : children)}</span>
         {data.description && <div className={styles.optionDescription}>{data.description}</div>}
         {data.component && <data.component />}
       </div>


### PR DESCRIPTION
**What is this feature?**

This PR fixes incorrect behavior in dashboard filter selectors when using variables with multi-select, custom values, and an "All" option enabled.

**Why do we need this feature?**

Currently, the filter selector shows "$__all" instead of "All", keeps the typed filter text after a selection, and allows both "All" and specific options to be selected at the same time. This leads to confusing and inconsistent user experience in dashboards such as Kubernetes app and Cost Management.

**Who is this feature for?**

Grafana Cloud and OSS users who rely on dashboard variable filters with an "All" option enabled.

**Which issue(s) does this PR fix?**:

Fixes #109320

**Checklist**
- [x] Not a user facing change, no changelog entry needed.