### PR TITLE
search: Force index IDX_dashboard_title when searching dashboards

### DIFF
--- a/pkg/services/sqlstore/searchstore/builder.go
+++ b/pkg/services/sqlstore/searchstore/builder.go
@@ -136,7 +136,12 @@ func (b *Builder) applyFilters() (ordering string) {
 		}
 	}
 
-	b.sql.WriteString("SELECT dashboard.id FROM dashboard")
+	forceIndex := ""
+	if b.Dialect.DriverName() == migrator.MySQL {
+		forceIndex = " FORCE INDEX (IDX_dashboard_title) "
+	}
+
+	b.sql.WriteString(fmt.Sprintf("SELECT dashboard.id FROM dashboard %s", forceIndex))
 	b.sql.WriteString(strings.Join(joins, ""))
 
 	if len(wheres) > 0 {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR modifies the legacy search query to explicitly use the IDX_dashboard_title in the subquery that orders by dashboard title.

**Why do we need this feature?**

On stacks that have up to 30k dashboard records this represents a performance improvement of 50% of query time.

While investigating performance issues with stacks running more than 30k dashboards, we found that the subquery added by [ApplyFilters](https://github.com/grafana/grafana/blob/647c1424d44f21647f92985c393c66faac84f196/pkg/services/sqlstore/searchstore/builder.go#L95) was the bottleneck.

Executing EXPLAIN ANALYZE on the query above for one of the impacted stacks showed that performance could be improved by 50% by using the already existing IDX_dashboard_title index.

However, the MySQL planner does not pick the index when running queries, so we are adding an explicit clause to nudge the planner to use the right index.

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/hosted-grafana/issues/6715 also https://github.com/grafana/pir-actions/issues/282

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
