### PR TITLE
NPM: Publish canary packages

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -74,56 +74,56 @@ jobs:
         run: |
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
           echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
-  # Triggers the same workflow in `grafana-enterprise` on the same ref
-  # downstream:
-  #   runs-on: github-hosted-ubuntu-x64-small
-  #   needs: [setup]
-  #   permissions:
-  #     contents: read
-  #     id-token: write
-  #   name: Dispatch grafana-enterprise build
-  #   steps:
-  #     - id: vault-secrets
-  #       uses: grafana/shared-workflows/actions/get-vault-secrets@main
-  #       with:
-  #         repo_secrets: |
-  #           GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
-  #     - name: Generate token
-  #       id: generate_token
-  #       uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-  #       with:
-  #         app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
-  #         private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
-  #         repositories: '["grafana-enterprise"]'
-  #         permissions: '{"actions": "write"}'
-  #     - uses: actions/github-script@v7
-  #       env:
-  #         REF: ${{ github.ref_name }}
-  #         VERSION: ${{ needs.setup.outputs.version }}
-  #         BUILD_ID: ${{ github.run_id }}
-  #         BUCKET: grafana-prerelease
-  #         GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
-  #         SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
-  #         REPO: ${{ github.repository }}
-  #       with:
-  #         github-token: ${{ steps.generate_token.outputs.token }}
-  #         script: |
-  #           const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
+  Triggers the same workflow in `grafana-enterprise` on the same ref
+  downstream:
+    runs-on: github-hosted-ubuntu-x64-small
+    needs: [setup]
+    permissions:
+      contents: read
+      id-token: write
+    name: Dispatch grafana-enterprise build
+    steps:
+      - id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+          repositories: '["grafana-enterprise"]'
+          permissions: '{"actions": "write"}'
+      - uses: actions/github-script@v7
+        env:
+          REF: ${{ github.ref_name }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          BUILD_ID: ${{ github.run_id }}
+          BUCKET: grafana-prerelease
+          GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
+          SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
+          REPO: ${{ github.repository }}
+        with:
+          github-token: ${{ steps.generate_token.outputs.token }}
+          script: |
+            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
 
-  #           await github.rest.actions.createWorkflowDispatch({
-  #               owner: 'grafana',
-  #               repo: 'grafana-enterprise',
-  #               workflow_id: 'release-build.yml',
-  #               ref:  REF,
-  #               inputs: {
-  #                 "version": VERSION,
-  #                 "build-id": String(BUILD_ID),
-  #                 "bucket": BUCKET,
-  #                 "grafana-commit": GRAFANA_COMMIT,
-  #                 "source-event": SOURCE_EVENT,
-  #                 "upstream": REPO,
-  #               }
-  #           })
+            await github.rest.actions.createWorkflowDispatch({
+                owner: 'grafana',
+                repo: 'grafana-enterprise',
+                workflow_id: 'release-build.yml',
+                ref:  REF,
+                inputs: {
+                  "version": VERSION,
+                  "build-id": String(BUILD_ID),
+                  "bucket": BUCKET,
+                  "grafana-commit": GRAFANA_COMMIT,
+                  "source-event": SOURCE_EVENT,
+                  "upstream": REPO,
+                }
+            })
 
   build:
     runs-on: github-hosted-ubuntu-x64-large
@@ -141,32 +141,32 @@ jobs:
         # This could be a future improvement.
         include:
           - name: linux-amd64 # publish-npm relies on this step building npm packages
-            artifacts: npm:grafana,storybook
+            artifacts: targz:grafana:linux/amd64,deb:grafana:linux/amd64,rpm:grafana:linux/amd64,docker:grafana:linux/amd64,docker:grafana:linux/amd64:ubuntu,npm:grafana,storybook
             verify: true
-          # - name: linux-arm64
-          #   artifacts: targz:grafana:linux/arm64,deb:grafana:linux/arm64,rpm:grafana:linux/arm64,docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
-          #   verify: false
-          # - name: linux-s390x
-          #   artifacts: targz:grafana:linux/s390x,deb:grafana:linux/s390x,rpm:grafana:linux/s390x,docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
-          #   verify: true
-          # - name: linux-armv7
-          #   artifacts: targz:grafana:linux/arm/v7,deb:grafana:linux/arm/v7,docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
-          #   verify: true
-          # - name: linux-armv6
-          #   artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
-          #   verify: true
-          # - name: windows-amd64
-          #   artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
-          #   verify: true
-          # - name: windows-arm64
-          #   artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
-          #   verify: true
-          # - name: darwin-amd64
-          #   artifacts: targz:grafana:darwin/amd64
-          #   verify: true
-          # - name: darwin-arm64
-          #   artifacts: targz:grafana:darwin/arm64
-          #   verify: true
+          - name: linux-arm64
+            artifacts: targz:grafana:linux/arm64,deb:grafana:linux/arm64,rpm:grafana:linux/arm64,docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
+            verify: false
+          - name: linux-s390x
+            artifacts: targz:grafana:linux/s390x,deb:grafana:linux/s390x,rpm:grafana:linux/s390x,docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
+            verify: true
+          - name: linux-armv7
+            artifacts: targz:grafana:linux/arm/v7,deb:grafana:linux/arm/v7,docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
+            verify: true
+          - name: linux-armv6
+            artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
+            verify: true
+          - name: windows-amd64
+            artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
+            verify: true
+          - name: windows-arm64
+            artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
+            verify: true
+          - name: darwin-amd64
+            artifacts: targz:grafana:darwin/amd64
+            verify: true
+          - name: darwin-arm64
+            artifacts: targz:grafana:darwin/arm64
+            verify: true
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: actions/checkout@v5
@@ -198,20 +198,20 @@ jobs:
           path: ${{ steps.build.outputs.dist-dir }}
           retention-days: 1
 
-  # publish-artifacts:
-  #   name: Upload artifacts
-  #   uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-  #   permissions:
-  #     id-token: write
-  #   needs:
-  #     - setup
-  #     - build
-  #   with:
-  #     bucket: grafana-prerelease
-  #     pattern: artifacts-*
-  #     run-id: ${{ github.run_id }}
-  #     bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-  #     environment: prod
+  publish-artifacts:
+    name: Upload artifacts
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-*
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
 
   publish-dockerhub:
     if: github.ref_name == 'main'
@@ -272,10 +272,11 @@ jobs:
           docker manifest push "grafana/grafana-dev:${VERSION}-ubuntu"
 
   publish-npm:
-    # if: github.ref_name == 'main'
+    if: github.ref_name == 'main'
     permissions:
       contents: read
       id-token: write
+    # NPM Trusted Publishing does not yet support self-hosted runners
     runs-on: github-hosted-ubuntu-x64-small
     needs:
       - setup
@@ -295,21 +296,18 @@ jobs:
           node-version-file: '.nvmrc'
 
       # Trusted Publishing is only available in npm v11.5.1 and later
-      - name: Install NPM
+      - name: Update npm
         run: npm install -g npm@^11.5.1
-
-      - run: echo "publishing as version ${PACKAGES_VERSION}"
 
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: artifacts-linux-amd64
           path: dist
 
-      - run: mv dist/"${PACKAGES_VERSION}"/npm-packages npm-artifacts
+      - name: Copy packages
+        run: mv dist/"${PACKAGES_VERSION}"/npm-packages npm-artifacts
 
-      - run: ls -lah npm-artifacts
-
-      - name: Publish
+      - name: Publish to NPM
         env:
           NPM_TOKEN: "oidc"
         run: ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org/'

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -311,7 +311,7 @@ jobs:
 
       - run: tree . -a -L 4
 
-      - run: mv dist/artifacts-linux-amd64/npm-artifacts npm-artifacts
+      - run: mv dist/"${PACKAGES_VERSION}"/npm-packages npm-artifacts
 
       - run: ls -lah npm-artifacts
 
@@ -319,4 +319,3 @@ jobs:
         env:
           NPM_TOKEN: "oidc"
         run: ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org/'
-

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -75,55 +75,55 @@ jobs:
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
           echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
   # Triggers the same workflow in `grafana-enterprise` on the same ref
-  downstream:
-    runs-on: github-hosted-ubuntu-x64-small
-    needs: [setup]
-    permissions:
-      contents: read
-      id-token: write
-    name: Dispatch grafana-enterprise build
-    steps:
-      - id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
-      - name: Generate token
-        id: generate_token
-        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
-        with:
-          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
-          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
-          repositories: '["grafana-enterprise"]'
-          permissions: '{"actions": "write"}'
-      - uses: actions/github-script@v7
-        env:
-          REF: ${{ github.ref_name }}
-          VERSION: ${{ needs.setup.outputs.version }}
-          BUILD_ID: ${{ github.run_id }}
-          BUCKET: grafana-prerelease
-          GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
-          SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
-          REPO: ${{ github.repository }}
-        with:
-          github-token: ${{ steps.generate_token.outputs.token }}
-          script: |
-            const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
+  # downstream:
+  #   runs-on: github-hosted-ubuntu-x64-small
+  #   needs: [setup]
+  #   permissions:
+  #     contents: read
+  #     id-token: write
+  #   name: Dispatch grafana-enterprise build
+  #   steps:
+  #     - id: vault-secrets
+  #       uses: grafana/shared-workflows/actions/get-vault-secrets@main
+  #       with:
+  #         repo_secrets: |
+  #           GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+  #     - name: Generate token
+  #       id: generate_token
+  #       uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+  #       with:
+  #         app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+  #         private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+  #         repositories: '["grafana-enterprise"]'
+  #         permissions: '{"actions": "write"}'
+  #     - uses: actions/github-script@v7
+  #       env:
+  #         REF: ${{ github.ref_name }}
+  #         VERSION: ${{ needs.setup.outputs.version }}
+  #         BUILD_ID: ${{ github.run_id }}
+  #         BUCKET: grafana-prerelease
+  #         GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
+  #         SOURCE_EVENT: ${{ inputs.source-event || github.event_name }}
+  #         REPO: ${{ github.repository }}
+  #       with:
+  #         github-token: ${{ steps.generate_token.outputs.token }}
+  #         script: |
+  #           const {REF, VERSION, BUILD_ID, BUCKET, GRAFANA_COMMIT, SOURCE_EVENT, REPO} = process.env;
 
-            await github.rest.actions.createWorkflowDispatch({
-                owner: 'grafana',
-                repo: 'grafana-enterprise',
-                workflow_id: 'release-build.yml',
-                ref:  REF,
-                inputs: {
-                  "version": VERSION,
-                  "build-id": String(BUILD_ID),
-                  "bucket": BUCKET,
-                  "grafana-commit": GRAFANA_COMMIT,
-                  "source-event": SOURCE_EVENT,
-                  "upstream": REPO,
-                }
-            })
+  #           await github.rest.actions.createWorkflowDispatch({
+  #               owner: 'grafana',
+  #               repo: 'grafana-enterprise',
+  #               workflow_id: 'release-build.yml',
+  #               ref:  REF,
+  #               inputs: {
+  #                 "version": VERSION,
+  #                 "build-id": String(BUILD_ID),
+  #                 "bucket": BUCKET,
+  #                 "grafana-commit": GRAFANA_COMMIT,
+  #                 "source-event": SOURCE_EVENT,
+  #                 "upstream": REPO,
+  #               }
+  #           })
 
   build:
     runs-on: github-hosted-ubuntu-x64-large
@@ -140,33 +140,33 @@ jobs:
         # The downside to this is that the frontend will be built for each one when it could be reused for all of them.
         # This could be a future improvement.
         include:
-          - name: linux-amd64
-            artifacts: targz:grafana:linux/amd64,deb:grafana:linux/amd64,rpm:grafana:linux/amd64,docker:grafana:linux/amd64,docker:grafana:linux/amd64:ubuntu,npm:grafana,storybook
+          - name: linux-amd64 # publish-npm relies on this step building npm packages
+            artifacts: npm:grafana,storybook
             verify: true
-          - name: linux-arm64
-            artifacts: targz:grafana:linux/arm64,deb:grafana:linux/arm64,rpm:grafana:linux/arm64,docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
-            verify: false
-          - name: linux-s390x
-            artifacts: targz:grafana:linux/s390x,deb:grafana:linux/s390x,rpm:grafana:linux/s390x,docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
-            verify: true
-          - name: linux-armv7
-            artifacts: targz:grafana:linux/arm/v7,deb:grafana:linux/arm/v7,docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
-            verify: true
-          - name: linux-armv6
-            artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
-            verify: true
-          - name: windows-amd64
-            artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
-            verify: true
-          - name: windows-arm64
-            artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
-            verify: true
-          - name: darwin-amd64
-            artifacts: targz:grafana:darwin/amd64
-            verify: true
-          - name: darwin-arm64
-            artifacts: targz:grafana:darwin/arm64
-            verify: true
+          # - name: linux-arm64
+          #   artifacts: targz:grafana:linux/arm64,deb:grafana:linux/arm64,rpm:grafana:linux/arm64,docker:grafana:linux/arm64,docker:grafana:linux/arm64:ubuntu
+          #   verify: false
+          # - name: linux-s390x
+          #   artifacts: targz:grafana:linux/s390x,deb:grafana:linux/s390x,rpm:grafana:linux/s390x,docker:grafana:linux/s390x,docker:grafana:linux/s390x:ubuntu
+          #   verify: true
+          # - name: linux-armv7
+          #   artifacts: targz:grafana:linux/arm/v7,deb:grafana:linux/arm/v7,docker:grafana:linux/arm/v7,docker:grafana:linux/arm/v7:ubuntu
+          #   verify: true
+          # - name: linux-armv6
+          #   artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
+          #   verify: true
+          # - name: windows-amd64
+          #   artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
+          #   verify: true
+          # - name: windows-arm64
+          #   artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
+          #   verify: true
+          # - name: darwin-amd64
+          #   artifacts: targz:grafana:darwin/amd64
+          #   verify: true
+          # - name: darwin-arm64
+          #   artifacts: targz:grafana:darwin/arm64
+          #   verify: true
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: actions/checkout@v5
@@ -197,20 +197,22 @@ jobs:
           name: artifacts-${{ matrix.name }}
           path: ${{ steps.build.outputs.dist-dir }}
           retention-days: 1
-  publish-artifacts:
-    name: Upload artifacts
-    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
-    permissions:
-      id-token: write
-    needs:
-      - setup
-      - build
-    with:
-      bucket: grafana-prerelease
-      pattern: artifacts-*
-      run-id: ${{ github.run_id }}
-      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
-      environment: prod
+
+  # publish-artifacts:
+  #   name: Upload artifacts
+  #   uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+  #   permissions:
+  #     id-token: write
+  #   needs:
+  #     - setup
+  #     - build
+  #   with:
+  #     bucket: grafana-prerelease
+  #     pattern: artifacts-*
+  #     run-id: ${{ github.run_id }}
+  #     bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+  #     environment: prod
+
   publish-dockerhub:
     if: github.ref_name == 'main'
     permissions:
@@ -268,3 +270,61 @@ jobs:
           docker manifest push grafana/grafana:main-ubuntu
           docker manifest push "grafana/grafana-dev:${VERSION}"
           docker manifest push "grafana/grafana-dev:${VERSION}-ubuntu"
+
+  publish-npm:
+    # if: github.ref_name == 'main'
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-x64-small
+    needs:
+      - setup
+      - build
+    env:
+      PACKAGES_VERSION: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      # - name: Setup Node.js
+      #   uses: ./.github/actions/setup-node
+
+      # - name: Yarn install
+      #   run: yarn install --immutable
+      #   env:
+      #     PUPPETEER_SKIP_DOWNLOAD: true
+      #     CYPRESS_INSTALL_BINARY: 0
+
+      # - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+      #   with:
+      #     name: artifacts-list-linux-amd64
+      #     path: .
+
+      - run: echo "publishing as version ${PACKAGES_VERSION}"
+
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: artifacts-linux-amd64
+          path: dist
+
+      - run: mv dist/"${PACKAGES_VERSION}"/npm-artifacts npm-artifacts
+
+      - run: ls -lah npm-artifacts
+
+      - name: Publish
+        env:
+          NPM_TOKEN: "oidc"
+        run: ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org/'
+
+      # - name: Publish
+      #   env:
+      #     DIST_TAG: "canary"
+      #     REGISTRY: "https://registry.npmjs.org/"
+      #   run: |
+      #     for file in ./npm-artifacts/*.tgz; do
+      #         npm publish "$file" --tag "$DIST_TAG" --registry "$REGISTRY"
+      #     done
+
+

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -309,7 +309,9 @@ jobs:
           name: artifacts-linux-amd64
           path: dist
 
-      - run: mv dist/"${PACKAGES_VERSION}"/npm-artifacts npm-artifacts
+      - run: tree . -a -L 4
+
+      - run: mv dist/artifacts-linux-amd64/npm-artifacts npm-artifacts
 
       - run: ls -lah npm-artifacts
 
@@ -317,14 +319,4 @@ jobs:
         env:
           NPM_TOKEN: "oidc"
         run: ./scripts/publish-npm-packages.sh --dist-tag 'canary' --registry 'https://registry.npmjs.org/'
-
-      # - name: Publish
-      #   env:
-      #     DIST_TAG: "canary"
-      #     REGISTRY: "https://registry.npmjs.org/"
-      #   run: |
-      #     for file in ./npm-artifacts/*.tgz; do
-      #         npm publish "$file" --tag "$DIST_TAG" --registry "$REGISTRY"
-      #     done
-
 

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           echo "version=$(cat VERSION)" >> "$GITHUB_OUTPUT"
           echo "grafana_commit=$(git rev-parse HEAD)" | tee -a "$GITHUB_OUTPUT"
-  Triggers the same workflow in `grafana-enterprise` on the same ref
+  # Triggers the same workflow in `grafana-enterprise` on the same ref
   downstream:
     runs-on: github-hosted-ubuntu-x64-small
     needs: [setup]

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -276,7 +276,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    runs-on: ubuntu-x64-small
+    runs-on: github-hosted-ubuntu-x64-small
     needs:
       - setup
       - build
@@ -288,19 +288,15 @@ jobs:
         with:
           persist-credentials: false
 
-      # - name: Setup Node.js
-      #   uses: ./.github/actions/setup-node
+      # Setting nodejs up just for npm publish. Not restoring the cache for all our dependencies
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: '.nvmrc'
 
-      # - name: Yarn install
-      #   run: yarn install --immutable
-      #   env:
-      #     PUPPETEER_SKIP_DOWNLOAD: true
-      #     CYPRESS_INSTALL_BINARY: 0
-
-      # - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
-      #   with:
-      #     name: artifacts-list-linux-amd64
-      #     path: .
+      # Trusted Publishing is only available in npm v11.5.1 and later
+      - name: Install NPM
+        run: npm install -g npm@^11.5.1
 
       - run: echo "publishing as version ${PACKAGES_VERSION}"
 
@@ -308,8 +304,6 @@ jobs:
         with:
           name: artifacts-linux-amd64
           path: dist
-
-      - run: tree . -a -L 4
 
       - run: mv dist/"${PACKAGES_VERSION}"/npm-packages npm-artifacts
 

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
-  "version": "12.0.0-123456789"
+  "version": "12.2.0-pre"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
   "npmClient": "yarn",
-  "version": "12.2.0-pre"
+  "version": "12.0.0-123456789"
 }

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -34,8 +34,7 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
-echo "Starting to release $dist_tag version"
-
+echo "Starting to release $dist_tag version with NPM version $(npm --version) to registry $registry"
 
 if [[ "$NPM_TOKEN" != "oidc" ]]; then
   registry_without_protocol=${registry#*:}

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -43,9 +43,21 @@ if [[ "$NPM_TOKEN" != "oidc" ]]; then
 fi
 
 # Loop over .tar files in directory and publish them to npm registry
+failed_packages=()
 for file in ./npm-artifacts/*.tgz; do
-    npm publish "$file" --tag "$dist_tag" --registry "$registry"
+    if ! npm publish "$file" --tag "$dist_tag" --registry "$registry"; then
+        failed_packages+=("$file")
+    fi
 done
+
+# Log failed packages and exit with error if any failed
+if (( ${#failed_packages[@]} > 0 )); then
+    echo "\nERROR: The following packages failed to publish:"
+    for pkg in "${failed_packages[@]}"; do
+        echo "  - $pkg"
+    done
+    exit 1
+fi
 
 # Check if any files in packages/grafana-e2e-selectors were changed. If so, add a 'modified' tag to the package
 CHANGES_COUNT=$(git diff HEAD~1..HEAD --name-only -- packages/grafana-e2e-selectors | awk 'END{print NR}')

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -36,9 +36,11 @@ done
 
 echo "Starting to release $dist_tag version"
 
-registry_without_protocol=${registry#*:}
 
-echo "$registry_without_protocol/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+if [[ "$NPM_TOKEN" != "oidc" ]]; then
+  registry_without_protocol=${registry#*:}
+  echo "$registry_without_protocol/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+fi
 
 # Loop over .tar files in directory and publish them to npm registry
 for file in ./npm-artifacts/*.tgz; do

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -5,9 +5,6 @@
 dist_tag="canary"
 registry="http://localhost:4873"
 
-# shellcheck source=./scripts/helpers/exit-if-fail.sh
-source "$(dirname "$0")/helpers/exit-if-fail.sh"
-
 if [ -z "$NPM_TOKEN" ]; then
   echo "The NPM_TOKEN environment variable does not exist."
   exit 1

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -51,7 +51,8 @@ done
 
 # Log failed packages and exit with error if any failed
 if (( ${#failed_packages[@]} > 0 )); then
-    echo "\nERROR: The following packages failed to publish:"
+    echo ""
+    echo "ERROR: The following packages failed to publish:"
     for pkg in "${failed_packages[@]}"; do
         echo "  - $pkg"
     done


### PR DESCRIPTION
Updates the release-build.yml workflow to publish matching 'canary' NPM packages on commit to main.

Instead of using NPM tokens, we're using the new OIDC-based [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) to publish the packages. This required a few other changes:
- Need to manually install npm v11.5.1 or greater
- Update the `publish-npm-packages.sh` script to allow tokenless publishing
- Update the `publish-npm-packages.sh` script to fail when a package fails to publish. This used to silently fail!

Fixes https://github.com/grafana/grafana/issues/110200