### PR TITLE
Snapshots: Fix breadcrumb when not logged in

### DIFF
--- a/public/app/core/selectors/navModel.test.ts
+++ b/public/app/core/selectors/navModel.test.ts
@@ -49,4 +49,26 @@ describe('getNavModel', () => {
     expect(navModel.main.children![2].active).toBe(undefined);
     expect(navModel.main.children![2].children![0].active).toBe(true);
   });
+
+  test('returns fallback nav model when provided for non-existent node', () => {
+    const fallbackNavModel = {
+      main: { id: 'fallback-main', text: 'Fallback Main', url: '/fallback' },
+      node: { id: 'fallback-node', text: 'Fallback Node', url: '/fallback/node' },
+    };
+
+    const navModel = getNavModel(navIndex, 'non-existent-id', fallbackNavModel);
+    expect(navModel).toBe(fallbackNavModel);
+    expect(navModel.main.id).toBe('fallback-main');
+    expect(navModel.node.id).toBe('fallback-node');
+  });
+
+  test('returns not found nav model when no fallback provided for non-existent node', () => {
+    const navModel = getNavModel(navIndex, 'non-existent-id');
+    expect(navModel.main.id).toBe('not-found');
+    expect(navModel.node.id).toBe('not-found');
+    expect(navModel.main.text).toBe('Page not found');
+    expect(navModel.main.subTitle).toBe('404 Error');
+    expect(navModel.main.icon).toBe('exclamation-triangle');
+    expect(navModel.main.url).toBe('not-found');
+  });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -32,7 +32,15 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const scopesContext = useContext(ScopesContext);
   const navIndex = useSelector((state) => state.navIndex);
   const pageNav = model.getPageNav(location, navIndex);
-  const navModel = getNavModel(navIndex, `dashboards/${type === 'snapshot' ? 'snapshots' : 'browse'}`);
+  const navModel =
+    type === 'snapshot'
+      ? getNavModel(
+          navIndex,
+          'dashboards/snapshots',
+          // fallback navModel to prevent showing `Page not found` in snapshots
+          getNavModel(navIndex, 'home')
+        )
+      : getNavModel(navIndex, 'dashboards/browse');
   const isSettingsOpen = editview !== undefined;
   const soloPanelContext = useDefineSoloPanelContext(viewPanel);
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes `Page not found` breadcrumb when the user is not signed in.
Now, it shows `Home`.
As mentioned [here](https://github.com/grafana/grafana/issues/96988#issuecomment-3127392630), I prefer displaying `Home` breadcrumb instead of `Snapshots`, because if redirects you to the login page if you click on it

| Signed in | Not signed in (before) | Not signed in (now) |
|--------|--------|--------|
| <img width="449" height="50" alt="image" src="https://github.com/user-attachments/assets/a5bef5db-f0b8-46c7-b811-bbe54c0d8ce7" /> | <img width="322" height="49" alt="image" src="https://github.com/user-attachments/assets/d77e2e3b-88ea-41e4-a6aa-23bf346639d6" /> | <img width="253" height="49" alt="image" src="https://github.com/user-attachments/assets/7c54bfe2-d4ef-48d7-a49f-e224fa2911a5" /> |


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/96988

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
