### PR TITLE
use standard sql in secure_value_lease_inactive.sql

### DIFF
--- a/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
@@ -1,14 +1,20 @@
+WITH to_update AS (
+  SELECT guid FROM (
+    SELECT 
+      guid,
+      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+    FROM {{ .Ident "secret_secure_value" }} 
+    WHERE 
+      {{ .Ident "active" }} = FALSE AND
+      {{ .Arg .Now }} - {{ .Ident "created" }} > {{ .Arg .MinAge }} AND
+      {{ .Arg .Now }} - {{ .Ident "lease_created" }} > {{ .Arg .LeaseTTL }}
+  ) AS sub
+  WHERE rn <= {{ .Arg .MaxBatchSize }}
+)
 UPDATE
   {{ .Ident "secret_secure_value" }}
 SET
   {{ .Ident "lease_token" }} = {{ .Arg .LeaseToken }},
   {{ .Ident "lease_created" }} = {{ .Arg .Now }}
-WHERE 
-  {{ .Ident "guid" }} IN (SELECT {{ .Ident "guid"}} 
-                          FROM {{ .Ident "secret_secure_value" }} 
-                          WHERE 
-                            {{ .Ident "active" }} = FALSE AND
-                            {{ .Arg .Now }} - {{ .Ident "created" }} > {{ .Arg .MinAge }} AND
-                            {{ .Arg .Now }} - {{ .Ident "lease_created" }} > {{ .Arg .LeaseTTL }}
-                          LIMIT {{ .Arg .MaxBatchSize }})
+WHERE guid IN (SELECT guid FROM to_update)
 ;

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
@@ -1,14 +1,20 @@
+WITH to_update AS (
+  SELECT guid FROM (
+    SELECT 
+      guid,
+      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+    FROM `secret_secure_value` 
+    WHERE 
+      `active` = FALSE AND
+      10 - `created` > 300 AND
+      10 - `lease_created` > 30
+  ) AS sub
+  WHERE rn <= 10
+)
 UPDATE
   `secret_secure_value`
 SET
   `lease_token` = 'token',
   `lease_created` = 10
-WHERE 
-  `guid` IN (SELECT `guid` 
-                          FROM `secret_secure_value` 
-                          WHERE 
-                            `active` = FALSE AND
-                            10 - `created` > 300 AND
-                            10 - `lease_created` > 30
-                          LIMIT 10)
+WHERE guid IN (SELECT guid FROM to_update)
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
@@ -1,14 +1,20 @@
+WITH to_update AS (
+  SELECT guid FROM (
+    SELECT 
+      guid,
+      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+    FROM "secret_secure_value" 
+    WHERE 
+      "active" = FALSE AND
+      10 - "created" > 300 AND
+      10 - "lease_created" > 30
+  ) AS sub
+  WHERE rn <= 10
+)
 UPDATE
   "secret_secure_value"
 SET
   "lease_token" = 'token',
   "lease_created" = 10
-WHERE 
-  "guid" IN (SELECT "guid" 
-                          FROM "secret_secure_value" 
-                          WHERE 
-                            "active" = FALSE AND
-                            10 - "created" > 300 AND
-                            10 - "lease_created" > 30
-                          LIMIT 10)
+WHERE guid IN (SELECT guid FROM to_update)
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
@@ -1,14 +1,20 @@
+WITH to_update AS (
+  SELECT guid FROM (
+    SELECT 
+      guid,
+      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+    FROM "secret_secure_value" 
+    WHERE 
+      "active" = FALSE AND
+      10 - "created" > 300 AND
+      10 - "lease_created" > 30
+  ) AS sub
+  WHERE rn <= 10
+)
 UPDATE
   "secret_secure_value"
 SET
   "lease_token" = 'token',
   "lease_created" = 10
-WHERE 
-  "guid" IN (SELECT "guid" 
-                          FROM "secret_secure_value" 
-                          WHERE 
-                            "active" = FALSE AND
-                            10 - "created" > 300 AND
-                            10 - "lease_created" > 30
-                          LIMIT 10)
+WHERE guid IN (SELECT guid FROM to_update)
 ;


### PR DESCRIPTION
- Use SQL syntax that's supposed to work in all databases that support standard SQL