### PR TITLE
LBAC for data sources: Add access squad as CODEOWNERS for teamlbac

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -397,6 +397,10 @@
 /pkg/services/pluginsintegration/pluginsettings/ @grafana/plugins-platform-backend
 /pkg/services/plugindashboards/ @grafana/plugins-platform-backend
 
+# LBAC for data sources
+/pkg/extensions/teamlbac @grafana/access-squad
+/pkg/extensions/pluginsintegration/teamhttpheaders @grafana/access-squad
+
 # Backend code docs
 /contribute/backend/ @grafana/grafana-backend-group
 


### PR DESCRIPTION
**What/why**
We own the code, previously when we added a change to the files, the backend squad would be notified; now it's only the access squad.