### PR TITLE
[InfluxDB] Detect product from URL

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/ConfigEditor.tsx
@@ -62,7 +62,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       },
     }),
     alertHeight: css({
-      width: '100px',
+      height: '100px',
     }),
   };
 };

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -252,7 +252,7 @@ describe('UrlAndAuthenticationSection', () => {
         expect.objectContaining({
           jsonData: expect.objectContaining({
             product: 'InfluxDB OSS 1.x',
-            version: undefined, 
+            version: undefined,
           }),
         })
       );
@@ -281,7 +281,7 @@ describe('UrlAndAuthenticationSection', () => {
         expect.objectContaining({
           jsonData: expect.objectContaining({
             product: 'InfluxDB OSS 2.x',
-            version: undefined, 
+            version: undefined,
           }),
         })
       );
@@ -377,6 +377,4 @@ export function mockFetchPing(resp: { ok?: boolean; build?: string; version?: st
       },
     },
   });
-};
-
-
+}

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/UrlAndAuthenticationSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 import { InfluxVersion } from '../../../types';
 
@@ -87,4 +87,181 @@ describe('UrlAndAuthenticationSection', () => {
     render(<UrlAndAuthenticationSection {...props} />);
     expect(screen.queryByText(/requires DBRP mapping/i)).not.toBeInTheDocument();
   });
+
+  it('leaves product and version undefined when URL does not match any product', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: undefined },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://some-random-host.example.com' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: undefined,
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
+  it('auto-detects InfluxDB Cloud Dedicated from url', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: '' },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'influxdb.io' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: 'InfluxDB Cloud Dedicated',
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
+  it('auto-detects InfluxDB Cloud Serverless from url', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: '' },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://us-east-1-1.aws.cloud2.influxdata.com' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: 'InfluxDB Cloud Serverless',
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
+  it('auto-detects InfluxDB Cloud (TSM) from url', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: '' },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://us-west-2-1.aws.cloud2.influxdata.com' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: 'InfluxDB Cloud (TSM)',
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
+  it('auto-detects InfluxDB Cloud 1 from url', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: '' },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://influxcloud.net' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: 'InfluxDB Cloud 1',
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
+  it('clears product and version when URL changes to one without a match', async () => {
+    const props = {
+      ...defaultProps,
+      options: {
+        ...defaultProps.options,
+        jsonData: { ...defaultProps.options.jsonData, url: '' },
+      },
+    };
+
+    render(<UrlAndAuthenticationSection {...props} />);
+    const input = screen.getByTestId('influxdb-v2-config-url-input');
+
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://us-east-1-1.aws.cloud2.influxdata.com' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: 'InfluxDB Cloud Serverless',
+            version: undefined,
+          }),
+        })
+      );
+    });
+
+    onOptionsChangeMock.mockClear();
+    fireEvent.blur(input, { target: { value: 'https://influxdb.example.com' } });
+
+    await waitFor(() => {
+      expect(onOptionsChangeMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonData: expect.objectContaining({
+            product: undefined,
+            version: undefined,
+          }),
+        })
+      );
+    });
+  });
+
 });

--- a/public/app/plugins/datasource/influxdb/components/editor/config-v2/versions.ts
+++ b/public/app/plugins/datasource/influxdb/components/editor/config-v2/versions.ts
@@ -14,7 +14,7 @@ interface DetectionMethod {
   urlContains?: string[];
   pingHeaderResponse?: Record<string, string>;
 }
-interface InfluxDBProduct {
+export interface InfluxDBProduct {
   name: string;
   queryLanguages?: QueryLanguageConfig[];
   detectionMethod?: DetectionMethod;


### PR DESCRIPTION
An addition to the InfluxDB configuration page introduced a dropdown for selecting the product. To streamline this step, this PR adds auto-detection when the user enters a URL. Detection is attempted first via known URL patterns, and if no match is found, by pinging the /ping endpoint. This improves usability by pre-selecting the likely product and reducing manual configuration.

At this stage, detection is supported for all InfluxDB products **except** InfluxDB Enterprise.

This PR also fixes a bug where the property `width` was declared instead of `height` for the Alert indicating users are viewing a new version of the configuration page.