### PR TITLE
Alerting: Bump alerting package to include change to NewTLSClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,7 +77,7 @@ require (
 	github.com/googleapis/go-sql-spanner v1.11.1 // @grafana/grafana-search-and-storage
 	github.com/gorilla/mux v1.8.1 // @grafana/grafana-backend-group
 	github.com/gorilla/websocket v1.5.3 // @grafana/grafana-app-platform-squad
-	github.com/grafana/alerting v0.0.0-20250821190846-ce29dcf7efd3 // @grafana/alerting-backend
+	github.com/grafana/alerting v0.0.0-20250903141736-c9c007e7f0a8 // @grafana/alerting-backend
 	github.com/grafana/authlib v0.0.0-20250325095148-d6da9c164a7d // @grafana/identity-access-team
 	github.com/grafana/authlib/types v0.0.0-20250325095148-d6da9c164a7d // @grafana/identity-access-team
 	github.com/grafana/dataplane/examples v0.0.1 // @grafana/observability-metrics

--- a/go.sum
+++ b/go.sum
@@ -1573,6 +1573,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/alerting v0.0.0-20250821190846-ce29dcf7efd3 h1:Xhwbbk+5BMtNbn6Fh1uOQ5uN/khi0nkb6wz9g3TNv2c=
 github.com/grafana/alerting v0.0.0-20250821190846-ce29dcf7efd3/go.mod h1:3ER/8BhIEhvrddcztLQSc5ez1f1jNHIPdquc1F+DzOw=
+github.com/grafana/alerting v0.0.0-20250903141736-c9c007e7f0a8 h1:tXDlMjugyEbsrSJC2Np/9ZvBzEoa1xB+KGHUBnvPIFw=
+github.com/grafana/alerting v0.0.0-20250903141736-c9c007e7f0a8/go.mod h1:3ER/8BhIEhvrddcztLQSc5ez1f1jNHIPdquc1F+DzOw=
 github.com/grafana/authlib v0.0.0-20250325095148-d6da9c164a7d h1:TDVZemfYeJHPyXeYCnqL7BQqsa+mpaZYth/Qm3TKaT8=
 github.com/grafana/authlib v0.0.0-20250325095148-d6da9c164a7d/go.mod h1:PBtQaXwkFu4BAt2aXsR7w8p8NVpdjV5aJYhqRDei9Us=
 github.com/grafana/authlib/types v0.0.0-20250325095148-d6da9c164a7d h1:34E6btDAhdDOiSEyrMaYaHwnJpM8w9QKzVQZIBzLNmM=


### PR DESCRIPTION
**What is this feature?**

This includes the changes from https://github.com/grafana/alerting/pull/374

**Why do we need this feature?**

This change disables keep alive on the NewTLSClient function since this client is only used as a short lived client - thus preventing connection re-use.

**Which issue(s) does this PR fix?**:

Fixes #109787

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
