### PR TITLE
Refactor: Remove unused extension links from DataSourceTestingStatus …

### DIFF
--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -57,7 +57,6 @@ const AlertSuccessMessage = ({
   exploreUrl,
   dataSourceId,
   onDashboardLinkClicked,
-  extensionLinks = [],
 }: AlertMessageProps) => {
   const theme = useTheme2();
 
@@ -90,26 +89,6 @@ const AlertSuccessMessage = ({
         </Link>
         .
       </Trans>
-
-      {/* Extension links for allowed datasource extension plugins */}
-      {extensionLinks.length > 0 && (
-        <div className={styles.extensionLinks}>
-          <Trans i18nKey="data-source-testing-status-page.success-more-details-links-extensions">
-            You can also explore data with the following extensions:
-          </Trans>
-          {extensionLinks.map((link) => (
-            <Link
-              key={link.id}
-              href={link.path || '#'}
-              title={link.description}
-              className="external-link"
-              onClick={'onClick' in link ? link.onClick : undefined}
-            >
-              {link.title}
-            </Link>
-          ))}
-        </div>
-      )}
     </div>
   );
 };
@@ -236,7 +215,6 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
                   exploreUrl={exploreUrl}
                   dataSourceId={dataSource.uid}
                   onDashboardLinkClicked={onDashboardLinkClicked}
-                  extensionLinks={extensionLinks}
                 />
               ) : null}
               {severity === 'error' && errorDetailsLink ? <ErrorDetailsLink link={String(errorDetailsLink)} /> : null}

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -52,12 +52,7 @@ const getStyles = (theme: GrafanaTheme2, hasTitle: boolean) => {
   };
 };
 
-const AlertSuccessMessage = ({
-  title,
-  exploreUrl,
-  dataSourceId,
-  onDashboardLinkClicked,
-}: AlertMessageProps) => {
+const AlertSuccessMessage = ({ title, exploreUrl, dataSourceId, onDashboardLinkClicked }: AlertMessageProps) => {
   const theme = useTheme2();
 
   const hasTitle = Boolean(title);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6421,8 +6421,7 @@
   },
   "data-source-testing-status-page": {
     "error-more-details-link": "Click <2>here</2> to learn more about this error.",
-    "success-more-details-links": "Next, you can start to visualize data by <2>building a dashboard</2>, or by querying data in the <5>Explore view</5>.",
-    "success-more-details-links-extensions": "You can also explore data with the following extensions:"
+    "success-more-details-links": "Next, you can start to visualize data by <2>building a dashboard</2>, or by querying data in the <5>Explore view</5>."
   },
   "data-sources": {
     "datasource-add-button": {


### PR DESCRIPTION
Removing extra `extensionLinks` usage list introduced in https://github.com/grafana/grafana/pull/108350

Noticed it while working with the nightly release here: https://github.com/grafana/metrics-drilldown/pull/572

Before:

<img width="892" height="310" alt="image" src="https://github.com/user-attachments/assets/15e6821a-eeb5-42a4-8ad9-b5a6a9fe27d1" />

After:

<img width="663" height="337" alt="image" src="https://github.com/user-attachments/assets/dd8d8aa1-d67a-4d3a-b1c4-fd3f1eb0ac68" />
