### PR TITLE
docs: clarify that data links must use variable names, not labels

### DIFF
--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -312,7 +312,6 @@ To add a data link, follow these steps:
 
 1. Enter the **URL** to which you want to link.
 1. (Optional) To add a data link variable, do the following:
-
    - Click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
    - Ensure that you use the variable _name_ and not the variable _label_ in the URL. The label is only used as display text.
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -307,10 +307,7 @@ To add a data link, follow these steps:
    This is a human-readable label for the link displayed in the UI. This is a required field.
 
 1. Enter the **URL** to which you want to link.
-1. (Optional) To add a data link variable, do the following:
-   - Click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
-   - Ensure that the target dashboard has the same variable name defined so it can be used in subsequent queries. 
-
+1. (Optional) To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables. 
 1. If you want the link to open in a new tab, toggle the **Open in a new tab** switch.
 1. If you want the data link to open with a single click on the visualization, toggle the **One click** switch.
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -307,7 +307,7 @@ To add a data link, follow these steps:
    This is a human-readable label for the link displayed in the UI. This is a required field.
 
 1. Enter the **URL** to which you want to link.
-1. (Optional) To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables. 
+1. (Optional) To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
 1. If you want the link to open in a new tab, toggle the **Open in a new tab** switch.
 1. If you want the data link to open with a single click on the visualization, toggle the **One click** switch.
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -313,7 +313,7 @@ To add a data link, follow these steps:
 1. Enter the **URL** to which you want to link.
 1. (Optional) To add a data link variable, do the following:
    - Click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
-   - Ensure that you use the variable _name_ and not the variable _label_ in the URL. The label is only used as display text.
+   - Ensure that the target dashboard has the same variable name defined so it can be used in subsequent queries. 
 
 1. If you want the link to open in a new tab, toggle the **Open in a new tab** switch.
 1. If you want the data link to open with a single click on the visualization, toggle the **One click** switch.

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -278,20 +278,16 @@ When linking to another dashboard that uses template variables, select variable 
 
 If you want to add all of the current dashboard's variables to the URL, then use `${__all_variables}`.
 
-#### Variable names and labels
+When you link to another dashboard, ensure that:
 
-If you're using a data link to link to another dashboard, always use the _variable name_, not the label.  
-Labels are only used as display text and aren't recognized in URLs.
+- The target dashboard has the same variable name. If it doesn't (for example, `server` in the source dashboard and `host` in the target), you must align them or explicitly map values (for example, `&var-host=${server}`).
+- You use the variable _name_, and not the label. Labels are only used as display text and aren't recognized in URLs.
 
 For example, if you have a variable with the name `var-server` and the label `ChooseYourServer`, you must use `var-server` in the URL, as shown in the following table:
 
 | Correct link                                   | Incorrect link                                           |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | `/d/xxxx/dashboard-b?orgId=1&var-server=web02` | `/d/xxxx/dashboard-b?orgId=1&var-ChooseYourServer=web02` |
-
-{{< admonition type="note">}}
-If two dashboards use different variable names (for example, `server` in one and `host` in another), you must either align them or explicitly map values (for example, `&var-host=${server}`).
-{{< /admonition >}}
 
 ## Add data links or actions {#add-a-data-link}
 

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -278,19 +278,19 @@ When linking to another dashboard that uses template variables, select variable 
 
 If you want to add all of the current dashboard's variables to the URL, then use `${__all_variables}`.
 
-### Variable names vs. labels
+#### Variable names and labels
 
-When creating data links between dashboards, always use the **variable name**, not its label.  
-Labels are only display text for users and are not recognized in URLs.
+If you're using a data link to link to another dashboard, always use the _variable name_, not the label.  
+Labels are only used as display text and aren't recognized in URLs.
 
-For example:
+For example, if you have a variable with the name `var-server` and the label `ChooseYourServer`, you must use `var-server` in the URL, as shown in the following table:
 
 | Correct link                                   | Incorrect link                                           |
 | ---------------------------------------------- | -------------------------------------------------------- |
 | `/d/xxxx/dashboard-b?orgId=1&var-server=web02` | `/d/xxxx/dashboard-b?orgId=1&var-ChooseYourServer=web02` |
 
-{{< admonition type="note" >}}
-Data links depend on variable names. If two dashboards use different variable names (for example, `server` in one and `host` in another), you must either align them or explicitly map values (for example, `&var-host=${server}`).
+{{< admonition type="note">}}
+If two dashboards use different variable names (for example, `server` in one and `host` in another), you must either align them or explicitly map values (for example, `&var-host=${server}`).
 {{< /admonition >}}
 
 ## Add data links or actions {#add-a-data-link}
@@ -311,8 +311,10 @@ To add a data link, follow these steps:
    This is a human-readable label for the link displayed in the UI. This is a required field.
 
 1. Enter the **URL** to which you want to link.
+1. (Optional) To add a data link variable, do the following:
 
-   To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables. This is a required field.
+   - Click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
+   - Ensure that you use the variable _name_ and not the variable _label_ in the URL. The label is only used as display text.
 
 1. If you want the link to open in a new tab, toggle the **Open in a new tab** switch.
 1. If you want the data link to open with a single click on the visualization, toggle the **One click** switch.

--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -278,6 +278,21 @@ When linking to another dashboard that uses template variables, select variable 
 
 If you want to add all of the current dashboard's variables to the URL, then use `${__all_variables}`.
 
+### Variable names vs. labels
+
+When creating data links between dashboards, always use the **variable name**, not its label.  
+Labels are only display text for users and are not recognized in URLs.
+
+For example:
+
+| Correct link                                   | Incorrect link                                           |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| `/d/xxxx/dashboard-b?orgId=1&var-server=web02` | `/d/xxxx/dashboard-b?orgId=1&var-ChooseYourServer=web02` |
+
+{{< admonition type="note" >}}
+Data links depend on variable names. If two dashboards use different variable names (for example, `server` in one and `host` in another), you must either align them or explicitly map values (for example, `&var-host=${server}`).
+{{< /admonition >}}
+
 ## Add data links or actions {#add-a-data-link}
 
 The following tasks describe how to configure data links and actions.


### PR DESCRIPTION
### What this PR does
This PR improves the Configure data links and actions documentation by clarifying that data links must use the variable name, not the label.

- Added a new section "Variable names vs. labels"
- Included a comparison table with correct vs. incorrect examples
- Added a note on aligning/mapping variable names across dashboards

### Why this is needed
Previously, the docs didn’t explain that labels are not recognized in URLs.  
This caused confusion and broken links. The update makes this explicit.

### Screenshot
<img width="1440" height="900" alt="Screenshot 2025-08-23 at 7 48 41 PM" src="https://github.com/user-attachments/assets/667227fa-185b-457b-9a8b-fccf1b98d0ef" />

### Checklist
- [x] Tested locally with `make docs`
- [x] Section follows Grafana docs style guide
- [x] Added table + note for clarity

Closes #44475
