### PR TITLE
fix(docs): Fix broken link in Entra ID SAML docs

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/_index.md
@@ -30,7 +30,7 @@ Related links:
 
 Ensure you have permission to administer SAML authentication. For more information about roles and permissions in Grafana, refer to [Roles and permissions](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/).
 
-If you have users that belong to more than 150 groups, configure a registered application to provide an Entra ID Graph API to retrieve the groups. Refer to [Setup Entra ID Graph API applications](#configure-a-graph-api-application-in-azure-ad).
+If you have users that belong to more than 150 groups, configure a registered application to provide an Entra ID Graph API to retrieve the groups. Refer to [Setup Entra ID Graph API applications](#configure-a-graph-api-application-in-entra-id).
 
 ## Generate self-signed certificates
 


### PR DESCRIPTION
The current link is outdated, from when it was called Azure AD instead of Entra ID, and the section it points to has been renamed. You can go to https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/#configure-a-graph-api-application-in-azure-ad to see that it doesn't take you to the intended section in the docs, which is https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/saml/configure-saml-with-azuread/#configure-a-graph-api-application-in-entra-id