### PR TITLE
Alerting: fix error log in multiorg alertmanager

### DIFF
--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -236,7 +236,7 @@ func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
 
 		err = peer.Join(alertingCluster.DefaultReconnectInterval, cfg.UnifiedAlerting.HAReconnectTimeout)
 		if err != nil {
-			moa.logger.Error("Msg", "Unable to join gossip mesh while initializing cluster for high availability mode", "error", err)
+			moa.logger.Error("Unable to join gossip mesh while initializing cluster for high availability mode", "error", err)
 		}
 		// Attempt to verify the number of peers for 30s every 2s. The risk here is what we send a notification "too soon".
 		// Which should _never_ happen given we share the notification log via the database so the risk of double notification is very low.


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

fixes a log message in the multiorg alertmanager

**Why do we need this feature?**

the log interface expects the first argument to be the log message, the second to be a key, the third to be a value and so on... 
the current code produces log messages like this: 
```
{
	"1 error occurred:\\n\\t* Failed to resolve grafana-headless:9094: lookup grafana-headless on 0.0.0.0:53: no such host\\n\\n":
	"(MISSING)",
	"Unable to join gossip mesh while initializing cluster for high availability mode":"error",
	"level":"error",
	"logger":"ngalert.multiorg.alertmanager",
	"msg":"Msg",
	"t":"<time>"
}
```

it should be like this:
```
{
	"error": "1 error occurred:\\n\\t* Failed to resolve grafana-headless:9094: lookup grafana-headless on 0.0.0.0:53: no such host\\n\\n"
	"msg", "Unable to join gossip mesh while initializing cluster for high availability mode",
	"level":"error",
	"logger":"ngalert.multiorg.alertmanager",
	"t":"<time>"
}
```


~~**Who is this feature for?**~~

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

didn't create one since it is a small fix. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
