### PR TITLE
Transformations: Account for group by / count when assessing if calculation is needed

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -5,7 +5,7 @@ import { mockTransformationsRegistry } from '../../utils/tests/mockTransformatio
 import { ReducerID } from '../fieldReducer';
 import { transformDataFrame } from '../transformDataFrame';
 
-import { GroupByOperationID, groupByTransformer, GroupByTransformerOptions } from './groupBy';
+import { GroupByOperationID, groupByTransformer, GroupByTransformerOptions, shouldCalculateField } from './groupBy';
 import { DataTransformerID } from './ids';
 
 // returns a simple group by / reducer pair
@@ -31,7 +31,7 @@ const getSimpleGroupByConfig = (
   };
 };
 
-describe('GroupBy transformer', () => {
+describe.skip('GroupBy transformer', () => {
   beforeAll(() => {
     mockTransformationsRegistry([groupByTransformer]);
   });
@@ -491,5 +491,28 @@ describe('GroupBy transformer', () => {
       ];
       expect(result[0].fields).toEqual(expected);
     });
+  });
+});
+
+describe('should calculate field', () => {
+  it.each([
+    [GroupByOperationID.aggregate, [], false],
+    [GroupByOperationID.aggregate, [ReducerID.count], true],
+    [GroupByOperationID.aggregate, [ReducerID.sum, ReducerID.count], true],
+    [GroupByOperationID.groupBy, [], false],
+    [GroupByOperationID.groupBy, [ReducerID.count], true],
+    [GroupByOperationID.groupBy, [ReducerID.sum], false],
+    [GroupByOperationID.groupBy, [ReducerID.sum, ReducerID.count], false],
+  ])('formats with the supplied time zone %s', (operation, aggregations, expected) => {
+    const field: Field = {
+      name: 'testField',
+      type: FieldType.string,
+      config: {},
+      values: [],
+    };
+    const options: GroupByTransformerOptions = {
+      fields: { testField: { aggregations, operation } },
+    };
+    expect(shouldCalculateField(field, options)).toBe(expected);
   });
 });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -31,7 +31,7 @@ const getSimpleGroupByConfig = (
   };
 };
 
-describe.skip('GroupBy transformer', () => {
+describe('GroupBy transformer', () => {
   beforeAll(() => {
     mockTransformationsRegistry([groupByTransformer]);
   });

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -494,7 +494,7 @@ describe('GroupBy transformer', () => {
   });
 });
 
-describe('should calculate field', () => {
+describe('shouldCalculateField()', () => {
   it.each([
     [GroupByOperationID.aggregate, [], false],
     [GroupByOperationID.aggregate, [ReducerID.count], true],
@@ -503,7 +503,7 @@ describe('should calculate field', () => {
     [GroupByOperationID.groupBy, [ReducerID.count], true],
     [GroupByOperationID.groupBy, [ReducerID.sum], false],
     [GroupByOperationID.groupBy, [ReducerID.sum, ReducerID.count], false],
-  ])('formats with the supplied time zone %s', (operation, aggregations, expected) => {
+  ])('when provided operation %s and aggregations %s, should return %s', (operation, aggregations, expected) => {
     const field: Field = {
       name: 'testField',
       type: FieldType.string,

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -493,7 +493,7 @@ describe('GroupBy transformer', () => {
     });
   });
 
-  it.only('should calculate count on a grouped field when selected', async () => {
+  it('should calculate count on a grouped field when selected', async () => {
     const testSeries = toDataFrame({
       name: 'A',
       fields: [

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -497,8 +497,8 @@ describe('GroupBy transformer', () => {
     const testSeries = toDataFrame({
       name: 'A',
       fields: [
-        { name: 'category', type: FieldType.string, values: ['A', 'A', 'B', 'B'], config: {} },
-        { name: 'values', type: FieldType.number, values: [1, 2, 3, 4], config: {} },
+        { name: 'category', type: FieldType.string, values: ['A', 'A', 'B', 'B', 'B'], config: {} },
+        { name: 'values', type: FieldType.number, values: [1, 2, 3, 4, 5], config: {} },
       ],
     });
 
@@ -529,7 +529,7 @@ describe('GroupBy transformer', () => {
         {
           name: 'category (count)',
           type: FieldType.number,
-          values: [2, 2],
+          values: [2, 3],
           config: {},
         },
       ];

--- a/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.test.ts
@@ -492,6 +492,50 @@ describe('GroupBy transformer', () => {
       expect(result[0].fields).toEqual(expected);
     });
   });
+
+  it.only('should calculate count on a grouped field when selected', async () => {
+    const testSeries = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'category', type: FieldType.string, values: ['A', 'A', 'B', 'B'], config: {} },
+        { name: 'values', type: FieldType.number, values: [1, 2, 3, 4], config: {} },
+      ],
+    });
+
+    let cfg = {
+      id: DataTransformerID.groupBy,
+      options: {
+        fields: {
+          category: {
+            operation: GroupByOperationID.groupBy,
+            aggregations: [ReducerID.count],
+          },
+          values: {
+            operation: undefined,
+          },
+        },
+      },
+    };
+
+    await expect(transformDataFrame([cfg], [testSeries])).toEmitValuesWith((received) => {
+      const result = received[0];
+      const expected: Field[] = [
+        {
+          name: 'category',
+          type: FieldType.string,
+          values: ['A', 'B'],
+          config: {},
+        },
+        {
+          name: 'category (count)',
+          type: FieldType.number,
+          values: [2, 2],
+          config: {},
+        },
+      ];
+      expect(result[0].fields).toEqual(expected);
+    });
+  });
 });
 
 describe('shouldCalculateField()', () => {

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -144,13 +144,21 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
     ),
 };
 
-const shouldCalculateField = (field: Field, options: GroupByTransformerOptions): boolean => {
+// exported for test
+export const shouldCalculateField = (field: Field, options: GroupByTransformerOptions): boolean => {
   const fieldName = getFieldDisplayName(field);
-  return (
-    options?.fields[fieldName]?.operation === GroupByOperationID.aggregate &&
-    Array.isArray(options?.fields[fieldName]?.aggregations) &&
-    options?.fields[fieldName].aggregations.length > 0
-  );
+  if (!Array.isArray(options?.fields[fieldName]?.aggregations)) {
+    return false;
+  } else if (options?.fields[fieldName]?.operation === GroupByOperationID.aggregate) {
+    return options?.fields[fieldName].aggregations.length > 0;
+  } else if (options?.fields[fieldName]?.operation === GroupByOperationID.groupBy) {
+    return (
+      options?.fields[fieldName].aggregations.length === 1 &&
+      options?.fields[fieldName]?.aggregations[0] === ReducerID.count
+    );
+  } else {
+    return false;
+  }
 };
 
 /**

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -147,7 +147,8 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
 // exported for test
 export const shouldCalculateField = (field: Field, options: GroupByTransformerOptions): boolean => {
   const fieldName = getFieldDisplayName(field);
-  const { operation, aggregations = [] } = options?.fields[fieldName];
+  const operation = options?.fields[fieldName]?.operation;
+  const aggregations = options?.fields[fieldName]?.aggregations ?? [];
 
   if (!Array.isArray(aggregations)) {
     return false;

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -147,8 +147,7 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
 // exported for test
 export const shouldCalculateField = (field: Field, options: GroupByTransformerOptions): boolean => {
   const fieldName = getFieldDisplayName(field);
-  const operation = options?.fields[fieldName]?.operation;
-  const aggregations = options?.fields[fieldName]?.aggregations ?? [];
+  const { operation, aggregations = [] } = options.fields[fieldName] ?? {};
 
   if (!Array.isArray(aggregations)) {
     return false;

--- a/packages/grafana-data/src/transformations/transformers/groupBy.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupBy.ts
@@ -147,15 +147,14 @@ export const groupByTransformer: DataTransformerInfo<GroupByTransformerOptions> 
 // exported for test
 export const shouldCalculateField = (field: Field, options: GroupByTransformerOptions): boolean => {
   const fieldName = getFieldDisplayName(field);
-  if (!Array.isArray(options?.fields[fieldName]?.aggregations)) {
+  const { operation, aggregations = [] } = options?.fields[fieldName];
+
+  if (!Array.isArray(aggregations)) {
     return false;
-  } else if (options?.fields[fieldName]?.operation === GroupByOperationID.aggregate) {
-    return options?.fields[fieldName].aggregations.length > 0;
-  } else if (options?.fields[fieldName]?.operation === GroupByOperationID.groupBy) {
-    return (
-      options?.fields[fieldName].aggregations.length === 1 &&
-      options?.fields[fieldName]?.aggregations[0] === ReducerID.count
-    );
+  } else if (operation === GroupByOperationID.aggregate) {
+    return aggregations.length > 0;
+  } else if (operation === GroupByOperationID.groupBy) {
+    return aggregations.length === 1 && aggregations[0] === ReducerID.count;
   } else {
     return false;
   }


### PR DESCRIPTION
**What is this feature?**

This fixes a regression caused by https://github.com/grafana/grafana/pull/109430 where we neglected to take into account the change in logic introduced in https://github.com/grafana/grafana/pull/108079 

As a result, group by / count no longer counts as a valid calculation.

**Why do we need this feature?**

So the group by / count feature developed in #108079 will function.

**Special notes for your reviewer:**

To ensure no regressions, please test the following

- The original bug was that clearing the operation field before the calculation field would result in a calculation when it should not.
- The new feature was that selecting a field to group by, then selecting "count" as a calculation, would result in a calculation.

An example of the bug on play is [here](https://play.grafana.org/d/feavrpzb4wu0wa/kristina-demos?orgId=1&from=now-30d&to=now&timezone=utc&var-fruit=apple&var-fuelType=Battery%20storage&var-stand=ice-king&var-employeeLastName=Swan&viewPanel=panel-38). Note there is no calculated field as we would expect.

<details><summary>Example dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 0,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource",
        "uid": "PD8C576611E62080A"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "hideFrom": {
              "viz": false
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "maxDataPoints": 100,
      "options": {
        "cellHeight": "sm",
        "footer": {
          "countRows": false,
          "fields": "",
          "reducer": [
            "sum"
          ],
          "show": false
        },
        "showHeader": true
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "refId": "A"
        }
      ],
      "title": "New panel",
      "transformations": [
        {
          "id": "formatTime",
          "options": {
            "outputFormat": "MMM",
            "timeField": "time",
            "useTimezone": true
          }
        },
        {
          "id": "groupBy",
          "options": {
            "fields": {
              "time": {
                "aggregations": [
                  "count"
                ],
                "operation": "groupby"
              }
            }
          }
        }
      ],
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 41,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-7d",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Group by count example",
  "uid": "adk4s8n",
  "version": 3
}

```
</details>

Following recent advisement to add bug fixes to the changelog.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
