### PR TITLE
fix: Synchronously notify subscribers when writing Create events to CDK backend

### DIFF
--- a/pkg/apiserver/storage/testing/utils.go
+++ b/pkg/apiserver/storage/testing/utils.go
@@ -198,7 +198,7 @@ func testCheckStop(t *testing.T, w watch.Interface) {
 func testCheckResultsInStrictOrder(t *testing.T, w watch.Interface, expectedEvents []watch.Event) {
 	fmt.Printf("expectedEvents: %+v\n", expectedEvents)
 	for i, expectedEvent := range expectedEvents {
-		fmt.Printf("expectedEvent[%d]: %+v\n", i, expectedEvent)
+		fmt.Printf("expectedEvent[%d]: [%+v] %+v\n", i, expectedEvent.Type, expectedEvent.Object)
 		testCheckResult(t, w, expectedEvent)
 	}
 }

--- a/pkg/apiserver/storage/testing/utils.go
+++ b/pkg/apiserver/storage/testing/utils.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"path"
 	"reflect"
-	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -111,7 +110,6 @@ func expectNoDiff(t *testing.T, msg string, expected, actual interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
 		if diff := cmp.Diff(expected, actual); diff != "" {
-			debug.PrintStack()
 			t.Errorf("%s: %s", msg, diff)
 		} else {
 			t.Errorf("%s:\nexpected: %#v\ngot: %#v", msg, expected, actual)
@@ -196,9 +194,7 @@ func testCheckStop(t *testing.T, w watch.Interface) {
 }
 
 func testCheckResultsInStrictOrder(t *testing.T, w watch.Interface, expectedEvents []watch.Event) {
-	fmt.Printf("expectedEvents: %+v\n", expectedEvents)
-	for i, expectedEvent := range expectedEvents {
-		fmt.Printf("expectedEvent[%d]: [%+v] %+v\n", i, expectedEvent.Type, expectedEvent.Object)
+	for _, expectedEvent := range expectedEvents {
 		testCheckResult(t, w, expectedEvent)
 	}
 }

--- a/pkg/apiserver/storage/testing/utils.go
+++ b/pkg/apiserver/storage/testing/utils.go
@@ -196,6 +196,7 @@ func testCheckStop(t *testing.T, w watch.Interface) {
 }
 
 func testCheckResultsInStrictOrder(t *testing.T, w watch.Interface, expectedEvents []watch.Event) {
+	fmt.Printf("expectedEvents: %+v\n", expectedEvents)
 	for _, expectedEvent := range expectedEvents {
 		testCheckResult(t, w, expectedEvent)
 	}

--- a/pkg/apiserver/storage/testing/utils.go
+++ b/pkg/apiserver/storage/testing/utils.go
@@ -197,7 +197,8 @@ func testCheckStop(t *testing.T, w watch.Interface) {
 
 func testCheckResultsInStrictOrder(t *testing.T, w watch.Interface, expectedEvents []watch.Event) {
 	fmt.Printf("expectedEvents: %+v\n", expectedEvents)
-	for _, expectedEvent := range expectedEvents {
+	for i, expectedEvent := range expectedEvents {
+		fmt.Printf("expectedEvent[%d]: %+v\n", i, expectedEvent)
 		testCheckResult(t, w, expectedEvent)
 	}
 }

--- a/pkg/apiserver/storage/testing/utils.go
+++ b/pkg/apiserver/storage/testing/utils.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"path"
 	"reflect"
+	"runtime/debug"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -110,6 +111,7 @@ func expectNoDiff(t *testing.T, msg string, expected, actual interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(expected, actual) {
 		if diff := cmp.Diff(expected, actual); diff != "" {
+			debug.PrintStack()
 			t.Errorf("%s: %s", msg, diff)
 		} else {
 			t.Errorf("%s:\nexpected: %#v\ngot: %#v", msg, expected, actual)

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -148,17 +148,15 @@ func (s *cdkBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64
 
 	// Async notify all subscribers
 	if s.stream != nil {
-		go func() {
-			write := &WrittenEvent{
-				Type:            event.Type,
-				Key:             event.Key,
-				PreviousRV:      event.PreviousRV,
-				Value:           event.Value,
-				Timestamp:       time.Now().UnixMilli(),
-				ResourceVersion: rv,
-			}
-			s.stream <- write
-		}()
+		write := &WrittenEvent{
+			Type:            event.Type,
+			Key:             event.Key,
+			PreviousRV:      event.PreviousRV,
+			Value:           event.Value,
+			Timestamp:       time.Now().UnixMilli(),
+			ResourceVersion: rv,
+		}
+		s.stream <- write
 	}
 	return rv, err
 }

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -146,7 +146,7 @@ func (s *cdkBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64
 		})
 	}
 
-	// Async notify all subscribers
+	// notify all subscribers
 	if s.stream != nil {
 		write := &WrittenEvent{
 			Type:            event.Type,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR modifies the unified storage CDK backend implementation to synchronously notify all subscribers when writing Create events.

**Why do we need this feature?**

This change fixes the intermittent failures we were having with [TestEtcdWatchSemantics](https://github.com/grafana/grafana/actions/runs/17262862392/job/48988244405#step:8:691).

These failures were not being observed until we moved the CI runners to slower ones on https://github.com/grafana/grafana/pull/109846. After moving to slower runners on August 19th, we started to observe frequent failures with `TestEtcdWatchSemantics`, specially at times when there were multiple pipelines running at once. 

The usage of a goroutine to send write events to the channel was breaking the strict order guarantee.
That stems from the fact that **there's no guarantee that a goroutine will be actually executed when we run a `go func`** instruction. It's up to the go scheduler to decide when, and in which order, a particular go routine will be scheduled.

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/454

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
