### PR TITLE
DashboardReloadBehavior: Remove version tracking from dashboard reload behavior to prevent unnecessary reloads

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardReloadBehavior.ts
@@ -60,7 +60,6 @@ export class DashboardReloadBehavior extends SceneObjectBase<DashboardReloadBeha
       from: timeRange.from.toISOString(),
       to: timeRange.to.toISOString(),
       ...sceneUtils.getUrlState(this._dashboardScene?.state.$variables!),
-      version: this._dashboardScene?.state.version,
     };
   }
 


### PR DESCRIPTION
This removes version tracking in the reload behavior - changes in the version may cause unneccessary API calls. Now, the behavior will only reload when variable/scope changed, and the state manager will stop the reload cycle if the version comparison returns true. 