### PR TITLE
Provisioning: Hide badge if folder is managed by non-repo source

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { Badge, Stack } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
@@ -18,7 +19,11 @@ export function FolderRepo({ folder }: Props) {
   // if whole instance is provisioned
   const isProvisionedInstance = useIsProvisionedInstance();
   const skipRender =
-    !folder || ('parentUID' in folder && folder.parentUID) || !folder.managedBy || isProvisionedInstance;
+    !folder ||
+    ('parentUID' in folder && folder.parentUID) ||
+    !folder.managedBy ||
+    folder.managedBy !== ManagerKind.Repo ||
+    isProvisionedInstance;
 
   const { isReadOnlyRepo, repoType } = useGetResourceRepositoryView({
     folderName: skipRender ? undefined : folder?.uid,


### PR DESCRIPTION
**What is this feature?**
Noticed when using the mock API (that had an annotation of `managedBy: user` set on one of the folder responses) that we were always showing the folder provisioning badge if there was a value for the `managedBy` annotation. Elsewhere, we seem to be using the check of
`folder.managedBy === ManagerKind.Repo`
so I made this one consistent with the others

**Why do we need this feature?**
So we don't mistakenly show the provisioning badge when not needed (though it could be argued that we should show it for all values of `ManagerKind`?)