### PR TITLE
Alerting: Comprehensive payload for Alertmanager convert API tests

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -1992,6 +1992,19 @@ receivers:
 		require.Equal(t, http.StatusOK, response.Status())
 
 		expectedResponse := `alertmanager_config: |
+  global:
+      resolve_timeout: 5m
+      http_config:
+          follow_redirects: true
+          enable_http2: true
+      smtp_hello: localhost
+      smtp_require_tls: true
+      pagerduty_url: https://events.pagerduty.com/v2/enqueue
+      opsgenie_api_url: https://api.opsgenie.com/
+      wechat_api_url: https://qyapi.weixin.qq.com/cgi-bin/
+      victorops_api_url: https://alert.victorops.com/integrations/generic/20131114/alert/
+      telegram_api_url: https://api.telegram.org
+      webex_api_url: https://webexapis.com/v1/messages
   route:
       receiver: webhook
       continue: false

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -719,9 +719,6 @@ func (c *ExtraConfiguration) GetSanitizedAlertmanagerConfigYAML() (string, error
 		return "", err
 	}
 
-	// Remove global settings as they are not used in Grafana
-	prometheusConfig.Global = nil
-
 	configYAML, err := yaml.Marshal(prometheusConfig)
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal sanitized configuration: %w", err)

--- a/pkg/tests/api/alerting/test-data/mimir-alertmanager-get.yaml
+++ b/pkg/tests/api/alerting/test-data/mimir-alertmanager-get.yaml
@@ -1,0 +1,360 @@
+global:
+  resolve_timeout: 5m
+  http_config:
+    follow_redirects: true
+    enable_http2: true
+  smtp_from: alertmanager@example.com
+  smtp_hello: localhost
+  smtp_smarthost: localhost:1025
+  smtp_auth_username: alertmanager
+  smtp_auth_password: <secret>
+  smtp_require_tls: false
+  slack_api_url: <secret>
+  pagerduty_url: http://localhost/pagerduty-default
+  opsgenie_api_url: http://localhost/opsgenie-default
+  opsgenie_api_key: <secret>
+  wechat_api_url: http://localhost/wechat-default
+  wechat_api_secret: <secret>
+  wechat_api_corp_id: corp123
+  victorops_api_url: http://localhost/victorops-default/
+  victorops_api_key: <secret>
+  telegram_api_url: http://localhost/telegram-default
+  webex_api_url: http://localhost/webes-default
+  jira_api_url: http://localhost/jira-default
+templates:
+  - mimir-alertmanager.tmpl
+route:
+  receiver: webhook
+  group_by:
+    - alertname
+    - cluster
+  continue: false
+  routes:
+    - receiver: pagerduty
+      matchers:
+        - severity="critical"
+      continue: false
+    - receiver: slack
+      matchers:
+        - severity="warning"
+      mute_time_intervals:
+        - maintenance_window
+        - us_independence_day
+      continue: false
+    - receiver: email
+      matchers:
+        - severity="info"
+      mute_time_intervals:
+        - maintenance_window
+        - off_hours
+        - us_independence_day
+      continue: false
+    - receiver: wechat
+      matchers:
+        - severity="notice"
+      continue: false
+    - receiver: webex
+      matchers:
+        - severity="minor"
+      continue: false
+    - receiver: telegram
+      matchers:
+        - severity="major"
+      continue: false
+    - receiver: sns
+      matchers:
+        - severity="low"
+      continue: false
+    - receiver: msteams
+      matchers:
+        - severity="high"
+      continue: false
+    - receiver: jira
+      matchers:
+        - severity="medium"
+      continue: false
+    - receiver: discord
+      matchers:
+        - severity="debug"
+      mute_time_intervals:
+        - maintenance_window
+        - off_hours
+        - us_independence_day
+      continue: false
+  group_wait: 1s
+  group_interval: 5s
+  repeat_interval: 1m
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal:
+      - alertname
+      - cluster
+receivers:
+  - name: discord
+    discord_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: false
+          enable_http2: true
+        webhook_url: <secret>
+        title: '{{ template "discord.default.title" . }}'
+        message: '{{ template "discord.default.message" . }}'
+  - name: email
+    email_configs:
+      - send_resolved: true
+        to: team@example.com
+        from: alertmanager@example.com
+        hello: localhost
+        smarthost: smtp.example.com:587
+        auth_username: alertmanager
+        auth_password: <secret>
+        headers:
+          Subject: test subject
+        html: '{{ template "email.default.html" . }}'
+        text: test email
+        require_tls: true
+  - name: jira
+    jira_configs:
+      - send_resolved: true
+        http_config:
+          basic_auth:
+            username: alertmanager@example.com
+            password: <secret>
+          follow_redirects: true
+          enable_http2: true
+        api_url: http://localhost/jira
+        project: PROJ
+        summary: '{{ template "jira.default.summary" . }}'
+        description: '{{ template "jira.default.description" . }}'
+        labels:
+          - alertmanager
+          - '{{ .CommonLabels.severity }}'
+        priority: '{{ template "jira.default.priority" . }}'
+        issue_type: Bug
+        fields:
+          customfield_10000: test customfield_10000
+  - name: msteams
+    msteams_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+          proxy_url: http://proxy.example.com:8080
+        webhook_url: <secret>
+        title: '{{ template "msteams.default.title" . }}'
+        summary: '{{ template "msteams.default.summary" . }}'
+        text: '{{ template "msteams.default.text" . }}'
+  - name: opsgenie
+    opsgenie_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        api_key: <secret>
+        api_url: http://localhost/opsgenie/
+        message: test message
+        description: test description
+        source: Alertmanager
+        details:
+          firing: test firing
+        entity: test entity
+        responders:
+          - name: ops-team
+            type: team
+        actions: test actions
+        tags: test-tags
+        note: Triggered by Alertmanager
+        priority: P3
+        update_alerts: true
+  - name: pagerduty
+    pagerduty_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        service_key: <secret>
+        routing_key: <secret>
+        url: http://localhost/pagerduty
+        client: Alertmanager
+        client_url: https://monitoring.example.com
+        description: test description
+        details:
+          firing: test firing
+          num_firing: '{{ .Alerts.Firing | len }}'
+          num_resolved: '{{ .Alerts.Resolved | len }}'
+          resolved: '{{ template "pagerduty.default.instances" .Alerts.Resolved }}'
+        images:
+          - src: test src
+            alt: test alt
+            href: http://localhost
+        links:
+          - href: http://localhost
+            text: test text
+        source: test source
+        severity: test severity
+        class: test class
+        component: test component
+        group: test group
+  - name: pushover
+    pushover_configs:
+      - send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: <secret>
+          follow_redirects: true
+          enable_http2: true
+        user_key: <secret>
+        token: <secret>
+        title: '{{ template "pushover.default.title" . }}'
+        message: '{{ template "pushover.default.message" . }}'
+        url: http://localhost/pushover
+        priority: '{{ if eq .Status "firing" }}2{{ else }}0{{ end }}'
+        retry: 30s
+        expire: 1h0m0s
+        html: false
+  - name: slack
+    slack_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        api_url: <secret>
+        channel: '#alerts'
+        username: Alerting Team
+        color: danger
+        title: test title
+        title_link: http://localhost
+        pretext: test pretext
+        text: test text
+        fields:
+          - title: test title
+            value: test value
+            short: true
+        short_fields: false
+        footer: test footer
+        fallback: test fallback
+        callback_id: test callback id
+        icon_emoji: ':warning:'
+        icon_url: https://example.com/icon.png
+        image_url: https://example.com/image.png
+        thumb_url: https://example.com/thumb.png
+        link_names: true
+        mrkdwn_in:
+          - fallback
+          - pretext
+          - text
+        actions:
+          - type: test-type
+            text: test-text
+            style: test-style
+            name: test-name
+            value: test-value
+            confirm:
+              text: test-text
+              title: test-title
+              ok_text: test-ok-text
+              dismiss_text: test-dismiss-text
+  - name: sns
+    sns_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: false
+        sigv4:
+          region: us-east-1
+          access_key: secret-access-key
+          secret_key: <secret>
+          profile: default,
+          role_arn: arn:aws:iam::123456789012:role/role-name
+        topic_arn: arn:aws:sns:us-east-1:123456789012:alerts
+        subject: '{{ template "sns.default.subject" . }}'
+        message: '{{ template "sns.default.message" . }}'
+        attributes:
+          key1: value1
+  - name: telegram
+    telegram_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        api_url: http://localhost/telegram-default
+        bot_token: <secret>
+        chat_id: -1001234567890
+        message: '{{ template "telegram.default.message" . }}'
+        parse_mode: MarkdownV2
+  - name: victorops
+    victorops_configs:
+      - send_resolved: true
+        http_config:
+          tls_config:
+            server_name: victorops.com
+            insecure_skip_verify: false
+          follow_redirects: true
+          enable_http2: true
+        api_key: <secret>
+        api_url: http://localhost/victorops-default/
+        routing_key: team1
+        message_type: CRITICAL
+        state_message: '{{ template "victorops.default.state_message" . }}'
+        entity_display_name: '{{ template "victorops.default.entity_display_name" . }}'
+        monitoring_tool: '{{ template "victorops.default.monitoring_tool" . }}'
+  - name: webex
+    webex_configs:
+      - send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: <secret>
+          follow_redirects: true
+          enable_http2: true
+        api_url: http://localhost/webes-default
+        message: '{{ template "webex.default.message" . }}'
+        room_id: Y2lzY29zcGFyazovL3VzL1JPT00v12345678
+  - name: webhook
+    webhook_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        url: <secret>
+        url_file: ""
+        max_alerts: 10
+        timeout: 0s
+  - name: wechat
+    wechat_configs:
+      - send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        api_secret: <secret>
+        corp_id: "12345"
+        message: test message
+        api_url: http://localhost/wechat/
+        to_user: user1
+        to_party: party1
+        to_tag: tag1
+        agent_id: "1000002"
+        message_type: text
+time_intervals:
+  - name: maintenance_window
+    time_intervals:
+      - times:
+          - start_time: "02:00"
+            end_time: "04:00"
+        weekdays: [ saturday ]
+  - name: off_hours
+    time_intervals:
+      - times:
+          - start_time: "20:00"
+            end_time: "23:59"
+          - start_time: "00:00"
+            end_time: "06:00"
+        weekdays: [ monday, tuesday, wednesday, thursday, friday ]
+  - name: us_independence_day
+    time_intervals:
+      - days_of_month: [ "4" ]
+        months: [ "7" ]

--- a/pkg/tests/api/alerting/test-data/mimir-alertmanager-post.yaml
+++ b/pkg/tests/api/alerting/test-data/mimir-alertmanager-post.yaml
@@ -1,0 +1,321 @@
+global:
+  resolve_timeout: 5m
+  smtp_smarthost: localhost:1025
+  smtp_from: alertmanager@example.com
+  smtp_auth_username: alertmanager
+  smtp_auth_password: password123
+  smtp_require_tls: false
+  smtp_hello: localhost
+  http_config:
+    follow_redirects: true
+    enable_http2: true
+  pagerduty_url: http://localhost/pagerduty-default
+  opsgenie_api_key: opsgenie-api-key-secret
+  opsgenie_api_url: http://localhost/opsgenie-default
+  victorops_api_key: victorops-api-key-secret
+  victorops_api_url: http://localhost/victorops-default
+  slack_api_url: http://localhost/slack-default
+  wechat_api_url: http://localhost/wechat-default
+  wechat_api_secret: wechat-api-secret
+  wechat_api_corp_id: corp123
+  telegram_api_url: http://localhost/telegram-default
+  webex_api_url: http://localhost/webes-default
+  jira_api_url: http://localhost/jira-default
+templates:
+  - mimir-alertmanager.tmpl
+time_intervals:
+  - name: maintenance_window
+    time_intervals:
+      - times:
+          - start_time: 02:00
+            end_time: 04:00
+        weekdays:
+          - saturday
+  - name: off_hours
+    time_intervals:
+      - times:
+          - start_time: 20:00
+            end_time: 23:59
+          - start_time: 00:00
+            end_time: 06:00
+        weekdays:
+          - monday
+          - tuesday
+          - wednesday
+          - thursday
+          - friday
+  - name: us_independence_day
+    time_intervals:
+      - months:
+          - july
+        days_of_month:
+          - 4
+route:
+  receiver: webhook
+  group_by:
+    - alertname
+    - cluster
+  group_wait: 1s
+  group_interval: 5s
+  repeat_interval: 60s
+  routes:
+    - matchers:
+        - severity="critical"
+      receiver: pagerduty
+    - matchers:
+        - severity="warning"
+      receiver: slack
+      mute_time_intervals:
+        - maintenance_window
+        - us_independence_day
+    - matchers:
+        - severity="info"
+      receiver: email
+      mute_time_intervals:
+        - maintenance_window
+        - off_hours
+        - us_independence_day
+    - matchers:
+        - severity="notice"
+      receiver: wechat
+    - matchers:
+        - severity="minor"
+      receiver: webex
+    - matchers:
+        - severity="major"
+      receiver: telegram
+    - matchers:
+        - severity="low"
+      receiver: sns
+    - matchers:
+        - severity="high"
+      receiver: msteams
+    - matchers:
+        - severity="medium"
+      receiver: jira
+    - matchers:
+        - severity="debug"
+      receiver: discord
+      mute_time_intervals:
+        - maintenance_window
+        - off_hours
+        - us_independence_day
+receivers:
+  - name: discord
+    discord_configs:
+      - webhook_url: http://localhost/discord
+        send_resolved: true
+        http_config:
+          follow_redirects: false
+          enable_http2: true
+        title: '{{ template "discord.default.title" . }}'
+        message: '{{ template "discord.default.message" . }}'
+  - name: email
+    email_configs:
+      - to: team@example.com
+        from: alertmanager@example.com
+        smarthost: smtp.example.com:587
+        auth_username: alertmanager
+        auth_password: password123
+        require_tls: true
+        send_resolved: true
+        text: test email
+        hello: localhost
+        headers:
+          Subject: test subject
+  - name: jira
+    jira_configs:
+      - api_url: http://localhost/jira
+        send_resolved: true
+        http_config:
+          basic_auth:
+            username: alertmanager@example.com
+            password: pat123
+        project: PROJ
+        issue_type: Bug
+        summary: '{{ template "jira.default.summary" . }}'
+        description: '{{ template "jira.default.description" . }}'
+        priority: '{{ template "jira.default.priority" . }}'
+        labels:
+          - alertmanager
+          - '{{ .CommonLabels.severity }}'
+        fields:
+          customfield_10000: test customfield_10000
+  - name: msteams
+    msteams_configs:
+      - webhook_url: http://localhost/msteams
+        send_resolved: true
+        http_config:
+          proxy_url: http://proxy.example.com:8080
+        title: '{{ template "msteams.default.title" . }}'
+        summary: '{{ template "msteams.default.summary" . }}'
+        text: '{{ template "msteams.default.text" . }}'
+  - name: opsgenie
+    opsgenie_configs:
+      - api_key: api-secret-key
+        api_url: http://localhost/opsgenie
+        message: test message
+        description: test description
+        source: Alertmanager
+        details:
+          firing: test firing
+        entity: test entity
+        responders:
+          - type: team
+            name: ops-team
+        actions: test actions
+        tags: test-tags
+        note: Triggered by Alertmanager
+        priority: P3
+        update_alerts: true
+        send_resolved: true
+  - name: pagerduty
+    pagerduty_configs:
+      - url: http://localhost/pagerduty
+        routing_key: test-routing-secret-key
+        service_key: test-service-secret-key
+        client: Alertmanager
+        client_url: https://monitoring.example.com
+        description: test description
+        severity: test severity
+        details:
+          firing: test firing
+        images:
+          - alt: test alt
+            src: test src
+            href: http://localhost
+        links:
+          - href: http://localhost
+            text: test text
+        source: test source
+        class: test class
+        component: test component
+        group: test group
+        send_resolved: true
+  - name: pushover
+    pushover_configs:
+      - user_key: secret-user-key
+        token: secret-token
+        send_resolved: true
+        http_config:
+          bearer_token: token123
+        title: '{{ template "pushover.default.title" . }}'
+        message: '{{ template "pushover.default.message" . }}'
+        url: http://localhost/pushover
+        priority: '{{ if eq .Status "firing" }}2{{ else }}0{{ end }}'
+        retry: 30s
+        expire: 1h
+  - name: slack
+    slack_configs:
+      - api_url: http://localhost/slack
+        channel: '#alerts'
+        username: Alerting Team
+        color: danger
+        title: test title
+        title_link: http://localhost
+        pretext: test pretext
+        text: test text
+        fields:
+          - title: test title
+            value: test value
+            short: true
+        short_fields: false
+        footer: test footer
+        fallback: test fallback
+        callback_id: test callback id
+        icon_emoji: ':warning:'
+        icon_url: https://example.com/icon.png
+        image_url: https://example.com/image.png
+        thumb_url: https://example.com/thumb.png
+        link_names: true
+        mrkdwn_in:
+          - fallback
+          - pretext
+          - text
+        actions:
+          - type: test-type
+            text: test-text
+            style: test-style
+            name: test-name
+            value: test-value
+            confirm:
+              title: test-title
+              text: test-text
+              ok_text: test-ok-text
+              dismiss_text: test-dismiss-text
+        send_resolved: true
+  - name: sns
+    sns_configs:
+      - topic_arn: arn:aws:sns:us-east-1:123456789012:alerts
+        send_resolved: true
+        sigv4:
+          region: us-east-1
+          access_key: secret-access-key
+          secret_key: secret-secret-key
+          profile: default,
+          role_arn: "arn:aws:iam::123456789012:role/role-name"
+        http_config:
+          enable_http2: false
+        subject: '{{ template "sns.default.subject" . }}'
+        message: '{{ template "sns.default.message" . }}'
+        attributes:
+          key1: value1
+  - name: telegram
+    telegram_configs:
+      - bot_token: 123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+        chat_id: -1001234567890
+        send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        message: '{{ template "telegram.default.message" . }}'
+        parse_mode: MarkdownV2
+  - name: victorops
+    victorops_configs:
+      - api_key: victorops-api-key-secret
+        send_resolved: true
+        http_config:
+          tls_config:
+            server_name: victorops.com
+        routing_key: team1
+        message_type: CRITICAL
+        entity_display_name: '{{ template "victorops.default.entity_display_name" . }}'
+        state_message: '{{ template "victorops.default.state_message" . }}'
+        monitoring_tool: '{{ template "victorops.default.monitoring_tool" . }}'
+  - name: webex
+    webex_configs:
+      - send_resolved: true
+        http_config:
+          authorization:
+            type: Bearer
+            credentials: webex-secret-token
+        room_id: Y2lzY29zcGFyazovL3VzL1JPT00v12345678
+        message: '{{ template "webex.default.message" . }}'
+  - name: webhook
+    webhook_configs:
+      - url: http://localhost/webhook
+        send_resolved: true
+        http_config:
+          follow_redirects: true
+          enable_http2: true
+        max_alerts: 10
+  - name: wechat
+    wechat_configs:
+      - send_resolved: true
+        api_url: http://localhost/wechat
+        api_secret: wechat-api-secret
+        corp_id: 12345
+        to_user: user1
+        to_party: party1
+        to_tag: tag1
+        agent_id: 1000002
+        message: test message
+        message_type: text
+inhibit_rules:
+  - source_matchers:
+      - severity="critical"
+    target_matchers:
+      - severity="warning"
+    equal:
+      - alertname
+      - cluster

--- a/pkg/tests/api/alerting/test-data/mimir-alertmanager.tmpl
+++ b/pkg/tests/api/alerting/test-data/mimir-alertmanager.tmpl
@@ -1,0 +1,48 @@
+{{ define "alert.title" }}
+[{{ .Status | toUpper }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}] {{ .GroupLabels.SortedPairs.Values | join " " }} {{ if gt (len .CommonLabels) (len .GroupLabels) }}({{ with .CommonLabels.Remove .GroupLabels.Names }}{{ .Values | join " " }}{{ end }}){{ end }}
+{{ end }}
+
+{{ define "alert.severity" }}
+{{- if eq .Labels.severity "critical" -}}
+🔴 CRITICAL
+{{- else if eq .Labels.severity "warning" -}}
+🟡 WARNING
+{{- else if eq .Labels.severity "info" -}}
+🔵 INFO
+{{- else -}}
+⚪️ UNKNOWN
+{{- end }}
+{{ end }}
+
+{{ define "alert.message" }}
+{{ range .Alerts }}
+*Alert:* {{ .Annotations.summary }}{{ if .Annotations.description }}
+*Description:* {{ .Annotations.description }}{{ end }}
+*Severity:* {{ template "alert.severity" . }}
+*Status:* {{ .Status }}
+*Started:* {{ .StartsAt }}
+*Labels:*
+{{ range .Labels.SortedPairs }}  - {{ .Name }}: {{ .Value }}
+{{ end }}
+{{ end }}
+{{ end }}
+
+{{ define "slack.message" }}
+{{ template "alert.title" . }}
+{{ template "alert.message" . }}
+{{ end }}
+
+{{ define "email.message" }}
+<!DOCTYPE html>
+<html>
+<body>
+<h2>{{ template "alert.title" . }}</h2>
+<pre>{{ template "alert.message" . }}</pre>
+</body>
+</html>
+{{ end }}
+
+{{ define "default" }}
+{{ template "alert.title" . }}
+{{ template "alert.message" . }}
+{{ end }}


### PR DESCRIPTION
**What is this feature?**
1. This PR updates integration tests for Alertmanager convert API to use configuration with all resources defined.
2. API is updated to not remove Global configuration. Although the configuration is not used by Grafana Alertmanager, they are used when config is unmarshaled.

**Why**
- The introduced config will be used in other integration tests in https://github.com/grafana/grafana/pull/109878

Related https://github.com/grafana/alerting-squad/issues/1194
