### PR TITLE
CI: Run gofmt on Linting action

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -33,6 +33,27 @@ jobs:
         with:
           self: .github/workflows/go-lint.yml
 
+  go-fmt:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-go@v5.5.0
+        with:
+          go-version-file: ./go.mod
+      - name: Run gofmt
+        run: |
+          GOFMT="$(go list -m -f '{{.Dir}}' | xargs -I{} sh -c 'test ! -f {}/.nolint && echo {}' | xargs gofmt -s -e -l 2>&1 | grep -v '/pkg/build/' || true)"
+          if [ -n "$GOFMT" ]; then
+            echo "Found files that are not gofmt'ed"
+            echo "Run 'gofmt -s -w .' or 'make gofmt' or install the pre-commit hook with 'make lefthook-install'"
+            echo "${GOFMT}"
+            exit 1
+          fi
+
   lint-go:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'

--- a/Makefile
+++ b/Makefile
@@ -384,6 +384,10 @@ lint-go-diff:
 		sed 's,^,./,' | \
 		$(XARGSR) $(golangci-lint) run --config .golangci.yml
 
+.PHONY: gofmt
+gofmt: ## Run gofmt for all Go files.
+	gofmt -s -w .
+
 # with disabled SC1071 we are ignored some TCL,Expect `/usr/bin/env expect` scripts
 .PHONY: shellcheck
 shellcheck: $(SH_FILES) ## Run checks for shell scripts.

--- a/pkg/build/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/BindInjectorArg/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/BindInjectorArgPointer/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/BindInjectorArgPointer/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/BindInterfaceWithValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/BindInterfaceWithValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/bar/bar.go
+++ b/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/bar/bar.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build !wireinject
+//go:build !wireinject
+// +build !wireinject
 
 // Package bar includes both wireinject and non-wireinject variants.
 package bar

--- a/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/bar/bar_inject.go
+++ b/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/bar/bar_inject.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package bar
 

--- a/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/BuildTagsAllPackages/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/Chain/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Chain/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/Cleanup/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Cleanup/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/CopyOtherDecls/foo/foo.go
+++ b/pkg/build/wire/internal/wire/testdata/CopyOtherDecls/foo/foo.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 // All of the declarations are in one file.
 // Wire should copy non-injectors over, preserving imports.

--- a/pkg/build/wire/internal/wire/testdata/Cycle/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Cycle/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/DocComment/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/DocComment/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/EmptyVar/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/EmptyVar/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ExampleWithMocks/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ExampleWithMocks/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ExportedValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ExportedValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ExportedValueDifferentPackage/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ExportedValueDifferentPackage/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfCycle/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfCycle/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfImportedStruct/main/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfImportedStruct/main/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfStruct/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfStruct/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfStructDoNotProvidePtrToField/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfStructPointer/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfStructPointer/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FieldsOfValueStruct/main/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FieldsOfValueStruct/main/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/FuncArgProvider/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/FuncArgProvider/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/Header/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Header/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ImportedInterfaceBinding/bar/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ImportedInterfaceBinding/bar/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InjectInput/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InjectInput/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InjectInputConflict/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InjectInputConflict/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InjectWithPanic/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InjectWithPanic/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InjectorMissingCleanup/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InjectorMissingCleanup/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InjectorMissingError/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InjectorMissingError/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceBinding/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceBinding/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceBindingDoesntImplement/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceBindingDoesntImplement/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceBindingInvalidArg0/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceBindingInvalidArg0/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceBindingNotEnoughArgs/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceBindingNotEnoughArgs/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceBindingReuse/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceBindingReuse/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceValueDoesntImplement/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceValueDoesntImplement/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceValueInvalidArg0/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceValueInvalidArg0/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InterfaceValueNotEnoughArgs/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InterfaceValueNotEnoughArgs/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/InvalidInjector/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/InvalidInjector/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/MultipleArgsSameType/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/MultipleArgsSameType/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/MultipleBindings/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/MultipleBindings/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/MultipleMissingInputs/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/MultipleMissingInputs/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/MultipleSimilarPackages/main/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/MultipleSimilarPackages/main/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/NamingWorstCase/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/NamingWorstCase/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/NamingWorstCaseAllInOne/foo/foo.go
+++ b/pkg/build/wire/internal/wire/testdata/NamingWorstCaseAllInOne/foo/foo.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 // This file is specifically designed to cause issues with copying the
 // AST, particularly with the identifier "context".

--- a/pkg/build/wire/internal/wire/testdata/NiladicIdentity/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/NiladicIdentity/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/NiladicValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/NiladicValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/NoImplicitInterface/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/NoImplicitInterface/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/NoInjectParamNames/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/NoInjectParamNames/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/PartialCleanup/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/PartialCleanup/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/PkgImport/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/PkgImport/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ProviderSetBindingMissingConcreteType/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/RelativePkg/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/RelativePkg/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ReservedKeywords/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ReservedKeywords/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ReturnArgumentAsInterface/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ReturnArgumentAsInterface/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ReturnError/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ReturnError/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/Struct/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Struct/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/StructNotAStruct/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/StructNotAStruct/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/StructPointer/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/StructPointer/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/StructWithPreventTag/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/StructWithPreventTag/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/TwoDeps/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/TwoDeps/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/UnexportedStruct/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/UnexportedStruct/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/UnexportedValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/UnexportedValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/UnusedProviders/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/UnusedProviders/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ValueChain/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ValueChain/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ValueConversion/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ValueConversion/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ValueFromFunctionScope/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ValueFromFunctionScope/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ValueIsInterfaceValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ValueIsInterfaceValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/ValueIsStruct/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/ValueIsStruct/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/VarValue/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/VarValue/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/build/wire/internal/wire/testdata/Varargs/foo/wire.go
+++ b/pkg/build/wire/internal/wire/testdata/Varargs/foo/wire.go
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//+build wireinject
+//go:build wireinject
+// +build wireinject
 
 package main
 

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -382,7 +382,7 @@ func TestSearchGetOrCreateIndexWithIndexUpdate(t *testing.T) {
 		buildEmptyIndexCalls: []buildEmptyIndexCall{},
 
 		cache: map[NamespacedResource]ResourceIndex{
-			NamespacedResource{Namespace: "ns", Group: "group", Resource: "bad"}: &MockResourceIndex{
+			{Namespace: "ns", Group: "group", Resource: "bad"}: &MockResourceIndex{
 				updateIndexError: failedErr,
 			},
 		},

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -524,7 +524,7 @@ func runTestIntegrationBackendListModifiedSince(t *testing.T, backend resource.S
 		require.GreaterOrEqual(t, latestRv, rvDeleted)
 
 		counter := 0
-		for _, _ = range seq {
+		for range seq {
 			counter++
 		}
 		require.Equal(t, 0, counter) // no events should be returned


### PR DESCRIPTION
**What is this feature?**

Runs `gofmt` together with `golangci-lint` changes.

**Why do we need this feature?**

Keeps the code formatted properly and avoid drifts in other people's setups.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
