### PR TITLE
DashboardMigration: V16 was removing panels when repeatInteration is null

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v16.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16.go
@@ -66,7 +66,7 @@ func upgradeToGridLayout(dashboard map[string]interface{}) {
 		}
 
 		// Skip repeated rows (line 1031-1033 in TS)
-		if _, hasRepeatIteration := row["repeatIteration"]; hasRepeatIteration {
+		if repeatIteration, hasRepeatIteration := row["repeatIteration"]; hasRepeatIteration && repeatIteration != nil {
 			continue
 		}
 
@@ -283,7 +283,11 @@ func getMaxPanelID(rows []interface{}) int {
 func shouldShowRows(rows []interface{}) bool {
 	for _, rowInterface := range rows {
 		if row, ok := rowInterface.(map[string]interface{}); ok {
-			if GetBoolValue(row, "collapse") || GetBoolValue(row, "showTitle") || GetStringValue(row, "repeat") != "" {
+			collapse := GetBoolValue(row, "collapse")
+			showTitle := GetBoolValue(row, "showTitle")
+			repeat := GetStringValue(row, "repeat")
+
+			if collapse || showTitle || repeat != "" {
 				return true
 			}
 		}

--- a/apps/dashboard/pkg/migration/schemaversion/v16_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16_test.go
@@ -9,6 +9,63 @@ import (
 func TestV16(t *testing.T) {
 	tests := []migrationTestCase{
 		{
+			name: "should handle repeatIteration null",
+			input: map[string]interface{}{
+				"schemaVersion": 15,
+				"rows": []interface{}{
+					map[string]interface{}{
+						"collapse":        false,
+						"showTitle":       true,
+						"title":           "Overview",
+						"type":            "row",
+						"repeat":          nil,
+						"repeatIteration": nil,
+						"repeatRowId":     nil,
+						"panels": []interface{}{
+							map[string]interface{}{
+								"id":    2,
+								"type":  "stat",
+								"span":  12,
+								"title": "Customer Stats",
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": 16,
+				"panels": []interface{}{
+					// The stat panel should be processed and added
+					map[string]interface{}{
+						"id":    2,
+						"type":  "stat",
+						"title": "Customer Stats",
+						"gridPos": map[string]interface{}{
+							"x": 0,
+							"y": 1,
+							"w": 24,
+							"h": 7, // default height
+						},
+					},
+					// The row panel should be created because showTitle is true
+					map[string]interface{}{
+						"id":        3, // Next ID after max panel ID (2)
+						"type":      "row",
+						"title":     "Overview",
+						"collapsed": false,
+						"repeat":    "",
+						"panels":    []interface{}{},
+						"gridPos": map[string]interface{}{
+							"x": 0,
+							"y": 0,
+							"w": 24,
+							"h": 7, // default height
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "should create proper grid",
 			input: map[string]interface{}{
 				"schemaVersion": 15,

--- a/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash-min.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash-min.json
@@ -1,0 +1,118 @@
+{
+    "annotations": {
+      "list": [
+       
+      ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": false,
+    "id": 22815,
+    "links": [
+      
+    ],
+    "refresh": "1m",
+    "rows": [
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": 0 }]
+                },
+                "unit": "none"
+              }
+            },
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+            "id": 2,
+            "links": [],
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": ["mean"],
+                "fields": "",
+                "values": false
+              },
+              "textMode": "auto"
+            },
+            "pluginVersion": "7",
+            "targets": [
+              {
+                "expr": "sum(rate(http_requests_total{environment=\"$env\", region=\"$region\", service=\"webapp\"}[5m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Requests/sec",
+                "refId": "A"
+              },
+              {
+                "expr": "avg(memory_usage_bytes{environment=\"$env\", region=\"$region\", service=\"webapp\"}) / 1024 / 1024",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Memory (MB)",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.95, rate(response_time_bucket{environment=\"$env\", region=\"$region\", service=\"webapp\"}[5m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "95th percentile latency",
+                "refId": "C"
+              }
+            ],
+            "title": "Service Stats",
+            "transparent": false,
+            "type": "stat"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Overview",
+        "titleSize": "h6",
+        "type": "row"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": ["example-service", "as-code"],
+    "templating": {
+      "list": [
+   
+      ]
+    },
+    "time": { "from": "now-2h", "to": "now" },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    },
+    "timezone": "browser",
+    "title": "Service Overview Dashboard",
+    "uid": "ba9b93e998e09d254266b11192894a8d",
+    "version": 1
+  }

--- a/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash.json
@@ -1,0 +1,3369 @@
+{
+    "annotations": {
+      "list": [
+        {
+          "datasource": "$datasourcelogs",
+          "enable": true,
+          "expr": "{cluster=\"$cluster\", component=\"logger\"} | json | namespace_extracted=~\"example-service.*\" | name_extracted=\"example-api\"",
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "instant": false,
+          "name": "Deployments",
+          "titleFormat": "{{cluster}}/{{namespace}}"
+        }
+      ]
+    },
+    "editable": false,
+    "gnetId": null,
+    "graphTooltip": 1,
+    "hideControls": false,
+    "id": 22815,
+    "links": [
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": ["cache-overview"],
+        "targetBlank": false,
+        "title": "Cache Dashboard",
+        "type": "dashboards",
+        "url": ""
+      },
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": ["database-monitoring"],
+        "targetBlank": false,
+        "title": "Database Dashboard",
+        "type": "dashboards",
+        "url": ""
+      },
+      {
+        "asDropdown": true,
+        "icon": "external link",
+        "includeVars": true,
+        "keepTime": true,
+        "tags": ["Database", "monitoring"],
+        "targetBlank": false,
+        "title": "Database Metrics Dashboard",
+        "type": "dashboards",
+        "url": ""
+      }
+    ],
+    "refresh": "1m",
+    "rows": [
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": 0 }]
+                },
+                "unit": "none"
+              }
+            },
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+            "id": 2,
+            "links": [],
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": ["mean"],
+                "fields": "",
+                "values": false
+              },
+              "textMode": "auto"
+            },
+            "pluginVersion": "7",
+            "targets": [
+              {
+                "expr": "sum(app_metric_counter_a{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Tenants",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(app_metric_counter_b{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Collectors",
+                "refId": "B"
+              },
+              {
+                "expr": "sum(app_metric_counter_c{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Pipelines",
+                "refId": "C"
+              }
+            ],
+            "title": "Customer Stats",
+            "transparent": false,
+            "type": "stat"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "blue", "value": 0 },
+                    { "color": "green", "value": 40 },
+                    { "color": "yellow", "value": 60 },
+                    { "color": "orange", "value": 80 },
+                    { "color": "red", "value": 100 }
+                  ]
+                },
+                "unit": "percent"
+              }
+            },
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+            "id": 3,
+            "links": [],
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": ["mean"],
+                "fields": "",
+                "values": false
+              },
+              "textMode": "auto"
+            },
+            "pluginVersion": "7",
+            "targets": [
+              {
+                "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "API Mem",
+                "refId": "A"
+              },
+              {
+                "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=\"cache-server\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Cache Server Mem",
+                "refId": "B"
+              },
+              {
+                "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Gateway Mem ",
+                "refId": "C"
+              },
+              {
+                "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "API CPU",
+                "refId": "D"
+              },
+              {
+                "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=\"cache-server\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Cache Server CPU",
+                "refId": "E"
+              },
+              {
+                "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\"})",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Gateway CPU",
+                "refId": "F"
+              }
+            ],
+            "title": "Requested Resource Usage",
+            "transparent": false,
+            "type": "stat"
+          },
+          {
+            "datasource": "$datasource",
+            "fieldConfig": {
+              "defaults": {
+                "links": [],
+                "mappings": [],
+                "thresholds": {
+                  "mode": "absolute",
+                  "steps": [{ "color": "green", "value": 0 }]
+                },
+                "unit": "reqps"
+              }
+            },
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+            "id": 4,
+            "links": [],
+            "options": {
+              "colorMode": "value",
+              "graphMode": "none",
+              "justifyMode": "auto",
+              "orientation": "auto",
+              "reduceOptions": {
+                "calcs": ["mean"],
+                "fields": "",
+                "values": false
+              },
+              "textMode": "auto"
+            },
+            "pluginVersion": "7",
+            "targets": [
+              {
+                "expr": "sum by () (\n  label_replace(\n    rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"\",\n    \"([0-9])..\")\n  )\n",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{}}",
+                "refId": "A"
+              }
+            ],
+            "title": "Api Requests",
+            "transparent": false,
+            "type": "stat"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Overview",
+        "titleSize": "h6",
+        "type": "row"
+      },
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 0 },
+            "id": 5,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 0 },
+            "id": 6,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"}[1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "1xx": "#EAB839",
+              "2xx": "#7EB26D",
+              "3xx": "#6ED0E0",
+              "4xx": "#EF843C",
+              "5xx": "#E24D42"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "decimals": 2,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 0 },
+            "id": 7,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (status_code) (\n  label_replace(\n    rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{status_code}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 9 },
+            "id": 8,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 9 },
+            "id": 9,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\", status_code=~\"5..\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) OR on() vector(0)",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Error rate",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Error rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "datasource": "$datasourcelogs",
+            "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+            "id": 10,
+            "options": {
+              "showLabels": false,
+              "showTime": true,
+              "sortOrder": "Descending",
+              "wrapLogMessage": true
+            },
+            "span": 12,
+            "targets": [
+              {
+                "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"}",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Logs",
+            "type": "logs"
+          },
+          {
+            "datasource": "$datasourcelogs",
+            "gridPos": { "h": 9, "w": 24, "x": 0, "y": 9 },
+            "id": 11,
+            "options": {
+              "showLabels": false,
+              "showTime": true,
+              "sortOrder": "Descending",
+              "wrapLogMessage": true
+            },
+            "span": 12,
+            "targets": [
+              {
+                "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"} | logfmt | level=\"error\"",
+                "legendFormat": "",
+                "refId": "A"
+              }
+            ],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Errors",
+            "type": "logs"
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "API",
+        "titleSize": "h6",
+        "type": "row"
+      },
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 0 },
+            "id": 12,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p99",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 0 },
+            "id": 13,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p90",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 0 },
+            "id": 14,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p50",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 9 },
+            "id": 15,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Total",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\"GetConfig.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "GetConfig",
+                "refId": "B"
+              },
+              {
+                "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\"GetConfig.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Other",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 9 },
+            "id": 16,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (db_pool_in_use_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}/Active",
+                "refId": "A"
+              },
+              {
+                "expr": "sum by (pod) (db_pool_idle_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}/Idle",
+                "refId": "B"
+              },
+              {
+                "expr": "sum by (pod) (db_pool_max_open_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}/Max",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Connections",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+            "id": 17,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(db_pool_wait_duration_seconds_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Connection Wait Duration",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "short",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Database",
+        "titleSize": "h6",
+        "type": "row"
+      },
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+            "id": 18,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+            "id": 19,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"}[1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+            "id": 20,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(cache_set_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Sets",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+            "id": 21,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Requests",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 18 },
+            "id": 22,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(cache_request_hit_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]) / rate(cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Cache Request Hit Rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 18 },
+            "id": 23,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/request",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/set",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p99",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 27 },
+            "id": 24,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/request",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/set",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p90",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 27 },
+            "id": 25,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/request",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{method}}/set",
+                "refId": "B"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Client Latency p50",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 0, "y": 36 },
+            "id": 26,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Total",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Config",
+                "refId": "B"
+              },
+              {
+                "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Other",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Request Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 12, "x": 12, "y": 36 },
+            "id": 27,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Total",
+                "refId": "A"
+              },
+              {
+                "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Config",
+                "refId": "B"
+              },
+              {
+                "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Other",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Set Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Cache",
+        "titleSize": "h6",
+        "type": "row"
+      },
+      {
+        "collapse": false,
+        "collapsed": false,
+        "panels": [
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 0 },
+            "id": 28,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Memory Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "bytes",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": { "Limit": "#E24D42", "Requested": "#Ffa500" },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 0,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 0 },
+            "id": 29,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 6,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"}[1m]))",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "{{pod}}",
+                "refId": "A"
+              },
+              {
+                "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Requested",
+                "refId": "B"
+              },
+              {
+                "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+                "format": "time_series",
+                "intervalFactor": 2,
+                "legendFormat": "Limit",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "CPU Usage",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              },
+              {
+                "format": "none",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": null,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 0 },
+            "id": 30,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Authenticator latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 9 },
+            "id": 31,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.95, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p95",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.9, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "C"
+              },
+              {
+                "expr": "histogram_quantile(0.5, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "D"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "GCOM cached client latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 9 },
+            "id": 32,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Handler latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "1xx": "#EAB839",
+              "2xx": "#7EB26D",
+              "3xx": "#6ED0E0",
+              "4xx": "#EF843C",
+              "5xx": "#E24D42"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "decimals": 2,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 9 },
+            "id": 33,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (code) (\n  label_replace(\n    rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"code\",\n    \"([0-9])..\")\n  )\n",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{code}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Grafana.com HTTP Client - Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 18 },
+            "id": 34,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Grafana.com HTTP Client - Latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 18 },
+            "id": 35,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", code=~\"5..|error\"}[$__rate_interval]) / rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Error rate",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Grafana.com HTTP Client - Error rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {
+              "1xx": "#EAB839",
+              "2xx": "#7EB26D",
+              "3xx": "#6ED0E0",
+              "4xx": "#EF843C",
+              "5xx": "#E24D42"
+            },
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "decimals": 2,
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 16, "y": 18 },
+            "id": 36,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "sum by (status_code) (\n  label_replace(\n    rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "{{status_code}}",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Auth API HTTP Client - Throughput (requests/sec)",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "decimals": 2,
+                "format": "reqps",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 0, "y": 27 },
+            "id": 37,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "histogram_quantile(0.99, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p99",
+                "refId": "A"
+              },
+              {
+                "expr": "histogram_quantile(0.90, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p90",
+                "refId": "B"
+              },
+              {
+                "expr": "histogram_quantile(0.50, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                "format": "time_series",
+                "interval": "5m",
+                "intervalFactor": 2,
+                "legendFormat": "p50",
+                "refId": "C"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Auth API HTTP Client - Latency",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "ms",
+                "label": null,
+                "logBase": 1,
+                "max": null,
+                "min": 0,
+                "show": true
+              }
+            ]
+          },
+          {
+            "aliasColors": {},
+            "bars": false,
+            "dashLength": 10,
+            "dashes": false,
+            "datasource": "$datasource",
+            "fill": 1,
+            "fillGradient": 0,
+            "gridPos": { "h": 9, "w": 8, "x": 8, "y": 27 },
+            "id": 38,
+            "legend": {
+              "alignAsTable": false,
+              "avg": false,
+              "current": false,
+              "max": false,
+              "min": false,
+              "rightSide": false,
+              "show": true,
+              "sideWidth": null,
+              "total": false,
+              "values": false
+            },
+            "lines": true,
+            "linewidth": 1,
+            "links": [],
+            "nullPointMode": "null as zero",
+            "percentage": false,
+            "pointradius": 5,
+            "points": false,
+            "renderer": "flot",
+            "repeat": null,
+            "seriesOverrides": [],
+            "spaceLength": 10,
+            "span": 4,
+            "stack": false,
+            "steppedLine": false,
+            "targets": [
+              {
+                "expr": "(rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", status_code=~\"5..|error\"}[$__rate_interval]) / rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+                "format": "time_series",
+                "interval": "1m",
+                "intervalFactor": 2,
+                "legendFormat": "Error rate",
+                "refId": "A"
+              }
+            ],
+            "thresholds": [],
+            "timeFrom": null,
+            "timeShift": null,
+            "title": "Auth API HTTP Client - Error rate",
+            "tooltip": {
+              "shared": true,
+              "sort": 0,
+              "value_type": "individual"
+            },
+            "type": "graph",
+            "xaxis": {
+              "buckets": null,
+              "mode": "time",
+              "name": null,
+              "show": true,
+              "values": []
+            },
+            "yaxes": [
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              },
+              {
+                "format": "percentunit",
+                "label": null,
+                "logBase": 1,
+                "max": 1,
+                "min": 0,
+                "show": true
+              }
+            ]
+          }
+        ],
+        "repeat": null,
+        "repeatIteration": null,
+        "repeatRowId": null,
+        "showTitle": true,
+        "title": "Gateway",
+        "titleSize": "h6",
+        "type": "row"
+      }
+    ],
+    "schemaVersion": 14,
+    "style": "dark",
+    "tags": ["example-service", "as-code"],
+    "templating": {
+      "list": [
+        {
+          "current": { "value": "prometheus-datasource" },
+          "hide": 0,
+          "label": null,
+          "name": "datasource",
+          "options": [],
+          "query": "prometheus",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        },
+        {
+          "current": { "value": "logs-datasource" },
+          "hide": 0,
+          "label": null,
+          "name": "datasourcelogs",
+          "options": [],
+          "query": "loki",
+          "refresh": 1,
+          "regex": "",
+          "type": "datasource"
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "cluster-1",
+            "value": "cluster-1"
+          },
+          "datasource": "$datasource",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "cluster",
+          "options": [],
+          "query": "label_values(example_service_inflight_requests{}, cluster)",
+          "refresh": 2,
+          "regex": "",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": null,
+          "current": {
+            "text": "cluster-1",
+            "value": "cluster-1"
+          },
+          "datasource": "$datasource",
+          "hide": 0,
+          "includeAll": false,
+          "label": null,
+          "multi": false,
+          "name": "namespace",
+          "options": [],
+          "query": "label_values(example_service_inflight_requests{cluster=\"$cluster\"}, namespace)",
+          "refresh": 2,
+          "regex": "example-service.*",
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        }
+      ]
+    },
+    "time": { "from": "now-2h", "to": "now" },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+    },
+    "timezone": "browser",
+    "title": "Service Overview Dashboard",
+    "uid": "ba9b93e998e09d254266b11192894a8d",
+    "version": 1
+  }

--- a/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash1.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash1.json
@@ -1,0 +1,3968 @@
+ {
+            "__inputs": [
+
+            ],
+            "__requires": [
+
+            ],
+            "annotations": {
+                "list": [
+                    {
+                        "datasource": "$datasourcelogs",
+                        "enable": true,
+                        "expr": "{cluster=\"$cluster\", component=\"kube-diff-logger\"} | json | namespace_extracted=~\"example-service.*\" | name_extracted=\"example-api\"",
+                        "iconColor": "rgba(0, 211, 255, 1)",
+                        "instant": false,
+                        "name": "Deployments",
+                        "titleFormat": "{{cluster}}/{{namespace}}"
+                    }
+                ]
+            },
+            "editable": false,
+            "gnetId": null,
+            "graphTooltip": 1,
+            "hideControls": false,
+            "id": null,
+            "links": [
+                {
+                    "asDropdown": true,
+                    "icon": "external link",
+                    "includeVars": true,
+                    "keepTime": true,
+                    "tags": [
+                        "cache-overview"
+                    ],
+                    "targetBlank": false,
+                    "title": "Cache Dashboard",
+                    "type": "dashboards",
+                    "url": ""
+                },
+                {
+                    "asDropdown": true,
+                    "icon": "external link",
+                    "includeVars": true,
+                    "keepTime": true,
+                    "tags": [
+                        "cloudsql-stackdriver"
+                    ],
+                    "targetBlank": false,
+                    "title": "CloudSQL Dashboard",
+                    "type": "dashboards",
+                    "url": ""
+                },
+                {
+                    "asDropdown": true,
+                    "icon": "external link",
+                    "includeVars": true,
+                    "keepTime": true,
+                    "tags": [
+                        "Database",
+                        "percona"
+                    ],
+                    "targetBlank": false,
+                    "title": "Database Dashboard",
+                    "type": "dashboards",
+                    "url": ""
+                }
+            ],
+            "refresh": "1m",
+            "rows": [
+                {
+                    "collapse": false,
+                    "collapsed": false,
+                    "panels": [
+                        {
+                            "datasource": "$datasource",
+                            "fieldConfig": {
+                                "defaults": {
+                                    "links": [
+
+                                    ],
+                                    "mappings": [
+
+                                    ],
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "color": "green",
+                                                "value": 0
+                                            }
+                                        ]
+                                    },
+                                    "unit": "none"
+                                }
+                            },
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 2,
+                            "links": [
+
+                            ],
+                            "options": {
+                                "colorMode": "value",
+                                "graphMode": "none",
+                                "justifyMode": "auto",
+                                "orientation": "auto",
+                                "reduceOptions": {
+                                    "calcs": [
+                                        "mean"
+                                    ],
+                                    "fields": "",
+                                    "values": false
+                                },
+                                "textMode": "auto"
+                            },
+                            "pluginVersion": "7",
+                            "targets": [
+                                {
+                                    "expr": "sum(app_metric_counter_a{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Tenants",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "sum(app_metric_counter_b{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Collectors",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "sum(app_metric_counter_c{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Pipelines",
+                                    "refId": "C"
+                                }
+                            ],
+                            "title": "Customer Stats",
+                            "transparent": false,
+                            "type": "stat"
+                        },
+                        {
+                            "datasource": "$datasource",
+                            "fieldConfig": {
+                                "defaults": {
+                                    "links": [
+
+                                    ],
+                                    "mappings": [
+
+                                    ],
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "color": "blue",
+                                                "value": 0
+                                            },
+                                            {
+                                                "color": "green",
+                                                "value": 40
+                                            },
+                                            {
+                                                "color": "yellow",
+                                                "value": 60
+                                            },
+                                            {
+                                                "color": "orange",
+                                                "value": 80
+                                            },
+                                            {
+                                                "color": "red",
+                                                "value": 100
+                                            }
+                                        ]
+                                    },
+                                    "unit": "percent"
+                                }
+                            },
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 0
+                            },
+                            "id": 3,
+                            "links": [
+
+                            ],
+                            "options": {
+                                "colorMode": "value",
+                                "graphMode": "none",
+                                "justifyMode": "auto",
+                                "orientation": "auto",
+                                "reduceOptions": {
+                                    "calcs": [
+                                        "mean"
+                                    ],
+                                    "fields": "",
+                                    "values": false
+                                },
+                                "textMode": "auto"
+                            },
+                            "pluginVersion": "7",
+                            "targets": [
+                                {
+                                    "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "API Mem",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=\"cache-server\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Cache Server Mem",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Gateway Mem ",
+                                    "refId": "C"
+                                },
+                                {
+                                    "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "API CPU",
+                                    "refId": "D"
+                                },
+                                {
+                                    "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=\"cache-server\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Cache Server CPU",
+                                    "refId": "E"
+                                },
+                                {
+                                    "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\"})",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Gateway CPU",
+                                    "refId": "F"
+                                }
+                            ],
+                            "title": "Requested Resource Usage",
+                            "transparent": false,
+                            "type": "stat"
+                        },
+                        {
+                            "datasource": "$datasource",
+                            "fieldConfig": {
+                                "defaults": {
+                                    "links": [
+
+                                    ],
+                                    "mappings": [
+
+                                    ],
+                                    "thresholds": {
+                                        "mode": "absolute",
+                                        "steps": [
+                                            {
+                                                "color": "green",
+                                                "value": 0
+                                            }
+                                        ]
+                                    },
+                                    "unit": "reqps"
+                                }
+                            },
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 4,
+                            "links": [
+
+                            ],
+                            "options": {
+                                "colorMode": "value",
+                                "graphMode": "none",
+                                "justifyMode": "auto",
+                                "orientation": "auto",
+                                "reduceOptions": {
+                                    "calcs": [
+                                        "mean"
+                                    ],
+                                    "fields": "",
+                                    "values": false
+                                },
+                                "textMode": "auto"
+                            },
+                            "pluginVersion": "7",
+                            "targets": [
+                                {
+                                    "expr": "sum by () (\n  label_replace(\n    rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"\",\n    \"([0-9])..\")\n  )\n",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "title": "Api Requests",
+                            "transparent": false,
+                            "type": "stat"
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Overview",
+                    "titleSize": "h6",
+                    "type": "row"
+                },
+                {
+                    "collapse": false,
+                    "collapsed": false,
+                    "panels": [
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 5,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Memory Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 0
+                            },
+                            "id": 6,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"}[1m]))",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "CPU Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "1xx": "#EAB839",
+                                "2xx": "#7EB26D",
+                                "3xx": "#6ED0E0",
+                                "4xx": "#EF843C",
+                                "5xx": "#E24D42"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "decimals": 2,
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 0
+                            },
+                            "id": 7,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (status_code) (\n  label_replace(\n    rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{status_code}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 8,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 9
+                            },
+                            "id": 9,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "(rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\", status_code=~\"5..\"}[$__rate_interval]) / rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) OR on() vector(0)",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Error rate",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Error rate",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "datasource": "$datasourcelogs",
+                            "gridPos": {
+                                "h": 9,
+                                "w": 24,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 10,
+                            "options": {
+                                "showLabels": false,
+                                "showTime": true,
+                                "sortOrder": "Descending",
+                                "wrapLogMessage": true
+                            },
+                            "span": 12,
+                            "targets": [
+                                {
+                                    "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"}",
+                                    "legendFormat": "",
+                                    "refId": "A"
+                                }
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Logs",
+                            "type": "logs"
+                        },
+                        {
+                            "datasource": "$datasourcelogs",
+                            "gridPos": {
+                                "h": 9,
+                                "w": 24,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 11,
+                            "options": {
+                                "showLabels": false,
+                                "showTime": true,
+                                "sortOrder": "Descending",
+                                "wrapLogMessage": true
+                            },
+                            "span": 12,
+                            "targets": [
+                                {
+                                    "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"} | logfmt | level=\"error\"",
+                                    "legendFormat": "",
+                                    "refId": "A"
+                                }
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Errors",
+                            "type": "logs"
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "API",
+                    "titleSize": "h6",
+                    "type": "row"
+                },
+                {
+                    "collapse": false,
+                    "collapsed": false,
+                    "panels": [
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 12,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p99",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 0
+                            },
+                            "id": 13,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p90",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 0
+                            },
+                            "id": 14,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p50",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 15,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Total",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\"GetConfig.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "GetConfig",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\"GetConfig.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Other",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 9
+                            },
+                            "id": 16,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (go_sql_in_use_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}/Active",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "sum by (pod) (go_sql_idle_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}/Idle",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "sum by (pod) (go_sql_max_open_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}/Max",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Connections",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 9
+                            },
+                            "id": 17,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(go_sql_wait_duration_seconds_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Connection Wait Duration",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Database",
+                    "titleSize": "h6",
+                    "type": "row"
+                },
+                {
+                    "collapse": false,
+                    "collapsed": false,
+                    "panels": [
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 18,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Memory Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 0
+                            },
+                            "id": 19,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"}[1m]))",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "CPU Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 20,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(example_service_cache_set_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Sets",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 9
+                            },
+                            "id": 21,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(example_service_cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Requests",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 18
+                            },
+                            "id": 22,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(example_service_cache_request_hit_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]) / rate(example_service_cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Cache Request Hit Rate",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 18
+                            },
+                            "id": 23,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/request",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/set",
+                                    "refId": "B"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p99",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 27
+                            },
+                            "id": 24,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/request",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/set",
+                                    "refId": "B"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p90",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 27
+                            },
+                            "id": 25,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/request",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{method}}/set",
+                                    "refId": "B"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Client Latency p50",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 0,
+                                "y": 36
+                            },
+                            "id": 26,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Total",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Config",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Other",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Request Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 12,
+                                "x": 12,
+                                "y": 36
+                            },
+                            "id": 27,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Total",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Config",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Other",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Set Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Cache",
+                    "titleSize": "h6",
+                    "type": "row"
+                },
+                {
+                    "collapse": false,
+                    "collapsed": false,
+                    "panels": [
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 0
+                            },
+                            "id": 28,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Memory Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "bytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "Limit": "#E24D42",
+                                "Requested": "#Ffa500"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 0,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 0
+                            },
+                            "id": 29,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"}[1m]))",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{pod}}",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Requested",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Limit",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "CPU Usage",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "none",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 0
+                            },
+                            "id": 30,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Authenticator latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 9
+                            },
+                            "id": 31,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.95, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p95",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.9, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "C"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.5, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "D"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "GCOM cached client latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 9
+                            },
+                            "id": 32,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Handler latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "1xx": "#EAB839",
+                                "2xx": "#7EB26D",
+                                "3xx": "#6ED0E0",
+                                "4xx": "#EF843C",
+                                "5xx": "#E24D42"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "decimals": 2,
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 9
+                            },
+                            "id": 33,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (code) (\n  label_replace(\n    rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"code\",\n    \"([0-9])..\")\n  )\n",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{code}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Grafana.com HTTP Client - Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 18
+                            },
+                            "id": 34,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Grafana.com HTTP Client - Latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 18
+                            },
+                            "id": 35,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "(rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", code=~\"5..|error\"}[$__rate_interval]) / rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Error rate",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Grafana.com HTTP Client - Error rate",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+                                "1xx": "#EAB839",
+                                "2xx": "#7EB26D",
+                                "3xx": "#6ED0E0",
+                                "4xx": "#EF843C",
+                                "5xx": "#E24D42"
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "decimals": 2,
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 16,
+                                "y": 18
+                            },
+                            "id": 36,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "sum by (status_code) (\n  label_replace(\n    rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{status_code}}",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Auth API HTTP Client - Throughput (requests/sec)",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "decimals": 2,
+                                    "format": "reqps",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 0,
+                                "y": 27
+                            },
+                            "id": 37,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "histogram_quantile(0.99, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p99",
+                                    "refId": "A"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.90, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p90",
+                                    "refId": "B"
+                                },
+                                {
+                                    "expr": "histogram_quantile(0.50, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+                                    "format": "time_series",
+                                    "interval": "5m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "p50",
+                                    "refId": "C"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Auth API HTTP Client - Latency",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "ms",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {
+
+                            },
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "$datasource",
+                            "fill": 1,
+                            "fillGradient": 0,
+                            "gridPos": {
+                                "h": 9,
+                                "w": 8,
+                                "x": 8,
+                                "y": 27
+                            },
+                            "id": 38,
+                            "legend": {
+                                "alignAsTable": false,
+                                "avg": false,
+                                "current": false,
+                                "max": false,
+                                "min": false,
+                                "rightSide": false,
+                                "show": true,
+                                "sideWidth": null,
+                                "total": false,
+                                "values": false
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [
+
+                            ],
+                            "nullPointMode": "null as zero",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "repeat": null,
+                            "seriesOverrides": [
+
+                            ],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "(rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", status_code=~\"5..|error\"}[$__rate_interval]) / rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+                                    "format": "time_series",
+                                    "interval": "1m",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Error rate",
+                                    "refId": "A"
+                                }
+                            ],
+                            "thresholds": [
+
+                            ],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Auth API HTTP Client - Error rate",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                },
+                                {
+                                    "format": "percentunit",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": 1,
+                                    "min": 0,
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Gateway",
+                    "titleSize": "h6",
+                    "type": "row"
+                }
+            ],
+            "schemaVersion": 14,
+            "style": "dark",
+            "tags": [
+                "example-service",
+                "as-code"
+            ],
+            "templating": {
+                "list": [
+                    {
+                        "current": {
+                            "value": "prometheus-datasource"
+                        },
+                        "hide": 0,
+                        "label": null,
+                        "name": "datasource",
+                        "options": [
+
+                        ],
+                        "query": "prometheus",
+                        "refresh": 1,
+                        "regex": "",
+                        "type": "datasource"
+                    },
+                    {
+                        "current": {
+                            "value": "logs-datasource"
+                        },
+                        "hide": 0,
+                        "label": null,
+                        "name": "datasourcelogs",
+                        "options": [
+
+                        ],
+                        "query": "loki",
+                        "refresh": 1,
+                        "regex": "",
+                        "type": "datasource"
+                    },
+                    {
+                        "allValue": null,
+                        "current": {
+                            "text": "cluster-1",
+                            "value": "cluster-1"
+                        },
+                        "datasource": "$datasource",
+                        "hide": 0,
+                        "includeAll": false,
+                        "label": null,
+                        "multi": false,
+                        "name": "cluster",
+                        "options": [
+
+                        ],
+                        "query": "label_values(example_service_inflight_requests{}, cluster)",
+                        "refresh": 2,
+                        "regex": "",
+                        "sort": 0,
+                        "tagValuesQuery": "",
+                        "tags": [
+
+                        ],
+                        "tagsQuery": "",
+                        "type": "query",
+                        "useTags": false
+                    },
+                    {
+                        "allValue": null,
+                        "current": {
+                            "text": "cluster-1",
+                            "value": "cluster-1"
+                        },
+                        "datasource": "$datasource",
+                        "hide": 0,
+                        "includeAll": false,
+                        "label": null,
+                        "multi": false,
+                        "name": "namespace",
+                        "options": [
+
+                        ],
+                        "query": "label_values(example_service_inflight_requests{cluster=\"$cluster\"}, namespace)",
+                        "refresh": 2,
+                        "regex": "example-service.*",
+                        "sort": 0,
+                        "tagValuesQuery": "",
+                        "tags": [
+
+                        ],
+                        "tagsQuery": "",
+                        "type": "query",
+                        "useTags": false
+                    }
+                ]
+            },
+            "time": {
+                "from": "now-2h",
+                "to": "now"
+            },
+            "timepicker": {
+                "refresh_intervals": [
+                    "5s",
+                    "10s",
+                    "30s",
+                    "1m",
+                    "5m",
+                    "15m",
+                    "30m",
+                    "1h",
+                    "2h",
+                    "1d"
+                ],
+                "time_options": [
+                    "5m",
+                    "15m",
+                    "1h",
+                    "6h",
+                    "12h",
+                    "24h",
+                    "2d",
+                    "7d",
+                    "30d"
+                ]
+            },
+            "timezone": "browser",
+            "title": "Service Overview Dashboard",
+            "uid": "ba9b93e998e09d254266b11192894a8d",
+            "version": 0
+        }

--- a/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash2.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v14.broken-dash2.json
@@ -1,0 +1,1951 @@
+{
+  "__requires": [
+    {
+      "id": "grafana",
+      "name": "Grafana",
+      "type": "grafana",
+      "version": "8.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "datasource": "$datasource",
+        "enable": true,
+        "expr": "ALERTS{alertname=\"MetricsRolloutUnderway\", region=~\"$region\", env=~\"$environment\", alertstate=\"firing\"}",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "name": "rollouts",
+        "showIn": 0,
+        "tags": [],
+        "titleFormat": "Rollout was underway in {{cluster}}/{{namespace}}",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "links": [],
+  "refresh": "5m",
+  "rows": [
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "content": "The 'Status' panel shows an overview on the cluster health over the time.\nTo investigate failures, see a specific dashboard:\n\n- <a target=\"_blank\" href=\"./d/8280707b8f16e7b87b840fc1cc92d4c5/service-writes?${__url_time_range}&${__all_variables}\">Writes</a>\n- <a target=\"_blank\" href=\"./d/e327503188913dc38ad571c647eef643/service-reads?${__url_time_range}&${__all_variables}\">Reads</a>\n- <a target=\"_blank\" href=\"./d/631e15d5d85afb2ca8e35d62984eeaa0/service-ruler?${__url_time_range}&${__all_variables}\">Rule evaluations</a>\n- <a target=\"_blank\" href=\"./d/b0d38d318bbddd80476246d4930f9e55/service-alertmanager?${__url_time_range}&${__all_variables}\">Alerting notifications</a>\n- <a target=\"_blank\" href=\"./d/e1324ee2a434f4158c00a9ee279d3292/service-object-store?${__url_time_range}&${__all_variables}\">Object storage</a>\n",
+          "datasource": null,
+          "description": "",
+          "id": 1,
+          "mode": "markdown",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "#7EB26D",
+                    "value": null
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.01
+                  },
+                  {
+                    "color": "#E24D42",
+                    "value": 0.05
+                  }
+                ]
+              }
+            }
+          },
+          "id": 2,
+          "options": {
+            "showValue": "never"
+          },
+          "span": 6,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\",status_code=~\"5.*|error\"}[$__rate_interval])))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
+              "instant": false,
+              "legendFormat": "Writes",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\",status_code=~\"5.*|error\"}[$__rate_interval]))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+              "instant": false,
+              "legendFormat": "Writes",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\",status_code=~\"5.*|error\"}[$__rate_interval])))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
+              "instant": false,
+              "legendFormat": "Reads",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\",status_code=~\"5.*|error\"}[$__rate_interval]))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+              "instant": false,
+              "legendFormat": "Reads",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "(\n  (\n      sum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))\n      +\n      # Consider missed evaluations as failures.\n      sum(rate(monitoring_rule_group_iterations_missed_total{service=~\"rule-engine\"}[$__rate_interval]))\n  )\n  or\n  # Handle the case no failure has been tracked yet.\n  vector(0)\n)\n/\nsum(rate(monitoring_rule_evaluations_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+              "instant": false,
+              "legendFormat": "Rule evaluations",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "(\n  # Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(service_integration:alerting_service_notifications_failed_total:rate5m{service=~\"alerting\"}) or vector(0)\n) or vector(0))\n)\n/\n(\n  # Total notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(alert_notifications_sent_total{service=~\"rule-engine\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Total notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(service_integration:alerting_service_notifications_total:rate5m{service=~\"alerting\"}) or vector(0)\n) or vector(0))\n)\n",
+              "instant": false,
+              "legendFormat": "Alerting notifications",
+              "range": true
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "exemplar": false,
+              "expr": "sum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n/\nsum(rate(storage_operations_total{env!=\"\"}[$__rate_interval]))\n",
+              "instant": false,
+              "legendFormat": "Object storage",
+              "range": true
+            }
+          ],
+          "title": "Status",
+          "type": "state-timeline"
+        },
+        {
+          "id": 3,
+          "options": {
+            "alertInstanceLabelFilter": "env!=\"\"",
+            "alertName": "Metrics",
+            "dashboardAlerts": false,
+            "maxItems": 100,
+            "sortOrder": 3,
+            "stateFilter": {
+              "error": true,
+              "firing": true,
+              "noData": false,
+              "normal": false,
+              "pending": false
+            }
+          },
+          "span": 3,
+          "title": "Firing alerts",
+          "type": "alertlist"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Service cluster health",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "content": "These panels show an overview on the write path. Requests rate and latency is measured on the gateway.\nTo examine the write path in detail, see a specific dashboard:\n\n- <a target=\"_blank\" href=\"./d/8280707b8f16e7b87b840fc1cc92d4c5/service-writes?${__url_time_range}&${__all_variables}\">Writes</a>\n- <a target=\"_blank\" href=\"./d/bc9160e50b52e89e0e49c840fea3d379/service-writes-resources?${__url_time_range}&${__all_variables}\">Writes resources</a>\n- <a target=\"_blank\" href=\"./d/978c1cb452585c96697a238eaac7fe2d/service-writes-networking?${__url_time_range}&${__all_variables}\">Writes networking</a>\n- <a target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}&${__all_variables}\">Overview resources</a>\n- <a target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}&${__all_variables}\">Overview networking</a>\n",
+          "datasource": null,
+          "description": "",
+          "id": 4,
+          "mode": "markdown",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EAB839",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6ED0E0",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EF843C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "OK"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cancel"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EAB839",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6ED0E0",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EF843C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Canceled"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "OK"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cancel"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 5,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "(sum by (status) (\n  label_replace(label_replace(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "{{status}}",
+              "refId": "A_classic"
+            },
+            {
+              "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Write requests / sec (gateway)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 1,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "id": 6,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "(histogram_quantile(0.99, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "99th percentile",
+              "refId": "A_classic"
+            },
+            {
+              "expr": "(histogram_quantile(0.99, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "99th percentile",
+              "refId": "A_native"
+            },
+            {
+              "expr": "(histogram_quantile(0.50, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "50th percentile",
+              "refId": "B_classic"
+            },
+            {
+              "expr": "(histogram_quantile(0.50, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "50th percentile",
+              "refId": "B_native"
+            },
+            {
+              "expr": "(1e3 * sum(service_route:http_request_duration_seconds_sum:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"}) /\nsum(service_route:http_request_duration_seconds_count:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})\n) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "Average",
+              "refId": "C_classic"
+            },
+            {
+              "expr": "(1e3 * sum(histogram_sum(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) /\nsum(histogram_count(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"}))\n) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "Average",
+              "refId": "C_native"
+            }
+          ],
+          "title": "Write latency (gateway)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "cps"
+            },
+            "overrides": []
+          },
+          "id": 7,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum(cluster_namespace_job:ingestion_service_received_samples:rate5m{job=~\"(.*)/(distributor.*|service|metrics)\"})",
+              "format": "time_series",
+              "legendFormat": "samples / sec",
+              "legendLink": null
+            },
+            {
+              "expr": "sum(cluster_namespace_job:ingestion_service_received_exemplars:rate5m{job=~\"(.*)/(distributor.*|service|metrics)\"})",
+              "format": "time_series",
+              "legendFormat": "exemplars / sec",
+              "legendLink": null
+            }
+          ],
+          "title": "Ingestion / sec",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Writes",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "content": "These panels show an overview on the read path. Requests rate and latency is measured on the gateway.\nTo examine the read path in detail, see a specific dashboard:\n\n- <a target=\"_blank\" href=\"./d/e327503188913dc38ad571c647eef643/service-reads?${__url_time_range}&${__all_variables}\">Reads</a>\n- <a target=\"_blank\" href=\"./d/cc86fd5aa9301c6528986572ad974db9/service-reads-resources?${__url_time_range}&${__all_variables}\">Reads resources</a>\n- <a target=\"_blank\" href=\"./d/54b2a0a4748b3bd1aefa92ce5559a1c2/service-reads-networking?${__url_time_range}&${__all_variables}\">Reads networking</a>\n- <a target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}&${__all_variables}\">Overview resources</a>\n- <a target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}&${__all_variables}\">Overview networking</a>\n- <a target=\"_blank\" href=\"./d/b3abe8d5c040395cc36615cb4334c92d/service-queries?${__url_time_range}&${__all_variables}\">Queries</a>\n- <a target=\"_blank\" href=\"./d/1b3443aea86db629e6efdb7d05c53823/service-compactor?${__url_time_range}&${__all_variables}\">Compactor</a>\n",
+          "datasource": null,
+          "description": "",
+          "id": 8,
+          "mode": "markdown",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EAB839",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6ED0E0",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EF843C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "OK"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cancel"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EAB839",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "2xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "3xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#6ED0E0",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "4xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#EF843C",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "5xx"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Canceled"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "OK"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "cancel"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A9A9A9",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "error"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 9,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "(sum by (status) (\n  label_replace(label_replace(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "{{status}}",
+              "refId": "A_classic"
+            },
+            {
+              "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "{{status}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Read requests / sec (gateway)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 1,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "ms"
+            },
+            "overrides": []
+          },
+          "id": 10,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "(histogram_quantile(0.99, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "99th percentile",
+              "refId": "A_classic"
+            },
+            {
+              "expr": "(histogram_quantile(0.99, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "99th percentile",
+              "refId": "A_native"
+            },
+            {
+              "expr": "(histogram_quantile(0.50, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "50th percentile",
+              "refId": "B_classic"
+            },
+            {
+              "expr": "(histogram_quantile(0.50, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "50th percentile",
+              "refId": "B_native"
+            },
+            {
+              "expr": "(1e3 * sum(service_route:http_request_duration_seconds_sum:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"}) /\nsum(service_route:http_request_duration_seconds_count:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})\n) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "Average",
+              "refId": "C_classic"
+            },
+            {
+              "expr": "(1e3 * sum(histogram_sum(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) /\nsum(histogram_count(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"}))\n) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "Average",
+              "refId": "C_native"
+            }
+          ],
+          "title": "Read latency (gateway)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_query($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "instant queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#429D48",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_query_range($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "range queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#F1C731",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_labels($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "\"label names\" queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#2A66CF",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_label_name_values($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "\"label values\" queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#9E44C1",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_series($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "series queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#FFAB57",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_read($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "remote read queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#C79424",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_metadata($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "metadata queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#84D586",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_query_exemplars($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "exemplar queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#A1C4FC",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_cardinality_active_series($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "\"active series\" queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#C788DE",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_cardinality_label_names($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "\"label name cardinality\" queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#3F6833",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byRegexp",
+                  "options": "/.*_api_v1_cardinality_label_values($|[^_])/"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "\"label value cardinality\" queries"
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#447EBC",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 11,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "(sum by (route) (rate(http_request_duration_seconds_count{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendLink": null
+            },
+            {
+              "expr": "(sum by (route) (histogram_count(rate(http_request_duration_seconds{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendLink": null
+            },
+            {
+              "expr": "(sum (rate(http_request_duration_seconds_count{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+              "format": "time_series",
+              "legendFormat": "other",
+              "legendLink": null
+            },
+            {
+              "expr": "(sum (histogram_count(rate(http_request_duration_seconds{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+              "format": "time_series",
+              "legendFormat": "other",
+              "legendLink": null
+            }
+          ],
+          "title": "Queries / sec",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Reads",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "content": "These panels show an overview on the recording and alerting rules evaluation.\nTo examine the rules evaluation and alerts notifications in detail, see a specific dashboard:\n\n- <a target=\"_blank\" href=\"./d/631e15d5d85afb2ca8e35d62984eeaa0/service-ruler?${__url_time_range}&${__all_variables}\">Ruler</a>\n- <a target=\"_blank\" href=\"./d/b0d38d318bbddd80476246d4930f9e55/service-alertmanager?${__url_time_range}&${__all_variables}\">Alertmanager</a>\n- <a target=\"_blank\" href=\"./d/a6883fb22799ac74479c7db872451092/service-alertmanager-resources?${__url_time_range}&${__all_variables}\">Alertmanager resources</a>\n- <a target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}&${__all_variables}\">Overview resources</a>\n- <a target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}&${__all_variables}\">Overview networking</a>\n",
+          "datasource": null,
+          "description": "",
+          "id": 12,
+          "mode": "markdown",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 1,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "success"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 13,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum(rate(monitoring_rule_evaluations_total{service=~\"rule-engine\"}[$__rate_interval]))\n-\nsum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "success",
+              "legendLink": null
+            },
+            {
+              "expr": "sum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))",
+              "format": "time_series",
+              "legendFormat": "failed",
+              "legendLink": null
+            },
+            {
+              "expr": "sum(rate(monitoring_rule_group_iterations_missed_total{service=~\"rule-engine\"}[$__rate_interval]))",
+              "format": "time_series",
+              "legendFormat": "missed",
+              "legendLink": null
+            }
+          ],
+          "title": "Rule evaluations / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 1,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "id": 14,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum (rate(monitoring_rule_evaluation_duration_seconds_sum{service=~\"rule-engine\"}[$__rate_interval]))\n  /\nsum (rate(monitoring_rule_evaluation_duration_seconds_count{service=~\"rule-engine\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "average",
+              "legendLink": null
+            }
+          ],
+          "title": "Rule evaluations latency",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "successful"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 15,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum(rate(alert_notifications_sent_total{service=~\"rule-engine\"}[$__rate_interval]))\n  -\nsum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "successful",
+              "legendLink": null
+            },
+            {
+              "expr": "sum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "failed",
+              "legendLink": null
+            }
+          ],
+          "title": "Alerting notifications sent to Alertmanager / sec",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Recording and alerting rules",
+      "titleSize": "h6"
+    },
+    {
+      "collapse": false,
+      "height": "250px",
+      "panels": [
+        {
+          "content": "These panels show an overview on the long-term storage (object storage).\nTo examine the storage in detail, see a specific dashboard:\n\n- <a target=\"_blank\" href=\"./d/e1324ee2a434f4158c00a9ee279d3292/service-object-store?${__url_time_range}&${__all_variables}\">Object store</a>\n- <a target=\"_blank\" href=\"./d/1b3443aea86db629e6efdb7d05c53823/service-compactor?${__url_time_range}&${__all_variables}\">Compactor</a>\n",
+          "datasource": null,
+          "description": "",
+          "id": 16,
+          "mode": "markdown",
+          "span": 3,
+          "title": "",
+          "transparent": true,
+          "type": "text"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "reqps"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "failed"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#E24D42",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "successful"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "#7EB26D",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "id": 17,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum(rate(storage_operations_total{env!=\"\"}[$__rate_interval]))\n-\nsum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "successful",
+              "legendLink": null
+            },
+            {
+              "expr": "sum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n",
+              "format": "time_series",
+              "legendFormat": "failed",
+              "legendLink": null
+            }
+          ],
+          "title": "Requests / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "lineWidth": 0,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "normal"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "reqps"
+            },
+            "overrides": []
+          },
+          "id": 18,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "seriesOverrides": [
+            {
+              "alias": "attributes",
+              "color": "#429D48"
+            },
+            {
+              "alias": "delete",
+              "color": "#F1C731"
+            },
+            {
+              "alias": "exists",
+              "color": "#2A66CF"
+            },
+            {
+              "alias": "get",
+              "color": "#9E44C1"
+            },
+            {
+              "alias": "get_range",
+              "color": "#FFAB57"
+            },
+            {
+              "alias": "iter",
+              "color": "#C79424"
+            },
+            {
+              "alias": "upload",
+              "color": "#84D586"
+            }
+          ],
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum by(operation) (rate(storage_operations_total{env!=\"\"}[$__rate_interval]))",
+              "format": "time_series",
+              "legendFormat": "{{operation}}",
+              "legendLink": null
+            }
+          ],
+          "title": "Operations / sec",
+          "type": "timeseries"
+        },
+        {
+          "datasource": "$datasource",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "drawStyle": "line",
+                "fillOpacity": 1,
+                "lineWidth": 1,
+                "pointSize": 5,
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                }
+              },
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": []
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "id": 19,
+          "links": [],
+          "options": {
+            "legend": {
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "span": 3,
+          "targets": [
+            {
+              "expr": "sum(max by(user) (max_over_time(storage_blocks_count{job=~\"(.*)/(compactor.*|service|metrics)\"}[15m])))",
+              "format": "time_series",
+              "legendFormat": "blocks",
+              "legendLink": null
+            }
+          ],
+          "title": "Total number of blocks in the storage",
+          "type": "timeseries"
+        }
+      ],
+      "repeat": null,
+      "repeatIteration": null,
+      "repeatRowId": null,
+      "showTitle": true,
+      "title": "Long-term storage (object storage)",
+      "titleSize": "h6"
+    }
+  ],
+  "schemaVersion": 14,
+  "style": "dark",
+  "tags": ["metrics", "scoped", "as-code"],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/(dev-prometheus|ops-prometheus|service-prometheus|critical-prometheus)/",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "classic",
+          "value": "1"
+        },
+        "description": "Choose between showing latencies based on low precision classic or high precision native histogram metrics.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Latency metrics",
+        "multi": false,
+        "name": "latency_metrics",
+        "options": [
+          {
+            "selected": false,
+            "text": "native",
+            "value": "-1"
+          },
+          {
+            "selected": true,
+            "text": "classic",
+            "value": "1"
+          }
+        ],
+        "query": "native : -1,classic : 1",
+        "skipUrlSync": false,
+        "type": "custom",
+        "useTags": false
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "filters": [],
+        "name": "filters",
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
+  },
+  "timezone": "utc",
+  "title": "Service Overview Dashboard",
+  "uid": "e540f8b0ce5b02335ec443a769d1a74e",
+  "version": 0
+}

--- a/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash-min.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash-min.json
@@ -1,0 +1,159 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": 22815,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(http_requests_total{environment=\"$env\", region=\"$region\", service=\"webapp\"}[5m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Requests/sec",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(memory_usage_bytes{environment=\"$env\", region=\"$region\", service=\"webapp\"}) / 1024 / 1024",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Memory (MB)",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.95, rate(response_time_bucket{environment=\"$env\", region=\"$region\", service=\"webapp\"}[5m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "95th percentile latency",
+          "refId": "C"
+        }
+      ],
+      "title": "Service Stats",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 3,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Overview",
+      "type": "row"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "style": "dark",
+  "tags": [
+    "example-service",
+    "as-code"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Service Overview Dashboard",
+  "uid": "ba9b93e998e09d254266b11192894a8d",
+  "version": 1
+}

--- a/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash.json
@@ -1,0 +1,3989 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "datasource": {
+          "uid": "$datasourcelogs"
+        },
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", component=\"logger\"} | json | namespace_extracted=~\"example-service.*\" | name_extracted=\"example-api\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": 22815,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "cache-overview"
+      ],
+      "targetBlank": false,
+      "title": "Cache Dashboard",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "database-monitoring"
+      ],
+      "targetBlank": false,
+      "title": "Database Dashboard",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "Database",
+        "monitoring"
+      ],
+      "targetBlank": false,
+      "title": "Database Metrics Dashboard",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_a{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Tenants",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_b{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Collectors",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_c{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Pipelines",
+          "refId": "C"
+        }
+      ],
+      "title": "Customer Stats",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 40
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "API Mem",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=\"cache-server\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Cache Server Mem",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Gateway Mem ",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "API CPU",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=\"cache-server\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Cache Server CPU",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Gateway CPU",
+          "refId": "F"
+        }
+      ],
+      "title": "Requested Resource Usage",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by () (\n  label_replace(\n    rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Api Requests",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 39,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 6,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (status_code) (\n  label_replace(\n    rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(http_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\", status_code=~\"5..\"}[$__rate_interval]) / rate(http_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"health|status\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "uid": "$datasourcelogs"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasourcelogs"
+          },
+          "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "uid": "$datasourcelogs"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 11,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasourcelogs"
+          },
+          "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"} | logfmt | level=\"error\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Errors",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 40,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "API",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 38
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p99",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 38
+      },
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p90",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 38
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(database_query_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p50",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 15,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\"GetConfig.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "GetConfig",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(database_query_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\"GetConfig.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 16,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (db_pool_in_use_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (db_pool_idle_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Idle",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (db_pool_max_open_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Max",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 17,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(db_pool_wait_duration_seconds_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connection Wait Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 41,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 18,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 19,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "id": 20,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(cache_set_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Sets",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "id": 21,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(cache_request_hit_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]) / rate(cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Cache Request Hit Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "id": 23,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p99",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "id": 24,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p90",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "id": 25,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p50",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 74
+      },
+      "id": 26,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Config",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Request Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 74
+      },
+      "id": 27,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Config",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Set Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 42,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "id": 28,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 82
+      },
+      "id": 29,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 89
+      },
+      "id": 30,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Authenticator latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 89
+      },
+      "id": 31,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.9, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCOM cached client latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 89
+      },
+      "id": 32,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Handler latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 96
+      },
+      "id": 33,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (code) (\n  label_replace(\n    rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 96
+      },
+      "id": 34,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 96
+      },
+      "id": 35,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", code=~\"5..|error\"}[$__rate_interval]) / rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 103
+      },
+      "id": 36,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (status_code) (\n  label_replace(\n    rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 103
+      },
+      "id": 37,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 103
+      },
+      "id": 38,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", status_code=~\"5..|error\"}[$__rate_interval]) / rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 43,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway",
+      "type": "row"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "style": "dark",
+  "tags": [
+    "example-service",
+    "as-code"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "value": "prometheus-datasource"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "value": "logs-datasource"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasourcelogs",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "cluster-1",
+          "value": "cluster-1"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(example_service_inflight_requests{}, cluster)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "cluster-1",
+          "value": "cluster-1"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(example_service_inflight_requests{cluster=\"$cluster\"}, namespace)",
+        "refresh": 1,
+        "regex": "example-service.*",
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Service Overview Dashboard",
+  "uid": "ba9b93e998e09d254266b11192894a8d",
+  "version": 1
+}

--- a/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash1.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash1.json
@@ -1,0 +1,3991 @@
+{
+  "__inputs": [],
+  "__requires": [],
+  "annotations": {
+    "list": [
+      {
+        "datasource": {
+          "uid": "$datasourcelogs"
+        },
+        "enable": true,
+        "expr": "{cluster=\"$cluster\", component=\"kube-diff-logger\"} | json | namespace_extracted=~\"example-service.*\" | name_extracted=\"example-api\"",
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "instant": false,
+        "name": "Deployments",
+        "titleFormat": "{{cluster}}/{{namespace}}"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "cache-overview"
+      ],
+      "targetBlank": false,
+      "title": "Cache Dashboard",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "cloudsql-stackdriver"
+      ],
+      "targetBlank": false,
+      "title": "CloudSQL Dashboard",
+      "type": "dashboards",
+      "url": ""
+    },
+    {
+      "asDropdown": true,
+      "icon": "external link",
+      "includeVars": true,
+      "keepTime": true,
+      "tags": [
+        "Database",
+        "percona"
+      ],
+      "targetBlank": false,
+      "title": "Database Dashboard",
+      "type": "dashboards",
+      "url": ""
+    }
+  ],
+  "panels": [
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "none"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_a{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Tenants",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_b{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Collectors",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(app_metric_counter_c{env=\"$environment\", region=\"$region\", service=\"api\"}) - 1",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Pipelines",
+          "refId": "C"
+        }
+      ],
+      "title": "Customer Stats",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 40
+              },
+              {
+                "color": "yellow",
+                "value": 60
+              },
+              {
+                "color": "orange",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "API Mem",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=\"cache-server\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Cache Server Mem",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}) * 100) / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Gateway Mem ",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "API CPU",
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=\"cache-server\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=\"cache-server\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Cache Server CPU",
+          "refId": "E"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "avg(sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\"}[1m]))) * 100 / min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\"})",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Gateway CPU",
+          "refId": "F"
+        }
+      ],
+      "title": "Requested Resource Usage",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          },
+          "unit": "reqps"
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 1
+      },
+      "id": 4,
+      "links": [],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "mean"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "7",
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by () (\n  label_replace(\n    rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Api Requests",
+      "transparent": false,
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 39,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 9
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 9
+      },
+      "id": 6,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"example-api.*\", component=~\".*\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"example-api.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 7,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (status_code) (\n  label_replace(\n    rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 8,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(example_service_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 9,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\", status_code=~\"5..\"}[$__rate_interval]) / rate(example_service_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", route!~\"|root|other|ready|metrics|debug_pprof\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "uid": "$datasourcelogs"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasourcelogs"
+          },
+          "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"}",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Logs",
+      "type": "logs"
+    },
+    {
+      "datasource": {
+        "uid": "$datasourcelogs"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 30
+      },
+      "id": 11,
+      "options": {
+        "showLabels": false,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasourcelogs"
+          },
+          "expr": "{env=\"$environment\", region=\"$region\", service=\"api\"} | logfmt | level=\"error\"",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Errors",
+      "type": "logs"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 40,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "API",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 38
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p99",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 38
+      },
+      "id": 13,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p90",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 38
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(example_service_database_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p50",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 45
+      },
+      "id": 15,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\"GetConfig.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "GetConfig",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_database_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\"GetConfig.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 45
+      },
+      "id": 16,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_sql_in_use_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Active",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_sql_idle_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Idle",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (go_sql_max_open_connections {env=\"$environment\", region=\"$region\", service=\"api\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}/Max",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connections",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 45
+      },
+      "id": 17,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(go_sql_wait_duration_seconds_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Connection Wait Duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 37
+      },
+      "id": 41,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Database",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 53
+      },
+      "id": 18,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 53
+      },
+      "id": 19,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"cache.*\", component=~\"cache-server\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"cache.*\", component=~\"cache-server\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 60
+      },
+      "id": 20,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(example_service_cache_set_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Sets",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 60
+      },
+      "id": 21,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(example_service_cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Requests",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 60
+      },
+      "id": 22,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(example_service_cache_request_hit_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]) / rate(example_service_cache_request_total{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Cache Request Hit Rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 67
+      },
+      "id": 23,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p99",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 67
+      },
+      "id": 24,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p90",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 67
+      },
+      "id": 25,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(example_service_cache_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/request",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(example_service_cache_set_duration_seconds_bucket{env=\"$environment\", region=\"$region\", service=\"api\"}[$__rate_interval])) by (le, method)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{method}}/set",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Client Latency p50",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 74
+      },
+      "id": 26,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Config",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_request_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Request Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 74
+      },
+      "id": 27,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Total",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method=~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Config",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(example_service_cache_set_duration_seconds_count{env=\"$environment\", region=\"$region\", service=\"api\", method!~\".*Config.*\"}[1m]))",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Other",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Set Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 42,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Cache",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 82
+      },
+      "id": 28,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (app_memory_usage_bytes{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"memory\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Memory Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "Limit": "#E24D42",
+        "Requested": "#Ffa500"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 82
+      },
+      "id": 29,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (pod) (rate(app_cpu_usage_ratio{env=\"$environment\", region=\"$region\", instance=~\"gateway.*\", component=~\".*\"}[1m]))",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_quota{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Requested",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "min(app_resource_limit{env=\"$environment\", region=\"$region\", resource=\"cpu\", instance=~\"gateway.*\", component=~\".*\"})",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "Limit",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "CPU Usage",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "none",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 89
+      },
+      "id": 30,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(agent_management_gateway_grafanacloud_authenticator_authentication_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Authenticator latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 89
+      },
+      "id": 31,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.95, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.9, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.5, sum(rate(agent_management_gateway_grafanacloud_cachedclient_get_instance_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "D"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCOM cached client latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 89
+      },
+      "id": 32,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(agent_management_request_downstream_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Handler latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 96
+      },
+      "id": 33,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (code) (\n  label_replace(\n    rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 96
+      },
+      "id": 34,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(grafanacom_api_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 96
+      },
+      "id": 35,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", code=~\"5..|error\"}[$__rate_interval]) / rate(grafanacom_api_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Grafana.com HTTP Client - Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {
+        "1xx": "#EAB839",
+        "2xx": "#7EB26D",
+        "3xx": "#6ED0E0",
+        "4xx": "#EF843C",
+        "5xx": "#E24D42"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "decimals": 2,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 103
+      },
+      "id": 36,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by (status_code) (\n  label_replace(\n    rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval]),\n    \"status\",\n    \"${1}xx\",\n    \"status_code\",\n    \"([0-9])..\")\n  )\n",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "{{status_code}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Throughput (requests/sec)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "decimals": 2,
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 103
+      },
+      "id": 37,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.99, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p99",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.90, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p90",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "histogram_quantile(0.50, sum(rate(auth_client_request_duration_seconds_bucket{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) by (le)) * 1e3",
+          "format": "time_series",
+          "interval": "5m",
+          "intervalFactor": 2,
+          "legendFormat": "p50",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 103
+      },
+      "id": 38,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "sideWidth": null,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "repeat": null,
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\", status_code=~\"5..|error\"}[$__rate_interval]) / rate(auth_client_request_duration_seconds_count{env=\"$environment\", region=\"$region\", job=\"$namespace/gateway\"}[$__rate_interval])) OR on() vector(0)",
+          "format": "time_series",
+          "interval": "1m",
+          "intervalFactor": 2,
+          "legendFormat": "Error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Auth API HTTP Client - Error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": 1,
+          "min": 0,
+          "show": true
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 81
+      },
+      "id": 43,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Gateway",
+      "type": "row"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "style": "dark",
+  "tags": [
+    "example-service",
+    "as-code"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "value": "prometheus-datasource"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "value": "logs-datasource"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "datasourcelogs",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "cluster-1",
+          "value": "cluster-1"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "cluster",
+        "options": [],
+        "query": "label_values(example_service_inflight_requests{}, cluster)",
+        "refresh": 1,
+        "regex": "",
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": null,
+        "current": {
+          "text": "cluster-1",
+          "value": "cluster-1"
+        },
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "namespace",
+        "options": [],
+        "query": "label_values(example_service_inflight_requests{cluster=\"$cluster\"}, namespace)",
+        "refresh": 1,
+        "regex": "example-service.*",
+        "sort": 0,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-2h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Service Overview Dashboard",
+  "uid": "ba9b93e998e09d254266b11192894a8d",
+  "version": 0
+}

--- a/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash2.json
+++ b/apps/dashboard/pkg/migration/testdata/output/v14.broken-dash2.json
@@ -1,0 +1,2343 @@
+{
+  "__requires": [
+    {
+      "id": "grafana",
+      "name": "Grafana",
+      "type": "grafana",
+      "version": "8.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "datasource": {
+          "uid": "$datasource"
+        },
+        "enable": true,
+        "expr": "ALERTS{alertname=\"MetricsRolloutUnderway\", region=~\"$region\", env=~\"$environment\", alertstate=\"firing\"}",
+        "hide": false,
+        "iconColor": "rgba(255, 96, 96, 1)",
+        "name": "rollouts",
+        "showIn": 0,
+        "tags": [],
+        "titleFormat": "Rollout was underway in {{cluster}}/{{namespace}}",
+        "type": "tags"
+      }
+    ]
+  },
+  "editable": false,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "hideControls": false,
+  "links": [],
+  "panels": [
+    {
+      "content": "The 'Status' panel shows an overview on the cluster health over the time.\nTo investigate failures, see a specific dashboard:\n\n- \u003ca target=\"_blank\" href=\"./d/8280707b8f16e7b87b840fc1cc92d4c5/service-writes?${__url_time_range}\u0026${__all_variables}\"\u003eWrites\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/e327503188913dc38ad571c647eef643/service-reads?${__url_time_range}\u0026${__all_variables}\"\u003eReads\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/631e15d5d85afb2ca8e35d62984eeaa0/service-ruler?${__url_time_range}\u0026${__all_variables}\"\u003eRule evaluations\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/b0d38d318bbddd80476246d4930f9e55/service-alertmanager?${__url_time_range}\u0026${__all_variables}\"\u003eAlerting notifications\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/e1324ee2a434f4158c00a9ee279d3292/service-object-store?${__url_time_range}\u0026${__all_variables}\"\u003eObject storage\u003c/a\u003e\n",
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "mode": "markdown",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#7EB26D",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0.01
+              },
+              {
+                "color": "#E24D42",
+                "value": 0.05
+              }
+            ]
+          }
+        }
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 6,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "showValue": "never"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\",status_code=~\"5.*|error\"}[$__rate_interval])))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
+          "instant": false,
+          "legendFormat": "Writes",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\",status_code=~\"5.*|error\"}[$__rate_interval]))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+          "instant": false,
+          "legendFormat": "Writes",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\",status_code=~\"5.*|error\"}[$__rate_interval])))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval])))\n) and on() (vector($latency_metrics) == -1)",
+          "instant": false,
+          "legendFormat": "Reads",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "((\n    # gRPC errors are not tracked as 5xx but \"error\".\n    sum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\",status_code=~\"5.*|error\"}[$__rate_interval]))\n    or\n    # Handle the case no failure has been tracked yet.\n    vector(0)\n)\n/\nsum(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval]))\n) and on() (vector($latency_metrics) == 1)",
+          "instant": false,
+          "legendFormat": "Reads",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "(\n  (\n      sum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))\n      +\n      # Consider missed evaluations as failures.\n      sum(rate(monitoring_rule_group_iterations_missed_total{service=~\"rule-engine\"}[$__rate_interval]))\n  )\n  or\n  # Handle the case no failure has been tracked yet.\n  vector(0)\n)\n/\nsum(rate(monitoring_rule_evaluations_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+          "instant": false,
+          "legendFormat": "Rule evaluations",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "(\n  # Failed notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Failed notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(service_integration:alerting_service_notifications_failed_total:rate5m{service=~\"alerting\"}) or vector(0)\n) or vector(0))\n)\n/\n(\n  # Total notifications from ruler to Alertmanager (handling the case the ruler metrics are missing).\n  ((sum(rate(alert_notifications_sent_total{service=~\"rule-engine\"}[$__rate_interval]))\n) or vector(0))\n  +\n  # Total notifications from Alertmanager to receivers (handling the case the alertmanager metrics are missing).\n  ((sum(service_integration:alerting_service_notifications_total:rate5m{service=~\"alerting\"}) or vector(0)\n) or vector(0))\n)\n",
+          "instant": false,
+          "legendFormat": "Alerting notifications",
+          "range": true
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "exemplar": false,
+          "expr": "sum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n/\nsum(rate(storage_operations_total{env!=\"\"}[$__rate_interval]))\n",
+          "instant": false,
+          "legendFormat": "Object storage",
+          "range": true
+        }
+      ],
+      "title": "Status",
+      "type": "state-timeline"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "alertInstanceLabelFilter": "env!=\"\"",
+        "alertName": "Metrics",
+        "dashboardAlerts": false,
+        "maxItems": 100,
+        "sortOrder": 3,
+        "stateFilter": {
+          "error": true,
+          "firing": true,
+          "noData": false,
+          "normal": false,
+          "pending": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Firing alerts",
+      "type": "alertlist"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 20,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Service cluster health",
+      "type": "row"
+    },
+    {
+      "content": "These panels show an overview on the write path. Requests rate and latency is measured on the gateway.\nTo examine the write path in detail, see a specific dashboard:\n\n- \u003ca target=\"_blank\" href=\"./d/8280707b8f16e7b87b840fc1cc92d4c5/service-writes?${__url_time_range}\u0026${__all_variables}\"\u003eWrites\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/bc9160e50b52e89e0e49c840fea3d379/service-writes-resources?${__url_time_range}\u0026${__all_variables}\"\u003eWrites resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/978c1cb452585c96697a238eaac7fe2d/service-writes-networking?${__url_time_range}\u0026${__all_variables}\"\u003eWrites networking\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}\u0026${__all_variables}\"\u003eOverview resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}\u0026${__all_variables}\"\u003eOverview networking\u003c/a\u003e\n",
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 9
+      },
+      "id": 4,
+      "mode": "markdown",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EF843C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OK"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cancel"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EF843C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Canceled"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OK"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cancel"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 9
+      },
+      "id": 5,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (status) (\n  label_replace(label_replace(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "{{status}}",
+          "refId": "A_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_write\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Write requests / sec (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 1,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 9
+      },
+      "id": 6,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.99, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "99th percentile",
+          "refId": "A_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.99, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "99th percentile",
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.50, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "50th percentile",
+          "refId": "B_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.50, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "50th percentile",
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(1e3 * sum(service_route:http_request_duration_seconds_sum:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"}) /\nsum(service_route:http_request_duration_seconds_count:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})\n) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "Average",
+          "refId": "C_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(1e3 * sum(histogram_sum(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"})) /\nsum(histogram_count(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_write\"}))\n) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "Average",
+          "refId": "C_native"
+        }
+      ],
+      "title": "Write latency (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 9
+      },
+      "id": 7,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(cluster_namespace_job:ingestion_service_received_samples:rate5m{job=~\"(.*)/(distributor.*|service|metrics)\"})",
+          "format": "time_series",
+          "legendFormat": "samples / sec",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(cluster_namespace_job:ingestion_service_received_exemplars:rate5m{job=~\"(.*)/(distributor.*|service|metrics)\"})",
+          "format": "time_series",
+          "legendFormat": "exemplars / sec",
+          "legendLink": null
+        }
+      ],
+      "title": "Ingestion / sec",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 21,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Writes",
+      "type": "row"
+    },
+    {
+      "content": "These panels show an overview on the read path. Requests rate and latency is measured on the gateway.\nTo examine the read path in detail, see a specific dashboard:\n\n- \u003ca target=\"_blank\" href=\"./d/e327503188913dc38ad571c647eef643/service-reads?${__url_time_range}\u0026${__all_variables}\"\u003eReads\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/cc86fd5aa9301c6528986572ad974db9/service-reads-resources?${__url_time_range}\u0026${__all_variables}\"\u003eReads resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/54b2a0a4748b3bd1aefa92ce5559a1c2/service-reads-networking?${__url_time_range}\u0026${__all_variables}\"\u003eReads networking\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}\u0026${__all_variables}\"\u003eOverview resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}\u0026${__all_variables}\"\u003eOverview networking\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/b3abe8d5c040395cc36615cb4334c92d/service-queries?${__url_time_range}\u0026${__all_variables}\"\u003eQueries\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/1b3443aea86db629e6efdb7d05c53823/service-compactor?${__url_time_range}\u0026${__all_variables}\"\u003eCompactor\u003c/a\u003e\n",
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 17
+      },
+      "id": 8,
+      "mode": "markdown",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EF843C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OK"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cancel"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "1xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EAB839",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "2xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "3xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#6ED0E0",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "4xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#EF843C",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "5xx"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Canceled"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OK"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cancel"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A9A9A9",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "error"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 17
+      },
+      "id": 9,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (status) (\n  label_replace(label_replace(rate(http_request_duration_seconds_count{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval]),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "{{status}}",
+          "refId": "A_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (status) (\n  label_replace(label_replace(histogram_count(rate(http_request_duration_seconds{service=~\"gateway\", route=~\"api_v1_query\"}[$__rate_interval])),\n  \"status\", \"${1}xx\", \"status_code\", \"([0-9])..\"),\n  \"status\", \"${1}\", \"status_code\", \"([a-zA-Z]+)\"))\n) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Read requests / sec (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 1,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 17
+      },
+      "id": 10,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.99, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "99th percentile",
+          "refId": "A_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.99, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "99th percentile",
+          "refId": "A_native"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.50, sum by (le) (service_route:http_request_duration_seconds_bucket:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "50th percentile",
+          "refId": "B_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(histogram_quantile(0.50, sum (service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) * 1e3) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "50th percentile",
+          "refId": "B_native"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(1e3 * sum(service_route:http_request_duration_seconds_sum:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"}) /\nsum(service_route:http_request_duration_seconds_count:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})\n) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "Average",
+          "refId": "C_classic"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(1e3 * sum(histogram_sum(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"})) /\nsum(histogram_count(service_route:http_request_duration_seconds:sum_rate{job=~\"(.*)((gateway|service-gw.*))\", route=~\"api_v1_query\"}))\n) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "Average",
+          "refId": "C_native"
+        }
+      ],
+      "title": "Read latency (gateway)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_query($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "instant queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#429D48",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_query_range($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "range queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#F1C731",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_labels($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "\"label names\" queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#2A66CF",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_label_name_values($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "\"label values\" queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#9E44C1",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_series($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "series queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#FFAB57",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_read($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "remote read queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C79424",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_metadata($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "metadata queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#84D586",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_query_exemplars($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "exemplar queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#A1C4FC",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_cardinality_active_series($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "\"active series\" queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#C788DE",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_cardinality_label_names($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "\"label name cardinality\" queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#3F6833",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": "/.*_api_v1_cardinality_label_values($|[^_])/"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "\"label value cardinality\" queries"
+              },
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#447EBC",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 17
+      },
+      "id": 11,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (route) (rate(http_request_duration_seconds_count{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum by (route) (histogram_count(rate(http_request_duration_seconds{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum (rate(http_request_duration_seconds_count{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval]))) and on() (vector($latency_metrics) == 1)",
+          "format": "time_series",
+          "legendFormat": "other",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "(sum (histogram_count(rate(http_request_duration_seconds{job=~\"(.*)/(query-frontend.*|service|metrics)\",route=~\"(prometheus|api_prom)_api_v1_.*\",route!~\"(prometheus|api_prom)(_api_v1_query|_api_v1_query_range|_api_v1_labels|_api_v1_label_name_values|_api_v1_series|_api_v1_read|_api_v1_metadata|_api_v1_query_exemplars|_api_v1_cardinality_active_series|_api_v1_cardinality_label_names|_api_v1_cardinality_label_values)\"}[$__rate_interval])))) and on() (vector($latency_metrics) == -1)",
+          "format": "time_series",
+          "legendFormat": "other",
+          "legendLink": null
+        }
+      ],
+      "title": "Queries / sec",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 16
+      },
+      "id": 22,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Reads",
+      "type": "row"
+    },
+    {
+      "content": "These panels show an overview on the recording and alerting rules evaluation.\nTo examine the rules evaluation and alerts notifications in detail, see a specific dashboard:\n\n- \u003ca target=\"_blank\" href=\"./d/631e15d5d85afb2ca8e35d62984eeaa0/service-ruler?${__url_time_range}\u0026${__all_variables}\"\u003eRuler\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/b0d38d318bbddd80476246d4930f9e55/service-alertmanager?${__url_time_range}\u0026${__all_variables}\"\u003eAlertmanager\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/a6883fb22799ac74479c7db872451092/service-alertmanager-resources?${__url_time_range}\u0026${__all_variables}\"\u003eAlertmanager resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/a9b92d3c4d1af325d872a9e9a7083d71/service-overview-resources?${__url_time_range}\u0026${__all_variables}\"\u003eOverview resources\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/e15c71d372cc541367a088f10d9fcd92/service-overview-networking?${__url_time_range}\u0026${__all_variables}\"\u003eOverview networking\u003c/a\u003e\n",
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 25
+      },
+      "id": 12,
+      "mode": "markdown",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 1,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "success"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 25
+      },
+      "id": 13,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(monitoring_rule_evaluations_total{service=~\"rule-engine\"}[$__rate_interval]))\n-\nsum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "success",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(monitoring_rule_evaluation_failures_total{service=~\"rule-engine\"}[$__rate_interval]))",
+          "format": "time_series",
+          "legendFormat": "failed",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(monitoring_rule_group_iterations_missed_total{service=~\"rule-engine\"}[$__rate_interval]))",
+          "format": "time_series",
+          "legendFormat": "missed",
+          "legendLink": null
+        }
+      ],
+      "title": "Rule evaluations / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 1,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 25
+      },
+      "id": 14,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum (rate(monitoring_rule_evaluation_duration_seconds_sum{service=~\"rule-engine\"}[$__rate_interval]))\n  /\nsum (rate(monitoring_rule_evaluation_duration_seconds_count{service=~\"rule-engine\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "average",
+          "legendLink": null
+        }
+      ],
+      "title": "Rule evaluations latency",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "successful"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 25
+      },
+      "id": 15,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(alert_notifications_sent_total{service=~\"rule-engine\"}[$__rate_interval]))\n  -\nsum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "successful",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(alert_notifications_errors_total{service=~\"rule-engine\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "failed",
+          "legendLink": null
+        }
+      ],
+      "title": "Alerting notifications sent to Alertmanager / sec",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 24
+      },
+      "id": 23,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Recording and alerting rules",
+      "type": "row"
+    },
+    {
+      "content": "These panels show an overview on the long-term storage (object storage).\nTo examine the storage in detail, see a specific dashboard:\n\n- \u003ca target=\"_blank\" href=\"./d/e1324ee2a434f4158c00a9ee279d3292/service-object-store?${__url_time_range}\u0026${__all_variables}\"\u003eObject store\u003c/a\u003e\n- \u003ca target=\"_blank\" href=\"./d/1b3443aea86db629e6efdb7d05c53823/service-compactor?${__url_time_range}\u0026${__all_variables}\"\u003eCompactor\u003c/a\u003e\n",
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "description": "",
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "mode": "markdown",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "",
+      "transparent": true,
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#E24D42",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "successful"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#7EB26D",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 6,
+        "y": 33
+      },
+      "id": 17,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(storage_operations_total{env!=\"\"}[$__rate_interval]))\n-\nsum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "successful",
+          "legendLink": null
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(rate(storage_operation_failures_total{env!=\"\"}[$__rate_interval]))\n",
+          "format": "time_series",
+          "legendFormat": "failed",
+          "legendLink": null
+        }
+      ],
+      "title": "Requests / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 100,
+            "lineWidth": 0,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 12,
+        "y": 33
+      },
+      "id": 18,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "seriesOverrides": [
+        {
+          "alias": "attributes",
+          "color": "#429D48"
+        },
+        {
+          "alias": "delete",
+          "color": "#F1C731"
+        },
+        {
+          "alias": "exists",
+          "color": "#2A66CF"
+        },
+        {
+          "alias": "get",
+          "color": "#9E44C1"
+        },
+        {
+          "alias": "get_range",
+          "color": "#FFAB57"
+        },
+        {
+          "alias": "iter",
+          "color": "#C79424"
+        },
+        {
+          "alias": "upload",
+          "color": "#84D586"
+        }
+      ],
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum by(operation) (rate(storage_operations_total{env!=\"\"}[$__rate_interval]))",
+          "format": "time_series",
+          "legendFormat": "{{operation}}",
+          "legendLink": null
+        }
+      ],
+      "title": "Operations / sec",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "$datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 1,
+            "lineWidth": 1,
+            "pointSize": 5,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": []
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 33
+      },
+      "id": 19,
+      "links": [],
+      "options": {
+        "legend": {
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "expr": "sum(max by(user) (max_over_time(storage_blocks_count{job=~\"(.*)/(compactor.*|service|metrics)\"}[15m])))",
+          "format": "time_series",
+          "legendFormat": "blocks",
+          "legendLink": null
+        }
+      ],
+      "title": "Total number of blocks in the storage",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 24,
+      "panels": [],
+      "repeat": "",
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Long-term storage (object storage)",
+      "type": "row"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 41,
+  "style": "dark",
+  "tags": [
+    "metrics",
+    "scoped",
+    "as-code"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "/(dev-prometheus|ops-prometheus|service-prometheus|critical-prometheus)/",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "classic",
+          "value": "1"
+        },
+        "description": "Choose between showing latencies based on low precision classic or high precision native histogram metrics.",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Latency metrics",
+        "multi": false,
+        "name": "latency_metrics",
+        "options": [
+          {
+            "selected": false,
+            "text": "native",
+            "value": "-1"
+          },
+          {
+            "selected": true,
+            "text": "classic",
+            "value": "1"
+          }
+        ],
+        "query": "native : -1,classic : 1",
+        "skipUrlSync": false,
+        "type": "custom"
+      },
+      {
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "filters": [],
+        "name": "filters",
+        "type": "adhoc"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "utc",
+  "title": "Service Overview Dashboard",
+  "uid": "e540f8b0ce5b02335ec443a769d1a74e",
+  "version": 0
+}


### PR DESCRIPTION
Fix V16 migration bug where rows with repeatIteration: null were incorrectly skipped

*Problem*

The V16 dashboard schema migration was incorrectly skipping rows with repeatIteration: null during migration from old row-based layout to new grid-based layout. This caused normal dashboard rows to be completely ignored, resulting in empty panels arrays after migration.

*Solution*

Fixed the condition to properly handle null values by changing from checking only key existence to checking both key existence and non-null value. This ensures rows with repeatIteration: null are processed as normal rows, matching the TypeScript implementation behavior.

*How to test*

Run the V16 migration tests: `go test -v -run ^TestV16 ./apps/dashboard/pkg/migration/schemaversion`. The new test case "should_handle_repeatIteration_null" should pass, verifying that rows with repeatIteration: null are properly processed and converted to grid layout.

Compare backend and frontend migration results: `yarn test app/features/dashboard/state/DashboardMigratorToBackend.test.ts`. This test should now pass, confirming that the backend migration produces the same output as the frontend migration.