### PR TITLE
Table: Fields and Column Widths arrays can get out-of-sync on length

### DIFF
--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -56,6 +56,10 @@ const disableAllTextWrap = async (loc: Page | Locator, selectors: E2ESelectorGro
   }
 };
 
+const assertNoErrors = async (page: Page) => {
+  await expect(page.getByTestId('data-testid Alert error')).not.toBeVisible();
+};
+
 test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] }, () => {
   test('Tests word wrap, hover overflow, and cell inspect', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
@@ -105,6 +109,8 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     const loremIpsumText = await loremIpsumCell.textContent();
     expect(loremIpsumText).toBeDefined();
     await expect(page.getByRole('dialog').getByText(loremIpsumText!)).toBeVisible();
+
+    await assertNoErrors(page);
   });
 
   test('Tests visibility and display name via overrides', async ({ gotoDashboardPage, selectors, page }) => {
@@ -133,6 +139,13 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await displayNameInput.fill('State (renamed)');
     await displayNameInput.press('Enter');
     expect(page.getByRole('row').nth(0)).toContainText('State (renamed)');
+
+    // toggle the "State" column visibility again to hide it again. this confirms that we avoid bugs related to
+    // array lengths between the fields array and the column widths array.
+    await hideStateColumnSwitch.click();
+    expect(page.getByRole('row').nth(0)).not.toContainText('State');
+
+    await assertNoErrors(page);
   });
 
   // we test niche cases for sorting, filtering, pagination, etc. in a unit tests already.
@@ -162,6 +175,8 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     await stateColumnHeader.getByText('Info').click();
     await expect(stateColumnHeader).not.toHaveAttribute('aria-sort');
+
+    await assertNoErrors(page);
   });
 
   test('Tests filtering within a column', async ({ gotoDashboardPage, selectors, page }) => {
@@ -199,6 +214,8 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     // did it actually filter out our value?
     await expect(getCell(page, 1, infoColumnIdx)).resolves.not.toHaveText(firstStateValue);
+
+    await assertNoErrors(page);
   });
 
   test('Tests pagination, row height adjustment', async ({ gotoDashboardPage, selectors, page }) => {
@@ -261,6 +278,8 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     expect(fourthPageStatus.start).toBe(largeRowStatus.end * 3 + 1);
     expect(fourthPageStatus.end).toBe(largeRowStatus.end * 4);
     expect(fourthPageStatus.total).toBe(largeRowStatus.total);
+
+    await assertNoErrors(page);
   });
 
   test.skip('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
@@ -351,9 +370,11 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     // add an Action to the whole table and check that the action button is added to the tooltip.
     // TODO -- saving for another day.
+
+    await assertNoErrors(page);
   });
 
-  test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors }) => {
+  test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '1' }),
@@ -414,9 +435,11 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await expect(
       dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Tooltip.Wrapper)
     ).not.toBeVisible();
+
+    await assertNoErrors(page);
   });
 
-  test('Empty Table panel', async ({ gotoDashboardPage, selectors }) => {
+  test('Empty Table panel', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '3' }),
@@ -428,5 +451,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await expect(
       dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Table - Kitchen Sink'))
     ).not.toBeVisible();
+
+    await assertNoErrors(page);
   });
 });

--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -362,7 +362,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     // TODO -- saving for another day.
   });
 
-  test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors, page }) => {
+  test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '1' }),
@@ -425,7 +425,7 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     ).not.toBeVisible();
   });
 
-  test('Empty Table panel', async ({ gotoDashboardPage, selectors, page }) => {
+  test('Empty Table panel', async ({ gotoDashboardPage, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '3' }),

--- a/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
+++ b/e2e-playwright/panels-suite/table-kitchenSink.spec.ts
@@ -56,10 +56,6 @@ const disableAllTextWrap = async (loc: Page | Locator, selectors: E2ESelectorGro
   }
 };
 
-const assertNoErrors = async (page: Page) => {
-  await expect(page.getByTestId('data-testid Alert error')).not.toBeVisible();
-};
-
 test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] }, () => {
   test('Tests word wrap, hover overflow, and cell inspect', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
@@ -109,8 +105,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     const loremIpsumText = await loremIpsumCell.textContent();
     expect(loremIpsumText).toBeDefined();
     await expect(page.getByRole('dialog').getByText(loremIpsumText!)).toBeVisible();
-
-    await assertNoErrors(page);
   });
 
   test('Tests visibility and display name via overrides', async ({ gotoDashboardPage, selectors, page }) => {
@@ -145,7 +139,9 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await hideStateColumnSwitch.click();
     expect(page.getByRole('row').nth(0)).not.toContainText('State');
 
-    await assertNoErrors(page);
+    // since the previous assertion is just for the absence of text, let's also confirm that the table is
+    // actually still on the page and that an error has not been throw.
+    await waitForTableLoad(page);
   });
 
   // we test niche cases for sorting, filtering, pagination, etc. in a unit tests already.
@@ -175,8 +171,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     await stateColumnHeader.getByText('Info').click();
     await expect(stateColumnHeader).not.toHaveAttribute('aria-sort');
-
-    await assertNoErrors(page);
   });
 
   test('Tests filtering within a column', async ({ gotoDashboardPage, selectors, page }) => {
@@ -214,8 +208,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     // did it actually filter out our value?
     await expect(getCell(page, 1, infoColumnIdx)).resolves.not.toHaveText(firstStateValue);
-
-    await assertNoErrors(page);
   });
 
   test('Tests pagination, row height adjustment', async ({ gotoDashboardPage, selectors, page }) => {
@@ -278,8 +270,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     expect(fourthPageStatus.start).toBe(largeRowStatus.end * 3 + 1);
     expect(fourthPageStatus.end).toBe(largeRowStatus.end * 4);
     expect(fourthPageStatus.total).toBe(largeRowStatus.total);
-
-    await assertNoErrors(page);
   });
 
   test.skip('Tests DataLinks (single and multi) and actions', async ({ gotoDashboardPage, selectors, page }) => {
@@ -370,8 +360,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
 
     // add an Action to the whole table and check that the action button is added to the tooltip.
     // TODO -- saving for another day.
-
-    await assertNoErrors(page);
   });
 
   test('Tests tooltip interactions', async ({ gotoDashboardPage, selectors, page }) => {
@@ -435,8 +423,6 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await expect(
       dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Tooltip.Wrapper)
     ).not.toBeVisible();
-
-    await assertNoErrors(page);
   });
 
   test('Empty Table panel', async ({ gotoDashboardPage, selectors, page }) => {
@@ -451,7 +437,5 @@ test.describe('Panels test: Table - Kitchen Sink', { tag: ['@panels', '@table'] 
     await expect(
       dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Table - Kitchen Sink'))
     ).not.toBeVisible();
-
-    await assertNoErrors(page);
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -551,6 +551,20 @@ describe('TableNG hooks', () => {
 
       expect(heightFn).toHaveBeenCalledWith('Longer name that needs wrapping', 26, modifiedFields[0], -1, 22);
     });
+
+    it('does not throw if a field has been deleted but the colWidth has not yet been updated', () => {
+      const { fields } = setupData();
+      const { result } = renderHook(() => {
+        return useHeaderHeight({
+          fields,
+          columnWidths: [100, 100, 100, 100],
+          enabled: true,
+          typographyCtx,
+          sortColumns: [],
+        });
+      });
+      expect(result.current).toBe(28);
+    });
   });
 
   describe('useRowHeight', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -353,13 +353,19 @@ export function useHeaderHeight({
   const columnAvailableWidths = useMemo(
     () =>
       columnWidths.map((c, idx) => {
+        if (idx >= fields.length) {
+          return 0; // no width available for this column yet
+        }
+
         let width = c - 2 * TABLE.CELL_PADDING - TABLE.BORDER_RIGHT;
+        const field = fields[idx];
+
         // filtering icon
-        if (fields[idx]?.config?.custom?.filterable) {
+        if (field.config?.custom?.filterable) {
           width -= perIconSpace;
         }
         // sorting icon
-        if (sortColumns.some((col) => col.columnKey === getDisplayName(fields[idx]))) {
+        if (sortColumns.some((col) => col.columnKey === getDisplayName(field))) {
           width -= perIconSpace;
         }
         // type icon


### PR DESCRIPTION
After merging https://github.com/grafana/grafana/pull/109929, I noticed this introduced a bug: if a column is removed from the table for rendering, we throw an error in the `useHeaderHeight` hook, because the length of the fields array briefly doesn't match the length of the colWidths array, since that array is now state, and we pass undefined into `getDisplayName` for the last column.

This PR addresses the bug, adds a unit test for the specific case, and updates the existing e2e for hidden fields to catch failures of this kind.

To reproduce the bug:

1. Open the kitchen sink table in edit mode
2. Look at the Organize Transformation
3. Toggle any field on and off

Any other method of hiding and showing a field will trigger the bug, like toggling the "Hide in table" field override.