### PR TITLE
Unistore: Only Shadow Search Traffic when running on modes > 0

### DIFF
--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -134,12 +134,12 @@ func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceSta
 		client = s.unifiedClient
 	}
 
-	shouldMakeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
 	if err != nil {
 		return nil, err
 	}
 
-	if shouldMakeBackgroundCall {
+	if makeBackgroundCall {
 		// Create background context with timeout but ignore parent cancelation
 		ctxBg := context.WithoutCancel(ctx)
 
@@ -170,12 +170,12 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 		client = s.unifiedClient
 	}
 
-	shouldMakeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	makeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
 	if err != nil {
 		return nil, err
 	}
 
-	if shouldMakeBackgroundCall {
+	if makeBackgroundCall {
 		// Get the legacy result first
 		legacyResponse, legacyErr := s.legacyClient.Search(ctx, in, opts...)
 		if legacyErr != nil {

--- a/pkg/storage/unified/resource/search_client.go
+++ b/pkg/storage/unified/resource/search_client.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
@@ -38,6 +39,7 @@ var (
 type DualWriter interface {
 	IsEnabled(schema.GroupResource) bool
 	ReadFromUnified(context.Context, schema.GroupResource) (bool, error)
+	Status(ctx context.Context, gr schema.GroupResource) (dualwrite.StorageStatus, error)
 }
 
 func NewSearchClient(dual DualWriter, gr schema.GroupResource, unifiedClient resourcepb.ResourceIndexClient,
@@ -99,6 +101,28 @@ func calculateMatchPercentage(legacyUIDs, unifiedUIDs map[string]struct{}) float
 	return float64(matches) / float64(len(legacyUIDs)) * 100.0
 }
 
+// If dual reader feature flag is enabled, and legacy is the main storage,
+// and we are writing to unified (which means we are effectively dual writing),
+// then make a background call to unified
+func shouldMakeBackgroundCall(ctx context.Context, features featuremgmt.FeatureToggles, dual DualWriter, gr schema.GroupResource) (bool, error) {
+	unifiedIsMainStorage, err := dual.ReadFromUnified(ctx, gr)
+	if err != nil {
+		return false, err
+	}
+
+	status, err := dual.Status(ctx, gr)
+	if err != nil {
+		return false, err
+	}
+
+	res := features != nil &&
+		features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) &&
+		!unifiedIsMainStorage &&
+		status.WriteUnified
+
+	return res, nil
+}
+
 func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest,
 	opts ...grpc.CallOption) (*resourcepb.ResourceStatsResponse, error) {
 	client := s.legacyClient
@@ -110,9 +134,12 @@ func (s *searchWrapper) GetStats(ctx context.Context, in *resourcepb.ResourceSta
 		client = s.unifiedClient
 	}
 
-	// If dual reader feature flag is enabled, and legacy is the main storage,
-	// make a background call to unified
-	if s.features != nil && s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) && !unified {
+	shouldMakeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldMakeBackgroundCall {
 		// Create background context with timeout but ignore parent cancelation
 		ctxBg := context.WithoutCancel(ctx)
 
@@ -143,9 +170,12 @@ func (s *searchWrapper) Search(ctx context.Context, in *resourcepb.ResourceSearc
 		client = s.unifiedClient
 	}
 
-	// If dual reader feature flag is enabled, and legacy is the main storage,
-	// make a background call to unified and compare results
-	if s.features != nil && s.features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearchDualReaderEnabled) && !unified {
+	shouldMakeBackgroundCall, err := shouldMakeBackgroundCall(ctx, s.features, s.dual, s.groupResource)
+	if err != nil {
+		return nil, err
+	}
+
+	if shouldMakeBackgroundCall {
 		// Get the legacy result first
 		legacyResponse, legacyErr := s.legacyClient.Search(ctx, in, opts...)
 		if legacyErr != nil {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR modifies the search client to only send shadow traffic to Unified Storage if we are using Legacy as Main Storage and also Writing to Unified Storage (which means that we are using the dual writer).

**Why do we need this feature?**

Before this change, the search client was sending queries to unified storage on modes 0, 1 and 2.
For mode 0, we should send queries only to legacy storage.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/446

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
