### PR TITLE
search-after-write: Reuse index even if docs count doesn't match

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1146,19 +1146,20 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 
 	// Add the sort fields
 	sorting := getSortFields(req)
-	if len(sorting) > 0 {
-		searchrequest.SortBy(sorting)
-	} else {
-		// When no sort fields are provided, sort by score first if there is a query, otherwise sort only by title
+	searchrequest.SortBy(sorting)
+
+	// When no sort fields are provided, sort by score if there is a query, otherwise sort by title
+	if len(sorting) == 0 {
 		if req.Query != "" && req.Query != "*" {
 			searchrequest.Sort = append(searchrequest.Sort, &search.SortScore{
 				Desc: true,
 			})
+		} else {
+			searchrequest.Sort = append(searchrequest.Sort, &search.SortField{
+				Field: resource.SEARCH_FIELD_TITLE_PHRASE,
+				Desc:  false,
+			})
 		}
-		searchrequest.Sort = append(searchrequest.Sort, &search.SortField{
-			Field: resource.SEARCH_FIELD_TITLE_PHRASE,
-			Desc:  false,
-		})
 	}
 
 	return searchrequest, nil


### PR DESCRIPTION
Reuse index even if docs count in the index doesn't match number of documents returned by GetResourceStats. This can easily happen if new resource was created while index server was down. 