### PR TITLE
Alerting: Fix folder permissions for Editor role in Prometheus import

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -461,7 +461,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 func (srv *ConvertPrometheusSrv) getOrCreateNamespace(c *contextmodel.ReqContext, title string, logger log.Logger, workingFolderUID string) (*folder.FolderReference, response.Response) {
 	logger.Debug("Getting or creating a new folder")
 
-	ns, err := srv.ruleStore.GetOrCreateNamespaceByTitle(
+	ns, created, err := srv.ruleStore.GetOrCreateNamespaceByTitle(
 		c.Req.Context(),
 		title,
 		c.GetOrgID(),
@@ -471,6 +471,26 @@ func (srv *ConvertPrometheusSrv) getOrCreateNamespace(c *contextmodel.ReqContext
 	if err != nil {
 		logger.Error("Failed to get or create a new folder", "error", err)
 		return nil, namespaceErrorResponse(err)
+	}
+
+	// Not all users have global-scoped permissions, even if they can create folders.
+	// For example, Editor users can create folders, but they have UID-scoped folder permissions.
+	// Permissions are populated in a middleware before this handler, and the folder we just created
+	// is not included in the permissions yet. We add it manually.
+	if created {
+		orgID := c.GetOrgID()
+		if c.Permissions == nil {
+			c.Permissions = make(map[int64]map[string][]string)
+		}
+		if c.Permissions[orgID] == nil {
+			c.Permissions[orgID] = make(map[string][]string)
+		}
+
+		folderScope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(ns.UID)
+		if c.Permissions[orgID][dashboards.ActionFoldersRead] == nil {
+			c.Permissions[orgID][dashboards.ActionFoldersRead] = []string{}
+		}
+		c.Permissions[orgID][dashboards.ActionFoldersRead] = append(c.Permissions[orgID][dashboards.ActionFoldersRead], folderScope)
 	}
 
 	logger.Debug("Using folder for the converted rules", "folder_uid", ns.UID)

--- a/pkg/services/ngalert/api/persist.go
+++ b/pkg/services/ngalert/api/persist.go
@@ -16,7 +16,7 @@ type RuleStore interface {
 	GetUserVisibleNamespaces(context.Context, int64, identity.Requester) (map[string]*folder.Folder, error)
 	GetNamespaceByUID(ctx context.Context, uid string, orgID int64, user identity.Requester) (*folder.Folder, error)
 	GetNamespaceByTitle(ctx context.Context, fullpath string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, error)
-	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, error)
+	GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, bool, error)
 	// GetNamespaceChildren returns all children (first level) of the namespace with the given id.
 	GetNamespaceChildren(ctx context.Context, uid string, orgID int64, user identity.Requester) ([]*folder.FolderReference, error)
 

--- a/pkg/services/ngalert/store/namespace_test.go
+++ b/pkg/services/ngalert/store/namespace_test.go
@@ -78,7 +78,8 @@ func TestGetNamespaceByTitle(t *testing.T) {
 
 func TestGetOrCreateNamespaceByTitle(t *testing.T) {
 	store := DBstore{}
-	_, err := store.GetOrCreateNamespaceByTitle(context.Background(), "", 1, nil, folder.RootFolderUID)
+	_, created, err := store.GetOrCreateNamespaceByTitle(context.Background(), "", 1, nil, folder.RootFolderUID)
+	require.False(t, created)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "title is empty")
 

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -363,13 +363,13 @@ func (f *RuleStore) GetNamespaceByUID(_ context.Context, uid string, orgID int64
 	return nil, dashboards.ErrFolderNotFound
 }
 
-func (f *RuleStore) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, error) {
+func (f *RuleStore) GetOrCreateNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, bool, error) {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 
 	for _, folder := range f.Folders[orgID] {
 		if folder.Title == title && folder.ParentUID == parentUID {
-			return folder.ToFolderReference(), nil
+			return folder.ToFolderReference(), false, nil
 		}
 	}
 
@@ -382,7 +382,7 @@ func (f *RuleStore) GetOrCreateNamespaceByTitle(ctx context.Context, title strin
 	}
 
 	f.Folders[orgID] = append(f.Folders[orgID], newFolder)
-	return newFolder.ToFolderReference(), nil
+	return newFolder.ToFolderReference(), true, nil
 }
 
 func (f *RuleStore) GetNamespaceByTitle(ctx context.Context, title string, orgID int64, user identity.Requester, parentUID string) (*folder.FolderReference, error) {


### PR DESCRIPTION
**What is this feature?**

Fixes the case when a user with an Editor role imports Prometheus rules into a non-existent folder. Folder in this case should be created, but the user sees an error with the 403 error: `user is not authorized to access rule group '%s' in folder '%s'`. The second attempt works.

It's currently not possible in the UI, because it's available only to admin users but it will be: https://github.com/grafana/grafana/pull/109950

The issue happens because:
1. Editor role users have folder-specific permissions (by UID)
2. During HTTP requests user permissions are cached before the folder exists
3. When a new folder is created, the cached permissions don't include it
4. The next permission check for the newly created folder fails
5. On the second request, fresh permissions are loaded that include the new folder and the import works

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
