### PR TITLE
NestedFolderPicker: Add rootFolderUID prop

### DIFF
--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -13,6 +13,9 @@ interface FolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
+  /* Only show folders inside this root folder */
+  rootFolderUID?: string;
+
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';
 

--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -13,7 +13,7 @@ interface FolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
-  /* Only show folders inside this root folder */
+  /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -36,7 +36,7 @@ export interface NestedFolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
-  /* Only show folders inside this root folder */
+  /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
@@ -226,10 +226,6 @@ export function NestedFolderPicker({
           },
         })) ?? [];
     }
-
-    // if (rootFolderUID) {
-    //   flatTree = filterByRootFolder(flatTree, rootFolderUID);
-    // }
 
     // It's not super optimal to filter these in an additional iteration, but
     // these options are used infrequently that its not a big deal

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -36,6 +36,9 @@ export interface NestedFolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
+  /* Only show folders inside this root folder */
+  rootFolderUID?: string;
+
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';
 
@@ -69,6 +72,7 @@ export function NestedFolderPicker({
   showRootFolder = true,
   clearable = false,
   excludeUIDs,
+  rootFolderUID,
   permission = 'edit',
   onChange,
   id,
@@ -106,7 +110,7 @@ export function NestedFolderPicker({
     items: browseFlatTree,
     isLoading: isBrowseLoading,
     requestNextPage: fetchFolderPage,
-  } = useFoldersQuery(isBrowsing, foldersOpenState, permissionLevel);
+  } = useFoldersQuery(isBrowsing, foldersOpenState, permissionLevel, rootFolderUID);
 
   useEffect(() => {
     if (!search) {
@@ -222,6 +226,10 @@ export function NestedFolderPicker({
           },
         })) ?? [];
     }
+
+    // if (rootFolderUID) {
+    //   flatTree = filterByRootFolder(flatTree, rootFolderUID);
+    // }
 
     // It's not super optimal to filter these in an additional iteration, but
     // these options are used infrequently that its not a big deal

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -8,6 +8,7 @@ export function useFoldersQuery(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
   permission?: PermissionLevelString,
+  /* Start tree from this folder instead of root */
   rootFolderUID?: string
 ) {
   const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID);

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -7,10 +7,11 @@ import { useFoldersQueryLegacy } from './useFoldersQueryLegacy';
 export function useFoldersQuery(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
-  permission?: PermissionLevelString
+  permission?: PermissionLevelString,
+  rootFolderUID?: string
 ) {
-  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission);
-  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders);
+  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID);
+  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders, rootFolderUID);
 
   // Running the hooks themselves don't have any side effects, so we can just conditionally use one or the other
   // requestNextPage function from the result

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -28,6 +28,7 @@ const collator = new Intl.Collator();
 export function useFoldersQueryAppPlatform(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
+  /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string
 ) {
   const dispatch = useDispatch();

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -25,7 +25,11 @@ const collator = new Intl.Collator();
  * This version uses the getFolderChildren API from the folder v1beta1 API. Compared to legacy API, the v1beta1 API
  * does not have pagination at the moment.
  */
-export function useFoldersQueryAppPlatform(isBrowsing: boolean, openFolders: Record<string, boolean>) {
+export function useFoldersQueryAppPlatform(
+  isBrowsing: boolean,
+  openFolders: Record<string, boolean>,
+  rootFolderUID?: string
+) {
   const dispatch = useDispatch();
 
   // Keep a list of all request subscriptions so we can unsubscribe from them when the component is unmounted
@@ -150,11 +154,12 @@ export function useFoldersQueryAppPlatform(isBrowsing: boolean, openFolders: Rec
       return list;
     }
 
-    const rootFlatTree = createFlatList(rootFolderToken, state.responseByParent[rootFolderToken], 1);
+    const startingToken = rootFolderUID ?? rootFolderToken;
+    const rootFlatTree = createFlatList(startingToken, state.responseByParent[startingToken], 1);
     rootFlatTree.unshift(getRootFolderItem());
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders]);
+  }, [state, isBrowsing, openFolders, rootFolderUID]);
 
   return {
     items: treeList,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -180,10 +180,9 @@ export function useFoldersQueryLegacy(
       return flatList;
     }
 
-    const startingParentUid = rootFolderUID ?? undefined;
     const startingPages = rootFolderUID ? state.pagesByParent[rootFolderUID] : state.rootPages;
 
-    const rootFlatTree = createFlatList(startingParentUid, startingPages ?? [], 1);
+    const rootFlatTree = createFlatList(rootFolderUID ?? undefined, startingPages ?? [], 1);
     rootFlatTree.unshift(getRootFolderItem());
 
     return rootFlatTree;

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -49,6 +49,7 @@ export function useFoldersQueryLegacy(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
   permission?: PermissionLevelString,
+  /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string
 ) {
   const dispatch = useDispatch();

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -48,7 +48,8 @@ function getPagesLoadStatus(pages: ListFoldersQuery[]): [boolean, number | undef
 export function useFoldersQueryLegacy(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
-  permission?: PermissionLevelString
+  permission?: PermissionLevelString,
+  rootFolderUID?: string
 ) {
   const dispatch = useDispatch();
 
@@ -178,11 +179,14 @@ export function useFoldersQueryLegacy(
       return flatList;
     }
 
-    const rootFlatTree = createFlatList(undefined, state.rootPages, 1);
+    const startingParentUid = rootFolderUID ?? undefined;
+    const startingPages = rootFolderUID ? state.pagesByParent[rootFolderUID] : state.rootPages;
+
+    const rootFlatTree = createFlatList(startingParentUid, startingPages ?? [], 1);
     rootFlatTree.unshift(getRootFolderItem());
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders]);
+  }, [state, isBrowsing, openFolders, rootFolderUID]);
 
   return {
     items: treeList,


### PR DESCRIPTION
**What is this feature?**
When `rootFolderUID` is provided to `NestedFolderPicker`, the hooks will start their tree from that folder instead of the root. 
- `NestedFolderPicker` : Added `rootFolderUID` prop
- `useFoldersQueryLegacy`: Added `rootFolderUID` param to configure which folder to start browsing from.
-  `useFoldersQueryAppPlatform`: Same as above

**Why do we need this feature?**

- This enables provisioned resource workflows to limit user navigation within designated folders while preventing access to the broader folder hierarchy which can lead to incorrectly move resource or confusing UX.

**Who is this feature for?**

- Devs 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/109624

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
