### PR TITLE
Chore: Removes angular from externals

### DIFF
--- a/packages/grafana-plugin-configs/webpack.config.ts
+++ b/packages/grafana-plugin-configs/webpack.config.ts
@@ -89,7 +89,6 @@ const config = async (env: Env): Promise<Configuration> => {
       'rxjs/operators',
       'react-router',
       'd3',
-      'angular',
       /^@grafana\/ui/i,
       /^@grafana\/runtime/i,
       /^@grafana\/data/i,


### PR DESCRIPTION
**What is this feature?**

This pull request makes a small change to the `packages/grafana-plugin-configs/webpack.config.ts` file by removing `angular` from the list of external dependencies. This PR doesn't remove legacy SDK parts because they're still in `create-plugin` webpack.config. We should look into that part together with `create-plugin`.

**Why do we need this feature?**

https://github.com/grafana/grafana/issues/103872

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #110854

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
