### PR TITLE
Add url configuration to openfeature settings

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2027,6 +2027,7 @@ enable =
 # This is EXPERIMENTAL. Please, do not use this section
 enable_api = true
 provider = static
+url =
 
 [feature_toggles.openfeature.context]
 # This is EXPERIMENTAL. Please, do not use this section


### PR DESCRIPTION
It looks like it's not possible to override with env variables those settings that does not exist in config.ini.
So adding `url` to `openfeature` subsection.