### PR TITLE
Storybook: Run a11y tests against both light and dark theme

### DIFF
--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           self: .github/workflows/storybook-a11y.yml
 
-  test-storybook-a11y:
+  test-storybook-a11y-light:
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
@@ -46,7 +46,36 @@ jobs:
     - name: Install Playwright browsers
       run: npx playwright install --with-deps
     - name: Start Storybook
-      run: yarn storybook &
+      run: STORYBOOK_THEME=light yarn storybook &
+    - name: Run tests
+      # the chromium browser used by Playwright sets its locale to "en_US@posix" by default
+      # this is not a valid language code, and causes some stories to fail to load!
+      # instead, we set the LANG environment variable to en_US to override this
+      # see https://github.com/microsoft/playwright/issues/34046
+      env:
+        LANG: en_US
+      run: npx wait-on --timeout 120000 http://localhost:9001 && yarn test:storybook
+
+  test-storybook-a11y-dark:
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+      id-token: write
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    name: "Run Storybook a11y tests"
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+    - run: yarn install --immutable --check-cache
+    - name: Install Playwright browsers
+      run: npx playwright install --with-deps
+    - name: Start Storybook
+      run: STORYBOOK_THEME=dark yarn storybook &
     - name: Run tests
       # the chromium browser used by Playwright sets its locale to "en_US@posix" by default
       # this is not a valid language code, and causes some stories to fail to load!

--- a/packages/grafana-data/src/themes/createColors.ts
+++ b/packages/grafana-data/src/themes/createColors.ts
@@ -107,7 +107,7 @@ class DarkColors implements ThemeColorsBase<Partial<ThemeRichColor>> {
   text = {
     primary: `rgb(${this.whiteBase})`,
     secondary: `rgba(${this.whiteBase}, 0.65)`,
-    disabled: `rgba(${this.whiteBase}, 0.6)`,
+    disabled: `rgba(${this.whiteBase}, 0.61)`,
     link: palette.blueDarkText,
     maxContrast: palette.white,
   };

--- a/packages/grafana-ui/.storybook/preview.ts
+++ b/packages/grafana-ui/.storybook/preview.ts
@@ -183,6 +183,9 @@ const preview: Preview = {
   },
   tags: ['autodocs'],
   loaders: [mswLoader],
+  initialGlobals: {
+    theme: process.env.STORYBOOK_THEME || 'system',
+  },
 };
 
 export default preview;

--- a/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/ColorPicker.story.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof ColorPicker> = {
   },
   args: {
     enableNamedColors: false,
-    color: '#0000ff',
+    color: '#ee0000',
   },
 };
 
@@ -60,7 +60,7 @@ export const CustomTrigger: StoryFn<typeof ColorPicker> = ({ color, enableNamedC
           ref={ref}
           onMouseLeave={hideColorPicker}
           onClick={showColorPicker}
-          style={{ color }}
+          style={{ color: 'white', backgroundColor: color, padding: '8px' }}
           className={clearButton}
         >
           Open color picker

--- a/packages/grafana-ui/src/components/Tabs/Counter.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Counter.tsx
@@ -21,7 +21,7 @@ const getStyles = (theme: GrafanaTheme2, variant: CounterVariant) => ({
     label: 'counter',
     marginLeft: theme.spacing(1),
     borderRadius: theme.spacing(3),
-    backgroundColor: variant === 'primary' ? theme.colors.primary.main : theme.colors.action.hover,
+    backgroundColor: variant === 'primary' ? theme.colors.primary.main : theme.colors.secondary.main,
     padding: theme.spacing(0.25, 1),
     color: theme.colors.text.secondary,
     fontWeight: theme.typography.fontWeightMedium,

--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -2,7 +2,6 @@
 import { css, cx } from '@emotion/css';
 import { useId, useState } from 'react';
 import * as React from 'react';
-import tinycolor from 'tinycolor2';
 
 import { colorManipulator, GrafanaTheme2, ThemeRichColor, ThemeVizHue } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/ThemeDemo.tsx
@@ -2,6 +2,7 @@
 import { css, cx } from '@emotion/css';
 import { useId, useState } from 'react';
 import * as React from 'react';
+import tinycolor from 'tinycolor2';
 
 import { colorManipulator, GrafanaTheme2, ThemeRichColor, ThemeVizHue } from '@grafana/data';
 
@@ -316,7 +317,7 @@ export function RichColorDemo({ theme, color }: RichColorDemoProps) {
         <div
           className={css({
             background: color.shade,
-            color: color.contrastText,
+            color: theme.colors.getContrastText(color.shade, 4.5),
             borderRadius: theme.shape.radius.default,
             padding: '8px',
           })}

--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.story.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.story.tsx
@@ -34,7 +34,10 @@ export const BottomLegend: StoryFn = ({ height, width, legendItems }) => {
   const legend = (
     <VizLayout.Legend placement="bottom" maxHeight="30%">
       {items.map((_, index) => (
-        <div style={{ height: '30px', width: '100%', background: 'lightblue', marginBottom: '2px' }} key={index}>
+        <div
+          style={{ height: '30px', width: '100%', background: 'lightblue', color: 'black', marginBottom: '2px' }}
+          key={index}
+        >
           Legend item {index}
         </div>
       ))}
@@ -65,7 +68,13 @@ export const RightLegend: StoryFn = ({ height, width, legendItems, legendWidth }
     <VizLayout.Legend placement="right" maxWidth="50%">
       {items.map((_, index) => (
         <div
-          style={{ height: '30px', width: `${legendWidth}px`, background: 'lightblue', marginBottom: '2px' }}
+          style={{
+            height: '30px',
+            width: `${legendWidth}px`,
+            background: 'lightblue',
+            color: 'black',
+            marginBottom: '2px',
+          }}
           key={index}
         >
           Legend item {index}

--- a/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/TracePageHeader.test.tsx
@@ -299,7 +299,6 @@ describe('TracePageHeader test', () => {
 
       const button = screen.getByRole('button', { name: /Test Extension/i });
       expect(button).toBeInTheDocument();
-      expect(button).toHaveClass('css-7byezq-button'); // Grafana button primary class
     });
 
     it('should render extension icons when provided', () => {
@@ -485,7 +484,6 @@ describe('TracePageHeader test', () => {
       const buttonElement = feedbackButton.closest('a');
 
       expect(buttonElement).toBeInTheDocument();
-      expect(buttonElement).toHaveClass('css-125ehy6-button'); // Secondary variant class
 
       // Check for icon
       const iconElement = buttonElement?.querySelector('svg');

--- a/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
+++ b/public/app/plugins/datasource/cloud-monitoring/components/__snapshots__/VariableQueryEditor.test.tsx.snap
@@ -19,7 +19,7 @@ exports[`VariableQueryEditor renders correctly 1`] = `
     <div>
       <div>
         <div
-          class="css-rebjtg-input-wrapper css-smf98s"
+          class="css-1d4urid-input-wrapper css-smf98s"
         >
           <span
             class="css-1f43avz-a11yText-A11yText"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds separate `test-storybook-a11y-light` and `test-storybook-a11y-dark` steps
- these use a `STORYBOOK_THEME` env var to set the initial theme global
- some minor fixes to make sure the currently passing stories in light mode are also passing in dark mode:
  - adjusts `Counter` to use a proper theme token

  | | before | after |
  | --- | --- | --- |
  | light | <img width="142" height="40" alt="image" src="https://github.com/user-attachments/assets/8f1eeb1a-0e5c-4d55-b750-6f4fad29b809" /> | <img width="146" height="39" alt="image" src="https://github.com/user-attachments/assets/7b7ba999-f885-4e6b-8acf-cc1b28047baa" /> |
  | dark | <img width="148" height="40" alt="image" src="https://github.com/user-attachments/assets/d1c801bc-810c-40fb-b647-e270161d6da7" /> | <img width="137" height="38" alt="image" src="https://github.com/user-attachments/assets/b8302ec4-b2f3-46fb-9946-559e216c350f" />|
  - adjusts our dark `disabled` token to properly meet 4.5:1 contrast ratio
  - adjusts custom `ColorPicker` to use a starting color that works in both light/dark mode
    - this isn't really a fix, more just isolated to storybook
  - adjusts `ThemeDemo` to use properly contrasting text over the backgrounds
    - this isn't really a fix, more just isolated to storybook
  - adjusts `VizLayout` to use colors that work in both light and dark mode
    - this isn't really a fix, more just isolated to storybook

**Why do we need this feature?**

- maintain baseline a11y standards in both themes

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/109451
Fixes https://github.com/grafana/grafana/issues/72868

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
