### PR TITLE
getDashboardChanges: Ignore version field differences in provisioned dashboard change detection

### DIFF
--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -102,7 +102,14 @@ export function getRawDashboardChanges(
   saveRefresh?: boolean
 ) {
   const initialSaveModel = initial;
-  const changedSaveModel = changed;
+  let changedSaveModel = changed;
+
+  // If initial dashboard didn't have version, remove it from changed model for comparison
+  if (initialSaveModel.version === undefined && changedSaveModel.version === 0) {
+    changedSaveModel = { ...changedSaveModel };
+    delete changedSaveModel.version;
+  }
+
   const hasTimeChanged = getHasTimeChanged(changedSaveModel.time, initialSaveModel.time);
   const hasVariableValueChanges = applyVariableChanges(changedSaveModel, initialSaveModel, saveVariables);
   const hasRefreshChanged = changedSaveModel.refresh !== initialSaveModel.refresh;


### PR DESCRIPTION
**What is this feature?**

When a git provisioned dashboard is loaded from a branch that doesn't contain a `version` field:
1. The dashboard state gets normalized to `version: 0` during load (via DashboardModel)
2. The initial save model preserves the original structure (no version field)
3. Change detection compares initial model (no version) vs current model (version: 0)
4. This creates a false positive diff showing `"version": 0` as an addition
5. Dashboard incorrectly appears to have unsaved version changes
<img width="1304" height="758" alt="image" src="https://github.com/user-attachments/assets/dda4abef-2158-48d4-b8db-32b20a69e1e2" />


**Why do we need this feature?**

This prevents unintended version changes on branch preview dashboard. 

**Who is this feature for?**

Git user

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
