### PR TITLE
Docs: Deprecate `grafana/grafana-oss` docker repo in favor of `grafana/grafana`

### DIFF
--- a/apps/iam/local/yamls/zanzana.yaml
+++ b/apps/iam/local/yamls/zanzana.yaml
@@ -159,7 +159,7 @@ spec:
           env:
             - name: GF_PATHS_CONFIG
               value: /etc/grafana-config/grafana.ini
-          image: grafana/grafana-oss-dev:12.2.0-257970
+          image: grafana/grafana-dev:12.2.0-257970
           imagePullPolicy: IfNotPresent
           name: zanzana
           volumeMounts:
@@ -175,3 +175,4 @@ spec:
         - emptyDir: {}
           name: zanzana-storage
 ---
+

--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -20,7 +20,7 @@ weight: 1800
 
 {{< admonition type="caution" >}}
 Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we encourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
 {{< /admonition >}}
 
 # Configure a Grafana Docker image

--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -20,7 +20,7 @@ weight: 1800
 
 {{< admonition type="caution" >}}
 Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we enourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Instead, we encourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
 {{< /admonition >}}
 
 # Configure a Grafana Docker image
@@ -61,7 +61,7 @@ The Ubuntu-based Grafana Enterprise and OSS images are built using the [Ubuntu](
 
 ## Run a specific version of Grafana
 
-You can also run a specific version of Grafana or a beta version based on the main branch of the [grafana/grafana GitHub repository](https://github.com/grafana/grafana).
+You can also run a specific version of Grafana or a beta version based on the main branch of the [`grafana/grafana` GitHub repository](https://github.com/grafana/grafana).
 
 > **Note:** If you use a Linux operating system such as Debian or Ubuntu and encounter permission errors when running Docker commands, you might need to prefix the command with `sudo` or add your user to the `docker` group. The official Docker documentation provides instructions on how to [run Docker without a non-root user](https://docs.docker.com/engine/install/linux-postinstall/).
 
@@ -83,11 +83,11 @@ For recent releases of Grafana, there are also `minor` version tags in the `graf
 
 ## Run the Grafana main branch
 
-After every successful build of the main branch, two tags, `grafana/grafana:main` and `grafana/grafana:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-dev:<version>` and `grafana/grafana-dev:<version>-ubuntu`, where `version` is the a prerelease version of Grafana (e.g. `12.2.0-1234`, where `1234` is the GitHub Run ID of the build). These tags provide access to the most recent Grafana main builds. For more information, refer to [grafana/grafana-dev](https://hub.docker.com/r/grafana/grafana-dev/tags).
+After every successful build of the main branch, two tags, `grafana/grafana:main` and `grafana/grafana:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-dev:<version>` and `grafana/grafana-dev:<version>-ubuntu`, where `version` is the a prerelease version of Grafana (e.g. `12.2.0-1234`, where `1234` is the GitHub Run ID of the build). These tags provide access to the most recent Grafana main builds. For more information, refer to [`grafana/grafana-dev`](https://hub.docker.com/r/grafana/grafana-dev/tags).
 
 To ensure stability and consistency, we strongly recommend using the `grafana/grafana-dev:<version>` tag when running the Grafana main branch in a production environment. This tag ensures that you are using a specific version of Grafana instead of the most recent commit, which could potentially introduce bugs or issues. It also avoids polluting the tag namespace for the main Grafana images with thousands of pre-release tags.
 
-For a list of available tags, refer to [grafana/grafana](https://hub.docker.com/r/grafana/grafana/tags/) and [grafana/grafana-dev](https://hub.docker.com/r/grafana/grafana-dev/tags/).
+For a list of available tags, refer to [`grafana/grafana`](https://hub.docker.com/r/grafana/grafana/tags/) and [`grafana/grafana-dev`](https://hub.docker.com/r/grafana/grafana-dev/tags/).
 
 ## Default paths
 

--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -18,6 +18,11 @@ title: Configure a Grafana Docker image
 weight: 1800
 ---
 
+{{< admonition type="caution" >}}
+Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
+Instead, we enourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+{{< /admonition >}}
+
 # Configure a Grafana Docker image
 
 This topic explains how to run Grafana on Docker in complex environments that require you to:
@@ -27,7 +32,7 @@ This topic explains how to run Grafana on Docker in complex environments that re
 - Define secrets on the Cloud
 - Configure plugins
 
-> **Note:** The examples in this topic use the Grafana Enterprise Docker image. You can use the Grafana Open Source edition by changing the Docker image to `grafana/grafana-oss`.
+> **Note:** The examples in this topic use the Grafana Enterprise Docker image. You can use the Grafana Open Source edition by changing the Docker image to `grafana/grafana`.
 
 ## Supported Docker image variants
 
@@ -35,7 +40,7 @@ You can install and run Grafana using the following official Docker images.
 
 - **Grafana Enterprise**: `grafana/grafana-enterprise`
 
-- **Grafana Open Source**: `grafana/grafana-oss`
+- **Grafana Open Source**: `grafana/grafana`
 
 Each edition is available in two variants: Alpine and Ubuntu.
 
@@ -52,7 +57,7 @@ The Ubuntu-based Grafana Enterprise and OSS images are built using the [Ubuntu](
 
 - **Grafana Enterprise**: `grafana/grafana-enterprise:<version>-ubuntu`
 
-- **Grafana Open Source**: `grafana/grafana-oss:<version>-ubuntu`
+- **Grafana Open Source**: `grafana/grafana:<version>-ubuntu`
 
 ## Run a specific version of Grafana
 
@@ -74,13 +79,15 @@ The following command runs the Grafana Enterprise container and specifies versio
 docker run -d -p 3000:3000 --name grafana grafana/grafana-enterprise:9.4.7
 ```
 
+For recent releases of Grafana, there are also `minor` version tags in the `grafana/grafana` and `grafana/grafana-enterprise` docker repositories. For example, if you want to always have the latest `12.1` version, you can use `grafana/grafana-enterprise:12.1` or `grafana/grafana-enterprise:12.1-ubuntu`.
+
 ## Run the Grafana main branch
 
-After every successful build of the main branch, two tags, `grafana/grafana-oss:main` and `grafana/grafana-oss:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-oss-dev:<version><build ID>-pre` and `grafana/grafana-oss-dev:<version><build ID>-pre-ubuntu`, where `version` is the next version of Grafana and `build ID `is the ID of the corresponding CI build. These tags provide access to the most recent Grafana main builds. For more information, refer to [grafana/grafana-oss-dev](https://hub.docker.com/r/grafana/grafana-oss-dev/tags).
+After every successful build of the main branch, two tags, `grafana/grafana:main` and `grafana/grafana:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-dev:<version>` and `grafana/grafana-dev:<version>-ubuntu`, where `version` is the a prerelease version of Grafana (e.g. `12.2.0-1234`, where `1234` is the GitHub Run ID of the build). These tags provide access to the most recent Grafana main builds. For more information, refer to [grafana/grafana-dev](https://hub.docker.com/r/grafana/grafana-dev/tags).
 
-To ensure stability and consistency, we strongly recommend using the `grafana/grafana-oss-dev:<version><build ID>-pre` tag when running the Grafana main branch in a production environment. This tag ensures that you are using a specific version of Grafana instead of the most recent commit, which could potentially introduce bugs or issues. It also avoids polluting the tag namespace for the main Grafana images with thousands of pre-release tags.
+To ensure stability and consistency, we strongly recommend using the `grafana/grafana-dev:<version>` tag when running the Grafana main branch in a production environment. This tag ensures that you are using a specific version of Grafana instead of the most recent commit, which could potentially introduce bugs or issues. It also avoids polluting the tag namespace for the main Grafana images with thousands of pre-release tags.
 
-For a list of available tags, refer to [grafana/grafana-oss](https://hub.docker.com/r/grafana/grafana-oss/tags/) and [grafana/grafana-oss-dev](https://hub.docker.com/r/grafana/grafana-oss-dev/tags/).
+For a list of available tags, refer to [grafana/grafana](https://hub.docker.com/r/grafana/grafana/tags/) and [grafana/grafana-dev](https://hub.docker.com/r/grafana/grafana-dev/tags/).
 
 ## Default paths
 

--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -19,8 +19,8 @@ weight: 1800
 ---
 
 {{< admonition type="caution" >}}
-Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Starting with Grafana release `12.4.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
+Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same Grafana OSS docker images.
 {{< /admonition >}}
 
 # Configure a Grafana Docker image

--- a/docs/sources/setup-grafana/configure-docker.md
+++ b/docs/sources/setup-grafana/configure-docker.md
@@ -83,7 +83,7 @@ For recent releases of Grafana, there are also `minor` version tags in the `graf
 
 ## Run the Grafana main branch
 
-After every successful build of the main branch, two tags, `grafana/grafana:main` and `grafana/grafana:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-dev:<version>` and `grafana/grafana-dev:<version>-ubuntu`, where `version` is the a prerelease version of Grafana (e.g. `12.2.0-1234`, where `1234` is the GitHub Run ID of the build). These tags provide access to the most recent Grafana main builds. For more information, refer to [`grafana/grafana-dev`](https://hub.docker.com/r/grafana/grafana-dev/tags).
+After every successful build of the main branch, two tags, `grafana/grafana:main` and `grafana/grafana:main-ubuntu`, are updated. Additionally, two new tags are created: `grafana/grafana-dev:<version>` and `grafana/grafana-dev:<version>-ubuntu`, where `version` is a prerelease version of Grafana. For example, if `1234` is the GitHub Run ID of the build, `12.2.0-1234`. These tags provide access to the most recent Grafana main builds. For more information, refer to [`grafana/grafana-dev`](https://hub.docker.com/r/grafana/grafana-dev/tags).
 
 To ensure stability and consistency, we strongly recommend using the `grafana/grafana-dev:<version>` tag when running the Grafana main branch in a production environment. This tag ensures that you are using a specific version of Grafana instead of the most recent commit, which could potentially introduce bugs or issues. It also avoids polluting the tag namespace for the main Grafana images with thousands of pre-release tags.
 

--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -11,6 +11,11 @@ title: Run Grafana Docker image
 weight: 400
 ---
 
+{{< admonition type="caution" >}}
+Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
+Instead, we enourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+{{< /admonition >}}
+
 # Run Grafana Docker image
 
 This topic guides you through installing Grafana via the official Docker images. Specifically, it covers running Grafana via the Docker command line interface (CLI) and docker-compose.
@@ -20,7 +25,7 @@ This topic guides you through installing Grafana via the official Docker images.
 Grafana Docker images come in two editions:
 
 - **Grafana Enterprise**: `grafana/grafana-enterprise`
-- **Grafana Open Source**: `grafana/grafana-oss`
+- **Grafana Open Source**: `grafana/grafana`
 
 > **Note:** The recommended and default edition of Grafana is Grafana Enterprise. It is free and includes all the features of the OSS edition. Additionally, you have the option to upgrade to the [full Enterprise feature set](/products/enterprise/?utm_source=grafana-install-page), which includes support for [Enterprise plugins](/grafana/plugins/?enterprise=1&utcm_source=grafana-install-page).
 

--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -13,7 +13,7 @@ weight: 400
 
 {{< admonition type="caution" >}}
 Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we encourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
 {{< /admonition >}}
 
 # Run Grafana Docker image

--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -12,8 +12,8 @@ weight: 400
 ---
 
 {{< admonition type="caution" >}}
-Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Starting with Grafana release `12.4.0` , the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
+Instead, we encourage you to use the `grafana/grafana` Docker Hub repository. These two repositories have the same Grafana OSS docker images.
 {{< /admonition >}}
 
 # Run Grafana Docker image

--- a/docs/sources/setup-grafana/installation/docker/index.md
+++ b/docs/sources/setup-grafana/installation/docker/index.md
@@ -13,7 +13,7 @@ weight: 400
 
 {{< admonition type="caution" >}}
 Starting with Grafana releases `12.4.0` and `13.0.0`, the `grafana/grafana-oss` Docker Hub repository will no longer be updated.
-Instead, we enourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
+Instead, we encourage users to use the `grafana/grafana` Docker Hub repository. These two repositories have the same docker images.
 {{< /admonition >}}
 
 # Run Grafana Docker image

--- a/docs/sources/setup-grafana/installation/kubernetes/index.md
+++ b/docs/sources/setup-grafana/installation/kubernetes/index.md
@@ -392,10 +392,10 @@ Instead of using the `annotate` flag, you can still use the `--record` flag. How
 
    For example:
    - From
-     - `yaml image: grafana/grafana-oss:10.0.1`
+     - `yaml image: grafana/grafana:12.1.0`
 
    - To
-     - `yaml image: grafana/grafana-oss-dev:10.1.0-124419pre`
+     - `yaml image: grafana/grafana-dev:12.2.0-17161637292`
 
 1. Save the changes.
 
@@ -421,7 +421,7 @@ Instead of using the `annotate` flag, you can still use the `--record` flag. How
    kubectl get all --namespace=my-grafana -o wide
    ```
 
-   You should see the newly deployed `grafana-oss-dev` image.
+   You should see the newly deployed `grafana-dev` image.
 
 1. To verify it, access the Grafana UI in the browser using the provided IP:Port from the command above.
 
@@ -435,7 +435,7 @@ Instead of using the `annotate` flag, you can still use the `--record` flag. How
 1. Add the `change cause` metadata to keep track of things using the commands:
 
    ```bash
-   kubectl annotate deployment grafana --namespace=my-grafana kubernetes.io/change-cause='using grafana-oss-dev:10.1.0-124419pre for testing'
+   kubectl annotate deployment grafana --namespace=my-grafana kubernetes.io/change-cause='using grafana-dev:12.2.0-17161637292 for testing'
    ```
 
 1. To verify, run the `kubectl rollout history` command:
@@ -450,7 +450,7 @@ Instead of using the `annotate` flag, you can still use the `--record` flag. How
    deployment.apps/grafana
    REVISION  CHANGE-CAUSE
    1         deploying the default yaml
-   2         using grafana-oss-dev:10.1.0-124419pre for testing
+   2         using grafana-dev:12.2.0-17161637292 for testing
    ```
 
 This means that `REVISION#2` is the current version.


### PR DESCRIPTION
# Deprecation notice

As of the `12.4.0`` and `13.0.0` releases of Grafana, the `grafana/grafana-oss` docker repository will no longer receive new images.

The `grafana/grafana` docker repository should be used instead of `grafana/grafana-oss`.