### PR TITLE
Alerting: disable error alerts in Filter V2

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -54,6 +54,7 @@ export function useNamespaceAndGroupOptions(): {
       ruleSource: { uid: ds.uid },
       excludeAlerts: true,
       groupLimit: 500,
+      notificationOptions: { showErrorAlert: false },
     })
   );
 


### PR DESCRIPTION
This PR disables display of error alerts from the filter autocomplete query