### PR TITLE
Remove unused `style` prop from FlameGraph

### DIFF
--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
@@ -18,7 +18,6 @@
 // THIS SOFTWARE.
 import { css, cx } from '@emotion/css';
 import { useEffect, useState } from 'react';
-import * as React from 'react';
 
 import { Icon } from '@grafana/ui';
 

--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.tsx
@@ -37,7 +37,6 @@ type Props = {
   matchedLabels?: Set<string>;
   setRangeMin: (range: number) => void;
   setRangeMax: (range: number) => void;
-  style?: React.CSSProperties;
   onItemFocused: (data: ClickedItemData) => void;
   focusedItemData?: ClickedItemData;
   textAlign: TextAlign;


### PR DESCRIPTION
**What is this feature?**

Removes an unused prop that, seemingly, has never been used since the component's inception

**Why do we need this feature?**

I was using the FlameGraph component and was confused why styles passed using the `style` prop weren't being applied. After source diving, I discovered the prop isn't wired up to any DOM node. This PR removes that confusion for anyone using the FlameGraph in the future by simply removing the prop.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #108345 

