### PR TITLE
Table: Add some error-case handling to ImageCell

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/ImageCell.tsx
@@ -1,17 +1,23 @@
 import { css } from '@emotion/css';
+import { useState } from 'react';
 
 import { TableCellDisplayMode } from '../../types';
 import { MaybeWrapWithLink } from '../components/MaybeWrapWithLink';
 import { ImageCellProps, TableCellStyles } from '../types';
 
 export const ImageCell = ({ cellOptions, field, value, rowIdx }: ImageCellProps) => {
+  const [error, setError] = useState(false);
   const { text } = field.display!(value);
   const { alt, title } =
     cellOptions.type === TableCellDisplayMode.Image ? cellOptions : { alt: undefined, title: undefined };
 
+  if (!text) {
+    return null;
+  }
+
   return (
     <MaybeWrapWithLink field={field} rowIdx={rowIdx}>
-      <img alt={alt} src={text} title={title} />
+      {error ? text : <img alt={alt} src={text} title={title} onError={() => setError(true)} />}
     </MaybeWrapWithLink>
   );
 };


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/18197

I want us to consider two potential enhancements to failure cases for the ImageCell in light of a customer escalation.

- The first seems pretty obviously good to me. If `text` is null or an empty string, don't render any content. this is for empty data, noValue, etc.
- The second is: if the image string is malformed or the image is unreachable, render the text instead of the dead image as a backup by triggering off of the image's `onError` handler. This does add state for all `ImageCell`s so is likely to be more controversial.