### PR TITLE
AzureMonitorDatasource: Add bounds check to fix panics

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -573,6 +573,10 @@ func addTraceDataLinksToFields(query *AzureLogAnalyticsQuery, azurePortalBaseUrl
 		return err
 	}
 
+	if len(queryJSONModel.AzureTraces.Resources) == 0 {
+		return fmt.Errorf("no resources specified for Azure traces data link")
+	}
+
 	traceIdVariable := "${__data.fields.traceID}"
 	resultFormat := dataquery.ResultFormatTrace
 	queryJSONModel.AzureTraces.ResultFormat = &resultFormat
@@ -668,6 +672,9 @@ func (e *AzureLogAnalyticsDatasource) createRequest(ctx context.Context, queryUR
 	if query.AppInsightsQuery {
 		// If the query type is traces then we only need the first resource as the rest are specified in the query
 		if query.QueryType == dataquery.AzureQueryTypeAzureTraces {
+			if len(query.Resources) == 0 {
+				return nil, fmt.Errorf("no resources specified for Azure traces Application Insights query")
+			}
 			body["applications"] = []string{query.Resources[0]}
 		} else {
 			body["applications"] = query.Resources

--- a/pkg/tsdb/azuremonitor/loganalytics/traces.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/traces.go
@@ -207,6 +207,10 @@ func buildAppInsightsQuery(ctx context.Context, query backend.DataQuery, dsInfo 
 		resources = []string{fmt.Sprintf("/subscriptions/%s", subscription)}
 	}
 
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no resources specified for Azure traces query")
+	}
+
 	resourceOrWorkspace := resources[0]
 	appInsightsQuery := appInsightsRegExp.Match([]byte(resourceOrWorkspace))
 	resourcesMap := make(map[string]bool, 0)
@@ -236,6 +240,9 @@ func buildAppInsightsQuery(ctx context.Context, query backend.DataQuery, dsInfo 
 
 	if query.QueryType == string(dataquery.AzureQueryTypeTraceExemplar) {
 		resources = queryResources
+		if len(resources) == 0 {
+			return nil, fmt.Errorf("no correlation resources found for trace exemplar query with operation ID: %s", operationId)
+		}
 		resourceOrWorkspace = resources[0]
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fixes some out of bound index checks[ i found in the logs](https://ops.grafana-ops.net/d/2204b1bb-f663-46b1-919b-98a239480caf/datasource-release-dashboard?orgId=1&from=now-24h&to=now&timezone=utc&var-plugin_id=grafana-azure-monitor-datasource&var-remoteAppName=azure-monitor-datasource-grafana-app) in production. 

Stack trace below:
```
goroutine 160475 [running]:
runtime/debug.Stack()
    runtime/debug/stack.go:26 +0x5e
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*RecoveryMiddleware).QueryData.(*RecoveryMiddleware).recoveryFunc.func1()
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/recovery_middleware.go:58 +0x152
panic({0x1b4a560?, 0xc0014b6090?})
    runtime/panic.go:792 +0x132
github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics.buildAppInsightsQuery({_, _}, {{0x3f03bb0, 0x1}, {0xc001ffe520, 0xc}, 0xa8c0, 0x3b9aca00, {{0x0, 0xee052b7f2, ...}, ...}, ...}, ...)
    github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics/traces.go:210 +0xdb6
github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics.(*AzureLogAnalyticsDatasource).buildQuery(_, {_, _}, {{0x3f03bb0, 0x1}, {0xc001ffe520, 0xc}, 0xa8c0, 0x3b9aca00, {{0x0, ...}, ...}, ...}, ...)
    github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go:396 +0x35b
github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics.(*AzureLogAnalyticsDatasource).ExecuteTimeSeriesQuery(0xc001421540, {0x3d061a8, 0xc0023dbaa0}, {0xc002517100, 0x1, 0xa60745e?}, {{0x3c45460, 0xc0032bc550}, {{0xc003a9a4e0, 0x24}, ...}, ...}, ...)
    github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go:281 +0x1a5
github.com/grafana/grafana/pkg/tsdb/azuremonitor.(*Service).newQueryMux.func1({0x3d061a8, 0xc0023dbaa0}, 0xc002517080)
    github.com/grafana/grafana/pkg/tsdb/azuremonitor/azuremonitor.go:207 +0x3bb
github.com/grafana/grafana-plugin-sdk-go/backend.QueryDataHandlerFunc.QueryData(0x130dba0?, {0x3d061a8?, 0xc0023dbaa0?}, 0x1?)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/data.go:38 +0x29
github.com/grafana/grafana-plugin-sdk-go/backend/datasource.(*QueryTypeMux).QueryData(0xc001d4dbf0, {0x3d061a8, 0xc0023dbaa0}, 0xc002516c80)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/datasource/query_type_mux.go:85 +0x4bd
github.com/grafana/grafana/pkg/tsdb/azuremonitor.(*Service).QueryData(0xc001399ac0, {0x3d061a8, 0xc0023dba10}, 0xc002516c80)
    github.com/grafana/grafana/pkg/tsdb/azuremonitor/azuremonitor.go:82 +0x78
github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin.(*corePlugin).QueryData(0xc0022c3d80, {0x3d061a8?, 0xc0023db9e0?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/plugins/backendplugin/coreplugin/core_plugin.go:93 +0x73
github.com/grafana/grafana/pkg/plugins.(*Plugin).QueryData(0x139?, {0x3d061a8?, 0xc0023db9e0?}, 0xc00191a620?)
    github.com/grafana/grafana/pkg/plugins/plugins.go:334 +0xcd
github.com/grafana/grafana/pkg/plugins/manager/client.(*Service).QueryData(0x7fb0f4edbf10?, {0x3d061a8, 0xc0023db9e0}, 0xc002516c80)
    github.com/grafana/grafana/pkg/plugins/manager/client/client.go:60 +0x8b
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*RecoveryMiddleware).QueryData(0xa608825?, {0x3d061a8?, 0xc0023db9e0?}, 0xa667101?)
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/recovery_middleware.go:32 +0x75
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana-plugin-sdk-go/backend.(*ErrorSourceMiddleware).QueryData(0xc0037273c0, {0x3d061a8, 0xc0023db9e0}, 0x1421f60?)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/error_source_middleware.go:40 +0x42
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*HTTPClientMiddleware).QueryData(0xc0037273d0, {0x3d061a8?, 0xc0023db8c0?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/httpclient_middleware.go:74 +0x57
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*LicenseMiddleware).QueryData(0xc00250b1c0, {0x3d061a8?, 0xc0023db8c0?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/license_middleware.go:68 +0xa3
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*TenantIDMiddleware).QueryData(0xc000e062a0, {0x3d061a8?, 0xc0023db560?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/tenant_id_middleware.go:69 +0x5f
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*HTTPClientMiddleware).QueryData(0xc003727420, {0x3d061a8?, 0xc0023db440?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/http_contextual_middlewares.go:47 +0x4c
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana-plugin-sdk-go/backend.(*loggerMiddleware).QueryData.func1({0x3d061a8, 0xc0023db440})
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/logger_middleware.go:66 +0x5d
github.com/grafana/grafana-plugin-sdk-go/backend.(*loggerMiddleware).logRequest(0xc0023db260, {0x3d061a8, 0xc0023db440}, {0x1, {0xc00191a620, 0x20}, {0xc00250d9e0, 0x12}, 0xc00250b140, 0x0, ...}, ...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/logger_middleware.go:40 +0x1fc
github.com/grafana/grafana-plugin-sdk-go/backend.(*loggerMiddleware).QueryData(0xc0018485c8?, {0x3d061a8?, 0xc0023db440?}, 0xc0029d1740?)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/logger_middleware.go:64 +0xc5
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*LoggerMiddleware).QueryData.func1({0x3d061a8, 0xc0023db440})
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go:82 +0x68
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*LoggerMiddleware).logRequest(0xc0023db2f0, {0x3d061a8, 0xc0023db440}, {0x1, {0xc00191a620, 0x20}, {0xc00250d9e0, 0x12}, 0xc00250b140, 0x0, ...}, ...)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go:56 +0x25c
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*LoggerMiddleware).QueryData(0x3d061a8?, {0x3d061a8?, 0xc0023db440?}, 0x165112c0?)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/logger_middleware.go:80 +0xc5
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/extensions/datasource/pluginclient.(*ContextualLoggerMiddleware).QueryData(0xc003727430, {0x3d061a8?, 0xc0023db3b0?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/extensions/datasource/pluginclient/contextual_logger_middleware.go:47 +0x53
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*ContextualLoggerMiddleware).QueryData(0xc003727440, {0x3d061a8?, 0xc0023db380?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/contextual_logger_middleware.go:47 +0xaa
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana-plugin-sdk-go/backend.(*metricsMiddleware).QueryData.func1({0x3d061a8?, 0xc0023db380?})
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/metrics_middleware.go:60 +0x44
github.com/grafana/grafana-plugin-sdk-go/backend.(*metricsMiddleware).instrumentRequest(0xc000e062e0, {0x3d061a8, 0xc0023db380}, {0x1, {0xc00191a620, 0x20}, {0xc00250d9e0, 0x12}, 0xc00250b140, 0x0, ...}, ...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/metrics_middleware.go:43 +0x42
github.com/grafana/grafana-plugin-sdk-go/backend.(*metricsMiddleware).QueryData(0xc001848d80?, {0x3d061a8?, 0xc0023db380?}, 0xc001848d68?)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/metrics_middleware.go:58 +0xc5
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*MetricsMiddleware).QueryData.func1({0x3d061a8?, 0xc0023db380?})
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go:175 +0x44
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*MetricsMiddleware).instrumentPluginRequest(0xc0027d92c0, {0x3d061a8, 0xc0023db380}, {0x1, {0xc00191a620, 0x20}, {0xc00250d9e0, 0x12}, 0xc00250b140, 0x0, ...}, ...)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go:129 +0xbd
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*MetricsMiddleware).QueryData(0xc0027d92c0, {0x3d061a8, 0xc0023db380}, 0xc002516c80)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/metrics_middleware.go:173 +0x1f0
github.com/grafana/grafana-plugin-sdk-go/backend.BaseHandler.QueryData(...)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler.go:33
github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware.(*TracingMiddleware).QueryData(0xc000e06300, {0x3d061a8?, 0xc0023db200?}, 0xc002516c80)
    github.com/grafana/grafana/pkg/services/pluginsintegration/clientmiddleware/tracing_middleware.go:86 +0x11b
github.com/grafana/grafana-plugin-sdk-go/backend.(*MiddlewareHandler).QueryData(0xc0013ff110, {0x3d061a8?, 0xc0023dae40?}, 0xc002516c80)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler_middleware.go:66 +0xf6
github.com/grafana/grafana-plugin-sdk-go/backend.(*MiddlewareHandler).QueryData(0xc0013ff950, {0x3d061a8?, 0xc0023da060?}, 0xc002516c80)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/handler_middleware.go:66 +0xf6
github.com/grafana/grafana-plugin-sdk-go/backend.(*dataSDKAdapter).QueryData(0xc001434420, {0x3d061a8, 0xc0023da060}, 0x0?)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/backend/data_adapter.go:32 +0x4b
github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2._Data_QueryData_Handler.func1({0x3d061a8?, 0xc0023da060?}, {0x19ae560?, 0xc0027d9220?})
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/genproto/pluginv2/backend_grpc.pb.go:203 +0xcb
github.com/grafana/grafana/pkg/extensions/datasource/grpc.messageSizeInterceptor({0x3d061a8, 0xc0023da060}, {0x19ae560, 0xc0027d9220}, 0xc000e061a0, 0xc002113278)
    github.com/grafana/grafana/pkg/extensions/datasource/grpc/server.go:304 +0x148
google.golang.org/grpc.getChainUnaryHandler.func1({0x3d061a8?, 0xc0023da060?}, {0x19ae560?, 0xc0027d9220?})
    google.golang.org/grpc@v1.74.2/server.go:1243 +0x153
github.com/grafana/grafana/pkg/extensions/datasource/grpc.grpcOpts.(*ServerMetrics).UnaryServerInterceptor.UnaryServerInterceptor.func8({0x3d061a8, 0xc0023da060}, {0x19ae560, 0xc0027d9220}, 0xc000e061a0?, 0xc00250b100)
    github.com/grpc-ecosystem/go-grpc-middleware/v2@v2.3.2/interceptors/server.go:22 +0x275
google.golang.org/grpc.NewServer.chainUnaryServerInterceptors.chainUnaryInterceptors.func1({0x3d061a8, 0xc0023da060}, {0x19ae560, 0xc0027d9220}, 0xc000e061a0, 0x80?)
    google.golang.org/grpc@v1.74.2/server.go:1234 +0x7c
github.com/grafana/grafana-plugin-sdk-go/genproto/pluginv2._Data_QueryData_Handler({0xce6f40, 0xc001434420}, {0x3d061a8, 0xc0023da060}, 0xc002516700, 0xc0014212c0)
    github.com/grafana/grafana-plugin-sdk-go@v0.278.0/genproto/pluginv2/backend_grpc.pb.go:205 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc001e87c00, {0x3d061a8, 0xc001abfbc0}, 0xc0044d58c0, 0xc0013ff9e0, 0x162259c0, 0x0)
    google.golang.org/grpc@v1.74.2/server.go:1431 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc001e87c00, {0x3d0b108, 0xc0023604e0}, 0xc0044d58c0)
    google.golang.org/grpc@v1.74.2/server.go:1841 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
    google.golang.org/grpc@v1.74.2/server.go:1061 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 160428
    google.golang.org/grpc@v1.74.2/server.go:1072 +0x11d
```

[Add a brief description of what the feature or update does.]

Somehow, someway resources are empty and its blowing up the plugin however its getting caught on recovery middlewear.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
