### PR TITLE
Provisioning Action Drawer: Organize action and cancel button order to match existing pattern

### DIFF
--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -96,13 +96,13 @@ function FormContent({ initialValues, selectedItems, repository, workflowOptions
                 hidePath
               />
               <Stack gap={2}>
+                <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={isCreatingJob}>
+                  <Trans i18nKey="browse-dashboards.bulk-delete-resources-form.button-cancel">Cancel</Trans>
+                </Button>
                 <Button type="submit" disabled={disableBtn} variant="destructive">
                   {job?.status?.state === 'working' || job?.status?.state === 'pending'
                     ? t('browse-dashboards.bulk-delete-resources-form.button-deleting', 'Deleting...')
                     : t('browse-dashboards.bulk-delete-resources-form.button-delete', 'Delete')}
-                </Button>
-                <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={isCreatingJob}>
-                  <Trans i18nKey="browse-dashboards.bulk-delete-resources-form.button-cancel">Cancel</Trans>
                 </Button>
               </Stack>
             </>

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -149,6 +149,9 @@ function FormContent({ initialValues, selectedItems, repository, workflowOptions
               />
 
               <Stack gap={2}>
+                <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={isCreatingJob}>
+                  <Trans i18nKey="browse-dashboards.bulk-move-resources-form.button-cancel">Cancel</Trans>
+                </Button>
                 <Button
                   type="submit"
                   disabled={!!job || isCreatingJob || hasSubmitted || targetFolderUID === undefined}
@@ -156,9 +159,6 @@ function FormContent({ initialValues, selectedItems, repository, workflowOptions
                   {isCreatingJob
                     ? t('browse-dashboards.bulk-move-resources-form.button-moving', 'Moving...')
                     : t('browse-dashboards.bulk-move-resources-form.button-move', 'Move')}
-                </Button>
-                <Button variant="secondary" fill="outline" onClick={onDismiss} disabled={isCreatingJob}>
-                  <Trans i18nKey="browse-dashboards.bulk-move-resources-form.button-cancel">Cancel</Trans>
                 </Button>
               </Stack>
             </>

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
@@ -136,13 +136,13 @@ export function DeleteProvisionedDashboardForm({
 
             {/* Save / Cancel button */}
             <Stack gap={2}>
+              <Button variant="secondary" onClick={onDismiss} fill="outline">
+                <Trans i18nKey="dashboard-scene.delete-provisioned-dashboard-form.cancel-action">Cancel</Trans>
+              </Button>
               <Button variant="destructive" type="submit" disabled={request.isLoading || readOnly}>
                 {request.isLoading
                   ? t('dashboard-scene.delete-provisioned-dashboard-form.deleting', 'Deleting...')
                   : t('dashboard-scene.delete-provisioned-dashboard-form.delete-action', 'Delete dashboard')}
-              </Button>
-              <Button variant="secondary" onClick={onDismiss} fill="outline">
-                <Trans i18nKey="dashboard-scene.delete-provisioned-dashboard-form.cancel-action">Cancel</Trans>
               </Button>
             </Stack>
           </Stack>

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -228,6 +228,9 @@ export function MoveProvisionedDashboardForm({
             />
 
             <Stack gap={2}>
+              <Button variant="secondary" onClick={onDismiss} fill="outline">
+                <Trans i18nKey="dashboard-scene.move-provisioned-dashboard-form.cancel-action">Cancel</Trans>
+              </Button>
               <Button
                 variant="primary"
                 type="submit"
@@ -236,9 +239,6 @@ export function MoveProvisionedDashboardForm({
                 {isLoading
                   ? t('dashboard-scene.move-provisioned-dashboard-form.moving', 'Moving...')
                   : t('dashboard-scene.move-provisioned-dashboard-form.move-action', 'Move dashboard')}
-              </Button>
-              <Button variant="secondary" onClick={onDismiss} fill="outline">
-                <Trans i18nKey="dashboard-scene.move-provisioned-dashboard-form.cancel-action">Cancel</Trans>
               </Button>
             </Stack>
           </Stack>

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -243,13 +243,13 @@ export function SaveProvisionedDashboardForm({
           />
 
           <Stack gap={2}>
+            <Button variant="secondary" onClick={drawer.onClose} fill="outline">
+              <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.cancel">Cancel</Trans>
+            </Button>
             <Button variant="primary" type="submit" disabled={request.isLoading || !isDirty || readOnly}>
               {request.isLoading
                 ? t('dashboard-scene.save-provisioned-dashboard-form.saving', 'Saving...')
                 : t('dashboard-scene.save-provisioned-dashboard-form.save', 'Save')}
-            </Button>
-            <Button variant="secondary" onClick={drawer.onClose} fill="outline">
-              <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.cancel">Cancel</Trans>
             </Button>
           </Stack>
         </Stack>

--- a/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
@@ -131,13 +131,13 @@ function FormContent({ initialValues, parentFolder, repository, workflowOptions,
 
           {/* Delete / Cancel button */}
           <Stack gap={2}>
+            <Button variant="secondary" fill="outline" onClick={onDismiss}>
+              <Trans i18nKey="browse-dashboards.delete-provisioned-folder-form.button-cancel">Cancel</Trans>
+            </Button>
             <Button type="submit" disabled={request.isLoading} variant="destructive">
               {request.isLoading
                 ? t('browse-dashboards.delete-provisioned-folder-form.button-deleting', 'Deleting...')
                 : t('browse-dashboards.delete-provisioned-folder-form.button-delete', 'Delete')}
-            </Button>
-            <Button variant="secondary" fill="outline" onClick={onDismiss}>
-              <Trans i18nKey="browse-dashboards.delete-provisioned-folder-form.button-cancel">Cancel</Trans>
             </Button>
           </Stack>
         </Stack>

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -187,13 +187,13 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
           )}
 
           <Stack gap={2}>
+            <Button variant="secondary" fill="outline" onClick={onDismiss}>
+              <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.cancel">Cancel</Trans>
+            </Button>
             <Button type="submit" disabled={request.isLoading || !!formState?.errors.title}>
               {request.isLoading
                 ? t('browse-dashboards.new-provisioned-folder-form.button-creating', 'Creating...')
                 : t('browse-dashboards.new-provisioned-folder-form.button-create', 'Create')}
-            </Button>
-            <Button variant="secondary" fill="outline" onClick={onDismiss}>
-              <Trans i18nKey="browse-dashboards.new-provisioned-folder-form.cancel">Cancel</Trans>
             </Button>
           </Stack>
         </Stack>


### PR DESCRIPTION
**What is this feature?**

- Organize provisioning action drawer buttons order to align with other part of platform: Action | Cancel -> Cancel | Action 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

Git users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/493

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
