### PR TITLE
unified-storage search: return results matching all search terms

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1072,16 +1072,18 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 		// Query 1: Match the exact query string
 		queryExact := bleve.NewMatchQuery(req.Query)
 		queryExact.SetBoost(10.0)
-		queryExact.Analyzer = keyword.Name // don't analyze the query input - treat it as a single token
+		queryExact.Analyzer = keyword.Name                // don't analyze the query input - treat it as a single token
+		queryExact.Operator = query.MatchQueryOperatorAnd // This doesn't make a difference for keyword analyzer, we add it just to be explicit.
 
 		// Query 2: Phrase query with standard analyzer
 		queryPhrase := bleve.NewMatchPhraseQuery(req.Query)
-		queryExact.SetBoost(5.0)
+		queryPhrase.SetBoost(5.0)
 		queryPhrase.Analyzer = standard.Name
 
 		// Query 3: Match query with standard analyzer
 		queryAnalyzed := bleve.NewMatchQuery(req.Query)
 		queryAnalyzed.Analyzer = standard.Name
+		queryAnalyzed.Operator = query.MatchQueryOperatorAnd // Make sure all terms from the query are matched
 
 		// At least one of the queries must match
 		searchQuery := bleve.NewDisjunctionQuery(queryExact, queryAnalyzed, queryPhrase)

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -87,7 +87,17 @@ func TestCanSearchByTitle(t *testing.T) {
 			"name2": "New dashboard 10",
 		})
 
-		checkSearchQuery(t, index, newTestQuery("New dash"), []string{"name2", "name1"})
+		checkSearchQuery(t, index, newTestQuery("dashboard"), []string{"name2", "name1"})
+	})
+
+	t.Run("all terms must match", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "Dashboard",
+			"name2": "New dashboard 10",
+		})
+
+		checkSearchQuery(t, index, newTestQuery("dashboard new"), []string{"name2"})
 	})
 
 	t.Run("will boost exact match query over match phrase query results", func(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -22,8 +22,7 @@ import (
 const threshold = 9999
 
 func indexDocumentsWithTitles(t *testing.T, index resource.ResourceIndex, key resource.NamespacedResource, docsWithTitles map[string]string) {
-	var result []*resource.BulkIndexItem
-
+	result := make([]*resource.BulkIndexItem, 0, len(docsWithTitles))
 	for name, title := range docsWithTitles {
 		result = append(result, &resource.BulkIndexItem{
 			Action: resource.ActionIndex,

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -22,9 +22,9 @@ import (
 const threshold = 9999
 
 func indexDocumentsWithTitles(t *testing.T, index resource.ResourceIndex, key resource.NamespacedResource, docsWithTitles map[string]string) {
-	result := make([]*resource.BulkIndexItem, 0, len(docsWithTitles))
+	items := make([]*resource.BulkIndexItem, 0, len(docsWithTitles))
 	for name, title := range docsWithTitles {
-		result = append(result, &resource.BulkIndexItem{
+		items = append(items, &resource.BulkIndexItem{
 			Action: resource.ActionIndex,
 			Doc: &resource.IndexableDocument{
 				RV:   1,
@@ -39,7 +39,7 @@ func indexDocumentsWithTitles(t *testing.T, index resource.ResourceIndex, key re
 			},
 		})
 	}
-	req := &resource.BulkIndexRequest{Items: result}
+	req := &resource.BulkIndexRequest{Items: items}
 	require.NoError(t, index.BulkIndex(req))
 }
 


### PR DESCRIPTION
When multiple search terms are provided, they must all be matched.

For reviewers: I suggest reviewing individual commits. First two commits are only refactor of the tests, without changing any behaviour. Only the last commit implements the change.