### PR TITLE
Provisioning: Allow disabling controllers

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -211,7 +211,7 @@ func RegisterAPIService(
 	}
 
 	builder := NewAPIBuilder(
-		false, // Run controllers
+		cfg.ProvisioningDisableControllers,
 		repoFactory,
 		features,
 		client,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -132,15 +132,16 @@ type Cfg struct {
 	HomePath                   string
 	ProvisioningPath           string
 	PermittedProvisioningPaths []string
-	// Job History Configuration
-	ProvisioningLokiURL      string
-	ProvisioningLokiUser     string
-	ProvisioningLokiPassword string
-	ProvisioningLokiTenantID string
-	DataPath                 string
-	LogsPath                 string
-	PluginsPath              string
-	EnterpriseLicensePath    string
+	// Provisioning config
+	ProvisioningDisableControllers bool
+	ProvisioningLokiURL            string
+	ProvisioningLokiUser           string
+	ProvisioningLokiPassword       string
+	ProvisioningLokiTenantID       string
+	DataPath                       string
+	LogsPath                       string
+	PluginsPath                    string
+	EnterpriseLicensePath          string
 
 	// SMTP email settings
 	Smtp SmtpSettings
@@ -2102,6 +2103,8 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 			cfg.PermittedProvisioningPaths[i] = makeAbsolute(s, cfg.HomePath)
 		}
 	}
+
+	cfg.ProvisioningDisableControllers = iniFile.Section("provisioning").Key("disable_controllers").MustBool(false)
 
 	// Read job history configuration
 	cfg.ProvisioningLokiURL = valueAsString(iniFile.Section("provisioning"), "loki_url", "")


### PR DESCRIPTION
**What is this feature?**

This PR allows us to disable controllers for provisioning, in case the controllers are being run external to grafana itself:
```
[provisioning]
disable_controllers = true
```


**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/git-ui-sync-project/issues/512
