### PR TITLE
chore(rbac): Remove settings resources mappings

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -125,9 +125,6 @@ func NewMapperRegistry() MapperRegistry {
 			"securevalues": newResourceTranslation("secret.securevalues", "uid", false),
 			"keepers":      newResourceTranslation("secret.keepers", "uid", false),
 		},
-		"settings.grafana.app": {
-			"settings": newResourceTranslation("settings", "uid", false),
-		},
 		"query.grafana.app": {
 			"query": translation{
 				resource:  "datasources",


### PR DESCRIPTION
Removing settings service resources from authz rbac mapper as they're no longer required.

Originally added on https://github.com/grafana/grafana/pull/109742