### PR TITLE
SQL Expressions: Add Exemplars to instrumentation

### DIFF
--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -178,7 +178,6 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 		} else {
 			obsCells.Observe(float64(tc))
 		}
-
 	}()
 
 	allFrames := []*data.Frame{}

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -283,3 +283,7 @@ func (ts *testSpan) SetStatus(code codes.Code, msg string) {}
 func (ts *testSpan) AddEvent(name string, opts ...trace.EventOption) {}
 
 func (ts *testSpan) SetAttributes(kv ...attribute.KeyValue) {}
+
+func (ts *testSpan) SpanContext() trace.SpanContext {
+	return trace.SpanContext{}
+}


### PR DESCRIPTION
**What is this feature?**

Follow up to error instrumentation of SQL expressions #109633 as I forgot about exemplars, in particular, as we get error types, exemplars will be useful to find traces that correspond to the error type in the metric (in particular if it is "unknown")

<img width="1133" height="921" alt="image" src="https://github.com/user-attachments/assets/a3bbea39-b561-45a5-92d6-a6cd7edf6832" />



**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
