### PR TITLE
[release-11.6.6] Mixed datasource: Use getDefaultQuery from the datasource when creating new queries when using the mixed datasource

### DIFF
--- a/public/app/features/query/components/QueryEditorRows.test.tsx
+++ b/public/app/features/query/components/QueryEditorRows.test.tsx
@@ -1,9 +1,12 @@
-import { fireEvent, queryByLabelText, render, screen } from '@testing-library/react';
+import { fireEvent, queryByLabelText, render, screen, waitFor } from '@testing-library/react';
 
+import type { DataSourceApi } from '@grafana/data';
+import type { DataSourceSrv, GetDataSourceListFilters } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
 import { DataSourceType } from 'app/features/alerting/unified/utils/datasource';
 import createMockPanelData from 'app/plugins/datasource/azuremonitor/__mocks__/panelData';
+import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { QueryEditorRows, Props } from './QueryEditorRows';
 
@@ -17,22 +20,16 @@ const mockVariable = mockDataSource({
   type: 'datasource',
 });
 
-jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
-  return {
-    getDataSourceSrv: () => ({
-      get: () => Promise.resolve({ ...mockDS, getRef: () => {} }),
-      getList: ({ variables }: { variables: boolean }) => (variables ? [mockDS, mockVariable] : [mockDS]),
-      getInstanceSettings: () => ({
-        ...mockDS,
-        meta: {
-          ...mockDS.meta,
-          alerting: true,
-          mixed: true,
-        },
-      }),
-    }),
-  };
-});
+const dsSrvMock: Pick<DataSourceSrv, 'get' | 'getList' | 'getInstanceSettings'> = {
+  get: jest.fn(async () => ({ getDefaultQuery: undefined }) as unknown as DataSourceApi),
+  getList: jest.fn((filters?: GetDataSourceListFilters) => (filters?.variables ? [mockDS, mockVariable] : [mockDS])),
+  getInstanceSettings: jest.fn(() => mockDS),
+};
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => dsSrvMock,
+}));
 
 const props: Props = {
   queries: [
@@ -57,16 +54,6 @@ const props: Props = {
   },
   data: createMockPanelData(),
 };
-
-jest.mock('@grafana/runtime/src/services/dataSourceSrv', () => {
-  return {
-    getDataSourceSrv: () => ({
-      get: () => Promise.resolve(mockDS),
-      getList: ({ variables }: { variables: boolean }) => (variables ? [mockDS, mockVariable] : [mockDS]),
-      getInstanceSettings: () => mockDS,
-    }),
-  };
-});
 
 describe('QueryEditorRows', () => {
   it('Should render queries', async () => {
@@ -140,6 +127,36 @@ describe('QueryEditorRows', () => {
 
     expect(onQueriesChange).toHaveBeenCalledTimes(queryEditorRows.length);
     expect(onQueryRemoved).toHaveBeenCalledTimes(queryEditorRows.length);
+  });
+
+  it('Should call getDefaultQuery when changing datasource with mixed datasource enabled', async () => {
+    const onQueriesChangeMock = jest.fn();
+
+    const mixedDsSettings = mockDataSource(
+      { name: MIXED_DATASOURCE_NAME, uid: MIXED_DATASOURCE_NAME },
+      { mixed: true }
+    );
+
+    const component = new QueryEditorRows({
+      ...props,
+      dsSettings: mixedDsSettings,
+      onQueriesChange: onQueriesChangeMock,
+    });
+
+    const getDefaultQuery = jest.fn(() => ({ defaultFromDS: 'yes' }));
+    // Mutate singleton dsSrvMock to return a datasource that has getDefaultQuery
+    dsSrvMock.get = jest.fn(() => Promise.resolve({ getDefaultQuery } as unknown as DataSourceApi));
+    dsSrvMock.getInstanceSettings = jest.fn(() => ({ ...mockDS, type: 'alertmanager' }));
+
+    // Change to a different type than existing to trigger default query path
+    const newDS = mockDataSource({ uid: 'prom', name: 'Prometheus', type: 'prometheus' });
+    component.onDataSourceChange(newDS, 0);
+
+    await waitFor(() => expect(onQueriesChangeMock).toHaveBeenCalled());
+
+    const updatedQueries = onQueriesChangeMock.mock.calls[0][0] as Array<DataQuery & { defaultFromDS?: string }>;
+    expect(updatedQueries[0].defaultFromDS).toBe('yes');
+    expect(getDefaultQuery).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/public/app/features/query/components/QueryEditorRows.tsx
+++ b/public/app/features/query/components/QueryEditorRows.tsx
@@ -60,8 +60,8 @@ export class QueryEditorRows extends PureComponent<Props> {
   onDataSourceChange(dataSource: DataSourceInstanceSettings, index: number) {
     const { queries, onQueriesChange } = this.props;
 
-    onQueriesChange(
-      queries.map((item, itemIndex) => {
+    Promise.all(
+      queries.map(async (item, itemIndex) => {
         if (itemIndex !== index) {
           return item;
         }
@@ -79,12 +79,15 @@ export class QueryEditorRows extends PureComponent<Props> {
           }
         }
 
-        return {
-          refId: item.refId,
-          hide: item.hide,
-          datasource: dataSourceRef,
-        };
+        const ds = await getDataSourceSrv().get(dataSourceRef);
+
+        return { ...ds.getDefaultQuery?.(CoreApp.PanelEditor), ...item, datasource: dataSourceRef };
       })
+    ).then(
+      (values) => onQueriesChange(values),
+      () => {
+        throw new Error(`Failed to get datasource ${dataSource.name ?? dataSource.uid}`);
+      }
     );
   }
 


### PR DESCRIPTION
Backport be80f36248ac75641ea19730e8574874a8c6ccb6 from #110158

---

**What is this feature?**

When we create a new query using the normal data source picker, we always call the datasources `getDefaultQuery`. Some datasource plugins rely on this happening.

When we're using the mixed datasource, new queries created when selecting the datasource does not get populated with the default query.

**Why do we need this feature?**

Reconciles behaviors for the query editor between using the datasource on the top level and using the datasource in a mixed datasource.
