### PR TITLE
Loki: resource frontend browser cache

### DIFF
--- a/pkg/tsdb/loki/loki.go
+++ b/pkg/tsdb/loki/loki.go
@@ -162,6 +162,13 @@ func callResource(ctx context.Context, req *backend.CallResourceRequest, sender 
 	respHeaders := map[string][]string{
 		"content-type": {"application/json"},
 	}
+
+	// frontend sets the X-Grafana-Cache with the desired response cache control value
+	if len(req.GetHTTPHeaders().Get("X-Grafana-Cache")) > 0 {
+		respHeaders["X-Grafana-Cache"] = []string{"y"}
+		respHeaders["Cache-Control"] = []string{req.GetHTTPHeaders().Get("X-Grafana-Cache")}
+	}
+
 	if rawLokiResponse.Encoding != "" {
 		respHeaders["content-encoding"] = []string{rawLokiResponse.Encoding}
 	}


### PR DESCRIPTION
**What is this feature?**

Allowing the frontend to set `Cache-Control` header for resource calls.
Following example of Prometheus datasource in https://github.com/grafana/grafana/pull/62033, https://github.com/grafana/grafana/pull/63060

**Why do we need this feature?**
The new `/config` [endpoint](https://github.com/grafana/loki/pull/19028) doesn't need to be re-queried very often, and should be cached across sessions, refreshes, etc. Native browser functionality can be used to clear/invalidate the cache instead of needing to build more functionality (or import additional packages) in the client application.

Additionally the config call may need to block rendering portions of the UI, so even shaving a few milliseconds off subsequent requests can have a noticeable impact on performance.

**Who is this feature for?**
Logs Drilldown users

**Special notes for your reviewer:**
Also allows us to use the browser cache for other resource calls (assuming they are GET requests that the browser will cache).

Example frontend code:

```
 const config: ConfigResponse = await ds.getResource(
        'config',
        {},
        {
          headers: {
            'X-Grafana-Cache': `private, max-age=60000`,
          },
        }
      );
```

tests for `X-Grafana-Cache` are in [middleware_test.go](https://github.com/grafana/grafana/blob/main/pkg/middleware/middleware_test.go#L119-L141), I couldn't find any unit tests covering loki's `callResource`, or tests for any other datasource's `callResource` method

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
