### PR TITLE
SQL Expressions: Return error on malformed input

### DIFF
--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -378,6 +378,7 @@ func handleSqlInput(ctx context.Context, tracer trace.Tracer, refID string, forR
 		convertedFrames, err := ConvertToFullLong(dataFrames)
 		if err != nil {
 			result.Error = sql.MakeInputConvertError(err, refID, forRefIDs, dsType)
+			return result, true
 		}
 
 		if len(convertedFrames) == 0 {

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -236,6 +236,17 @@ func TestHandleSqlInput(t *testing.T) {
 			expectFrame: true,
 			converted:   true,
 		},
+		{
+			name: "supported type (timeseries-multi) but malformed returns error",
+			frames: data.Frames{
+				data.NewFrame("",
+					data.NewField("time", nil, []string{"1"}), // string is not valid for time field
+					data.NewField("value", data.Labels{"host": "a"}, []*float64{fp(2)}),
+				).SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti}),
+			},
+			expectErr: "missing time field",
+			converted: true,
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
**What is this feature?**

Fixup on a misleading error being returned due to a missing return statement in the code. Was returning the error "conversion succeeded but no frames" even though there was an error.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
