### PR TITLE
Alerting: Fix field names on webhook HMAC/TLS config HCL export

### DIFF
--- a/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/redacted/all-integrations.hcl
@@ -261,14 +261,14 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     title                   = "test-title"
     message                 = "test-message"
 
-    tlsConfig {
+    tls_config {
       insecure_skip_verify = false
       ca_certificate       = "[REDACTED]"
       client_certificate   = "[REDACTED]"
       client_key           = "[REDACTED]"
     }
 
-    hmacConfig {
+    hmac_config {
       secret           = "[REDACTED]"
       header           = "X-Grafana-Alerting-Signature"
       timestamp_header = "X-Grafana-Alerting-Timestamp"

--- a/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
+++ b/pkg/services/ngalert/api/test-data/receiver-exports/unredacted/all-integrations.hcl
@@ -240,14 +240,14 @@ resource "grafana_contact_point" "contact_point_2b661702215368fe" {
     title                = "test-title"
     message              = "test-message"
 
-    tlsConfig {
+    tls_config {
       insecure_skip_verify = false
       ca_certificate       = "-----BEGIN CERTIFICATE-----\nMIGrMF+gAwIBAgIBATAFBgMrZXAwADAeFw0yNDExMTYxMDI4MzNaFw0yNTExMTYx\nMDI4MzNaMAAwKjAFBgMrZXADIQCf30GvRnHbs9gukA3DLXDK6W5JVgYw6mERU/60\n2M8+rjAFBgMrZXADQQCGmeaRp/AcjeqmJrF5Yh4d7aqsMSqVZvfGNDc0ppXyUgS3\nWMQ1+3T+/pkhU612HR0vFd3vyFhmB4yqFoNV8RML\n-----END CERTIFICATE-----"
       client_certificate   = "-----BEGIN CERTIFICATE-----\nMIIBhTCCASugAwIBAgIQIRi6zePL6mKjOipn+dNuaTAKBggqhkjOPQQDAjASMRAw\nDgYDVQQKEwdBY21lIENvMB4XDTE3MTAyMDE5NDMwNloXDTE4MTAyMDE5NDMwNlow\nEjEQMA4GA1UEChMHQWNtZSBDbzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABD0d\n7VNhbWvZLWPuj/RtHFjvtJBEwOkhbN/BnnE8rnZR8+sbwnc/KhCk3FhnpHZnQz7B\n5aETbbIgmuvewdjvSBSjYzBhMA4GA1UdDwEB/wQEAwICpDATBgNVHSUEDDAKBggr\nBgEFBQcDATAPBgNVHRMBAf8EBTADAQH/MCkGA1UdEQQiMCCCDmxvY2FsaG9zdDo1\nNDUzgg4xMjcuMC4wLjE6NTQ1MzAKBggqhkjOPQQDAgNIADBFAiEA2zpJEPQyz6/l\nWf86aX6PepsntZv2GYlA5UpabfT2EZICICpJ5h/iI+i341gBmLiAFQOyTDT+/wQc\n6MF9+Yw1Yy0t\n-----END CERTIFICATE-----"
       client_key           = "-----BEGIN EC PRIVATE KEY-----\nMHcCAQEEIIrYSSNQFaA2Hwf1duRSxKtLYX5CB04fSeQ6tF1aY/PuoAoGCCqGSM49\nAwEHoUQDQgAEPR3tU2Fta9ktY+6P9G0cWO+0kETA6SFs38GecTyudlHz6xvCdz8q\nEKTcWGekdmdDPsHloRNtsiCa697B2O9IFA==\n-----END EC PRIVATE KEY-----"
     }
 
-    hmacConfig {
+    hmac_config {
       secret           = "test-hmac-secret"
       header           = "X-Grafana-Alerting-Signature"
       timestamp_header = "X-Grafana-Alerting-Timestamp"

--- a/pkg/services/ngalert/api/tooling/definitions/contact_points.go
+++ b/pkg/services/ngalert/api/tooling/definitions/contact_points.go
@@ -325,8 +325,8 @@ type WebhookIntegration struct {
 	ExtraHeaders             *map[string]string `json:"headers,omitempty" yaml:"headers,omitempty" hcl:"headers"`
 	Title                    *string            `json:"title,omitempty" yaml:"title,omitempty" hcl:"title"`
 	Message                  *string            `json:"message,omitempty" yaml:"message,omitempty" hcl:"message"`
-	TLSConfig                *TLSConfig         `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty" hcl:"tlsConfig,block"`
-	HMACConfig               *HMACConfig        `json:"hmacConfig,omitempty" yaml:"hmacConfig,omitempty" hcl:"hmacConfig,block"`
+	TLSConfig                *TLSConfig         `json:"tlsConfig,omitempty" yaml:"tlsConfig,omitempty" hcl:"tls_config,block"`
+	HMACConfig               *HMACConfig        `json:"hmacConfig,omitempty" yaml:"hmacConfig,omitempty" hcl:"hmac_config,block"`
 	HTTPConfig               *HTTPClientConfig  `json:"http_config,omitempty" yaml:"http_config,omitempty" hcl:"http_config,block"`
 
 	Payload *CustomPayload `json:"payload,omitempty" yaml:"payload,omitempty" hcl:"payload,block"`


### PR DESCRIPTION
`tlsConfig` -> `tls_config`
`hmacConfig` -> `hmac_config`

NOTE: `tls_config` export still does not match TF provider, as the provider currently treats `tls_config` as a schema-less map. Once this is improved, they will now match.
