### PR TITLE
Restricted APIs: Remove type assertion from Betterer

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -31,9 +31,6 @@ exports[`better eslint`] = {
     "packages/grafana-alerting/src/grafana/notificationPolicies/utils.ts:5381": [
       [0, 0, 0, "Do not use any type assertions.", "0"]
     ],
-    "packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx:5381": [
-      [0, 0, 0, "Do not use any type assertions.", "0"]
-    ],
     "packages/grafana-data/src/dataframe/ArrayDataFrame.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],

--- a/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
+++ b/packages/grafana-data/src/context/plugins/RestrictedGrafanaApis.tsx
@@ -35,6 +35,7 @@ export function RestrictedGrafanaApisContextProvider(props: PropsWithChildren<Pr
   const allowedApis = useMemo(() => {
     const allowedApis: RestrictedGrafanaApisContextType = {};
 
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     for (const api of Object.keys(apis) as Array<keyof RestrictedGrafanaApisContextType>) {
       if (
         apiAllowList &&


### PR DESCRIPTION
### What changed?

Removed a type assertion from Betterer as in this case there seems to be no "better" ways for making typing stricter: TypeScript cannot be certain that an object won't have other properties during runtime than what is defined in an `interface`, so the type of `Object.keys()` is always `string`. On the other hand - in this scenario - we can be certain that this wouldn't happen unless the frontend runtime is tempered with, or if a compile time error is neglected.

Also discussed it with @joshhunt and @ashharrison90 offline before making the change.