### PR TITLE
Create option to read ini file without validating frontend files

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1088,7 +1088,7 @@ func NewCfgFromBytes(bytes []byte) (*Cfg, error) {
 }
 
 // prevents a log line from being printed when the static root path is not found, useful for apiservers that have no frontend
-func NewCfgFromBytesWithoutValidation(bytes []byte) (*Cfg, error) {
+func NewCfgFromBytesWithoutJSValidation(bytes []byte) (*Cfg, error) {
 	skipStaticRootValidation = true
 	return NewCfgFromBytes(bytes)
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1087,6 +1087,12 @@ func NewCfgFromBytes(bytes []byte) (*Cfg, error) {
 	return NewCfgFromINIFile(parsedFile)
 }
 
+// prevents a log line from being printed when the static root path is not found, useful for apiservers that have no frontend
+func NewCfgFromBytesWithoutValidation(bytes []byte) (*Cfg, error) {
+	skipStaticRootValidation = true
+	return NewCfgFromBytes(bytes)
+}
+
 // NewCfgFromINIFile specialized function to create a new Cfg from an ini.File.
 func NewCfgFromINIFile(iniFile *ini.File) (*Cfg, error) {
 	cfg := NewCfg()


### PR DESCRIPTION
We are currently getting a log line about js files while reading configuration settings for backend apiservers, seems useful to have an option to not do that. 