### PR TITLE
Tests: Move Canvas tests to panel folder and add testing README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -460,6 +460,7 @@
 /e2e-playwright/fixtures/long-trace-response.json @grafana/observability-traces-and-profiling
 /e2e-playwright/fixtures/tempo-response.json @grafana/oss-big-tent
 /e2e-playwright/fixtures/prometheus-response.json @grafana/datapro
+/e2e-playwright/panels-suite/canvas-scene.spec.ts @grafana/dataviz-squad
 /e2e-playwright/panels-suite/dashlist.spec.ts @grafana/grafana-search-navigate-organise
 /e2e-playwright/panels-suite/datagrid-data-change.spec.ts @grafana/dataviz-squad
 /e2e-playwright/panels-suite/datagrid-editing-features.spec.ts @grafana/dataviz-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -416,6 +416,7 @@
 /e2e-playwright/dashboards/cujs/ @grafana/dashboards-squad
 /e2e-playwright/dashboards/DashboardForConditionalRendering.json @grafana/dashboards-squad
 /e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json @grafana/dashboards-squad
+/e2e-playwright/dashboards/README.md @grafana/dashboards-squad
 /e2e-playwright/dashboards/AdHocFilterTest.json @grafana/datapro
 /e2e-playwright/dashboards/DashboardLiveTest.json @grafana/dashboards-squad
 /e2e-playwright/dashboards/DataLinkWithoutSlugTest.json @grafana/dashboards-squad

--- a/e2e-playwright/dashboards/README.md
+++ b/e2e-playwright/dashboards/README.md
@@ -1,0 +1,9 @@
+# Dashboards
+
+## Adding Dashboard JSONs
+
+When adding dashboard JSON files to this folder that were exported from Grafana:
+
+⚠️ **Important:** Don't forget to remove the `"id"` field from the exported JSON before adding it to this folder.
+
+Exported dashboard JSONs contain an `id` field that should be removed to avoid conflicts when importing the dashboard in tests.

--- a/e2e-playwright/panels-suite/canvas-scene.spec.ts
+++ b/e2e-playwright/panels-suite/canvas-scene.spec.ts
@@ -43,10 +43,10 @@ test.describe('Canvas Panel - Scene Tests', () => {
     await expect(viewerBounds).toBeDefined();
 
     // Test pan functionality
-    const startX = viewerBounds.x + 50;
-    const startY = viewerBounds.y + 50;
-    const endX = viewerBounds.x + 250;
-    const endY = viewerBounds.y + 250;
+    const startX = viewerBounds!.x + 50;
+    const startY = viewerBounds!.y + 50;
+    const endX = viewerBounds!.x + 250;
+    const endY = viewerBounds!.y + 250;
     await page.getByTestId('canvas-scene-pan-zoom');
     await page.mouse.move(startX, startY);
     await page.mouse.down({ button: 'middle' });
@@ -79,9 +79,9 @@ async function isOutsideViewport(element: Locator, viewPort: Locator): Promise<b
   const elementBounds = await element.boundingBox();
   const viewportBounds = await viewPort.boundingBox();
   return (
-    elementBounds.x + elementBounds.width < viewportBounds.x ||
-    elementBounds.x > viewportBounds.x + viewportBounds.width ||
-    elementBounds.y + elementBounds.height < viewportBounds.y ||
-    elementBounds.y > viewportBounds.y + viewportBounds.height
+    elementBounds!.x + elementBounds!.width < viewportBounds!.x ||
+    elementBounds!.x > viewportBounds!.x + viewportBounds!.width ||
+    elementBounds!.y + elementBounds!.height < viewportBounds!.y ||
+    elementBounds!.y > viewportBounds!.y + viewportBounds!.height
   );
 }


### PR DESCRIPTION
Description:
- Moved Canvas-related tests into the panel folder for better organization and clarity.
- Added a small README with instructions on how to add dashboards for testing.

This improves test discoverability and makes it easier for contributors to set up and extend dashboard tests.