### PR TITLE
Kubernetes Dashboards: Delete resourceVersion (on update and create) and name (on create)

### DIFF
--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -71,18 +71,22 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
       };
     }
 
+    // remove resource version because it's not allowed to be set
+    // and the api server will throw an error
+    delete obj.metadata.resourceVersion;
+
     // for v1 in g12, we will ignore the schema version validation from all default clients,
     // as we implement the necessary backend conversions, we will drop this query param
     if (dashboard.uid) {
       obj.metadata.name = dashboard.uid;
-      // remove resource version when updating
-      delete obj.metadata.resourceVersion;
       return this.client.update(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
     }
     obj.metadata.annotations = {
       ...obj.metadata.annotations,
       [AnnoKeyGrantPermissions]: 'default',
     };
+    // non-scene dashboard will have obj.metadata.name when trying to save a dashboard copy
+    delete obj.metadata.name;
     return this.client.create(obj, { fieldValidation: 'Ignore' }).then((v) => this.asSaveDashboardResponseDTO(v));
   }
 


### PR DESCRIPTION
Fixes an issue with the k8s API server returning an error when trying to save a dashboard copy. Dashboards that use legacy (non-scene) architecture will have resourceVersion and name set which will throw errors because dashboard cannot be created with a resourceVersion, and can't have a name (which is a unique identifier and it's passed from dashboard we want't to copy from).

Fixes: https://github.com/grafana/support-escalations/issues/18127

Please check that:
- [ ] It works as expected from a user's perspective.
