### PR TITLE
unified-storage: reuse index if RV is set even if it is outdated

### DIFF
--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -244,7 +244,7 @@ func (s *server) BulkProcess(stream resourcepb.BulkStore_BulkProcessServer) erro
 				Namespace: summary.Namespace,
 				Group:     summary.Group,
 				Resource:  summary.Resource,
-			}, summary.Count, summary.ResourceVersion, "rebuildAfterBatchLoad")
+			}, summary.Count, summary.ResourceVersion, "rebuildAfterBatchLoad", true)
 			if err != nil {
 				s.log.Warn("error building search index after batch load", "err", err)
 				rsp.Error = &resourcepb.ErrorResult{

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -147,7 +147,7 @@ func (m *mockSearchBackend) GetIndex(ctx context.Context, key NamespacedResource
 	return m.cache[key], nil
 }
 
-func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, resourceVersion int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn) (ResourceIndex, error) {
+func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, resourceVersion int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, searchAfterWrite bool) (ResourceIndex, error) {
 	index := &MockResourceIndex{}
 	index.On("BulkIndex", mock.Anything).Return(nil).Maybe()
 	index.On("DocCount", mock.Anything, mock.Anything).Return(int64(0), nil).Maybe()
@@ -538,7 +538,7 @@ func (m *slowSearchBackendWithCache) GetIndex(ctx context.Context, key Namespace
 	return m.cache[key], nil
 }
 
-func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, resourceVersion int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn) (ResourceIndex, error) {
+func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, resourceVersion int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, searchAfterWrite bool) (ResourceIndex, error) {
 	m.wg.Add(1)
 	defer m.wg.Done()
 
@@ -548,7 +548,7 @@ func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key Namespa
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	idx, err := m.mockSearchBackend.BuildIndex(ctx, key, size, resourceVersion, fields, reason, builder, updater)
+	idx, err := m.mockSearchBackend.BuildIndex(ctx, key, size, resourceVersion, fields, reason, builder, updater, rebuild, searchAfterWrite)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -551,7 +551,7 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, batchSize
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, rv, info.Fields, "test", writer, nil)
+	}, size, rv, info.Fields, "test", writer, nil, false, false)
 	require.NoError(t, err)
 
 	return index

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -763,9 +763,9 @@ func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, 
 	metrics := resource.ProvideIndexMetrics(reg)
 
 	backend, err := NewBleveBackend(BleveOptions{
-		Root:          dir,
-		FileThreshold: int64(fileThreshold),
-		IndexCacheTTL: cacheTTL,
+		Root:             dir,
+		FileThreshold:    int64(fileThreshold),
+		IndexCacheTTL:    cacheTTL,
 		SearchAfterWrite: searchAfterWrite,
 	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(), metrics)
 	require.NoError(t, err)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -190,7 +190,7 @@ func TestBleveBackend(t *testing.T) {
 				return 0, err
 			}
 			return rv, nil
-		}, nil)
+		}, nil, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 		dashboardsIndex = index
@@ -419,7 +419,7 @@ func TestBleveBackend(t *testing.T) {
 				return 0, err
 			}
 			return rv, nil
-		}, nil)
+		}, nil, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 		foldersIndex = index
@@ -755,7 +755,7 @@ func Test_isPathWithinRoot(t *testing.T) {
 	}
 }
 
-func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, dir string, searchAfterWrite bool) (*bleveBackend, prometheus.Gatherer) {
+func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, dir string) (*bleveBackend, prometheus.Gatherer) {
 	if dir == "" {
 		dir = t.TempDir()
 	}
@@ -766,7 +766,6 @@ func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, 
 		Root:             dir,
 		FileThreshold:    int64(fileThreshold),
 		IndexCacheTTL:    cacheTTL,
-		SearchAfterWrite: searchAfterWrite,
 	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(), metrics)
 	require.NoError(t, err)
 	require.NotNil(t, backend)
@@ -775,7 +774,7 @@ func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, 
 }
 
 func TestBleveInMemoryIndexExpiration(t *testing.T) {
-	backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "", false)
+	backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "")
 
 	ns := resource.NamespacedResource{
 		Namespace: "test",
@@ -783,7 +782,7 @@ func TestBleveInMemoryIndexExpiration(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	builtIndex, err := backend.BuildIndex(context.Background(), ns, 1 /* below FileThreshold */, 100, nil, "test", indexTestDocs(ns, 1, 100), nil)
+	builtIndex, err := backend.BuildIndex(context.Background(), ns, 1 /* below FileThreshold */, 100, nil, "test", indexTestDocs(ns, 1, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Wait for index expiration, which is 1ns
@@ -806,7 +805,7 @@ func TestBleveInMemoryIndexExpiration(t *testing.T) {
 }
 
 func TestBleveFileIndexExpiration(t *testing.T) {
-	backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "", false)
+	backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "")
 
 	ns := resource.NamespacedResource{
 		Namespace: "test",
@@ -815,7 +814,7 @@ func TestBleveFileIndexExpiration(t *testing.T) {
 	}
 
 	// size=100 is above FileThreshold, this will be file-based index
-	builtIndex, err := backend.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 1, 100), nil)
+	builtIndex, err := backend.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 1, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Wait for index expiration, which is 1ns
@@ -846,8 +845,8 @@ func TestFileIndexIsReusedOnSameSizeAndRVLessThanIndexRV(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil)
+	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify one open index.
@@ -869,8 +868,8 @@ func TestFileIndexIsReusedOnSameSizeAndRVLessThanIndexRV(t *testing.T) {
 	`), "index_server_open_indexes"))
 
 	// We open new backend using same directory, and run indexing with same size (10) and RV (100). This should reuse existing index, and skip indexing.
-	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil)
+	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -895,8 +894,8 @@ func TestFileIndexIsReusedOnSameSizeAndRVLessThanIndexRV(t *testing.T) {
 	`), "index_server_open_indexes"))
 
 	// We repeat with backend3 and RV 99. This should also reuse existing index and skip indexing
-	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1000, 99), nil)
+	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1000, 99), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -921,14 +920,208 @@ func TestFileIndexIsReusedOnSameSizeAndRVLessThanIndexRV(t *testing.T) {
 	`), "index_server_open_indexes"))
 
 	// again now RV > 100. Should NOT reuse index
-	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1000, 100), nil)
+	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1000, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify that we're NOT existing index and there is only 1000 documents in it, not 10.
 	cnt, err = idx.DocCount(context.Background(), "")
 	require.NoError(t, err)
 	require.Equal(t, int64(1000), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg4, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend4.CloseAllIndexes()
+}
+
+func TestFileIndexIsIgnoredIfRebuildFlagIsTrueWithoutSearchAfterWrite(t *testing.T) {
+	ns := resource.NamespacedResource{
+		Namespace: "test",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	tmpDir := t.TempDir()
+
+	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, true, false)
+	require.NoError(t, err)
+
+	// Verify one open index.
+	require.NoError(t, testutil.GatherAndCompare(reg1, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend1.CloseAllIndexes()
+
+	// Verify that there are no open indexes after CloseAllIndexes call.
+	require.NoError(t, testutil.GatherAndCompare(reg1, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 0
+	`), "index_server_open_indexes"))
+
+	// We open new backend using same directory, and run indexing with same size (10) and RV (100). This should NOT
+	// reuse existing index, due to the rebuild flag being true
+	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil, true, false)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1000 documents, not 10.
+	cnt, err := idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg2, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend2.CloseAllIndexes()
+	// Verify that there are no open indexes after closeAllIndexes call.
+	require.NoError(t, testutil.GatherAndCompare(reg2, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 0
+	`), "index_server_open_indexes"))
+
+	// We repeat with backend3 and RV 99. This should also NOT reuse existing index
+	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1001, 99), nil, true, false)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1001 documents
+	cnt, err = idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1001), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg3, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend3.CloseAllIndexes()
+
+	// again now RV > 100. Should still rebuild the index due to the rebuild flag
+	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1002, 100), nil, true, false)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1002 documents
+	cnt, err = idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1002), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg4, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend4.CloseAllIndexes()
+}
+
+func TestFileIndexIsIgnoredIfRebuildFlagIsTrueWithSearchAfterWrite(t *testing.T) {
+	ns := resource.NamespacedResource{
+		Namespace: "test",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	tmpDir := t.TempDir()
+
+	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, true, true)
+	require.NoError(t, err)
+
+	// Verify one open index.
+	require.NoError(t, testutil.GatherAndCompare(reg1, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend1.CloseAllIndexes()
+
+	// Verify that there are no open indexes after CloseAllIndexes call.
+	require.NoError(t, testutil.GatherAndCompare(reg1, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 0
+	`), "index_server_open_indexes"))
+
+	// We open new backend using same directory, and run indexing with same size (10) and RV (100). This should NOT
+	// reuse existing index, due to the rebuild flag being true
+	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil, true, true)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1000 documents, not 10.
+	cnt, err := idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg2, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend2.CloseAllIndexes()
+	// Verify that there are no open indexes after closeAllIndexes call.
+	require.NoError(t, testutil.GatherAndCompare(reg2, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 0
+	`), "index_server_open_indexes"))
+
+	// We repeat with backend3 and RV 99. This should also NOT reuse existing index
+	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1001, 99), nil, true, true)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1001 documents
+	cnt, err = idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1001), cnt)
+
+	require.NoError(t, testutil.GatherAndCompare(reg3, bytes.NewBufferString(`
+		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
+		# TYPE index_server_open_indexes gauge
+		index_server_open_indexes{index_storage="memory"} 0
+		index_server_open_indexes{index_storage="file"} 1
+	`), "index_server_open_indexes"))
+
+	backend3.CloseAllIndexes()
+
+	// again now RV > 100. Should still rebuild the index due to the rebuild flag
+	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1002, 100), nil, true, true)
+	require.NoError(t, err)
+
+	// Verify that we've re-built the index. There should be 1002 documents
+	cnt, err = idx.DocCount(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, int64(1002), cnt)
 
 	require.NoError(t, testutil.GatherAndCompare(reg4, bytes.NewBufferString(`
 		# HELP index_server_open_indexes Number of open indexes per storage type. An open index corresponds to single resource group.
@@ -949,8 +1142,8 @@ func TestFileIndexIsReusedIfRVisPresentAndSearhAfterWriteIsEnabled(t *testing.T)
 
 	tmpDir := t.TempDir()
 
-	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, true)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil)
+	backend1, reg1 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, false, true)
 	require.NoError(t, err)
 
 	// Verify one open index.
@@ -972,8 +1165,8 @@ func TestFileIndexIsReusedIfRVisPresentAndSearhAfterWriteIsEnabled(t *testing.T)
 	`), "index_server_open_indexes"))
 
 	// We open new backend using same directory, and run indexing with same size (10) and RV (100). This should reuse existing index, and skip indexing.
-	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, true)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil)
+	backend2, reg2 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 1000, 100), nil, false, true)
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -998,8 +1191,8 @@ func TestFileIndexIsReusedIfRVisPresentAndSearhAfterWriteIsEnabled(t *testing.T)
 	`), "index_server_open_indexes"))
 
 	// We repeat with backend3 and RV 99. This should also reuse existing index and skip indexing
-	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, true)
-	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1000, 99), nil)
+	backend3, reg3 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend3.BuildIndex(context.Background(), ns, 10 /* file based */, 99, nil, "test", indexTestDocs(ns, 1000, 99), nil, false, true)
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -1017,8 +1210,8 @@ func TestFileIndexIsReusedIfRVisPresentAndSearhAfterWriteIsEnabled(t *testing.T)
 	backend3.CloseAllIndexes()
 
 	// again now RV > 100. Should still reuse index
-	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, true)
-	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1000, 100), nil)
+	backend4, reg4 := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err = backend4.BuildIndex(context.Background(), ns, 10 /* file based */, 101, nil, "test", indexTestDocs(ns, 1000, 100), nil, false, true)
 	require.NoError(t, err)
 
 	// Verify that we're reusing existing index and there is only 10 documents in it, not 1000.
@@ -1045,14 +1238,14 @@ func TestFileIndexIsNotReusedOnDifferentSize(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10, 100), nil)
+	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, false, false)
 	require.NoError(t, err)
 	backend1.CloseAllIndexes()
 
 	// We open new backend using same directory, but with different size. Index should be rebuilt.
-	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 100, 100), nil)
+	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 100, 100, nil, "test", indexTestDocs(ns, 100, 100), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify that index has updated number of documents.
@@ -1070,14 +1263,14 @@ func TestFileIndexIsNotReusedOnDifferentRV(t *testing.T) {
 
 	tmpDir := t.TempDir()
 
-	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10, 100), nil)
+	backend1, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	_, err := backend1.BuildIndex(context.Background(), ns, 10, 100, nil, "test", indexTestDocs(ns, 10, 100), nil, false, false)
 	require.NoError(t, err)
 	backend1.CloseAllIndexes()
 
 	// We open new backend using same directory, but with different RV. Index should be rebuilt.
-	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir, false)
-	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 999999, nil, "test", indexTestDocs(ns, 100, 999999), nil)
+	backend2, _ := setupBleveBackend(t, 5, time.Nanosecond, tmpDir)
+	idx, err := backend2.BuildIndex(context.Background(), ns, 10 /* file based */, 999999, nil, "test", indexTestDocs(ns, 100, 999999), nil, false, false)
 	require.NoError(t, err)
 
 	// Verify that index has updated number of documents.
@@ -1103,13 +1296,13 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 		"file, file":           {false, false},
 	} {
 		t.Run(name, func(t *testing.T) {
-			backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "", false)
+			backend, reg := setupBleveBackend(t, 5, time.Nanosecond, "")
 
 			firstSize := 100
 			if testCase.firstInMemory {
 				firstSize = 1
 			}
-			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), 100, nil, "test", indexTestDocs(ns, firstSize, 100), nil)
+			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), 100, nil, "test", indexTestDocs(ns, firstSize, 100), nil, false, false)
 			require.NoError(t, err)
 
 			if testCase.firstInMemory {
@@ -1125,7 +1318,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 				secondSize = 1
 				openInMemoryIndexes = 1
 			}
-			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), 100, nil, "test", indexTestDocs(ns, secondSize, 100), nil)
+			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), 100, nil, "test", indexTestDocs(ns, secondSize, 100), nil, false, false)
 			require.NoError(t, err)
 
 			if testCase.secondInMemory {
@@ -1221,7 +1414,7 @@ func updateTestDocs(ns resource.NamespacedResource, docs int) resource.UpdateFn 
 func TestCleanOldIndexes(t *testing.T) {
 	dir := t.TempDir()
 
-	b, _ := setupBleveBackend(t, 5, time.Nanosecond, dir, false)
+	b, _ := setupBleveBackend(t, 5, time.Nanosecond, dir)
 
 	t.Run("with skip", func(t *testing.T) {
 		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0750))
@@ -1257,7 +1450,7 @@ func TestBleveIndexWithFailures(t *testing.T) {
 }
 
 func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
-	backend, _ := setupBleveBackend(t, 5, time.Nanosecond, "", false)
+	backend, _ := setupBleveBackend(t, 5, time.Nanosecond, "")
 
 	ns := resource.NamespacedResource{
 		Namespace: "test",
@@ -1272,11 +1465,11 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 	}
 	_, err := backend.BuildIndex(context.Background(), ns, size, 100, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 0, fmt.Errorf("fail")
-	}, nil)
+	}, nil, false, false)
 	require.Error(t, err)
 
 	// Even though previous build of the index failed, new building of the index should work.
-	_, err = backend.BuildIndex(context.Background(), ns, size, 100, nil, "test", indexTestDocs(ns, int(size), 100), nil)
+	_, err = backend.BuildIndex(context.Background(), ns, size, 100, nil, "test", indexTestDocs(ns, int(size), 100), nil, false, false)
 	require.NoError(t, err)
 }
 
@@ -1287,8 +1480,8 @@ func TestIndexUpdate(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "", false)
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5))
+	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "")
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, false)
 	require.NoError(t, err)
 
 	resp := searchTitle(t, idx, "gen", 10, ns)
@@ -1342,7 +1535,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 		return sinceRV + int64(5), 5, err
 	}
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, false)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1350,7 +1543,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 	_, err = idx.UpdateIndex(ctx, "test")
 	require.NoError(t, err)
 
-	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn)
+	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, false)
 	require.NoError(t, err)
 
 	_, err = idx.UpdateIndex(ctx, "test")
@@ -1364,9 +1557,9 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "", false)
+	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "")
 
-	_, err := be.BuildIndex(t.Context(), ns, 10, 0, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5))
+	_, err := be.BuildIndex(t.Context(), ns, 10, 0, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, false)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -1429,7 +1622,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for ctx.Err() == nil {
-			_, err := be.BuildIndex(t.Context(), ns, 10, 0, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5))
+			_, err := be.BuildIndex(t.Context(), ns, 10, 0, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, false)
 			require.NoError(t, err)
 			rebuilds.Inc()
 		}
@@ -1450,9 +1643,9 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "", false)
+	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "")
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5))
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, false)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -1509,14 +1702,14 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "", false)
+	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "")
 
 	updateErr := fmt.Errorf("failed to update index")
 	updaterFn := func(context context.Context, index resource.ResourceIndex, sinceRV int64) (newRV int64, updatedDocs int, _ error) {
 		time.Sleep(100 * time.Millisecond)
 		return 0, 0, updateErr
 	}
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn)
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, 100, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, false)
 	require.NoError(t, err)
 
 	t.Run("update fail", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -763,9 +763,9 @@ func setupBleveBackend(t *testing.T, fileThreshold int, cacheTTL time.Duration, 
 	metrics := resource.ProvideIndexMetrics(reg)
 
 	backend, err := NewBleveBackend(BleveOptions{
-		Root:             dir,
-		FileThreshold:    int64(fileThreshold),
-		IndexCacheTTL:    cacheTTL,
+		Root:          dir,
+		FileThreshold: int64(fileThreshold),
+		IndexCacheTTL: cacheTTL,
 	}, tracing.NewNoopTracerService(), featuremgmt.WithFeatures(), metrics)
 	require.NoError(t, err)
 	require.NotNil(t, backend)
@@ -1511,7 +1511,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "", false)
+	be, _ := setupBleveBackend(t, 5, 1*time.Minute, "")
 
 	updaterFn := func(context context.Context, index resource.ResourceIndex, sinceRV int64) (newRV int64, updatedDocs int, _ error) {
 		var items []*resource.BulkIndexItem

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -24,10 +24,11 @@ func NewSearchOptions(features featuremgmt.FeatureToggles, cfg *setting.Cfg, tra
 			return resource.SearchOptions{}, err
 		}
 		bleve, err := NewBleveBackend(BleveOptions{
-			Root:          root,
-			FileThreshold: int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
-			BatchSize:     cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
-			IndexCacheTTL: cfg.IndexCacheTTL,             // How long to keep the index cache in memory
+			Root:             root,
+			FileThreshold:    int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
+			BatchSize:        cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
+			IndexCacheTTL:    cfg.IndexCacheTTL,             // How long to keep the index cache in memory
+			SearchAfterWrite: features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchAfterWriteExperimentalAPI),
 		}, tracer, features, indexMetrics)
 
 		if err != nil {

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -24,11 +24,10 @@ func NewSearchOptions(features featuremgmt.FeatureToggles, cfg *setting.Cfg, tra
 			return resource.SearchOptions{}, err
 		}
 		bleve, err := NewBleveBackend(BleveOptions{
-			Root:             root,
-			FileThreshold:    int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
-			BatchSize:        cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
-			IndexCacheTTL:    cfg.IndexCacheTTL,             // How long to keep the index cache in memory
-			SearchAfterWrite: features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchAfterWriteExperimentalAPI),
+			Root:          root,
+			FileThreshold: int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
+			BatchSize:     cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
+			IndexCacheTTL: cfg.IndexCacheTTL,             // How long to keep the index cache in memory
 		}, tracer, features, indexMetrics)
 
 		if err != nil {

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -217,7 +217,7 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 	size := int64(10000) // force the index to be on disk
 	index, err := backend.BuildIndex(ctx, nr, size, 0, nil, "benchmark", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
-	}, nil)
+	}, nil, false, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize backend: %w", err)
 	}

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -86,7 +86,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 			return 0, err
 		}
 		return 1, nil
-	}, nil)
+	}, nil, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
@@ -152,7 +152,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 		})
 		require.NoError(t, err)
 		return int64(2), nil
-	}, nil)
+	}, nil, false, false)
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
@@ -294,7 +294,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 			})
 			require.NoError(t, err)
 			return int64(3), nil
-		}, nil)
+		}, nil, false, false)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 


### PR DESCRIPTION
if search after write is enabled we can reuse the index even if it's not updated, as it will be updated at request time