### PR TITLE
DashboardGridItem: Trigger row repeat behaviour on panel edit complete

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -12,6 +12,7 @@ import {
   MultiValueVariable,
   CustomVariable,
   VariableValueSingle,
+  SceneGridRow,
 } from '@grafana/scenes';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
@@ -24,6 +25,7 @@ import { DashboardLayoutItem } from '../types/DashboardLayoutItem';
 import { getDashboardGridItemOptions } from './DashboardGridItemEditor';
 import { DashboardGridItemRenderer } from './DashboardGridItemRenderer';
 import { DashboardGridItemVariableDependencyHandler } from './DashboardGridItemVariableDependencyHandler';
+import { RowRepeaterBehavior } from './RowRepeaterBehavior';
 
 export interface DashboardGridItemState extends SceneGridItemStateLike {
   body: VizPanel;
@@ -121,6 +123,12 @@ export class DashboardGridItem
   public editingCompleted(withChanges: boolean) {
     if (withChanges) {
       this._prevRepeatValues = undefined;
+      if (this.parent instanceof SceneGridRow) {
+        const repeater = this.parent.state.$behaviors?.find((b) => b instanceof RowRepeaterBehavior);
+        if (repeater) {
+          repeater.resetPrevRepeatValues();
+        }
+      }
     }
 
     if (this.state.variableName && this.state.repeatDirection === 'h' && this.state.width !== GRID_COLUMN_COUNT) {

--- a/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/layout-default/RowRepeaterBehavior.ts
@@ -183,6 +183,10 @@ export class RowRepeaterBehavior extends SceneObjectBase<RowRepeaterBehaviorStat
     // Remove behavior and the scoped local variable
     row.setState({ $behaviors: row.state.$behaviors!.filter((b) => b !== this), $variables: undefined });
   }
+
+  public resetPrevRepeatValues() {
+    this._prevRepeatValues = undefined;
+  }
 }
 
 function getRowContentHeight(panels: SceneGridItemLike[]): number {


### PR DESCRIPTION
Issue: in scenes dashboard (with `dashboardNewLayouts = false`) when editing repeated panel inside repeated row only panels in the original repeated row are update immediately (leaving panels in other repeated rows with old state)

Solution: reseting `_prevRepeatValues` in row repeat behaviour will trigger repeats re-render
