### PR TITLE
Postgres: Fix JSON data type mapping with PGX driver

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_pgx.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_pgx.go
@@ -502,6 +502,15 @@ func convertResultsToFrame(results []*pgconn.Result, rowLimit int64) (*data.Fram
 						return nil, err
 					}
 					row[colIdx] = d
+				case pgtype.JSONOID, pgtype.JSONBOID:
+					var d *string
+					scanPlan := m.PlanScan(dataTypeOID, format, &d)
+					err := scanPlan.Scan(rawValue, &d)
+					if err != nil {
+						return nil, err
+					}
+					j := json.RawMessage(*d)
+					row[colIdx] = &j
 				default:
 					var d *string
 					scanPlan := m.PlanScan(dataTypeOID, format, &d)


### PR DESCRIPTION
**What is this feature?**

Postgres data sources with PGX driver enabled is reporting the error `interface conversion: interface {} is *string, not *json.RawMessage`. This PR fixes the data type mapping for JSON/JSONB with PGX driver.

**Who is this feature for?**

Postgres data source.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/110565
