### PR TITLE
fix: enforce timeout for requests run in qos

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -28,15 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/util/scheduler"
 )
 
-const (
-	// DefaultMaxBackoff is the default maximum backoff duration for enqueue operations.
-	DefaultMaxBackoff = 1 * time.Second
-	// DefaultMinBackoff is the default minimum backoff duration for enqueue operations.
-	DefaultMinBackoff = 100 * time.Millisecond
-	// DefaultMaxRetries is the default maximum number of retries for enqueue operations.
-	DefaultMaxRetries = 3
-)
-
 // ResourceServer implements all gRPC services
 type ResourceServer interface {
 	resourcepb.ResourceStoreServer
@@ -162,6 +153,13 @@ type QOSEnqueuer interface {
 	Enqueue(ctx context.Context, tenantID string, runnable func()) error
 }
 
+type QueueConfig struct {
+	MaxBackoff time.Duration
+	MinBackoff time.Duration
+	MaxRetries int
+	Timeout    time.Duration
+}
+
 type BlobConfig struct {
 	// The CDK configuration URL
 	URL string
@@ -240,7 +238,8 @@ type ResourceServerOptions struct {
 	MaxPageSizeBytes int
 
 	// QOSQueue is the quality of service queue used to enqueue
-	QOSQueue QOSEnqueuer
+	QOSQueue  QOSEnqueuer
+	QOSConfig QueueConfig
 
 	Ring           *ring.Ring
 	RingLifecycler *ring.BasicLifecycler
@@ -279,6 +278,19 @@ func NewResourceServer(opts ResourceServerOptions) (*server, error) {
 
 	if opts.QOSQueue == nil {
 		opts.QOSQueue = scheduler.NewNoopQueue()
+	}
+
+	if opts.QOSConfig.Timeout == 0 {
+		opts.QOSConfig.Timeout = 30 * time.Second
+	}
+	if opts.QOSConfig.MaxBackoff == 0 {
+		opts.QOSConfig.MaxBackoff = 1 * time.Second
+	}
+	if opts.QOSConfig.MinBackoff == 0 {
+		opts.QOSConfig.MinBackoff = 100 * time.Millisecond
+	}
+	if opts.QOSConfig.MaxRetries == 0 {
+		opts.QOSConfig.MaxRetries = 3
 	}
 
 	// Initialize the blob storage
@@ -375,6 +387,7 @@ type server struct {
 	maxPageSizeBytes int
 	reg              prometheus.Registerer
 	queue            QOSEnqueuer
+	queueConfig      QueueConfig
 }
 
 // Init implements ResourceServer.
@@ -635,8 +648,8 @@ func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*re
 		res *resourcepb.CreateResponse
 		err error
 	)
-	runErr := s.runInQueue(ctx, req.Key.Namespace, func() {
-		res, err = s.create(ctx, user, req)
+	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
+		res, err = s.create(queueCtx, user, req)
 	})
 	if runErr != nil {
 		return HandleQueueError(runErr, func(e *resourcepb.ErrorResult) *resourcepb.CreateResponse {
@@ -689,8 +702,8 @@ func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*re
 		res *resourcepb.UpdateResponse
 		err error
 	)
-	runErr := s.runInQueue(ctx, req.Key.Namespace, func() {
-		res, err = s.update(ctx, user, req)
+	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
+		res, err = s.update(queueCtx, user, req)
 	})
 	if runErr != nil {
 		return HandleQueueError(runErr, func(e *resourcepb.ErrorResult) *resourcepb.UpdateResponse {
@@ -757,8 +770,8 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*re
 		err error
 	)
 
-	runErr := s.runInQueue(ctx, req.Key.Namespace, func() {
-		res, err = s.delete(ctx, user, req)
+	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
+		res, err = s.delete(queueCtx, user, req)
 	})
 	if runErr != nil {
 		return HandleQueueError(runErr, func(e *resourcepb.ErrorResult) *resourcepb.DeleteResponse {
@@ -868,8 +881,8 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 		res *resourcepb.ReadResponse
 		err error
 	)
-	runErr := s.runInQueue(ctx, req.Key.Namespace, func() {
-		res, err = s.read(ctx, user, req)
+	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
+		res, err = s.read(queueCtx, user, req)
 	})
 	if runErr != nil {
 		return HandleQueueError(runErr, func(e *resourcepb.ErrorResult) *resourcepb.ReadResponse {
@@ -1375,40 +1388,44 @@ func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (*
 	return rsp, nil
 }
 
-func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func()) error {
-	boff := backoff.New(ctx, backoff.Config{
-		MinBackoff: DefaultMinBackoff,
-		MaxBackoff: DefaultMaxBackoff,
-		MaxRetries: DefaultMaxRetries,
+func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func(ctx context.Context)) error {
+	// Enforce a timeout for the entire operation, including queueing and execution.
+	queueCtx, cancel := context.WithTimeout(ctx, s.queueConfig.Timeout)
+	defer cancel()
+
+	done := make(chan struct{})
+	wrappedRunnable := func() {
+		defer close(done)
+		runnable(queueCtx)
+	}
+
+	// Retry enqueueing with backoff, respecting the timeout context.
+	boff := backoff.New(queueCtx, backoff.Config{
+		MinBackoff: s.queueConfig.MinBackoff,
+		MaxBackoff: s.queueConfig.MaxBackoff,
+		MaxRetries: s.queueConfig.MaxRetries,
 	})
 
-	var (
-		wg  sync.WaitGroup
-		err error
-	)
-	wg.Add(1)
-	wrapped := func() {
-		defer wg.Done()
-		runnable()
-	}
-	for boff.Ongoing() {
-		err = s.queue.Enqueue(ctx, tenantID, wrapped)
+	for {
+		err := s.queue.Enqueue(queueCtx, tenantID, wrappedRunnable)
 		if err == nil {
+			// Successfully enqueued.
 			break
 		}
-		s.log.Warn("failed to enqueue runnable, retrying",
-			"maxRetries", DefaultMaxRetries,
-			"tenantID", tenantID,
-			"error", err)
+
+		s.log.Warn("failed to enqueue runnable, retrying", "tenantID", tenantID, "error", err)
+		if !boff.Ongoing() {
+			// Backoff finished (retries exhausted or context canceled).
+			return fmt.Errorf("failed to enqueue runnable for tenant %s after %d retries: %w", tenantID, s.queueConfig.MaxRetries, err)
+		}
 		boff.Wait()
 	}
-	if err != nil {
-		s.log.Error("failed to enqueue runnable",
-			"maxRetries", DefaultMaxRetries,
-			"tenantID", tenantID,
-			"error", err)
-		return fmt.Errorf("failed to enqueue runnable for tenant %s: %w", tenantID, err)
+
+	// Wait for the runnable to complete or for the context to be done.
+	select {
+	case <-done:
+		return nil // Completed successfully.
+	case <-queueCtx.Done():
+		return queueCtx.Err() // Timed out or canceled while waiting for execution.
 	}
-	wg.Wait()
-	return nil
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -338,6 +338,7 @@ func NewResourceServer(opts ResourceServerOptions) (*server, error) {
 		maxPageSizeBytes: opts.MaxPageSizeBytes,
 		reg:              opts.Reg,
 		queue:            opts.QOSQueue,
+		queueConfig:      opts.QOSConfig,
 	}
 
 	if opts.Search.Resources != nil {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1416,7 +1416,7 @@ func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func(
 		s.log.Warn("failed to enqueue runnable, retrying", "tenantID", tenantID, "error", err)
 		if !boff.Ongoing() {
 			// Backoff finished (retries exhausted or context canceled).
-			return fmt.Errorf("failed to enqueue runnable for tenant %s after %d retries: %w", tenantID, s.queueConfig.MaxRetries, err)
+			return fmt.Errorf("failed to enqueue for tenant %s: %w", tenantID, err)
 		}
 		boff.Wait()
 	}

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -289,6 +289,9 @@ func TestRunInQueue(t *testing.T) {
 		}
 		err := q.Enqueue(context.Background(), testTenantID, blockingRunnable)
 		require.NoError(t, err)
+		for q.Len() > 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
 		err = q.Enqueue(context.Background(), testTenantID, blockingRunnable)
 		require.NoError(t, err)
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -323,7 +323,8 @@ func newTestServerWithQueue(t *testing.T, maxSizePerTenant int, numWorkers int) 
 	err := services.StartAndAwaitRunning(context.Background(), q)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		services.StopAndAwaitTerminated(context.Background(), q)
+		err := services.StopAndAwaitTerminated(context.Background(), q)
+		require.NoError(t, err)
 	})
 
 	// Create a worker to consume from the queue
@@ -335,7 +336,8 @@ func newTestServerWithQueue(t *testing.T, maxSizePerTenant int, numWorkers int) 
 	err = services.StartAndAwaitRunning(context.Background(), worker)
 	require.NoError(t, err)
 	t.Cleanup(func() {
-		services.StopAndAwaitTerminated(context.Background(), worker)
+		err := services.StopAndAwaitTerminated(context.Background(), worker)
+		require.NoError(t, err)
 	})
 
 	s := &server{


### PR DESCRIPTION
In this PR, we are enforcing a timeout for the requests that are sent to qos.

Previously, qos was not relying on a context timeout (except a client enforced one). We are now passing a context `queueCtx` into the `Enqueue` operation so that we can enforce a hardcoded (for now) timeout to the incoming requests.

**Note:** We can even inject the queue configuration values (timeout, max retries, backoff, etc.) through the `unified_storage` section in config.ini. I did not include it in this PR, but could be leveraged in case it is deemed necessary.

Ticket: https://github.com/grafana/search-and-storage-team/issues/449