### PR TITLE
Folders: Refresh children at root level when creating new folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -755,6 +755,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 
 # public folder
 /public/app/api/ @grafana/grafana-frontend-platform
+/public/app/api/clients/folder/ @grafana/grafana-search-navigate-organise
 /public/app/core/actions/ @grafana/grafana-frontend-platform
 /public/app/core/app_events.ts @grafana/grafana-frontend-platform
 /public/app/core/components/AccessControl/ @grafana/identity-access-team

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -250,7 +250,7 @@ describe.each([
   // app platform
   true,
   // legacy
-  false,
+  // false,
 ])('folderAppPlatformAPI toggle set to: %s', (toggle) => {
   beforeEach(() => {
     config.featureToggles.foldersAppPlatformAPI = toggle;
@@ -260,12 +260,22 @@ describe.each([
   });
 
   describe('useCreateFolder', () => {
-    it('creates a folder', async () => {
+    it('creates a folder at the root level', async () => {
       const { user } = setupCreateFolder();
 
-      await user.click(screen.getByText('Create Folder'));
+      await user.click(screen.getByText(/Create Folder at root/));
 
       expect(await screen.findByText('Folder created')).toBeInTheDocument();
+      expect(dispatchMockFn).toHaveBeenCalled();
+    });
+
+    it('creates a folder in a nested folder', async () => {
+      const { user } = setupCreateFolder();
+
+      await user.click(screen.getByText(/Create Folder in nested folder/));
+
+      expect(await screen.findByText('Folder created')).toBeInTheDocument();
+      expect(dispatchMockFn).toHaveBeenCalled();
     });
   });
 

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -250,7 +250,7 @@ describe.each([
   // app platform
   true,
   // legacy
-  // false,
+  false,
 ])('folderAppPlatformAPI toggle set to: %s', (toggle) => {
   beforeEach(() => {
     config.featureToggles.foldersAppPlatformAPI = toggle;

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -379,7 +379,8 @@ function useRefreshFolders() {
     if (options.parentsOf) {
       dispatch(refreshParents(options.parentsOf));
     }
-    if (options.childrenOf) {
+    // Refetch children even if we passed in `childrenOf: undefined`, as this corresponds to the root folder
+    if (options.childrenOf || 'childrenOf' in options) {
       dispatch(
         refetchChildren({
           parentUID: options.childrenOf,

--- a/public/app/api/clients/folder/v1beta1/test-utils.tsx
+++ b/public/app/api/clients/folder/v1beta1/test-utils.tsx
@@ -14,7 +14,10 @@ const TestCreationComponent = () => {
   return (
     <>
       <AppNotificationList />
-      <button onClick={() => createFolder({ title: 'test', parentUid: folderA.item.uid })}>Create Folder</button>
+      <button onClick={() => createFolder({ title: 'test' })}>Create Folder at root</button>
+      <button onClick={() => createFolder({ title: 'test', parentUid: folderA.item.uid })}>
+        Create Folder in nested folder
+      </button>
       <div>{result.isSuccess ? 'Folder created' : 'Error creating folder'}</div>
     </>
   );


### PR DESCRIPTION
**What is this feature?**
Fixes the UI not refreshing the list of folders when creating a new folder - specifically, at the root level.

**Why do we need this feature?**
There was a small regression in https://github.com/grafana/grafana/issues/110550 which meant we weren't calling to refresh the child folders of the root/general level

**Who is this feature for?**
Dashboards/folders users