### PR TITLE
Cloud Monitoring: Add support for Google Cloud universe_domain

### DIFF
--- a/docs/sources/datasources/google-cloud-monitoring/_index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/_index.md
@@ -103,10 +103,11 @@ To configure basic settings for the data source, complete the following steps:
 
 1. Set the data source's basic configuration options:
 
-   | Name        | Description                                                              |
-   | ----------- | ------------------------------------------------------------------------ |
-   | **Name**    | Sets the name you use to refer to the data source in panels and queries. |
-   | **Default** | Sets whether the data source is pre-selected for new panels.             |
+   | Name             | Description                                                              |
+   | ---------------- | ------------------------------------------------------------------------ |
+   | **Name**         | Sets the name you use to refer to the data source in panels and queries. |
+   | **Default**      | Sets whether the data source is pre-selected for new panels.             |
+   | **Universe Domain** | The universe domain to connect to. For more information, see [Documentation on universe domains](https://documentation.s3ns.fr/docs/get-started-tpc/use-client-libraries?hl=en). |
 
 ### Provision the data source
 
@@ -129,6 +130,7 @@ datasources:
       clientEmail: stackdriver@myproject.iam.gserviceaccount.com
       authenticationType: jwt
       defaultProject: my-project-name
+      universeDomain: googleapis.com
     secureJsonData:
       privateKey: |
         -----BEGIN PRIVATE KEY-----
@@ -152,6 +154,7 @@ datasources:
       clientEmail: stackdriver@myproject.iam.gserviceaccount.com
       authenticationType: jwt
       defaultProject: my-project-name
+      universeDomain: googleapis.com
       privateKeyPath: /etc/secrets/gce.pem
 ```
 
@@ -166,6 +169,7 @@ datasources:
     access: proxy
     jsonData:
       authenticationType: gce
+      universeDomain: googleapis.com
 ```
 
 ## Import pre-configured dashboards

--- a/pkg/tsdb/cloud-monitoring/httpclient.go
+++ b/pkg/tsdb/cloud-monitoring/httpclient.go
@@ -23,12 +23,12 @@ type routeInfo struct {
 var routes = map[string]routeInfo{
 	cloudMonitor: {
 		method: "GET",
-		url:    "https://monitoring.googleapis.com",
+		url:    "https://monitoring.",
 		scopes: []string{cloudMonitorScope},
 	},
 	resourceManager: {
 		method: "GET",
-		url:    "https://cloudresourcemanager.googleapis.com",
+		url:    "https://cloudresourcemanager.",
 		scopes: []string{resourceManagerScope},
 	},
 }
@@ -66,6 +66,13 @@ func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middlewa
 	}
 
 	return tokenprovider.AuthMiddleware(provider), nil
+}
+
+func buildURL(route string, universeDomain string) string {
+	if universeDomain == "" {
+		universeDomain = "googleapis.com"
+	}
+	return routes[route].url + universeDomain
 }
 
 func newHTTPClient(model *datasourceInfo, opts httpclient.Options, clientProvider *httpclient.Provider, route string) (*http.Client, error) {

--- a/pkg/tsdb/cloud-monitoring/resource_handler_test.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler_test.go
@@ -111,7 +111,7 @@ func Test_setRequestVariables(t *testing.T) {
 		im: &fakeInstance{
 			services: map[string]datasourceService{
 				cloudMonitor: {
-					url:    routes[cloudMonitor].url,
+					url:    buildURL(cloudMonitor, "googleapis.com"),
 					client: &http.Client{},
 				},
 			},

--- a/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/ConfigEditor/ConfigEditor.tsx
@@ -44,6 +44,24 @@ export const ConfigEditor = memo(({ options, onOptionsChange }: Props) => {
           </ConfigSection>
         </>
       )}
+      <Divider />
+      <div className="gf-form-group">
+        <h5 className="section-heading">Advanced settings</h5>
+        <div className="gf-form">
+          <label className="gf-form-label width-12">Universe Domain</label>
+          <input
+            className="gf-form-input width-30"
+            value={options.jsonData.universeDomain}
+            onChange={(event) =>
+              this.handleOnOptionsChange({
+                ...options,
+                jsonData: { ...options.jsonData, universeDomain: event.target.value },
+              })
+            }
+            placeholder="googleapis.com"
+          />
+        </div>
+      </div>
     </>
   );
 });

--- a/public/app/plugins/datasource/cloud-monitoring/types/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types/types.ts
@@ -38,6 +38,7 @@ export interface Aggregation {
 export interface CloudMonitoringOptions extends DataSourceOptions {
   gceDefaultProject?: string;
   enableSecureSocksProxy?: boolean;
+  universeDomain?: string;
 }
 
 export interface CloudMonitoringSecureJsonData extends DataSourceSecureJsonData {}


### PR DESCRIPTION
This change introduces support for Google Cloud's `universe_domain`, enabling connections to sovereign cloud environments with custom API endpoints.

- Adds an optional "Universe Domain" field in the Google Cloud Monitoring data source configuration (frontend and backend).
- Allows specifying a custom API domain (e.g., `s3nsapis.fr`) for use in sovereign environments.
- Defaults to `googleapis.com` to ensure backward compatibility for existing configurations.

**What is this feature?**

This PR introduces an optional **"Universe Domain"** configuration field to the Google Cloud Monitoring data source. This allows the data source to connect to custom Google Cloud API endpoints, such as those used in sovereign cloud environments.

**Why do we need this feature?**

Google Cloud uses the `universe_domain` concept to support sovereign cloud offerings, which have distinct API endpoints from the global default (`googleapis.com`). Without the ability to configure this domain, the Grafana data source cannot connect to projects hosted in these environments. This change unblocks users who are required to use sovereign clouds for data residency or regulatory compliance reasons.

**Who is this feature for?**

This feature is for Grafana users who manage projects within **Google's sovereign cloud environments**. This includes organizations and teams subject to strict data sovereignty regulations (e.g., in Europe) that prevent them from using global cloud endpoints.

**Which issue(s) does this PR fix?**:

Fixes #110084

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [[notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new)](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [[What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/)](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.