### PR TITLE
ds-querier: Handle top level datasourceuids

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -252,6 +252,28 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 			connectLogger.Error("error unmarshalling", err)
 		}
 
+		/*
+			most queries are stored like this:
+			{
+				datasource: {
+					uid: "123",
+					type: "cool-ds",
+				}
+			}
+			but sometimes queries are stored like:
+			{
+				datasourceUid: "123",
+				datasource: {
+					type: "cool-ds",
+				}
+			}
+			this sets the second case to match the first
+		*/
+		if sjQuery.Get("datasourceUid").MustString() != "" && sjQuery.Get("datasource").Get("uid").MustString() == "" {
+			connectLogger.Debug("datasourceUid was top level, moving to datasource.uid")
+			sjQuery.Get("datasource").Set("uid", sjQuery.Get("datasourceUid").MustString())
+		}
+
 		jsonQueries = append(jsonQueries, sjQuery)
 	}
 

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -243,7 +243,6 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuilder, httpreq *http.Request, responder responderWrapper, connectLogger log.Logger) (*backend.QueryDataResponse, error) {
 	var jsonQueries = make([]*simplejson.Json, 0, len(raw.Queries))
 	for _, query := range raw.Queries {
-
 		dsRef, err := getValidDataSourceRef(ctx, query.Datasource, query.DatasourceID, b.legacyDatasourceLookup)
 		if err != nil {
 			connectLogger.Error("error getting valid datasource ref", err)

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -247,7 +247,9 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 		if err != nil {
 			connectLogger.Error("error getting valid datasource ref", err)
 		}
-		query.Datasource = dsRef
+		if dsRef != nil {
+			query.Datasource = dsRef
+		}
 
 		jsonBytes, err := json.Marshal(query)
 		if err != nil {

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"slices"
 	"strconv"
@@ -242,6 +243,13 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuilder, httpreq *http.Request, responder responderWrapper, connectLogger log.Logger) (*backend.QueryDataResponse, error) {
 	var jsonQueries = make([]*simplejson.Json, 0, len(raw.Queries))
 	for _, query := range raw.Queries {
+
+		dsRef, err := getValidDataSourceRef(ctx, query.Datasource, query.DatasourceID, b.legacyDatasourceLookup)
+		if err != nil {
+			connectLogger.Error("error getting valid datasource ref", err)
+		}
+		query.Datasource = dsRef
+
 		jsonBytes, err := json.Marshal(query)
 		if err != nil {
 			connectLogger.Error("error marshalling", err)
@@ -250,28 +258,6 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 		sjQuery, _ := simplejson.NewJson(jsonBytes)
 		if err != nil {
 			connectLogger.Error("error unmarshalling", err)
-		}
-
-		/*
-			most queries are stored like this:
-			{
-				datasource: {
-					uid: "123",
-					type: "cool-ds",
-				}
-			}
-			but sometimes queries are stored like:
-			{
-				datasourceUid: "123",
-				datasource: {
-					type: "cool-ds",
-				}
-			}
-			this sets the second case to match the first
-		*/
-		if sjQuery.Get("datasourceUid").MustString() != "" && sjQuery.Get("datasource").Get("uid").MustString() == "" {
-			connectLogger.Debug("datasourceUid was top level, moving to datasource.uid")
-			sjQuery.Get("datasource").Set("uid", sjQuery.Get("datasourceUid").MustString())
 		}
 
 		jsonQueries = append(jsonQueries, sjQuery)
@@ -390,4 +376,68 @@ func mergeHeaders(main http.Header, extra http.Header, l log.Logger) {
 			}
 		}
 	}
+}
+
+/*
+most queries are stored like this:
+
+	{
+		datasource: {
+			uid: "123",
+			type: "cool-ds",
+		}
+	}
+
+but sometimes queries are stored like:
+
+	{
+		datasourceUid: "123",
+		datasource: {
+			type: "cool-ds",
+		}
+	}
+
+this sets the second case to match the first and looks up missing types
+*/
+func getValidDataSourceRef(ctx context.Context, ds *v0alpha1.DataSourceRef, id int64, legacyDatasourceLookup ds_service.LegacyDataSourceLookup) (*v0alpha1.DataSourceRef, error) {
+	if ds == nil {
+		if id == 0 {
+			return nil, fmt.Errorf("missing datasource reference or id")
+		}
+		if legacyDatasourceLookup == nil {
+			return nil, fmt.Errorf("legacy datasource lookup unsupported (id:%d)", id)
+		}
+		return legacyDatasourceLookup.GetDataSourceFromDeprecatedFields(ctx, "", id)
+	}
+
+	// we need to special-case the "grafana" data source
+	if ds.UID == "grafana" {
+		return &v0alpha1.DataSourceRef{
+			// it does not really matter what `type` we set here,
+			// we will always detect this case by `uid` later.
+			// here we go with what the data source's plugin.json says.
+			Type: "grafana",
+			UID:  "grafana",
+		}, nil
+	}
+
+	if ds.Type == "" {
+		if ds.UID == "" {
+			return nil, fmt.Errorf("missing name/uid in data source reference")
+		}
+		if expr.IsDataSource(ds.UID) {
+			return ds, nil
+		}
+		if legacyDatasourceLookup == nil {
+			return nil, fmt.Errorf("legacy datasource lookup unsupported (name:%s)", ds.UID)
+		}
+		return legacyDatasourceLookup.GetDataSourceFromDeprecatedFields(ctx, ds.UID, 0)
+	}
+
+	if ds.UID == "" && expr.IsDataSource(ds.Type) {
+		ds.UID = ds.Type
+		return ds, nil
+	}
+
+	return ds, nil
 }


### PR DESCRIPTION
No new features for customers, fixing a bug in an internally used service.



The query service (aka ds querier) has a bug where it doesn't handle requests that only have a datasourceUid stored at a top level of query rather than nested inside of a datasource object. 

It seems we allow alert rules to be provisioned this way and it seems to work when the query service is disabled, and when the query service is enabled it breaks with the error: `invalid data source identifier`

My hope is this fixes the issue as I see in the database we store these in this format: 
```
			{
				datasourceUid: "_expr_",
				datasource: {
					type: "_expr_",
				}
			}
```

Other times we don't have the datasource object at all and only a datasourceUid and we need to look up the type and stuff: 

```
			{
				datasourceUid: "123",
			}
```


