### PR TITLE
Provisioning: Build unified storage client for operators

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -8,11 +8,14 @@ import (
 	"time"
 
 	"github.com/grafana/authlib/authn"
+	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/transport"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	authrt "github.com/grafana/grafana/apps/provisioning/pkg/auth"
@@ -20,6 +23,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/github"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository/local"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	secretdecrypt "github.com/grafana/grafana/pkg/registry/apis/secret/decrypt"
 )
 
@@ -28,6 +32,7 @@ type provisioningControllerConfig struct {
 	provisioningClient *client.Clientset
 	resyncInterval     time.Duration
 	repoFactory        repository.Factory
+	unified            resources.ResourceStore
 }
 
 // expects:
@@ -40,6 +45,10 @@ type provisioningControllerConfig struct {
 // grpc_server_use_tls =
 // grpc_server_tls_ca_file =
 // grpc_server_tls_skip_verify =
+// [unified_storage]
+// grpc_address =
+// grpc_index_address =
+// allow_insecure =
 // [operator]
 // provisioning_server_url =
 // tls_insecure =
@@ -115,9 +124,24 @@ func setupFromConfig(cfg *setting.Cfg) (controllerCfg *provisioningControllerCon
 		return nil, fmt.Errorf("failed to setup repository getter: %w", err)
 	}
 
+	// HACK: This logic directly connects to unified storage. We are doing this for now as there is no global
+	// search endpoint. But controllers, in general, should not connect directly to unified storage and instead
+	// go through the api server. Once there is a global search endpoint, we will switch to that here as well.
+	resourceClientCfg := resource.RemoteResourceClientConfig{
+		Token:            token,
+		TokenExchangeURL: tokenExchangeURL,
+		Audiences:        gRPCAuth.Key("audiences").Strings("|"),
+		Namespace:        gRPCAuth.Key("token_namespace").String(),
+	}
+	unified, err := setupUnifiedStorageClient(cfg, tracer, resourceClientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup unified storage: %w", err)
+	}
+
 	return &provisioningControllerConfig{
 		provisioningClient: provisioningClient,
 		repoFactory:        repoFactory,
+		unified:            unified,
 		resyncInterval:     operatorSec.Key("resync_interval").MustDuration(60 * time.Second),
 	}, nil
 }
@@ -237,4 +261,40 @@ func setupDecrypter(cfg *setting.Cfg, tracer tracing.Tracer, tokenExchangeClient
 	}
 
 	return repository.ProvideDecrypter(decryptSvc), nil
+}
+
+// HACK: This logic directly connects to unified storage. We are doing this for now as there is no global
+// search endpoint. But controllers, in general, should not connect directly to unified storage and instead
+// go through the api server. Once there is a global search endpoint, we will switch to that here as well.
+func setupUnifiedStorageClient(cfg *setting.Cfg, tracer tracing.Tracer, resourceClientCfg resource.RemoteResourceClientConfig) (resources.ResourceStore, error) {
+	unifiedStorageSec := cfg.SectionWithEnvOverrides("unified_storage")
+	// Connect to Server
+	address := unifiedStorageSec.Key("grpc_address").String()
+	if address == "" {
+		return nil, fmt.Errorf("grpc_address is required in [unified_storage] section")
+	}
+	registry := prometheus.NewPedanticRegistry()
+	conn, err := unified.GrpcConn(address, registry)
+	if err != nil {
+		return nil, fmt.Errorf("create unified storage gRPC connection: %w", err)
+	}
+
+	// Connect to Index
+	indexAddress := unifiedStorageSec.Key("grpc_index_address").String()
+	if indexAddress == "" {
+		indexAddress = address
+	}
+	indexConn, err := unified.GrpcConn(indexAddress, registry)
+	if err != nil {
+		return nil, fmt.Errorf("create unified storage index gRPC connection: %w", err)
+	}
+
+	// Create client
+	resourceClientCfg.AllowInsecure = unifiedStorageSec.Key("allow_insecure").MustBool(false)
+	client, err := resource.NewRemoteResourceClient(tracer, conn, indexConn, resourceClientCfg)
+	if err != nil {
+		return nil, fmt.Errorf("create unified storage client: %w", err)
+	}
+
+	return client, nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Build unified storage client in config to be used across operators.
- Testing ticker to count managed objects

**Why do we need this feature?**

We need unified storage client to search for managed objects in repository and jobs controllers.

**Who is this feature for?**

Users of Git Sync / Provisioning.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes <https://github.com/grafana/git-ui-sync-project/issues/525>

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Testing Notes**

- ini config
```
[unified_storage]
grpc_address = "localhost:1000"
grpc_index_address = "localhost:1000"
allow_insecure = true
audiences = resourceStore

```
- output logs
```
{"time":"2025-09-05T12:24:20.592787+02:00","level":"INFO","msg":"starting periodic managed resource lister","logger":"provisioning-job-controller","interval":"5m0s"}
{"time":"2025-09-05T12:24:20.627031+02:00","level":"INFO","msg":"no managed objects found","logger":"provisioning-job-controller"}
```