### PR TITLE
Docs: improve form field accessibility guidance

### DIFF
--- a/contribute/style-guides/accessibility.md
+++ b/contribute/style-guides/accessibility.md
@@ -17,21 +17,27 @@ The form components from `grafana/ui` provide an easier way to achieve that. The
 For example:
 
 ```tsx
-<Field label="Name">
-  <Input id="name" placeholder="Enter a name" />
-</Field>
+const id = useId(); // React's useId provides a stable globally unique identifier
+
+return (
+  <Field label="Name">
+    <Input id={id} placeholder="Enter a name" />
+  </Field>
+);
 ```
 
 In the previous example, the code is rendered as:
 
 ```html
 <div>
-  <label for="name"> Name </label>
-  <input name="name" type="text" id="name" placeholder="Enter a name" value="" />
+  <label for=":r0:"> Name </label>
+  <input name="name" type="text" id=":r0:" placeholder="Enter a name" value="" />
 </div>
 ```
 
-As long as the form element has a unique `id` attribute specified, it's automatically accessible when rendered.
+As long as the form element has a globally unique `id` attribute specified and is the direct child element of Field, it's automatically accessible when rendered.
+
+Make sure you test that each field can be selected by clicking its label!
 
 ### Write tests with accessibility in mind
 


### PR DESCRIPTION
**What is this feature?**

Update form field accessibility guidance to use useId in the example and specify some of the other requirements for Field to label the ID properly (globally unique ID, input is direct child of Field).

**Why do we need this feature?**

To better guide devs

**Who is this feature for?**

Developers

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
