### PR TITLE
Alerting: Minor papercut for data sources in the list view

### DIFF
--- a/public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsx
@@ -10,13 +10,14 @@ import { Labels, PromAlertingRuleState, RulerRuleDTO, RulesSourceApplication } f
 
 import { logError } from '../../Analytics';
 import { AlertLabels } from '../../components/AlertLabels';
+import ConditionalWrap from '../../components/ConditionalWrap';
 import { MetaText } from '../../components/MetaText';
 import { ProvisioningBadge } from '../../components/Provisioning';
 import { PluginOriginBadge } from '../../plugins/PluginOriginBadge';
 import { GRAFANA_RULES_SOURCE_NAME, getDataSourceByUid } from '../../utils/datasource';
 import { getGroupOriginName } from '../../utils/groupIdentifier';
 import { labelsSize } from '../../utils/labels';
-import { createContactPointSearchLink } from '../../utils/misc';
+import { createContactPointSearchLink, makeDataSourceLink } from '../../utils/misc';
 import { RulePluginOrigin } from '../../utils/rules';
 
 import { ListItem } from './ListItem';
@@ -314,15 +315,34 @@ const QuerySourceIcons = memo(function QuerySourceIcons({ queriedDatasourceUIDs 
     .map(getDataSourceByUid)
     .filter((ds): ds is DataSourceInstanceSettings => ds !== undefined);
 
+  const firstSource = dataSources[0];
+  const singleSource = dataSources.length === 1;
+
+  const label = singleSource
+    ? firstSource.name
+    : t('alerting.alert-rules.multiple-sources', '{{numSources}} data sources', { numSources: dataSources.length });
+
   return (
     <Stack direction="row" alignItems="center" gap={0.5}>
-      {dataSources.map((dataSource) => {
-        return (
-          <Tooltip key={dataSource.uid} content={dataSource.name}>
-            <DataSourceLogo dataSource={dataSource} />
-          </Tooltip>
-        );
-      })}
+      {dataSources.map((dataSource) => (
+        <ConditionalWrap
+          key={dataSource.uid}
+          shouldWrap={!singleSource}
+          wrap={(children) => <Tooltip content={dataSource.name}>{children}</Tooltip>}
+        >
+          <DataSourceLogo dataSource={dataSource} />
+        </ConditionalWrap>
+      ))}
+
+      {singleSource ? (
+        <TextLink variant="bodySmall" inline={false} color="primary" href={makeDataSourceLink(firstSource.uid)}>
+          {label}
+        </TextLink>
+      ) : (
+        <Text variant="bodySmall" color="primary">
+          {label}
+        </Text>
+      )}
     </Stack>
   );
 });
@@ -474,8 +494,8 @@ DataSourceLogo.displayName = 'DataSourceLogo';
 
 const dataSourceLogoStyles = (theme: GrafanaTheme2) => ({
   logo: css({
-    height: '14px',
-    width: '14px',
+    height: '12px',
+    width: '12px',
     borderRadius: theme.shape.radius.default,
   }),
   filter: css({

--- a/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
@@ -31,7 +31,7 @@ export const ListItem = (props: ListItemProps) => {
         {/* icon */}
         <span className={styles.statusIcon}>{icon}</span>
 
-        <Stack direction="column" gap={0} flex="1" minWidth={0}>
+        <Stack direction="column" gap={0.5} flex="1" minWidth={0}>
           {/* title */}
           <Stack direction="column" gap={0}>
             <div className={styles.textOverflow}>{title}</div>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -549,6 +549,7 @@
     },
     "alert-rules": {
       "firing-for": "Firing for",
+      "multiple-sources": "{{numSources}} data sources",
       "next-evaluation": "Next evaluation",
       "next-evaluation-in": "next evaluation in",
       "rule-definition": "Rule definition"


### PR DESCRIPTION
**What is this feature?**

Minor fix for displaying the data sources in the list view

* Adds a link link to go to the datasource
* Shows the data source name in full
* Shows count of data sources for multiple

<img width="365" height="107" alt="Screenshot 2025-09-02 at 15 59 45" src="https://github.com/user-attachments/assets/2e38c551-3038-4fa9-a300-855ea8554b78" />
<img width="767" height="313" alt="Screenshot 2025-09-02 at 15 59 24" src="https://github.com/user-attachments/assets/5a411ce4-6116-48d5-ae39-e583ac740c85" />

## For reviewers

How useful do we think it is to navigate to the data source? Would it make more sense for clicking it to act as a filter? This might be weird behaviour since the other links don't really allow filtering. Thoughts?