### PR TITLE
Fix: avoid logging context reuse when logging an error

### DIFF
--- a/pkg/plugins/manager/pipeline/initialization/initialization.go
+++ b/pkg/plugins/manager/pipeline/initialization/initialization.go
@@ -50,7 +50,7 @@ func (i *Initialize) Initialize(ctx context.Context, ps *plugins.Plugin) (*plugi
 	for _, init := range i.initializeSteps {
 		ip, err = init(ctx, ps)
 		if err != nil {
-			i.log.Error("Could not initialize plugin", "pluginId", ps.ID, "error", err)
+			ps.Logger().Error("Could not initialize plugin", "pluginId", ps.ID, "error", err)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Example of logger context reuse right now:

```
t=2025-08-22T07:23:22.985725569Z level=error msg="Could not register plugin" pluginId=table error="plugin table is already registered" logger=plugins.initialization
t=2025-08-22T07:23:22.98573039Z level=error msg="Could not initialize plugin" pluginId=table error="plugin table is already registered" logger=plugin.grafana-azure-monitor-datasource
```

`table` plugin here has nothing to do with `plugin.grafana-azure-monitor-datasource`

**Why do we need this feature?**
Less confusion in log messages is always good

**Who is this feature for?**
Devs / Ops

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
