### PR TITLE
Accessibility: Constrain popups to screen height

### DIFF
--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.tsx
@@ -95,6 +95,8 @@ const getStyles = stylesFactory((theme: GrafanaTheme2) => {
       color: theme.colors.text.primary,
       maxWidth: '400px',
       fontSize: theme.typography.size.sm,
+      maxHeight: '100vh',
+      overflow: 'auto',
     }),
   };
 });

--- a/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/ButtonSelect.tsx
@@ -127,6 +127,8 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     menuWrapper: css({
       zIndex: theme.zIndex.dropdown,
+      maxHeight: '100vh',
+      overflow: 'auto',
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

Constrain popups to screen height with scrolling overflow so that on very small screens you can still access all options or content.

**Why do we need this feature?**

Accessibility

**Who is this feature for?**

Users on small screens that are zoomed in (effectively less than 300 px).

**Which issue(s) does this PR fix?**:

For https://github.com/grafana/grafana/issues/107127

**Special notes for your reviewer:**

Here's what it looks like zoomed in, in panel edit opening a threshhold color picker. Previously, the bottom would have been cut off, now it has a scrollbar.

<img width="1279" height="592" alt="image" src="https://github.com/user-attachments/assets/1dd5308b-2ff9-4c4a-9bba-41c465a7ba42" />

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
