### PR TITLE
fix: dashboard list page bugs while in mode 3

### DIFF
--- a/public/app/features/browse-dashboards/api/services.test.ts
+++ b/public/app/features/browse-dashboards/api/services.test.ts
@@ -44,6 +44,7 @@ describe('browse-dashboards services', () => {
         location: 'abc-123',
         from: expectedFrom,
         limit: PAGE_SIZE,
+        offset: expectedFrom,
       });
     });
   });

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -51,6 +51,7 @@ export async function listDashboards(parentUID?: string, page = 1, pageSize = PA
     location: parentUID || 'general',
     from: (page - 1) * pageSize, // our pages are 1-indexed, so we need to -1 to convert that to correct value to skip
     limit: pageSize,
+    offset: (page - 1) * pageSize,
   });
 
   return dashboardsResults.view.map((item) => {

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -41,6 +41,7 @@ export interface SearchQuery {
   starred?: boolean;
   permission?: PermissionLevelString;
   deleted?: boolean;
+  offset?: number;
 }
 
 export interface DashboardQueryResult {

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -260,6 +260,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
     uri += `?query=${encodeURIComponent(query.query ?? '*')}`;
     uri += `&limit=${query.limit ?? pageSize}`;
 
+    if (query.offset) {
+      uri += `&offset=${query.offset}`
+    }
+
     if (!isEmpty(query.location)) {
       uri += `&folder=${query.location}`;
     }

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -261,7 +261,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
     uri += `&limit=${query.limit ?? pageSize}`;
 
     if (query.offset) {
-      uri += `&offset=${query.offset}`
+      uri += `&offset=${query.offset}`;
     }
 
     if (!isEmpty(query.location)) {

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -202,7 +202,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
       totalRows: meta.count ?? first.length,
       view,
       loadMoreItems: async (startIndex: number, stopIndex: number): Promise<void> => {
-        loadMax = Math.max(loadMax, stopIndex);
+        loadMax = Math.max(loadMax, stopIndex + 1);
         if (!pending) {
           pending = getNextPage();
         }


### PR DESCRIPTION
closes https://github.com/grafana/search-and-storage-team/issues/481

### While using the folder tree view

Without the offset app just keeps refetching the first 50 items forever:

<img width="1066" height="481" alt="image" src="https://github.com/user-attachments/assets/f9ba1092-667a-437b-8216-b119bc86b2e6" />

with the offset we're good:

<img width="1256" height="976" alt="image" src="https://github.com/user-attachments/assets/8835ec19-e133-477d-bcc2-86af942120c0" />

### off by one error when listing dashboards

This PR also fixes an off by one error that happens when you have exactly one more item to fetch: 

<img width="1044" height="492" alt="image" src="https://github.com/user-attachments/assets/391d90bc-c73e-4e1b-b29e-082499c6dd19" />

The loader knows there's one more item to fetch, so it renders the row in loading state. But as you can see in the network tab, it never sends the request to fetch more data. 

With this PR this is fixed. Below example getting the last 101st element:

<img width="2119" height="259" alt="image" src="https://github.com/user-attachments/assets/d47ea6b3-0ffb-44bf-8f84-34381d5b577d" />


