### PR TITLE
FS: Add support for local dev configs

### DIFF
--- a/devenv/frontend-service/.gitignore
+++ b/devenv/frontend-service/.gitignore
@@ -1,1 +1,3 @@
 build
+configs/grafana-api.local.ini
+configs/frontend-service.local.ini

--- a/devenv/frontend-service/README.md
+++ b/devenv/frontend-service/README.md
@@ -17,6 +17,14 @@ To start the stack, from the root of the Grafana project run `make frontend-serv
 
 Quitting the process will not stop the service from running. Run `make frontend-service-down` when done to shut down the docker containers.
 
+### Grafana config
+
+The Grafana API and frontend-service containers are configured in two places:
+
+- `GF_` environment variables in the docker-compose file. Config specific to this development stack, that should be the same for everyone, is set here.
+
+- `configs/{frontend-service,grafana-api}.local.ini` file is where you can set your own personal config values, such as feature toggles. This file is git-ignored.
+
 ### Bootdata unavailable
 
 To simulate the `/bootdata` endpoint being available, there are special control URLs you can visit that use cookies to control behaviour:

--- a/devenv/frontend-service/README.md
+++ b/devenv/frontend-service/README.md
@@ -34,3 +34,7 @@ To simulate the `/bootdata` endpoint being available, there are special control 
 - `/-/up` - Restores the endpoint to being available.
 
 When unavailable, the API will return `HTTP 503 Service Unavailable` with a JSON payload.
+
+### Leave service running
+
+By default, Tilt services stay running after you close the CLI, but `make frontend-service` wraps Tilt and auto shuts down the services. Set the environment variable `AUTO_DOWN=false` when running `make frontend-service` to leave the services running after quitting make. This is useful if you're restarting tilt often in quick succession for developing it.

--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -87,6 +87,8 @@ docker_build('grafana-fs-dev',
   only=[
     'devenv/frontend-service/build/grafana',
     'devenv/frontend-service/provisioning',
+    'devenv/frontend-service/configs/grafana-api.local.ini',
+    'devenv/frontend-service/configs/frontend-service.local.ini',
     'conf/defaults.ini',
     'public/emails',
     'public/views',
@@ -109,6 +111,8 @@ docker_build('grafana-fs-dev',
     sync('../../public/app/plugins', '/grafana/public/app/plugins'),
     sync('../../public/build/assets-manifest.json', '/grafana/public/build/assets-manifest.json'),
     sync('./provisioning', '/ignore/provisioning'),  # Just to trigger a restart instead of rebuild
+    sync('./configs/grafana-api.local.ini', '/ignore/grafana-api.local.ini'),  # Just to trigger a restart instead of rebuild
+    sync('./configs/frontend-service.local.ini', '/ignore/frontend-service.local.ini'),  # Just to trigger a restart instead of rebuild
     restart_container()
   ]
 )

--- a/devenv/frontend-service/Tiltfile
+++ b/devenv/frontend-service/Tiltfile
@@ -1,8 +1,3 @@
-config.define_bool("use-zig")
-cfg = config.parse()
-
-use_zig = cfg.get('docker-builder', False)
-
 # --- Frontend processes
 local_resource(
   'yarn install',
@@ -30,10 +25,6 @@ local_resource(
   labels=["local"]
 )
 
-build_backend_env = {}
-if use_zig:
-  build_backend_env['USE_ZIG'] = "true"
-
 local_resource(
   'backend-build',
   "bash ./build-grafana.sh",
@@ -48,7 +39,6 @@ local_resource(
     '../../go.sum',
     '../../go.mod',
   ],
-  env=build_backend_env,
   allow_parallel=True,
   labels=["local"]
 )

--- a/devenv/frontend-service/build-grafana.sh
+++ b/devenv/frontend-service/build-grafana.sh
@@ -5,21 +5,13 @@ cd ../../
 echo "Go mod cache: $(go env GOMODCACHE), $(ls -1 $(go env GOMODCACHE) | wc -l) items"
 echo "Go build cache: $(go env GOCACHE), $(ls -1 $(go env GOCACHE) | wc -l) items"
 
-# Set cross-compilation env vars only on macOS (Darwin)
+# The docker container, even on macOS, is linux, so we need to cross-compile
+# on macOS hosts to work on linux.
 if [[ "$(uname)" == "Darwin" ]]; then
   echo "Setting up cross-compilation environment for macOS"
   export CGO_ENABLED=0
   export GOOS=linux
   export GOARCH=arm64
-fi
-
-# It's not used by default now that we have CGO-less builds, but keeping this here for a
-# little bit in case it causes issues for anyone.
-if [[ -n "$USE_ZIG" ]]; then
-  echo "Using Zig for cross-compilation"
-  export CGO_ENABLED=1
-  export CC="zig cc -target aarch64-linux"
-  export CXX="zig c++ -target aarch64-linux"
 fi
 
 # Need to build version into the binary so plugin compatibility works correctly

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -29,6 +29,7 @@ services:
       - ./provisioning/datasources:/grafana/conf/provisioning/datasources
       - ./provisioning/dashboards:/grafana/conf/provisioning/dashboards
       - ../dev-dashboards:/grafana/conf/dev-dashboards
+      - ./configs/grafana-api.local.ini:/grafana/conf/custom.ini
     environment:
       OTEL_BSP_SCHEDULE_DELAY: 500
       GF_DEFAULT_APP_MODE: development
@@ -53,6 +54,8 @@ services:
       context: ../..
       dockerfile: devenv/frontend-service/grafana-fs-dev.dockerfile
     entrypoint: ['bin/grafana', 'server', 'target']
+    volumes:
+      - ./configs/frontend-service.local.ini:/grafana/conf/custom.ini
     ports:
       - '3012:3000'
     labels:

--- a/devenv/frontend-service/run.sh
+++ b/devenv/frontend-service/run.sh
@@ -7,7 +7,13 @@ function tilt_down()
     tilt down -f devenv/frontend-service/Tiltfile
 }
 
+# Create placeholder files to prevent docker from creating folders here instead
+# when it attempts to mount them into the docker containers
+touch devenv/frontend-service/configs/grafana-api.local.ini
+touch devenv/frontend-service/configs/frontend-service.local.ini
 
-trap tilt_down SIGINT
+if [[ "${AUTO_DOWN}" != "false" ]]; then
+  trap tilt_down SIGINT
+fi
 
 tilt up -f devenv/frontend-service/Tiltfile


### PR DESCRIPTION
Extends the `make frontend-service` development stack to support local gitignorred Grafana config.ini-s.

.ini config files are created in `devenv/frontend-service/configs/` that you can edit. The environment variables in the docker compose config still remain as the config that all should use, and these values overwrite what's in the ini files.

