### PR TITLE
Add index IDX_folder_org_id_parent_uid_uid

### DIFF
--- a/pkg/services/sqlstore/migrations/folder_mig.go
+++ b/pkg/services/sqlstore/migrations/folder_mig.go
@@ -87,9 +87,9 @@ func addFolderMigrations(mg *migrator.Migrator) {
 		Cols: []string{"org_id", "parent_uid", "title"},
 	}))
 
-	mg.AddMigration("Add index IDX_folder_org_id_parent_uid_uid", migrator.NewAddIndexMigration(folderv1(), &migrator.Index{
-		Name: "IDX_folder_org_id_parent_uid_uid",
-		Cols: []string{"org_id", "parent_uid", "uid"},
+	mg.AddMigration("Add index IDX_folder_org_id_parent_uid", migrator.NewAddIndexMigration(folderv1(), &migrator.Index{
+		Name: "IDX_folder_org_id_parent_uid",
+		Cols: []string{"org_id", "parent_uid"},
 	}))
 }
 

--- a/pkg/services/sqlstore/migrations/folder_mig.go
+++ b/pkg/services/sqlstore/migrations/folder_mig.go
@@ -86,6 +86,11 @@ func addFolderMigrations(mg *migrator.Migrator) {
 		Type: migrator.UniqueIndex,
 		Cols: []string{"org_id", "parent_uid", "title"},
 	}))
+
+	mg.AddMigration("Add index IDX_folder_org_id_parent_uid_uid", migrator.NewAddIndexMigration(folderv1(), &migrator.Index{
+		Name: "IDX_folder_org_id_parent_uid_uid",
+		Cols: []string{"org_id", "parent_uid", "uid"},
+	}))
 }
 
 func folderv1() migrator.Table {

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -37,6 +37,8 @@ type accessControlDashboardPermissionFilter struct {
 	// any recursive CTE queries (if supported)
 	recQueries                   []clause
 	recursiveQueriesAreSupported bool
+
+	dialect migrator.Dialect
 }
 
 type PermissionsFilter interface {
@@ -104,12 +106,12 @@ func NewAccessControlDashboardPermissionFilter(user identity.Requester, permissi
 		f = &accessControlDashboardPermissionFilterNoFolderSubquery{
 			accessControlDashboardPermissionFilter: accessControlDashboardPermissionFilter{
 				user: user, folderAction: folderAction, folderActionSets: folderActionSets, dashboardAction: dashboardAction, dashboardActionSets: dashboardActionSets,
-				features: features, recursiveQueriesAreSupported: recursiveQueriesAreSupported,
+				features: features, recursiveQueriesAreSupported: recursiveQueriesAreSupported, dialect: dialect,
 			},
 		}
 	} else {
 		f = &accessControlDashboardPermissionFilter{user: user, folderAction: folderAction, folderActionSets: folderActionSets, dashboardAction: dashboardAction, dashboardActionSets: dashboardActionSets,
-			features: features, recursiveQueriesAreSupported: recursiveQueriesAreSupported,
+			features: features, recursiveQueriesAreSupported: recursiveQueriesAreSupported, dialect: dialect,
 		}
 	}
 	f.buildClauses(dialect)
@@ -331,6 +333,11 @@ func (f *accessControlDashboardPermissionFilter) With() (string, []any) {
 }
 
 func (f *accessControlDashboardPermissionFilter) addRecQry(queryName string, whereUIDSelect string, whereParams []any, orgID int64) {
+	forceIndex := ""
+	if f.dialect.DriverName() == migrator.MySQL {
+		forceIndex = " FORCE INDEX (IDX_folder_org_id_parent_uid_uid) "
+	}
+
 	if f.recQueries == nil {
 		f.recQueries = make([]clause, 0, maximumRecursiveQueries)
 	}
@@ -341,8 +348,8 @@ func (f *accessControlDashboardPermissionFilter) addRecQry(queryName string, whe
 		// covered by UQE_folder_org_id_uid and UQE_folder_org_id_parent_uid_title
 		string: fmt.Sprintf(`%s AS (
 			SELECT uid, parent_uid, org_id FROM folder WHERE org_id = ? AND uid IN %s
-			UNION ALL SELECT f.uid, f.parent_uid, f.org_id FROM folder f INNER JOIN %s r ON f.parent_uid = r.uid and f.org_id = r.org_id
-		)`, queryName, whereUIDSelect, queryName),
+			UNION ALL SELECT f.uid, f.parent_uid, f.org_id FROM folder f %s INNER JOIN %s r ON f.parent_uid = r.uid and f.org_id = r.org_id
+		)`, queryName, whereUIDSelect, forceIndex, queryName),
 		params: c,
 	})
 }

--- a/pkg/services/sqlstore/permissions/dashboard.go
+++ b/pkg/services/sqlstore/permissions/dashboard.go
@@ -335,7 +335,7 @@ func (f *accessControlDashboardPermissionFilter) With() (string, []any) {
 func (f *accessControlDashboardPermissionFilter) addRecQry(queryName string, whereUIDSelect string, whereParams []any, orgID int64) {
 	forceIndex := ""
 	if f.dialect.DriverName() == migrator.MySQL {
-		forceIndex = " FORCE INDEX (IDX_folder_org_id_parent_uid_uid) "
+		forceIndex = " FORCE INDEX (IDX_folder_org_id_parent_uid) "
 	}
 
 	if f.recQueries == nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a new index to `folder` table on columns `org_id`, `parent_uid` and `uid`  

Also, it modifies the Legacy SQL Dashboard Permission Filter to explicitly use this index when running against a MySQL database.

**Why do we need this feature?**

While investigating performance issues with stacks running more than 400k permissions, we found that the recursive queries generated by [accessControlDashboardPermissionFilter.addRecQry](https://github.com/grafana/grafana/blob/649e9aa8ca9e8f7f16e9198b3858aaf12714a6a8/pkg/services/sqlstore/permissions/dashboard.go#L333) we the bottleneck.

Executing EXPLAIN ANALYZE on the query above for one of the impacted stacks showed that performance could be improved by adding an index to the permissions table.

However, the MySQL planner does not pick the new index when running queries, so we are adding also an explicit clause to nudge the planner to use the right index.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/hosted-grafana/issues/6715 also https://github.com/grafana/pir-actions/issues/282

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
