### PR TITLE
Metrics: Add http_response_size_bytes metric

### DIFF
--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -29,8 +29,6 @@ var (
 func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promRegister prometheus.Registerer) web.Middleware {
 	log := log.New("middleware.request-metrics")
 
-	log.Info("initializing request metrics middleware", "size_buckets", sizeDefBuckets)
-
 	httpRequestsInFlight := prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "grafana",

--- a/pkg/middleware/request_metrics.go
+++ b/pkg/middleware/request_metrics.go
@@ -18,14 +18,18 @@ import (
 )
 
 var (
-	// DefBuckets are histogram buckets for the response time (in seconds)
-	// of a network service, including one that is responding very slowly.
-	defBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25}
+	// Histogram buckets for the response time, in seconds
+	durationDefBuckets = []float64{.005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5, 10, 25}
+
+	// Histogram buckets for response sizes, in bytes
+	sizeDefBuckets = prometheus.ExponentialBuckets(128, 2, 16) // 128 bytes ... 4 MB
 )
 
 // RequestMetrics is a middleware handler that instruments the request.
 func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promRegister prometheus.Registerer) web.Middleware {
 	log := log.New("middleware.request-metrics")
+
+	log.Info("initializing request metrics middleware", "size_buckets", sizeDefBuckets)
 
 	httpRequestsInFlight := prometheus.NewGauge(
 		prometheus.GaugeOpts{
@@ -41,11 +45,18 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 		histogramLabels = append(histogramLabels, "grafana_team")
 	}
 
-	histogramOptions := prometheus.HistogramOpts{
+	reqDurationOptions := prometheus.HistogramOpts{
 		Namespace: "grafana",
 		Name:      "http_request_duration_seconds",
 		Help:      "Histogram of latencies for HTTP requests.",
-		Buckets:   defBuckets,
+		Buckets:   durationDefBuckets,
+	}
+
+	reqSizeOptions := prometheus.HistogramOpts{
+		Namespace: "grafana",
+		Name:      "http_response_size_bytes",
+		Help:      "Histogram of request sizes for HTTP requests.",
+		Buckets:   sizeDefBuckets, // 100B ... ~1MB
 	}
 
 	if features.IsEnabledGlobally(featuremgmt.FlagEnableNativeHTTPHistogram) {
@@ -53,25 +64,34 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 		// https://github.com/prometheus/client_golang/blob/main/prometheus/histogram.go#L411
 		// Giving this variable a value means the client will expose a native
 		// histogram.
-		histogramOptions.NativeHistogramBucketFactor = 1.1
+		reqDurationOptions.NativeHistogramBucketFactor = 1.1
+		reqSizeOptions.NativeHistogramBucketFactor = 1.1
 		// The default value in OTel. It probably good enough for us as well.
-		histogramOptions.NativeHistogramMaxBucketNumber = 160
-		histogramOptions.NativeHistogramMinResetDuration = time.Hour
+		reqDurationOptions.NativeHistogramMaxBucketNumber = 160
+		reqSizeOptions.NativeHistogramMaxBucketNumber = 160
+		reqDurationOptions.NativeHistogramMinResetDuration = time.Hour
+		reqSizeOptions.NativeHistogramMinResetDuration = time.Hour
 
 		if features.IsEnabledGlobally(featuremgmt.FlagDisableClassicHTTPHistogram) {
 			// setting Buckets to nil with native options set means the classic
 			// histogram will no longer be exposed - this can be a good way to
 			// reduce cardinality in the exposed metrics
-			histogramOptions.Buckets = nil
+			reqDurationOptions.Buckets = nil
+			reqSizeOptions.Buckets = nil
 		}
 	}
 
 	httpRequestDurationHistogram := prometheus.NewHistogramVec(
-		histogramOptions,
+		reqDurationOptions,
 		histogramLabels,
 	)
 
-	promRegister.MustRegister(httpRequestsInFlight, httpRequestDurationHistogram)
+	httpRequestSizeHistogram := prometheus.NewHistogramVec(
+		reqSizeOptions,
+		histogramLabels,
+	)
+
+	promRegister.MustRegister(httpRequestsInFlight, httpRequestDurationHistogram, httpRequestSizeHistogram)
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -111,7 +131,9 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 
 			// avoiding the sanitize functions for in the new instrumentation
 			// since they dont make much sense. We should remove them later.
-			histogram := httpRequestDurationHistogram.
+			durationHistogram := httpRequestDurationHistogram.
+				WithLabelValues(labelValues...)
+			sizeHistogram := httpRequestSizeHistogram.
 				WithLabelValues(labelValues...)
 
 			elapsedTime := time.Since(now).Seconds()
@@ -120,12 +142,14 @@ func RequestMetrics(features featuremgmt.FeatureToggles, cfg *setting.Cfg, promR
 				// Need to type-convert the Observer to an
 				// ExemplarObserver. This will always work for a
 				// HistogramVec.
-				histogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
+				durationHistogram.(prometheus.ExemplarObserver).ObserveWithExemplar(
 					elapsedTime, prometheus.Labels{"traceID": traceID},
 				)
 			} else {
-				histogram.Observe(elapsedTime)
+				durationHistogram.Observe(elapsedTime)
 			}
+
+			sizeHistogram.Observe(float64(rw.Size()))
 
 			switch {
 			case strings.HasPrefix(r.RequestURI, "/api/datasources/proxy"):

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -46,9 +46,9 @@ var unnamedHandlers = []struct {
 	handler     string
 }{
 	{handler: "plugin-assets", pathPattern: regexp.MustCompile("^/public/plugins/")},
-	{handler: "public-build-assets", pathPattern: regexp.MustCompile("^/public/build/")},
+	{handler: "public-build-assets", pathPattern: regexp.MustCompile("^/public/build/")}, // All Grafana core assets should come from this path
 	{handler: "public-assets", pathPattern: regexp.MustCompile("^/favicon.ico")},
-	{handler: "public-assets", pathPattern: regexp.MustCompile("^/public/")},
+	{handler: "public-assets", pathPattern: regexp.MustCompile("^/public/")}, // Fallback for other assets, this should go down to 0
 	{handler: "/metrics", pathPattern: regexp.MustCompile("^/metrics")},
 	{handler: "/healthz", pathPattern: regexp.MustCompile("^/healthz")},
 	{handler: "/api/health", pathPattern: regexp.MustCompile("^/api/health")},

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -45,6 +45,8 @@ var unnamedHandlers = []struct {
 	pathPattern *regexp.Regexp
 	handler     string
 }{
+	{handler: "plugin-assets", pathPattern: regexp.MustCompile("^/public/plugins/")},
+	{handler: "public-build-assets", pathPattern: regexp.MustCompile("^/public/build/")},
 	{handler: "public-assets", pathPattern: regexp.MustCompile("^/favicon.ico")},
 	{handler: "public-assets", pathPattern: regexp.MustCompile("^/public/")},
 	{handler: "/metrics", pathPattern: regexp.MustCompile("^/metrics")},

--- a/pkg/services/frontend/frontend_service_test.go
+++ b/pkg/services/frontend/frontend_service_test.go
@@ -143,8 +143,8 @@ func TestFrontendService_Middleware(t *testing.T) {
 
 		metricsBody := recorder.Body.String()
 		assert.Contains(t, metricsBody, "# TYPE grafana_http_request_duration_seconds histogram")
-		assert.Contains(t, metricsBody, "grafana_http_request_duration_seconds_bucket{handler=\"public-assets\"") // assets 404
-		assert.Contains(t, metricsBody, "grafana_http_request_duration_seconds_bucket{handler=\"/*\"")            // index route
+		assert.Contains(t, metricsBody, "grafana_http_request_duration_seconds_bucket{handler=\"public-build-assets\"") // assets 404
+		assert.Contains(t, metricsBody, "grafana_http_request_duration_seconds_bucket{handler=\"/*\"")                  // index route
 	})
 
 	t.Run("should add context middleware", func(t *testing.T) {


### PR DESCRIPTION
- Adds a http_response_size_bytes histogram metric to track response sizes. 
- Breaks the `/public/` route handler label value down into more granular `plugin-assets` and `public-build-assets`. `public-assets` is still there, but is a fallback that we want to get down to 0.

Fixes https://github.com/grafana/grafana-frontend-platform/issues/33