### PR TITLE
fix(search): bump the limit for locationinfo search

### DIFF
--- a/public/app/features/search/service/unified.test.ts
+++ b/public/app/features/search/service/unified.test.ts
@@ -22,7 +22,7 @@ const mockFallbackSearcher = {
 } as unknown as GrafanaSearcher;
 
 const getResponse = (uri: string) => {
-  if (uri.endsWith('?type=folders')) {
+  if (uri.includes('?type=folders')) {
     return Promise.resolve(mockFolders);
   }
   return Promise.resolve(mockResults);

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -385,7 +385,8 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
 }
 
 async function loadLocationInfo(): Promise<Record<string, LocationInfo>> {
-  const uri = `${searchURI}?type=folders`;
+  // TODO: use proper pagination for search.
+  const uri = `${searchURI}?type=folders&limit=100000`;
   const rsp = getBackendSrv()
     .get<SearchAPIResponse>(uri)
     .then((rsp) => {


### PR DESCRIPTION
This PR adds a workaround for now to load up to 100k folders for the location service. This fixes an issue that would display most folders as "Shared with me", as this is the fallback for not found folders. 

Long term we want to have proper pagination.