### PR TITLE
Unistore: Wire up inline secure values

### DIFF
--- a/pkg/registry/apis/secret/inline/service.go
+++ b/pkg/registry/apis/secret/inline/service.go
@@ -35,7 +35,6 @@ func NewGRPCSecureValueService(tokenCfg *grpcutils.GrpcClientConfig,
 	tlsCfg TLSConfig,
 	tracer trace.Tracer,
 ) (contracts.InlineSecureValueSupport, error) {
-
 	if address == "" {
 		return nil, fmt.Errorf("grpc_server_address is required when grpc client is enabled")
 	}

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -149,6 +149,15 @@ func (o *StorageOptions) Validate() []error {
 			errs = append(errs, fmt.Errorf("grpc client auth namespace is required for unified-grpc storage"))
 		}
 	}
+
+	if o.SecretsManagerGrpcClientEnable {
+		if o.SecretsManagerGrpcServerAddress == "" {
+			errs = append(errs, fmt.Errorf("secrets manager grpc server address is required for secrets manager grpc client"))
+		}
+		if o.SecretsManagerGrpcServerUseTLS && !o.SecretsManagerGrpcServerTLSSkipVerify && o.SecretsManagerGrpcServerTLSCAFile == "" {
+			errs = append(errs, fmt.Errorf("secrets manager grpc server ca file is required for secrets manager grpc client"))
+		}
+	}
 	return errs
 }
 

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -11,7 +11,6 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
-	genericoptions "k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/rest"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -161,7 +160,7 @@ func (o *StorageOptions) Validate() []error {
 	return errs
 }
 
-func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfig, etcdOptions *options.EtcdOptions, tracer tracing.Tracer, secureServing *genericoptions.SecureServingOptions) error {
+func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfig, etcdOptions *options.EtcdOptions, tracer tracing.Tracer, secureServing *options.SecureServingOptions) error {
 	if o.StorageType != StorageTypeUnifiedGrpc {
 		return nil
 	}

--- a/pkg/services/apiserver/options/storage_test.go
+++ b/pkg/services/apiserver/options/storage_test.go
@@ -30,6 +30,47 @@ func TestStorageOptions_Validate(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "with secrets manager grpc client and no server address",
+			Opts: StorageOptions{
+				StorageType:                              StorageTypeUnifiedGrpc,
+				Address:                                  "localhost:10000",
+				GrpcClientAuthenticationToken:            "1234",
+				GrpcClientAuthenticationTokenExchangeURL: "http://localhost:8080",
+				GrpcClientAuthenticationTokenNamespace:   "*",
+				SecretsManagerGrpcClientEnable:           true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "with secrets manager grpc client and no server ca file",
+			Opts: StorageOptions{
+				StorageType:                              StorageTypeUnifiedGrpc,
+				Address:                                  "localhost:10000",
+				GrpcClientAuthenticationToken:            "1234",
+				GrpcClientAuthenticationTokenExchangeURL: "http://localhost:8080",
+				GrpcClientAuthenticationTokenNamespace:   "*",
+				SecretsManagerGrpcClientEnable:           true,
+				SecretsManagerGrpcServerAddress:          "localhost:10000",
+				SecretsManagerGrpcServerUseTLS:           true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "with secrets manager grpc client and server ca file",
+			Opts: StorageOptions{
+				StorageType:                              StorageTypeUnifiedGrpc,
+				Address:                                  "localhost:10000",
+				GrpcClientAuthenticationToken:            "1234",
+				GrpcClientAuthenticationTokenExchangeURL: "http://localhost:8080",
+				GrpcClientAuthenticationTokenNamespace:   "*",
+				SecretsManagerGrpcClientEnable:           true,
+				SecretsManagerGrpcServerAddress:          "localhost:10000",
+				SecretsManagerGrpcServerUseTLS:           true,
+				SecretsManagerGrpcServerTLSCAFile:        "ca.crt",
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -2,6 +2,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/dskit/services"
 	infraDB "github.com/grafana/grafana/pkg/infra/db"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
+	inlinesecurevalue "github.com/grafana/grafana/pkg/registry/apis/secret/inline"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
@@ -48,6 +50,20 @@ func NewResourceServer(
 	opts ServerOptions,
 ) (resource.ResourceServer, error) {
 	apiserverCfg := opts.Cfg.SectionWithEnvOverrides("grafana-apiserver")
+
+	if opts.SecureValues == nil && opts.Cfg != nil && opts.Cfg.SecretsManagement.GrpcClientEnable {
+		inlineSecureValueService, err := inlinesecurevalue.ProvideInlineSecureValueService(
+			opts.Cfg,
+			opts.Tracer,
+			nil, // not needed for gRPC client mode
+			nil, // not needed for gRPC client mode
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create inline secure value service: %w", err)
+		}
+		opts.SecureValues = inlineSecureValueService
+	}
+
 	serverOptions := resource.ResourceServerOptions{
 		Tracer: opts.Tracer,
 		Blob: resource.BlobConfig{


### PR DESCRIPTION
This PR wires up the inline secure values.

Specifically it:
- Allows the unified storage server to connect to secrets for the owner reference check (set on the storage.ini)
- Allows unistore clients to connect to secrets (set via flags)

It also refactors the ProvideInlineSecureValueService, to allow the setup to be cleaner for the unistore clients