### PR TITLE
Secrets: Dont run GC if stack_id is set

### DIFF
--- a/pkg/registry/apis/secret/garbagecollectionworker/worker.go
+++ b/pkg/registry/apis/secret/garbagecollectionworker/worker.go
@@ -39,7 +39,7 @@ func ProvideWorker(
 }
 
 func (w *Worker) Run(ctx context.Context) error {
-	if !w.Cfg.SecretsManagement.GCWorkerEnabled {
+	if !w.Cfg.SecretsManagement.GCWorkerEnabled || w.Cfg.StackID != "" {
 		return nil
 	}
 


### PR DESCRIPTION
In case the stack_id is set in the config, we don't need to run the GC.