### PR TITLE
Data source config: Add extension point for components

### DIFF
--- a/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
@@ -300,9 +300,9 @@ describe('<DataSourceTestingStatus />', () => {
           title: overrides.title ?? 'Test Component',
           description: overrides.description ?? 'Test component description',
           pluginId: overrides.pluginId ?? 'grafana-monitoring-app',
-        }
+        },
       });
-      
+
       return Comp;
     };
 

--- a/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
@@ -290,16 +290,19 @@ describe('<DataSourceTestingStatus />', () => {
       }> = {}
     ) => {
       const text = overrides.text ?? 'Test Component';
-      const Comp = (() => (
+      const Comp = ((_props: PluginExtensionDataSourceConfigStatusContext) => (
         <div>{text}</div>
-      )) as unknown as ComponentTypeWithExtensionMeta<PluginExtensionDataSourceConfigStatusContext>;
-      (Comp as any).meta = {
-        id: overrides.id ?? 'test-component',
-        type: PluginExtensionTypes.component,
-        title: overrides.title ?? 'Test Component',
-        description: overrides.description ?? 'Test component description',
-        pluginId: overrides.pluginId ?? 'grafana-monitoring-app',
-      };
+      )) as ComponentTypeWithExtensionMeta<PluginExtensionDataSourceConfigStatusContext>;
+      Object.assign(Comp, {
+        meta: {
+          id: overrides.id ?? 'test-component',
+          type: PluginExtensionTypes.component,
+          title: overrides.title ?? 'Test Component',
+          description: overrides.description ?? 'Test component description',
+          pluginId: overrides.pluginId ?? 'grafana-monitoring-app',
+        }
+      });
+      
       return Comp;
     };
 

--- a/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.test.tsx
@@ -290,7 +290,9 @@ describe('<DataSourceTestingStatus />', () => {
       }> = {}
     ) => {
       const text = overrides.text ?? 'Test Component';
-      const Comp = (() => <div>{text}</div>) as unknown as ComponentTypeWithExtensionMeta<PluginExtensionDataSourceConfigStatusContext>;
+      const Comp = (() => (
+        <div>{text}</div>
+      )) as unknown as ComponentTypeWithExtensionMeta<PluginExtensionDataSourceConfigStatusContext>;
       (Comp as any).meta = {
         id: overrides.id ?? 'test-component',
         type: PluginExtensionTypes.component,
@@ -306,7 +308,10 @@ describe('<DataSourceTestingStatus />', () => {
     });
 
     it('should render plugin component from allowed plugin', () => {
-      const AllowedComponent = createMockComponent({ pluginId: 'grafana-monitoring-app', text: 'Allowed Component' }) as unknown as ComponentTypeWithExtensionMeta<{}>;
+      const AllowedComponent = createMockComponent({
+        pluginId: 'grafana-monitoring-app',
+        text: 'Allowed Component',
+      }) as unknown as ComponentTypeWithExtensionMeta<{}>;
       setPluginComponentsHook(() => ({ components: [AllowedComponent], isLoading: false }));
 
       render(<DataSourceTestingStatus {...getProps()} />);
@@ -315,7 +320,10 @@ describe('<DataSourceTestingStatus />', () => {
     });
 
     it('should NOT render plugin component from non-allowed plugin', () => {
-      const BlockedComponent = createMockComponent({ pluginId: 'not-allowed-plugin', text: 'Blocked Component' }) as unknown as ComponentTypeWithExtensionMeta<{}>;
+      const BlockedComponent = createMockComponent({
+        pluginId: 'not-allowed-plugin',
+        text: 'Blocked Component',
+      }) as unknown as ComponentTypeWithExtensionMeta<{}>;
       setPluginComponentsHook(() => ({ components: [BlockedComponent], isLoading: false }));
 
       render(<DataSourceTestingStatus {...getProps()} />);

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -200,7 +200,9 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
 
   // Filter to only allow grafana-owned plugins
   const statusLinks = allStatusLinks.filter((link) => ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(link.pluginId));
-  const statusComponents = extensionComponents.filter((c) => ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(c.meta.pluginId));
+  const statusComponents = extensionComponents.filter((c) =>
+    ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(c.meta.pluginId)
+  );
   const errorLinks = allErrorLinks.filter((link) => ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(link.pluginId));
 
   // Combine links: show error-specific only for errors, status-general for all

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -200,9 +200,6 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
 
   // Filter to only allow grafana-owned plugins
   const statusLinks = allStatusLinks.filter((link) => ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(link.pluginId));
-  const statusComponents = extensionComponents.filter((c) =>
-    ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(c.meta.pluginId)
-  );
   const errorLinks = allErrorLinks.filter((link) => ALLOWED_DATASOURCE_EXTENSION_PLUGINS.includes(link.pluginId));
 
   // Combine links: show error-specific only for errors, status-general for all
@@ -246,12 +243,13 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
               })}
             </div>
           )}
-          {statusComponents.length > 0 && (
+          {extensionComponents.length > 0 && (
             <div className={styles.linksContainer}>
               {renderLimitedComponents<PluginExtensionDataSourceConfigStatusContext>({
                 props: extensionStatusContext,
-                components: statusComponents,
+                components: extensionComponents,
                 limit: 2,
+                pluginId: ALLOWED_DATASOURCE_EXTENSION_PLUGINS,
               })}
             </div>
           )}

--- a/public/app/features/datasources/constants.ts
+++ b/public/app/features/datasources/constants.ts
@@ -28,4 +28,5 @@ export const ALLOWED_DATASOURCE_EXTENSION_PLUGINS = [
   'grafana-pyroscope-app',
   'grafana-monitoring-app',
   'grafana-troubleshooting-app',
+  'grafana-assistant-app',
 ];


### PR DESCRIPTION
This PR adds an extension point for components, so we can use assistant button for when `severity === error`.

<img width="692" height="173" alt="image" src="https://github.com/user-attachments/assets/0ac494aa-8f3a-436d-ad26-e50a144ae2d2" />

<img width="679" height="415" alt="image" src="https://github.com/user-attachments/assets/1ca2c95e-029a-4f4e-9fca-84c4018e65e0" />

Assistant PR: https://github.com/grafana/grafana-assistant-app/pull/1815