### PR TITLE
Transformations: Organize by fields betterer fix

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -2941,9 +2941,6 @@ exports[`better eslint`] = {
     "public/app/features/transformers/editors/GroupToNestedTableTransformerEditor.tsx:5381": [
       [0, 0, 0, "Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.", "0"]
     ],
-    "public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx:5381": [
-      [0, 0, 0, "React Hook \\"useStyles2\\" is called conditionally. React Hooks must be called in the exact same order in every component render.", "0"]
-    ],
     "public/app/features/transformers/editors/ReduceTransformerEditor.tsx:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],

--- a/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/OrganizeFieldsTransformerEditor.tsx
@@ -243,6 +243,8 @@ const OrganizeFieldsTransformerEditor = ({ options, input, onChange }: OrganizeF
     [options, onChange, uiOrderByItems]
   );
 
+  const styles = useStyles2(getDraggableStyles);
+
   // Show warning that we only apply the first frame
   if (input.length > 1) {
     return (
@@ -254,8 +256,6 @@ const OrganizeFieldsTransformerEditor = ({ options, input, onChange }: OrganizeF
       </FieldValidationMessage>
     );
   }
-
-  const styles = useStyles2(getDraggableStyles);
 
   return (
     <>


### PR DESCRIPTION
Fixes betterer issue in `OrganizeFieldsTransformerEditor.tsx`. We were calling a hook after an if statement, which makes it a conditionally called hook. React is _not_ a fan of that. So just moved it ahead of the if statement. Nothing should be impacted.

Fixes #110049