### PR TITLE
Chore: cleans up Angular tests

### DIFF
--- a/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
@@ -98,14 +98,4 @@ describe('PluginListItemBadges', () => {
     );
     expect(screen.queryByText(/update available/i)).toBeNull();
   });
-
-  it('does not render an angular badge (when plugin is angular), because its not loaded', () => {
-    render(<PluginListItemBadges plugin={{ ...plugin, angularDetected: true }} />);
-    expect(screen.queryByText(/angular/i)).not.toBeInTheDocument();
-  });
-
-  it('does not render an angular badge (when plugin is not angular)', () => {
-    render(<PluginListItemBadges plugin={{ ...plugin, angularDetected: false }} />);
-    expect(screen.queryByText(/angular/i)).toBeNull();
-  });
 });


### PR DESCRIPTION
**What is this feature?**

This pull request makes a small change to the `PluginListItemBadges.test.tsx` file by removing tests related to the rendering of the Angular badge. The removed tests checked that the Angular badge does not render when the plugin is either Angular but not loaded, or not Angular.

([public/app/features/plugins/admin/components/PluginListItemBadges.test.tsxL101-L110](diffhunk://#diff-af21cdc17cedebb6f43c513ce852e08ab5ae9ece2155d8b74f7dd6376d590430L101-L110))

**Why do we need this feature?**

https://github.com/grafana/grafana/issues/103872

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #110755

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
