### PR TITLE
ProvisioningAwarefolderPicker: Exclude current folder UID from selection

### DIFF
--- a/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/GeneralSettingsEditView.tsx
@@ -290,6 +290,7 @@ function GeneralSettingsEditViewComponent({ model }: SceneComponentProps<General
               value={meta.folderUid}
               onChange={dashboard.isManagedRepository() ? model.onProvisionedFolderChange : model.onFolderChange}
               repositoryName={dashboard.getManagerIdentity()}
+              excludeUIDs={meta?.folderUid ? [meta.folderUid] : undefined}
             />
           </Field>
 

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -137,6 +137,7 @@ function FormContent({ initialValues, selectedItems, repository, workflowOptions
                     clearErrors('targetFolderUID');
                   }}
                   repositoryName={repository.name}
+                  excludeUIDs={[...Object.keys(selectedItems?.folder).map((uid) => uid)]}
                 />
               </Field>
               <ResourceEditFormSharedFields


### PR DESCRIPTION
**What is this feature?**

Exclude current / selected folder from NestedFolderPicker select options

**Why do we need this feature?**

Prevent parent folder move into child folder

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/503

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
