### PR TITLE
[release-11.5.9] Auditing: Document new options for recording datasource query request/response body

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -198,6 +198,14 @@ List of enabled loggers.
 
 Keep dashboard content in the logs (request or response fields). This can significantly increase the size of your logs.
 
+### log_datasource_query_request_body
+
+Whether to record data source queries' request body. This can significantly increase the size of your logs. Enabled by default.
+
+### log_datasource_query_response_body
+
+Whether to record data source queries' response body. This can significantly increase the size of your logs. Enabled by default.
+
 ### verbose
 
 Log all requests and keep requests and responses body. This can significantly increase the size of your logs.

--- a/docs/sources/setup-grafana/configure-security/audit-grafana.md
+++ b/docs/sources/setup-grafana/configure-security/audit-grafana.md
@@ -373,6 +373,10 @@ enabled = false
 loggers = file
 # Keep dashboard content in the logs (request or response fields); this can significantly increase the size of your logs.
 log_dashboard_content = false
+# Whether to record data source queries' request body. This can significantly increase the size of your logs. Enabled by default.
+log_datasource_query_request_body = true
+# Whether to record data source queries' response body. This can significantly increase the size of your logs. Enabled by default.
+log_datasource_query_response_body = true
 # Keep requests and responses body; this can significantly increase the size of your logs.
 verbose = false
 # Write an audit log for every status code.


### PR DESCRIPTION
Backport 91748fe1156ea121f5dd8b0cc3e9aeb8a13951ab from #109951

---

Documentation for https://github.com/grafana/grafana-enterprise/pull/9418
