### PR TITLE
NestedFolderPicker: Only display provisioning icon on root folder

### DIFF
--- a/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
+++ b/public/app/core/components/NestedFolderPicker/FolderRepo.tsx
@@ -1,3 +1,5 @@
+import { memo } from 'react';
+
 import { t } from '@grafana/i18n';
 import { Badge, Stack } from '@grafana/ui';
 import { ManagerKind } from 'app/features/apiserver/types';
@@ -11,7 +13,7 @@ export interface Props {
   folder?: FolderDTO | DashboardViewItem;
 }
 
-export function FolderRepo({ folder }: Props) {
+export const FolderRepo = memo(function FolderRepo({ folder }: Props) {
   // skip rendering if:
   // folder is not present
   // folder have parentUID
@@ -47,7 +49,7 @@ export function FolderRepo({ folder }: Props) {
       />
     </Stack>
   );
-}
+});
 
 function getShouldSkipRender(folder: FolderDTO | DashboardViewItem | undefined, isProvisionedInstance?: boolean) {
   // Skip render if parentUID is present, then we should skip rendering. we only display icon for root folders

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -233,6 +233,7 @@ export function NestedFolderPicker({
             kind: 'folder' as const,
             title: item.title,
             uid: item.uid,
+            parentUID: item.parentUID,
           },
         })) ?? [];
     }

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryAppPlatform.ts
@@ -139,6 +139,7 @@ export function useFoldersQueryAppPlatform({
             uid: name,
             // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
             managedBy: item.metadata?.annotations?.[AnnoKeyManagerKind] as ManagerKind | undefined,
+            parentUID: item.parentUID,
           },
         };
 

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -160,6 +160,7 @@ export function useFoldersQueryLegacy({
               title: item.title,
               uid: item.uid,
               managedBy: item.managedBy,
+              parentUID: item.parentUid,
             },
           };
 

--- a/public/app/types/folders.ts
+++ b/public/app/types/folders.ts
@@ -6,6 +6,7 @@ export interface FolderListItemDTO {
   uid: string;
   title: string;
   managedBy?: ManagerKind;
+  parentUid?: string;
 }
 
 export type FolderParent = Pick<FolderDTO, 'title' | 'uid' | 'url'>;


### PR DESCRIPTION
**What is this feature?**

- `NestedFolderPicker`: Only display provisioning badge on root folder level
<img width="706" height="462" alt="image" src="https://github.com/user-attachments/assets/46f51aa7-bb66-45dd-ae4a-c7aee41fc4da" />


**Why do we need this feature?**

Better UX. 

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/502

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
