### PR TITLE
Alerting: Annotation CanUse for receiver resource

### DIFF
--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/ext.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/ext.go
@@ -3,3 +3,4 @@ package v0alpha1
 const InternalPrefix = "grafana.com/"
 const ProvenanceStatusAnnotationKey = InternalPrefix + "provenance"
 const ProvenanceStatusNone = "none"
+const CanUseAnnotationKey = InternalPrefix + "canUse"

--- a/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_ext.go
+++ b/apps/alerting/notifications/pkg/apis/alerting/v0alpha1/receiver_ext.go
@@ -35,6 +35,13 @@ func (o *Receiver) SetAccessControl(action string) {
 	o.Annotations[AccessControlAnnotation(action)] = "true"
 }
 
+func (o *Receiver) SetCanUse(canUse bool) {
+	if o.Annotations == nil {
+		o.Annotations = make(map[string]string, 1)
+	}
+	o.Annotations[CanUseAnnotationKey] = fmt.Sprintf("%v", canUse)
+}
+
 // AccessControlAnnotation returns the key for the access control annotation for the given action.
 // Ex. grafana.com/access/canDelete.
 func AccessControlAnnotation(action string) string {

--- a/pkg/registry/apps/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/receiver/conversions.go
@@ -120,6 +120,7 @@ func convertToDomainModel(receiver *model.Receiver) (*ngmodels.Receiver, map[str
 		Integrations: make([]*ngmodels.Integration, 0, len(receiver.Spec.Integrations)),
 		Version:      receiver.ResourceVersion,
 		Provenance:   ngmodels.ProvenanceNone,
+		Origin:       ngmodels.ResourceOriginGrafana, // Set to Grafana by default.
 	}
 	storedSecureFields := make(map[string][]string, len(receiver.Spec.Integrations))
 	for _, integration := range receiver.Spec.Integrations {

--- a/pkg/registry/apps/alerting/notifications/receiver/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/receiver/conversions.go
@@ -101,6 +101,7 @@ func convertToK8sResource(
 			rules = append(rules, rule.UID)
 		}
 		r.SetInUse(metadata.InUseByRoutes, rules)
+		r.SetCanUse(metadata.CanUse)
 	}
 	r.UID = gapiutil.CalculateClusterWideUID(r)
 	return r, nil

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -37,7 +37,19 @@ type GetReceiversQuery struct {
 type ReceiverMetadata struct {
 	InUseByRules  []AlertRuleKey
 	InUseByRoutes int
+	// CanUse is true if the receiver can be used in routes and rules.
+	CanUse bool
 }
+
+// ResourceOrigin represents the origin or source of the resource.
+type ResourceOrigin string
+
+const (
+	// ResourceOriginGrafana indicates that the resource is in the Grafana configuration
+	ResourceOriginGrafana ResourceOrigin = "grafana"
+	// ResourceOriginStaging indicates that the resource is from the staging configuration
+	ResourceOriginStaging ResourceOrigin = "staging"
+)
 
 // Receiver is the domain model representation of a receiver / contact point.
 type Receiver struct {
@@ -46,6 +58,7 @@ type Receiver struct {
 	Integrations []*Integration
 	Provenance   Provenance
 	Version      string
+	Origin       ResourceOrigin
 }
 
 func (r *Receiver) Clone() Receiver {
@@ -54,6 +67,7 @@ func (r *Receiver) Clone() Receiver {
 		Name:       r.Name,
 		Provenance: r.Provenance,
 		Version:    r.Version,
+		Origin:     r.Origin,
 	}
 
 	if r.Integrations != nil {

--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -47,8 +47,8 @@ type ResourceOrigin string
 const (
 	// ResourceOriginGrafana indicates that the resource is in the Grafana configuration
 	ResourceOriginGrafana ResourceOrigin = "grafana"
-	// ResourceOriginStaging indicates that the resource is from the staging configuration
-	ResourceOriginStaging ResourceOrigin = "staging"
+	// ResourceOriginImported indicates that the resource is from the imported configuration
+	ResourceOriginImported ResourceOrigin = "imported"
 )
 
 // Receiver is the domain model representation of a receiver / contact point.

--- a/pkg/services/ngalert/models/receivers_test.go
+++ b/pkg/services/ngalert/models/receivers_test.go
@@ -378,6 +378,7 @@ func TestReceiver_Fingerprint(t *testing.T) {
 		fingerprint := baseReceiver.Fingerprint()
 		excludedFields := map[string]struct{}{
 			"Version": {},
+			"Origin":  {},
 		}
 
 		reflectVal := reflect.ValueOf(&completelyDifferentReceiver).Elem()

--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -1180,6 +1180,7 @@ func ReceiverGen(mutators ...Mutator[Receiver]) func() Receiver {
 			Name:         name,
 			Integrations: []*Integration{&integration},
 			Provenance:   ProvenanceNone,
+			Origin:       ResourceOriginGrafana,
 		}
 		for _, mutator := range mutators {
 			mutator(&c)
@@ -1243,6 +1244,12 @@ func (n ReceiverMutators) Encrypted(fn EncryptFn) Mutator[Receiver] {
 func (n ReceiverMutators) Decrypted(fn DecryptFn) Mutator[Receiver] {
 	return func(r *Receiver) {
 		_ = r.Decrypt(fn)
+	}
+}
+
+func (n ReceiverMutators) WithOrigin(origin ResourceOrigin) Mutator[Receiver] {
+	return func(r *Receiver) {
+		r.Origin = origin
 	}
 }
 

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -65,19 +65,7 @@ func ReceiverToPostableApiReceiver(r *models.Receiver) (*apimodels.PostableApiRe
 	}, nil
 }
 
-func PostableApiReceiversToReceivers(postables []*apimodels.PostableApiReceiver, storedProvenances map[string]models.Provenance) ([]*models.Receiver, error) {
-	receivers := make([]*models.Receiver, 0, len(postables))
-	for _, postable := range postables {
-		r, err := PostableApiReceiverToReceiver(postable, GetReceiverProvenance(storedProvenances, postable))
-		if err != nil {
-			return nil, err
-		}
-		receivers = append(receivers, r)
-	}
-	return receivers, nil
-}
-
-func PostableApiReceiverToReceiver(postable *apimodels.PostableApiReceiver, provenance models.Provenance) (*models.Receiver, error) {
+func PostableApiReceiverToReceiver(postable *apimodels.PostableApiReceiver, provenance models.Provenance, origin models.ResourceOrigin) (*models.Receiver, error) {
 	integrations, err := PostableGrafanaReceiversToIntegrations(postable.GrafanaManagedReceivers)
 	if err != nil {
 		return nil, err
@@ -87,6 +75,7 @@ func PostableApiReceiverToReceiver(postable *apimodels.PostableApiReceiver, prov
 		Name:         postable.GetName(),
 		Integrations: integrations,
 		Provenance:   provenance,
+		Origin:       origin,
 	}
 	r.Version = r.Fingerprint()
 	return r, nil

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -82,7 +82,11 @@ func PostableApiReceiverToReceiver(postable *apimodels.PostableApiReceiver, prov
 }
 
 // GetReceiverProvenance determines the provenance of a definitions.PostableApiReceiver based on the provenance of its integrations.
-func GetReceiverProvenance(storedProvenances map[string]models.Provenance, r *apimodels.PostableApiReceiver) models.Provenance {
+func GetReceiverProvenance(storedProvenances map[string]models.Provenance, r *apimodels.PostableApiReceiver, origin models.ResourceOrigin) models.Provenance {
+	if origin == models.ResourceOriginStaging {
+		return models.ProvenanceConvertedPrometheus
+	}
+
 	if len(r.GrafanaManagedReceivers) == 0 || len(storedProvenances) == 0 {
 		return models.ProvenanceNone
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -83,7 +83,7 @@ func PostableApiReceiverToReceiver(postable *apimodels.PostableApiReceiver, prov
 
 // GetReceiverProvenance determines the provenance of a definitions.PostableApiReceiver based on the provenance of its integrations.
 func GetReceiverProvenance(storedProvenances map[string]models.Provenance, r *apimodels.PostableApiReceiver, origin models.ResourceOrigin) models.Provenance {
-	if origin == models.ResourceOriginStaging {
+	if origin == models.ResourceOriginImported {
 		return models.ProvenanceConvertedPrometheus
 	}
 

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -43,7 +43,7 @@ func (rev *ConfigRevision) CreateReceiver(receiver *models.Receiver) (*models.Re
 		return nil, err
 	}
 
-	return PostableApiReceiverToReceiver(postable, receiver.Provenance)
+	return PostableApiReceiverToReceiver(postable, receiver.Provenance, receiver.Origin)
 }
 
 func (rev *ConfigRevision) UpdateReceiver(receiver *models.Receiver) (*models.Receiver, error) {
@@ -69,7 +69,7 @@ func (rev *ConfigRevision) UpdateReceiver(receiver *models.Receiver) (*models.Re
 		return nil, err
 	}
 
-	return PostableApiReceiverToReceiver(newReceiver, receiver.Provenance)
+	return PostableApiReceiverToReceiver(newReceiver, receiver.Provenance, receiver.Origin)
 }
 
 // ReceiverNameUsedByRoutes checks if a receiver name is used in any routes.
@@ -89,7 +89,7 @@ func (rev *ConfigRevision) GetReceiver(uid string, prov Provenances) (*models.Re
 		if NameToUid(r.GetName()) != uid {
 			continue
 		}
-		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r))
+		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r), models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}
@@ -109,7 +109,7 @@ func (rev *ConfigRevision) GetReceivers(uids []string, prov Provenances) ([]*mod
 		if len(uids) > 0 && !slices.Contains(uids, uid) {
 			continue
 		}
-		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r))
+		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r), models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}
@@ -131,7 +131,7 @@ func DecryptedReceivers(receivers []*definitions.PostableApiReceiver, decryptFn 
 	decrypted := make([]*definitions.PostableApiReceiver, len(receivers))
 	for i, r := range receivers {
 		// We don't care about the provenance here, so we pass ProvenanceNone.
-		rcv, err := PostableApiReceiverToReceiver(r, models.ProvenanceNone)
+		rcv, err := PostableApiReceiverToReceiver(r, models.ProvenanceNone, models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func EncryptedReceivers(receivers []*definitions.PostableApiReceiver, encryptFn 
 	encrypted := make([]*definitions.PostableApiReceiver, len(receivers))
 	for i, r := range receivers {
 		// We don't care about the provenance here, so we pass ProvenanceNone.
-		rcv, err := PostableApiReceiverToReceiver(r, models.ProvenanceNone)
+		rcv, err := PostableApiReceiverToReceiver(r, models.ProvenanceNone, models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/ngalert/notifier/legacy_storage/receivers.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/receivers.go
@@ -89,7 +89,7 @@ func (rev *ConfigRevision) GetReceiver(uid string, prov Provenances) (*models.Re
 		if NameToUid(r.GetName()) != uid {
 			continue
 		}
-		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r), models.ResourceOriginGrafana)
+		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r, models.ResourceOriginGrafana), models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}
@@ -109,7 +109,7 @@ func (rev *ConfigRevision) GetReceivers(uids []string, prov Provenances) ([]*mod
 		if len(uids) > 0 && !slices.Contains(uids, uid) {
 			continue
 		}
-		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r), models.ResourceOriginGrafana)
+		recv, err := PostableApiReceiverToReceiver(r, GetReceiverProvenance(prov, r, models.ResourceOriginGrafana), models.ResourceOriginGrafana)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert receiver %q: %w", r.Name, err)
 		}

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -338,7 +338,9 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 	if err := rs.authz.AuthorizeCreate(ctx, user); err != nil {
 		return nil, err
 	}
-
+	if r.Origin != models.ResourceOriginGrafana {
+		return nil, makeErrReceiverOrigin(r, "create")
+	}
 	revision, err := rs.cfgStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -538,6 +538,7 @@ func (rs *ReceiverService) InUseMetadata(ctx context.Context, orgID int64, recei
 		results[rcv.GetUID()] = models.ReceiverMetadata{
 			InUseByRoutes: receiverUses[rcv.Name],
 			InUseByRules:  byReceiver[rcv.Name],
+			CanUse:        rcv.Origin == models.ResourceOriginGrafana, // Only receivers from the Grafana configuration can be used.
 		}
 	}
 

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -38,8 +38,8 @@ var (
 	)
 
 	ErrReceiverOrigin = errutil.BadRequest("alerting.notifications.receivers.originInvalid").MustTemplate(
-		"Receiver '{{ .Public.Name }} cannot be {{ .Public.Action }}ed because it belongs to a configuration in staging mode.",
-		errutil.WithPublic("Receiver '{{ .Public.Name }} cannot be {{ .Public.Action }}ed because it belongs to a configuration in staging mode. Commit the staged configuration first."),
+		"Receiver '{{ .Public.Name }} cannot be {{ .Public.Action }}d because it belongs to an imported configuration.",
+		errutil.WithPublic("Receiver '{{ .Public.Name }} cannot be {{ .Public.Action }}d because it belongs to an imported configuration. Finish the import of the configuration first."),
 	)
 )
 

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -734,13 +734,6 @@ func TestReceiverService_Update(t *testing.T) {
 			existing:    util.Pointer(baseReceiver.Clone()),
 			expectedErr: legacy_storage.ErrReceiverInvalid,
 		},
-		{
-			name:        "update of non-Grafana origin fails",
-			user:        writer,
-			receiver:    models.CopyReceiverWith(baseReceiver),
-			existing:    util.Pointer(models.CopyReceiverWith(baseReceiver.Clone(), models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging))),
-			expectedErr: ErrReceiverOrigin,
-		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sut := createReceiverServiceSut(t, &secretsService)

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -405,6 +405,12 @@ func TestReceiverService_Create(t *testing.T) {
 			expectedProvenances: map[string]models.Provenance{generated(0): models.ProvenanceNone, generated(1): models.ProvenanceNone}, // Mark UIDs as generated so that test will insert generated UID.
 		},
 		{
+			name:        "create receiver with non-Grafana origin fails",
+			user:        writer,
+			receiver:    models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging)),
+			expectedErr: ErrReceiverOrigin,
+		},
+		{
 			name: "create integration with invalid UID fails",
 			user: writer,
 			receiver: models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithIntegrations(
@@ -727,6 +733,13 @@ func TestReceiverService_Update(t *testing.T) {
 			receiver:    models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithInvalidIntegration("slack")),
 			existing:    util.Pointer(baseReceiver.Clone()),
 			expectedErr: legacy_storage.ErrReceiverInvalid,
+		},
+		{
+			name:        "update of non-Grafana origin fails",
+			user:        writer,
+			receiver:    models.CopyReceiverWith(baseReceiver),
+			existing:    util.Pointer(models.CopyReceiverWith(baseReceiver.Clone(), models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging))),
+			expectedErr: ErrReceiverOrigin,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -1456,8 +1456,6 @@ func TestReceiverService_InUseMetadata(t *testing.T) {
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"))()),
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"))()),
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver4"))()),
-				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver5"),
-					models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging))()),
 			},
 			storeSettings: map[models.AlertRuleKey][]models.NotificationSettings{
 				{OrgID: 1, UID: "rule1uid"}: {
@@ -1503,11 +1501,6 @@ func TestReceiverService_InUseMetadata(t *testing.T) {
 					InUseByRules:  []models.AlertRuleKey{},
 					InUseByRoutes: 1,
 					CanUse:        true,
-				},
-				legacy_storage.NameToUid("receiver5"): {
-					InUseByRules:  []models.AlertRuleKey{},
-					InUseByRoutes: 0,
-					CanUse:        false,
 				},
 			},
 		},

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -1450,6 +1450,8 @@ func TestReceiverService_InUseMetadata(t *testing.T) {
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver2"))()),
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver3"))()),
 				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver4"))()),
+				util.Pointer(models.ReceiverGen(models.ReceiverMuts.WithName("receiver5"),
+					models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging))()),
 			},
 			storeSettings: map[models.AlertRuleKey][]models.NotificationSettings{
 				{OrgID: 1, UID: "rule1uid"}: {
@@ -1479,18 +1481,27 @@ func TestReceiverService_InUseMetadata(t *testing.T) {
 				legacy_storage.NameToUid("receiver1"): {
 					InUseByRules:  []models.AlertRuleKey{{OrgID: 1, UID: "rule1uid"}},
 					InUseByRoutes: 2,
+					CanUse:        true,
 				},
 				legacy_storage.NameToUid("receiver2"): {
 					InUseByRules:  []models.AlertRuleKey{{OrgID: 1, UID: "rule1uid"}, {OrgID: 1, UID: "rule2uid"}},
 					InUseByRoutes: 1,
+					CanUse:        true,
 				},
 				legacy_storage.NameToUid("receiver3"): {
 					InUseByRules:  []models.AlertRuleKey{{OrgID: 1, UID: "rule2uid"}},
 					InUseByRoutes: 2,
+					CanUse:        true,
 				},
 				legacy_storage.NameToUid("receiver4"): {
 					InUseByRules:  []models.AlertRuleKey{},
 					InUseByRoutes: 1,
+					CanUse:        true,
+				},
+				legacy_storage.NameToUid("receiver5"): {
+					InUseByRules:  []models.AlertRuleKey{},
+					InUseByRoutes: 0,
+					CanUse:        false,
 				},
 			},
 		},

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -407,7 +407,7 @@ func TestReceiverService_Create(t *testing.T) {
 		{
 			name:        "create receiver with non-Grafana origin fails",
 			user:        writer,
-			receiver:    models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithOrigin(models.ResourceOriginStaging)),
+			receiver:    models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithOrigin(models.ResourceOriginImported)),
 			expectedErr: ErrReceiverOrigin,
 		},
 		{

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -608,6 +608,7 @@ func TestIntegrationAccessControl(t *testing.T) {
 				// Set expected metadata.
 				expectedWithMetadata := expected.Copy().(*v0alpha1.Receiver)
 				expectedWithMetadata.SetInUse(0, nil)
+				expectedWithMetadata.SetCanUse(true)
 				if tc.canUpdate {
 					expectedWithMetadata.SetAccessControl("canWrite")
 				}

--- a/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/receiver_test.go
@@ -1295,6 +1295,7 @@ func TestIntegrationCRUD(t *testing.T) {
 		receiver.SetAccessControl("canReadSecrets")
 		receiver.SetAccessControl("canAdmin")
 		receiver.SetInUse(0, nil)
+		receiver.SetCanUse(true)
 
 		// Use export endpoint because it's the only way to get decrypted secrets fast.
 		cliCfg := helper.Org1.Admin.NewRestConfig()


### PR DESCRIPTION
**What is this feature?**
This PR introduces a new field "origin" in the structure `models.Receiver`. The field indicates the origin of the receiver: Grafana configuration or Staged (Extra) configuration. 

Currently, only Grafana origin is possible.

The origin is used to determine provisioned status, in the case of staged origin, the provisioning status is set to `converted_prometheus`. Also, the origin is converted to a new annotation `grafana.com/canUse` and set to "true" when origin is Grafana, and "false" - Staged.
The annotation determines whether a resource can be referred to by rules or notification policies. Staged resources are those that are brought to Grafana via convert API and stored separately from the Grafana notification configuration until it is committed into it.
The motivation behind the annotation + provenance status is to not couple a specific provenance status to whether a resource can be referred. 
The motivation behind origin is the same - decouple from managing specific provenance status in CRUD APIs and return better formed error in case user tries to update\delete a receiver that does not belong to the main configuration. 

**Why do we need this feature?**
"Staged" origin will be used for receivers that come from extra configuration. UI will be updated to distinguish between normal receivers and staged. 

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/pull/109878 and https://github.com/grafana/alerting-squad/issues/1214

**Special notes for your reviewer:**

Currently, the legacy_storage cannot provide "staged" receivers, and therefore, it's not possible to write unit-tests to cover the functionality. They will be added in a follow-up PR