### PR TITLE
Provisioning: Fix patching released resources when Repository is deleted

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -52,12 +52,16 @@ func (f *finalizer) process(ctx context.Context,
 		case ReleaseOrphanResourcesFinalizer:
 			err := f.processExistingItems(ctx, repo.Config(),
 				func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error {
-					_, err := client.Patch(ctx, item.Name, types.JSONPatchType, []byte(`[
-						{"op": "remove", "path": "/metadata/annotations/`+utils.AnnoKeyManagerKind+`" },
-						{"op": "remove", "path": "/metadata/annotations/`+utils.AnnoKeyManagerIdentity+`" },
-						{"op": "remove", "path": "/metadata/annotations/`+utils.AnnoKeySourcePath+`" },
-						{"op": "remove", "path": "/metadata/annotations/`+utils.AnnoKeySourceChecksum+`" }
-					]`), v1.PatchOptions{})
+					_, err := client.Patch(ctx, item.Name, types.MergePatchType, []byte(`{
+						"metadata": {
+							"annotations": {
+								"`+utils.AnnoKeyManagerKind+`": null,
+								"`+utils.AnnoKeyManagerIdentity+`": null,
+								"`+utils.AnnoKeySourcePath+`": null,
+								"`+utils.AnnoKeySourceChecksum+`": null
+							}
+						}
+					}`), v1.PatchOptions{})
 					return err
 				})
 			if err != nil {

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -123,20 +123,20 @@ func (f *finalizer) processExistingItems(
 
 func getPatchedAnnotations(item *provisioning.ResourceListItem) []byte {
 	annotations := []string{
-		`{"op": "remove", "path": "/metadata/annotations/"` + escapePatchString(utils.AnnoKeyManagerKind) + "}",
-		`{"op": "remove", "path": "/metadata/annotations/"` + escapePatchString(utils.AnnoKeyManagerIdentity) + "}",
+		`{"op": "remove", "path": "/metadata/annotations/` + escapePatchString(utils.AnnoKeyManagerKind) + `"}`,
+		`{"op": "remove", "path": "/metadata/annotations/` + escapePatchString(utils.AnnoKeyManagerIdentity) + `"}`,
 	}
 
 	if item.Path != "" {
 		annotations = append(
 			annotations,
-			`{"op": "remove", "path": "/metadata/annotations/"`+escapePatchString(utils.AnnoKeySourcePath)+"}",
+			`{"op": "remove", "path": "/metadata/annotations/`+escapePatchString(utils.AnnoKeySourcePath)+`"}`,
 		)
 	}
 	if item.Hash != "" {
 		annotations = append(
 			annotations,
-			`{"op": "remove", "path": "/metadata/annotations/"`+escapePatchString(utils.AnnoKeySourceChecksum)+"}",
+			`{"op": "remove", "path": "/metadata/annotations/`+escapePatchString(utils.AnnoKeySourceChecksum)+`"}`,
 		)
 	}
 

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -682,3 +682,11 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	require.Error(t, err, "should delete the internal resource")
 	require.True(t, apierrors.IsNotFound(err))
 }
+
+// TODO(ferruvich): write integration tests.
+//
+//	It should:
+//	 - Create a repository with some resources in it
+//	 - Delete the repository keeping the resources in place
+//	 - Verifying that resources have been released (annotations removed)
+func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.T) {}

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -753,16 +753,8 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 		for _, v := range foundFolders.Items {
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 		}
 	}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
-
-	// Cleanup resources
-	for _, v := range foundDashboards.Items {
-		err = helper.DashboardsV1.Resource.Delete(ctx, v.GetName(), metav1.DeleteOptions{})
-		require.NoError(t, err, "should delete dashboard")
-	}
-	for _, v := range foundFolders.Items {
-		err = helper.Folders.Resource.Delete(ctx, v.GetName(), metav1.DeleteOptions{})
-		require.NoError(t, err, "should delete folder")
-	}
 }

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -683,10 +684,85 @@ func TestIntegrationProvisioning_ImportAllPanelsFromLocalRepository(t *testing.T
 	require.True(t, apierrors.IsNotFound(err))
 }
 
-// TODO(ferruvich): write integration tests.
-//
-//	It should:
-//	 - Create a repository with some resources in it
-//	 - Delete the repository keeping the resources in place
-//	 - Verifying that resources have been released (annotations removed)
-func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.T) {}
+func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	const repo = "gh-repo"
+	testRepo := TestRepo{
+		Name:               repo,
+		Template:           "testdata/github-readonly.json.tmpl",
+		Target:             "folder",
+		ExpectedDashboards: 3,
+		ExpectedFolders:    3,
+	}
+	helper.CreateRepo(t, testRepo)
+
+	// Checking resources are there and are managed
+	foundFolders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "can list folders")
+	for _, v := range foundFolders.Items {
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+	}
+
+	foundDashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+	require.NoError(t, err, "can list dashboards")
+	for _, v := range foundDashboards.Items {
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
+		assert.Contains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
+	}
+
+	_, err = helper.Repositories.Resource.Patch(ctx, repo, types.JSONPatchType, []byte(`[
+		{
+			"op": "replace",
+			"path": "/metadata/finalizers",
+			"value": ["cleanup", "release-orphan-resources"]
+		}
+	]`), metav1.PatchOptions{})
+	require.NoError(t, err, "should successfully patch finalizers")
+
+	err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
+	require.NoError(t, err, "should delete repository")
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
+		assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
+	}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		foundDashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err, "can list values")
+		for _, v := range foundDashboards.Items {
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
+		}
+	}, time.Second*20, time.Millisecond*10, "Expected dashboards to be released")
+
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		foundFolders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+		assert.NoError(t, err, "can list values")
+		for _, v := range foundFolders.Items {
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
+			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+		}
+	}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+
+	// Cleanup resources
+	for _, v := range foundDashboards.Items {
+		err = helper.DashboardsV1.Resource.Delete(ctx, v.GetName(), metav1.DeleteOptions{})
+		require.NoError(t, err, "should delete dashboard")
+	}
+	for _, v := range foundFolders.Items {
+		err = helper.Folders.Resource.Delete(ctx, v.GetName(), metav1.DeleteOptions{})
+		require.NoError(t, err, "should delete folder")
+	}
+}


### PR DESCRIPTION
**What is this feature?**

This feature changes the way we're patching the orphaned resources when:
- A Repository is deleted;
- The user decides to keep its managed resources around;

Moving from a JSON Patch to a Merge Patch.

**Why do we need this feature?**

When deleting a Repository, choosing to keep the resources - as introduced in https://github.com/grafana/grafana/pull/109955 - the orphaned resources' annotations are not correctly deleted.

The current JSON patch is failing due to the following reasons, based on the resource it's trying to patch:
- **Dashboards**: all the annotations have the `/` character in them (e.g. `grafana.app/managedBy`), which is also used to separate path entries - therefore our request is getting rejected as the `path` is technically malformed (e.g, `/metadata/annotations/grafana.app/managedBy`) - _this could_ be fixed by escaling the `/` character in the annotation with a `~1`;
- **Folders**: the same problem as above + I have noticed that folders lack the `utils.AnnoKeySourcePath` and `utils.AnnoKeySourceChecksum` annotations. Trying to do a `remove` operation via JSON patch on a non-existing entry is being rejected by the server with a `422 - Unprocessable Entity`

The Merge patch instead has the following advantages:
- It has a more clear way of setting which entry is being deleted, w/o having to escape any value;
- It ignores missing keys.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/469
