### PR TITLE
Provisioning: Decrypt using Secrets Service in Operators

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -36,6 +36,7 @@ type provisioningControllerConfig struct {
 // token_exchange_url =
 // [secrets_manager]
 // grpc_server_address =
+// grpc_server_tls_server_name =
 // grpc_server_use_tls =
 // grpc_server_tls_ca_file =
 // grpc_server_tls_skip_verify =
@@ -219,10 +220,9 @@ func setupDecrypter(cfg *setting.Cfg, tracer tracing.Tracer, tokenExchangeClient
 	}
 
 	secretsTls := secretdecrypt.TLSConfig{
-		UseTLS: secretsSec.Key("grpc_server_use_tls").MustBool(true),
-		CAFile: secretsSec.Key("grpc_server_tls_ca_file").String(),
-		// TODO: do we need this one?
-		// ServerName:         secretsSec.Key("grpc_server_tls_server_name").String(),
+		UseTLS:             secretsSec.Key("grpc_server_use_tls").MustBool(true),
+		CAFile:             secretsSec.Key("grpc_server_tls_ca_file").String(),
+		ServerName:         secretsSec.Key("grpc_server_tls_server_name").String(),
 		InsecureSkipVerify: secretsSec.Key("grpc_server_tls_skip_verify").MustBool(false),
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Decrypt using Secrets Service in Provisioning operators, and implemented in the same way we did in [API Server](https://github.com/grafana/grafana-enterprise/blob/f033c627c084b01b5d1c336f60bbc792a7da624d/src/pkg/extensions/apiserver/factory.go?plain=1#L904-L924)

**Why do we need this feature?**

We want to decrypt secrets in the same way we do for monolitith Grafana.

**Who is this feature for?**

Users of Git Sync / Provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/517>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Testing notes:

-  custom ini
```
[secrets_manager]
grpc_server_address = localhost:4000
grpc_server_use_tls = false
grpc_server_tls_skip_verify = true

```
- see we decrypted and could authenticate with the secret
```

{"time":"2025-09-04T16:16:17.587527+02:00","level":"DEBUG","msg":"Processing work item from queue","key":"default/test11"}
{"time":"2025-09-04T16:16:17.587535+02:00","level":"DEBUG","msg":"Processing repository","namespace":"default","name":"test11","type":"github","generation":1,"observedGeneration":1}
INFO [09-04|16:16:17] Instantiating Github repository          caller=logger.go:214 time=2025-09-04T16:16:17.587545+02:00 url=https://github.com/grafana/git-ui-sync-demo branch=main path=roberto/
{"time":"2025-09-04T16:16:18.469311+02:00","level":"DEBUG","msg":"Repository test results","results":{"code":200,"success":true},"namespace":"default","name":"test11"}
{"time":"2025-09-04T16:16:18.469417+02:00","level":"DEBUG","msg":"Successfully processed work item","key":"default/test11"}

```