### PR TITLE
Provisioning: Fix panic in webhook extra

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -30,7 +30,7 @@ type WebhookExtraBuilder struct {
 
 // FIXME: separate the URL provider from connector to simplify operators
 func (b *WebhookExtraBuilder) WebhookURL(ctx context.Context, r *provisioning.Repository) string {
-	if !b.isPublic {
+	if b == nil || !b.isPublic {
 		return ""
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes the following panic:
```
logger=grafana-apiserver t=2025-09-09T22:05:55.037280436Z level=error msg="Observed a panic" panic="runtime error: invalid memory address or nil pointer dereference\ngoroutine 2804 [running]:\nk8s.io/apiserver/pkg/endpoints/handlers/finisher.finishRequest.func1.1()\n\tk8s.io/apiserver@v0.33.3/pkg/endpoints/handlers/finisher/finisher.go:105 +0xa5\npanic({0xe59c40?, 0x161f7ea0?})\n\truntime/panic.go:792 +0x132\ngithub.com/grafana/grafana/pkg/registry/apis/provisioning/webhooks.(*WebhookExtraBuilder).WebhookURL(0x3d07148?, {0xc0034faea0?, 0xc003269b88?}, 0x3e26460?)\n\tgithub.com/grafana/grafana/pkg/registry/apis/provisioning/webhooks/register.go:33 +0x1d\ngithub.com/grafana/grafana/apps/provisioning/pkg/repository/github.(*extra).Build(0xc0010b4420, {0x3d07148, 0xc0034faea0}, 0xc003269b88)\n\tgithub.com/grafana/grafana/apps/provisioning/pkg/repository/github/extra.go:70 +0x471\ngithub.com/grafana/grafana/apps/provisioning/pkg/repository.(*factory).Build(0xc0010446b0, {0x3d07148, 0xc0034faea0}, 0xc003269b88)\n\tgithub.com/grafana/grafana/apps/provisioning/pkg/repository/factory.go:71 +0x126\ngithub.com/grafana/grafana/pkg/registry/apis/provisioning.(*APIBuilder).asRepository(0xc001ae86e0?, {0x3d07148?, 0xc0034faea0?}, {0x3c86460?, 0xc003269b88?}, {0x3c86460?, 0xc00376e008?})\n\tgithub.com/grafana/grafana/pkg/registry/apis/provisioning/register.go:1281 +0x317\ngithub.com/grafana/grafana/pkg/registry/apis/provisioning.(*APIBuilder).Validate(0xc001ae86e0, {0x3d07148, 0xc0034faea0}, {0x3e10cb0, 0xc003763c20}, {0xffc?, 0xa62e247?})\n\tgithub.com/grafana/grafana/pkg/registry/apis/provisioning/register.go:534 
[...]
```

There is a [check](https://github.com/grafana/grafana/blob/ebd1f63aab70387c1bf0bd9cfe4be9149abad015/apps/provisioning/pkg/repository/github/extra.go#L66) in extra.go that the _interface_ is not nil, but the underlying struct can still be nil.