### PR TITLE
Chore: Remove unused bus.Bus events

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -122,6 +122,7 @@ type HTTPServer struct {
 	httpSrv          *http.Server
 	middlewares      []web.Handler
 	namedMiddlewares []routing.RegisterNamedMiddleware
+	bus              bus.Bus
 
 	pluginContextProvider        *plugincontext.Provider
 	RouteRegister                routing.RouteRegister
@@ -234,7 +235,7 @@ type ServerOptions struct {
 	Listener net.Listener
 }
 
-func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, _ bus.Bus,
+func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, bus bus.Bus,
 	renderService rendering.Service, licensing licensing.Licensing, hooksService *hooks.HooksService,
 	cacheService *localcache.CacheService, sqlStore db.DB,
 	dataSourceRequestValidator validations.DataSourceRequestValidator, pluginStaticRouteResolver plugins.StaticRouteResolver,
@@ -278,6 +279,7 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	hs := &HTTPServer{
 		Cfg:                          cfg,
 		RouteRegister:                routeRegister,
+		bus:                          bus,
 		RenderService:                renderService,
 		License:                      licensing,
 		HooksService:                 hooksService,

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -122,7 +122,6 @@ type HTTPServer struct {
 	httpSrv          *http.Server
 	middlewares      []web.Handler
 	namedMiddlewares []routing.RegisterNamedMiddleware
-	bus              bus.Bus
 
 	pluginContextProvider        *plugincontext.Provider
 	RouteRegister                routing.RouteRegister
@@ -235,7 +234,7 @@ type ServerOptions struct {
 	Listener net.Listener
 }
 
-func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, bus bus.Bus,
+func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routing.RouteRegister, _ bus.Bus,
 	renderService rendering.Service, licensing licensing.Licensing, hooksService *hooks.HooksService,
 	cacheService *localcache.CacheService, sqlStore db.DB,
 	dataSourceRequestValidator validations.DataSourceRequestValidator, pluginStaticRouteResolver plugins.StaticRouteResolver,
@@ -279,7 +278,6 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 	hs := &HTTPServer{
 		Cfg:                          cfg,
 		RouteRegister:                routeRegister,
-		bus:                          bus,
 		RenderService:                renderService,
 		License:                      licensing,
 		HooksService:                 hooksService,

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -7,26 +7,6 @@ import (
 // Events can be passed to external systems via for example AMQP
 // Treat these events as basically DTOs so changes has to be backward compatible
 
-type OrgCreated struct {
-	Timestamp time.Time `json:"timestamp"`
-	Id        int64     `json:"id"`
-	Name      string    `json:"name"`
-}
-
-type OrgUpdated struct {
-	Timestamp time.Time `json:"timestamp"`
-	Id        int64     `json:"id"`
-	Name      string    `json:"name"`
-}
-
-type UserCreated struct {
-	Timestamp time.Time `json:"timestamp"`
-	Id        int64     `json:"id"`
-	Name      string    `json:"name"`
-	Login     string    `json:"login"`
-	Email     string    `json:"email"`
-}
-
 type SignUpStarted struct {
 	Timestamp time.Time `json:"timestamp"`
 	Email     string    `json:"email"`
@@ -39,31 +19,7 @@ type SignUpCompleted struct {
 	Email     string    `json:"email"`
 }
 
-type UserUpdated struct {
-	Timestamp time.Time `json:"timestamp"`
-	Id        int64     `json:"id"`
-	Name      string    `json:"name"`
-	Login     string    `json:"login"`
-	Email     string    `json:"email"`
-}
-
 type DataSourceDeleted struct {
-	Timestamp time.Time `json:"timestamp"`
-	Name      string    `json:"name"`
-	ID        int64     `json:"id"`
-	UID       string    `json:"uid"`
-	OrgID     int64     `json:"org_id"`
-}
-
-type DataSourceSecretDeleted struct {
-	Timestamp time.Time `json:"timestamp"`
-	Name      string    `json:"name"`
-	ID        int64     `json:"id"`
-	UID       string    `json:"uid"`
-	OrgID     int64     `json:"org_id"`
-}
-
-type DataSourceCreated struct {
 	Timestamp time.Time `json:"timestamp"`
 	Name      string    `json:"name"`
 	ID        int64     `json:"id"`

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -300,14 +300,6 @@ func (ss *SqlStore) AddDataSource(ctx context.Context, cmd *datasources.AddDataS
 				return err
 			}
 		}
-
-		sess.PublishAfterCommit(&events.DataSourceCreated{
-			Timestamp: time.Now(),
-			Name:      cmd.Name,
-			ID:        ds.ID,
-			UID:       cmd.UID,
-			OrgID:     cmd.OrgID,
-		})
 		return nil
 	})
 }

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -109,33 +109,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 			_, err := ss.AddDataSource(context.Background(), &cmd)
 			require.ErrorContains(t, err, "invalid format of UID")
 		})
-
-		t.Run("fires an event when the datasource is added", func(t *testing.T) {
-			db := db.InitTestDB(t)
-			sqlStore := SqlStore{db: db}
-			var created *events.DataSourceCreated
-			db.Bus().AddEventListener(func(ctx context.Context, e *events.DataSourceCreated) error {
-				created = e
-				return nil
-			})
-
-			_, err := sqlStore.AddDataSource(context.Background(), &defaultAddDatasourceCommand)
-			require.NoError(t, err)
-
-			require.Eventually(t, func() bool {
-				return assert.NotNil(t, created)
-			}, time.Second, time.Millisecond)
-
-			query := datasources.GetDataSourcesQuery{OrgID: 10}
-			dataSources, err := sqlStore.GetDataSources(context.Background(), &query)
-			require.NoError(t, err)
-			require.Equal(t, 1, len(dataSources))
-
-			require.Equal(t, dataSources[0].ID, created.ID)
-			require.Equal(t, dataSources[0].UID, created.UID)
-			require.Equal(t, int64(10), created.OrgID)
-			require.Equal(t, "nisse", created.Name)
-		})
 	})
 
 	t.Run("UpdateDataSource", func(t *testing.T) {

--- a/pkg/services/org/orgimpl/store.go
+++ b/pkg/services/org/orgimpl/store.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -96,11 +95,6 @@ func (ss *sqlStore) Insert(ctx context.Context, orga *org.Org) (int64, error) {
 				return err
 			}
 		}
-		sess.PublishAfterCommit(&events.OrgCreated{
-			Timestamp: orga.Created,
-			Id:        orga.ID,
-			Name:      orga.Name,
-		})
 		return nil
 	})
 	if err != nil {
@@ -156,12 +150,6 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *org.UpdateOrgCommand) error
 			return org.ErrOrgNotFound.Errorf("failed to update organization with ID: %d", cmd.OrgId)
 		}
 
-		sess.PublishAfterCommit(&events.OrgUpdated{
-			Timestamp: orga.Updated,
-			Id:        orga.ID,
-			Name:      orga.Name,
-		})
-
 		return nil
 	})
 }
@@ -199,12 +187,6 @@ func (ss *sqlStore) UpdateAddress(ctx context.Context, cmd *org.UpdateOrgAddress
 		if _, err := sess.ID(cmd.OrgID).Update(&org); err != nil {
 			return err
 		}
-
-		sess.PublishAfterCommit(&events.OrgUpdated{
-			Timestamp: org.Updated,
-			Id:        org.ID,
-			Name:      org.Name,
-		})
 
 		return nil
 	})
@@ -344,12 +326,6 @@ func (ss *sqlStore) CreateWithMember(ctx context.Context, cmd *org.CreateOrgComm
 		}
 
 		_, err := sess.Insert(&user)
-
-		sess.PublishAfterCommit(&events.OrgCreated{
-			Timestamp: orga.Created,
-			Id:        orga.ID,
-			Name:      orga.Name,
-		})
 
 		return err
 	}); err != nil {

--- a/pkg/services/sqlstore/session.go
+++ b/pkg/services/sqlstore/session.go
@@ -31,10 +31,6 @@ type DBSession struct {
 
 type DBTransactionFunc func(sess *DBSession) error
 
-func (sess *DBSession) publishAfterCommit(msg any) {
-	sess.events = append(sess.events, msg)
-}
-
 func (sess *DBSession) PublishAfterCommit(msg any) {
 	sess.events = append(sess.events, msg)
 }

--- a/pkg/services/sqlstore/user.go
+++ b/pkg/services/sqlstore/user.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
@@ -99,14 +98,6 @@ func (ss *SQLStore) createUser(ctx context.Context, sess *DBSession, args user.C
 		return usr, err
 	}
 
-	sess.publishAfterCommit(&events.UserCreated{
-		Timestamp: usr.Created,
-		Id:        usr.ID,
-		Name:      usr.Name,
-		Login:     usr.Login,
-		Email:     usr.Email,
-	})
-
 	orgUser := org.OrgUser{
 		OrgID:   orgID,
 		UserID:  usr.ID,
@@ -182,12 +173,6 @@ func (ss *SQLStore) getOrCreateOrg(sess *DBSession, orgName string) (int64, erro
 			return 0, err
 		}
 	}
-
-	sess.publishAfterCommit(&events.OrgCreated{
-		Timestamp: org.Created,
-		Id:        org.ID,
-		Name:      org.Name,
-	})
 
 	return org.ID, nil
 }

--- a/pkg/services/user/userimpl/store.go
+++ b/pkg/services/user/userimpl/store.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/grafana/pkg/events"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -63,13 +62,6 @@ func (ss *sqlStore) Insert(ctx context.Context, cmd *user.User) (int64, error) {
 		if _, err = sess.Insert(cmd); err != nil {
 			return err
 		}
-		sess.PublishAfterCommit(&events.UserCreated{
-			Timestamp: cmd.Created,
-			Id:        cmd.ID,
-			Name:      cmd.Name,
-			Login:     cmd.Login,
-			Email:     cmd.Email,
-		})
 		return nil
 	})
 
@@ -293,14 +285,6 @@ func (ss *sqlStore) Update(ctx context.Context, cmd *user.UpdateUserCommand) err
 				return err
 			}
 		}
-
-		sess.PublishAfterCommit(&events.UserUpdated{
-			Timestamp: usr.Created,
-			Id:        usr.ID,
-			Name:      usr.Name,
-			Login:     usr.Login,
-			Email:     usr.Email,
-		})
 
 		return nil
 	})


### PR DESCRIPTION
This removes the unused events set to `bus.Bus()` -- this will help reduce the things we need to think about as we migrate services