### PR TITLE
DS-Querier: Fix data source not found

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -167,7 +167,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		raw := &query.QueryDataRequest{}
 		err := web.Bind(httpreq, raw)
 		if err != nil {
-			b.log.Error("Hit unexpected error when reading query", "err", err)
+			connectLogger.Error("Hit unexpected error when reading query", "err", err)
 			err = errorsK8s.NewBadRequest("error reading query")
 			// TODO: can we wrap the error so details are not lost?!
 			// errutil.BadRequest(
@@ -181,8 +181,8 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 		qdr, err := handleQuery(ctx, *raw, *b, httpreq, *responder, connectLogger)
 
 		if err != nil {
-			b.log.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
-			logEmptyRefids(raw.Queries, b.log)
+			connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
+			logEmptyRefids(raw.Queries, connectLogger)
 			if qdr != nil { // if we have a response, we assume the err is set in the response
 				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
 					QueryDataResponse: *qdr,
@@ -190,19 +190,40 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 				return
 			} else {
 				var errorDataResponse backend.DataResponse
-				if errors.Is(err, service.ErrInvalidDatasourceID) || errors.Is(err, service.ErrNoQueriesFound) || errors.Is(err, service.ErrMissingDataSourceInfo) || errors.Is(err, service.ErrQueryParamMismatch) || errors.Is(err, service.ErrDuplicateRefId) {
+
+				badRequestErrors := []error{
+					service.ErrInvalidDatasourceID,
+					service.ErrNoQueriesFound,
+					service.ErrMissingDataSourceInfo,
+					service.ErrQueryParamMismatch,
+					service.ErrDuplicateRefId,
+					datasources.ErrDataSourceNotFound,
+				}
+				isTypedBadRequestError := false
+				for _, badRequestError := range badRequestErrors {
+					if errors.Is(err, badRequestError) {
+						isTypedBadRequestError = true
+					}
+				}
+				if isTypedBadRequestError {
 					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
 				} else if strings.Contains(err.Error(), "expression request error") {
-					b.log.Error("Error calling TransformData in an expression", "err", err)
+					connectLogger.Error("Error calling TransformData in an expression", "err", err)
 					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
 				} else {
-					b.log.Error("unknown error, treated as a 500", "err", err)
+					connectLogger.Error("unknown error, treated as a 500", "err", err)
 					responder.Error(err)
 					return
 				}
+				// TODO ensure errors also return the refId wherever possible
+				errorRefId := raw.Queries[0].RefID
+				if errorRefId == "" {
+					errorRefId = "A"
+				}
+
 				qdr = &backend.QueryDataResponse{
 					Responses: map[string]backend.DataResponse{
-						"A": errorDataResponse,
+						errorRefId: errorDataResponse,
 					},
 				}
 				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
@@ -223,12 +244,12 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 	for _, query := range raw.Queries {
 		jsonBytes, err := json.Marshal(query)
 		if err != nil {
-			b.log.Error("error marshalling", err)
+			connectLogger.Error("error marshalling", err)
 		}
 
 		sjQuery, _ := simplejson.NewJson(jsonBytes)
 		if err != nil {
-			b.log.Error("error unmarshalling", err)
+			connectLogger.Error("error unmarshalling", err)
 		}
 
 		jsonQueries = append(jsonQueries, sjQuery)


### PR DESCRIPTION
A few fixes here: 
- previously when "data source not found" was thrown in parsing requests, it was getting marked as an unknown error and getting marked as 500 instead of 400
- I noticed a few places where we log without rule id
- I thought some of our error handling was getting a little bit hard to look at so I put it in an array
- previously our errors here were always return refId A, but while refId A is often the first query, it's not always, as user can name these whatever they'd like. This is still not REALLY right because the first datasource in a multiquery request might not be the one that fails, but editing this to return the datasource in question would be a larger refactor that would potentially impact code unrelated to the ds-querier so I feel like that fix can happen later. At least this way it will be the first datasource error which might be enough for now. 
