### PR TITLE
Alerting: allow hiding alert rule column in CentralAlertHistoryScene

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -229,6 +229,7 @@ export type CentralAlertHistorySceneV1Props = {
   defaultLabelsFilter?: string;
   defaultTimeRange?: { from: string; to: string };
   hideFilters?: boolean;
+  hideAlertRuleColumn?: boolean;
 };
 
 export type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context = {

--- a/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/CentralAlertHistoryScene.tsx
@@ -65,6 +65,7 @@ export const CentralAlertHistoryScene = ({
     to: 'now',
   },
   hideFilters,
+  hideAlertRuleColumn,
 }: CentralAlertHistorySceneV1Props = {}) => {
   //track the loading of the central alert state history
 
@@ -134,12 +135,12 @@ export const CentralAlertHistoryScene = ({
         children: [
           getEventsScenesFlexItem(),
           new SceneFlexItem({
-            body: new HistoryEventsListObject({}),
+            body: new HistoryEventsListObject({ hideAlertRuleColumn }),
           }),
         ],
       }),
     });
-  }, [defaultLabelsFilter, defaultTimeRange, hideFilters]);
+  }, [defaultLabelsFilter, defaultTimeRange, hideFilters, hideAlertRuleColumn]);
 
   // we need to call this to sync the url with the scene state
   const isUrlSyncInitialized = useUrlSync(scene);

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventListSceneObject.tsx
@@ -9,6 +9,7 @@ import {
   CustomVariable,
   SceneComponentProps,
   SceneObjectBase,
+  SceneObjectState,
   TextBoxVariable,
   VariableDependencyConfig,
   VariableValue,
@@ -55,6 +56,7 @@ interface HistoryEventsListProps {
   valueInStateToFilter: VariableValue;
   valueInStateFromFilter: VariableValue;
   addFilter: (key: string, value: string, type: FilterType) => void;
+  hideAlertRuleColumn?: boolean;
 }
 export const HistoryEventsList = ({
   timeRange,
@@ -62,6 +64,7 @@ export const HistoryEventsList = ({
   valueInStateToFilter,
   valueInStateFromFilter,
   addFilter,
+  hideAlertRuleColumn,
 }: HistoryEventsListProps) => {
   const from = timeRange?.from.unix();
   const to = timeRange?.to.unix();
@@ -114,7 +117,12 @@ export const HistoryEventsList = ({
         </Alert>
       )}
       <LoadingIndicator visible={isLoading} />
-      <HistoryLogEvents logRecords={historyRecords} addFilter={addFilter} timeRange={timeRange} />
+      <HistoryLogEvents
+        logRecords={historyRecords}
+        addFilter={addFilter}
+        timeRange={timeRange}
+        hideAlertRuleColumn={hideAlertRuleColumn}
+      />
     </Stack>
   );
 };
@@ -129,15 +137,16 @@ interface HistoryLogEventsProps {
   logRecords: LogRecord[];
   addFilter: (key: string, value: string, type: FilterType) => void;
   timeRange: TimeRange;
+  hideAlertRuleColumn?: boolean;
 }
-function HistoryLogEvents({ logRecords, addFilter, timeRange }: HistoryLogEventsProps) {
+function HistoryLogEvents({ logRecords, addFilter, timeRange, hideAlertRuleColumn }: HistoryLogEventsProps) {
   const { page, pageItems, numberOfPages, onPageChange } = usePagination(logRecords, 1, PAGE_SIZE);
   const styles = useStyles2(getStyles);
 
   return (
     <Stack direction="column" gap={0}>
       <div className={styles.headerContainer}>
-        <ListHeader />
+        <ListHeader hideAlertRuleColumn={hideAlertRuleColumn} />
 
         <div className={styles.triageButtonContainer}>
           <AITriageButtonComponent logRecords={logRecords} timeRange={timeRange} />
@@ -151,6 +160,7 @@ function HistoryLogEvents({ logRecords, addFilter, timeRange }: HistoryLogEvents
               record={record}
               addFilter={addFilter}
               timeRange={timeRange}
+              hideAlertRuleColumn={hideAlertRuleColumn}
             />
           );
         })}
@@ -161,7 +171,7 @@ function HistoryLogEvents({ logRecords, addFilter, timeRange }: HistoryLogEvents
   );
 }
 
-function ListHeader() {
+function ListHeader({ hideAlertRuleColumn }: { hideAlertRuleColumn?: boolean }) {
   const styles = useStyles2(getStyles);
   return (
     <div className={styles.mainHeader}>
@@ -175,11 +185,13 @@ function ListHeader() {
           <Trans i18nKey="alerting.central-alert-history.details.header.state">State</Trans>
         </Text>
       </div>
-      <div className={styles.alertNameCol}>
-        <Text variant="body">
-          <Trans i18nKey="alerting.central-alert-history.details.header.alert-rule">Alert rule</Trans>
-        </Text>
-      </div>
+      {!hideAlertRuleColumn && (
+        <div className={styles.alertNameCol}>
+          <Text variant="body">
+            <Trans i18nKey="alerting.central-alert-history.details.header.alert-rule">Alert rule</Trans>
+          </Text>
+        </div>
+      )}
       <div className={styles.labelsCol}>
         <Text variant="body">
           <Trans i18nKey="alerting.central-alert-history.details.header.instance">Instance</Trans>
@@ -193,8 +205,9 @@ interface EventRowProps {
   record: LogRecord;
   addFilter: (key: string, value: string, type: FilterType) => void;
   timeRange: TimeRange;
+  hideAlertRuleColumn?: boolean;
 }
-function EventRow({ record, addFilter, timeRange }: EventRowProps) {
+function EventRow({ record, addFilter, timeRange, hideAlertRuleColumn }: EventRowProps) {
   const styles = useStyles2(getStyles);
   const [isCollapsed, setIsCollapsed] = useState(true);
   function onLabelClick(label: string, value: string) {
@@ -220,9 +233,11 @@ function EventRow({ record, addFilter, timeRange }: EventRowProps) {
           <div className={styles.transitionCol}>
             <EventTransition previous={record.line.previous} current={record.line.current} addFilter={addFilter} />
           </div>
-          <div className={styles.alertNameCol}>
-            {record.line.labels ? <AlertRuleName labels={record.line.labels} ruleUID={record.line.ruleUID} /> : null}
-          </div>
+          {!hideAlertRuleColumn && (
+            <div className={styles.alertNameCol}>
+              {record.line.labels ? <AlertRuleName labels={record.line.labels} ruleUID={record.line.ruleUID} /> : null}
+            </div>
+          )}
           <div className={styles.labelsCol}>
             <AlertLabels labels={record.line.labels ?? {}} size="xs" onClick={onLabelClick} />
           </div>
@@ -521,7 +536,11 @@ export const getStyles = (theme: GrafanaTheme2) => {
  * This is a scene object that displays a list of history events.
  */
 
-export class HistoryEventsListObject extends SceneObjectBase {
+interface HistoryEventsListObjectState extends SceneObjectState {
+  hideAlertRuleColumn?: boolean;
+}
+
+export class HistoryEventsListObject extends SceneObjectBase<HistoryEventsListObjectState> {
   public static Component = HistoryEventsListObjectRenderer;
 
   protected _variableDependency = new VariableDependencyConfig(this, {
@@ -533,7 +552,7 @@ export type FilterType = 'label' | 'stateFrom' | 'stateTo';
 
 export function HistoryEventsListObjectRenderer({ model }: SceneComponentProps<HistoryEventsListObject>) {
   // This make sure the component is re-rendered when the variables change
-  model.useState();
+  const { hideAlertRuleColumn } = model.useState();
 
   const { value: timeRange } = sceneGraph.getTimeRange(model).useState(); // get time range from scene graph
 
@@ -568,6 +587,7 @@ export function HistoryEventsListObjectRenderer({ model }: SceneComponentProps<H
         addFilter={addFilter}
         valueInStateToFilter={stateToFilterVariable.state.value}
         valueInStateFromFilter={stateFromFilterVariable.state.value}
+        hideAlertRuleColumn={hideAlertRuleColumn}
       />
     );
   } else {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Allow consumer of CentralAlertHistoryScene to hide Alert Rule column

**Why do we need this feature?**

In IRM CentralAlertHistoryScene is used per a single alert rule so showing the column doesn't make sense and takes some necessary space.

**Who is this feature for?**

IRM users

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/irm/issues/644
Corresponding PR in IRM: https://github.com/grafana/irm/pull/6917

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
<img width="1120" height="595" alt="image" src="https://github.com/user-attachments/assets/e4784b42-1518-4e79-b612-3c4b611701f9" />


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
