### PR TITLE
Unified Storage: Dont need to test casing with ordering

### DIFF
--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/uuid"
-	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -556,28 +555,22 @@ func runTestIntegrationBackendListModifiedSince(t *testing.T, backend resource.S
 	})
 
 	t.Run("will order events by resource version ascending and name descending", func(t *testing.T) {
-		// When we order by name ASC, sqlite orders upper case strings first - so skipping for sqlite
-		// For example: for this test, the actual ordering of events for sqlite is CItem, aItem, bItem
-		if db.IsTestDbSQLite() {
-			t.Skip("Skipping test for sqlite since ordering by name is different than mysql due to case sensitivity")
-		}
-
 		key := resource.NamespacedResource{
 			Namespace: ns,
 			Group:     "group",
 			Resource:  "resource",
 		}
 
-		rvCreated1, _ := writeEvent(ctx, backend, "aItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
-		rvCreated2, _ := writeEvent(ctx, backend, "bItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
-		rvCreated3, _ := writeEvent(ctx, backend, "CItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+		rvCreated1, _ := writeEvent(ctx, backend, "cItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+		rvCreated2, _ := writeEvent(ctx, backend, "aItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
+		rvCreated3, _ := writeEvent(ctx, backend, "bItem", resourcepb.WatchEvent_ADDED, WithNamespace(ns))
 
 		latestRv, seq := backend.ListModifiedSince(ctx, key, rvCreated1-1)
 		require.Greater(t, latestRv, rvCreated3)
 
 		counter := 0
-		names := []string{"aItem", "bItem", "CItem"}
-		rvs := []int64{rvCreated1, rvCreated2, rvCreated3}
+		names := []string{"aItem", "bItem", "cItem"}
+		rvs := []int64{rvCreated2, rvCreated3, rvCreated1}
 		for res, err := range seq {
 			require.NoError(t, err)
 			require.Equal(t, key.Namespace, res.Key.Namespace)


### PR DESCRIPTION
We don't need to test casing anymore since our check for `key.name <= lastSeen` was removed. 

Also apparently postgres orders strings the same as sqlite in regards to casing. So removing casing from the test!