### PR TITLE
ExtensionSidebar: add min-width/initial-width support

### DIFF
--- a/e2e-playwright/test-plugins/grafana-extensionstest-app/plugins/grafana-extensionexample2-app/module.tsx
+++ b/e2e-playwright/test-plugins/grafana-extensionstest-app/plugins/grafana-extensionexample2-app/module.tsx
@@ -11,6 +11,7 @@ export const plugin = new AppPlugin<{}>()
     targets: 'plugins/grafana-extensionstest-app/addComponent/v1',
     title: 'Added component from B',
     description: 'A component that can be reused by other app plugins. Shared using addComponent api',
+    minWidth: 400, // Set minimum width to 400px for sidebar extensions
     component: ({ name }: { name: string }) => (
       <div data-testid={testIds.appB.reusableAddedComponent}>Hello {name}!</div>
     ),

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2040,21 +2040,6 @@
       "count": 2
     }
   },
-  "public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroupCondition.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingGroupVisibility.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "public/app/features/dashboard-scene/conditional-rendering/ConditionalRenderingTimeRangeSize.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -126,6 +126,8 @@ export type ExtensionInfo = {
   targets: string | string[];
   title: string;
   description?: string;
+  minWidth?: number | string;
+  initialWidth?: number | string;
 };
 
 export interface PluginExtensions {

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -85,6 +85,19 @@ export type PluginExtensionAddedComponentConfig<Props = {}> = PluginExtensionCon
    * The React component that will added to the target extension points
    */
   component: React.ComponentType<Props>;
+
+  /**
+   * Minimum width for the sidebar when this component is active (only applies to sidebar extension points)
+   * Can be a number (pixels) or a CSS width string (e.g., "320px", "20rem")
+   */
+  minWidth?: number | string;
+
+  /**
+   * Initial width for the sidebar when this component is first opened (only applies to sidebar extension points)
+   * Can be a number (pixels) or a CSS width string (e.g., "400px", "25rem")
+   * If not specified, uses the stored width from localStorage or the global default
+   */
+  initialWidth?: number | string;
 };
 export type PluginExtensionAddedFunctionConfig<Signature = unknown> = PluginExtensionConfigBase & {
   /**

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -15,11 +15,7 @@ import { ScopesDashboards } from 'app/features/scopes/dashboards/ScopesDashboard
 
 import { AppChromeMenu } from './AppChromeMenu';
 import { AppChromeService, DOCKED_LOCAL_STORAGE_KEY } from './AppChromeService';
-import {
-  ExtensionSidebar,
-  MAX_EXTENSION_SIDEBAR_WIDTH,
-  MIN_EXTENSION_SIDEBAR_WIDTH,
-} from './ExtensionSidebar/ExtensionSidebar';
+import { ExtensionSidebar, MAX_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar/ExtensionSidebar';
 import { useExtensionSidebarContext } from './ExtensionSidebar/ExtensionSidebarProvider';
 import { MegaMenu, MENU_WIDTH } from './MegaMenu/MegaMenu';
 import { useMegaMenuFocusHelper } from './MegaMenu/utils';
@@ -35,6 +31,8 @@ export function AppChrome({ children }: Props) {
     isOpen: isExtensionSidebarOpen,
     extensionSidebarWidth,
     setExtensionSidebarWidth,
+    currentComponentMinWidth,
+    currentComponentInitialWidth,
   } = useExtensionSidebarContext();
   const state = chrome.useState();
   const scopes = useScopes();
@@ -140,11 +138,11 @@ export function AppChrome({ children }: Props) {
           {!state.chromeless && isExtensionSidebarOpen && (
             <Resizable
               className={styles.sidebarContainer}
-              defaultSize={{ width: extensionSidebarWidth }}
+              defaultSize={{ width: currentComponentInitialWidth }}
               enable={{ left: true }}
               onResize={(_evt, _direction, ref) => setExtensionSidebarWidth(ref.getBoundingClientRect().width)}
               handleClasses={{ left: dragStyles.dragHandleBaseVertical }}
-              minWidth={MIN_EXTENSION_SIDEBAR_WIDTH}
+              minWidth={currentComponentMinWidth}
               maxWidth={MAX_EXTENSION_SIDEBAR_WIDTH}
             >
               <ExtensionSidebar />

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.test.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.test.tsx
@@ -5,7 +5,7 @@ import { config, usePluginComponents } from '@grafana/runtime';
 import { AddedComponentRegistryItem } from 'app/features/plugins/extensions/registry/AddedComponentsRegistry';
 import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 
-import { ExtensionSidebar } from './ExtensionSidebar';
+import { ExtensionSidebar, MIN_EXTENSION_SIDEBAR_WIDTH, DEFAULT_EXTENSION_SIDEBAR_WIDTH } from './ExtensionSidebar';
 import {
   ExtensionSidebarContextType,
   getComponentIdFromComponentMeta,
@@ -50,6 +50,8 @@ const extensionSidebarContextMock: ExtensionSidebarContextType = {
   availableComponents: new Map(),
   extensionSidebarWidth: 300,
   setExtensionSidebarWidth: jest.fn(),
+  currentComponentMinWidth: MIN_EXTENSION_SIDEBAR_WIDTH,
+  currentComponentInitialWidth: DEFAULT_EXTENSION_SIDEBAR_WIDTH,
 };
 
 const addedComponentRegistryItemMock: AddedComponentRegistryItem = {

--- a/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedComponentsRegistry.ts
@@ -15,6 +15,8 @@ export type AddedComponentRegistryItem<Props = {}> = {
   title: string;
   description?: string;
   component: React.ComponentType<Props>;
+  minWidth?: number | string;
+  initialWidth?: number | string;
 };
 
 export class AddedComponentsRegistry extends Registry<
@@ -70,6 +72,8 @@ export class AddedComponentsRegistry extends Registry<
           }),
           description: config.description,
           title: config.title,
+          minWidth: config.minWidth,
+          initialWidth: config.initialWidth,
         };
 
         pointIdLog.debug('Added component extension successfully registered');


### PR DESCRIPTION
**What is this feature?**

This PR adds an way to set min and initial width to the extension sidebar.

**Why do we need this feature?**

While using Assistant, there are some user requests that legitimately ask for such support, which we can hack directly from Assistant app, but we think it should be fixed directly from the extension sidebar support. 

Some requests that created the demand for this PR:

- [Slack message](https://raintank-corp.slack.com/archives/C08GW7KDCJ0/p1756923108118859) 
- [GH Issue](https://github.com/grafana/grafana-assistant-app/issues/1268) 

**Who is this feature for?**

The assistant app has some immediate requests, but it for sure impacts the future of extension sidebar customization.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-assistant-app/issues/1268
