### PR TITLE
Dashboard Controls: Only render the "stack" if the drop-down is menu is visible

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -124,6 +124,10 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const { links, editPanel } = dashboard.useState();
   const styles = useStyles2(getStyles);
   const showDebugger = window.location.search.includes('scene-debugger');
+  const hasControlMenuVariables = sceneGraph
+    .getVariables(dashboard)
+    .useState()
+    .variables.some((v) => v.state.showInControlsMenu === true);
 
   if (!model.hasControls()) {
     // To still have spacing when no controls are rendered
@@ -152,9 +156,11 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
           <refreshPicker.Component model={refreshPicker} />
         </Stack>
       )}
-      <Stack>
-        <DropdownVariableControls dashboard={dashboard} />
-      </Stack>
+      {hasControlMenuVariables && (
+        <Stack>
+          <DropdownVariableControls dashboard={dashboard} />
+        </Stack>
+      )}
       {showDebugger && <SceneDebugger scene={model} key={'scene-debugger'} />}
     </div>
   );


### PR DESCRIPTION
**Related Slack thread:** https://raintank-corp.slack.com/archives/C068ZP1HBGQ/p1757069790637389
 
### What changed?
The recently added dropdown menu for dashboard controls introduced a regression in the UX: it was rendering the surrounding `<Stack>` component even if the drop-down itself was empty and not rendered. This PR is fixing it. Thanks @torkelo for spotting it.

 | Before | After |
  |--------|-------|
  | <img width="445" height="294" alt="Screenshot 2025-09-10 at 8 27 17" src="https://github.com/user-attachments/assets/6922b3ed-d096-481f-b04a-01ae24d227bb" /> | <img width="445" height="294" alt="Screenshot 2025-09-10 at 8 24 58" src="https://github.com/user-attachments/assets/6e5de228-6be5-4c63-a376-2b919b6ad607" /> |

