### PR TITLE
Fix TSDoc for suppressing error alerts from backendSrc

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -153,7 +153,7 @@ export function isFetchError<T = any>(e: unknown): e is FetchError<T> {
  *
  * @remarks
  * By default, Grafana displays an error message alert if the remote call fails. To prevent this from
- * happening `showErrorAlert = true` on the options object.
+ * happening `showErrorAlert = false` on the options object.
  *
  * @public
  */


### PR DESCRIPTION
**What is this feature?**

The TSDoc incorrectly states that you can prevent error message alerts by setting `showErrorAlert` to `true`. This PR swaps `true` for `false`, which is the correct value to accomplish this.
