### PR TITLE
Fix name of the summary, remove _total suffix

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -74,7 +74,7 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
 		UpdatedDocuments: promauto.With(reg).NewSummary(prometheus.SummaryOpts{
-			Name: "index_server_update_documents_total",
+			Name: "index_server_update_documents",
 			Help: "Number of documents indexed during index update",
 		}),
 		SearchUpdateWaitTime: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{


### PR DESCRIPTION
Changes name of `grafana_index_server_update_documents_total` Summary metric to `grafana_index_server_update_documents`, since summaries automatically get `_count` and `_sum` suffixes already.