### PR TITLE
LokiOptionFields: track max lines

### DIFF
--- a/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
+++ b/public/app/plugins/datasource/loki/components/LokiOptionFields.tsx
@@ -2,7 +2,7 @@ import { memo } from 'react';
 import * as React from 'react';
 
 import { SelectableValue } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { InlineField, Input, Stack } from '@grafana/ui';
 
 import { LokiQuery, LokiQueryDirection, LokiQueryType } from '../types';
@@ -59,8 +59,12 @@ export function LokiOptionFields(props: LokiOptionFieldsProps) {
   const query = props.query ?? {};
 
   function onChangeQueryLimit(value: string) {
-    const nextQuery = { ...query, maxLines: preprocessMaxLines(value) };
+    const maxLines = preprocessMaxLines(value);
+    const nextQuery = { ...query, maxLines };
     onChange(nextQuery);
+    reportInteraction('grafana_loki_max_lines_changed', {
+      maxLines,
+    });
   }
 
   function onMaxLinesChange(e: React.SyntheticEvent<HTMLInputElement>) {


### PR DESCRIPTION
It'd be good to know the distribution of line limits used by people.