### PR TITLE
Revert "Folders: Use authlib.AccessClient in authorizer"

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -19,7 +19,7 @@ import (
 	"k8s.io/kube-openapi/pkg/spec3"
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
-	authlib "github.com/grafana/authlib/types"
+	claims "github.com/grafana/authlib/types"
 	internal "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
@@ -79,7 +79,7 @@ type DashboardsAPIBuilder struct {
 
 	authorizer                   authorizer.Authorizer
 	accessControl                accesscontrol.AccessControl
-	accessClient                 authlib.AccessClient
+	accessClient                 claims.AccessClient
 	legacy                       *DashboardStorage
 	unified                      resource.ResourceClient
 	dashboardProvisioningService dashboards.DashboardProvisioningService
@@ -113,7 +113,7 @@ func RegisterAPIService(
 	dashboardPermissions dashboards.PermissionsRegistrationService,
 	dashboardPermissionsSvc accesscontrol.DashboardPermissionsService,
 	accessControl accesscontrol.AccessControl,
-	accessClient authlib.AccessClient,
+	accessClient claims.AccessClient,
 	provisioning provisioning.ProvisioningService,
 	dashStore dashboards.Store,
 	reg prometheus.Registerer,
@@ -167,7 +167,7 @@ func RegisterAPIService(
 	return builder
 }
 
-func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceInfoProvider, pluginStore *pluginstore.Service) *DashboardsAPIBuilder {
+func NewAPIService(ac claims.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceInfoProvider, pluginStore *pluginstore.Service) *DashboardsAPIBuilder {
 	// TODO: Plugin store will soon be removed,
 	// as the cases for plugin fetching is not needed. Keeping it now to not break implementation
 	if pluginStore == nil {
@@ -274,7 +274,7 @@ func (b *DashboardsAPIBuilder) validateDelete(ctx context.Context, a admission.A
 		return nil
 	}
 
-	nsInfo, err := authlib.ParseNamespace(a.GetNamespace())
+	nsInfo, err := claims.ParseNamespace(a.GetNamespace())
 	if err != nil {
 		return fmt.Errorf("%v: %w", "failed to parse namespace", err)
 	}
@@ -380,7 +380,7 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 	}
 
 	// Parse namespace for old dashboard
-	nsInfo, err := authlib.ParseNamespace(oldAccessor.GetNamespace())
+	nsInfo, err := claims.ParseNamespace(oldAccessor.GetNamespace())
 	if err != nil {
 		return fmt.Errorf("failed to parse namespace: %w", err)
 	}

--- a/pkg/registry/apis/folders/authorizer.go
+++ b/pkg/registry/apis/folders/authorizer.go
@@ -2,20 +2,89 @@ package folders
 
 import (
 	"context"
+	"errors"
+	"slices"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
-	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 )
 
-func newAuthorizer(ac authlib.AccessChecker) authorizer.Authorizer {
+// newLegacyAuthorizer creates an authorizer using legacy access control, this is only usable for single tenant api.
+func newLegacyAuthorizer(ac accesscontrol.AccessControl) authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(func(ctx context.Context, attr authorizer.Attributes) (authorizer.Decision, string, error) {
+		in, err := authorizerFunc(ctx, attr)
+		if err != nil {
+			if errors.Is(err, errNoUser) {
+				return authorizer.DecisionDeny, "", nil
+			}
+			return authorizer.DecisionNoOpinion, "", nil
+		}
+
+		ok, err := ac.Evaluate(ctx, in.user, in.evaluator)
+		if ok {
+			return authorizer.DecisionAllow, "", nil
+		}
+		return authorizer.DecisionDeny, "folder", err
+	})
+}
+
+func authorizerFunc(ctx context.Context, attr authorizer.Attributes) (*authorizerParams, error) {
+	allowedVerbs := []string{utils.VerbCreate, utils.VerbDelete, utils.VerbList}
+	verb := attr.GetVerb()
+	name := attr.GetName()
+	if (!attr.IsResourceRequest()) || (name == "" && verb != utils.VerbCreate && slices.Contains(allowedVerbs, verb)) {
+		return nil, errNoResource
+	}
+
+	// require a user
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, errNoUser
+	}
+
+	scope := dashboards.ScopeFoldersProvider.GetResourceScopeUID(name)
+	var eval accesscontrol.Evaluator
+
+	// "get" is used for sub-resources with GET http (parents, access, count)
+	switch verb {
+	case utils.VerbCreate:
+		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersCreate)
+	case utils.VerbPatch:
+		fallthrough
+	case utils.VerbUpdate:
+		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersWrite, scope)
+	case utils.VerbDeleteCollection:
+		fallthrough
+	case utils.VerbDelete:
+		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersDelete, scope)
+	case utils.VerbList:
+		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersRead)
+	default:
+		eval = accesscontrol.EvalPermission(dashboards.ActionFoldersRead, scope)
+	}
+	return &authorizerParams{evaluator: eval, user: user}, nil
+}
+
+// newMultiTenantAuthorizer creates an authorizer suitable to multi-tenant setup.
+// For now it only allow authorization of access tokens.
+func newMultiTenantAuthorizer(ac types.AccessClient) authorizer.Authorizer {
 	return authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-		info, ok := authlib.AuthInfoFrom(ctx)
+		info, ok := types.AuthInfoFrom(ctx)
 		if !ok {
 			return authorizer.DecisionDeny, "missing auth info", nil
 		}
 
-		res, err := ac.Check(ctx, info, authlib.CheckRequest{
+		// For now we only allow access policy to authorize with multi-tenant setup
+		if !types.IsIdentityType(info.GetIdentityType(), types.TypeAccessPolicy) {
+			return authorizer.DecisionDeny, "permission denied", nil
+		}
+
+		res, err := ac.Check(ctx, info, types.CheckRequest{
 			Verb:        a.GetVerb(),
 			Group:       a.GetAPIGroup(),
 			Resource:    a.GetResource(),
@@ -25,7 +94,7 @@ func newAuthorizer(ac authlib.AccessChecker) authorizer.Authorizer {
 		})
 
 		if err != nil {
-			return authorizer.DecisionDeny, "failed to perform authorization", err
+			return authorizer.DecisionDeny, "faild to perform authorization", err
 		}
 
 		if !res.Allowed {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -2,6 +2,7 @@ package folders
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -19,6 +20,7 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/iam/pkg/reconcilers"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -37,6 +39,9 @@ var _ builder.APIGroupBuilder = (*FolderAPIBuilder)(nil)
 var _ builder.APIGroupValidation = (*FolderAPIBuilder)(nil)
 
 var resourceInfo = folders.FolderResourceInfo
+
+var errNoUser = errors.New("valid user is required")
+var errNoResource = errors.New("resource name is required")
 
 // This is used just so wire has something unique to return
 type FolderAPIBuilder struct {
@@ -77,7 +82,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 		acService:            acService,
 		ac:                   accessControl,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
-		authorizer:           newAuthorizer(accessClient),
+		authorizer:           newLegacyAuthorizer(accessControl),
 		searcher:             unified,
 		permissionStore:      reconcilers.NewZanzanaPermissionStore(zanzanaClient),
 	}
@@ -87,7 +92,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 
 func NewAPIService(ac authlib.AccessClient) *FolderAPIBuilder {
 	return &FolderAPIBuilder{
-		authorizer:   newAuthorizer(ac),
+		authorizer:   newMultiTenantAuthorizer(ac),
 		ignoreLegacy: true,
 	}
 }
@@ -209,6 +214,11 @@ func (b *FolderAPIBuilder) GetOpenAPIDefinitions() common.GetOpenAPIDefinitions 
 func (b *FolderAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
 	oas.Info.Description = "Grafana folders"
 	return oas, nil
+}
+
+type authorizerParams struct {
+	user      identity.Requester
+	evaluator accesscontrol.Evaluator
 }
 
 func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {

--- a/pkg/services/authz/rbac/models.go
+++ b/pkg/services/authz/rbac/models.go
@@ -2,11 +2,11 @@ package rbac
 
 import claims "github.com/grafana/authlib/types"
 
-type checkRequest struct {
+type CheckRequest struct {
 	Namespace    claims.NamespaceInfo
 	IdentityType claims.IdentityType
 	UserUID      string
-	Action       string // Verb has been mapped into an action
+	Action       string
 	Group        string
 	Resource     string
 	Verb         string
@@ -14,7 +14,7 @@ type checkRequest struct {
 	ParentFolder string
 }
 
-type listRequest struct {
+type ListRequest struct {
 	Namespace    claims.NamespaceInfo
 	IdentityType claims.IdentityType
 	UserUID      string

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -228,7 +228,7 @@ func (s *Service) List(ctx context.Context, req *authzv1.ListRequest) (*authzv1.
 	return resp, err
 }
 
-func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRequest) (*checkRequest, error) {
+func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRequest) (*CheckRequest, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.validateCheckRequest")
 	defer span.End()
 
@@ -247,7 +247,7 @@ func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRe
 		return nil, err
 	}
 
-	checkReq := &checkRequest{
+	checkReq := &CheckRequest{
 		Namespace:    ns,
 		UserUID:      userUID,
 		IdentityType: idType,
@@ -261,7 +261,7 @@ func (s *Service) validateCheckRequest(ctx context.Context, req *authzv1.CheckRe
 	return checkReq, nil
 }
 
-func (s *Service) validateListRequest(ctx context.Context, req *authzv1.ListRequest) (*listRequest, error) {
+func (s *Service) validateListRequest(ctx context.Context, req *authzv1.ListRequest) (*ListRequest, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.validateListRequest")
 	defer span.End()
 
@@ -280,7 +280,7 @@ func (s *Service) validateListRequest(ctx context.Context, req *authzv1.ListRequ
 		return nil, err
 	}
 
-	listReq := &listRequest{
+	listReq := &ListRequest{
 		Namespace:    ns,
 		UserUID:      userUID,
 		IdentityType: idType,
@@ -331,19 +331,18 @@ func (s *Service) validateSubject(ctx context.Context, subject string) (string, 
 	return userUID, identityType, nil
 }
 
-// Find the action for a selected verb
 func (s *Service) validateAction(ctx context.Context, group, resource, verb string) (string, error) {
 	ctxLogger := s.logger.FromContext(ctx)
 
 	t, ok := s.mapper.Get(group, resource)
 	if !ok {
-		ctxLogger.Error("unsupported resource", "group", group, "resource", resource)
+		ctxLogger.Error("unsupport resource", "group", group, "resource", resource)
 		return "", status.Error(codes.NotFound, "unsupported resource")
 	}
 
 	action, ok := t.Action(verb)
 	if !ok {
-		ctxLogger.Error("unsupported verb", "group", group, "resource", resource, "verb", verb)
+		ctxLogger.Error("unsupport verb", "group", group, "resource", resource, "verb", verb)
 		return "", status.Error(codes.NotFound, "unsupported verb")
 	}
 
@@ -571,7 +570,7 @@ func (s *Service) getUserBasicRole(ctx context.Context, ns types.NamespaceInfo, 
 	return *basicRole, nil
 }
 
-func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *checkRequest) (bool, error) {
+func (s *Service) checkPermission(ctx context.Context, scopeMap map[string]bool, req *CheckRequest) (bool, error) {
 	ctx, span := s.tracer.Start(ctx, "authz_direct_db.service.checkPermission", trace.WithAttributes(
 		attribute.Int("scope_count", len(scopeMap))))
 	defer span.End()
@@ -620,7 +619,7 @@ func getScopeMap(permissions []accesscontrol.Permission) map[string]bool {
 	return permMap
 }
 
-func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *checkRequest) (bool, error) {
+func (s *Service) checkInheritedPermissions(ctx context.Context, scopeMap map[string]bool, req *CheckRequest) (bool, error) {
 	if req.ParentFolder == "" {
 		return false, nil
 	}
@@ -697,7 +696,7 @@ func (s *Service) buildFolderTree(ctx context.Context, ns types.NamespaceInfo) (
 	return res.(folderTree), nil
 }
 
-func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, req *listRequest) (*authzv1.ListResponse, error) {
+func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, req *ListRequest) (*authzv1.ListResponse, error) {
 	if scopeMap["*"] {
 		return &authzv1.ListResponse{All: true}, nil
 	}
@@ -708,7 +707,7 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 
 	t, ok := s.mapper.Get(req.Group, req.Resource)
 	if !ok {
-		ctxLogger.Error("unsupported resource", "group", req.Group, "resource", req.Resource)
+		ctxLogger.Error("unsupport resource", "group", req.Group, "resource", req.Resource)
 		return nil, status.Error(codes.NotFound, "unsupported resource")
 	}
 


### PR DESCRIPTION
Reverts grafana/grafana#110602

There is an edge case where ST users might loose access to nested folders on which they solely have inherited permissions

To replicate, I created three folders `top` > `middle` > `sub` and granted `viewer1 can View` on `top`.

List works as expected as viewer1:
```
grafana % kubectl --kubeconfig test.kubeconfig.bck --user viewer1 get folders.folder.grafana.app
NAME             TITLE    PARENT
dexk3xsbpttkwb   Top      
fexk3zf33u7eoe   Middle   dexk3xsbpttkwb
fexk3zyteyr5sc   Sub      fexk3zf33u7eoe
```

Get on `top` as well:
```
grafana % kubectl --kubeconfig test.kubeconfig.bck --user viewer1 get folders.folder.grafana.app/dexk3xsbpttkwb
NAME             TITLE   PARENT
dexk3xsbpttkwb   Top     
```

But get on `sub` now fails:
```
grafana % kubectl --kubeconfig test.kubeconfig.bck --user viewer1 get folders.folder.grafana.app/fexk3zyteyr5sc
Error from server (Forbidden): folders.folder.grafana.app "fexk3zyteyr5sc" is forbidden: User "viewer1" cannot get resource "folders" in API group "folder.grafana.app" in the namespace "default": permission denied
```