### PR TITLE
FolderRepo: Prevent no basic role user getting infinite api calls on provisioning settings endpoint

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
+import { ManagerKind } from 'app/features/apiserver/types';
+import { DashboardViewItem } from 'app/features/search/types';
+
+import { FolderRepo } from './FolderRepo';
+
+jest.mock('@grafana/runtime', () => ({
+  config: { featureToggles: { provisioning: true } },
+}));
+
+const mockUseGetFrontendSettingsQuery = jest.fn();
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  useGetFrontendSettingsQuery: () => mockUseGetFrontendSettingsQuery(),
+}));
+
+const mockUseGetResourceRepositoryView = jest.fn();
+jest.mock('app/features/provisioning/hooks/useGetResourceRepositoryView', () => ({
+  useGetResourceRepositoryView: () => mockUseGetResourceRepositoryView(),
+}));
+
+function mockSettings(items: Array<Partial<RepositoryView>>) {
+  mockUseGetFrontendSettingsQuery.mockReturnValue({ data: { items } });
+}
+
+function mockRepoView({ isReadOnlyRepo = false, repoType = 'github' }) {
+  mockUseGetResourceRepositoryView.mockReturnValue({ isReadOnlyRepo, repoType });
+}
+
+const MOCK_FOLDER: DashboardViewItem = {
+  uid: 'A',
+  managedBy: ManagerKind.Repo,
+  parentUID: undefined,
+  kind: 'folder',
+  title: 'test',
+};
+
+function setup({
+  folder = undefined,
+  repoViewMock = {},
+  settingsMock = [],
+}: {
+  folder?: DashboardViewItem;
+  repoViewMock?: { isReadOnlyRepo?: boolean; repoType?: string };
+  settingsMock?: Array<Partial<RepositoryView>>;
+}) {
+  mockSettings(settingsMock);
+  mockRepoView(repoViewMock);
+
+  return {
+    ...render(<FolderRepo folder={folder} />),
+  };
+}
+
+describe('FolderRepo', () => {
+  afterEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+  });
+
+  it('returns null when folder is undefined', () => {
+    setup({ folder: undefined });
+    expect(screen.queryByText('Read only')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('returns null when folder has parentUID', () => {
+    setup({ folder: { ...MOCK_FOLDER, parentUID: 'repo-123' } });
+    expect(screen.queryByText('Read only')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('returns null when folder is not managed', () => {
+    setup({ folder: { ...MOCK_FOLDER, managedBy: undefined } });
+    expect(screen.queryByText('Read only')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('returns null when whole instance is provisioned', () => {
+    setup({ folder: MOCK_FOLDER, settingsMock: [{ target: 'instance' }] });
+    expect(screen.queryByText('Read only')).not.toBeInTheDocument();
+    expect(screen.queryByTitle('Provisioned')).not.toBeInTheDocument();
+  });
+
+  it('renders Read only badge when repo is read-only (empty workflows)', () => {
+    setup({ folder: MOCK_FOLDER, repoViewMock: { isReadOnlyRepo: true, repoType: 'github' } });
+    expect(screen.getByText('Read only')).toBeInTheDocument();
+    expect(screen.queryByTitle('Provisioned')).toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -17,7 +17,7 @@ export function FolderRepo({ folder }: Props) {
   // folder have parentUID
   // folder is not managed
   // if whole instance is provisioned
-  const isProvisionedInstance = useIsProvisionedInstance(undefined);
+  const isProvisionedInstance = useIsProvisionedInstance();
   const skipRender =
     !folder ||
     Boolean('parentUID' in folder && folder.parentUID) ||

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { Badge, Stack } from '@grafana/ui';
+import { ManagerKind } from 'app/features/apiserver/types';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
@@ -16,12 +17,16 @@ export function FolderRepo({ folder }: Props) {
   // folder have parentUID
   // folder is not managed
   // if whole instance is provisioned
-  const isProvisionedInstance = useIsProvisionedInstance();
+  const isProvisionedInstance = useIsProvisionedInstance(undefined);
   const skipRender =
-    !folder || ('parentUID' in folder && folder.parentUID) || !folder.managedBy || isProvisionedInstance;
+    !folder ||
+    Boolean('parentUID' in folder && folder.parentUID) ||
+    folder.managedBy !== ManagerKind.Repo ||
+    isProvisionedInstance;
 
   const { isReadOnlyRepo, repoType } = useGetResourceRepositoryView({
     folderName: skipRender ? undefined : folder?.uid,
+    skipQuery: skipRender,
   });
 
   if (skipRender) {

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -4,11 +4,11 @@ import { ManagerKind } from 'app/features/apiserver/types';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
-import { NestedFolderDTO } from 'app/features/search/service/types';
-import { FolderDTO, FolderListItemDTO } from 'app/types/folders';
+import { DashboardViewItem } from 'app/features/search/types';
+import { FolderDTO } from 'app/types/folders';
 
 export interface Props {
-  folder?: FolderListItemDTO | NestedFolderDTO | FolderDTO;
+  folder?: FolderDTO | DashboardViewItem;
 }
 
 export function FolderRepo({ folder }: Props) {
@@ -43,7 +43,12 @@ export function FolderRepo({ folder }: Props) {
           tooltip={getReadOnlyTooltipText({ isLocal: repoType === 'local' })}
         />
       )}
-      <Badge color="purple" icon="exchange-alt" tooltip={t('folder-repo.provisioned-badge', 'Provisioned')} />
+      <Badge
+        title={t('folder-repo.provisioned-badge', 'Provisioned')}
+        color="purple"
+        icon="exchange-alt"
+        tooltip={t('folder-repo.provisioned-badge', 'Provisioned')}
+      />
     </Stack>
   );
 }

--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -18,11 +18,7 @@ export function FolderRepo({ folder }: Props) {
   // folder is not managed
   // if whole instance is provisioned
   const isProvisionedInstance = useIsProvisionedInstance();
-  const skipRender =
-    !folder ||
-    Boolean('parentUID' in folder && folder.parentUID) ||
-    folder.managedBy !== ManagerKind.Repo ||
-    isProvisionedInstance;
+  const skipRender = getShouldSkipRender(folder, isProvisionedInstance);
 
   const { isReadOnlyRepo, repoType } = useGetResourceRepositoryView({
     folderName: skipRender ? undefined : folder?.uid,
@@ -51,4 +47,13 @@ export function FolderRepo({ folder }: Props) {
       />
     </Stack>
   );
+}
+
+function getShouldSkipRender(folder: FolderDTO | DashboardViewItem | undefined, isProvisionedInstance?: boolean) {
+  // Skip render if parentUID is present, then we should skip rendering. we only display icon for root folders
+  const hasParent = folder && Boolean('parentUID' in folder && folder.parentUID);
+  // Skip render if folder is not managed by Repo
+  const isNotManaged = folder && folder.managedBy !== ManagerKind.Repo;
+
+  return !folder || hasParent || isNotManaged || isProvisionedInstance;
 }

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,10 +1,12 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo } from 'react';
 
+import { OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { CallToActionCard, EmptyState, LinkButton, TextLink } from '@grafana/ui';
 import { useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { contextSrv } from 'app/core/core';
 import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { DashboardViewItem } from 'app/features/search/types';
 import { useDispatch, useSelector } from 'app/types/store';
@@ -41,7 +43,8 @@ export function BrowseView({ folderUID, width, height, permissions }: BrowseView
   const canSelect = canSelectItems(permissions);
   const isProvisionedInstance = useIsProvisionedInstance();
   const provisioningEnabled = config.featureToggles.provisioning;
-  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled ? skipToken : undefined);
+  const hasNoRole = contextSrv.user.orgRole === OrgRole.None;
+  const { data: settingsData } = useGetFrontendSettingsQuery(!provisioningEnabled || hasNoRole ? skipToken : undefined);
   const rootItems = useSelector(rootItemsSelector);
 
   const excludeUIDs = useMemo(() => {

--- a/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
+++ b/public/app/features/provisioning/hooks/useIsProvisionedInstance.ts
@@ -1,12 +1,15 @@
 import { skipToken } from '@reduxjs/toolkit/query';
 
+import { OrgRole } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { RepositoryViewList, useGetFrontendSettingsQuery } from 'app/api/clients/provisioning/v0alpha1';
+import { contextSrv } from 'app/core/core';
 
 export function useIsProvisionedInstance(settings?: RepositoryViewList) {
-  const settingsQuery = useGetFrontendSettingsQuery(
-    settings || !config.featureToggles.provisioning ? skipToken : undefined
-  );
+  const hasNoRole = contextSrv.user.orgRole === OrgRole.None;
+  const skip = !config.featureToggles.provisioning || hasNoRole;
+
+  const settingsQuery = useGetFrontendSettingsQuery(settings || skip ? skipToken : undefined);
   if (!settings) {
     settings = settingsQuery.data;
   }


### PR DESCRIPTION
**What is this feature?**

- Bugfix when user has `No basic role` assigned, they are seeing infinite api calls to /settings endpoint. 

Root cause: 
- The provisioning settings endpoint returns 403 for users without any role. RTK Query treats 403 as an error (not a fulfilled, cacheable result), so every mount/re-render re-subscribes and re-requests. 
- `BrowseDashboardsPage` has multiple subscribers (e.g., BrowseView → DashboardsTree → NameCell → FolderRepo), which ends up in an apparent “infinite” call pattern.
- Adding a “no role” check gates the settings query (skip when the user has no role), preventing the error state from being re-subscribed to and eliminating the repeated requests.

<img width="1301" height="497" alt="image" src="https://github.com/user-attachments/assets/7d523f58-a71d-4414-91f8-196ecfd4995e" />


**Why do we need this feature?**

- Prevent user browser crash

**Who is this feature for?**

- No basic role user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/474

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
