### PR TITLE
Alerting: Fix ticker tests to not fail if channel is empty

### DIFF
--- a/pkg/services/ngalert/schedule/ticker/ticker_test.go
+++ b/pkg/services/ngalert/schedule/ticker/ticker_test.go
@@ -30,8 +30,6 @@ func TestTicker(t *testing.T) {
 			return tick
 		case <-ctx.Done():
 			require.Failf(t, fmt.Sprintf("%v", ctx.Err()), "timeout reading the channel")
-		default:
-			require.Failf(t, "channel is empty but it should have a tick", "")
 		}
 		return time.Time{}
 	}


### PR DESCRIPTION
**What is this feature?**
This pull request includes a minor update to the ticker test logic. The change removes an unnecessary check for an empty channel, simplifying the test and making it less prone to false failures.
* Removed the `default` case in the ticker test, which previously failed the test if the channel was empty, ensuring the test only fails on timeout or error.
