### PR TITLE
Alerting: Evaluation History in Loki

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1153,4 +1153,9 @@ export interface FeatureToggles {
   * @default false
   */
   pluginContainers?: boolean;
+  /**
+  * Enables sending evaluation history to Loki
+  * @default false
+  */
+  alertingEvaluationHistory?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1999,6 +1999,14 @@ var (
 			Expression:      "false",
 			RequiresRestart: true,
 		},
+		{
+			Name:            "alertingEvaluationHistory",
+			Description:     "Enables sending evaluation history to Loki",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaAlertingSquad,
+			Expression:      "false",
+			RequiresRestart: true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -256,3 +256,4 @@ azureResourcePickerUpdates,preview,@grafana/partner-datasources,false,false,true
 prometheusTypeMigration,experimental,@grafana/partner-datasources,false,true,false
 dskitBackgroundServices,experimental,@grafana/plugins-platform-backend,false,true,false
 pluginContainers,privatePreview,@grafana/plugins-platform-backend,false,true,false
+alertingEvaluationHistory,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -1034,4 +1034,8 @@ const (
 	// FlagPluginContainers
 	// Enables running plugins in containers
 	FlagPluginContainers = "pluginContainers"
+
+	// FlagAlertingEvaluationHistory
+	// Enables sending evaluation history to Loki
+	FlagAlertingEvaluationHistory = "alertingEvaluationHistory"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -265,6 +265,20 @@
     },
     {
       "metadata": {
+        "name": "alertingEvaluationHistory",
+        "resourceVersion": "1757522966563",
+        "creationTimestamp": "2025-09-10T16:49:26Z"
+      },
+      "spec": {
+        "description": "Enables sending evaluation history to Loki",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingFilterV2",
         "resourceVersion": "1753448760331",
         "creationTimestamp": "2024-09-11T11:29:26Z"

--- a/pkg/services/ngalert/metrics/eval_historian.go
+++ b/pkg/services/ngalert/metrics/eval_historian.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"github.com/grafana/dskit/instrument"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+type EvalHistorian struct {
+	Info          prometheus.Gauge
+	WritesTotal   *prometheus.CounterVec
+	WritesFailed  *prometheus.CounterVec
+	WriteDuration *instrument.HistogramCollector
+	BytesWritten  prometheus.Counter
+}
+
+func NewEvalHistorianMetrics(r prometheus.Registerer, subsystem string) *EvalHistorian {
+	return &EvalHistorian{
+		Info: promauto.With(r).NewGauge(prometheus.GaugeOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "eval_history_info",
+			Help:      "Information about the evaluation history store.",
+		}),
+		WritesTotal: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "eval_history_writes_total",
+			Help:      "The total number of evaluation history batches that were attempted to be written.",
+		}, []string{"org"}),
+		WritesFailed: promauto.With(r).NewCounterVec(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "eval_history_writes_failed_total",
+			Help:      "The total number of failed writes of evaluation history batches.",
+		}, []string{"org"}),
+		WriteDuration: instrument.NewHistogramCollector(promauto.With(r).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "eval_history_request_duration_seconds",
+			Help:      "Histogram of request durations to the evaluation history store. Only valid when using external stores.",
+			Buckets:   instrument.DefBuckets,
+		}, instrument.HistogramCollectorBuckets)),
+		BytesWritten: promauto.With(r).NewCounter(prometheus.CounterOpts{
+			Namespace: Namespace,
+			Subsystem: subsystem,
+			Name:      "eval_history_writes_bytes_total",
+			Help:      "The total number of bytes sent within a batch to the evaluation history store. Only valid when using the Loki store.",
+		}),
+	}
+}

--- a/pkg/services/ngalert/metrics/ngalert.go
+++ b/pkg/services/ngalert/metrics/ngalert.go
@@ -33,6 +33,7 @@ type NGAlert struct {
 	notificationHistorianMetrics *NotificationHistorian
 	remoteAlertmanagerMetrics    *RemoteAlertmanager
 	remoteWriterMetrics          *RemoteWriter
+	evalHistorianMetrics         *EvalHistorian
 }
 
 // NewNGAlert manages the metrics of all the alerting components.
@@ -44,6 +45,7 @@ func NewNGAlert(r prometheus.Registerer) *NGAlert {
 		multiOrgAlertmanagerMetrics:  NewMultiOrgAlertmanagerMetrics(r),
 		apiMetrics:                   NewAPIMetrics(r),
 		historianMetrics:             NewHistorianMetrics(r, Subsystem),
+		evalHistorianMetrics:         NewEvalHistorianMetrics(r, Subsystem),
 		notificationHistorianMetrics: NewNotificationHistorianMetrics(r),
 		remoteAlertmanagerMetrics:    NewRemoteAlertmanagerMetrics(r),
 		remoteWriterMetrics:          NewRemoteWriterMetrics(r),
@@ -68,6 +70,10 @@ func (ng *NGAlert) GetMultiOrgAlertmanagerMetrics() *MultiOrgAlertmanager {
 
 func (ng *NGAlert) GetHistorianMetrics() *Historian {
 	return ng.historianMetrics
+}
+
+func (ng *NGAlert) GetEvalHistorianMetrics() *EvalHistorian {
+	return ng.evalHistorianMetrics
 }
 
 func (ng *NGAlert) GetNotificationHistorianMetrics() *NotificationHistorian {

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -785,5 +785,6 @@ func (ng *AlertNG) createEvaluationHistorian(ctx context.Context) (schedule.Hist
 		m,
 		ng.Cfg.UnifiedAlerting.StateHistory.ExternalLabels,
 		0, // TODO add to config
+		false,
 	), nil
 }

--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -69,6 +69,7 @@ func newRuleFactory(
 	recordingWriter RecordingWriter,
 	evalAppliedHook evalAppliedFunc,
 	stopAppliedHook stopAppliedFunc,
+	historian Historian,
 ) ruleFactoryFunc {
 	return func(ctx context.Context, rule *ngmodels.AlertRule) Rule {
 		if rule.Type() == ngmodels.RuleTypeRecording {
@@ -85,6 +86,7 @@ func newRuleFactory(
 				recordingWriter,
 				evalAppliedHook,
 				stopAppliedHook,
+				historian,
 			)
 		}
 		return newAlertRule(
@@ -103,6 +105,7 @@ func newRuleFactory(
 			featureToggles,
 			evalAppliedHook,
 			stopAppliedHook,
+			historian,
 		)
 	}
 }
@@ -135,6 +138,7 @@ type alertRule struct {
 	logger         log.Logger
 	tracer         tracing.Tracer
 	featureToggles featuremgmt.FeatureToggles
+	historian      Historian
 }
 
 func newAlertRule(
@@ -153,6 +157,7 @@ func newAlertRule(
 	featureToggles featuremgmt.FeatureToggles,
 	evalAppliedHook func(ngmodels.AlertRuleKey, time.Time),
 	stopAppliedHook func(ngmodels.AlertRuleKey),
+	historian Historian,
 ) *alertRule {
 	ctx, stop := util.WithCancelCause(ngmodels.WithRuleKey(parent, key.AlertRuleKey))
 
@@ -175,6 +180,7 @@ func newAlertRule(
 		logger:               logger.FromContext(ctx),
 		tracer:               tracer,
 		featureToggles:       featureToggles,
+		historian:            historian,
 	}
 }
 

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -503,7 +503,7 @@ func blankRuleForTests(ctx context.Context, key models.AlertRuleKeyWithGroup) *a
 		Log:       log.NewNopLogger(),
 	}
 	st := state.NewManager(managerCfg, state.NewNoopPersister())
-	return newAlertRule(ctx, key, nil, false, RetryConfig{}, nil, st, nil, nil, nil, log.NewNopLogger(), nil, featuremgmt.WithFeatures(), nil, nil)
+	return newAlertRule(ctx, key, nil, false, RetryConfig{}, nil, st, nil, nil, nil, log.NewNopLogger(), nil, featuremgmt.WithFeatures(), nil, nil, nil)
 }
 
 func TestRuleRoutine(t *testing.T) {

--- a/pkg/services/ngalert/schedule/historian/historian.go
+++ b/pkg/services/ngalert/schedule/historian/historian.go
@@ -1,0 +1,129 @@
+package historian
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"time"
+
+	jsoniter "github.com/json-iterator/go"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/ngalert/lokiclient"
+	"github.com/grafana/grafana/pkg/services/ngalert/metrics"
+	historianModels "github.com/grafana/grafana/pkg/services/ngalert/schedule/historian/models"
+)
+
+var json = jsoniter.ConfigCompatibleWithStandardLibrary
+
+const (
+	LokiClientSpanName  = "ngalert.evaluation-historian.client"
+	historyWriteTimeout = time.Minute
+	historyKey          = "from"
+	historyLabelValue   = "evaluation-history"
+	orgIDLabel          = "orgID"
+	groupLabel          = "group"
+	folderUIDLabel      = "folderUID"
+)
+
+type entry struct {
+	SchemaVersion  int    `json:"schemaVersion"`
+	RuleUID        string `json:"ruleUID"`
+	Version        string `json:"version"`
+	EvaluationTime int64  `json:"evaluationTime"`
+	FingerPrint    string `json:"fingerprint"`
+	Attempt        int64  `json:"attempt"`
+	Error          string `json:"error,omitempty"`
+	Duration       int64  `json:"duration"`
+	Status         string `json:"status"`
+}
+
+type LokiClient interface {
+	Push(context.Context, []lokiclient.Stream) error
+}
+
+type Historian struct {
+	client         LokiClient
+	externalLabels map[string]string
+	metrics        *metrics.EvalHistorian
+	log            log.Logger
+	timeout        time.Duration
+}
+
+func NewHistorian(
+	logger log.Logger,
+	lokiClient LokiClient,
+	metrics *metrics.EvalHistorian,
+	externalLabels map[string]string,
+	timeout time.Duration,
+) *Historian {
+	if timeout <= 0 {
+		timeout = historyWriteTimeout
+	}
+	return &Historian{
+		client:         lokiClient,
+		externalLabels: externalLabels,
+		metrics:        metrics,
+		log:            logger,
+		timeout:        timeout,
+	}
+}
+
+func (h *Historian) Record(ctx context.Context, opts historianModels.Record) {
+	logger := h.log.FromContext(ctx)
+	stream := h.prepareStream(opts, logger)
+	if len(stream) == 0 {
+		return
+	}
+	org := fmt.Sprint(opts.GroupKey.OrgID)
+
+	writeCtx, cancel := context.WithTimeout(ctx, h.timeout)
+	defer cancel()
+	defer h.metrics.WritesTotal.WithLabelValues(org).Inc()
+
+	err := h.client.Push(writeCtx, stream)
+	if err != nil {
+		logger.Error("Failed to save evaluation history", "error", err)
+		h.metrics.WritesFailed.WithLabelValues(org).Inc()
+	}
+}
+
+func (h *Historian) prepareStream(record historianModels.Record, logger log.Logger) []lokiclient.Stream {
+	entry := entry{
+		SchemaVersion:  1,
+		RuleUID:        record.RuleUID,
+		Version:        strconv.FormatInt(record.RuleVersion, 10),
+		FingerPrint:    record.RuleFingerprint,
+		Attempt:        int64(record.Attempt),
+		Duration:       record.Duration.Milliseconds(),
+		Status:         string(record.Status),
+		Error:          record.Error,
+		EvaluationTime: record.EvaluationTime.Unix(),
+	}
+
+	entryJSON, err := json.Marshal(entry)
+	if err != nil {
+		logger.Error("Failed to convert to stream", "error", err)
+		return nil
+	}
+
+	streamLabels := make(map[string]string)
+	for k, v := range h.externalLabels {
+		streamLabels[k] = v
+	}
+	streamLabels[historyKey] = historyLabelValue
+	streamLabels[orgIDLabel] = fmt.Sprint(record.GroupKey.OrgID)
+	streamLabels[groupLabel] = fmt.Sprint(record.GroupKey.RuleGroup)
+	streamLabels[folderUIDLabel] = fmt.Sprint(record.GroupKey.NamespaceUID)
+
+	return []lokiclient.Stream{
+		{
+			Stream: streamLabels,
+			Values: []lokiclient.Sample{
+				{
+					T: record.Tick,
+					V: string(entryJSON),
+				}},
+		},
+	}
+}

--- a/pkg/services/ngalert/schedule/historian/historian_test.go
+++ b/pkg/services/ngalert/schedule/historian/historian_test.go
@@ -1,0 +1,70 @@
+package historian
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	historianModels "github.com/grafana/grafana/pkg/services/ngalert/schedule/historian/models"
+)
+
+func TestPrepareStream(t *testing.T) {
+	defaultLabels := map[string]string{
+		"env": "test",
+	}
+	h := &Historian{
+		externalLabels: defaultLabels,
+		log:            &logtest.Fake{},
+	}
+
+	tickTime := time.Unix(123423, 0)
+	evalTime := time.Unix(123123, 0)
+
+	record := historianModels.Record{
+		Attempt:     10,
+		RuleUID:     "rule-uid-213",
+		RuleVersion: 22,
+		GroupKey: models.AlertRuleGroupKey{
+			OrgID:        4,
+			NamespaceUID: "folder-uid-123",
+			RuleGroup:    "rule-group-123",
+		},
+		RuleFingerprint: "fingerprint-123",
+		Status:          historianModels.EvalStatusSuccess,
+		Error:           "test-error",
+		Duration:        152 * time.Millisecond,
+		Tick:            tickTime,
+		EvaluationTime:  evalTime,
+	}
+
+	streams := h.prepareStream(record, h.log)
+
+	require.Len(t, streams, 1)
+	stream := streams[0]
+	require.Len(t, stream.Values, 1)
+	value := stream.Values[0]
+
+	assert.Equal(t, stream.Stream, map[string]string{
+		"env":       "test",
+		"orgID":     "4",
+		"from":      "evaluation-history",
+		"folderUID": "folder-uid-123",
+		"group":     "rule-group-123",
+	})
+	assert.Equal(t, value.T, tickTime)
+	assert.JSONEq(t, `{
+		"schemaVersion":1,
+		"evaluationTime": 123123,
+		"ruleUID":"rule-uid-213",
+		"version":"22",
+		"fingerprint":"fingerprint-123",
+		"attempt":10,
+		"duration":152,
+		"status":"success",
+		"error":"test-error"       
+	}`, value.V)
+}

--- a/pkg/services/ngalert/schedule/historian/models/models.go
+++ b/pkg/services/ngalert/schedule/historian/models/models.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type EvalStatus string
+
+const (
+	EvalStatusSuccess      EvalStatus = "success"
+	EvalStatusNoData       EvalStatus = "no-data"
+	EvalStatusEvalError    EvalStatus = "eval-error"
+	EvalStatusProcessError EvalStatus = "process-error"
+)
+
+type Record struct {
+	GroupKey        models.AlertRuleGroupKey
+	RuleUID         string
+	RuleVersion     int64
+	RuleFingerprint string
+	Attempt         int
+	Status          EvalStatus
+	Error           string
+	Duration        time.Duration
+	Tick            time.Time
+	EvaluationTime  time.Time
+}

--- a/pkg/services/ngalert/schedule/recording_rule.go
+++ b/pkg/services/ngalert/schedule/recording_rule.go
@@ -51,9 +51,10 @@ type recordingRule struct {
 	evalAppliedHook evalAppliedFunc
 	stopAppliedHook stopAppliedFunc
 
-	logger  log.Logger
-	metrics *metrics.Scheduler
-	tracer  tracing.Tracer
+	logger    log.Logger
+	metrics   *metrics.Scheduler
+	tracer    tracing.Tracer
+	historian Historian
 }
 
 func newRecordingRule(
@@ -69,6 +70,7 @@ func newRecordingRule(
 	writer RecordingWriter,
 	evalAppliedHook evalAppliedFunc,
 	stopAppliedHook stopAppliedFunc,
+	historian Historian,
 ) *recordingRule {
 	ctx, stop := util.WithCancelCause(ngmodels.WithRuleKey(parent, key.AlertRuleKey))
 	return &recordingRule{
@@ -90,6 +92,7 @@ func newRecordingRule(
 		metrics:             metrics,
 		tracer:              tracer,
 		writer:              writer,
+		historian:           historian,
 	}
 }
 

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -179,7 +179,7 @@ func blankRecordingRuleForTests(ctx context.Context) *recordingRule {
 		Enabled: true,
 	}
 
-	return newRecordingRule(context.Background(), models.AlertRuleKeyWithGroup{}, RetryConfig{}, nil, nil, st, log.NewNopLogger(), nil, nil, writer.FakeWriter{}, nil, nil)
+	return newRecordingRule(context.Background(), models.AlertRuleKeyWithGroup{}, RetryConfig{}, nil, nil, st, log.NewNopLogger(), nil, nil, writer.FakeWriter{}, nil, nil, nil)
 }
 
 func TestRecordingRule_Integration(t *testing.T) {

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1298,6 +1298,7 @@ func setupScheduler(
 		FeatureToggles:         featuremgmt.WithFeatures(),
 		RecordingWriter:        fakeRecordingWriter,
 		RuleStopReasonProvider: ruleStopReasonProvider,
+		Historian:              &fakeHistorian{},
 	}
 	managerCfg := state.ManagerCfg{
 		Metrics:                 m.GetStateMetrics(),

--- a/pkg/services/ngalert/schedule/testing.go
+++ b/pkg/services/ngalert/schedule/testing.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	historianModels "github.com/grafana/grafana/pkg/services/ngalert/schedule/historian/models"
 )
 
 // waitForTimeChannel blocks the execution until either the channel ch has some data or a timeout of 10 second expires.
@@ -109,4 +110,21 @@ func (m *SyncAlertsSenderMock) Calls() []mock.Call {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return slices.Clone(m.AlertsSenderMock.Calls)
+}
+
+type fakeHistorian struct {
+	Records []historianModels.Record
+	mu      sync.Mutex
+}
+
+func (f *fakeHistorian) Record(_ context.Context, opts historianModels.Record) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Records = append(f.Records, opts)
+}
+
+func (f *fakeHistorian) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.Records = make([]historianModels.Record, 0)
 }

--- a/pkg/services/ngalert/writer/fake.go
+++ b/pkg/services/ngalert/writer/fake.go
@@ -2,24 +2,18 @@ package writer
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
 
 type FakeWriter struct {
-	WriteFunc func(ctx context.Context, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
+	WriteFunc func(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error
 }
 
 func (w FakeWriter) WriteDatasource(ctx context.Context, dsUID string, name string, t time.Time, frames data.Frames, orgID int64, extraLabels map[string]string) error {
 	if w.WriteFunc == nil {
 		return nil
 	}
-
-	if dsUID != "" {
-		return errors.New("expected empty data source uid")
-	}
-
-	return w.WriteFunc(ctx, name, t, frames, orgID, extraLabels)
+	return w.WriteFunc(ctx, dsUID, name, t, frames, orgID, extraLabels)
 }


### PR DESCRIPTION
**What is this feature?**
This is an experimental feature. The PR implements a new history writer for scheduler evaluations. 
It proposes a simple data model that contains information about the rule: UID, Group, NamespaceUID, Version and Fingerprint as well as information about evaluation of the group: tick, attempt, exact time of evaluation, status and error.
The status is an enumerable string and can have the following values:
- success. The evaluation was successful and results produced
- no-data. The evaluation was successful but no results produced
- eval-error. Evaluation returned error. The field Error contains the information about the error
- process-error. Processing of evaluation results failed. The field Error contains the information about the error. 
    - Alert rule does not return it but recording rule returns it when write failed.
I chose to use the same stream label and timestamp as in state history, so both can be correlated easier. 

**Why do we need this feature?**
This will give more visibility for end-users on how rules are evaluated, correlated with state history, it can give end-to-end picture of rule evaluation part of alerting.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
