### PR TITLE
Udate IAM Folder Reconciler Operator config

### DIFF
--- a/apps/iam/cmd/operator/config.go
+++ b/apps/iam/cmd/operator/config.go
@@ -109,7 +109,7 @@ func LoadConfigFromEnv() (*Config, error) {
 		cfg.KubeConfig = kubeConfig
 	}
 
-	cfg.ZanzanaClient.Address = os.Getenv("ZANZANA_ADDR")
+	cfg.ZanzanaClient.URL = os.Getenv("ZANZANA_ADDR")
 	cfg.ZanzanaClient.Token = os.Getenv("ZANZANA_TOKEN")
 	cfg.ZanzanaClient.TokenExchangeURL = os.Getenv("TOKEN_EXCHANGE_URL")
 	cfg.ZanzanaClient.ServerCertFile = os.Getenv("ZANZANA_SERVER_CERT_FILE")

--- a/go.mod
+++ b/go.mod
@@ -98,7 +98,6 @@ require (
 	github.com/grafana/grafana-api-golang-client v0.27.0 // @grafana/alerting-backend
 	github.com/grafana/grafana-app-sdk v0.40.3 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-app-sdk/logging v0.40.3 // @grafana/grafana-app-platform-squad
-	github.com/grafana/grafana-app-sdk/plugin v0.40.3 // @grafana/grafana-app-platform-squad
 	github.com/grafana/grafana-aws-sdk v1.1.0 // @grafana/aws-datasources
 	github.com/grafana/grafana-azure-sdk-go/v2 v2.2.0 // @grafana/partner-datasources
 	github.com/grafana/grafana-cloud-migration-snapshot v1.9.0 // @grafana/grafana-operator-experience-squad

--- a/go.sum
+++ b/go.sum
@@ -1605,8 +1605,6 @@ github.com/grafana/grafana-app-sdk v0.40.3 h1:JFo7uAfbAJUfZ9neD7/4sODKm1xgu9zhck
 github.com/grafana/grafana-app-sdk v0.40.3/go.mod h1:j0KzHo3Sa6kd+lnwSScBNoV9Vobkg/YY9HtEjxpyPrk=
 github.com/grafana/grafana-app-sdk/logging v0.40.3 h1:2VXsXXEQiqAavRP8wusRDB6rDqf5lufP7A6NfjELqPE=
 github.com/grafana/grafana-app-sdk/logging v0.40.3/go.mod h1:otUD9XpJD7A5sCLb8mcs9hIXGdeV6lnhzVwe747g4RU=
-github.com/grafana/grafana-app-sdk/plugin v0.40.3 h1:uH0oFZnYOUL+OXcyhd5NVYwoM+Wa0WUXvZ2Om1M91r0=
-github.com/grafana/grafana-app-sdk/plugin v0.40.3/go.mod h1:+ylwE0P8WgPu5zURK5aDnVJpwRpuK3573rwrVV28qzQ=
 github.com/grafana/grafana-aws-sdk v1.1.0 h1:G0fvwbQmHw14c5RXPd7Gnw9ZQcgzl139LtMDoe0KhmE=
 github.com/grafana/grafana-aws-sdk v1.1.0/go.mod h1:7e+47EdHynteYWGoT5Ere9KeOXQObsk8F0vkOLQ1tz8=
 github.com/grafana/grafana-azure-sdk-go/v2 v2.2.0 h1:0TYrkzAc3u0HX+9GK86cGrLTUAcmQfl3/LEB3tL+SOA=

--- a/pkg/operators/iam/README.md
+++ b/pkg/operators/iam/README.md
@@ -2,11 +2,13 @@ To build the operator, simply run `make build-go`
 
 To run the folder reconciler, you need a `./conf/operator.ini` config file. For example:
 ```
-[iam_folder_reconciler]
-folder_app_url = https://host.docker.internal:6446
-folder_app_namespace = *
-zanzana_address = zanzana.default.svc.cluster.local:50051
+[grpc_client_authentication]
+token = IamFolderReconcilerToken
 token_exchange_url = http://host.docker.internal:8080/v1/sign-access-token
-token = ProvisioningAdminToken
+
+[operator]
+folder_app_url = https://host.docker.internal:6446
+zanzana_url = zanzana.default.svc.cluster.local:50051
+tls_insecure = true
 ```
 After that, you can run it using: `GF_DEFAULT_TARGET=operator GF_OPERATOR_NAME=iam-folder-reconciler ./bin/linux-arm64/grafana server target --config=conf/operator.ini`. Beware that you will also need a TokenExchanger, a Zanzana Server and a Folder app running for the operator to behave. 

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -45,7 +45,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features 
 		return NewZanzanaClient(
 			fmt.Sprintf("stacks-%s", cfg.StackID),
 			ZanzanaClientConfig{
-				Address:          cfg.ZanzanaClient.Addr,
+				URL:              cfg.ZanzanaClient.Addr,
 				Token:            cfg.ZanzanaClient.Token,
 				TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
 				ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
@@ -94,7 +94,7 @@ func ProvideZanzana(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features 
 }
 
 type ZanzanaClientConfig struct {
-	Address          string
+	URL              string
 	Token            string
 	TokenExchangeURL string
 	ServerCertFile   string
@@ -128,7 +128,7 @@ func NewZanzanaClient(namespace string, cfg ZanzanaClientConfig) (zanzana.Client
 		),
 	}
 
-	conn, err := grpc.NewClient(cfg.Address, dialOptions...)
+	conn, err := grpc.NewClient(cfg.URL, dialOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create zanzana client to remote server: %w", err)
 	}


### PR DESCRIPTION
Update operator config to follow other operator patterns. For example the [provisioning operator](https://github.com/grafana/grafana/blob/e3e0a1b8cab6f9fedeab0350cd2e565c0f7d4091/pkg/operators/provisioning/config.go#L68)

This allows us to deploy it using the operator tanka library.
