### PR TITLE
Secrets: Remove feature toggle check in dependency register

### DIFF
--- a/pkg/registry/apis/secret/register.go
+++ b/pkg/registry/apis/secret/register.go
@@ -24,11 +24,6 @@ func RegisterDependencies(
 		return nil, fmt.Errorf("registering access control roles: %w", err)
 	}
 
-	// TODO: Remove once the DB schema is more stable.
-	if !features.IsEnabledGlobally(featuremgmt.FlagSecretsManagementAppPlatform) {
-		return nil, nil
-	}
-
 	// We shouldn't need to create the DB in HG, as that will use the MT api server.
 	if cfg.StackID == "" {
 		// Some DBs that claim to be MySQL/Postgres-compatible might not support table locking.


### PR DESCRIPTION
**What is this feature?**

Removes the feature toggle check in the dependency registration wire function.

> [!WARNING]
> This means that the DB migrations will now run even without feature toggle checks!!

**Why do we need this feature?**

Makes it simpler for GitSync (and other core apps) to integrate with Secrets.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1474

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
