### PR TITLE
Azure: Resource picker tests

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/azure_resource_graph/azure_resource_graph_datasource.test.ts
@@ -12,7 +12,7 @@ import { AzureQueryType } from '../types/query';
 import AzureResourceGraphDatasource from './azure_resource_graph_datasource';
 
 let getTempVars = () => [] as CustomVariableModel[];
-let replace = () => '';
+let replace = (value?: string) => value || '';
 
 jest.mock('@grafana/runtime', () => {
   return {
@@ -317,6 +317,256 @@ describe('AzureResourceGraphDatasource', () => {
       expect(query).toContain('"sub1","sub2"');
       expect(query).toContain('"microsoft.compute/virtualmachines"');
       expect(query).toContain('"eastus"');
+    });
+  });
+
+  describe('getResourceGroups', () => {
+    let datasource: AzureResourceGraphDatasource;
+    let pagedResourceGraphRequest: jest.SpyInstance;
+
+    beforeEach(() => {
+      const instanceSettings = createMockInstanceSetttings();
+      datasource = new AzureResourceGraphDatasource(instanceSettings);
+      pagedResourceGraphRequest = jest.spyOn(datasource, 'pagedResourceGraphRequest');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return resource groups without filters', async () => {
+      const mockResourceGroups = [
+        {
+          resourceGroup: 'rg1',
+          resourceGroupName: 'Resource Group 1',
+          resourceGroupURI: '/subscriptions/1/resourceGroups/rg1',
+          count: 2,
+        },
+        {
+          resourceGroup: 'rg2',
+          resourceGroupName: 'Resource Group 2',
+          resourceGroupURI: '/subscriptions/1/resourceGroups/rg2',
+          count: 1,
+        },
+      ];
+      pagedResourceGraphRequest.mockResolvedValue(mockResourceGroups);
+      const result = await datasource.getResourceGroups('1');
+      expect(result).toEqual(mockResourceGroups);
+      expect(pagedResourceGraphRequest).toHaveBeenCalledWith(expect.not.stringContaining('| where type in'));
+      expect(pagedResourceGraphRequest).toHaveBeenCalledWith(expect.not.stringContaining('| where location in'));
+    });
+
+    it('should generate correct query structure', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1');
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).toContain('resources');
+      expect(query).toContain("| where subscriptionId == '1'");
+      expect(query).toContain(
+        '| extend resourceGroupURI = strcat(\"/subscriptions/\", subscriptionId, \"/resourcegroups/\", resourceGroup)'
+      );
+      expect(query).toContain('join kind=leftouter');
+      expect(query).toContain('resourcecontainers');
+      expect(query).toContain("| where type =~ 'microsoft.resources/subscriptions/resourcegroups'");
+      expect(query).toContain(
+        '| project resourceGroupName=iff(resourceGroupName != \"\", resourceGroupName, resourceGroup), resourceGroupURI'
+      );
+      expect(query).toContain('summarize count=count() by resourceGroupName, resourceGroupURI');
+      expect(query).toContain('| order by tolower(resourceGroupName) asc');
+    });
+
+    it('should apply filters when provided', async () => {
+      const filters = {
+        subscriptions: [],
+        types: ['microsoft.compute/virtualmachines', 'microsoft.storage/storageaccounts'],
+        locations: ['eastus', 'westus'],
+      };
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1', undefined, filters);
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).toContain(
+        '| where type in ("microsoft.compute/virtualmachines","microsoft.storage/storageaccounts")'
+      );
+      expect(query).toContain('| where location in ("eastus","westus")');
+    });
+
+    it('should apply partial filters', async () => {
+      const filters = {
+        subscriptions: [],
+        types: [],
+        locations: ['eastus'],
+      };
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1', undefined, filters);
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).not.toContain('| where type in');
+      expect(query).toContain('| where location in ("eastus")');
+    });
+
+    it('should handle empty filters gracefully', async () => {
+      const filters = {
+        subscriptions: [],
+        types: [],
+        locations: [],
+      };
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1', undefined, filters);
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).not.toContain('| where type in');
+      expect(query).not.toContain('| where location in');
+    });
+
+    it('should return empty array when no resource groups found', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const result = await datasource.getResourceGroups('1');
+      expect(result).toEqual([]);
+    });
+
+    it('should lowercase filter values', async () => {
+      const filters = {
+        subscriptions: [],
+        types: ['Microsoft.Compute/VirtualMachines'],
+        locations: ['EastUS'],
+      };
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1', undefined, filters);
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).toContain('"microsoft.compute/virtualmachines"');
+      expect(query).toContain('"eastus"');
+    });
+
+    it('will ignore subscription filters', async () => {
+      const filters = {
+        subscriptions: ['1234'],
+        types: [],
+        locations: [],
+      };
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      await datasource.getResourceGroups('1', undefined, filters);
+      const query = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(query).not.toContain('| where subscriptionId in (1234)');
+      expect(query).toContain("| where subscriptionId == '1'");
+    });
+  });
+
+  describe('getResourceNames', () => {
+    let datasource: AzureResourceGraphDatasource;
+    let pagedResourceGraphRequest: jest.SpyInstance;
+
+    beforeEach(() => {
+      const instanceSettings = createMockInstanceSetttings();
+      datasource = new AzureResourceGraphDatasource(instanceSettings);
+      pagedResourceGraphRequest = jest.spyOn(datasource, 'pagedResourceGraphRequest');
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should return resource names without filters', async () => {
+      const mockResources = [
+        {
+          id: '/subscriptions/1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1',
+          name: 'vm1',
+          type: 'microsoft.compute/virtualmachines',
+          location: 'eastus',
+        },
+        {
+          id: '/subscriptions/1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2',
+          name: 'vm2',
+          type: 'microsoft.compute/virtualmachines',
+          location: 'westus',
+        },
+      ];
+      pagedResourceGraphRequest.mockResolvedValue(mockResources);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+      };
+      const result = await datasource.getResourceNames(query);
+      expect(result).toEqual(mockResources);
+      expect(pagedResourceGraphRequest).toHaveBeenCalledWith(expect.stringContaining('resources'));
+    });
+
+    it('should generate correct query structure', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+      };
+
+      await datasource.getResourceNames(query);
+      const builtQuery = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(builtQuery).toContain('resources');
+      expect(builtQuery).toContain('| where id hasprefix "/subscriptions/1/resourceGroups/rg1/"');
+      expect(builtQuery).toContain('| order by tolower(name) asc');
+    });
+
+    it('should apply metric namespace and region filters based on query parameters', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+        metricNamespace: 'Microsoft.Compute/virtualMachines',
+        region: 'eastus',
+      };
+      await datasource.getResourceNames(query);
+      const builtQuery = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(builtQuery).toContain("type == 'microsoft.compute/virtualmachines'");
+      expect(builtQuery).toContain("location == 'eastus'");
+    });
+
+    it('should apply resourceFilters if provided', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+      };
+      const resourceFilters = {
+        subscriptions: [],
+        types: ['microsoft.storage/storageaccounts'],
+        locations: ['westeurope'],
+      };
+      await datasource.getResourceNames(query, undefined, resourceFilters);
+      const builtQuery = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(builtQuery).toContain('| where type in ("microsoft.storage/storageaccounts")');
+      expect(builtQuery).toContain('| where location in ("westeurope")');
+    });
+
+    it('should handle empty resourceFilters gracefully', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+      };
+      const resourceFilters = { subscriptions: [], types: [], locations: [] };
+      await datasource.getResourceNames(query, undefined, resourceFilters);
+      const builtQuery = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(builtQuery).not.toContain('| where type in');
+      expect(builtQuery).not.toContain('| where location in');
+    });
+
+    it('should return empty array when no resources found', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+      };
+      const result = await datasource.getResourceNames(query);
+      expect(result).toEqual([]);
+    });
+
+    it('should lowercase metricNamespace', async () => {
+      pagedResourceGraphRequest.mockResolvedValue([]);
+      const query = {
+        subscriptionId: '1',
+        resourceGroup: 'rg1',
+        metricNamespace: 'Microsoft.Compute/VirtualMachines',
+        region: 'EastUS',
+      };
+      await datasource.getResourceNames(query);
+      const builtQuery = pagedResourceGraphRequest.mock.calls[0][0];
+      expect(builtQuery).toContain("type == 'microsoft.compute/virtualmachines'");
     });
   });
 });

--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.test.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.test.tsx
@@ -474,9 +474,9 @@ describe('AzureMonitor ResourcePicker', () => {
     // Combobox tests seem to be quite finnicky when it comes to selecting options
     // I've had to add multiple {ArrowDown} key-presses as sometimes the expected option isn't
     // at the top of the list
-    it('should call fetchFiltered when subscription filter changes', async () => {
+    it('should call fetchInitialRows when subscription filter changes', async () => {
       const user = userEvent.setup();
-      const mockFetchFiltered = jest.spyOn(resourcePickerData, 'fetchFiltered');
+      const mockFetchInitialRows = jest.spyOn(resourcePickerData, 'fetchInitialRows');
 
       await act(async () => render(<ResourcePicker {...defaultProps} />));
 
@@ -489,8 +489,9 @@ describe('AzureMonitor ResourcePicker', () => {
       });
 
       await waitFor(() => {
-        expect(mockFetchFiltered).toHaveBeenCalledWith(
+        expect(mockFetchInitialRows).toHaveBeenCalledWith(
           'logs',
+          undefined,
           expect.objectContaining({
             subscriptions: ['def-456'],
             types: [],
@@ -500,9 +501,9 @@ describe('AzureMonitor ResourcePicker', () => {
       });
     });
 
-    it('should call fetchFiltered when location filter changes', async () => {
+    it('should call fetchInitialRows when location filter changes', async () => {
       const user = userEvent.setup();
-      const mockFetchFiltered = jest.spyOn(resourcePickerData, 'fetchFiltered');
+      const mockFetchInitialRows = jest.spyOn(resourcePickerData, 'fetchInitialRows');
 
       await act(async () => render(<ResourcePicker {...defaultProps} />));
 
@@ -515,8 +516,9 @@ describe('AzureMonitor ResourcePicker', () => {
       await user.type(locationFilter, 'North Europe{ArrowDown}{Enter}');
 
       await waitFor(() => {
-        expect(mockFetchFiltered).toHaveBeenCalledWith(
+        expect(mockFetchInitialRows).toHaveBeenCalledWith(
           'logs',
+          undefined,
           expect.objectContaining({
             subscriptions: [],
             types: [],
@@ -526,9 +528,9 @@ describe('AzureMonitor ResourcePicker', () => {
       });
     });
 
-    it('should call fetchFiltered when resource type filter changes for metrics', async () => {
+    it('should call fetchInitialRows when resource type filter changes for metrics', async () => {
       const user = userEvent.setup();
-      const mockFetchFiltered = jest.spyOn(resourcePickerData, 'fetchFiltered');
+      const mockFetchInitialRows = jest.spyOn(resourcePickerData, 'fetchInitialRows');
 
       await act(async () => render(<ResourcePicker {...defaultProps} queryType="metrics" />));
 
@@ -539,8 +541,9 @@ describe('AzureMonitor ResourcePicker', () => {
 
       await user.type(typeFilter, 'Kubernetes services {ArrowDown}{Enter}');
       await waitFor(() => {
-        expect(mockFetchFiltered).toHaveBeenCalledWith(
+        expect(mockFetchInitialRows).toHaveBeenCalledWith(
           'metrics',
+          undefined,
           expect.objectContaining({
             subscriptions: [],
             types: ['microsoft.containerservice/managedclusters'],

--- a/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ResourcePicker/ResourcePicker.tsx
@@ -260,7 +260,7 @@ const ResourcePicker = ({
     async (filters: ResourceGraphFilters) => {
       try {
         setIsLoading(true);
-        const filteredRows = await resourcePickerData.fetchFiltered(queryType, filters);
+        const filteredRows = await resourcePickerData.fetchInitialRows(queryType, undefined, filters);
         setRows(filteredRows);
       } catch (error) {
         setErrorMessage(messageFromError(error));

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -172,6 +172,52 @@ describe('AzureMonitor resourcePickerData', () => {
         }
       }
     });
+
+    it('applies subscription filters in the query', async () => {
+      const mockResponse = createMockARGSubscriptionResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: ['sub1', 'sub2'], types: [], locations: [] };
+      await resourcePickerData.getSubscriptions(filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where subscriptionId in ("sub1","sub2")');
+    });
+
+    it('applies type filters in the query', async () => {
+      const mockResponse = createMockARGSubscriptionResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: ['microsoft.compute/virtualmachines'], locations: [] };
+      await resourcePickerData.getSubscriptions(filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where type in ("microsoft.compute/virtualmachines")');
+    });
+
+    it('applies location filters in the query', async () => {
+      const mockResponse = createMockARGSubscriptionResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: [], locations: ['eastus', 'westeurope'] };
+      await resourcePickerData.getSubscriptions(filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where location in ("eastus","westeurope")');
+    });
+
+    it('applies all filters together in the query', async () => {
+      const mockResponse = createMockARGSubscriptionResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = {
+        subscriptions: ['sub1'],
+        types: ['microsoft.compute/virtualmachines'],
+        locations: ['eastus'],
+      };
+      await resourcePickerData.getSubscriptions(filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where subscriptionId in ("sub1")');
+      expect(postBody.query).toContain('| where type in ("microsoft.compute/virtualmachines")');
+      expect(postBody.query).toContain('| where location in ("eastus")');
+    });
   });
 
   describe('getResourceGroupsBySubscriptionId', () => {
@@ -188,6 +234,36 @@ describe('AzureMonitor resourcePickerData', () => {
         'extend resourceGroupURI = strcat("/subscriptions/", subscriptionId, "/resourcegroups/", resourceGroup)'
       );
       expect(postBody.query).toContain("where subscriptionId == '123'");
+    });
+
+    it('does not apply subscription filters in the query - only the supplied subscription is used', async () => {
+      const mockResponse = createMockARGResourceGroupsResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: ['sub1', 'sub2'], types: [], locations: [] };
+      await resourcePickerData.getResourceGroupsBySubscriptionId('123', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where subscriptionId in ("123")');
+    });
+
+    it('applies type filters in the query', async () => {
+      const mockResponse = createMockARGResourceGroupsResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: ['microsoft.compute/virtualmachines'], locations: [] };
+      await resourcePickerData.getResourceGroupsBySubscriptionId('123', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where type in ("microsoft.compute/virtualmachines")');
+    });
+
+    it('applies location filters in the query', async () => {
+      const mockResponse = createMockARGResourceGroupsResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: [], locations: ['eastus', 'westeurope'] };
+      await resourcePickerData.getResourceGroupsBySubscriptionId('123', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where location in ("eastus","westeurope")');
     });
 
     it('returns formatted resourceGroups', async () => {
@@ -295,6 +371,36 @@ describe('AzureMonitor resourcePickerData', () => {
       expect(postBody.query).toContain('where id hasprefix "/subscription/sub1/resourceGroups/dev/"');
     });
 
+    it('applies subscription filters in the query', async () => {
+      const mockResponse = createARGResourcesResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: ['sub1', 'sub2'], types: [], locations: [] };
+      await resourcePickerData.getResourcesForResourceGroup('/subscription/sub1/resourceGroups/dev', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where subscriptionId in ("sub1","sub2")');
+    });
+
+    it('applies type filters in the query', async () => {
+      const mockResponse = createARGResourcesResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: ['microsoft.compute/virtualmachines'], locations: [] };
+      await resourcePickerData.getResourcesForResourceGroup('/subscription/sub1/resourceGroups/dev', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where type in ("microsoft.compute/virtualmachines")');
+    });
+
+    it('applies location filters in the query', async () => {
+      const mockResponse = createARGResourcesResponse();
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: [], locations: ['eastus', 'westeurope'] };
+      await resourcePickerData.getResourcesForResourceGroup('/subscription/sub1/resourceGroups/dev', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where location in ("eastus","westeurope")');
+    });
+
     it('returns formatted resources', async () => {
       const mockResponse = createARGResourcesResponse();
       const { resourcePickerData } = createResourcePickerData([mockResponse]);
@@ -387,6 +493,69 @@ describe('AzureMonitor resourcePickerData', () => {
         typeLabel: 'Virtual machines',
         uri: '/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Compute/virtualMachines/vmname',
       });
+    });
+
+    it('applies subscription filters in the query', async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName',
+            name: 'rgName',
+            type: 'microsoft.resources/subscriptions/resourcegroups',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'northeurope',
+          },
+        ],
+      };
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: ['sub1', 'sub2'], types: [], locations: [] };
+      await resourcePickerData.search('rgName', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where subscriptionId in ("sub1","sub2")');
+    });
+
+    it('applies type filters in the query', async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName',
+            name: 'rgName',
+            type: 'microsoft.resources/subscriptions/resourcegroups',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'northeurope',
+          },
+        ],
+      };
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: ['microsoft.compute/virtualmachines'], locations: [] };
+      await resourcePickerData.search('rgName', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where type in ("microsoft.compute/virtualmachines")');
+    });
+
+    it('applies location filters in the query', async () => {
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName',
+            name: 'rgName',
+            type: 'microsoft.resources/subscriptions/resourcegroups',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'northeurope',
+          },
+        ],
+      };
+      const { resourcePickerData, postResource } = createResourcePickerData([mockResponse]);
+      const filters = { subscriptions: [], types: [], locations: ['eastus', 'westeurope'] };
+      await resourcePickerData.search('rgName', 'logs', filters);
+      const firstCall = postResource.mock.calls[0];
+      const postBody = firstCall[1];
+      expect(postBody.query).toContain('| where location in ("eastus","westeurope")');
     });
     it('metrics searches - fallback namespaces', async () => {
       const mockSubscriptionsResponse = createMockARGSubscriptionResponse();
@@ -536,6 +705,47 @@ describe('AzureMonitor resourcePickerData', () => {
       expect(resourcePickerData.getResourceGroupsBySubscriptionId).toBeCalledTimes(1);
       // getResourcesForResourceGroup should only be called once because the resource group
       // of both resources is the same
+      expect(resourcePickerData.getResourcesForResourceGroup).toBeCalledTimes(1);
+    });
+
+    it('fetches filtered resource groups and resources', async () => {
+      const { resourcePickerData } = createResourcePickerData([createMockARGSubscriptionResponse()]);
+      resourcePickerData.getResourceGroupsBySubscriptionId = jest
+        .fn()
+        .mockResolvedValue([{ id: 'rg1', uri: '/subscriptions/1/resourceGroups/rg1' }]);
+      resourcePickerData.getResourcesForResourceGroup = jest.fn().mockResolvedValue([
+        { id: 'vm1', uri: '/subscriptions/1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm1' },
+        { id: 'vm2', uri: '/subscriptions/1/resourceGroups/rg1/providers/Microsoft.Compute/virtualMachines/vm2' },
+      ]);
+      const filters = { subscriptions: ['1'], types: [], locations: [] };
+      const rows = await resourcePickerData.fetchInitialRows(
+        'logs',
+        [
+          {
+            subscription: '1',
+            resourceGroup: 'rg1',
+            resourceName: 'vm1',
+            metricNamespace: 'Microsoft.Compute/virtualMachines',
+          },
+          {
+            subscription: '1',
+            resourceGroup: 'rg1',
+            resourceName: 'vm2',
+            metricNamespace: 'Microsoft.Compute/virtualMachines',
+          },
+        ],
+        filters
+      );
+      expect(rows[0]).toMatchObject({
+        id: '1',
+        children: [
+          {
+            id: 'rg1',
+            children: [{ id: 'vm1' }, { id: 'vm2' }],
+          },
+        ],
+      });
+      expect(resourcePickerData.getResourceGroupsBySubscriptionId).toBeCalledTimes(1);
       expect(resourcePickerData.getResourcesForResourceGroup).toBeCalledTimes(1);
     });
   });


### PR DESCRIPTION
Minor refactor as I originally had a separate function `fetchFiltered` but this is unnecessary.

Added tests for all methods added to the Resource Graph data source (`getResourceGroups`, and `getResourceNames`).

Also added complete tests for all methods on the `ResourcePickerData` class that makes use of filters.