### PR TITLE
LastModifiedSince: return latestRV even when it hasn't changed.

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -662,7 +662,7 @@ func (b *backend) ListModifiedSince(ctx context.Context, key resource.Namespaced
 
 	// If latest RV is the same as request RV, there's nothing to report, and we can avoid running another query.
 	if latestRv == sinceRv {
-		return 0, func(yield func(*resource.ModifiedResource, error) bool) { /* nothing to return */ }
+		return latestRv, func(yield func(*resource.ModifiedResource, error) bool) { /* nothing to return */ }
 	}
 
 	// since results are sorted by name ASC and rv DESC, we can get away with tracking the last seen

--- a/pkg/storage/unified/testing/storage_backend.go
+++ b/pkg/storage/unified/testing/storage_backend.go
@@ -538,7 +538,7 @@ func runTestIntegrationBackendListModifiedSince(t *testing.T, backend resource.S
 		isEmpty(t, seq)
 
 		latestRv2, seq := backend.ListModifiedSince(ctx, key, latestRv1)
-		require.GreaterOrEqual(t, latestRv1, latestRv2)
+		require.Equal(t, latestRv1, latestRv2)
 		isEmpty(t, seq)
 	})
 


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/110338#discussion_r2310648517