### PR TITLE
Saved Queries: Entry point removal in Alerting

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -456,12 +456,12 @@ describe('QueryEditorRow', () => {
       expect(mockQueryLibraryContext.renderQueryLibraryEditingHeader).not.toHaveBeenCalled();
     });
 
-    it('should not render query library buttons when app is unified alerting', async () => {
+    it('should not render saved queries buttons when app is unified alerting', async () => {
       render(<QueryEditorRow {...props(testData)} app={CoreApp.UnifiedAlerting} />);
 
       await waitFor(() => {
         expect(screen.queryByText('Save query')).not.toBeInTheDocument();
-        expect(screen.queryByText('Add query from library')).not.toBeInTheDocument();
+        expect(screen.queryByText('Replace with saved query')).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { PropsWithChildren } from 'react';
 
-import { DataQueryRequest, dateTime, LoadingState, PanelData, toDataFrame } from '@grafana/data';
+import { CoreApp, DataQueryRequest, dateTime, LoadingState, PanelData, toDataFrame } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 
@@ -454,6 +454,15 @@ describe('QueryEditorRow', () => {
       });
 
       expect(mockQueryLibraryContext.renderQueryLibraryEditingHeader).not.toHaveBeenCalled();
+    });
+
+    it('should not render query library buttons when app is unified alerting', async () => {
+      render(<QueryEditorRow {...props(testData)} app={CoreApp.UnifiedAlerting} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Save query')).not.toBeInTheDocument();
+        expect(screen.queryByText('Add query from library')).not.toBeInTheDocument();
+      });
     });
   });
 });

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -379,29 +379,30 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
   };
 
   renderActions = (props: QueryOperationRowRenderProps) => {
-    const { query, hideHideQueryButton: hideHideQueryButton = false, queryLibraryRef } = this.props;
+    const { query, hideHideQueryButton: hideHideQueryButton = false, queryLibraryRef, app } = this.props;
     const { datasource, showingHelp } = this.state;
     const isHidden = !!query.hide;
 
     const hasEditorHelp = datasource?.components?.QueryEditorHelp;
     const isEditingQueryLibrary = queryLibraryRef !== undefined;
+    const isUnifiedAlerting = app === CoreApp.UnifiedAlerting;
 
     return (
       <>
-        {!isEditingQueryLibrary && (
+        {!isEditingQueryLibrary && !isUnifiedAlerting && (
           <MaybeQueryLibrarySaveButton
             query={query}
-            app={this.props.app}
+            app={app}
             onSelectQuery={this.onSelectQueryFromLibrary}
             onUpdateSuccess={this.onExitQueryLibraryEditingMode}
           />
         )}
 
-        {!isEditingQueryLibrary && (
+        {!isEditingQueryLibrary && !isUnifiedAlerting && (
           <ReplaceQueryFromLibrary
             datasourceFilters={datasource?.name ? [datasource.name] : []}
             onSelectQuery={this.onSelectQueryFromLibrary}
-            app={this.props.app}
+            app={app}
           />
         )}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This removes Saved Queries entrypoints in Alerts.

**Why do we need this feature?**
We don't support Saved Queries in Alerting

**Who is this feature for?**
Saved Queries / Alerting users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/9473

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Before:
<img width="923" height="340" alt="Screenshot 2025-08-26 at 4 05 28 PM" src="https://github.com/user-attachments/assets/f1fc9ed6-f510-4112-a45b-abacb37382b2" />

After:
<img width="921" height="342" alt="Screenshot 2025-08-26 at 4 05 36 PM" src="https://github.com/user-attachments/assets/af1d72fe-a65f-4420-a3e3-fedd327af0b5" />
