### PR TITLE
New Log Details: Fix multiple displayed links and correlactions

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsComponent.tsx
@@ -118,6 +118,8 @@ export const LogLineDetailsComponent = memo(
       !labelGroups.length &&
       !fieldsWithoutLinks.length;
 
+    const hasLinks = fieldsWithLinks.links.length > 0 || fieldsWithLinks.linksFromVariableMap.length > 0;
+
     return (
       <>
         <LogLineDetailsHeader focusLogLine={focusLogLine} log={log} search={search} onSearch={handleSearch} />
@@ -141,7 +143,7 @@ export const LogLineDetailsComponent = memo(
               <LogLineDetailsDisplayedFields />
             </ControlledCollapse>
           )}
-          {fieldsWithLinks.links.length > 0 && (
+          {hasLinks && (
             <ControlledCollapse
               className={styles.collapsable}
               label={t('logs.log-line-details.links-section', 'Links')}

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -339,7 +339,7 @@ export const LogLineDetailsField = ({
         }
         return (
           <div className={styles.row} key={`${link.title}-${i}`}>
-            <div className={disableActions ? undefined : styles.link}>
+            <div className={disableActions ? styles.linkNoActions : styles.link}>
               <DataLinkButton
                 buttonProps={{
                   // Show tooltip message if max number of pinned lines has been reached
@@ -400,6 +400,10 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
   }),
   link: css({
     gridColumn: '2 / 4',
+  }),
+  linkNoActions: css({
+    gridColumn: 'span 2',
+    paddingBottom: theme.spacing(0.5),
   }),
   stats: css({
     paddingRight: theme.spacing(1),


### PR DESCRIPTION
Part of #110276

- Fixes multiple overlapping links

Before:

<img width="569" height="280" alt="before" src="https://github.com/user-attachments/assets/29c7c9be-0378-4d99-ae81-e33ece4e6ba2" />

After:

<img width="572" height="360" alt="after" src="https://github.com/user-attachments/assets/f5ad24dd-29d3-48ee-bbda-07b1b7edd620" />

- Fixes a wrong check that decided rendering the Links block in details.