### PR TITLE
Update select component deprecation message

### DIFF
--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/IndicatorsContainer.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/IndicatorsContainer.tsx
@@ -5,7 +5,7 @@ import { SelectableValue } from '@grafana/data';
 import { Icon } from '../../../Icon/Icon';
 import { Select } from '../../../Select/Select';
 
-/** @deprecated Please use the {@link Select} component*/
+/** @deprecated Please use the Combobox component instead */
 export const IndicatorsContainer = <T,>(props: IndicatorsContainerProps<SelectableValue<T>>) => {
   const isOpen = props.selectProps.menuIsOpen;
   return (

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/NoOptionsMessage.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/NoOptionsMessage.tsx
@@ -6,7 +6,7 @@ import { Select } from '../../../Select/Select';
 
 export type Props<T> = NoticeProps<SelectableValue<T>, boolean, GroupBase<SelectableValue<T>>>;
 
-/** @deprecated Please use the {@link Select} component*/
+/** @deprecated Please use the Combobox component instead */
 export const NoOptionsMessage = <T extends unknown>(props: Props<T>) => {
   const { children } = props;
   return (

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -53,7 +53,7 @@ export const MenuList = (props: MenuListProps) => {
   );
 };
 
-/** @deprecated Please use the `Select` component, as seen {@link https://developers.grafana.com/ui/latest/index.html?path=/story/forms-select--basic in Storybook}. */
+/** @deprecated Please use the `Combobox` component instead. */
 export class Select<T> extends PureComponent<LegacySelectProps<T>> {
   declare context: React.ContextType<typeof ThemeContext>;
   static contextType = ThemeContext;
@@ -171,7 +171,7 @@ export class Select<T> extends PureComponent<LegacySelectProps<T>> {
   }
 }
 
-/** @deprecated Please use the `Select` component with async functionality, as seen {@link https://developers.grafana.com/ui/latest/index.html?path=/story/forms-select--basic-select-async in Storybook}. */
+/** @deprecated Please use the `Combobox` component instead. */
 export class AsyncSelect<T> extends PureComponent<AsyncProps<T>> {
   static contextType = ThemeContext;
 


### PR DESCRIPTION
**What is this feature?**

Updates deprecation messages for legacy `Select` components to clearly recommend using the `Combobox` component instead.

**Why do we need this feature?**

The existing deprecation messages for `Select` components were outdated, sometimes pointing to non-existent Storybook pages or not clearly stating the recommended replacement. This change provides clear guidance to developers on which component to use instead of the deprecated `Select`, addressing an issue raised in a recent Slack discussion.

**Who is this feature for?**

Developers building with Grafana UI components.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Specifically, the following files were updated to recommend `Combobox`:
- `packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx` (for `Select` and `AsyncSelect` classes)
- `packages/grafana-ui/src/components/Forms/Legacy/Select/NoOptionsMessage.tsx`
- `packages/grafana-ui/src/components/Forms/Legacy/Select/IndicatorsContainer.tsx`

---
[Slack Thread](https://raintank-corp.slack.com/archives/C025WTVRBSN/p1756385463319889?thread_ts=1756385463.319889&cid=C025WTVRBSN)

<a href="https://cursor.com/background-agent?bcId=bc-cefa566b-c989-4056-9f67-3298269409e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cefa566b-c989-4056-9f67-3298269409e4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

