### PR TITLE
CloudMigrations: wrap assert in EventuallyWithTf in case async sync hasnt finished

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -342,21 +342,23 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		require.NotNil(t, snapshot)
 		require.Eventually(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 
-		snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
-			SnapshotUID: snapshotUID,
-			SessionUID:  sessionUID,
-			SnapshotResultQueryParams: cloudmigration.SnapshotResultQueryParams{
-				ResultLimit: 10,
-				ResultPage:  1,
-				SortColumn:  cloudmigration.SortColumnID,
-				SortOrder:   cloudmigration.SortOrderAsc,
-			},
-		})
-		require.NoError(t, err)
-		require.NotNil(t, snapshot)
-		require.Len(t, snapshot.Resources, 1)
-		require.Equal(t, "A", snapshot.Resources[0].RefID)
-		require.Equal(t, "fake", snapshot.Resources[0].Error)
+		require.EventuallyWithTf(t, func(t *assert.CollectT) {
+			snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+				SnapshotUID: snapshotUID,
+				SessionUID:  sessionUID,
+				SnapshotResultQueryParams: cloudmigration.SnapshotResultQueryParams{
+					ResultLimit: 10,
+					ResultPage:  1,
+					SortColumn:  cloudmigration.SortColumnID,
+					SortOrder:   cloudmigration.SortOrderAsc,
+				},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, snapshot)
+			require.Len(t, snapshot.Resources, 1)
+			require.Equal(t, "A", snapshot.Resources[0].RefID)
+			require.Equal(t, "fake", snapshot.Resources[0].Error)
+		}, 5*time.Second, 100*time.Millisecond, "DB wasn't applied to local snapshot in time")
 	})
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -343,7 +343,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		require.Eventually(t, func() bool { return gmsClientFake.GetSnapshotStatusCallCount() == 1 }, time.Second, 10*time.Millisecond)
 
 		require.EventuallyWithTf(t, func(t *assert.CollectT) {
-			snapshot, err = s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+			snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 				SnapshotUID: snapshotUID,
 				SessionUID:  sessionUID,
 				SnapshotResultQueryParams: cloudmigration.SnapshotResultQueryParams{

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -353,11 +353,11 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 					SortOrder:   cloudmigration.SortOrderAsc,
 				},
 			})
-			require.NoError(t, err)
-			require.NotNil(t, snapshot)
-			require.Len(t, snapshot.Resources, 1)
-			require.Equal(t, "A", snapshot.Resources[0].RefID)
-			require.Equal(t, "fake", snapshot.Resources[0].Error)
+			assert.NoError(t, err)
+			assert.NotNil(t, snapshot)
+			assert.Len(t, snapshot.Resources, 1)
+			assert.Equal(t, "A", snapshot.Resources[0].RefID)
+			assert.Equal(t, "fake", snapshot.Resources[0].Error)
 		}, 5*time.Second, 100*time.Millisecond, "DB wasn't applied to local snapshot in time")
 	})
 }


### PR DESCRIPTION
Quick fix for flaky test
There is an async updating of the local snapshot information here https://github.com/grafana/grafana/blob/main/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go#L637 , so we use `require.EventuallyWithTf` to retry in case the async work hasn't complete before the validation is run