### PR TITLE
Wire: Add provider lint

### DIFF
--- a/.citools/Variables.mk
+++ b/.citools/Variables.mk
@@ -25,7 +25,7 @@ cog = "$(call compile_tool,cog,github.com/grafana/cog/cmd/cli)"
 cue = "$(call compile_tool,cue,cuelang.org/go/cmd/cue)"
 
 # Tool: "golangci-lint"
-golangci-lint = "$(call compile_tool,golangci-lint,github.com/golangci/golangci-lint/v2/cmd/golangci-lint)"
+golangci-lint = "$(call compile_tool,golangci-lint,github.com/grafana/grafana/scripts/go/golangci-lint/cmd/golangci-lint)"
 
 # Tool: "jb"
 jb = "$(call compile_tool,jb,github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb)"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,6 +67,8 @@
 /scripts/modowners/ @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
+/scripts/go/golangci-lint/ @grafana/plugins-platform-backend
+/scripts/go/wirecheck/ @grafana/plugins-platform-backend
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,8 +67,8 @@
 /scripts/modowners/ @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
-/scripts/go/golangci-lint/ @grafana/plugins-platform-backend
-/scripts/go/wirecheck/ @grafana/plugins-platform-backend
+/scripts/go/golangci-lint/ @grafana/grafana-backend-services-squad
+/scripts/go/wirecheck/ @grafana/grafana-backend-services-squad
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,8 +67,8 @@
 /scripts/modowners/ @grafana/grafana-backend-services-squad
 /scripts/go-workspace @grafana/grafana-app-platform-squad
 /scripts/ci/backend-tests @grafana/grafana-operator-experience-squad
-/scripts/go/golangci-lint/ @grafana/grafana-backend-services-squad
-/scripts/go/wirecheck/ @grafana/grafana-backend-services-squad
+/scripts/go/golangci-lint/ @grafana/grafana-developer-enablement-squad
+/scripts/go/wirecheck/ @grafana/grafana-developer-enablement-squad
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -65,10 +65,10 @@ jobs:
       - uses: actions/setup-go@v5.5.0
         with:
           go-version-file: ./go.mod
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd
-        with:
-          version: v2.0.2
-          args: |
-            --verbose $(go list -m -f '{{.Dir}}' | xargs -I{} sh -c 'test ! -f {}/.nolint && echo {}/...')
-          install-mode: binary
+      - name: Run golangci-lint
+        run: |
+          make lint-go
+      - name: Run wirecheck
+        continue-on-error: true
+        run: |
+          make lint-go GO_LINT_FLAGS="--enable-only wirecheck --max-issues-per-linter 0"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,6 +32,13 @@ linters:
     - unused
     - whitespace
   settings:
+    custom:
+      wirecheck:
+        type: module
+        description: Check for direct dependency method calls in wire provider functions
+        settings:
+          wire-gen: ./pkg/server/wire_gen.go
+          recursive: true
     depguard:
       rules:
         aggregator:

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include .citools/Variables.mk
 
 GO = go
 GO_VERSION = 1.24.6
-GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
+GO_LINT_FILES ?= $(shell go list -m -f '{{.Dir}}' | xargs -I{} sh -c 'test ! -f {}/.nolint && echo {}/...')
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 GO_RACE  := $(shell [ -n "$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )
@@ -372,7 +372,7 @@ golangci-lint:
 	$(golangci-lint) run \
 		--config .golangci.yml \
 		$(if $(GO_BUILD_TAGS),--build-tags $(GO_BUILD_TAGS)) \
-		$(GO_LINT_FILES)
+		$(GO_LINT_FILES) $(GO_LINT_FLAGS)
 
 .PHONY: lint-go
 lint-go: golangci-lint ## Run all code checks for backend. You can use GO_LINT_FILES to specify exact files to check

--- a/scripts/go/golangci-lint/cmd/golangci-lint/main.go
+++ b/scripts/go/golangci-lint/cmd/golangci-lint/main.go
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Provenance-includes-location: https://github.com/golangci/golangci-lint/blob/main/cmd/golangci-lint/main.go
+// Provenance-includes-license: GPL-3.0
+// Provenance-includes-copyright: GolangCI
+
+package main
+
+import (
+	"cmp"
+	"fmt"
+	"os"
+	"regexp"
+	"runtime/debug"
+	"strings"
+
+	"github.com/golangci/golangci-lint/v2/pkg/commands"
+	"github.com/golangci/golangci-lint/v2/pkg/exitcodes"
+)
+
+var (
+	goVersion = "unknown"
+
+	// Populated by goreleaser during build
+	version = "unknown"
+	commit  = "?"
+	date    = ""
+)
+
+func main() {
+	info := createBuildInfo()
+
+	if err := commands.Execute(info); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "The command is terminated due to an error: %v\n", err)
+		os.Exit(exitcodes.Failure)
+	}
+}
+
+func createBuildInfo() commands.BuildInfo {
+	info := commands.BuildInfo{
+		Commit:    commit,
+		Version:   version,
+		GoVersion: goVersion,
+		Date:      date,
+	}
+
+	buildInfo, available := debug.ReadBuildInfo()
+	if !available {
+		return info
+	}
+
+	info.GoVersion = buildInfo.GoVersion
+
+	if date != "" {
+		return info
+	}
+
+	info.Version = buildInfo.Main.Version
+
+	matched, _ := regexp.MatchString(`v\d+\.\d+\.\d+`, buildInfo.Main.Version)
+	if matched {
+		info.Version = strings.TrimPrefix(buildInfo.Main.Version, "v")
+	}
+
+	var revision string
+	var modified string
+	for _, setting := range buildInfo.Settings {
+		// The `vcs.xxx` information is only available with `go build`.
+		// This information is not available with `go install` or `go run`.
+		switch setting.Key {
+		case "vcs.time":
+			info.Date = setting.Value
+		case "vcs.revision":
+			revision = setting.Value
+		case "vcs.modified":
+			modified = setting.Value
+		}
+	}
+
+	info.Date = cmp.Or(info.Date, "(unknown)")
+
+	info.Commit = fmt.Sprintf("(%s, modified: %s, mod sum: %q)",
+		cmp.Or(revision, "unknown"), cmp.Or(modified, "?"), buildInfo.Main.Sum)
+
+	return info
+}

--- a/scripts/go/golangci-lint/cmd/golangci-lint/plugins.go
+++ b/scripts/go/golangci-lint/cmd/golangci-lint/plugins.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"github.com/golangci/plugin-module-register/register"
+	"github.com/grafana/grafana/scripts/go/wirecheck"
+)
+
+func init() {
+	register.Plugin("wirecheck", wirecheck.New)
+}

--- a/scripts/go/golangci-lint/go.mod
+++ b/scripts/go/golangci-lint/go.mod
@@ -1,12 +1,14 @@
-module golangci-lint
+module github.com/grafana/grafana/scripts/go/golangci-lint
 
 go 1.24.5
 
-replace github.com/grafana/grafana/scripts/go/golangci-lint => ../../../scripts/go/golangci-lint
+replace github.com/grafana/grafana/scripts/go/wirecheck => ../wirecheck
 
-replace github.com/grafana/grafana/scripts/go/wirecheck => ../../../scripts/go/wirecheck
-
-tool github.com/grafana/grafana/scripts/go/golangci-lint/cmd/golangci-lint
+require (
+	github.com/golangci/golangci-lint/v2 v2.4.0
+	github.com/golangci/plugin-module-register v0.1.2
+	github.com/grafana/grafana/scripts/go/wirecheck v0.0.0
+)
 
 require (
 	4d63.com/gocheckcompilerdirectives v1.3.0 // indirect
@@ -81,10 +83,8 @@ require (
 	github.com/golangci/dupl v0.0.0-20250308024227-f665c8d69b32 // indirect
 	github.com/golangci/go-printf-func-name v0.1.0 // indirect
 	github.com/golangci/gofmt v0.0.0-20250106114630-d62b90e6713d // indirect
-	github.com/golangci/golangci-lint/v2 v2.4.0 // indirect
 	github.com/golangci/golines v0.0.0-20250217134842-442fd0091d95 // indirect
 	github.com/golangci/misspell v0.7.0 // indirect
-	github.com/golangci/plugin-module-register v0.1.2 // indirect
 	github.com/golangci/revgrep v0.8.0 // indirect
 	github.com/golangci/swaggoswag v0.0.0-20250504205917-77f2aca3143e // indirect
 	github.com/golangci/unconvert v0.0.0-20250410112200-a129a6e6413e // indirect
@@ -94,8 +94,6 @@ require (
 	github.com/gostaticanalysis/comment v1.5.0 // indirect
 	github.com/gostaticanalysis/forcetypeassert v0.2.0 // indirect
 	github.com/gostaticanalysis/nilerr v0.1.1 // indirect
-	github.com/grafana/grafana/scripts/go/golangci-lint v0.0.0-00010103000000-000000000000 // indirect
-	github.com/grafana/grafana/scripts/go/wirecheck v0.0.0 // indirect
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
@@ -124,6 +122,7 @@ require (
 	github.com/maratori/testableexamples v1.0.0 // indirect
 	github.com/maratori/testpackage v1.1.1 // indirect
 	github.com/matoous/godox v1.1.0 // indirect
+	github.com/matryer/is v1.4.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
@@ -159,6 +158,7 @@ require (
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.29.0 // indirect
 	github.com/securego/gosec/v2 v2.22.7 // indirect
+	github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 // indirect
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/sivchari/containedctx v1.0.3 // indirect
 	github.com/sonatard/noctx v0.4.0 // indirect
@@ -197,6 +197,7 @@ require (
 	go.uber.org/automaxprocs v1.6.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
+	golang.org/x/exp v0.0.0-20250506013437-ce4c2cf36ca6 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250620022241-b7579e27df2b // indirect
 	golang.org/x/mod v0.27.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect

--- a/scripts/go/golangci-lint/go.sum
+++ b/scripts/go/golangci-lint/go.sum
@@ -228,8 +228,11 @@ github.com/kisielk/errcheck v1.9.0 h1:9xt1zI9EBfcYBvdU1nVrzMzzUPUtPKs9bVSIM3TAb3
 github.com/kisielk/errcheck v1.9.0/go.mod h1:kQxWMMVZgIkDq7U8xtG/n2juOjbLgZtedi0D+/VL/i8=
 github.com/kkHAIKE/contextcheck v1.1.6 h1:7HIyRcnyzxL9Lz06NGhiKvenXq7Zw6Q0UQu/ttjfJCE=
 github.com/kkHAIKE/contextcheck v1.1.6/go.mod h1:3dDbMRNBFaq8HFXWC1JyvDSPm43CmE6IuHam8Wr0rkg=
+github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kulti/thelper v0.6.3 h1:ElhKf+AlItIu+xGnI990no4cE2+XaSu1ULymV2Yulxs=
@@ -569,9 +572,11 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/scripts/go/golangci-lint/vscode-wrapper.sh
+++ b/scripts/go/golangci-lint/vscode-wrapper.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Change to project root (3 levels up from scripts/go/golangci-lint/)
+pushd "$(dirname "$0")/../../.." > /dev/null
+
+# Use the same compile_tool approach as the Makefile
+tools_dir=".citools"
+src_dir="${tools_dir}/src"
+
+# Compile and get the golangci-lint binary path using the same method as Variables.mk
+golangci_lint_binary=$(cd "${src_dir}/golangci-lint" && GOWORK=off go tool -n github.com/grafana/grafana/scripts/go/golangci-lint/cmd/golangci-lint > /dev/null && GOWORK=off go tool -n github.com/grafana/grafana/scripts/go/golangci-lint/cmd/golangci-lint | sed 's/^[[:space:]]*//g')
+
+# change back to the original directory
+popd > /dev/null
+
+# Run the custom golangci-lint with VS Code's arguments
+# This preserves VS Code's ability to lint specific files/packages
+exec "${golangci_lint_binary}" "$@" --enable wirecheck

--- a/scripts/go/wirecheck/.gitignore
+++ b/scripts/go/wirecheck/.gitignore
@@ -1,0 +1,1 @@
+wirecheck

--- a/scripts/go/wirecheck/README.md
+++ b/scripts/go/wirecheck/README.md
@@ -1,0 +1,98 @@
+# Wire Checker
+
+A golangci-lint linter that detects direct dependency method calls in wire provider functions, helping maintain proper dependency injection patterns.
+
+## Overview
+
+Wire Checker analyzes Go code to find provider functions that directly call methods on their dependencies, which can lead to tight coupling and violate dependency injection principles.
+
+## Usage
+
+### Lint all files
+
+```bash
+make lint-go
+```
+
+### VS Code Integration
+
+Configure VS Code to use the custom golangci-lint with wirecheck:
+
+```json
+{
+  "go.lintTool": "golangci-lint-v2",
+  "go.lintFlags": ["--config=${workspaceRoot}/.golangci.yml"],
+  "go.alternateTools": {
+    "golangci-lint-v2": "${workspaceRoot}/scripts/go/golangci-lint/vscode-wrapper.sh"
+  },
+  "go.lintOnSave": "package"
+}
+```
+
+## Example
+
+Here is an example of a wire provider that calls a method on one of its dependencies. This is a problem because it breaks the dskit module/service startup guarantees. The database connection happens during wire initialization instead of during the service's starting phase, which can cause services to start in the wrong order or fail if dependencies aren't healthy and ready to accept requests.
+
+```go
+func ProvideUserService(db *Database) (*UserService, error) {
+    // BAD: Direct method calls on dependencies
+    if err := db.Connect(context.Background()); err != nil {    // ❌ Will be detected
+        return nil, err
+    }
+
+    return &UserService{db: db}, nil
+}
+```
+
+Wire Checker will report:
+
+```
+provide.go:95:2: ProvideUserService() directly calls db.Connect() in wire provider function
+```
+
+### Good Practice
+
+Use a dskit service starting function for initialization.
+
+```go
+
+import "github.com/grafana/dskit/services"
+
+func ProvideUserService(db *Database) *UserService {
+  service := &UserService{db: db}
+  service.NamedService = services.NewBasicService(service.starting, service.running, nil)
+  return service
+}
+
+type UserService struct {
+    db *Database
+    services.NamedService
+}
+
+func (s *UserService) starting(ctx context.Context) error {
+  return s.db.Connect(ctx)
+}
+
+func (s *UserService) running(ctx context.Context) error {
+  <- ctx.Done()
+  return nil
+}
+```
+
+## Configuration
+
+Configured in `.golangci.yml`:
+
+```yaml
+linters:
+  enable:
+    - wirecheck
+settings:
+  custom:
+    wirecheck:
+      type: module
+      description: Check for direct dependency method calls in wire provider functions
+      settings:
+        wire-gen: ./pkg/server/wire_gen.go
+        recursive: true
+```

--- a/scripts/go/wirecheck/analyzer.go
+++ b/scripts/go/wirecheck/analyzer.go
@@ -1,0 +1,381 @@
+package wirecheck
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"github.com/golangci/plugin-module-register/register"
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+)
+
+// Settings represents the configuration for the wire-checker plugin
+type Settings struct {
+	WireGen   string `json:"wire-gen"`  // Path to wire_gen.go file
+	Recursive bool   `json:"recursive"` // Enable recursive analysis
+}
+
+// methodCall represents a method call found in a provider function
+type methodCall struct {
+	receiver string
+	method   string
+	line     int
+	pos      token.Pos
+	callPath []string // Track the call path for recursive calls
+}
+
+// functionCall represents a function call that needs to be analyzed recursively
+type functionCall struct {
+	funcName string
+	pos      token.Pos
+	pkg      string
+}
+
+// DependencyParam represents a parameter that is a wire dependency
+type DependencyParam struct {
+	Name     string
+	Type     string
+	Position int
+}
+
+// ParameterFlow tracks how wire dependencies flow through function calls
+type ParameterFlow struct {
+	SourceParam DependencyParam
+	CallSite    token.Pos
+	TargetParam DependencyParam
+}
+
+// WireChecker represents the wire-checker plugin
+type WireChecker struct {
+	settings   Settings
+	wireParser *WireParser
+}
+
+// SetSettings allows setting the configuration for standalone usage
+func (w *WireChecker) SetSettings(settings Settings) {
+	w.settings = settings
+}
+
+// New creates a new instance of the wire-checker plugin for golangci-lint
+func New(settings any) (register.LinterPlugin, error) {
+	s, err := register.DecodeSettings[Settings](settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &WireChecker{
+		settings:   s,
+		wireParser: NewWireParser(),
+	}, nil
+}
+
+// BuildAnalyzers returns the analyzers for the wire-checker plugin
+func (w *WireChecker) BuildAnalyzers() ([]*analysis.Analyzer, error) {
+	fs := flag.NewFlagSet("wirechecker", flag.ExitOnError)
+	fs.StringVar(&w.settings.WireGen, "wire-gen", w.settings.WireGen, "path to wire_gen.go file to analyze provider functions from")
+	fs.BoolVar(&w.settings.Recursive, "recursive", w.settings.Recursive, "enable recursive analysis of function calls")
+	return []*analysis.Analyzer{
+		{
+			Name:     "wirecheck",
+			Doc:      "check for direct dependency method calls in wire provider functions",
+			Run:      w.run,
+			Flags:    *fs,
+			Requires: []*analysis.Analyzer{inspect.Analyzer},
+		},
+	}, nil
+}
+
+// GetLoadMode returns the load mode for the analyzer
+func (w *WireChecker) GetLoadMode() string {
+	return register.LoadModeTypesInfo
+}
+
+// run is the main analysis function for the wire-checker
+func (w *WireChecker) run(pass *analysis.Pass) (interface{}, error) {
+
+	// Require wire-gen setting to be specified
+	if w.settings.WireGen == "" {
+		return nil, fmt.Errorf("wire-gen setting is required")
+	}
+
+	// Get the inspector from the required analyzer
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	err := w.wireParser.Parse(w.settings.WireGen)
+	if err != nil {
+		// Report error and skip analysis if wire_gen.go parsing fails
+		pass.Report(analysis.Diagnostic{
+			Pos:     0,
+			Message: "failed to parse wire-gen file " + w.settings.WireGen + ": " + err.Error(),
+		})
+		return nil, nil
+	}
+
+	// Analyze only functions that are referenced in the wire_gen.go file
+	nodeFilter := []ast.Node{
+		(*ast.FuncDecl)(nil),
+	}
+
+	insp.Preorder(nodeFilter, func(n ast.Node) {
+		funcDecl := n.(*ast.FuncDecl)
+
+		// Only analyze functions that are actually used in wire dependency injection
+		funcName := funcDecl.Name.Name
+
+		// Check if this function should be analyzed using the wire parser helper
+		// Use the package's import path for consistent lookup
+		pkgImportPath := pass.Pkg.Path()
+		if w.wireParser.ShouldAnalyzeFunction(pkgImportPath, funcName) {
+			w.analyzeProviderFunctionForTightCoupling(pass, funcDecl, []analysis.RelatedInformation{})
+		}
+	})
+
+	return nil, nil
+}
+
+func (w *WireChecker) analyzeProviderFunctionForTightCoupling(pass *analysis.Pass, funcDecl *ast.FuncDecl, related []analysis.RelatedInformation) {
+	// For wire provider functions, all parameters are wire dependencies
+	wireDependencies := w.extractParameterNames(funcDecl)
+
+	// Analyze this function with parameter flow tracking
+	w.analyzeWithParameterFlow(pass, funcDecl, related, wireDependencies)
+}
+
+func (w *WireChecker) analyzeWithParameterFlow(pass *analysis.Pass, funcDecl *ast.FuncDecl, related []analysis.RelatedInformation, wireDependencies map[string]bool) {
+	// Find method calls on wire dependencies in this function
+	calls := w.findMethodCallsOnTrackedDependencies(funcDecl, pass.Fset, wireDependencies)
+
+	for _, call := range calls {
+		if !call.pos.IsValid() {
+			continue
+		}
+		pass.Report(analysis.Diagnostic{
+			Pos:     call.pos,
+			Message: "Wire provider dependency method called",
+			Related: related,
+		})
+	}
+
+	// If recursive analysis is enabled, find function calls and track parameter flow
+	if w.settings.Recursive {
+		functionCalls := w.findFunctionCallsInFunction(funcDecl)
+		for _, funcCall := range functionCalls {
+			if w.containsFunction(related, funcCall) {
+				continue
+			}
+
+			// Find the target function declaration
+			targetFunc := w.findFunctionDeclaration(pass, funcCall.funcName, funcCall.pkg)
+			if targetFunc != nil {
+				// Track which parameters flow from this call to the target function
+				flows := w.extractParameterFlowFromCall(funcCall, funcDecl, targetFunc, wireDependencies)
+
+				// Create new wire dependencies map for the target function
+				targetWireDeps := make(map[string]bool)
+				for _, flow := range flows {
+					targetWireDeps[flow.TargetParam.Name] = true
+				}
+
+				if len(targetWireDeps) > 0 {
+					newRelated := append(related, analysis.RelatedInformation{
+						Pos:     funcCall.pos,
+						Message: "This function call results in dependency method call",
+					})
+					w.analyzeWithParameterFlow(pass, targetFunc, newRelated, targetWireDeps)
+				}
+			}
+		}
+	}
+}
+
+// findMethodCallsOnTrackedDependencies finds method calls on specific tracked wire dependencies
+func (w *WireChecker) findMethodCallsOnTrackedDependencies(funcDecl *ast.FuncDecl, fset *token.FileSet, wireDependencies map[string]bool) []methodCall {
+	var calls []methodCall
+	w.findMethodCallsInScope(funcDecl, fset, &calls, wireDependencies)
+	return calls
+}
+
+// findMethodCallsInScope recursively finds method calls on tracked wire dependencies
+func (w *WireChecker) findMethodCallsInScope(node ast.Node, fset *token.FileSet, calls *[]methodCall, wireDependencies map[string]bool) {
+	ast.Inspect(node, func(n ast.Node) bool {
+		// When we encounter a function literal, recursively check it but keep tracking the same wire dependencies
+		if funcLit, ok := n.(*ast.FuncLit); ok {
+			w.findMethodCallsInScope(funcLit.Body, fset, calls, wireDependencies)
+			return false // Don't continue inspecting this node's children
+		}
+
+		if callExpr, ok := n.(*ast.CallExpr); ok {
+			if selExpr, ok := callExpr.Fun.(*ast.SelectorExpr); ok {
+				if ident, ok := selExpr.X.(*ast.Ident); ok {
+					// Only check method calls on tracked wire dependencies
+					if wireDependencies[ident.Name] {
+						*calls = append(*calls, methodCall{
+							receiver: ident.Name,
+							method:   selExpr.Sel.Name,
+							line:     fset.Position(callExpr.Pos()).Line,
+							pos:      callExpr.Pos(),
+						})
+					}
+				}
+			}
+		}
+		return true
+	})
+}
+
+// extractParameterNames returns a map of parameter names for the given function
+func (w *WireChecker) extractParameterNames(funcDecl *ast.FuncDecl) map[string]bool {
+	params := make(map[string]bool)
+	if funcDecl.Type.Params != nil {
+		for _, field := range funcDecl.Type.Params.List {
+			for _, name := range field.Names {
+				params[name.Name] = true
+			}
+		}
+	}
+	return params
+}
+
+// extractParameterFlowFromCall analyzes a function call to determine which wire dependencies
+// flow from the calling function to the called function
+func (w *WireChecker) extractParameterFlowFromCall(funcCall functionCall, callingFunc *ast.FuncDecl, targetFunc *ast.FuncDecl, wireDependencies map[string]bool) []ParameterFlow {
+	var flows []ParameterFlow
+
+	// Find the actual call expression in the calling function
+	var callExpr *ast.CallExpr
+	ast.Inspect(callingFunc, func(n ast.Node) bool {
+		if ce, ok := n.(*ast.CallExpr); ok && ce.Pos() == funcCall.pos {
+			callExpr = ce
+			return false
+		}
+		return true
+	})
+
+	if callExpr == nil {
+		return flows
+	}
+
+	// Get target function parameters
+	targetParams := w.extractDependencyParams(targetFunc)
+
+	// Match arguments to parameters
+	for i, arg := range callExpr.Args {
+		if i >= len(targetParams) {
+			break
+		}
+
+		// Check if this argument is a wire dependency
+		if ident, ok := arg.(*ast.Ident); ok {
+			if wireDependencies[ident.Name] {
+				flows = append(flows, ParameterFlow{
+					SourceParam: DependencyParam{
+						Name:     ident.Name,
+						Position: i,
+					},
+					CallSite:    funcCall.pos,
+					TargetParam: targetParams[i],
+				})
+			}
+		}
+	}
+
+	return flows
+}
+
+// extractDependencyParams returns a slice of DependencyParam for the given function
+func (w *WireChecker) extractDependencyParams(funcDecl *ast.FuncDecl) []DependencyParam {
+	var params []DependencyParam
+	if funcDecl.Type.Params != nil {
+		pos := 0
+		for _, field := range funcDecl.Type.Params.List {
+			for _, name := range field.Names {
+				params = append(params, DependencyParam{
+					Name:     name.Name,
+					Type:     w.typeToString(field.Type),
+					Position: pos,
+				})
+				pos++
+			}
+		}
+	}
+	return params
+}
+
+// typeToString converts an AST type expression to a string representation
+func (w *WireChecker) typeToString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		if pkg, ok := t.X.(*ast.Ident); ok {
+			return pkg.Name + "." + t.Sel.Name
+		}
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return "*" + w.typeToString(t.X)
+	default:
+		return "unknown"
+	}
+}
+
+// findFunctionCallsInFunction finds all function calls within a provider function
+func (w *WireChecker) findFunctionCallsInFunction(funcDecl *ast.FuncDecl) []functionCall {
+	var calls []functionCall
+
+	ast.Inspect(funcDecl, func(n ast.Node) bool {
+		if callExpr, ok := n.(*ast.CallExpr); ok {
+			switch fun := callExpr.Fun.(type) {
+			case *ast.Ident:
+				// Direct function call: SomeFunction()
+				calls = append(calls, functionCall{
+					funcName: fun.Name,
+					pos:      callExpr.Pos(),
+					pkg:      "", // Same package
+				})
+			case *ast.SelectorExpr:
+				// Package function call: package.SomeFunction()
+				if pkgIdent, ok := fun.X.(*ast.Ident); ok {
+					calls = append(calls, functionCall{
+						funcName: fun.Sel.Name,
+						pos:      callExpr.Pos(),
+						pkg:      pkgIdent.Name,
+					})
+				}
+			}
+		}
+		return true
+	})
+
+	return calls
+}
+
+// containsFunction checks if a function name is already in the call path
+func (w *WireChecker) containsFunction(callPath []analysis.RelatedInformation, funcCall functionCall) bool {
+	for _, related := range callPath {
+		if related.Pos == funcCall.pos {
+			return true
+		}
+	}
+	return false
+}
+
+// findFunctionDeclaration finds a function declaration by name in the current analysis pass
+func (w *WireChecker) findFunctionDeclaration(pass *analysis.Pass, funcName, pkg string) *ast.FuncDecl {
+	for _, file := range pass.Files {
+		for _, decl := range file.Decls {
+			if funcDecl, ok := decl.(*ast.FuncDecl); ok {
+				if funcDecl.Name.Name == funcName {
+					// If pkg is specified, we need to check if this is from the right package
+					// For now, we'll assume same package if pkg is empty
+					if pkg == "" || pkg == pass.Pkg.Name() {
+						return funcDecl
+					}
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/scripts/go/wirecheck/cmd/wirechecker/main.go
+++ b/scripts/go/wirecheck/cmd/wirechecker/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"log"
+
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/grafana/grafana/scripts/go/wirecheck"
+)
+
+func main() {
+	checker, err := wirecheck.New(nil)
+	if err != nil {
+		log.Fatalf("failed to create wirecheck: %v", err)
+		return
+	}
+	analyzers, err := checker.BuildAnalyzers()
+	if err != nil {
+		log.Fatalf("failed to build analyzers: %v", err)
+		return
+	}
+
+	if len(analyzers) > 0 {
+		singlechecker.Main(analyzers[0])
+	}
+}

--- a/scripts/go/wirecheck/go.mod
+++ b/scripts/go/wirecheck/go.mod
@@ -1,0 +1,14 @@
+module github.com/grafana/grafana/scripts/go/wirecheck
+
+go 1.24.5
+
+require (
+	github.com/golangci/plugin-module-register v0.1.2
+	golang.org/x/tools v0.36.0
+)
+
+require (
+	github.com/google/go-cmp v0.7.0 // indirect
+	golang.org/x/mod v0.27.0 // indirect
+	golang.org/x/sync v0.16.0 // indirect
+)

--- a/scripts/go/wirecheck/go.sum
+++ b/scripts/go/wirecheck/go.sum
@@ -1,0 +1,10 @@
+github.com/golangci/plugin-module-register v0.1.2 h1:e5WM6PO6NIAEcij3B053CohVp3HIYbzSuP53UAYgOpg=
+github.com/golangci/plugin-module-register v0.1.2/go.mod h1:1+QGTsKBvAIvPvoY/os+G5eoqxWn70HYDm2uvUyGuVw=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+golang.org/x/mod v0.27.0 h1:kb+q2PyFnEADO2IEF935ehFUXlWiNjJWtRNgBLSfbxQ=
+golang.org/x/mod v0.27.0/go.mod h1:rWI627Fq0DEoudcK+MBkNkCe0EetEaDSwJJkCcjpazc=
+golang.org/x/sync v0.16.0 h1:ycBJEhp9p4vXvUZNszeOq0kGTPghopOL8q0fq3vstxw=
+golang.org/x/sync v0.16.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
+golang.org/x/tools v0.36.0 h1:kWS0uv/zsvHEle1LbV5LE8QujrxB3wfQyxHfhOk0Qkg=
+golang.org/x/tools v0.36.0/go.mod h1:WBDiHKJK8YgLHlcQPYQzNCkUxUypCaa5ZegCVutKm+s=

--- a/scripts/go/wirecheck/testdata/bad/provide.go
+++ b/scripts/go/wirecheck/testdata/bad/provide.go
@@ -1,0 +1,115 @@
+package bad
+
+import (
+	"fmt"
+)
+
+// Database represents a database dependency
+type Database struct {
+	connectionString string
+}
+
+// NewDatabase creates a new database instance
+func NewDatabase(connStr string) *Database {
+	return &Database{connectionString: connStr}
+}
+
+// Connect establishes a database connection
+func (db *Database) Connect() error {
+	fmt.Printf("Connecting to database: %s\n", db.connectionString)
+	return nil
+}
+
+// Query executes a database query
+func (db *Database) Query(sql string) ([]string, error) {
+	fmt.Printf("Executing query: %s\n", sql)
+	return []string{"result1", "result2"}, nil
+}
+
+// Logger represents a logging dependency
+type Logger struct {
+	level string
+}
+
+// NewLogger creates a new logger instance
+func NewLogger(level string) *Logger {
+	return &Logger{level: level}
+}
+
+// Log logs a message
+func (logger *Logger) Log(message string) {
+	fmt.Printf("[%s] %s\n", logger.level, message)
+}
+
+// UserService represents a service that depends on database and logger
+type UserService struct {
+	db     *Database
+	logger *Logger
+}
+
+// NewUserService creates a new user service
+func NewUserService(db *Database, logger *Logger) *UserService {
+	return &UserService{db: db, logger: logger}
+}
+
+// GetUsers retrieves users from the database
+func (us *UserService) GetUsers() ([]string, error) {
+	us.logger.Log("Fetching users from database")
+	return us.db.Query("SELECT * FROM users")
+}
+
+// Server represents the main application server
+type Server struct {
+	userService *UserService
+	logger      *Logger
+}
+
+// NewServer creates a new server instance
+func NewServer(userService *UserService, logger *Logger) *Server {
+	return &Server{userService: userService, logger: logger}
+}
+
+// Start starts the server
+func (server *Server) Start() error {
+	server.logger.Log("Starting server")
+	users, err := server.userService.GetUsers()
+	if err != nil {
+		return err
+	}
+	server.logger.Log(fmt.Sprintf("Found %d users", len(users)))
+	return nil
+}
+
+// ProvideDatabase creates a database instance
+func ProvideDatabase() *Database {
+	return NewDatabase("postgres://localhost:5432/mydb")
+}
+
+// ProvideLogger creates a logger instance
+func ProvideLogger() *Logger {
+	return NewLogger("INFO")
+}
+
+// ProvideUserService creates a user service with dependencies
+// This function calls methods on dependencies - should be detected by wire-checker
+func ProvideUserService(db *Database, logger *Logger) *UserService {
+	// This is a dependency call that should be detected
+	db.Connect()
+
+	// This is another dependency call that should be detected
+	logger.Log("Initializing user service")
+
+	return NewUserService(db, logger)
+}
+
+// ProvideServer creates a server with dependencies
+// This function calls methods on dependencies - should be detected by wire-checker
+func ProvideServer(userService *UserService, logger *Logger) *Server {
+	// This is a dependency call that should be detected
+	logger.Log("Creating server instance")
+
+	// This is another dependency call that should be detected
+	userService.GetUsers()
+
+	return NewServer(userService, logger)
+}

--- a/scripts/go/wirecheck/testdata/bad/test/helper.go
+++ b/scripts/go/wirecheck/testdata/bad/test/helper.go
@@ -1,0 +1,83 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/scripts/go/wirecheck/testdata/bad"
+)
+
+// TestDatabase represents a test database
+type TestDatabase struct {
+	name string
+}
+
+// NewTestDatabase creates a test database
+func NewTestDatabase(name string) *TestDatabase {
+	return &TestDatabase{name: name}
+}
+
+// Reset resets the test database
+func (tdb *TestDatabase) Reset() {
+	// Reset logic here
+}
+
+// TestLogger represents a test logger
+type TestLogger struct {
+	messages []string
+}
+
+// NewTestLogger creates a test logger
+func NewTestLogger() *TestLogger {
+	return &TestLogger{messages: make([]string, 0)}
+}
+
+// GetMessages returns logged messages
+func (tl *TestLogger) GetMessages() []string {
+	return tl.messages
+}
+
+// Clear clears logged messages
+func (tl *TestLogger) Clear() {
+	tl.messages = tl.messages[:0]
+}
+
+// CreateTestServer creates a server for testing
+// This function calls methods on dependencies - should be detected by wire-checker
+func CreateTestServer() *bad.Server {
+	db := bad.ProvideDatabase()
+	logger := bad.ProvideLogger()
+
+	// This is a dependency call that should be detected
+	db.Connect()
+
+	// This is another dependency call that should be detected
+	logger.Log("Setting up test server")
+
+	userService := bad.ProvideUserService(db, logger)
+	return bad.ProvideServer(userService, logger)
+}
+
+// ProvideTestDatabase creates a test database
+// This function calls methods on dependencies - should be detected by wire-checker
+func ProvideTestDatabase(testDb *TestDatabase) *bad.Database {
+	// This is a dependency call that should be detected
+	testDb.Reset()
+
+	return bad.NewDatabase("test://localhost:5432/testdb")
+}
+
+// ProvideTestLogger creates a test logger
+// This function calls methods on dependencies - should be detected by wire-checker
+func ProvideTestLogger(testLogger *TestLogger) *bad.Logger {
+	// This is a dependency call that should be detected
+	testLogger.Clear()
+
+	return bad.NewLogger("DEBUG")
+}
+
+// ValidateServer validates a server instance
+func ValidateServer(t *testing.T, server *bad.Server) {
+	if server == nil {
+		t.Error("Server should not be nil")
+	}
+}

--- a/scripts/go/wirecheck/testdata/good/provide.go
+++ b/scripts/go/wirecheck/testdata/good/provide.go
@@ -1,0 +1,93 @@
+package good
+
+import (
+	"fmt"
+	"time"
+)
+
+// Config represents application configuration
+type Config struct {
+	Port    int
+	Host    string
+	Timeout time.Duration
+	Debug   bool
+}
+
+// NewConfig creates a new configuration instance
+func NewConfig(port int, host string, timeout time.Duration, debug bool) *Config {
+	return &Config{
+		Port:    port,
+		Host:    host,
+		Timeout: timeout,
+		Debug:   debug,
+	}
+}
+
+// Repository represents a data repository
+type Repository struct {
+	config *Config
+}
+
+// NewRepository creates a new repository instance
+func NewRepository(config *Config) *Repository {
+	return &Repository{config: config}
+}
+
+// Service represents a business service
+type Service struct {
+	config     *Config
+	repository *Repository
+}
+
+// NewService creates a new service instance
+func NewService(config *Config, repository *Repository) *Service {
+	return &Service{
+		config:     config,
+		repository: repository,
+	}
+}
+
+// Application represents the main application
+type Application struct {
+	config  *Config
+	service *Service
+}
+
+// NewApplication creates a new application instance
+func NewApplication(config *Config, service *Service) *Application {
+	return &Application{
+		config:  config,
+		service: service,
+	}
+}
+
+// Run starts the application
+func (app *Application) Run() error {
+	fmt.Printf("Starting application on %s:%d\n", app.config.Host, app.config.Port)
+	fmt.Printf("Timeout: %v, Debug: %v\n", app.config.Timeout, app.config.Debug)
+	return nil
+}
+
+// ProvideConfig creates a configuration instance
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideConfig() *Config {
+	return NewConfig(8080, "localhost", 30*time.Second, true)
+}
+
+// ProvideRepository creates a repository instance
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideRepository(config *Config) *Repository {
+	return NewRepository(config)
+}
+
+// ProvideService creates a service instance
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideService(config *Config, repository *Repository) *Service {
+	return NewService(config, repository)
+}
+
+// ProvideApplication creates an application instance
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideApplication(config *Config, service *Service) *Application {
+	return NewApplication(config, service)
+}

--- a/scripts/go/wirecheck/testdata/good/test/helper.go
+++ b/scripts/go/wirecheck/testdata/good/test/helper.go
@@ -1,0 +1,56 @@
+package test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/scripts/go/wirecheck/testdata/good"
+)
+
+// TestConfig represents test configuration
+type TestConfig struct {
+	Name string
+}
+
+// NewTestConfig creates a test configuration
+func NewTestConfig(name string) *TestConfig {
+	return &TestConfig{Name: name}
+}
+
+// TestHelper provides helper functions for testing
+type TestHelper struct {
+	config *TestConfig
+}
+
+// NewTestHelper creates a new test helper
+func NewTestHelper(config *TestConfig) *TestHelper {
+	return &TestHelper{config: config}
+}
+
+// CreateTestApp creates an application for testing
+// This function does NOT call methods on dependencies - should NOT be detected
+func CreateTestApp() *good.Application {
+	config := good.ProvideConfig()
+	repository := good.ProvideRepository(config)
+	service := good.ProvideService(config, repository)
+	return good.ProvideApplication(config, service)
+}
+
+// ProvideTestConfig creates a test configuration
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideTestConfig() *good.Config {
+	return good.NewConfig(9090, "testhost", 10*time.Second, false)
+}
+
+// ProvideTestHelper creates a test helper
+// This function does NOT call methods on dependencies - should NOT be detected
+func ProvideTestHelper(testConfig *TestConfig) *TestHelper {
+	return NewTestHelper(testConfig)
+}
+
+// ValidateApp validates an application instance
+func ValidateApp(t *testing.T, app *good.Application) {
+	if app == nil {
+		t.Error("Application should not be nil")
+	}
+}

--- a/scripts/go/wirecheck/testdata/wire_gen.go
+++ b/scripts/go/wirecheck/testdata/wire_gen.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/grafana/grafana/tools/wire-checker/testdata/bad"
+	badtest "github.com/grafana/grafana/tools/wire-checker/testdata/bad/test"
+	"github.com/grafana/grafana/tools/wire-checker/testdata/good"
+)
+
+// ComplexServer represents a complex server type for testing
+type ComplexServer struct {
+	Name string
+}
+
+// Initialize simulates a wire_gen.go Initialize function for testing
+// This function calls functions from imported packages to trigger wire-checker analysis
+func Initialize() (*ComplexServer, error) {
+	fmt.Println("Testing wire-checker on imported packages...")
+
+	// Call individual provide functions from imported packages - this should trigger analysis
+	// of the imported packages' provide functions for dependency calls
+	db := bad.ProvideDatabase()
+	logger := bad.ProvideLogger()
+	userService := bad.ProvideUserService(db, logger)
+	server := bad.ProvideServer(userService, logger)
+
+	// Also call provide functions from the package without deps
+	config := good.ProvideConfig()
+	repository := good.ProvideRepository(config)
+	service := good.ProvideService(config, repository)
+	application := good.ProvideApplication(config, service)
+
+	// Call provider functions from bad/test package
+	testDb := badtest.NewTestDatabase("test-db")
+	testLogger := badtest.NewTestLogger()
+	testDatabase := badtest.ProvideTestDatabase(testDb)
+	testLoggerProvider := badtest.ProvideTestLogger(testLogger)
+	testServer := badtest.CreateTestServer()
+
+	fmt.Printf("Created server: %T, application: %T, testServer: %T\n", server, application, testServer)
+	fmt.Printf("Test components: %T, %T\n", testDatabase, testLoggerProvider)
+
+	return &ComplexServer{Name: "test-server"}, nil
+}

--- a/scripts/go/wirecheck/wire_parser.go
+++ b/scripts/go/wirecheck/wire_parser.go
@@ -1,0 +1,179 @@
+package wirecheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+	"sync"
+)
+
+// WireParser handles parsing of wire_gen.go files to extract provider functions.
+// It caches parsed results to avoid re-parsing the same file multiple times.
+type WireParser struct {
+	mu                sync.RWMutex
+	wireFunctions     map[string]map[string]bool // Cache: import_path -> function -> true
+	importMap         map[string]string          // Mapping from package aliases to import paths
+	wireGenPackage    string
+	wireGenImportPath string
+}
+
+// NewWireParser creates a new WireParser instance.
+func NewWireParser() *WireParser {
+	return &WireParser{}
+}
+
+func (wp *WireParser) Parse(wireGenFilePath string) error {
+	if wireGenFilePath == "" {
+		return fmt.Errorf("file path cannot be empty")
+	}
+
+	// Check cache first
+	wp.mu.RLock()
+	if wp.wireFunctions != nil {
+		wp.mu.RUnlock()
+		return nil
+	}
+	wp.mu.RUnlock()
+
+	// Parse and cache
+	wp.mu.Lock()
+	defer wp.mu.Unlock()
+
+	// Double-check after acquiring write lock
+	if wp.wireFunctions != nil {
+		return nil
+	}
+
+	err := wp.parseFile(wireGenFilePath)
+	if err != nil {
+		return fmt.Errorf("failed to parse wire_gen.go file %q: %w", wireGenFilePath, err)
+	}
+
+	return nil
+}
+
+// ShouldAnalyzeFunction checks if a function in the given package should be analyzed.
+// It returns true if the function is referenced in the wire_gen.go file.
+// pkgImportPath should be the full import path of the package being analyzed.
+func (wp *WireParser) ShouldAnalyzeFunction(pkgImportPath, funcName string) bool {
+	wp.mu.RLock()
+	defer wp.mu.RUnlock()
+
+	if wp.wireFunctions == nil {
+		return false
+	}
+
+	// Check if the package exists in our wire functions using import path
+	if pkgFunctions, exists := wp.wireFunctions[pkgImportPath]; exists {
+		// Check if the function exists in this package
+		return pkgFunctions[funcName]
+	}
+
+	return false
+}
+
+// parseFile performs the actual parsing of the wire_gen.go file.
+func (wp *WireParser) parseFile(filePath string) error {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, filePath, nil, parser.ParseComments)
+	if err != nil {
+		return err
+	}
+
+	// Set private variables
+	wp.importMap = wp.buildImportMap(file)
+	wp.wireGenPackage = file.Name.Name
+	wp.wireFunctions = make(map[string]map[string]bool)
+
+	// Extract provider functions from all function declarations
+	ast.Inspect(file, func(n ast.Node) bool {
+		if funcDecl, ok := n.(*ast.FuncDecl); ok {
+			if funcDecl.Name.Name == "Initialize" {
+				wp.extractProviderFunctions(funcDecl)
+			}
+		}
+		return true
+	})
+	return nil
+}
+
+// buildImportMap creates a mapping from package aliases to their full import paths.
+func (wp *WireParser) buildImportMap(file *ast.File) map[string]string {
+	importMap := make(map[string]string)
+
+	for _, imp := range file.Imports {
+		if imp.Path == nil {
+			continue
+		}
+
+		importPath := strings.Trim(imp.Path.Value, "\"")
+
+		if imp.Name != nil {
+			// Named import: import alias "path"
+			importMap[imp.Name.Name] = importPath
+		} else {
+			// Default import: import "path" - extract package name from path
+			if pkgName := wp.extractPackageName(importPath); pkgName != "" {
+				importMap[pkgName] = importPath
+			}
+		}
+	}
+
+	return importMap
+}
+
+// extractPackageName extracts the package name from an import path.
+func (wp *WireParser) extractPackageName(importPath string) string {
+	parts := strings.Split(importPath, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+// extractProviderFunctions extracts provider function calls from a function declaration.
+func (wp *WireParser) extractProviderFunctions(funcDecl *ast.FuncDecl) {
+	ast.Inspect(funcDecl, func(n ast.Node) bool {
+		if callExpr, ok := n.(*ast.CallExpr); ok {
+			wp.extractProviderFromCall(callExpr)
+		}
+		return true
+	})
+}
+
+// extractProviderFromCall extracts provider function names from a call expression.
+func (wp *WireParser) extractProviderFromCall(callExpr *ast.CallExpr) {
+	switch fun := callExpr.Fun.(type) {
+	case *ast.Ident:
+		// Direct function call: ProvideService()
+		// Use the wire_gen.go package name as the package
+		wp.addProviderFunction(wp.wireGenPackage, fun.Name)
+
+	case *ast.SelectorExpr:
+		// Package function call: package.ProvideService()
+		if pkgIdent, ok := fun.X.(*ast.Ident); ok {
+			wp.addProviderFunction(pkgIdent.Name, fun.Sel.Name)
+		}
+	}
+}
+
+// addProviderFunction adds a provider function to the wire functions map.
+// It always uses import paths as keys for consistent lookup.
+func (wp *WireParser) addProviderFunction(pkgName, funcName string) {
+	var importPath string
+
+	if fullPath, exists := wp.importMap[pkgName]; exists {
+		// External package - use the full import path
+		importPath = fullPath
+	} else {
+		// Local package function (no package prefix) - use wire_gen.go's import path
+		importPath = wp.wireGenImportPath
+	}
+
+	if wp.wireFunctions[importPath] == nil {
+		wp.wireFunctions[importPath] = make(map[string]bool)
+	}
+	wp.wireFunctions[importPath][funcName] = true
+}

--- a/scripts/go/wirecheck/wirecheck.sh
+++ b/scripts/go/wirecheck/wirecheck.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -euo pipefail
+
+WIRE_CHECK_DIR="$(dirname "${BASH_SOURCE[0]}")"
+
+pushd "${WIRE_CHECK_DIR}" && GOWORK=off go build -o wirecheck ./cmd/wirechecker && popd
+
+exec "${WIRE_CHECK_DIR}/wirecheck" "$@"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

A golangci-lint linter that detects calls of methods on injected dependencies in wire provider functions. This is an issue because it breaks the background service startup ordering guarantees introduced in #110225. This is currently a silent failure in CI ([example](https://github.com/grafana/grafana/actions/runs/17591575488/job/49973437794?pr=110573#step:5:10))

VSCode config to use the custom golangci-lint with wirecheck:

<img width="809" height="417" alt="image" src="https://github.com/user-attachments/assets/1816815a-9dce-47ca-b427-f9de8ea324ee" />

```json
{
  "go.lintTool": "golangci-lint-v2",
  "go.lintFlags": ["--config=${workspaceRoot}/.golangci.yml"],
  "go.alternateTools": {
    "golangci-lint-v2": "${workspaceRoot}/scripts/go/golangci-lint/vscode-wrapper.sh"
  },
  "go.lintOnSave": "package"
}
```

Here is an example of a wire provider that calls a method on one of its dependencies. This is a problem because it breaks the dskit module/service startup guarantees. The database connection happens during wire initialization instead of during the service's starting phase, which can cause services to start in the wrong order or fail if dependencies aren't healthy and ready to accept requests.

```go
func ProvideUserService(db *Database) (*UserService, error) {
   
    if err := db.Connect(context.Background()); err != nil {  // Direct method calls on dependency
        return nil, err
    }

    return &UserService{db: db}, nil
}
```

Wire Checker will report:

```
provide.go:95:2: ProvideUserService() directly calls db.Connect() in wire provider function
```


To fix this, use a dskit service starting function for initilization.

```go

import "github.com/grafana/dskit/services"

func ProvideUserService(db *Database) *UserService {
  service := &UserService{db: db}
  service.NamedService = services.NewBasicService(service.starting, service.running, nil)
  return service
}

type UserService struct {
    db *Database
    services.NamedService
}

func (s *UserService) starting(ctx context.Context) error {
  return s.db.Connect(ctx)
}

func (s *UserService) running(ctx context.Context) error {
  <- ctx.Done()
  return nil
}
```

**Why do we need this feature?**

To avoid breaking background service startup ordering.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
