### PR TITLE
Grafana Advisor: Prometheus Type Migration check

### DIFF
--- a/apps/advisor/pkg/app/checks/datasourcecheck/check.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check.go
@@ -99,16 +99,16 @@ func (c *check) Init(ctx context.Context) error {
 func (c *check) Steps() []checks.Step {
 	c.pluginAvailabilityCache = make(map[string]bool)
 	return []checks.Step{
-		// &uidValidationStep{},
-		// &healthCheckStep{
-		// 	PluginContextProvider: c.PluginContextProvider,
-		// 	PluginClient:          c.PluginClient,
-		// },
-		// &missingPluginStep{
-		// 	PluginStore:    c.PluginStore,
-		// 	PluginRepo:     c.PluginRepo,
-		// 	GrafanaVersion: c.GrafanaVersion,
-		// },
+		&uidValidationStep{},
+		&healthCheckStep{
+			PluginContextProvider: c.PluginContextProvider,
+			PluginClient:          c.PluginClient,
+		},
+		&missingPluginStep{
+			PluginStore:    c.PluginStore,
+			PluginRepo:     c.PluginRepo,
+			GrafanaVersion: c.GrafanaVersion,
+		},
 		&promDepAuthStep{
 			IsPluginInstalledOrAvailableFunc: c.isPluginInstalled,
 		},

--- a/apps/advisor/pkg/app/checks/datasourcecheck/check.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check.go
@@ -18,6 +18,7 @@ const (
 	HealthCheckStepID   = "health-check"
 	UIDValidationStepID = "uid-validation"
 	MissingPluginStepID = "missing-plugin"
+	PromDepAuthStepID   = "prom-dep-auth"
 )
 
 type check struct {
@@ -99,6 +100,10 @@ func (c *check) Steps() []checks.Step {
 		},
 		&missingPluginStep{
 			PluginStore:    c.PluginStore,
+			PluginRepo:     c.PluginRepo,
+			GrafanaVersion: c.GrafanaVersion,
+		},
+		&promDepAuthStep{
 			PluginRepo:     c.PluginRepo,
 			GrafanaVersion: c.GrafanaVersion,
 		},

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -1,0 +1,131 @@
+package datasourcecheck
+
+import (
+	"context"
+	"fmt"
+	sysruntime "runtime"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	advisor "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/pkg/plugins/repo"
+	"github.com/grafana/grafana/pkg/services/datasources"
+)
+
+type promDepAuthStep struct {
+	PluginRepo     repo.Service
+	GrafanaVersion string
+}
+
+func (s *promDepAuthStep) Title() string {
+	return "Prometheus deprecated authentication check"
+}
+
+func (s *promDepAuthStep) Description() string {
+	return "Check if Prometheus data sources are using deprecated authentication methods (Azure and AWS)"
+}
+
+func (s *promDepAuthStep) Resolution() string {
+	return "Enable the feature flag for 'prometheusTypeMigration'. If the feature flag is enabled and the migration is failing, make sure to install 'Azure Monitor Managed Service for Prometheus' and/or 'Amazon Managed Service for Prometheus'."
+}
+
+func (s *promDepAuthStep) ID() string {
+	return PromDepAuthStepID
+}
+
+func (s *promDepAuthStep) Run(ctx context.Context, log logging.Logger, obj *advisor.CheckSpec, i any) ([]advisor.CheckReportFailure, error) {
+	ds, ok := i.(*datasources.DataSource)
+	if !ok {
+		return nil, fmt.Errorf("invalid item type %T", i)
+	}
+	links := []advisor.CheckErrorLink{}
+
+	awsLink, err := s.checkUsingAWSAuth(ctx, ds)
+	if err != nil {
+		return nil, err
+	}
+	if awsLink != nil {
+		links = append(links, *awsLink)
+	}
+
+	azureLink, err := s.checkUsingAzureAuth(ctx, ds)
+	if err != nil {
+		return nil, err
+	}
+	if azureLink != nil {
+		links = append(links, *azureLink)
+	}
+
+	if awsLink == nil && azureLink == nil {
+		return nil, nil
+	}
+
+	return []advisor.CheckReportFailure{checks.NewCheckReportFailureWithMoreInfo(
+		advisor.CheckReportFailureSeverityHigh,
+		s.ID(),
+		ds.Name,
+		ds.UID,
+		links,
+		fmt.Sprintf("Plugin: %s", ds.Type),
+	)}, nil
+
+}
+
+func (s *promDepAuthStep) checkUsingAWSAuth(ctx context.Context, ds *datasources.DataSource) (*advisor.CheckErrorLink, error) {
+	if sigV4Auth, found := ds.JsonData.CheckGet("sigV4Auth"); found {
+		if enabled, err := sigV4Auth.Bool(); err != nil || !enabled {
+			return nil, err
+		}
+		ro, err := checkReadOnly(ds)
+		if err != nil || ro != nil {
+			return ro, err
+		}
+		return s.linkDataSource(ctx, datasources.DS_AMAZON_PROMETHEUS)
+	}
+	return nil, nil
+}
+
+func (s *promDepAuthStep) checkUsingAzureAuth(ctx context.Context, ds *datasources.DataSource) (*advisor.CheckErrorLink, error) {
+	if azureAuth, found := ds.JsonData.CheckGet("azureCredentials"); found {
+		if val, err := azureAuth.Value(); err != nil || val == nil {
+			return nil, err
+		}
+		ro, err := checkReadOnly(ds)
+		if err != nil || ro != nil {
+			return ro, err
+		}
+		return s.linkDataSource(ctx, datasources.DS_AZURE_PROMETHEUS)
+	}
+	return nil, nil
+}
+
+func checkReadOnly(ds *datasources.DataSource) (*advisor.CheckErrorLink, error) {
+	if readOnly, found := ds.JsonData.CheckGet("readonly"); found {
+		if enabled, err := readOnly.Bool(); err != nil || !enabled {
+			return nil, err
+		}
+		return &advisor.CheckErrorLink{
+			Message: "Plugin is ReadOnly",
+			Url:     fmt.Sprintf("/plugins/%s", ds.Type),
+		}, nil
+	}
+	return nil, nil
+}
+
+func (s *promDepAuthStep) linkDataSource(ctx context.Context, dataSourceType string) (*advisor.CheckErrorLink, error) {
+	plugins, err := s.PluginRepo.GetPluginsInfo(ctx, repo.GetPluginsInfoOptions{
+		IncludeDeprecated: true,
+		Plugins:           []string{dataSourceType},
+	}, repo.NewCompatOpts(s.GrafanaVersion, sysruntime.GOOS, sysruntime.GOARCH))
+	if err != nil {
+		return nil, err
+	}
+	if len(plugins) > 0 {
+		// Plugin is available in the repo
+		return &advisor.CheckErrorLink{
+			Message: "View plugin",
+			Url:     fmt.Sprintf("/plugins/%s", dataSourceType),
+		}, nil
+	}
+	return nil, nil
+}

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -74,10 +74,7 @@ func (s *promDepAuthStep) checkUsingAWSAuth(ctx context.Context, dataSource *dat
 			// Disabled or not a valid boolean
 			return nil, nil
 		}
-		readOnlyLink, err := checkReadOnly(dataSource)
-		if err != nil {
-			return nil, err
-		}
+		readOnlyLink := checkReadOnly(dataSource)
 
 		if readOnlyLink != nil {
 			errorLinks = append(errorLinks, *readOnlyLink)
@@ -88,10 +85,7 @@ func (s *promDepAuthStep) checkUsingAWSAuth(ctx context.Context, dataSource *dat
 				Message: "View SigV4 docs",
 				Url:     "https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure/aws-authentication/",
 			})
-		pluginLink, err := s.linkDataSource(ctx, datasources.DS_AMAZON_PROMETHEUS, "Amazon Managed Service for Prometheus")
-		if err != nil {
-			return nil, err
-		}
+		pluginLink := s.linkDataSource(ctx, datasources.DS_AMAZON_PROMETHEUS, "Amazon Managed Service for Prometheus")
 		if pluginLink != nil {
 			errorLinks = append(errorLinks, *pluginLink)
 		}
@@ -106,10 +100,7 @@ func (s *promDepAuthStep) checkUsingAzureAuth(ctx context.Context, dataSource *d
 			// azureAuth does not have a value
 			return nil, nil
 		}
-		readOnlyLink, err := checkReadOnly(dataSource)
-		if err != nil {
-			return nil, err
-		}
+		readOnlyLink := checkReadOnly(dataSource)
 		if readOnlyLink != nil {
 			errorLinks = append(errorLinks, *readOnlyLink)
 		}
@@ -118,10 +109,7 @@ func (s *promDepAuthStep) checkUsingAzureAuth(ctx context.Context, dataSource *d
 				Message: "View Azure auth docs",
 				Url:     "https://grafana.com/docs/grafana-cloud/connect-externally-hosted/data-sources/prometheus/configure/azure-authentication/",
 			})
-		pluginLink, err := s.linkDataSource(ctx, datasources.DS_AZURE_PROMETHEUS, "Azure Monitor Managed Service for Prometheus")
-		if err != nil {
-			return errorLinks, err
-		}
+		pluginLink := s.linkDataSource(ctx, datasources.DS_AZURE_PROMETHEUS, "Azure Monitor Managed Service for Prometheus")
 		if pluginLink != nil {
 			errorLinks = append(errorLinks, *pluginLink)
 		}
@@ -129,31 +117,31 @@ func (s *promDepAuthStep) checkUsingAzureAuth(ctx context.Context, dataSource *d
 	return errorLinks, nil
 }
 
-func checkReadOnly(dataSource *datasources.DataSource) (*advisor.CheckErrorLink, error) {
+func checkReadOnly(dataSource *datasources.DataSource) *advisor.CheckErrorLink {
 	if readOnly, found := dataSource.JsonData.CheckGet("readonly"); found {
 		if enabled, err := readOnly.Bool(); err != nil || !enabled {
 			// Disabled or not a valid boolean
-			return nil, nil
+			return nil
 		}
 		return &advisor.CheckErrorLink{
 			Message: "Change provisioning file",
 			Url:     "https://grafana.com/docs/grafana/latest/administration/provisioning/#data-sources",
-		}, nil
+		}
 	}
-	return nil, nil
+	return nil
 }
 
-func (s *promDepAuthStep) linkDataSource(ctx context.Context, pluginType string, pluginName string) (*advisor.CheckErrorLink, error) {
+func (s *promDepAuthStep) linkDataSource(ctx context.Context, pluginType string, pluginName string) *advisor.CheckErrorLink {
 	isPluginAvailable, err := s.IsPluginInstalledOrAvailableFunc(ctx, pluginType)
 	if err != nil {
-		return nil, nil
+		return nil
 	}
 	if !isPluginAvailable {
 		// Plugin is available in the repo
 		return &advisor.CheckErrorLink{
 			Message: fmt.Sprintf("Install %s", pluginName),
 			Url:     fmt.Sprintf("/plugins/%s", pluginType),
-		}, nil
+		}
 	}
-	return nil, nil
+	return nil
 }

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -11,7 +11,7 @@ import (
 )
 
 type promDepAuthStep struct {
-	GetPluginExistsFunc func(ctx context.Context, pluginType string) (bool, error)
+	IsPluginInstalledOrAvailableFunc func(ctx context.Context, pluginType string) (bool, error)
 }
 
 func (s *promDepAuthStep) Title() string {
@@ -144,11 +144,11 @@ func checkReadOnly(dataSource *datasources.DataSource) (*advisor.CheckErrorLink,
 }
 
 func (s *promDepAuthStep) linkDataSource(ctx context.Context, pluginType string, pluginName string) (*advisor.CheckErrorLink, error) {
-	pluginAvailable, err := s.GetPluginExistsFunc(ctx, pluginType)
+	isPluginAvailable, err := s.IsPluginInstalledOrAvailableFunc(ctx, pluginType)
 	if err != nil {
 		return nil, nil
 	}
-	if pluginAvailable {
+	if !isPluginAvailable {
 		// Plugin is available in the repo
 		return &advisor.CheckErrorLink{
 			Message: fmt.Sprintf("Install %s", pluginName),

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -11,7 +11,7 @@ import (
 )
 
 type promDepAuthStep struct {
-	IsPluginInstalledOrAvailableFunc func(ctx context.Context, pluginType string) (bool, error)
+	canBeInstalled func(ctx context.Context, pluginType string) (bool, error)
 }
 
 func (s *promDepAuthStep) Title() string {
@@ -132,11 +132,11 @@ func checkReadOnly(dataSource *datasources.DataSource) *advisor.CheckErrorLink {
 }
 
 func (s *promDepAuthStep) linkDataSource(ctx context.Context, pluginType string, pluginName string) *advisor.CheckErrorLink {
-	isPluginAvailable, err := s.IsPluginInstalledOrAvailableFunc(ctx, pluginType)
+	canBeInstalled, err := s.canBeInstalled(ctx, pluginType)
 	if err != nil {
 		return nil
 	}
-	if !isPluginAvailable {
+	if canBeInstalled {
 		// Plugin is available in the repo
 		return &advisor.CheckErrorLink{
 			Message: fmt.Sprintf("Install %s", pluginName),

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -26,7 +26,7 @@ func (s *promDepAuthStep) Description() string {
 }
 
 func (s *promDepAuthStep) Resolution() string {
-	return "Enable the feature toggle for 'prometheusTypeMigration'. If this feature toggle is already enabled, install 'Azure Monitor Managed Service for Prometheus' and/or 'Amazon Managed Service for Prometheus' data sources."
+	return "Enable the feature toggle for 'prometheusTypeMigration'. If this feature toggle is already enabled, make sure that 'Azure Monitor Managed Service for Prometheus' and/or 'Amazon Managed Service for Prometheus' plugins are installed."
 }
 
 func (s *promDepAuthStep) ID() string {
@@ -74,7 +74,8 @@ func (s *promDepAuthStep) checkUsingAWSAuth(ctx context.Context, dataSource *dat
 	var errorLinks []advisor.CheckErrorLink
 	if sigV4Auth, found := dataSource.JsonData.CheckGet("sigV4Auth"); found {
 		if enabled, err := sigV4Auth.Bool(); err != nil || !enabled {
-			return nil, err
+			// Disabled or not a valid boolean
+			return nil, nil
 		}
 		readOnlyLink, err := checkReadOnly(dataSource)
 		if err != nil {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -38,6 +38,10 @@ func (s *promDepAuthStep) Run(ctx context.Context, log logging.Logger, obj *advi
 	if !ok {
 		return nil, fmt.Errorf("invalid item type %T", i)
 	}
+	if ds.Type != datasources.DS_PROMETHEUS {
+		return nil, nil
+	}
+
 	links := []advisor.CheckErrorLink{}
 
 	awsLink, err := s.checkUsingAWSAuth(ctx, ds)

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -65,7 +65,6 @@ func (s *promDepAuthStep) Run(ctx context.Context, log logging.Logger, obj *advi
 		errorLinks,
 		fmt.Sprintf("Plugin: %s", dataSource.Type),
 	)}, nil
-
 }
 
 func (s *promDepAuthStep) checkUsingAWSAuth(ctx context.Context, dataSource *datasources.DataSource) ([]advisor.CheckErrorLink, error) {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/prom_dep_auth_check_step.go
@@ -41,6 +41,9 @@ func (s *promDepAuthStep) Run(ctx context.Context, log logging.Logger, obj *advi
 	if dataSource.Type != datasources.DS_PROMETHEUS {
 		return nil, nil
 	}
+	if dataSource.JsonData == nil {
+		return nil, nil
+	}
 
 	awsAuthLinks, err := s.checkUsingAWSAuth(ctx, dataSource)
 	if err != nil {


### PR DESCRIPTION
https://github.com/grafana/data-sources/issues/650

Adds a check to the Grafana Advisor that sees if the Prometheus data sources are using SigV4 (aws auth) or Azure auth. If they are they are flagged as needing to migrate

<img width="1509" height="572" alt="image" src="https://github.com/user-attachments/assets/03ae1b3a-c0f5-4ee3-b2a6-b4f978c33ab2" />
