### PR TITLE
Trend: Fix x-axis max affected by null-append to bar series

### DIFF
--- a/public/app/core/components/GraphNG/utils.test.ts
+++ b/public/app/core/components/GraphNG/utils.test.ts
@@ -513,4 +513,288 @@ describe('GraphNG utils', () => {
       }
     `);
   });
+
+  test('preparePlotFrame DOES NOT append min bar spaced nulls when all visible bar series have same min spacing', () => {
+    const df1: DataFrame = {
+      name: 'A',
+      length: 5,
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [1, 2, 4, 6, 100], // should find smallest delta === 1 from here
+        },
+        {
+          name: 'value',
+          type: FieldType.number,
+          config: {
+            custom: {
+              drawStyle: GraphDrawStyle.Bars,
+            },
+          },
+          values: [1, 1, 1, 1, 1],
+        },
+      ],
+    };
+
+    const df2: DataFrame = {
+      name: 'B',
+      length: 5,
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [30, 31, 50, 90, 100],
+        },
+        {
+          name: 'value',
+          type: FieldType.number,
+          config: {
+            custom: {
+              drawStyle: GraphDrawStyle.Bars,
+            },
+          },
+          values: [2, 2, 2, 2, 2],
+        },
+        {
+          name: 'value',
+          type: FieldType.number,
+          config: {
+            custom: {
+              drawStyle: GraphDrawStyle.Line,
+            },
+          },
+          values: [3, 3, 3, 3, 3],
+        },
+      ],
+    };
+
+    const df3: DataFrame = {
+      name: 'C',
+      length: 2,
+      fields: [
+        {
+          name: 'time',
+          type: FieldType.time,
+          config: {},
+          values: [1, 1.1], // should not trip up on smaller deltas of non-bars
+        },
+        {
+          name: 'value',
+          type: FieldType.number,
+          config: {
+            custom: {
+              drawStyle: GraphDrawStyle.Line,
+            },
+          },
+          values: [4, 4],
+        },
+        {
+          name: 'value',
+          type: FieldType.number,
+          config: {
+            custom: {
+              drawStyle: GraphDrawStyle.Bars,
+              hideFrom: {
+                viz: true, // should ignore hidden bar series
+              },
+            },
+          },
+          values: [4, 4],
+        },
+      ],
+    };
+
+    let aligndFrame = preparePlotFrame([df1, df2, df3], {
+      x: fieldMatchers.get(FieldMatcherID.firstTimeField).get({}),
+      y: fieldMatchers.get(FieldMatcherID.numeric).get({}),
+    });
+
+    expect(aligndFrame).toMatchInlineSnapshot(`
+      {
+        "fields": [
+          {
+            "config": {},
+            "name": "time",
+            "state": {
+              "nullThresholdApplied": true,
+              "origin": {
+                "fieldIndex": 0,
+                "frameIndex": 0,
+              },
+            },
+            "type": "time",
+            "values": [
+              1,
+              1.1,
+              2,
+              4,
+              6,
+              30,
+              31,
+              50,
+              90,
+              100,
+            ],
+          },
+          {
+            "config": {
+              "custom": {
+                "drawStyle": "bars",
+              },
+            },
+            "labels": {
+              "name": "A",
+            },
+            "name": "value",
+            "state": {
+              "origin": {
+                "fieldIndex": 1,
+                "frameIndex": 0,
+              },
+            },
+            "type": "number",
+            "values": [
+              1,
+              undefined,
+              1,
+              1,
+              1,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              1,
+            ],
+          },
+          {
+            "config": {
+              "custom": {
+                "drawStyle": "bars",
+              },
+            },
+            "labels": {
+              "name": "B",
+            },
+            "name": "value",
+            "state": {
+              "origin": {
+                "fieldIndex": 1,
+                "frameIndex": 1,
+              },
+            },
+            "type": "number",
+            "values": [
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              2,
+              2,
+              2,
+              2,
+              2,
+            ],
+          },
+          {
+            "config": {
+              "custom": {
+                "drawStyle": "line",
+              },
+            },
+            "labels": {
+              "name": "B",
+            },
+            "name": "value",
+            "state": {
+              "origin": {
+                "fieldIndex": 2,
+                "frameIndex": 1,
+              },
+            },
+            "type": "number",
+            "values": [
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              3,
+              3,
+              3,
+              3,
+              3,
+            ],
+          },
+          {
+            "config": {
+              "custom": {
+                "drawStyle": "line",
+              },
+            },
+            "labels": {
+              "name": "C",
+            },
+            "name": "value",
+            "state": {
+              "origin": {
+                "fieldIndex": 1,
+                "frameIndex": 2,
+              },
+            },
+            "type": "number",
+            "values": [
+              4,
+              4,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+            ],
+          },
+          {
+            "config": {
+              "custom": {
+                "drawStyle": "bars",
+                "hideFrom": {
+                  "viz": true,
+                },
+              },
+            },
+            "labels": {
+              "name": "C",
+            },
+            "name": "value",
+            "state": {
+              "origin": {
+                "fieldIndex": 2,
+                "frameIndex": 2,
+              },
+            },
+            "type": "number",
+            "values": [
+              4,
+              4,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+            ],
+          },
+        ],
+        "length": 10,
+      }
+    `);
+  });
 });

--- a/public/app/core/components/GraphNG/utils.ts
+++ b/public/app/core/components/GraphNG/utils.ts
@@ -1,4 +1,12 @@
-import { DataFrame, Field, FieldType, outerJoinDataFrames, TimeRange, applyNullInsertThreshold } from '@grafana/data';
+import {
+  DataFrame,
+  Field,
+  FieldType,
+  outerJoinDataFrames,
+  TimeRange,
+  applyNullInsertThreshold,
+  roundDecimals,
+} from '@grafana/data';
 import { NULL_EXPAND, NULL_REMOVE, NULL_RETAIN, nullToUndefThreshold } from '@grafana/data/internal';
 import { GraphDrawStyle } from '@grafana/schema';
 
@@ -42,20 +50,22 @@ function applySpanNullsThresholds(frame: DataFrame, refFieldName?: string | null
   return frame;
 }
 
-export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) {
-  let xField: Field;
-  loop: for (let frame of frames) {
-    for (let field of frame.fields) {
-      if (dimFields.x(field, frame, frames)) {
-        xField = field;
-        break loop;
-      }
+function getXField(dimFields: XYFieldMatchers, frame: DataFrame, frames: DataFrame[]) {
+  for (let field of frame.fields) {
+    if (dimFields.x(field, frame, frames)) {
+      return field;
     }
   }
 
+  return;
+}
+
+export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers, timeRange?: TimeRange | null) {
   // apply null insertions at interval
   frames = frames.map((frame) => {
-    if (!xField?.state?.nullThresholdApplied) {
+    const xField = getXField(dimFields, frame, frames);
+
+    if (xField != null && !xField.state?.nullThresholdApplied) {
       return applyNullInsertThreshold({
         frame,
         refFieldName: xField.name,
@@ -73,22 +83,43 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
   );
 
   // to make bar widths of all series uniform (equal to narrowest bar series), find smallest distance between x points
-  let minXDelta = Infinity;
+  let minXDeltaGlobal: number | null = null;
 
   if (numBarSeries > 1) {
+    // collect for each frame and only set minXDeltaGlobal if they're different
+    const minXDeltas = new Set<number>();
+
     frames.forEach((frame) => {
       if (!frame.fields.some(isVisibleBarField)) {
         return;
       }
 
+      const xField = getXField(dimFields, frame, frames);
+
+      if (xField == null) {
+        return;
+      }
+
+      let minXDeltaFrame = Infinity;
+
       const xVals = xField.values;
 
       for (let i = 0; i < xVals.length; i++) {
         if (i > 0) {
-          minXDelta = Math.min(minXDelta, xVals[i] - xVals[i - 1]);
+          minXDeltaFrame = Math.min(minXDeltaFrame, xVals[i] - xVals[i - 1]);
         }
       }
+
+      if (!Number.isInteger(minXDeltaFrame)) {
+        minXDeltaFrame = roundDecimals(minXDeltaFrame, 6);
+      }
+
+      minXDeltas.add(minXDeltaFrame);
     });
+
+    if (minXDeltas.size > 1) {
+      minXDeltaGlobal = Math.min(...minXDeltas);
+    }
   }
 
   let alignedFrame = outerJoinDataFrames({
@@ -116,16 +147,16 @@ export function preparePlotFrame(frames: DataFrame[], dimFields: XYFieldMatchers
   });
 
   if (alignedFrame) {
-    alignedFrame = applySpanNullsThresholds(alignedFrame, xField!.name);
+    alignedFrame = applySpanNullsThresholds(alignedFrame, alignedFrame.fields[0].name);
 
-    // append 2 null vals at minXDelta to bar series
-    if (minXDelta !== Infinity) {
+    // append 2 null vals at minXDeltaGlobal to bar series
+    if (minXDeltaGlobal != null) {
       alignedFrame.fields.forEach((f, fi) => {
         let vals = f.values;
 
         if (fi === 0) {
           let lastVal = vals[vals.length - 1];
-          vals.push(lastVal + minXDelta, lastVal + 2 * minXDelta);
+          vals.push(lastVal + minXDeltaGlobal, lastVal + 2 * minXDeltaGlobal);
         } else if (isVisibleBarField(f)) {
           vals.push(null, null);
         } else {


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/102839

the way uPlot calculates bar width per series is by scanning the x value array and finding the minimum spacing between adjacent points, then multiplying that by a factor like 0.6. since this is done per series, if you have different spacing between points in different series, you could end up with different sized bars, which looks weird. what we do on the grafana side is find the global minimum x spacing across all visible bar series and then append two `null` data points to the final aligned/joined frame at that minimum spacing. this way when uPlot scans the x value array, it gets the globally min spacing value. (yes, it's a hack).

this generally works for TimeSeries panel because the x range there is governed by the dashboard time picker rather than the underlying query data, so any appended `null` data points beyond the x max are never visible. however, this doesnt work for Trend panel, where the x range comes from the x data points, so when we append two nulls, it artificially grows the x max.

the solution here fixes this for the common case of aligned data, where all bar series share the same min spacing between adjacent x points. in this case we avoid appending any `null` values, since uPlot will already see the same shared min spacing for all series.

<details><summary>trend-bars-append-nulls-bug.json</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 21434,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.1,
            "drawStyle": "bars",
            "fillOpacity": 100,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 0,
            "pointSize": 1,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "showValues": false,
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "normal"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          },
          "unit": "short"
        },
        "overrides": []
      },
      "gridPos": {
        "h": 19,
        "w": 13,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "mode": "multi",
          "sort": "none"
        }
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource",
            "uid": "PD8C576611E62080A"
          },
          "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"executedQueryString\": \"WITH print_outcomes AS (\\r\\n    SELECT\\r\\n        LEFT(version_number,1) || RIGHT(LEFT(version_number,4),2) || '.' || LEFT(RIGHT(version_number,4),1) AS version_string,\\r\\n        print_guid,\\r\\n        CASE\\r\\n            WHEN last_successfully_printed_layer <= 0 AND (print.status = 'ABORTED'\\r\\n                    OR LOWER(print.error) IN ('aborted','mixer hit debris','debris detected','printer out of level','resin could not be measured','could not read resin temperature')\\r\\n                    OR CONTAINS_SUBSTR(error_message,'aborted') OR CONTAINS_SUBSTR(error_message,'debris') OR CONTAINS_SUBSTR(error_message,'temperature could not be') OR CONTAINS_SUBSTR(error_message,'out of level') OR error_string = 'Task::RETRY_UNTIL_SUCCESS_FAILURE')\\r\\n                THEN 'Abort before print - not counted'\\r\\n            WHEN last_successfully_printed_layer <= 0 AND print.status = 'ERROR'\\r\\n                THEN 'Error before print'\\r\\n            WHEN print.status = 'ERROR' AND NOT CONTAINS_SUBSTR(error_message,'aborted')\\r\\n                THEN 'Error or resolution-abort during print'\\r\\n            WHEN print.status = 'ABORTED' OR (print.status = 'ERROR' AND CONTAINS_SUBSTR(error_message,'aborted'))\\r\\n                THEN 'Manual abort during print'\\r\\n            WHEN print.status = 'FINISHED'\\r\\n                THEN 'Finished with vote ' || IFNULL(print_run_success,'NULL')\\r\\n            ELSE 'Error'\\r\\n        END AS print_outcome\\r\\n    FROM productl_logs.print\\r\\n        LEFT JOIN company-data-warehouse.printernet_public.prints_printrunsuccess ON print_guid = print_run_id\\r\\n        JOIN company-data-warehouse.fl.prints_productl USING(job_guid,print_guid,printer_serial)\\r\\n        JOIN productl_logs.job USING(job_guid)\\r\\n    WHERE \\r\\n        NOT print.status IN ('PRINTING','PREPRINT','PAUSED')\\r\\n        AND is_customer_print AND CONTAINS_SUBSTR(print.printer_serial,'productL')\\r\\n        AND started_at BETWEEN '2025-02-23T21:41:25.892Z' AND '2025-03-25T20:41:25.892Z'\\r\\n)\\r\\n\\r\\nSELECT\\r\\n    CAST(version_string AS FLOAT64) AS version, * EXCEPT(version_string)\\r\\nFROM\\r\\n    (SELECT version_string, print_guid, print_outcome,\\r\\n        COUNTIF(print_outcome NOT IN ('Finished with vote NULL','Abort before print - not counted','Finished with vote SUCCESS')) OVER (PARTITION BY version_string) AS failures,\\r\\n        COUNTIF(print_outcome NOT IN ('Abort before print - not counted')) OVER (PARTITION BY version_string) AS pop,\\r\\n        100 * COUNTIF(print_outcome NOT IN ('Finished with vote NULL','Abort before print - not counted','Finished with vote SUCCESS')) OVER (PARTITION BY version_string)\\r\\n            / NULLIF(COUNTIF(print_outcome NOT IN ('Abort before print - not counted')) OVER (PARTITION BY version_string),0) AS failure_rate\\r\\n        FROM print_outcomes\\r\\n    )\\r\\n    PIVOT (COUNT(DISTINCT print_guid) FOR print_outcome IN ('Abort before print - not counted','Error before print','Error or resolution-abort during print','Manual abort during print','Finished with vote SUCCESS','Finished with vote FAILURE','Finished with vote NULL'))\\r\\nWHERE pop > 500\\r\\nORDER BY version ASC\",\n        \"preferredVisualisationType\": \"table\",\n        \"transformations\": [\n          \"organize\",\n          \"organize\",\n          \"organize\",\n          \"organize\",\n          \"organize\",\n          \"organize\"\n        ],\n        \"typeVersion\": [\n          0,\n          0\n        ]\n      },\n      \"name\": \"A\",\n      \"fields\": [\n        {\n          \"config\": {},\n          \"name\": \"uzguzkt_qrvyyuc\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"myvdytwq\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"bwo\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"bhzvozv_yvno\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Ancle buullb xzrvk - qys iuqwicz\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Eunbm tlqfnu oqhuw\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Eipww km wsbliqzdwy-usazu gnrxgx eunoi\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Mgxzot obfvl rgfqom hykya\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Fgzujcev rmkr zlfu SUCCESS\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Fsxexxol vcat iryg FAILURE\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        },\n        {\n          \"config\": {},\n          \"name\": \"Fdhrkajp tnyb xjlh NULL\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int64\",\n            \"nullable\": true\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          345,\n          345.1,\n          345.2\n        ],\n        [\n          55,\n          138,\n          157\n        ],\n        [\n          744,\n          1731,\n          2214\n        ],\n        [\n          7.39247311827957,\n          7.972270363951473,\n          7.091237579042457\n        ],\n        [\n          80,\n          163,\n          164\n        ],\n        [\n          0,\n          4,\n          2\n        ],\n        [\n          34,\n          59,\n          74\n        ],\n        [\n          8,\n          33,\n          42\n        ],\n        [\n          545,\n          1271,\n          1789\n        ],\n        [\n          13,\n          42,\n          39\n        ],\n        [\n          144,\n          322,\n          266\n        ]\n      ]\n    }\n  }\n]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "Reproduced with embedded data",
      "transformations": [
        {
          "id": "organize",
          "options": {
            "excludeByName": {
              "failures": true,
              "pop": true
            },
            "includeByName": {},
            "indexByName": {
              "Abort before print - not counted": 1,
              "Error before print": 2,
              "Error or resolution-abort during print": 3,
              "Finished with vote FAILURE": 6,
              "Finished with vote NULL": 7,
              "Finished with vote SUCCESS": 5,
              "Manual abort during print": 4,
              "failure_rate": 10,
              "failures": 8,
              "pop": 9,
              "version": 0
            },
            "renameByName": {
              "failure_rate": "Failure Rate",
              "four_week_trailing": "4 Week Trailing Failure Rate",
              "success_rate": "Print success rate",
              "version": "version",
              "version_number": "version"
            }
          }
        }
      ],
      "type": "trend"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [
    "debug",
    "debug-trend"
  ],
  "templating": {
    "list": []
  },
  "time": {
    "from": "2025-02-23T21:46:21.219Z",
    "to": "2025-03-25T20:46:21.219Z"
  },
  "timepicker": {},
  "timezone": "",
  "title": "trend-bars-append-nulls-bug",
  "uid": "b0baf4d5-36bd-4e7f-93fc-065eeaf40afc",
  "version": 5
}
```
</details>

---
before:

<img width="2066" height="1088" alt="image" src="https://github.com/user-attachments/assets/545fe2cc-af56-401f-b9cb-af36eea89f60" />

---
after:

<img width="2066" height="1088" alt="image" src="https://github.com/user-attachments/assets/a1358baf-2483-42fd-be39-c2a546ba0d29" />