### PR TITLE
[release-12.1.2] Chore: Don't show a "Not found" for public-dashboard fetches if the service is disabled via config

### DIFF
--- a/public/app/features/dashboard/api/publicDashboardApi.ts
+++ b/public/app/features/dashboard/api/publicDashboardApi.ts
@@ -43,7 +43,7 @@ export const publicDashboardApi = createApi({
         try {
           await queryFulfilled;
         } catch (e) {
-          if (isFetchBaseQueryError(e) && isFetchError(e.error)) {
+          if (isFetchBaseQueryError(e) && isFetchError(e.error) && config.publicDashboardsEnabled) {
             dispatch(notifyApp(createErrorNotification(e.error.data.message)));
           }
         }


### PR DESCRIPTION
This backports #108650 to Grafana 12.1.3. (Yes, the title disagrees; our branch naming is weird.)

Fixes: https://github.com/grafana/grafana/issues/108732
Fixes: https://github.com/grafana/support-escalations/issues/18035