### PR TITLE
Log line details: Update styles

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -67,6 +67,7 @@ const setup = (
     onResize: jest.fn(),
     timeRange: getDefaultTimeRange(),
     timeZone: 'browser',
+    showControls: true,
     ...(propOverrides || {}),
   };
 
@@ -581,6 +582,7 @@ describe('LogLineDetails', () => {
         logs: [logs[0]],
         timeRange: getDefaultTimeRange(),
         timeZone: 'browser',
+        showControls: true,
         onResize: jest.fn(),
       };
 

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -204,16 +204,15 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?
     marginRight: 1,
   }),
   inlineContainer: css({
-    backgroundColor: theme.colors.background.elevated,
+    backgroundColor: theme.colors.background.secondary,
     border: `1px solid ${theme.colors.border.weak}`,
     borderRadius: theme.shape.radius.default,
-    boxShadow: theme.shadows.z2,
     height: '100%',
     overflow: 'auto',
   }),
   container: css({
     backgroundColor: theme.colors.background.elevated,
-    border: `1px solid ${theme.colors.border.medium}`,
+    border: `1px solid ${theme.colors.border.weak}`,
     borderBottomRightRadius: showControls ? undefined : theme.shape.radius.default,
     borderRight: mode === 'sidebar' && showControls ? 'none' : undefined,
     borderTopRightRadius: showControls ? undefined : theme.shape.radius.default,

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -20,50 +20,53 @@ export interface Props {
   timeRange: TimeRange;
   timeZone: string;
   onResize(): void;
+  showControls: boolean;
 }
 
 export type LogLineDetailsMode = 'inline' | 'sidebar';
 
-export const LogLineDetails = memo(({ containerElement, focusLogLine, logs, timeRange, timeZone, onResize }: Props) => {
-  const { detailsWidth, noInteractions, setDetailsWidth } = useLogListContext();
-  const styles = useStyles2(getStyles, 'sidebar');
-  const dragStyles = useStyles2(getDragStyles);
-  const containerRef = useRef<HTMLDivElement | null>(null);
+export const LogLineDetails = memo(
+  ({ containerElement, focusLogLine, logs, timeRange, timeZone, onResize, showControls }: Props) => {
+    const { detailsWidth, noInteractions, setDetailsWidth } = useLogListContext();
+    const styles = useStyles2(getStyles, 'sidebar', showControls);
+    const dragStyles = useStyles2(getDragStyles);
+    const containerRef = useRef<HTMLDivElement | null>(null);
 
-  const handleResize = useCallback(() => {
-    if (containerRef.current) {
-      setDetailsWidth(containerRef.current.clientWidth);
-    }
-    onResize();
-  }, [onResize, setDetailsWidth]);
+    const handleResize = useCallback(() => {
+      if (containerRef.current) {
+        setDetailsWidth(containerRef.current.clientWidth);
+      }
+      onResize();
+    }, [onResize, setDetailsWidth]);
 
-  const reportResize = useCallback(() => {
-    if (containerRef.current && !noInteractions) {
-      reportInteraction('logs_log_line_details_sidebar_resized', {
-        width: Math.round(containerRef.current.clientWidth),
-      });
-    }
-  }, [noInteractions]);
+    const reportResize = useCallback(() => {
+      if (containerRef.current && !noInteractions) {
+        reportInteraction('logs_log_line_details_sidebar_resized', {
+          width: Math.round(containerRef.current.clientWidth),
+        });
+      }
+    }, [noInteractions]);
 
-  const maxWidth = containerElement.clientWidth - LOG_LIST_MIN_WIDTH;
+    const maxWidth = containerElement.clientWidth - LOG_LIST_MIN_WIDTH;
 
-  return (
-    <Resizable
-      onResize={handleResize}
-      onResizeStop={reportResize}
-      handleClasses={{ left: dragStyles.dragHandleVertical }}
-      defaultSize={{ width: detailsWidth, height: containerElement.clientHeight }}
-      size={{ width: detailsWidth, height: containerElement.clientHeight }}
-      enable={{ left: true }}
-      minWidth={40}
-      maxWidth={maxWidth}
-    >
-      <div className={styles.container} ref={containerRef}>
-        <LogLineDetailsTabs focusLogLine={focusLogLine} logs={logs} timeRange={timeRange} timeZone={timeZone} />
-      </div>
-    </Resizable>
-  );
-});
+    return (
+      <Resizable
+        onResize={handleResize}
+        onResizeStop={reportResize}
+        handleClasses={{ left: dragStyles.dragHandleVertical }}
+        defaultSize={{ width: detailsWidth, height: containerElement.clientHeight }}
+        size={{ width: detailsWidth, height: containerElement.clientHeight }}
+        enable={{ left: true }}
+        minWidth={40}
+        maxWidth={maxWidth}
+      >
+        <div className={styles.container} ref={containerRef}>
+          <LogLineDetailsTabs focusLogLine={focusLogLine} logs={logs} timeRange={timeRange} timeZone={timeZone} />
+        </div>
+      </Resizable>
+    );
+  }
+);
 LogLineDetails.displayName = 'LogLineDetails';
 
 const LogLineDetailsTabs = memo(
@@ -193,7 +196,7 @@ InlineLogLineDetails.displayName = 'InlineLogLineDetails';
 
 export const LOG_LINE_DETAILS_HEIGHT = 35;
 
-const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
+const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?: boolean) => ({
   inlineWrapper: css({
     gridColumn: '1 / -1',
     height: `${LOG_LINE_DETAILS_HEIGHT}vh`,
@@ -205,7 +208,7 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode) => ({
     height: '100%',
     boxShadow: theme.shadows.z1,
     border: `1px solid ${theme.colors.border.medium}`,
-    borderRight: mode === 'sidebar' ? 'none' : undefined,
+    borderRight: mode === 'sidebar' && showControls ? 'none' : undefined,
   }),
   scrollContainer: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -184,7 +184,7 @@ export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, time
 
   return (
     <div className={`${styles.inlineWrapper} log-line-inline-details`} style={{ maxWidth: detailsWidth }}>
-      <div className={styles.container}>
+      <div className={styles.inlineContainer}>
         <div className={styles.scrollContainer} ref={scrollRef} onScroll={saveScroll}>
           <LogLineDetailsComponent log={log} logs={logs} timeRange={timeRange} timeZone={timeZone} />
         </div>
@@ -203,12 +203,23 @@ const getStyles = (theme: GrafanaTheme2, mode: LogLineDetailsMode, showControls?
     padding: theme.spacing(1, 2, 1.5, 2),
     marginRight: 1,
   }),
-  container: css({
-    overflow: 'auto',
+  inlineContainer: css({
+    backgroundColor: theme.colors.background.elevated,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.default,
+    boxShadow: theme.shadows.z2,
     height: '100%',
-    boxShadow: theme.shadows.z1,
+    overflow: 'auto',
+  }),
+  container: css({
+    backgroundColor: theme.colors.background.elevated,
     border: `1px solid ${theme.colors.border.medium}`,
+    borderBottomRightRadius: showControls ? undefined : theme.shape.radius.default,
     borderRight: mode === 'sidebar' && showControls ? 'none' : undefined,
+    borderTopRightRadius: showControls ? undefined : theme.shape.radius.default,
+    boxShadow: theme.shadows.z3,
+    height: '100%',
+    overflow: 'auto',
   }),
   scrollContainer: css({
     overflow: 'auto',

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -247,7 +247,7 @@ export const LogLineDetailsHeader = ({ focusLogLine, log, search, onSearch }: Pr
         />
         <IconButton
           name="times"
-          aria-label={t('logs.log-line-details.close', 'Close log details')}
+          tooltip={t('logs.log-line-details.close', 'Close log details')}
           onClick={closeDetails}
         />
       </div>

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -423,6 +423,7 @@ const LogListComponent = ({
           timeRange={timeRange}
           timeZone={timeZone}
           onResize={handleLogDetailsResize}
+          showControls={showControls}
         />
       )}
       <div className={styles.logListWrapper} ref={wrapperRef}>


### PR DESCRIPTION
Updated:

- Background color
- Border radius
- Box shadow

#### Dashboards.

Inline details, no controls:

<img width="920" height="623" alt="Inline no controls" src="https://github.com/user-attachments/assets/34249c27-f47c-4be6-bf2b-45c42146a6e1" />

Sidebar details, no controls:

<img width="922" height="621" alt="Sidebar no controls" src="https://github.com/user-attachments/assets/935a35ad-2913-45e1-91a1-56f8713eeb81" />

Sidebar details, with controls:

<img width="662" height="464" alt="Sidebar controls" src="https://github.com/user-attachments/assets/193cd67b-759a-4ef9-8165-3ea7b8be01a7" />

Explore, Drilldown Logs, sidebar:

<img width="1552" height="771" alt="Sidebar controls dd" src="https://github.com/user-attachments/assets/2e6b947e-1097-44c6-805d-7a592343298e" />

