### PR TITLE
Alerting: Display Error Message in Alert History View

### DIFF
--- a/public/app/features/alerting/unified/components/rules/state-history/ErrorMessageRow.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/ErrorMessageRow.tsx
@@ -1,38 +1,36 @@
-import { css } from '@emotion/css';
-import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Text, useStyles2 } from '@grafana/ui';
+import { Box, Stack, Text } from '@grafana/ui';
 
 interface ErrorMessageRowProps {
   message: string;
 }
 
 export function ErrorMessageRow({ message }: ErrorMessageRowProps) {
-  const styles = useStyles2(getStyles);
-
   return (
-    <div className={styles.errorRow} data-testid="state-history-error">
-      <div className={styles.errorContainer}>
-        <Text variant="bodySmall" truncate element="p">
-          <strong>{t('alerting.state-history.error-message-prefix', 'Error message:')}</strong> {message}
-        </Text>
-      </div>
+    <div data-testid="state-history-error">
+      <Box
+        display="block"
+        backgroundColor="secondary"
+        borderStyle="solid"
+        borderColor="weak"
+        borderRadius="default"
+        paddingY={1}
+        paddingX={2}
+        marginTop={0.5}
+      >
+        <Stack direction="row" alignItems="center" gap={2} wrap={false}>
+          <Box shrink={0}>
+            <Text variant="bodySmall" weight="medium" element="span">
+              {t('alerting.state-history.error-message-prefix', 'Error message:')}
+            </Text>
+          </Box>
+          <Box grow={1} shrink={1} minWidth={0}>
+            <Text variant="bodySmall" truncate element="p">
+              {message}
+            </Text>
+          </Box>
+        </Stack>
+      </Box>
     </div>
   );
 }
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  errorRow: css({
-    color: theme.colors.text.secondary,
-    marginTop: theme.spacing(0.5),
-    display: 'block',
-  }),
-  errorContainer: css({
-    display: 'flex',
-    background: theme.colors.background.secondary,
-    border: `1px solid ${theme.colors.border.medium}`,
-    borderRadius: theme.shape.radius.default,
-    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
-    gap: theme.spacing(2),
-  }),
-});

--- a/public/app/features/alerting/unified/components/rules/state-history/ErrorMessageRow.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/ErrorMessageRow.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/css';
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Text, useStyles2 } from '@grafana/ui';
+
+interface ErrorMessageRowProps {
+  message: string;
+}
+
+export function ErrorMessageRow({ message }: ErrorMessageRowProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <div className={styles.errorRow} data-testid="state-history-error">
+      <div className={styles.errorContainer}>
+        <Text variant="bodySmall" truncate element="p">
+          <strong>{t('alerting.state-history.error-message-prefix', 'Error message:')}</strong> {message}
+        </Text>
+      </div>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  errorRow: css({
+    color: theme.colors.text.secondary,
+    marginTop: theme.spacing(0.5),
+    display: 'block',
+  }),
+  errorContainer: css({
+    display: 'flex',
+    background: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+    gap: theme.spacing(2),
+  }),
+});

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
@@ -37,7 +37,7 @@ describe('LogRecordViewerByTimestamp', () => {
     const records: LogRecord[] = [
       {
         timestamp: ts,
-        line: { current: 'Error (timeout)', previous: 'Pending', labels: { foo: 'bar' }, error: 'timeout' } as any,
+        line: { current: 'Error (timeout)', previous: 'Pending', labels: { foo: 'bar' }, error: 'timeout' },
       },
       { timestamp: ts, line: { current: 'Normal', previous: 'Alerting', labels: { foo: 'baz' } } },
       {
@@ -47,7 +47,7 @@ describe('LogRecordViewerByTimestamp', () => {
           previous: 'Pending',
           labels: { error: 'explicit message' },
           error: 'explicit message',
-        } as any,
+        },
       },
     ];
 

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import { byRole } from 'testing-library-selector';
 
 import { LogRecordViewerByTimestamp } from './LogRecordViewer';
@@ -30,5 +30,34 @@ describe('LogRecordViewerByTimestamp', () => {
 
     expect(entry2).toHaveTextContent('foo=bar');
     expect(entry2).toHaveTextContent('severity=warning');
+  });
+
+  it('renders error row only when current state is Error and shows message', () => {
+    const ts = 1681739700000;
+    const records: LogRecord[] = [
+      {
+        timestamp: ts,
+        line: { current: 'Error (timeout)', previous: 'Pending', labels: { foo: 'bar' }, error: 'timeout' } as any,
+      },
+      { timestamp: ts, line: { current: 'Normal', previous: 'Alerting', labels: { foo: 'baz' } } },
+      {
+        timestamp: ts,
+        line: {
+          current: 'Error',
+          previous: 'Pending',
+          labels: { error: 'explicit message' },
+          error: 'explicit message',
+        } as any,
+      },
+    ];
+
+    render(<LogRecordViewerByTimestamp records={records} commonLabels={[]} />);
+
+    const errorRows = screen.getAllByTestId('state-history-error');
+    expect(errorRows).toHaveLength(2);
+    expect(within(errorRows[0]).getByText(/Error message:/)).toBeInTheDocument();
+    expect(within(errorRows[0]).getByText(/timeout/)).toBeInTheDocument();
+    expect(within(errorRows[1]).getByText(/Error message:/)).toBeInTheDocument();
+    expect(within(errorRows[1]).getByText(/explicit message/)).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -11,8 +11,8 @@ import { GrafanaAlertState, mapStateWithReasonToBaseState } from 'app/types/unif
 import { Label } from '../../Label';
 import { AlertStateTag } from '../AlertStateTag';
 
-import { LogRecord, omitLabels } from './common';
 import { ErrorMessageRow } from './ErrorMessageRow';
+import { LogRecord, omitLabels } from './common';
 
 type LogRecordViewerProps = {
   records: LogRecord[];

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -6,12 +6,12 @@ import { Fragment, memo, useEffect } from 'react';
 import { GrafanaTheme2, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Box, Icon, Stack, TagList, Text, useStyles2 } from '@grafana/ui';
+import { GrafanaAlertState, mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 import { Label } from '../../Label';
 import { AlertStateTag } from '../AlertStateTag';
 
 import { LogRecord, omitLabels } from './common';
-import { GrafanaAlertState, mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 type LogRecordViewerProps = {
   records: LogRecord[];
@@ -93,25 +93,24 @@ export const LogRecordViewerByTimestamp = memo(
                         )}
                       </div>
                     </div>
-                    {mapStateWithReasonToBaseState(line.current) === GrafanaAlertState.Error &&
-                      (line as any)?.error && (
-                        <div className={styles.errorRow} data-testid="state-history-error">
-                          <Box
-                            display="flex"
-                            borderStyle="solid"
-                            borderColor="error"
-                            backgroundColor="error"
-                            paddingY={1}
-                            paddingX={2}
-                            borderRadius="default"
-                          >
-                            <Text variant="bodySmall">
-                              <strong>{t('alerting.state-history.error-message-prefix', 'Error message:')}</strong>{' '}
-                              {(line as any).error}
-                            </Text>
-                          </Box>
-                        </div>
-                      )}
+                    {mapStateWithReasonToBaseState(line.current) === GrafanaAlertState.Error && line.error && (
+                      <div className={styles.errorRow} data-testid="state-history-error">
+                        <Box
+                          display="flex"
+                          borderStyle="solid"
+                          borderColor="error"
+                          backgroundColor="error"
+                          paddingY={1}
+                          paddingX={2}
+                          borderRadius="default"
+                        >
+                          <Text variant="bodySmall">
+                            <strong>{t('alerting.state-history.error-message-prefix', 'Error message:')}</strong>{' '}
+                            {line.error}
+                          </Text>
+                        </Box>
+                      </div>
+                    )}
                   </Fragment>
                 );
               })}

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -5,7 +5,7 @@ import { Fragment, memo, useEffect, useRef, useState } from 'react';
 
 import { GrafanaTheme2, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Box, Icon, Stack, TagList, Text, useStyles2 } from '@grafana/ui';
+import { Icon, Stack, TagList, Text, useStyles2 } from '@grafana/ui';
 import { GrafanaAlertState, mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 import { Label } from '../../Label';
@@ -130,15 +130,7 @@ export const LogRecordViewerByTimestamp = memo(
                     </div>
                     {isErrorRow && (
                       <div className={styles.errorRow} data-testid="state-history-error">
-                        <Box
-                          display="flex"
-                          borderStyle="solid"
-                          borderColor="info"
-                          backgroundColor="info"
-                          paddingY={1}
-                          paddingX={2}
-                          borderRadius="default"
-                        >
+                        <div className={styles.errorContainer}>
                           <div
                             className={isExpanded ? styles.errorMessageExpanded : styles.errorMessageCollapsed}
                             ref={(el) => {
@@ -171,7 +163,7 @@ export const LogRecordViewerByTimestamp = memo(
                               </button>
                             </div>
                           )}
-                        </Box>
+                        </div>
                       </div>
                     )}
                   </Fragment>
@@ -270,6 +262,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     color: theme.colors.text.secondary,
     marginTop: theme.spacing(0.5),
     display: 'block',
+  }),
+  errorContainer: css({
+    display: 'flex',
+    background: theme.colors.background.secondary,
+    border: `1px solid ${theme.colors.border.medium}`,
+    borderRadius: theme.shape.radius.default,
+    padding: `${theme.spacing(1)} ${theme.spacing(2)}`,
+    gap: theme.spacing(2),
   }),
   errorMessageCollapsed: css({
     // default wrapping for single-line

--- a/public/app/features/alerting/unified/components/rules/state-history/common.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/common.ts
@@ -9,6 +9,7 @@ export interface Line {
   labels?: Record<string, string>;
   fingerprint?: string;
   ruleUID?: string;
+  error?: string;
 }
 
 export interface LogRecord {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12480,8 +12480,6 @@
     },
     "title": "Preferences"
   },
-  "show-less": "Show less",
-  "show-more": "Show more",
   "sign-up": {
     "back-button": "Back to login",
     "confirm-password-label": "Confirm password",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2781,6 +2781,7 @@
           "time": "Time"
         }
       },
+      "error-message-prefix": "Error message:",
       "filter-group": "Filter group",
       "filter-group-tooltip": "Filter each state history group either by exact match or a regular expression, for example:",
       "placeholder-search": "Search",
@@ -12479,6 +12480,8 @@
     },
     "title": "Preferences"
   },
+  "show-less": "Show less",
+  "show-more": "Show more",
   "sign-up": {
     "back-button": "Back to login",
     "confirm-password-label": "Confirm password",


### PR DESCRIPTION
This PR displays the Error Message in the Alert History view underneath the 'Error' state, see Slack thread: https://raintank-corp.slack.com/archives/C04LG9N6R4J/p1739785205421479 

<img width="1134" height="445" alt="image" src="https://github.com/user-attachments/assets/af4fba51-c421-4935-a77e-1e527f62b96e" />

![Kapture 2025-08-27 at 14 25 17](https://github.com/user-attachments/assets/62a0e5e4-0bc3-4db0-994c-d1bcf04c77d0)


**To reproduce:**
Add a new datasource with an invalid URL, create a new rule with this DS