### PR TITLE
Unified Storage: Add sort order to keys func in datastore

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -106,6 +106,7 @@ type ListRequestKey struct {
 	Group     string
 	Resource  string
 	Name      string
+	Sort      SortOrder
 }
 
 func (k ListRequestKey) Validate() error {
@@ -182,7 +183,7 @@ const (
 )
 
 // Keys returns all keys for a given key by iterating through the KV store
-func (d *dataStore) Keys(ctx context.Context, key ListRequestKey, sort SortOrder) iter.Seq2[DataKey, error] {
+func (d *dataStore) Keys(ctx context.Context, key ListRequestKey) iter.Seq2[DataKey, error] {
 	if err := key.Validate(); err != nil {
 		return func(yield func(DataKey, error) bool) {
 			yield(DataKey{}, err)
@@ -194,7 +195,7 @@ func (d *dataStore) Keys(ctx context.Context, key ListRequestKey, sort SortOrder
 		for k, err := range d.kv.Keys(ctx, dataSection, ListOptions{
 			StartKey: prefix,
 			EndKey:   PrefixRangeEnd(prefix),
-			Sort:     sort,
+			Sort:     key.Sort,
 		}) {
 			if err != nil {
 				yield(DataKey{}, err)

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -182,7 +182,7 @@ const (
 )
 
 // Keys returns all keys for a given key by iterating through the KV store
-func (d *dataStore) Keys(ctx context.Context, key ListRequestKey) iter.Seq2[DataKey, error] {
+func (d *dataStore) Keys(ctx context.Context, key ListRequestKey, sort SortOrder) iter.Seq2[DataKey, error] {
 	if err := key.Validate(); err != nil {
 		return func(yield func(DataKey, error) bool) {
 			yield(DataKey{}, err)
@@ -194,6 +194,7 @@ func (d *dataStore) Keys(ctx context.Context, key ListRequestKey) iter.Seq2[Data
 		for k, err := range d.kv.Keys(ctx, dataSection, ListOptions{
 			StartKey: prefix,
 			EndKey:   PrefixRangeEnd(prefix),
+			Sort:     sort,
 		}) {
 			if err != nil {
 				yield(DataKey{}, err)

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -656,7 +656,7 @@ func TestDataStore_List(t *testing.T) {
 
 		// List the data
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, resourceKey) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -690,7 +690,7 @@ func TestDataStore_List(t *testing.T) {
 		}
 
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, emptyResourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, emptyResourceKey) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -724,7 +724,7 @@ func TestDataStore_List(t *testing.T) {
 
 		// List should include deleted keys
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, deletedResourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, deletedResourceKey) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -778,7 +778,7 @@ func TestDataStore_Integration(t *testing.T) {
 
 		// List all versions
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, resourceKey) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -804,7 +804,7 @@ func TestDataStore_Integration(t *testing.T) {
 
 		// List should now have 2 items
 		results = nil
-		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, resourceKey) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -882,7 +882,7 @@ func TestDataStore_Keys(t *testing.T) {
 
 		// Get keys
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, resourceKey) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -911,7 +911,7 @@ func TestDataStore_Keys(t *testing.T) {
 		}
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, emptyResourceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, emptyResourceKey) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -942,7 +942,7 @@ func TestDataStore_Keys(t *testing.T) {
 		require.NoError(t, err)
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, partialKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, partialKey) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -975,7 +975,7 @@ func TestDataStore_Keys(t *testing.T) {
 		require.NoError(t, err)
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, namespaceOnlyKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, namespaceOnlyKey) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -998,7 +998,7 @@ func TestDataStore_Keys(t *testing.T) {
 
 		var keys []DataKey
 		var hasError bool
-		for key, err := range ds.Keys(ctx, emptyNamespaceKey, SortOrderAsc) {
+		for key, err := range ds.Keys(ctx, emptyNamespaceKey) {
 			if err != nil {
 				hasError = true
 				require.Error(t, err)

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -656,7 +656,7 @@ func TestDataStore_List(t *testing.T) {
 
 		// List the data
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey) {
+		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -690,7 +690,7 @@ func TestDataStore_List(t *testing.T) {
 		}
 
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, emptyResourceKey) {
+		for key, err := range ds.Keys(ctx, emptyResourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -724,7 +724,7 @@ func TestDataStore_List(t *testing.T) {
 
 		// List should include deleted keys
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, deletedResourceKey) {
+		for key, err := range ds.Keys(ctx, deletedResourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -778,7 +778,7 @@ func TestDataStore_Integration(t *testing.T) {
 
 		// List all versions
 		var results []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey) {
+		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -804,7 +804,7 @@ func TestDataStore_Integration(t *testing.T) {
 
 		// List should now have 2 items
 		results = nil
-		for key, err := range ds.Keys(ctx, resourceKey) {
+		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			results = append(results, key)
 		}
@@ -882,7 +882,7 @@ func TestDataStore_Keys(t *testing.T) {
 
 		// Get keys
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, resourceKey) {
+		for key, err := range ds.Keys(ctx, resourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -911,7 +911,7 @@ func TestDataStore_Keys(t *testing.T) {
 		}
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, emptyResourceKey) {
+		for key, err := range ds.Keys(ctx, emptyResourceKey, SortOrderAsc) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -942,7 +942,7 @@ func TestDataStore_Keys(t *testing.T) {
 		require.NoError(t, err)
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, partialKey) {
+		for key, err := range ds.Keys(ctx, partialKey, SortOrderAsc) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -975,7 +975,7 @@ func TestDataStore_Keys(t *testing.T) {
 		require.NoError(t, err)
 
 		var keys []DataKey
-		for key, err := range ds.Keys(ctx, namespaceOnlyKey) {
+		for key, err := range ds.Keys(ctx, namespaceOnlyKey, SortOrderAsc) {
 			require.NoError(t, err)
 			keys = append(keys, key)
 		}
@@ -998,7 +998,7 @@ func TestDataStore_Keys(t *testing.T) {
 
 		var keys []DataKey
 		var hasError bool
-		for key, err := range ds.Keys(ctx, emptyNamespaceKey) {
+		for key, err := range ds.Keys(ctx, emptyNamespaceKey, SortOrderAsc) {
 			if err != nil {
 				hasError = true
 				require.Error(t, err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -85,9 +85,16 @@ func (k *kvStorageBackend) pruneEvents(ctx context.Context, key PruningKey) erro
 		return fmt.Errorf("invalid pruning key, all fields must be set: %+v", key)
 	}
 
+	listKey := ListRequestKey{
+		Namespace: key.Namespace,
+		Group:     key.Group,
+		Resource:  key.Resource,
+		Name:      key.Name,
+		Sort:      SortOrderDesc,
+	}
 	counter := 0
 	// iterate over all keys for the resource and delete versions beyond the latest 20
-	for datakey, err := range k.dataStore.Keys(ctx, ListRequestKey(key), SortOrderDesc) {
+	for datakey, err := range k.dataStore.Keys(ctx, listKey) {
 		if err != nil {
 			return err
 		}
@@ -605,7 +612,7 @@ func (k *kvStorageBackend) listModifiedSinceDataStore(ctx context.Context, key N
 	return func(yield func(*ModifiedResource, error) bool) {
 		var lastSeenResource *ModifiedResource
 		var lastSeenDataKey DataKey
-		for dataKey, err := range k.dataStore.Keys(ctx, ListRequestKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource}, SortOrderAsc) {
+		for dataKey, err := range k.dataStore.Keys(ctx, ListRequestKey{Namespace: key.Namespace, Group: key.Group, Resource: key.Resource}) {
 			if err != nil {
 				yield(&ModifiedResource{}, err)
 				return
@@ -759,7 +766,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		Group:     key.Group,
 		Resource:  key.Resource,
 		Name:      key.Name,
-	}, SortOrderAsc) {
+	}) {
 		if err != nil {
 			return 0, err
 		}
@@ -1038,7 +1045,7 @@ func (k *kvStorageBackend) GetResourceStats(ctx context.Context, namespace strin
 	rvs := make(map[string]int64)
 
 	// Use datastore.Keys to get all data keys for the namespace
-	for dataKey, err := range k.dataStore.Keys(ctx, ListRequestKey{Namespace: namespace}, SortOrderAsc) {
+	for dataKey, err := range k.dataStore.Keys(ctx, ListRequestKey{Namespace: namespace}) {
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1258,7 +1258,8 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			Group:     "apps",
 			Resource:  "resources",
 			Name:      "test-resource",
-		}, SortOrderDesc) {
+			Sort:      SortOrderDesc,
+		}) {
 			require.NoError(t, err)
 			require.NotEqual(t, rv1, datakey.ResourceVersion)
 			counter++
@@ -1324,7 +1325,8 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			Group:     "apps",
 			Resource:  "resources",
 			Name:      "test-resource",
-		}, SortOrderDesc) {
+			Sort:      SortOrderDesc,
+		}) {
 			require.NoError(t, err)
 			counter++
 		}
@@ -1391,7 +1393,8 @@ func TestKvStorageBackend_PruneEvents(t *testing.T) {
 			Group:     "apps",
 			Resource:  "resources",
 			Name:      "test-resource",
-		}, SortOrderDesc) {
+			Sort:      SortOrderDesc,
+		}) {
 			require.NoError(t, err)
 			counter++
 		}


### PR DESCRIPTION
1. Passes sort order to Keys() so we can get RV in desc order. Uses that to simplify pruner logic.
2. Ensures pruner doesn't prune deleted events (should never happen since we keep 20 events, but wanted to add this just in case).

fixes https://github.com/grafana/hyperion-planning/issues/414