### PR TITLE
Chore: Update project urls for zipkin, jaeger, tempo and parca

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -136,7 +136,7 @@
     "name": "datasource/Tempo",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+      "url": "https://github.com/orgs/grafana/projects/457"
     }
   },
   {
@@ -152,7 +152,7 @@
     "name": "datasource/Parca",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+      "url": "https://github.com/orgs/grafana/projects/457"
     }
   },
   {
@@ -168,7 +168,7 @@
     "name": "datasource/Jaeger",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+      "url": "https://github.com/orgs/grafana/projects/457"
     }
   },
   {
@@ -176,7 +176,7 @@
     "name": "datasource/Zipkin",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/221"
+      "url": "https://github.com/orgs/grafana/projects/457"
     }
   },
   {


### PR DESCRIPTION
**What is this feature?**

When an issue created it will be automatically added to right project. [#oss-big-tent](https://github.com/orgs/grafana/projects/457)
