### PR TITLE
[OpenTSDB]: Support queries with different time ranges

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb_test.go
+++ b/pkg/tsdb/opentsdb/opentsdb_test.go
@@ -460,5 +460,4 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		require.Contains(t, bodies[1], `"start":3000`)
 		require.Contains(t, bodies[1], `"end":4000`)
 	})
-
 }

--- a/pkg/tsdb/opentsdb/opentsdb_test.go
+++ b/pkg/tsdb/opentsdb/opentsdb_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/pkg/infra/httpclient"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -406,43 +409,56 @@ func TestOpenTsdbExecutor(t *testing.T) {
 
 	t.Run("createRequest uses per-query time range", func(t *testing.T) {
 		qA := backend.DataQuery{
-			RefID: "A",
-			JSON:  []byte(`{"metric": "m", "aggregator": "avg"}`),
-			TimeRange: backend.TimeRange{
-				From: time.Unix(1000, 0),
-				To:   time.Unix(2000, 0),
-			},
+			RefID:     "A",
+			JSON:      []byte(`{"metric":"mA","aggregator":"avg"}`),
+			TimeRange: backend.TimeRange{From: time.Unix(1000, 0), To: time.Unix(2000, 0)},
 		}
-		tsdbA := OpenTsdbQuery{
-			Start:   qA.TimeRange.From.Unix(),
-			End:     qA.TimeRange.To.Unix(),
-			Queries: []map[string]any{service.buildMetric(qA)},
-		}
-		reqA, err := service.createRequest(context.Background(), logger, &datasourceInfo{URL: "http://x"}, tsdbA)
-		require.NoError(t, err)
-		bodyA, _ := io.ReadAll(reqA.Body)
-
 		qB := backend.DataQuery{
-			RefID: "B",
-			JSON:  []byte(`{"metric": "m", "aggregator": "avg"}`),
-			TimeRange: backend.TimeRange{
-				From: time.Unix(3000, 0),
-				To:   time.Unix(4000, 0),
-			},
+			RefID:     "B",
+			JSON:      []byte(`{"metric":"mB","aggregator":"avg"}`),
+			TimeRange: backend.TimeRange{From: time.Unix(3000, 0), To: time.Unix(4000, 0)},
 		}
-		tsdbB := OpenTsdbQuery{
-			Start:   qB.TimeRange.From.Unix(),
-			End:     qB.TimeRange.To.Unix(),
-			Queries: []map[string]any{service.buildMetric(qB)},
-		}
-		reqB, err := service.createRequest(context.Background(), logger, &datasourceInfo{URL: "http://x"}, tsdbB)
-		require.NoError(t, err)
-		bodyB, _ := io.ReadAll(reqB.Body)
 
-		require.Contains(t, string(bodyA), `"start":1000`)
-		require.Contains(t, string(bodyA), `"end":2000`)
-		require.Contains(t, string(bodyB), `"start":3000`)
-		require.Contains(t, string(bodyB), `"end":4000`)
+		var bodies []string
+		hits := 0 // count how many times the test server was hit
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			b, _ := io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			bodies = append(bodies, string(b))
+			hits++
+
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		}))
+		t.Cleanup(srv.Close)
+
+		service := &Service{
+			im: datasource.NewInstanceManager(newInstanceSettings(httpclient.NewProvider())),
+		}
+
+		settings := &backend.DataSourceInstanceSettings{
+			UID:      "opentsdb-test",
+			URL:      srv.URL,
+			JSONData: []byte(`{"tsdbVersion":4,"httpMethod":"post"}`),
+		}
+
+		req := backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: settings,
+			},
+			Queries: []backend.DataQuery{qA, qB},
+		}
+		_, err := service.QueryData(context.Background(), &req)
+		require.NoError(t, err)
+
+		require.Equal(t, 2, hits)
+		require.Len(t, bodies, 2)
+
+		require.Contains(t, bodies[0], `"start":1000`)
+		require.Contains(t, bodies[0], `"end":2000`)
+		require.Contains(t, bodies[1], `"start":3000`)
+		require.Contains(t, bodies[1], `"end":4000`)
 	})
 
 }


### PR DESCRIPTION
Previously, OpenTSDB ([and some other data sources](https://github.com/grafana/grafana/issues/103972)) batched queries into a single request using the time range from the first query. This assumption could lead to incorrect results in scenarios like alerting, where each query may require a different time range. This change updates the backend behavior to execute each query in a separate request, allowing each to define its own time range. 

Fixes #108071 