### PR TITLE
Trace view: Use `OpenAssistantButton` for trace view analyzing

### DIFF
--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -53,6 +53,11 @@ jest.mock('../../../../../core/config', () => ({
   },
 }));
 
+jest.mock('@grafana/assistant', () => ({
+  createAssistantContextItem: jest.fn(),
+  OpenAssistantButton: () => <div>OpenAssistantButton</div>,
+}));
+
 // Mock navigator.clipboard
 Object.assign(navigator, {
   clipboard: {
@@ -485,6 +490,43 @@ describe('TracePageHeader test', () => {
       // Check for icon
       const iconElement = buttonElement?.querySelector('svg');
       expect(iconElement).toBeInTheDocument();
+    });
+  });
+
+  describe('Assistant Button', () => {
+    it('renders assistant button for Tempo datasource', () => {
+      setup();
+
+      expect(screen.getByText('OpenAssistantButton')).toBeInTheDocument();
+    });
+
+    it('does not render assistant button for Jaeger datasource', () => {
+      const mockUsePluginLinks = usePluginLinks as jest.MockedFunction<typeof usePluginLinks>;
+      mockUsePluginLinks.mockReturnValue({ links: [], isLoading: false });
+
+      const props = {
+        trace,
+        timeZone: '',
+        search: DEFAULT_SPAN_FILTERS,
+        setSearch: jest.fn(),
+        showSpanFilters: true,
+        setShowSpanFilters: jest.fn(),
+        showSpanFilterMatchesOnly: false,
+        setShowSpanFilterMatchesOnly: jest.fn(),
+        showCriticalPathSpansOnly: false,
+        setShowCriticalPathSpansOnly: jest.fn(),
+        spanFilterMatches: undefined,
+        setFocusedSpanIdForSearch: jest.fn(),
+        datasourceType: 'jaeger',
+        setHeaderHeight: jest.fn(),
+        data: new MutableDataFrame(),
+        datasourceName: 'test-datasource',
+        datasourceUid: 'test-datasource-uid',
+      };
+
+      render(<TracePageHeader {...props} />);
+
+      expect(screen.queryByText('OpenAssistantButton')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -127,7 +127,7 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
     limitPerPlugin: 2,
   });
 
-  // TODO: Remove ina couple of days, once new assistant is released that does not use extension link
+  // TODO: Remove this filtering in a month. More info in https://github.com/grafana/grafana/issues/110541.
   // This is to prevent showing 2 buttons for the same feature
   const extensionLinksToShow = extensionLinks.filter(
     (link) => link.pluginId !== 'grafana-assistant-app' && link.title !== 'Explain in Assistant'
@@ -236,7 +236,6 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
               ]}
             />
           )}
-
           {config.feedbackLinksEnabled && (
             <Tooltip
               content={t(

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.tsx
@@ -16,6 +16,7 @@ import { css, cx } from '@emotion/css';
 import { memo, useEffect, useMemo, useState } from 'react';
 import * as React from 'react';
 
+import { createAssistantContextItem, OpenAssistantButton } from '@grafana/assistant';
 import {
   CoreApp,
   TraceSearchProps,
@@ -50,7 +51,6 @@ import { Trace, TraceViewPluginExtensionContext } from '../types/trace';
 import { formatDuration } from '../utils/date';
 
 import { SpanFilters } from './SpanFilters/SpanFilters';
-import { createAssistantContextItem, OpenAssistantButton } from '@grafana/assistant';
 
 export type TracePageHeaderProps = {
   trace: Trace | null;
@@ -220,12 +220,12 @@ export const TracePageHeader = memo((props: TracePageHeaderProps) => {
           )}
           {datasourceType === 'tempo' && (
             <OpenAssistantButton
-              title="Explain in Assistant"
+              title={t('explore.trace-page-header.explain-in-assistant', 'Explain in Assistant')}
               origin="grafana/trace-view"
               prompt="Analyze this trace"
               context={[
                 createAssistantContextItem('structured', {
-                  title: 'Trace View Query',
+                  title: t('explore.trace-page-header.trace-view-query', 'Trace View Query'),
                   data: {
                     query: trace.traceID,
                   },


### PR DESCRIPTION
We’re moving towards using a uniform Assistant button instead of extension links. The previous approach (extension links) didn’t allow us to apply custom styling, so I’ve updated the Analyze Trace action to use the OpenAssistantButton.

- The OpenAssistantButton is only shown if the Assistant is enabled.
- I considered using an extension component but decided against it because:
  - I don’t see other apps needing to reuse this component.
  - Keeping the analyze trace logic close to the trace code makes the implementation cleaner. We also do this with Logs.
  - This feature is essentially just a single button, so an extension feels like unnecessary overhead.
- Added tests to ensure the button is rendered only for Tempo traces.

I have created https://github.com/grafana/grafana/issues/110541 to remove temporary `extensionLinksToShow` filtering to prevent showing 2 Analyze buttons. I have assigned to myself.

### After:
<img width="1273" height="901" alt="image" src="https://github.com/user-attachments/assets/d90216f4-d28f-4958-81b4-0b96112771e0" />

### Before:
<img width="1286" height="614" alt="image" src="https://github.com/user-attachments/assets/8ef1545d-ba1e-4edf-b910-991add196db5" />

