### PR TITLE
unified-storage search: Return bad request error for incomplete request.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -301,6 +301,12 @@ func (s *searchSupport) Search(ctx context.Context, req *resourcepb.ResourceSear
 	ctx, span := s.tracer.Start(ctx, tracingPrexfixSearch+"Search")
 	defer span.End()
 
+	if req.Options.Key.Namespace == "" || req.Options.Key.Group == "" || req.Options.Key.Resource == "" {
+		return &resourcepb.ResourceSearchResponse{
+			Error: NewBadRequestError("missing namespace, group or resource"),
+		}, nil
+	}
+
 	nsr := NamespacedResource{
 		Group:     req.Options.Key.Group,
 		Namespace: req.Options.Key.Namespace,


### PR DESCRIPTION
Return bad request error if namespace, resource or group is missing.