### PR TITLE
New Log Details: fix attribute extension links

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -742,4 +742,26 @@ describe('LogLineDetails', () => {
 
     expect(screen.getByText('Could not retrieve trace.')).toBeInTheDocument();
   });
+
+  test('shows attribute extension links when they are available', () => {
+    const usePluginLinksMock = jest.fn().mockReturnValue({
+      links: [
+        {
+          type: 'link',
+          title: 'Open service overview for label',
+          path: 'https://example.com',
+          category: 'label',
+          icon: 'compass',
+        },
+      ],
+    });
+    setPluginLinksHook(usePluginLinksMock);
+    jest.requireMock('@grafana/runtime').usePluginLinks = usePluginLinksMock;
+
+    setup(undefined, { labels: { label: 'value' } });
+
+    expect(screen.getByText('label')).toBeInTheDocument();
+    expect(screen.getByText('value')).toBeInTheDocument();
+    expect(screen.getByText('Open service overview for label')).toBeInTheDocument();
+  });
 });

--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -63,7 +63,7 @@ export const LogLineDetailsComponent = memo(
           .map((label) => ({
             key: label,
             value: log.labels[label],
-            link: extensionLinks?.[label],
+            links: extensionLinks?.[label],
           })),
       [extensionLinks, log.labels]
     );

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -339,8 +339,7 @@ export const LogLineDetailsField = ({
         }
         return (
           <div className={styles.row} key={`${link.title}-${i}`}>
-            {!disableActions && <div />}
-            <div className={disableActions ? undefined : styles.linkNoActions}>
+            <div className={disableActions ? undefined : styles.link}>
               <DataLinkButton
                 buttonProps={{
                   // Show tooltip message if max number of pinned lines has been reached
@@ -360,7 +359,6 @@ export const LogLineDetailsField = ({
       })}
       {showFieldsStats && fieldStats && (
         <div className={styles.row}>
-          <div />
           <div className={disableActions ? undefined : styles.statsColumn}>
             <LogLabelStats
               className={styles.stats}
@@ -400,8 +398,8 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
       },
     },
   }),
-  linkNoActions: css({
-    gridColumn: 'span 2',
+  link: css({
+    gridColumn: '2 / 4',
   }),
   stats: css({
     paddingRight: theme.spacing(1),
@@ -410,7 +408,7 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
     maxWidth: '50vh',
   }),
   statsColumn: css({
-    gridColumn: 'span 2',
+    gridColumn: '2 / 4',
   }),
   valueContainer: css({
     display: 'flex',

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -339,7 +339,8 @@ export const LogLineDetailsField = ({
         }
         return (
           <div className={styles.row} key={`${link.title}-${i}`}>
-            <div className={disableActions ? styles.linkNoActions : styles.link}>
+            {!disableActions && <div />}
+            <div className={disableActions ? undefined : styles.linkNoActions}>
               <DataLinkButton
                 buttonProps={{
                   // Show tooltip message if max number of pinned lines has been reached
@@ -398,9 +399,6 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
         visibility: 'visible',
       },
     },
-  }),
-  link: css({
-    gridColumn: 'span 3',
   }),
   linkNoActions: css({
     gridColumn: 'span 2',


### PR DESCRIPTION
Part of #99075

This PR fixes the integration of attribute extension links, caused by an attribute that was expected to be called "links" but was actually called "link".

### How to test

<img width="719" height="442" alt="Demo" src="https://github.com/user-attachments/assets/53e2fa2c-c6b9-4a4e-9dfd-adda8b8bece1" />

When [this hook](https://github.com/grafana/grafana/blob/4eeb6c3ed8649c05a27ad5634f6e65b02a0d6b90/public/app/features/logs/components/LogDetails.tsx#L72) returns a `LinkWithIcon` for a given label, when the label is shown, it should show a button with the corresponding link.