### PR TITLE
Alerting: Fix alert enrichment API plural schema name

### DIFF
--- a/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1/schema.go
+++ b/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1/schema.go
@@ -7,7 +7,7 @@ import (
 // schema is unexported to prevent accidental overwrites
 var (
 	schemaAlertEnrichment = resource.NewSimpleSchema(APIGroup, APIVersion, &AlertEnrichment{}, &AlertEnrichmentList{}, resource.WithKind("AlertEnrichment"),
-		resource.WithPlural("alertenrichments"), resource.WithScope(resource.NamespacedScope))
+		resource.WithPlural("alert-enrichments"), resource.WithScope(resource.NamespacedScope))
 	kindAlertEnrichment = resource.Kind{
 		Schema: schemaAlertEnrichment,
 		Codecs: map[resource.KindEncoding]resource.Codec{


### PR DESCRIPTION
Should be `alert-enrichments` and reused [here](https://github.com/grafana/grafana-enterprise/blob/f034589b0159e2fc426cb08808f76201490742d5/src/pkg/extensions/apis/alertenrichment/v1beta1/register.go#L15) later.