### PR TITLE
fix: add intrumentation for auth server grpc client

### DIFF
--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -308,6 +308,7 @@ require (
 	github.com/openfga/api/proto v0.0.0-20250127102726-f9709139a369 // indirect
 	github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250220223040-ed0cfba54336 // indirect
 	github.com/openfga/openfga v1.8.13 // indirect
+	github.com/opentracing-contrib/go-grpc v0.1.1 // indirect
 	github.com/opentracing-contrib/go-stdlib v1.0.0 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect

--- a/apps/iam/go.sum
+++ b/apps/iam/go.sum
@@ -1100,6 +1100,8 @@ github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250220223040-ed0cfba54336 h
 github.com/openfga/language/pkg/go v0.2.0-beta.2.0.20250220223040-ed0cfba54336/go.mod h1:IWRgDIekw3UGSWINwmCALHpMmn6NEJzz6e7KZGm+xQ4=
 github.com/openfga/openfga v1.8.13 h1:ROURkotKhbmtyBX3188+cNElN8AOZmTl0CMkxUqwawo=
 github.com/openfga/openfga v1.8.13/go.mod h1:h1VGcVW81eY1YyDtFx5+gxxAIEhIiOGR9SRGgs/X/k8=
+github.com/opentracing-contrib/go-grpc v0.1.1 h1:Ws7IN1zyiL1DFqKQPhRXuKe5pLYzMfdxnC1qtajE2PE=
+github.com/opentracing-contrib/go-grpc v0.1.1/go.mod h1:Nu6sz+4zzgxXu8rvKfnwjBEmHsuhTigxRwV2RhELrS8=
 github.com/opentracing-contrib/go-stdlib v1.0.0 h1:TBS7YuVotp8myLon4Pv7BtCBzOTo1DeZCld0Z63mW2w=
 github.com/opentracing-contrib/go-stdlib v1.0.0/go.mod h1:qtI1ogk+2JhVPIXVc6q+NHziSmy2W5GbdQZFUHADCBU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -164,7 +164,9 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 	authzRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "authz_server_client_request_duration_seconds",
 		Help:    "Time spent executing requests to authz server.",
-		Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
+		NativeHistogramBucketFactor:     1.1,
+		NativeHistogramMaxBucketNumber:  160,
+		NativeHistogramMinResetDuration: time.Hour,
 	}, []string{"operation", "status_code"})
 
 	unaryInterceptors, streamInterceptors := grpcclient.Instrument(authzRequestDuration)

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -162,8 +162,8 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 	}
 
 	authzRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "authz_server_client_request_duration_seconds",
-		Help:    "Time spent executing requests to authz server.",
+		Name:                            "authz_server_client_request_duration_seconds",
+		Help:                            "Time spent executing requests to authz server.",
 		NativeHistogramBucketFactor:     1.1,
 		NativeHistogramMaxBucketNumber:  160,
 		NativeHistogramMinResetDuration: time.Hour,

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -161,13 +161,13 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 		}
 	}
 
-	authRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+	authzRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 		Name:    "authz_server_client_request_duration_seconds",
 		Help:    "Time spent executing requests to authz server.",
 		Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
 	}, []string{"operation", "status_code"})
 
-	unaryInterceptors, streamInterceptors := grpcclient.Instrument(authRequestDuration)
+	unaryInterceptors, streamInterceptors := grpcclient.Instrument(authzRequestDuration)
 
 	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCreds),

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -10,6 +10,7 @@ import (
 	"github.com/fullstorydev/grpchan/inprocgrpc"
 	grpcAuth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -21,6 +22,7 @@ import (
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	"github.com/grafana/authlib/cache"
 	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/dskit/grpcclient"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -69,7 +71,7 @@ func ProvideAuthZClient(
 
 	switch authCfg.mode {
 	case clientModeCloud:
-		rbacClient, err := newRemoteRBACClient(authCfg, tracer)
+		rbacClient, err := newRemoteRBACClient(authCfg, tracer, reg)
 		if features.IsEnabledGlobally(featuremgmt.FlagZanzana) {
 			return zanzana.WithShadowClient(rbacClient, zanzanaClient, reg)
 		}
@@ -128,7 +130,7 @@ func ProvideAuthZClient(
 // ProvideStandaloneAuthZClient provides a standalone AuthZ client, without registering the AuthZ service.
 // You need to provide a remote address in the configuration
 func ProvideStandaloneAuthZClient(
-	cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer trace.Tracer,
+	cfg *setting.Cfg, features featuremgmt.FeatureToggles, tracer trace.Tracer, reg prometheus.Registerer,
 ) (authlib.AccessClient, error) {
 	if !features.IsEnabledGlobally(featuremgmt.FlagAuthZGRPCServer) {
 		return nil, nil
@@ -139,10 +141,10 @@ func ProvideStandaloneAuthZClient(
 		return nil, err
 	}
 
-	return newRemoteRBACClient(authCfg, tracer)
+	return newRemoteRBACClient(authCfg, tracer, reg)
 }
 
-func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer) (authlib.AccessClient, error) {
+func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, reg prometheus.Registerer) (authlib.AccessClient, error) {
 	tokenClient, err := authnlib.NewTokenExchangeClient(authnlib.TokenExchangeConfig{
 		Token:            clientCfg.token,
 		TokenExchangeURL: clientCfg.tokenExchangeURL,
@@ -159,12 +161,26 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer) (a
 		}
 	}
 
-	conn, err := grpc.NewClient(
-		clientCfg.remoteAddress,
+	authRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+		Name:    "auth_server_client_request_duration_seconds",
+		Help:    "Time spent executing requests to auth server.",
+		Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
+	}, []string{"operation", "status_code"})
+
+	unaryInterceptors, streamInterceptors := grpcclient.Instrument(authRequestDuration)
+
+	opts := []grpc.DialOption{
 		grpc.WithTransportCredentials(transportCreds),
 		grpc.WithPerRPCCredentials(
 			NewGRPCTokenAuth(AuthzServiceAudience, clientCfg.tokenNamespace, tokenClient),
 		),
+		grpc.WithChainUnaryInterceptor(unaryInterceptors...),
+		grpc.WithChainStreamInterceptor(streamInterceptors...),
+	}
+
+	conn, err := grpc.NewClient(
+		clientCfg.remoteAddress,
+		opts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create authz client to remote server: %w", err)

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -162,8 +162,8 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 	}
 
 	authRequestDuration := promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "auth_server_client_request_duration_seconds",
-		Help:    "Time spent executing requests to auth server.",
+		Name:    "authz_server_client_request_duration_seconds",
+		Help:    "Time spent executing requests to authz server.",
 		Buckets: prometheus.ExponentialBuckets(0.008, 4, 7),
 	}, []string{"operation", "status_code"})
 

--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -178,10 +178,7 @@ func newRemoteRBACClient(clientCfg *authzClientSettings, tracer trace.Tracer, re
 		grpc.WithChainStreamInterceptor(streamInterceptors...),
 	}
 
-	conn, err := grpc.NewClient(
-		clientCfg.remoteAddress,
-		opts...,
-	)
+	conn, err := grpc.NewClient(clientCfg.remoteAddress, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create authz client to remote server: %w", err)
 	}

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -201,7 +201,7 @@ func (s *service) starting(ctx context.Context) error {
 		}
 	}
 
-	authzClient, err := authz.ProvideStandaloneAuthZClient(s.cfg, s.features, s.tracing)
+	authzClient, err := authz.ProvideStandaloneAuthZClient(s.cfg, s.features, s.tracing, s.reg)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds basic instrumentation for the access client (grpc). It introduces `authz_server_client_request_duration_seconds` histogram metric.