### PR TITLE
Unified Storage: Fix enterprise sort fields missing data

### DIFF
--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -148,8 +148,9 @@ export class UnifiedSearcher implements GrafanaSearcher {
       const field = first.fields.find((f) => f.name === meta.sortBy);
       if (field) {
         const name = getSortFieldDisplayName(field.name);
-        meta.sortBy = name;
-        field.name = name; // make it look nicer
+        // We don't want to directly change the field name, just the display name
+        // When the columns names get generated it uses getFieldDisplayName(), which will check if there is a field.config.displayName
+        field.config.displayName = name;
       }
     }
 


### PR DESCRIPTION
This fixes an issue where the enterprise sort fields would only be rendered for the first page of dashboard search results.

We were modifying the data frame field name to make the column name look nice, which broke things. This sets the display name instead of changing the field name.

**Before**
<img width="1641" height="990" alt="Screenshot 2025-09-05 at 5 28 32 PM" src="https://github.com/user-attachments/assets/3d7892e4-276e-4666-890a-88a11807c959" />

**After**

https://github.com/user-attachments/assets/af7db06c-23a8-4de9-86c7-4a6c196a2af8

