### PR TITLE
Alerting: Move enrichment tab between details and versions

### DIFF
--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewer.tsx
@@ -482,6 +482,8 @@ function usePageNav(rule: CombinedRule) {
           setActiveTab(ActiveTab.Details);
         },
       },
+      // Enterprise extensions (e.g. Alert enrichment) should appear after Details
+      ...useRuleViewExtensionsNav(activeTab, setActiveTabFromString),
       {
         text: t('alerting.use-page-nav.page-nav.text.versions', 'Versions'),
         active: activeTab === ActiveTab.VersionHistory,
@@ -490,8 +492,6 @@ function usePageNav(rule: CombinedRule) {
         },
         hideFromTabs: !isGrafanaAlertRule && !isGrafanaRecordingRule,
       },
-      // Enterprise extensions can append additional tabs here
-      ...useRuleViewExtensionsNav(activeTab, setActiveTabFromString),
     ],
     parentItem: {
       text: groupName,


### PR DESCRIPTION
This PR moves the Alert enrichment tab (and all tab extensions) between 'details' and 'versions' tab

<img width="1974" height="1013" alt="image" src="https://github.com/user-attachments/assets/577a11d8-4821-4ad1-808f-1bc6c40dda6d" />
