### PR TITLE
Provisioning: Save temporary repository with sync.target=folder

### DIFF
--- a/public/app/features/provisioning/Config/defaults.ts
+++ b/public/app/features/provisioning/Config/defaults.ts
@@ -18,7 +18,7 @@ export function getDefaultValues(repository?: RepositorySpec): RepositoryFormDat
       path: 'grafana/',
       sync: {
         enabled: false,
-        target: 'instance',
+        target: 'folder', // start with folder so we can shift to instance later (without an error)
         intervalSeconds: 60,
       },
     };


### PR DESCRIPTION
When creating provisioning repositories, we first save the credentials so we can then list the contents of the remote repository and decide what how best to guide the UX.  

We currently have the default value set to `instance` -- this is conceptually what we want, *BUT* it fails when a repository already exists.

This PR changes things so we start with `folder` and then switch to `instance` in the next step.

