### PR TITLE
Dashboard: Only show Conditional Rendering on Custom Grid when FF is enabled

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItemEditor.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { sceneGraph, SceneGridLayout } from '@grafana/scenes';
 import { RadioButtonGroup, Select } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -62,7 +63,13 @@ export function getDashboardGridItemOptions(gridItem: DashboardGridItem): Option
     )
   );
 
-  return [repeatCategory, conditionalRenderingCategory];
+  const options = [repeatCategory];
+
+  if (config.featureToggles.dashboardNewLayouts) {
+    options.push(conditionalRenderingCategory);
+  }
+
+  return options;
 }
 
 interface OptionComponentProps {


### PR DESCRIPTION
**What is this feature?**

Only show Conditional Rendering warning on the custom grid when the feature flag is enabled.

**Why do we need this feature?**

Fix bug.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
