### PR TITLE
LogLine: add min-height to fields wrapper

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -595,6 +595,7 @@ export const getStyles = (theme: GrafanaTheme2, virtualization?: LogLineVirtuali
       },
     }),
     fieldsWrapper: css({
+      minHeight: virtualization ? virtualization.getLineHeight() + virtualization.getPaddingBottom() : undefined,
       '&:hover': {
         background: hoverColor,
       },


### PR DESCRIPTION
With timestamps disabled, and an empty log line, there was a discrepancy between the calculated height and the actual height of the log line (0), causing an adjustment loop that looked like flickering.

B:

![2025-08-29 18 36 00](https://github.com/user-attachments/assets/13615f93-6f34-4ff4-bba7-d50a98eb8010)

A:

![2025-08-29 18 36 13](https://github.com/user-attachments/assets/9d16efab-2301-4633-9563-f5c94ee936e9)
