### PR TITLE
Alerting: Fix insights panel for Grafana missed iterations

### DIFF
--- a/public/app/features/alerting/unified/home/Insights.tsx
+++ b/public/app/features/alerting/unified/home/Insights.tsx
@@ -289,7 +289,7 @@ function getGrafanaManagedScenes() {
             new SceneFlexLayout({
               children: [
                 getGrafanaEvalSuccessVsFailuresScene(cloudUsageDs, 'Evaluation success vs failures'),
-                getGrafanaMissedIterationsScene(cloudUsageDs, 'Iterations missed per evaluation group'),
+                getGrafanaMissedIterationsScene(cloudUsageDs, 'Iterations missed per alert rule'),
               ],
             }),
           ],

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,10 +1,5 @@
-import { Observable, map } from 'rxjs';
-
-import { DataFrame } from '@grafana/data';
 import {
-  CustomTransformOperator,
   PanelBuilders,
-  SceneDataTransformer,
   SceneFlexItem,
   SceneQueryRunner,
 } from '@grafana/scenes';
@@ -14,7 +9,7 @@ import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';
 import { InsightsMenuButton } from '../InsightsMenuButton';
 
 export function getGrafanaMissedIterationsScene(datasource: DataSourceRef, panelTitle: string) {
-  const expr = `sum by(rule_group) (grafanacloud_instance_rule_group_iterations_missed_total:rate5m{id="${INSTANCE_ID}"})`;
+  const expr = `sum by(rule_title) (grafanacloud_grafana_instance_alerting_schedule_rule_evaluations_missed_total:rate5m{id="${INSTANCE_ID}"})`;
   const query = new SceneQueryRunner({
     datasource,
     queries: [
@@ -22,44 +17,17 @@ export function getGrafanaMissedIterationsScene(datasource: DataSourceRef, panel
         refId: 'A',
         expr,
         range: true,
-        legendFormat: '{{rule_group}}',
+        legendFormat: '{{rule_title}}',
       },
     ],
-  });
-
-  const legendTransformation: CustomTransformOperator = () => (source: Observable<DataFrame[]>) => {
-    return source.pipe(
-      map((data: DataFrame[]) => {
-        return data.map((frame: DataFrame) => {
-          return {
-            ...frame,
-            fields: frame.fields.map((field) => {
-              const displayNameFromDs = field.config.displayNameFromDS || '';
-              const matches = displayNameFromDs.match(/\/rules\/\d+\/(\w+);(\w+)/);
-
-              if (matches) {
-                field.config.displayName = `Folder: ${matches[1]} - Group: ${matches[2]}`;
-              }
-
-              return field;
-            }),
-          };
-        });
-      })
-    );
-  };
-
-  const transformation = new SceneDataTransformer({
-    $data: query,
-    transformations: [legendTransformation],
   });
 
   return new SceneFlexItem({
     ...PANEL_STYLES,
     body: PanelBuilders.timeseries()
       .setTitle(panelTitle)
-      .setDescription('The number of missed iterations per evaluation group')
-      .setData(transformation)
+      .setDescription('The number of missed iterations per alert rule')
+      .setData(query)
       .setOption('tooltip', { mode: TooltipDisplayMode.Multi })
       .setCustomFieldConfig('drawStyle', GraphDrawStyle.Line)
       .setHeaderActions([new InsightsMenuButton({ panel: panelTitle })])

--- a/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
+++ b/public/app/features/alerting/unified/insights/grafana/MissedIterationsScene.tsx
@@ -1,8 +1,4 @@
-import {
-  PanelBuilders,
-  SceneFlexItem,
-  SceneQueryRunner,
-} from '@grafana/scenes';
+import { PanelBuilders, SceneFlexItem, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef, GraphDrawStyle, TooltipDisplayMode } from '@grafana/schema';
 
 import { INSTANCE_ID, PANEL_STYLES } from '../../home/Insights';


### PR DESCRIPTION
Existing panel was copied from Mimir version, so it was using the wrong metric as well as incorrect assumptions on the series labels.

Metric:
`grafanacloud_instance_rule_group_iterations_missed_total:rate5m` -> `grafanacloud_grafana_instance_alerting_schedule_rule_evaluations_missed_total:rate5m`

Label parsing:
Parsing `rule_group` (ex. `/rules/12345/synthetic_monitoring;default`) -> using `rule_title` directly.

**Special notes for your reviewer:**

Sanity tested locally with mock recorded metric:

<img width="966" height="300" alt="Screenshot 2025-09-02 at 10-45-38 Alerting - Alerts   IRM - Grafana" src="https://github.com/user-attachments/assets/a0ef390e-a11f-4286-9c2c-711ef8fd1d41" />

The correct metric is in the process of being populated but should work on dev/ephemeral at the moment.
