### PR TITLE
Documentation: Fix inconsistency in Entra SAML docs

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
@@ -134,6 +134,6 @@ The following table shows what the permissions look like from the Entra ID porta
 | `User.Read`            | Delegated   | No                     | Granted |
 | `User.Read.All`        | Application | Yes                    | Granted |
 
-{{< figure src="/media/docs/grafana/saml/graph-api-app-permissions.png" caption="Screen shot of the permissions listed in Entra ID for the App registration" >}}
+{{< figure src="/media/docs/IAM/image.png" caption="Screen shot of the permissions listed in Entra ID for the App registration" >}}
 
 To test that Graph API has the correct permissions, refer to the [Troubleshoot Graph API calls](../troubleshoot-saml/#troubleshoot-graph-api-calls) section.

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
@@ -128,11 +128,11 @@ This app registration will be used as a Service Account to retrieve more informa
 
 The following table shows what the permissions look like from the Entra ID portal:
 
-| Permissions name | Type        | Admin consent required | Status  |
-| ---------------- | ----------- | ---------------------- | ------- |
-| `Group.Read.All` | Application | Yes                    | Granted |
-| `User.Read`      | Delegated   | No                     | Granted |
-| `User.Read.All`  | Application | Yes                    | Granted |
+| Permissions name       | Type        | Admin consent required | Status  |
+| ---------------------- | ----------- | ---------------------- | ------- |
+| `GroupMember.Read.All` | Application | Yes                    | Granted |
+| `User.Read`            | Delegated   | No                     | Granted |
+| `User.Read.All`        | Application | Yes                    | Granted |
 
 {{< figure src="/media/docs/grafana/saml/graph-api-app-permissions.png" caption="Screen shot of the permissions listed in Entra ID for the App registration" >}}
 


### PR DESCRIPTION
While setting up the Graph API permissions for Entra SAML, I noticed a slight inconsistency in the documentation. The instructions above say to use `GroupMember.Read.All`, but the table and the screenshot both said `Group.Read.All`. After speaking with our Microsoft admins and looking at what each role gives, it appears to me that `GroupMember.Read.All` is the correct one to use. This PR updates the table, but the screenshot below the table will need to be retaken as well.