### PR TITLE
ExtensionSidebar: Allow `Assistant` to be shown in compact mode

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItem.tsx
@@ -12,7 +12,13 @@ import { ExtensionToolbarItemButton } from './ExtensionToolbarItemButton';
 
 type ComponentWithPluginId = ExtensionInfo & { pluginId: string };
 
-export function ExtensionToolbarItem() {
+type Props = {
+  compact?: boolean;
+};
+
+const compactAllowedComponents = ['grafana-assistant-app'];
+
+export function ExtensionToolbarItem({ compact }: Props) {
   const { availableComponents, dockedComponentId, setDockedComponentId, isEnabled } = useExtensionSidebarContext();
 
   if (!isEnabled || availableComponents.size === 0) {
@@ -26,6 +32,12 @@ export function ExtensionToolbarItem() {
       const component = components[0];
       const componentId = getComponentIdFromComponentMeta(pluginId, component);
       const isActive = dockedComponentId === componentId;
+
+      // we now allow more components in the extension sidebar
+      // in compact mode we only want to allow the Assistant app right now
+      if (compact && !compactAllowedComponents.includes(pluginId)) {
+        return null;
+      }
 
       return (
         <ExtensionToolbarItemButton

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -104,7 +104,7 @@ export const SingleTopBar = memo(function SingleTopBar({
             </Dropdown>
           )}
           <NavToolbarSeparator />
-          {config.featureToggles.extensionSidebar && !isSmallScreen && <ExtensionToolbarItem />}
+          {config.featureToggles.extensionSidebar && <ExtensionToolbarItem compact={isSmallScreen} />}
           {!showToolbarLevel && actions}
           {!contextSrv.user.isSignedIn && <SignInLink />}
           <InviteUserButton />


### PR DESCRIPTION
**What is this feature?**

Right now we hide all extension sidebar toolbar buttons in small mode. There is much benefit of showing the Assistant button in small mode, though. The Assistant button will open an AI chat, which fits the nature of small displays, i.e. mobile screens.

<img width="450" height="634" alt="image" src="https://github.com/user-attachments/assets/956fc2ea-9652-4377-b6af-226a6297f780" />


Related: https://github.com/grafana/grafana-assistant-app/issues/1746