### PR TITLE
Alerting: Fix alert rule comparison with the same missing_evals_to_resolve

### DIFF
--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -92,7 +92,11 @@ func (a alertRuleVersion) EqualSpec(b alertRuleVersion) bool {
 		a.IsPaused == b.IsPaused &&
 		a.NotificationSettings == b.NotificationSettings &&
 		a.Metadata == b.Metadata &&
-		a.MissingSeriesEvalsToResolve == b.MissingSeriesEvalsToResolve
+		compareInt64Pointer(a.MissingSeriesEvalsToResolve, b.MissingSeriesEvalsToResolve)
+}
+
+func compareInt64Pointer(a, b *int64) bool {
+	return (a == nil && b == nil) || (a != nil && b != nil && *a == *b)
 }
 
 func (a alertRuleVersion) TableName() string {

--- a/pkg/services/ngalert/store/models_test.go
+++ b/pkg/services/ngalert/store/models_test.go
@@ -72,6 +72,30 @@ func TestAlertRuleVersion_EqualSpec(t *testing.T) {
 			expect: true,
 		},
 		{
+			name: "same MissingSeriesEvalsToResolve value, different pointers",
+			a: func() alertRuleVersion {
+				v := baseVersion
+				v.MissingSeriesEvalsToResolve = util.Pointer(int64(10))
+				return v
+			}(),
+			b: func() alertRuleVersion {
+				v := baseVersion
+				v.MissingSeriesEvalsToResolve = util.Pointer(int64(10))
+				return v
+			}(),
+			expect: true,
+		},
+		{
+			name: "different MissingSeriesEvalsToResolve",
+			a: func() alertRuleVersion {
+				v := baseVersion
+				v.MissingSeriesEvalsToResolve = util.Pointer(int64(123))
+				return v
+			}(),
+			b:      baseVersion,
+			expect: false,
+		},
+		{
 			name:   "different NotificationSettings",
 			a:      baseVersion,
 			b:      func() alertRuleVersion { v := baseVersion; v.NotificationSettings = "notify2"; return v }(),


### PR DESCRIPTION
Fixing a bug in alert rule comparison when the same alert rules with the same `missing_evals_to_resolve` were considered different.

When re-uploading identical Prometheus rules via the Prometheus conversion API, the API was creating unnecessary version increments due to pointer comparison bug in EqualSpec.