### PR TITLE
Alerting: Ensure failed query validation returns the proper error code

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -642,7 +642,7 @@ func (alertRule *AlertRule) PreSave(timeNow func() time.Time, userUID *UserUID) 
 	for i, q := range alertRule.Data {
 		err := q.PreSave()
 		if err != nil {
-			return fmt.Errorf("invalid alert query %s: %w", q.RefID, err)
+			return errors.Join(ErrAlertRuleFailedValidation, fmt.Errorf("invalid alert query %s: %w", q.RefID, err))
 		}
 		alertRule.Data[i] = q
 	}


### PR DESCRIPTION
**Why do we need this feature?**

Currently a rule failing pre-save returns a 500 error instead of the more appropriate error that's already returned when an `ErrAlertRuleFailedValidation` error is passed up through the call stack. This PR ensures `PreSave` returns an error of this type if a query fails to validate, which should result in a 400 error being returned to the client.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
