### PR TITLE
Data source: Modify docs to mention uids cannot be updated

### DIFF
--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -579,7 +579,7 @@ Content-Type: application/json
 {
   "datasource": {
     "id": 1,
-    "uid": "updated UID",
+    "uid": "uid",
     "orgId": 1,
     "name": "test_datasource",
     "type": "graphite",

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -482,6 +482,8 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 }
 ```
 
+Note that the UID cannot be modified.
+
 **Example Response**:
 
 ```http

--- a/docs/sources/developers/http_api/data_source.md
+++ b/docs/sources/developers/http_api/data_source.md
@@ -549,7 +549,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 
 {
   "id":1,
-  "uid": "updated UID",
+  "uid": "uid",
   "orgId":1,
   "name":"test_datasource",
   "type":"graphite",
@@ -567,6 +567,8 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
   "jsonData":null
 }
 ```
+
+Note that the UID cannot be modified.
 
 **Example Response**:
 


### PR DESCRIPTION
This PR updates the data source api documentation to state that we do not support modification of uids (changed here: https://github.com/grafana/grafana/pull/107486).


Side note: Please note that, going forward, modifications of any uid (not just data sources) will not be allowed. Instead, the resource should be deleted & re-created.