### PR TITLE
Update docs for pdc+sigv4

### DIFF
--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -195,7 +195,7 @@ Each data link configuration consists of:
 
 Use private data source connect (PDC) to connect to and query data within a secure network without opening that network to inbound traffic from Grafana Cloud. See [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) for more information on how PDC works and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
 
-If PDC is used with SIGv4 (AWS Signature Version 4 Authentication) the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
+If you use PDC with SIGv4 (AWS Signature Version 4 Authentication), the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
 
 - **Private data source connect** - Click in the box to set the default PDC connection from the dropdown menu or create a new connection.
 

--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -195,6 +195,8 @@ Each data link configuration consists of:
 
 Use private data source connect (PDC) to connect to and query data within a secure network without opening that network to inbound traffic from Grafana Cloud. See [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) for more information on how PDC works and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
 
+If PDC is used with SIGv4 (AWS Signature Version 4 Authentication) the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
+
 - **Private data source connect** - Click in the box to set the default PDC connection from the dropdown menu or create a new connection.
 
 Once you have configured your Elasticsearch data source options, click **Save & test** at the bottom to test out your data source connection. You can also remove a connection by clicking **Delete**.

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -233,9 +233,9 @@ You can add multiple exemplars.
 
 - **Private data source connect** - _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information regarding Grafana PDC refer to [Private data source connect (PDC)](ref:private-data-source-connect) and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
 
-  If PDC is used with SIGv4 (AWS Signature Version 4 Authentication) the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
+  If you use PDC with SIGv4 (AWS Signature Version 4 Authentication), the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
 
-  Click **Manage private data source connect** to be taken to your PDC connection page, where you’ll find your PDC configuration details.
+  Click **Manage private data source connect** to open your PDC connection page and view your configuration details.
 
 After you have configured your Prometheus data source options, click **Save & test** at the bottom to test out your data source connection.
 

--- a/docs/sources/datasources/prometheus/configure/_index.md
+++ b/docs/sources/datasources/prometheus/configure/_index.md
@@ -233,7 +233,9 @@ You can add multiple exemplars.
 
 - **Private data source connect** - _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information regarding Grafana PDC refer to [Private data source connect (PDC)](ref:private-data-source-connect) and [Configure Grafana private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/configure-pdc/#configure-grafana-private-data-source-connect-pdc) for steps on setting up a PDC connection.
 
-Click **Manage private data source connect** to be taken to your PDC connection page, where you’ll find your PDC configuration details.
+  If PDC is used with SIGv4 (AWS Signature Version 4 Authentication) the PDC agent must allow internet egress to`sts.<region>.amazonaws.com:443`.
+
+  Click **Manage private data source connect** to be taken to your PDC connection page, where you’ll find your PDC configuration details.
 
 After you have configured your Prometheus data source options, click **Save & test** at the bottom to test out your data source connection.
 


### PR DESCRIPTION
There was an update to the AWS SigV4 middleware that now runs the STS request for AWS SigV4 through the PDC network instead of directly. We believe that this is the correct behavior (and what users thought was happening when they used AWS SigV4 and PDC). This adds the connection requirement for that to the datasource docs.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Part of https://github.com/grafana/oss-plugin-partnerships/issues/1348

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
