### PR TITLE
Unified Storage: Fix yield statement

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -711,7 +711,9 @@ func (b *backend) ListModifiedSince(ctx context.Context, key resource.Namespaced
 
 			if mr.Key.Name <= lastSeen {
 				// resource names should be sorted alphabetically. So if not, the query is not correct.
-				yield(nil, fmt.Errorf("listModifiedSince: resources are not sorted by name ASC, lastSeen: %q, current: %q", lastSeen, mr.Key.Name))
+				if !yield(nil, fmt.Errorf("listModifiedSince: resources are not sorted by name ASC, lastSeen: %q, current: %q", lastSeen, mr.Key.Name)) {
+					return
+				}
 			}
 
 			lastSeen = mr.Key.Name


### PR DESCRIPTION
Was causing a panic:

```
panic: runtime error: range function continued iteration after function for loop body returned false [recovered]
	panic: runtime error: range function continued iteration after function for loop body returned false

goroutine 15042 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
	go.opentelemetry.io/otel/sdk@v1.37.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc0026b43c0, {0x0, 0x0, 0xc0019b81e0?})
	go.opentelemetry.io/otel/sdk@v1.37.0/trace/span.go:506 +0xb6e
panic({0xe4fb40?, 0x160c27c0?})
	runtime/panic.go:792 +0x132
github.com/grafana/grafana/pkg/storage/unified/resource.(*searchSupport).build.func2-range1(0x0?, {0x0?, 0x0?})
	github.com/grafana/grafana/pkg/storage/unified/resource/search.go:838 +0xe67
github.com/grafana/grafana/pkg/storage/unified/sql.(*backend).ListModifiedSince.func4(0xc0019a8ea0)
	github.com/grafana/grafana/pkg/storage/unified/sql/backend.go:719 +0x4e5
github.com/grafana/grafana/pkg/storage/unified/resource.(*searchSupport).build.func2({0x3cd47e8, 0xc0026a5ec0}, {0x3cfb988, 0xc003c58c80}, 0x63ccabcec9f4f)
	github.com/grafana/grafana/pkg/storage/unified/resource/search.go:838 +0x5f5
github.com/grafana/grafana/pkg/storage/unified/search.(*bleveIndex).updateIndexWithLatestModifications(0xc003c58c80, {0x3cd4820?, 0xc004255450?}, 0x1, 0xc0026a5e90)
	github.com/grafana/grafana/pkg/storage/unified/search/bleve.go:1271 +0x25a
github.com/grafana/grafana/pkg/storage/unified/search.(*bleveIndex).runUpdater(0xc003c58c80, {0x3cd4820, 0xc004255450})
	github.com/grafana/grafana/pkg/storage/unified/search/bleve.go:1256 +0x230
github.com/grafana/grafana/pkg/storage/unified/search.(*bleveIndex).startUpdater.func1()
	github.com/grafana/grafana/pkg/storage/unified/search/bleve.go:1211 +0x54
created by github.com/grafana/grafana/pkg/storage/unified/search.(*bleveIndex).startUpdater in goroutine 14987
	github.com/grafana/grafana/pkg/storage/unified/search/bleve.go:1200 +0xe5
```