### PR TITLE
EphemeralEnvs: Trigger workflow when PR is merged

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   handle-ephemeral-instances:
-    if: ${{ github.event.issue.pull_request && (startsWith(github.event.comment.body, '/deploy-to-hg') || github.event.action == 'closed') && github.repository_owner == 'grafana' }}
+    if: ${{ github.repository_owner == 'grafana' && ((github.event.issue.pull_request && startsWith(github.event.comment.body, '/deploy-to-hg')) || github.event.action == 'closed') }}
     runs-on:
       labels: ubuntu-x64-xlarge
     continue-on-error: true


### PR DESCRIPTION
Reading through the docs, I believe `github.event.issue.pull_request` won't exist when the PR is closed (merged or unmerged).

- https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#issue_comment-on-issues-only-or-pull-requests-only
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=closed#issue_comment
- https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=closed#pull_request