### PR TITLE
Unified Storage: Removes check for name ordering and adds test

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -709,13 +709,6 @@ func (b *backend) ListModifiedSince(ctx context.Context, key resource.Namespaced
 				continue
 			}
 
-			if mr.Key.Name <= lastSeen {
-				// resource names should be sorted alphabetically. So if not, the query is not correct.
-				if !yield(nil, fmt.Errorf("listModifiedSince: resources are not sorted by name ASC, lastSeen: %q, current: %q", lastSeen, mr.Key.Name)) {
-					return
-				}
-			}
-
 			lastSeen = mr.Key.Name
 
 			if !yield(mr, nil) {

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/uuid"
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -552,6 +553,39 @@ func runTestIntegrationBackendListModifiedSince(t *testing.T, backend resource.S
 			counter++
 		}
 		require.Equal(t, 1, counter) // only one event should be returned
+	})
+
+	t.Run("will order events by resource version ascending and name descending", func(t *testing.T) {
+		// When we order by name ASC, sqlite orders upper case strings first - so skipping for sqlite
+		// For example: for this test, the actual ordering of events for sqlite is CItem, aItem, bItem
+		if db.IsTestDbSQLite() {
+			t.Skip("Skipping test for sqlite since ordering by name is different than mysql due to case sensitivity")
+		}
+
+		key := resource.NamespacedResource{
+			Namespace: ns,
+			Group:     "group",
+			Resource:  "resource",
+		}
+
+		rvCreated1, _ := writeEvent(ctx, backend, "aItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+		rvCreated2, _ := writeEvent(ctx, backend, "bItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+		rvCreated3, _ := writeEvent(ctx, backend, "CItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+
+		latestRv, seq := backend.ListModifiedSince(ctx, key, rvCreated1-1)
+		require.Greater(t, latestRv, rvCreated3)
+
+		counter := 0
+		names := []string{"aItem", "bItem", "CItem"}
+		rvs := []int64{rvCreated1, rvCreated2, rvCreated3}
+		for res, err := range seq {
+			require.NoError(t, err)
+			require.Equal(t, key.Namespace, res.Key.Namespace)
+			require.Equal(t, names[counter], res.Key.Name)
+			require.Equal(t, rvs[counter], res.ResourceVersion)
+			counter++
+		}
+		require.Equal(t, 3, counter)
 	})
 }
 


### PR DESCRIPTION
I had to skip the test for sqlite as it orders events differently. For example if I create 3 events `a, b, C` and order by `ASC`, mysql will sort them `a, b, C` but sqlite will sort them `C, a, b`. 