### PR TITLE
Provisining: Fix flake in Github URL tests

### DIFF
--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -338,15 +338,6 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 				url, _, err := unstructured.NestedString(obj.Object, "spec", "github", "url")
 				require.NoError(t, err, "failed to read URL")
 				require.Equal(t, test.output, url)
-
-				err = helper.Repositories.Resource.Delete(ctx, test.name, metav1.DeleteOptions{})
-				require.NoError(t, err, "failed to delete")
-
-				// Wait for repository to be fully deleted before next test
-				require.EventuallyWithT(t, func(collect *assert.CollectT) {
-					_, err := helper.Repositories.Resource.Get(ctx, test.name, metav1.GetOptions{})
-					assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-				}, time.Second*5, time.Millisecond*50, "repository should be deleted")
 			})
 		}
 	})


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix flake in Provisioning's integration tests validating github url scenarios. [Failed Run](https://github.com/grafana/grafana/actions/runs/17290610832/job/49076877907?pr=110261)

The way this is solved is by removing the unnecessary removal and its assertion, as Git sync supports multi-repositories and those tests will create a different test for each scenario; that should give them enough isolation.

**Why do we need this feature?**

We don't like flaky tests.

**Who is this feature for?**

Contributors.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of <https://github.com/grafana/git-ui-sync-project/issues/442#event-19241610684>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
