### PR TITLE
unistore: use scorch indexing instead of upside_down

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -314,7 +314,7 @@ func (b *bleveBackend) BuildIndex(
 			defer closeIndexOnExit(index, indexDir) // Close index, and delete new index directory.
 		}
 	} else {
-		index, err = bleve.NewMemOnly(mapper)
+		index, err = bleve.NewUsing("", mapper, bleve.Config.DefaultIndexType, bleve.Config.DefaultMemKVStore, nil)
 		if err != nil {
 			return nil, fmt.Errorf("error creating new in-memory bleve index: %w", err)
 		}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -203,12 +203,12 @@ func (b *bleveBackend) updateIndexSizeMetric(indexPath string) {
 // If path is empty, creates an in-memory index.
 // If path is not empty, creates a file-based index at the specified path.
 func newBleveIndex(path string, mapper mapping.IndexMapping) (bleve.Index, error) {
+	kvstore := bleve.Config.DefaultKVStore
 	if path == "" {
-		// Create in-memory index
-		return bleve.NewUsing("", mapper, bleve.Config.DefaultIndexType, bleve.Config.DefaultMemKVStore, nil)
+		// use in-memory kvstore
+		kvstore = bleve.Config.DefaultMemKVStore
 	}
-	// Create file-based index with explicit configuration to match in-memory version
-	return bleve.NewUsing(path, mapper, bleve.Config.DefaultIndexType, bleve.Config.DefaultKVStore, nil)
+	return bleve.NewUsing(path, mapper, bleve.Config.DefaultIndexType, kvstore, nil)
 }
 
 // BuildIndex builds an index from scratch or retrieves it from the filesystem.


### PR DESCRIPTION
As per [the documentation](https://blevesearch.com/docs/Package-Structure/), scorch is the production ready one.
<img width="861" height="206" alt="image" src="https://github.com/user-attachments/assets/e4c555a1-61ef-4847-969f-a7b427cd04b3" />

We tested it to be significantly over 10x faster than upside_down.

```
Benchmark Results: 100000 documents / batch 1000 / 20 goroutines
Scenario                                 Duration        Throughput      Memory Usage    Disk Size       Search Time     Matched Docs  Memory Usage Search
--------                                 --------        ---------       ------------    ---------       -----------     ------------  -------------------
File: scorch                             2.338s          42770           62.4 MB         96.1 MB         2ms             192           1.5 MB
Memory: scorch + gtreap                  1.075s          93021           231.7 MB        0 B             5ms             177           5.6 MB
Memory: upside_down + gtreap             17.7s           5650            664.2 MB        0 B             3ms             200           1.7 MB
```
see [thread](https://raintank-corp.slack.com/archives/C08EP3BVBGV/p1756817191497839?thread_ts=1756799644.827469&cid=C08EP3BVBGV)  
