### PR TITLE
CI: Avoid running on 'push' in mirrors / forks

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/i18n-verify.yml
+++ b/.github/workflows/i18n-verify.yml
@@ -12,4 +12,6 @@ on:
 
 jobs:
   verify-i18n:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     uses: grafana/grafana-github-actions/.github/workflows/verify-i18n.yml@main

--- a/.github/workflows/lint-build-docs.yml
+++ b/.github/workflows/lint-build-docs.yml
@@ -20,6 +20,8 @@ permissions: {}
 
 jobs:
   docs:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Build & Verify Docs
     runs-on: ubuntu-latest
 

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -10,6 +10,8 @@ permissions: {}
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-x64-small
     permissions:

--- a/.github/workflows/reject-gh-secrets.yml
+++ b/.github/workflows/reject-gh-secrets.yml
@@ -12,6 +12,8 @@ permissions: {}
 
 jobs:
   reject-gh-secrets:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -49,7 +49,7 @@ jobs:
   setup:
     name: setup
     runs-on: github-hosted-ubuntu-x64-small
-    if: (github.repository == 'grafana/grafana') || (github.repository == 'grafana/grafana-security-mirror' && contains(github.ref_name, "+security"))
+    if: (github.repository == 'grafana/grafana') || (github.repository == 'grafana/grafana-security-mirror' && contains(github.ref_name, '+security'))
     outputs:
       version: ${{ steps.output.outputs.version }}
       grafana-commit: ${{ steps.output.outputs.grafana_commit }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -49,7 +49,7 @@ jobs:
   setup:
     name: setup
     runs-on: github-hosted-ubuntu-x64-small
-    if: github.repository == 'grafana/grafana'
+    if: (github.repository == 'grafana/grafana') || (github.repository == 'grafana/grafana-security-mirror' && contains(github.ref_name, "+security"))
     outputs:
       version: ${{ steps.output.outputs.version }}
       grafana-commit: ${{ steps.output.outputs.grafana_commit }}
@@ -104,10 +104,11 @@ jobs:
           BUCKET: grafana-prerelease
           GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
           SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
+          REPO: ${{ github.repository }}
         with:
           github-token: ${{ steps.generate_token.outputs.token }}
           script: |
-            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT} = process.env;
+            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
 
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',
@@ -120,6 +121,7 @@ jobs:
                   "bucket": BUCKET,
                   "grafana-commit": GRAFANA_COMMIT,
                   "source-event": SOURCE_EVENT,
+                  "upstream": REPO,
                 }
             })
 

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,6 +15,8 @@ permissions: {}
 
 jobs:
   shellcheck:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Shellcheck scripts
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -15,6 +15,8 @@ concurrency:
 
 jobs:
   detect-changes:
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' || (github.event_name == 'push' && github.repository == 'grafana/grafana'))
     name: Detect whether code changed
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/trigger-dashboard-search-e2e.yml
+++ b/.github/workflows/trigger-dashboard-search-e2e.yml
@@ -22,7 +22,8 @@ env:
 jobs:
   trigger-search-e2e:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    # Run on `grafana/grafana` main branch, or on pull requests to prevent double-running on mirrors
+    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event_name == 'push' && github.repository == 'grafana/grafana')
     steps:
       - name: Trigger Dashboard Search E2E
         run: echo "Triggered Dashboard Search e2e..."


### PR DESCRIPTION
For workflows that run on both `pull_request` and `push`, I've added filters that prevent them from running on push to `main` if the repository is not `grafana/grafana`.

This will help reduce waste in forks and in mirrors of the grafana repo.