### PR TITLE
Provisioning: Fix bug in config reading

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -282,7 +282,7 @@ func setupUnifiedStorageClient(cfg *setting.Cfg, tracer tracing.Tracer, resource
 	// Connect to Index
 	indexConn := conn
 	indexAddress := unifiedStorageSec.Key("grpc_index_address").String()
-	if indexAddress == "" {
+	if indexAddress != "" {
 		indexConn, err = unified.GrpcConn(indexAddress, registry)
 		if err != nil {
 			return nil, fmt.Errorf("create unified storage index gRPC connection: %w", err)


### PR DESCRIPTION
Follow up to https://github.com/grafana/grafana/pull/110671

We should only use a separate address if it is specified