### PR TITLE
Alerting: Hide list view loader if we don't have anything yet

### DIFF
--- a/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
@@ -111,7 +111,7 @@ function PaginatedGroupsLoader({ rulesSourceIdentifier, application, groupFilter
             ))}
           </ListSection>
         ))}
-        {hasMoreGroups && (
+        {hasMoreGroups && !hasNoRules && (
           // this div will make the button not stretch
           <div>
             <LoadMoreButton loading={isLoading} onClick={fetchMoreGroups} />


### PR DESCRIPTION
This prevents a race condition where we assume we can load more items but fetching a page of rules fails

The screenshot below shows the invalid UI state.

<img width="349" height="135" alt="image" src="https://github.com/user-attachments/assets/4913745b-f01e-486f-a5ac-2a58be877b06" />

**Special notes for your reviewer:**

None