### PR TITLE
Add permission role_id action index

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -214,4 +214,8 @@ func AddMigration(mg *migrator.Migrator) {
 	mg.AddMigration("add permission role_id action index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
 		Cols: []string{"role_id", "action"},
 	}))
+
+	mg.AddMigration("Remove permission role_id index", migrator.NewDropIndexMigration(permissionV1, &migrator.Index{
+		Cols: []string{"role_id"},
+	}))
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/migrations.go
@@ -210,4 +210,8 @@ func AddMigration(mg *migrator.Migrator) {
 		Type: migrator.UniqueIndex,
 		Cols: []string{"org_id", "user_id", "role_id"},
 	}))
+
+	mg.AddMigration("add permission role_id action index", migrator.NewAddIndexMigration(permissionV1, &migrator.Index{
+		Cols: []string{"role_id", "action"},
+	}))
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds a new index to the `permission` table, on columns `role_id` and `action`


**Why do we need this feature?**

While investigating performance issues with stacks running more than 400k permissions, we found that the query below was one of the bottlenecks:

```
SELECT `p` . `kind` , `p` . `attribute` , `p` . `identifier` , `p` . `scope` FROM `permission` AS `p` INNER JOIN ( SELECT `role_id` FROM `builtin_role` AS `br` WHERE ( `br` . `role` = ? AND ( `br` . `org_id` = ? OR `br` . `org_id` = ? ) ) UNION ALL SELECT `role_id` FROM `user_role` AS `ur` WHERE `ur` . `user_id` = ? AND ( `ur` . `org_id` = ? OR `ur` . `org_id` = ? ) ) AS `roles` 

ON `p` . `role_id` = `roles` . `role_id` WHERE `p` . ACTION = ? 
``` 

Executing `EXPLAIN ANALYZE` on the query above for one of the impacted stacks showed that performance could be improved by adding an index to the permissions table.

As there are fewer `role_id` entries than `action` entries,  we chose `role_id` to be the first field in the index.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/hosted-grafana/issues/6715

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
