### PR TITLE
FolderPicker: Add new prop allow customize root folder name

### DIFF
--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -16,6 +16,9 @@ interface FolderPickerProps {
   /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
+  /* Display name for the root folder, default is "Dashboards" */
+  rootFolderDisplay?: string;
+
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';
 

--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -1,15 +1,5 @@
 import * as React from 'react';
 
-interface FolderTreeItem {
-  isOpen: boolean;
-  level: number;
-  item: {
-    kind: 'folder';
-    title: string;
-    uid: string;
-  };
-}
-
 interface FolderPickerProps {
   /* Folder UID to show as selected */
   value?: string;
@@ -25,9 +15,6 @@ interface FolderPickerProps {
 
   /* Start tree from this folder instead of root */
   rootFolderUID?: string;
-
-  /* Custom root folder item, default is "Dashboards" */
-  rootFolderItem?: FolderTreeItem;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';

--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -1,5 +1,15 @@
 import * as React from 'react';
 
+interface FolderTreeItem {
+  isOpen: boolean;
+  level: number;
+  item: {
+    kind: 'folder';
+    title: string;
+    uid: string;
+  };
+}
+
 interface FolderPickerProps {
   /* Folder UID to show as selected */
   value?: string;
@@ -17,7 +27,7 @@ interface FolderPickerProps {
   rootFolderUID?: string;
 
   /* Custom root folder item, default is "Dashboards" */
-  rootFolderItem?: string;
+  rootFolderItem?: FolderTreeItem;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';

--- a/packages/grafana-runtime/src/components/FolderPicker.tsx
+++ b/packages/grafana-runtime/src/components/FolderPicker.tsx
@@ -16,8 +16,8 @@ interface FolderPickerProps {
   /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
-  /* Display name for the root folder, default is "Dashboards" */
-  rootFolderDisplay?: string;
+  /* Custom root folder item, default is "Dashboards" */
+  rootFolderItem?: string;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -39,6 +39,9 @@ export interface NestedFolderPickerProps {
   /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
+  /* Display name for the root folder, default is "Dashboards" */
+  rootFolderDisplay?: string;
+
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';
 
@@ -73,6 +76,7 @@ export function NestedFolderPicker({
   clearable = false,
   excludeUIDs,
   rootFolderUID,
+  rootFolderDisplay,
   permission = 'edit',
   onChange,
   id,
@@ -110,7 +114,13 @@ export function NestedFolderPicker({
     items: browseFlatTree,
     isLoading: isBrowseLoading,
     requestNextPage: fetchFolderPage,
-  } = useFoldersQuery(isBrowsing, foldersOpenState, permissionLevel, rootFolderUID);
+  } = useFoldersQuery({
+    isBrowsing,
+    openFolders: foldersOpenState,
+    permission: permissionLevel,
+    rootFolderUID,
+    rootFolderDisplay,
+  });
 
   useEffect(() => {
     if (!search) {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -39,8 +39,8 @@ export interface NestedFolderPickerProps {
   /* Start tree from this folder instead of root */
   rootFolderUID?: string;
 
-  /* Display name for the root folder, default is "Dashboards" */
-  rootFolderDisplay?: string;
+  /* Custom root folder item, default is "Dashboards" */
+  rootFolderItem?: DashboardsTreeItem;
 
   /* Show folders matching this permission, mainly used to also show folders user can view. Defaults to showing only folders user has Edit  */
   permission?: 'view' | 'edit';
@@ -76,7 +76,7 @@ export function NestedFolderPicker({
   clearable = false,
   excludeUIDs,
   rootFolderUID,
-  rootFolderDisplay,
+  rootFolderItem,
   permission = 'edit',
   onChange,
   id,
@@ -119,7 +119,7 @@ export function NestedFolderPicker({
     openFolders: foldersOpenState,
     permission: permissionLevel,
     rootFolderUID,
-    rootFolderDisplay,
+    rootFolderItem,
   });
 
   useEffect(() => {

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
@@ -51,7 +51,14 @@ describe('useFoldersQuery', () => {
 });
 
 async function testFn() {
-  const { result } = renderHook(() => useFoldersQuery(true, {}), { wrapper });
+  const { result } = renderHook(
+    () =>
+      useFoldersQuery({
+        isBrowsing: true,
+        openFolders: {},
+      }),
+    { wrapper }
+  );
 
   expect(result.current.items[0]).toEqual(getRootFolderItem());
   expect(result.current.isLoading).toBe(false);

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
@@ -5,11 +5,12 @@ import * as runtime from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { ManagerKind } from 'app/features/apiserver/types';
 
 import { DashboardViewItem } from '../../../features/search/types';
 
 import { useFoldersQuery } from './useFoldersQuery';
-import { getRootFolderItem } from './utils';
+import { getCustomRootFolderItem, getRootFolderItem } from './utils';
 
 const [_, { folderA, folderB, folderC }] = getFolderFixtures();
 
@@ -50,36 +51,18 @@ describe('useFoldersQuery', () => {
 
     it('uses custom root folder display name when rootFolderDisplay is provided', async () => {
       runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
-
-      const customRootName = 'Custom Root Folder';
       const { result } = renderHook(
         () =>
           useFoldersQuery({
             isBrowsing: true,
             openFolders: {},
-            rootFolderDisplay: customRootName,
+            rootFolderItem: getCustomRootFolderItem('Test Repo', ManagerKind.Repo),
           }),
         { wrapper }
       );
 
       // Test that root folder item uses the custom display name
-      expect(result.current.items[0]).toEqual(getRootFolderItem(customRootName));
-    });
-
-    it('uses empty string as rootFolderDisplay', async () => {
-      runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
-
-      const { result } = renderHook(
-        () =>
-          useFoldersQuery({
-            isBrowsing: true,
-            openFolders: {},
-            rootFolderDisplay: '',
-          }),
-        { wrapper }
-      );
-
-      expect(result.current.items[0]).toEqual(getRootFolderItem());
+      expect(result.current.items[0]).toEqual(getCustomRootFolderItem('Test Repo', ManagerKind.Repo));
     });
   });
 });

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
@@ -47,6 +47,40 @@ describe('useFoldersQuery', () => {
 
       expect(sortedItemTitles).toEqual(expectedTitles);
     });
+
+    it('uses custom root folder display name when rootFolderDisplay is provided', async () => {
+      runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
+
+      const customRootName = 'Custom Root Folder';
+      const { result } = renderHook(
+        () =>
+          useFoldersQuery({
+            isBrowsing: true,
+            openFolders: {},
+            rootFolderDisplay: customRootName,
+          }),
+        { wrapper }
+      );
+
+      // Test that root folder item uses the custom display name
+      expect(result.current.items[0]).toEqual(getRootFolderItem(customRootName));
+    });
+
+    it('uses empty string as rootFolderDisplay', async () => {
+      runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
+
+      const { result } = renderHook(
+        () =>
+          useFoldersQuery({
+            isBrowsing: true,
+            openFolders: {},
+            rootFolderDisplay: '',
+          }),
+        { wrapper }
+      );
+
+      expect(result.current.items[0]).toEqual(getRootFolderItem());
+    });
   });
 });
 

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.test.tsx
@@ -49,7 +49,7 @@ describe('useFoldersQuery', () => {
       expect(sortedItemTitles).toEqual(expectedTitles);
     });
 
-    it('uses custom root folder display name when rootFolderDisplay is provided', async () => {
+    it('uses custom root folder display name when rootFolderItem is provided', async () => {
       runtime.config.featureToggles.foldersAppPlatformAPI = featureToggleState;
       const { result } = renderHook(
         () =>

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -4,15 +4,22 @@ import { PermissionLevelString } from 'app/types/acl';
 import { useFoldersQueryAppPlatform } from './useFoldersQueryAppPlatform';
 import { useFoldersQueryLegacy } from './useFoldersQueryLegacy';
 
-export function useFoldersQuery(
-  isBrowsing: boolean,
-  openFolders: Record<string, boolean>,
-  permission?: PermissionLevelString,
+export function useFoldersQuery({
+  isBrowsing,
+  openFolders,
+  permission,
   /* Start tree from this folder instead of root */
-  rootFolderUID?: string
-) {
-  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID);
-  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders, rootFolderUID);
+  rootFolderUID,
+  rootFolderDisplay,
+}: {
+  isBrowsing: boolean;
+  openFolders: Record<string, boolean>;
+  permission?: PermissionLevelString;
+  rootFolderUID?: string;
+  rootFolderDisplay?: string;
+}) {
+  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID, rootFolderDisplay);
+  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders, rootFolderUID, rootFolderDisplay);
 
   // Running the hooks themselves don't have any side effects, so we can just conditionally use one or the other
   // requestNextPage function from the result

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -11,6 +11,7 @@ export function useFoldersQuery({
   permission,
   /* Start tree from this folder instead of root */
   rootFolderUID,
+  /* rootFolderItem: provide a custom root folder item, if no value passed in, default to "Dashboards" */
   rootFolderItem,
 }: {
   isBrowsing: boolean;

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,4 +1,5 @@
 import { config } from '@grafana/runtime';
+import { DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 import { PermissionLevelString } from 'app/types/acl';
 
 import { useFoldersQueryAppPlatform } from './useFoldersQueryAppPlatform';
@@ -10,16 +11,16 @@ export function useFoldersQuery({
   permission,
   /* Start tree from this folder instead of root */
   rootFolderUID,
-  rootFolderDisplay,
+  rootFolderItem,
 }: {
   isBrowsing: boolean;
   openFolders: Record<string, boolean>;
   permission?: PermissionLevelString;
   rootFolderUID?: string;
-  rootFolderDisplay?: string;
+  rootFolderItem?: DashboardsTreeItem;
 }) {
-  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID, rootFolderDisplay);
-  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders, rootFolderUID, rootFolderDisplay);
+  const resultLegacy = useFoldersQueryLegacy(isBrowsing, openFolders, permission, rootFolderUID, rootFolderItem);
+  const resultAppPlatform = useFoldersQueryAppPlatform(isBrowsing, openFolders, rootFolderUID, rootFolderItem);
 
   // Running the hooks themselves don't have any side effects, so we can just conditionally use one or the other
   // requestNextPage function from the result

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -29,7 +29,8 @@ export function useFoldersQueryAppPlatform(
   isBrowsing: boolean,
   openFolders: Record<string, boolean>,
   /* rootFolderUID: configure which folder to start browsing from */
-  rootFolderUID?: string
+  rootFolderUID?: string,
+  rootFolderDisplay?: string
 ) {
   const dispatch = useDispatch();
 
@@ -157,10 +158,10 @@ export function useFoldersQueryAppPlatform(
 
     const startingToken = rootFolderUID ?? rootFolderToken;
     const rootFlatTree = createFlatList(startingToken, state.responseByParent[startingToken], 1);
-    rootFlatTree.unshift(getRootFolderItem());
+    rootFlatTree.unshift(getRootFolderItem(rootFolderDisplay));
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders, rootFolderUID]);
+  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderDisplay]);
 
   return {
     items: treeList,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -30,7 +30,7 @@ export function useFoldersQueryAppPlatform(
   openFolders: Record<string, boolean>,
   /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string,
-  /* Custom root folder item, default is "Dashboards" */
+  /* rootFolderItem: provide a custom root folder item, if no value passed in, default to "Dashboards" */
   rootFolderItem?: DashboardsTreeItem
 ) {
   const dispatch = useDispatch();

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -30,7 +30,8 @@ export function useFoldersQueryAppPlatform(
   openFolders: Record<string, boolean>,
   /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string,
-  rootFolderDisplay?: string
+  /* Custom root folder item, default is "Dashboards" */
+  rootFolderItem?: DashboardsTreeItem
 ) {
   const dispatch = useDispatch();
 
@@ -158,10 +159,10 @@ export function useFoldersQueryAppPlatform(
 
     const startingToken = rootFolderUID ?? rootFolderToken;
     const rootFlatTree = createFlatList(startingToken, state.responseByParent[startingToken], 1);
-    rootFlatTree.unshift(getRootFolderItem(rootFolderDisplay));
+    rootFlatTree.unshift(rootFolderItem || getRootFolderItem());
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderDisplay]);
+  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderItem]);
 
   return {
     items: treeList,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -50,7 +50,8 @@ export function useFoldersQueryLegacy(
   openFolders: Record<string, boolean>,
   permission?: PermissionLevelString,
   /* rootFolderUID: configure which folder to start browsing from */
-  rootFolderUID?: string
+  rootFolderUID?: string,
+  rootFolderDisplay?: string
 ) {
   const dispatch = useDispatch();
 
@@ -183,10 +184,10 @@ export function useFoldersQueryLegacy(
     const startingPages = rootFolderUID ? state.pagesByParent[rootFolderUID] : state.rootPages;
 
     const rootFlatTree = createFlatList(rootFolderUID ?? undefined, startingPages ?? [], 1);
-    rootFlatTree.unshift(getRootFolderItem());
+    rootFlatTree.unshift(getRootFolderItem(rootFolderDisplay));
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders, rootFolderUID]);
+  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderDisplay]);
 
   return {
     items: treeList,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -51,6 +51,7 @@ export function useFoldersQueryLegacy(
   permission?: PermissionLevelString,
   /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string,
+  /* rootFolderItem: provide a custom root folder item, if no value passed in, default to "Dashboards" */
   rootFolderItem?: DashboardsTreeItem
 ) {
   const dispatch = useDispatch();

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -51,7 +51,7 @@ export function useFoldersQueryLegacy(
   permission?: PermissionLevelString,
   /* rootFolderUID: configure which folder to start browsing from */
   rootFolderUID?: string,
-  rootFolderDisplay?: string
+  rootFolderItem?: DashboardsTreeItem
 ) {
   const dispatch = useDispatch();
 
@@ -184,10 +184,10 @@ export function useFoldersQueryLegacy(
     const startingPages = rootFolderUID ? state.pagesByParent[rootFolderUID] : state.rootPages;
 
     const rootFlatTree = createFlatList(rootFolderUID ?? undefined, startingPages ?? [], 1);
-    rootFlatTree.unshift(getRootFolderItem(rootFolderDisplay));
+    rootFlatTree.unshift(rootFolderItem || getRootFolderItem());
 
     return rootFlatTree;
-  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderDisplay]);
+  }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderItem]);
 
   return {
     items: treeList,

--- a/public/app/core/components/NestedFolderPicker/utils.ts
+++ b/public/app/core/components/NestedFolderPicker/utils.ts
@@ -21,7 +21,7 @@ export const getCustomRootFolderItem = (
   item: {
     kind: 'folder' as const,
     title: title
-      ? t('browse-dashboards.folder-picker.root-title-custom', title)
+      ? t('browse-dashboards.folder-picker.root-title-custom', '{{title}}', { title })
       : t('browse-dashboards.folder-picker.root-title', 'Dashboards'),
     uid: '',
     managedBy: managedBy,

--- a/public/app/core/components/NestedFolderPicker/utils.ts
+++ b/public/app/core/components/NestedFolderPicker/utils.ts
@@ -1,8 +1,8 @@
 import { t } from '@grafana/i18n';
 import { ManagerKind } from 'app/features/apiserver/types';
-import { DashboardsTreeItem } from 'app/features/browse-dashboards/types';
+import { DashboardsTreeItem, DashboardViewItemWithUIItems } from 'app/features/browse-dashboards/types';
 
-export const getRootFolderItem = (): DashboardsTreeItem => ({
+export const getRootFolderItem = (): DashboardsTreeItem<DashboardViewItemWithUIItems> => ({
   isOpen: true,
   level: 0,
   item: {
@@ -12,7 +12,10 @@ export const getRootFolderItem = (): DashboardsTreeItem => ({
   },
 });
 
-export const getCustomRootFolderItem = (title?: string, managedBy?: ManagerKind): DashboardsTreeItem => ({
+export const getCustomRootFolderItem = (
+  title?: string,
+  managedBy?: ManagerKind
+): DashboardsTreeItem<DashboardViewItemWithUIItems> => ({
   isOpen: true,
   level: 0,
   item: {

--- a/public/app/core/components/NestedFolderPicker/utils.ts
+++ b/public/app/core/components/NestedFolderPicker/utils.ts
@@ -1,6 +1,18 @@
 import { t } from '@grafana/i18n';
+import { ManagerKind } from 'app/features/apiserver/types';
+import { DashboardsTreeItem } from 'app/features/browse-dashboards/types';
 
-export const getRootFolderItem = (title?: string) => ({
+export const getRootFolderItem = (): DashboardsTreeItem => ({
+  isOpen: true,
+  level: 0,
+  item: {
+    kind: 'folder' as const,
+    title: t('browse-dashboards.folder-picker.root-title', 'Dashboards'),
+    uid: '',
+  },
+});
+
+export const getCustomRootFolderItem = (title?: string, managedBy?: ManagerKind): DashboardsTreeItem => ({
   isOpen: true,
   level: 0,
   item: {
@@ -9,5 +21,6 @@ export const getRootFolderItem = (title?: string) => ({
       ? t('browse-dashboards.folder-picker.root-title-custom', title)
       : t('browse-dashboards.folder-picker.root-title', 'Dashboards'),
     uid: '',
+    managedBy: managedBy,
   },
 });

--- a/public/app/core/components/NestedFolderPicker/utils.ts
+++ b/public/app/core/components/NestedFolderPicker/utils.ts
@@ -1,11 +1,13 @@
 import { t } from '@grafana/i18n';
 
-export const getRootFolderItem = () => ({
+export const getRootFolderItem = (title?: string) => ({
   isOpen: true,
   level: 0,
   item: {
     kind: 'folder' as const,
-    title: t('browse-dashboards.folder-picker.root-title', 'Dashboards'),
+    title: title
+      ? t('browse-dashboards.folder-picker.root-title-custom', title)
+      : t('browse-dashboards.folder-picker.root-title', 'Dashboards'),
     uid: '',
   },
 });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3626,7 +3626,7 @@
       "error-title": "Error loading folders",
       "non-folder-item": "Non-folder {{itemKind}} {{itemUID}}",
       "root-title": "Dashboards",
-      "root-title-custom": "",
+      "root-title-custom": "{{title}}",
       "search-placeholder": "Search folders",
       "unknown-error": "Unknown error"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3626,6 +3626,7 @@
       "error-title": "Error loading folders",
       "non-folder-item": "Non-folder {{itemKind}} {{itemUID}}",
       "root-title": "Dashboards",
+      "root-title-custom": "",
       "search-placeholder": "Search folders",
       "unknown-error": "Unknown error"
     },


### PR DESCRIPTION
**What is this feature?**

`FolderPicker`: Added new optional prop `rootFolderItem` to allow root folder object customization. 

Example code: 

```
<FolderPicker
    ...other props,
    rootFolderItem={getCustomRootFolderItem(myTitle, ManagerKind.Repo)}
/>
```

Example:  
<img width="714" height="138" alt="image" src="https://github.com/user-attachments/assets/36c080d6-8460-4aa8-903e-6759fd673a67" />


**Why do we need this feature?**

Provide more flexibility to `FolderPicker` usage

**Who is this feature for?**

Devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/110283

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
