### PR TITLE
Grafana Schema: Extend the `VariableHide` enum

### DIFF
--- a/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
@@ -684,8 +684,8 @@ VariableSort: "disabled" | "alphabeticalAsc" | "alphabeticalDesc" | "numericalAs
 VariableRefresh: *"never" | "onDashboardLoad" | "onTimeRangeChanged"
 
 // Determine if the variable shows on dashboard
-// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing).
-VariableHide: *"dontHide" | "hideLabel" | "hideVariable"
+// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing), `inControlsMenu` (show in a drop-down menu).
+VariableHide: *"dontHide" | "hideLabel" | "hideVariable" | "inControlsMenu"
 
 // Determine the origin of the adhoc variable filter
 FilterOrigin: "dashboard"

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/dashboard_kind.cue
@@ -243,8 +243,8 @@ lineage: schemas: [{
 		#VariableRefresh: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="never|onDashboardLoad|onTimeRangeChanged")
 
 		// Determine if the variable shows on dashboard
-		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing).
-		#VariableHide: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable") @grafana(TSVeneer="type")
+		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing), 3 (show under the controls dropdown menu).
+		#VariableHide: 0 | 1 | 2 | 3 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable|inControlsMenu") @grafana(TSVeneer="type")
 
 		// Sort variable options
 		// Accepted values are:

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/dashboard_kind.cue
@@ -243,8 +243,8 @@ lineage: schemas: [{
 		#VariableRefresh: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="never|onDashboardLoad|onTimeRangeChanged")
 
 		// Determine if the variable shows on dashboard
-		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing).
-		#VariableHide: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable") @grafana(TSVeneer="type")
+		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing), 3 (show under the controls dropdown menu).
+		#VariableHide: 0 | 1 | 2 | 3 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable|inControlsMenu") @grafana(TSVeneer="type")
 
 		// Sort variable options
 		// Accepted values are:

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec.cue
@@ -688,8 +688,8 @@ VariableSort: "disabled" | "alphabeticalAsc" | "alphabeticalDesc" | "numericalAs
 VariableRefresh: *"never" | "onDashboardLoad" | "onTimeRangeChanged"
 
 // Determine if the variable shows on dashboard
-// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing).
-VariableHide: *"dontHide" | "hideLabel" | "hideVariable"
+// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing), `inControlsMenu` (show in a drop-down menu).
+VariableHide: *"dontHide" | "hideLabel" | "hideVariable" | "inControlsMenu"
 
 // Determine the origin of the adhoc variable filter
 FilterOrigin: "dashboard"

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec_gen.go
@@ -1282,14 +1282,15 @@ func NewDashboardVariableOption() *DashboardVariableOption {
 }
 
 // Determine if the variable shows on dashboard
-// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing).
+// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing), `inControlsMenu` (show in a drop-down menu).
 // +k8s:openapi-gen=true
 type DashboardVariableHide string
 
 const (
-	DashboardVariableHideDontHide     DashboardVariableHide = "dontHide"
-	DashboardVariableHideHideLabel    DashboardVariableHide = "hideLabel"
-	DashboardVariableHideHideVariable DashboardVariableHide = "hideVariable"
+	DashboardVariableHideDontHide       DashboardVariableHide = "dontHide"
+	DashboardVariableHideHideLabel      DashboardVariableHide = "hideLabel"
+	DashboardVariableHideHideVariable   DashboardVariableHide = "hideVariable"
+	DashboardVariableHideInControlsMenu DashboardVariableHide = "inControlsMenu"
 )
 
 // Options to config when to refresh a variable

--- a/kinds/dashboard/dashboard_kind.cue
+++ b/kinds/dashboard/dashboard_kind.cue
@@ -239,8 +239,8 @@ lineage: schemas: [{
 		#VariableRefresh: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="never|onDashboardLoad|onTimeRangeChanged")
 
 		// Determine if the variable shows on dashboard
-		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing).
-		#VariableHide: 0 | 1 | 2 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable") @grafana(TSVeneer="type")
+		// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing), 3 (show under the controls dropdown menu).
+		#VariableHide: 0 | 1 | 2 | 3 @cuetsy(kind="enum",memberNames="dontHide|hideLabel|hideVariable|inControlsMenu") @grafana(TSVeneer="type")
 
 		// Sort variable options
 		// Accepted values are:

--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -47,6 +47,7 @@ export enum VariableHide {
   dontHide,
   hideLabel,
   hideVariable,
+  inControlsMenu,
 }
 
 export interface AdHocVariableFilter {

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -246,12 +246,13 @@ export enum VariableRefresh {
 
 /**
  * Determine if the variable shows on dashboard
- * Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing).
+ * Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing), 3 (show under the controls dropdown menu).
  */
 export enum VariableHide {
   dontHide = 0,
   hideLabel = 1,
   hideVariable = 2,
+  inControlsMenu = 3,
 }
 
 /**

--- a/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
@@ -1039,8 +1039,8 @@ export const defaultVariableOption = (): VariableOption => ({
 });
 
 // Determine if the variable shows on dashboard
-// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing).
-export type VariableHide = "dontHide" | "hideLabel" | "hideVariable";
+// Accepted values are `dontHide` (show label and value), `hideLabel` (show value only), `hideVariable` (show nothing), `inControlsMenu` (show in a drop-down menu).
+export type VariableHide = "dontHide" | "hideLabel" | "hideVariable" | "inControlsMenu";
 
 export const defaultVariableHide = (): VariableHide => ("dontHide");
 

--- a/packages/grafana-schema/src/veneer/dashboard.types.ts
+++ b/packages/grafana-schema/src/veneer/dashboard.types.ts
@@ -18,6 +18,7 @@ export enum VariableHide {
   dontHide,
   hideLabel,
   hideVariable,
+  inControlsMenu,
 }
 
 export interface VariableModel extends Omit<raw.VariableModel, 'datasource'> {

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -766,13 +766,14 @@ const (
 )
 
 // Determine if the variable shows on dashboard
-// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing).
+// Accepted values are 0 (show label and value), 1 (show value only), 2 (show nothing), 3 (show under the controls dropdown menu).
 type VariableHide int64
 
 const (
-	VariableHideDontHide     VariableHide = 0
-	VariableHideHideLabel    VariableHide = 1
-	VariableHideHideVariable VariableHide = 2
+	VariableHideDontHide       VariableHide = 0
+	VariableHideHideLabel      VariableHide = 1
+	VariableHideHideVariable   VariableHide = 2
+	VariableHideInControlsMenu VariableHide = 3
 )
 
 // Option to be selected in a variable.


### PR DESCRIPTION
### What changed?

This PR is adding a new member `"inControlsMenu"` to the `VariableHide` enum exposed via the grafana-schema package. The idea is to rely on the `hide` property for dashboard variables to control where they are displayed instead of the previously introduced `showInControlsMenu?` property. 

**Next steps:**
- Update scenes to depend on the new version of `@grafana/schema` ([the `SceneVariableState` interface in scenes](https://github.com/grafana/scenes/blob/7f75a5cf20763c979f542a4946455d53382b6b2d/packages/scenes/src/variables/types.ts#L8) is relying on the `VariableHide`)
- Update the core Grafana code to use the `hide` property for controlling the placement (relies on the scenes change)
- Remove the `showInControlsMenu?` property from the variable models