### PR TITLE
Pyroscope: Add start and end date to profiletypes call

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -110,6 +110,10 @@ func (d *PyroscopeDatasource) profileTypes(ctx context.Context, req *backend.Cal
 			ctxLogger.Error("Failed to parse end as int", "error", err, "function", logEntrypoint())
 			return err
 		}
+	} else {
+		// Make sure to pass a valid time range to the client as v2 will not work without it.
+		start = time.Now().Add(-time.Hour).UnixMilli()
+		end = time.Now().Add(time.Hour).UnixMilli()
 	}
 
 	types, err := d.client.ProfileTypes(ctx, start, end)


### PR DESCRIPTION
This PR adds start and end date to the profiletypes call even if the frontend doesn't send one. This fixes an error shown when tempo data source config page calls profiletypes without start and end date.

Run Pyroscope with v2 to see the error without the fix.

```
docker run -p 4040:4040 -e PYROSCOPE_V2_EXPERIMENT=1 --workdir /data -t -i grafana/pyroscope:1.14.0 -storage.backend filesystem -write-path segment-writer -enable-query-backend
```

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/110211

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
