### PR TITLE
Secrets: Add result label for decryption errors

### DIFF
--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -3,7 +3,6 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"time"
 
 	claims "github.com/grafana/authlib/types"
@@ -88,13 +87,12 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 		} else {
 			span.SetStatus(codes.Error, "Decrypt failed")
 			span.RecordError(decryptErr)
-			args = append(args, "operation", "decrypt_secret_error", "error", decryptErr.Error())
+			args = append(args, "operation", "decrypt_secret_error", "error", decryptErr.Error(), "result", metrics.DecryptResultLabel(decryptErr))
 		}
 
 		logging.FromContext(ctx).Info("Secrets Audit Log", args...)
 
-		success := decryptErr == nil
-		s.metrics.DecryptDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
+		s.metrics.DecryptDuration.WithLabelValues(metrics.DecryptResultLabel(decryptErr)).Observe(time.Since(start).Seconds())
 	}()
 
 	// Basic authn check before reading a secure value metadata, it is here on purpose.

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -1,8 +1,10 @@
 package metrics
 
 import (
+	"errors"
 	"sync"
 
+	"github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -11,6 +13,7 @@ const (
 	subsystem = "storage"
 	// labels
 	successLabel = "success"
+	resultLabel  = "result"
 )
 
 // StorageMetrics is a struct that contains all the metrics for all operations of secrets storage.
@@ -121,7 +124,7 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "decrypt_duration_seconds",
 			Help:      "Duration of decrypt operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{successLabel}),
+		}, []string{resultLabel}),
 	}
 }
 
@@ -160,4 +163,19 @@ func NewStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 
 func NewTestMetrics() *StorageMetrics {
 	return newStorageMetrics()
+}
+
+// DecryptResultLabel returns a label value for the given decrypt error.
+func DecryptResultLabel(err error) string {
+	if err == nil {
+		return "success"
+	}
+
+	if errors.Is(err, contracts.ErrDecryptNotFound) {
+		return "error_not_found"
+	} else if errors.Is(err, contracts.ErrDecryptNotAuthorized) {
+		return "error_unauthorized"
+	}
+
+	return "error_generic_failure"
 }


### PR DESCRIPTION
**What is this feature?**

Adds a `result` label to decryption error metrics + logs.

**Why do we need this feature?**

Distinguish if the operation is an error and the type of error for alerting.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
