### PR TITLE
Docs: Add feature toggle name to dashboard schema v2 docs

### DIFF
--- a/docs/sources/observability-as-code/schema-v2/_index.md
+++ b/docs/sources/observability-as-code/schema-v2/_index.md
@@ -32,7 +32,7 @@ Observability as Code works with all versions of the JSON model, and it's fully 
 
 ## Before you begin
 
-Schema v2 is automatically enabled with the Dynamic Dashboards feature toggle.
+Schema v2 is automatically enabled with the Dynamic Dashboards (`dashboardNewLayouts`) feature toggle.
 To get early access to this feature, request it through [this form](https://docs.google.com/forms/d/e/1FAIpQLSd73nQzuhzcHJOrLFK4ef_uMxHAQiPQh1-rsQUT2MRqbeMLpg/viewform?usp=dialog).
 It also requires the new dashboards API feature toggle, `kubernetesDashboards`, to be enabled as well.
 


### PR DESCRIPTION
### What changed?

I have added the actual name of the feature toggle to the docs for enabling "Dynamic Dashboards", as the term "dynamic dashboard" doesn't relate to any of our feature toggles directly, and took me (as someone who is not familiar with this part of the codebase) some time to reverse-engineer it from the code. 

