### PR TITLE
Tempo: Remove experimental config option to select native histograms

### DIFF
--- a/devenv/datasources.yaml
+++ b/devenv/datasources.yaml
@@ -344,7 +344,6 @@ datasources:
             query: 'sum(rate({$$__tags}[5m]))'
       serviceMap:
         datasourceUid: 'gdev-prometheus'
-        histogramType: 'both' # 'classic' or 'native' or 'both'
 
   - name: gdev-pyroscope
     type: grafana-pyroscope-datasource

--- a/devenv/datasources_docker.yaml
+++ b/devenv/datasources_docker.yaml
@@ -218,4 +218,3 @@ datasources:
             query: 'sum(rate({$$__tags}[5m]))'
       serviceMap:
         datasourceUid: 'gdev-prometheus'
-        histogramType: 'both' # 'classic' or 'native' or 'both'

--- a/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
+++ b/public/app/plugins/datasource/tempo/configuration/ServiceGraphSettings.tsx
@@ -4,7 +4,7 @@ import {
   updateDatasourcePluginJsonDataOption,
 } from '@grafana/data';
 import { DataSourcePicker } from '@grafana/runtime';
-import { Button, InlineField, InlineFieldRow, useStyles2, Combobox, TextLink } from '@grafana/ui';
+import { Button, InlineField, InlineFieldRow, useStyles2 } from '@grafana/ui';
 
 import { TempoJsonData } from '../types';
 
@@ -14,47 +14,6 @@ interface Props extends DataSourcePluginOptionsEditorProps<TempoJsonData> {}
 
 export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
   const styles = useStyles2(getStyles);
-
-  const histogramOptions = [
-    { label: 'Classic', value: 'classic' },
-    { label: 'Native', value: 'native' },
-    { label: 'Both', value: 'both' },
-  ];
-
-  const nativeHistogramDocs = (
-    <>
-      Select which type of histograms are configured in the {metricsGeneratorDocsLink()}. If native histograms are
-      configured, you must also configure native histograms ingestion in {prometheusNativeHistogramsDocsLink()} or{' '}
-      {mimirNativeHistogramsDocsLink()}.
-    </>
-  );
-
-  function metricsGeneratorDocsLink() {
-    return (
-      <TextLink href="https://grafana.com/docs/tempo/latest/setup-and-configuration/metrics-generator/" external>
-        Tempo metrics generator
-      </TextLink>
-    );
-  }
-
-  function prometheusNativeHistogramsDocsLink() {
-    return (
-      <TextLink href="https://prometheus.io/docs/specs/native_histograms/#native-histograms" external>
-        Prometheus
-      </TextLink>
-    );
-  }
-
-  function mimirNativeHistogramsDocsLink() {
-    return (
-      <TextLink
-        href="https://grafana.com/docs/mimir/latest/configure/configure-native-histograms-ingestion/#configure-native-histograms-globally"
-        external
-      >
-        Mimir
-      </TextLink>
-    );
-  }
 
   return (
     <div className={styles.container}>
@@ -92,23 +51,6 @@ export function ServiceGraphSettings({ options, onOptionsChange }: Props) {
             Clear
           </Button>
         ) : null}
-      </InlineFieldRow>
-      <InlineFieldRow className={styles.row}>
-        {/* TODO: Remove this in favor of automatic detection of native histograms https://github.com/grafana/grafana/issues/109709 */}
-        <InlineField tooltip={nativeHistogramDocs} label="Histogram type" labelWidth={26} interactive={true}>
-          <Combobox
-            id="histogram-type-select"
-            value={options.jsonData.serviceMap?.histogramType || 'classic'}
-            width={40}
-            options={histogramOptions}
-            onChange={(value) =>
-              updateDatasourcePluginJsonDataOption({ onOptionsChange, options }, 'serviceMap', {
-                ...options.jsonData.serviceMap,
-                histogramType: value.value,
-              })
-            }
-          />
-        </InlineField>
       </InlineFieldRow>
     </div>
   );

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -114,7 +114,6 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
     datasourceUid?: string;
-    histogramType?: 'classic' | 'native' | 'both';
   };
   search?: {
     hide?: boolean;

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -7,7 +7,6 @@ export interface TempoJsonData extends DataSourceJsonData {
   tracesToLogs?: TraceToLogsOptions;
   serviceMap?: {
     datasourceUid?: string;
-    histogramType?: 'classic' | 'native' | 'both';
   };
   search?: {
     hide?: boolean;


### PR DESCRIPTION
## What is this?

Fixes https://github.com/grafana/grafana/issues/109709

This is a fix to remove an experimental config option for Tempo data source where a user configures the Service map to use native histograms, classic histograms or both. [This was the original PR](https://github.com/grafana/grafana/pull/105989)

## Why is it removed?

We now have automatic detection of native histograms so users do not have to configure something. If their Tempo instance generates native histograms, they get them in the [service graph automatically from this PR](https://github.com/grafana/grafana/pull/108394).

## Changes Made

### Removed Config Option Components
- **ServiceGraphSettings.tsx** - Removed Combobox for histogram type selection
- **types.ts** - Removed `histogramType` field from `TempoJsonData.serviceMap`
- **Configuration UI** - Simplified to show only datasource picker

### Preserved Core Native Histogram Functionality
- **`serviceMapUseNativeHistograms` field** - Maintained in `TempoQuery` type (types.ts:33)
- **Automatic detection** - `getNativeHistograms()` method remains in datasource.ts
- **Query logic** - Native histogram flag checking preserved (datasource.ts:589-591)
- **Native histogram metrics** - Constants and metric definitions maintained in graphTransform.ts
- **Test coverage** - All native histogram tests remain functional

### Automatic Migration Logic Preserved
The QueryField.tsx component (lines 61-88) continues to handle automatic detection:
- Calls `getNativeHistograms()` to detect Prometheus support
- Sets `serviceMapUseNativeHistograms` automatically based on detection
- Handles migration from undefined to detected value

## Benefits

- **Improved UX** - Users no longer need to understand technical histogram differences
- **Automatic optimization** - System uses the best available histogram type
- **Backward compatibility** - Existing queries continue to work seamlessly
- **Reduced configuration complexity** - One less setting for users to manage

**Special notes for your reviewer:**
The Tempo data source in devenv is still configured to produce native histograms. [This check was tested in this PR](https://github.com/grafana/grafana/pull/108394). For reviewing this, the tests should pass and the config section should no longer have the option to select native histograms.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
