### PR TITLE
OTel logs: Move OTel augmented attributes out of the log line to a field

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4547,11 +4547,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/panel/logs/types.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
-    }
-  },
   "public/app/plugins/panel/nodeGraph/Edge.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/LogsPanelCfg_types.gen.ts
@@ -41,6 +41,7 @@ export interface Options {
   showCommonLabels: boolean;
   showControls?: boolean;
   showLabels: boolean;
+  showLogAttributes?: boolean;
   showLogContextToggle: boolean;
   showTime: boolean;
   sortOrder: common.LogsSortOrder;

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -571,16 +571,13 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     [displayedFields, panelState?.logs, updatePanelState]
   );
 
-  const clearDisplayedFields = useCallback(
-    (fields: string[] = []) => {
-      updatePanelState({
-        ...panelState?.logs,
-        displayedFields: fields,
-      });
-      setDisplayedFields(fields);
-    },
-    [panelState?.logs, updatePanelState]
-  );
+  const clearDisplayedFields = useCallback(() => {
+    updatePanelState({
+      ...panelState?.logs,
+      displayedFields: [],
+    });
+    setDisplayedFields([]);
+  }, [panelState?.logs, updatePanelState]);
 
   const onCloseCallbackRef = useRef<() => void>(() => {});
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -205,7 +205,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     store.get(SETTINGS_KEYS.logsSortOrder) || LogsSortOrder.Descending
   );
   const [isFlipping, setIsFlipping] = useState<boolean>(false);
-  const [displayedFields, setDisplayedFields] = useState<string[]>([]);
+  const [displayedFields, setDisplayedFields] = useState<string[]>(panelState?.logs?.displayedFields ?? []);
   const [defaultDisplayedFields, setDefaultDisplayedFields] = useState<string[]>([]);
   const [contextOpen, setContextOpen] = useState<boolean>(false);
   const [contextRow, setContextRow] = useState<LogRowModel | undefined>(undefined);

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -288,7 +288,9 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       displayedFields = Object.values(panelState?.logs?.displayedFields);
     }
     setDisplayedFields(displayedFields);
-  }, [panelState?.logs?.displayedFields]);
+    // Run once
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useUnmount(() => {
     if (flipOrderTimer) {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -30,6 +30,7 @@ import {
   serializeStateToUrlParam,
   urlUtil,
   LogLevel,
+  shallowCompare,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
@@ -337,6 +338,16 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     ]
   );
 
+  useEffect(() => {
+    if (!shallowCompare(displayedFields, panelState?.logs?.displayedFields ?? [])) {
+      console.log('siyncinynng');
+      updatePanelState({
+        ...panelState?.logs,
+        displayedFields,
+      });
+    }
+  }, [displayedFields, panelState?.logs, updatePanelState]);
+
   // actions
   const onLogRowHover = useCallback(
     (row?: LogRowModel) => {
@@ -535,13 +546,9 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       if (index === -1) {
         const updatedDisplayedFields = displayedFields.concat(key);
         setDisplayedFields(updatedDisplayedFields);
-        updatePanelState({
-          ...panelState?.logs,
-          displayedFields: updatedDisplayedFields,
-        });
       }
     },
-    [displayedFields, panelState?.logs, updatePanelState]
+    [displayedFields]
   );
 
   const hideField = useCallback(
@@ -550,22 +557,14 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       if (index > -1) {
         const updatedDisplayedFields = displayedFields.filter((k) => key !== k);
         setDisplayedFields(updatedDisplayedFields);
-        updatePanelState({
-          ...panelState?.logs,
-          displayedFields: updatedDisplayedFields,
-        });
       }
     },
-    [displayedFields, panelState?.logs, updatePanelState]
+    [displayedFields]
   );
 
   const clearDisplayedFields = useCallback(() => {
-    updatePanelState({
-      ...panelState?.logs,
-      displayedFields: [],
-    });
     setDisplayedFields([]);
-  }, [panelState?.logs, updatePanelState]);
+  }, []);
 
   const onCloseCallbackRef = useRef<() => void>(() => {});
 

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -570,13 +570,16 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     [displayedFields, panelState?.logs, updatePanelState]
   );
 
-  const clearDetectedFields = useCallback(() => {
-    updatePanelState({
-      ...panelState?.logs,
-      displayedFields: [],
-    });
-    setDisplayedFields([]);
-  }, [panelState?.logs, updatePanelState]);
+  const clearDisplayedFields = useCallback(
+    (fields: string[] = []) => {
+      updatePanelState({
+        ...panelState?.logs,
+        displayedFields: fields,
+      });
+      setDisplayedFields(fields);
+    },
+    [panelState?.logs, updatePanelState]
+  );
 
   const onCloseCallbackRef = useRef<() => void>(() => {});
 
@@ -987,7 +990,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             dedupStrategy={dedupStrategy}
             dedupCount={dedupCount}
             displayedFields={displayedFields}
-            clearDetectedFields={clearDetectedFields}
+            clearDisplayedFields={clearDisplayedFields}
           />
         </div>
         <div className={cx(styles.logsSection, visualisationType === 'table' ? styles.logsTable : undefined)}>

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -281,18 +281,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
     store.set(visualisationTypeKey, visualisationType);
   }, [panelState?.logs?.visualisationType]);
 
-  useEffect(() => {
-    let displayedFields: string[] = [];
-    if (Array.isArray(panelState?.logs?.displayedFields)) {
-      displayedFields = panelState?.logs?.displayedFields;
-    } else if (panelState?.logs?.displayedFields && typeof panelState?.logs?.displayedFields === 'object') {
-      displayedFields = Object.values(panelState?.logs?.displayedFields);
-    }
-    setDisplayedFields(displayedFields);
-    // Run once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
   useUnmount(() => {
     if (flipOrderTimer) {
       window.clearTimeout(flipOrderTimer.current);

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -53,7 +53,7 @@ import { InfiniteScroll } from 'app/features/logs/components/InfiniteScroll';
 import { LogRows } from 'app/features/logs/components/LogRows';
 import { LogRowContextModal } from 'app/features/logs/components/log-context/LogRowContextModal';
 import { LogLineContext } from 'app/features/logs/components/panel/LogLineContext';
-import { LogList, LogListControlOptions } from 'app/features/logs/components/panel/LogList';
+import { LogList, LogListOptions } from 'app/features/logs/components/panel/LogList';
 import { isDedupStrategy, isLogsSortOrder } from 'app/features/logs/components/panel/LogListContext';
 import { LogLevelColor, dedupLogRows } from 'app/features/logs/logsModel';
 import { getLogLevelFromKey, getLogLevelInfo } from 'app/features/logs/utils';
@@ -206,6 +206,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   );
   const [isFlipping, setIsFlipping] = useState<boolean>(false);
   const [displayedFields, setDisplayedFields] = useState<string[]>([]);
+  const [defaultDisplayedFields, setDefaultDisplayedFields] = useState<string[]>([]);
   const [contextOpen, setContextOpen] = useState<boolean>(false);
   const [contextRow, setContextRow] = useState<LogRowModel | undefined>(undefined);
   const [pinLineButtonTooltipTitle, setPinLineButtonTooltipTitle] = useState<PopoverContent>(PINNED_LOGS_MESSAGE);
@@ -708,7 +709,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   const visibilityChangedRef = useRef(true);
   const onLogOptionsChange = useCallback(
-    (option: LogListControlOptions, value: string | string[] | boolean) => {
+    (option: LogListOptions, value: string | string[] | boolean) => {
       if (option === 'sortOrder' && isLogsSortOrder(value)) {
         sortOrderChanged(value);
       } else if (option === 'dedupStrategy' && isDedupStrategy(value)) {
@@ -762,6 +763,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
           return newLevels;
         });
+      } else if (option === 'defaultDisplayedFields' && Array.isArray(value)) {
+        setDefaultDisplayedFields(value);
       }
     },
     [logsVolumeData?.data, logsVolumeEnabled, sortOrderChanged]
@@ -991,6 +994,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             dedupCount={dedupCount}
             displayedFields={displayedFields}
             clearDisplayedFields={clearDisplayedFields}
+            defaultDisplayedFields={defaultDisplayedFields}
           />
         </div>
         <div className={cx(styles.logsSection, visualisationType === 'table' ? styles.logsTable : undefined)}>

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -340,7 +340,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   useEffect(() => {
     if (!shallowCompare(displayedFields, panelState?.logs?.displayedFields ?? [])) {
-      console.log('siyncinynng');
       updatePanelState({
         ...panelState?.logs,
         displayedFields,

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -26,7 +26,7 @@ const defaultProps: LogsMetaRowProps = {
   dedupCount: 0,
   displayedFields: [],
   logRows: [],
-  clearDetectedFields: jest.fn(),
+  clearDisplayedFields: jest.fn(),
 };
 
 const setup = (propOverrides?: object, disableDownload = false) => {
@@ -61,7 +61,7 @@ describe('LogsMetaRow', () => {
 
   it('renders a button to clear displayedfields', () => {
     const clearSpy = jest.fn();
-    setup({ displayedFields: ['testField1234'], clearDetectedFields: clearSpy });
+    setup({ displayedFields: ['testField1234'], clearDisplayedFields: clearSpy });
     fireEvent(
       screen.getByRole('button', {
         name: 'Show original line',

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -27,6 +27,7 @@ const defaultProps: LogsMetaRowProps = {
   displayedFields: [],
   logRows: [],
   clearDisplayedFields: jest.fn(),
+  defaultDisplayedFields: [],
 };
 
 const setup = (propOverrides?: object, disableDownload = false) => {

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -39,7 +39,7 @@ export type Props = {
   dedupCount: number;
   displayedFields: string[];
   logRows: LogRowModel[];
-  clearDisplayedFields: (fields?: string[]) => void;
+  clearDisplayedFields: () => void;
   defaultDisplayedFields: string[];
 };
 
@@ -76,7 +76,7 @@ export const LogsMetaRow = memo(
         {
           label: '',
           value: (
-            <Button variant="primary" fill="outline" size="sm" onClick={() => clearDisplayedFields()}>
+            <Button variant="primary" fill="outline" size="sm" onClick={clearDisplayedFields}>
               {t('explore.logs-meta-row.show-original-line', 'Show original line')}
             </Button>
           ),

--- a/public/app/features/explore/Logs/LogsTableAvailableFields.tsx
+++ b/public/app/features/explore/Logs/LogsTableAvailableFields.tsx
@@ -1,5 +1,6 @@
 import { t } from '@grafana/i18n';
 import { useTheme2 } from '@grafana/ui';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from 'app/features/logs/components/otel/formats';
 
 import { getLogsFieldsStyles } from './LogsTableActiveFields';
 import { LogsTableEmptyFields } from './LogsTableEmptyFields';
@@ -36,7 +37,9 @@ export const LogsTableAvailableFields = (props: {
   const theme = useTheme2();
 
   const styles = getLogsFieldsStyles(theme);
-  const labelKeys = Object.keys(labels).filter((labelName) => valueFilter(labelName));
+  const labelKeys = Object.keys(labels)
+    .filter((labelName) => labelName !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME)
+    .filter((labelName) => valueFilter(labelName));
   if (labelKeys.length) {
     // Otherwise show list with a hardcoded order
     return (

--- a/public/app/features/logs/components/ControlledLogRows.tsx
+++ b/public/app/features/logs/components/ControlledLogRows.tsx
@@ -20,7 +20,7 @@ import { LogsVisualisationType } from '../../explore/Logs/Logs';
 import { ControlledLogsTable } from './ControlledLogsTable';
 import { InfiniteScroll } from './InfiniteScroll';
 import { LogRows, Props } from './LogRows';
-import { LogListControlOptions } from './panel/LogList';
+import { LogListOptions } from './panel/LogList';
 import { LogListContextProvider, useLogListContext } from './panel/LogListContext';
 import { LogListControls } from './panel/LogListControls';
 import { ScrollToLogsEvent } from './panel/virtualization';
@@ -30,7 +30,7 @@ export interface ControlledLogRowsProps extends Omit<Props, 'scrollElement'> {
   logsMeta?: LogsMetaItem[];
   loadMoreLogs?: (range: AbsoluteTimeRange) => void;
   logOptionsStorageKey?: string;
-  onLogOptionsChange?: (option: LogListControlOptions, value: string | boolean | string[]) => void;
+  onLogOptionsChange?: (option: LogListOptions, value: string | boolean | string[]) => void;
   range: TimeRange;
   filterLevels?: LogLevel[];
 

--- a/public/app/features/logs/components/LogLabels.test.tsx
+++ b/public/app/features/logs/components/LogLabels.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 
 import { LOG_LINE_BODY_FIELD_NAME } from './LogDetailsBody';
 import { LogLabels, LogLabelsList } from './LogLabels';
+import { getNormalizedFieldName } from './panel/processing';
 
 describe('<LogLabels />', () => {
   it('renders notice when no labels are found', () => {
@@ -96,6 +97,6 @@ describe('<LogLabelsList />', () => {
     render(<LogLabelsList labels={['bar', '42', LOG_LINE_BODY_FIELD_NAME]} />);
     expect(screen.queryByText('bar')).toBeInTheDocument();
     expect(screen.queryByText('42')).toBeInTheDocument();
-    expect(screen.queryByText('log line')).toBeInTheDocument();
+    expect(screen.queryByText(getNormalizedFieldName(LOG_LINE_BODY_FIELD_NAME))).toBeInTheDocument();
   });
 });

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, Labels } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Icon, Tooltip, useStyles2 } from '@grafana/ui';
 
-import { LOG_LINE_BODY_FIELD_NAME } from './LogDetailsBody';
+import { getNormalizedFieldName } from './panel/processing';
 
 // Levels are already encoded in color, filename is a Loki-ism
 const HIDDEN_LABELS = ['detected_level', 'level', 'lvl', 'filename'];
@@ -111,7 +111,7 @@ export const LogLabelsList = memo(({ labels }: LogLabelsArrayProps) => {
     <span className={styles.logsLabels}>
       {labels.map((label) => (
         <LogLabel key={label} styles={styles} tooltip={label}>
-          {label === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-labels-list.log-line', 'log line') : label}
+          {getNormalizedFieldName(label)}
         </LogLabel>
       ))}
     </span>

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -1,7 +1,12 @@
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../mocks/logRow';
 
-import { getDisplayedFieldsForLogs, OTEL_PROBE_FIELD } from './formats';
+import {
+  getDisplayedFieldsForLogs,
+  getOtelAttributesField,
+  OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+  OTEL_PROBE_FIELD,
+} from './formats';
 
 describe('getDisplayedFieldsForLogs', () => {
   test('Does not return displayed fields if not an OTel log line', () => {
@@ -18,21 +23,75 @@ describe('getDisplayedFieldsForLogs', () => {
 
   test('Returns displayed fields if the OTel probe field is present', () => {
     const log = createLogLine({
-      labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'php', scope_name: 'scope' },
+      labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'php', thread_name: 'John' },
       entry: `place="luna" 1ms 3 KB`,
     });
 
-    expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
+    expect(getDisplayedFieldsForLogs([log])).toEqual([
+      'thread_name',
+      LOG_LINE_BODY_FIELD_NAME,
+      OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+    ]);
     expect(log.otelLanguage).toBe('php');
   });
 
   test('Returns displayed fields if the OTel probe field is present and the language unknown', () => {
     const log = createLogLine({
-      labels: { [OTEL_PROBE_FIELD]: '1', scope_name: 'scope' },
+      labels: { [OTEL_PROBE_FIELD]: '1', exception_type: 'fatal', exception_message: 'message' },
       entry: `place="luna" 1ms 3 KB`,
     });
 
-    expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
+    expect(getDisplayedFieldsForLogs([log])).toEqual([
+      'exception_type',
+      'exception_message',
+      LOG_LINE_BODY_FIELD_NAME,
+      OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+    ]);
     expect(log.otelLanguage).toBe('unknown');
+  });
+
+  test('Returns the minimal displayed fields if others are not present', () => {
+    const log = createLogLine({
+      labels: { [OTEL_PROBE_FIELD]: '1' },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getDisplayedFieldsForLogs([log])).toEqual([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
+  });
+});
+
+describe('getOtelAttributesField', () => {
+  test('Builds the OTel attributes fields from the log line fields including and excluding fields', () => {
+    const log = createLogLine({
+      labels: {
+        aws_something: 'nope',
+        k8s_something: 'nope',
+        cluster: 'nope',
+        namespace: 'nope',
+        pod: 'nope',
+        vcs_ref_head_name: 'main',
+        field: 'value',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getOtelAttributesField(log, true)).toEqual('vcs_ref_head_name=main field=value');
+  });
+
+  test('Removes new lines when wrapping is disabled', () => {
+    const log = createLogLine({
+      labels: {
+        aws_something: 'nope',
+        k8s_something: 'nope',
+        cluster: 'nope',
+        namespace: 'nope',
+        pod: 'nope',
+        vcs_ref_head_name: 'ma\nin',
+        field: 'val\nue',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getOtelAttributesField(log, false)).toEqual('vcs_ref_head_name=main field=value');
   });
 });

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -78,6 +78,28 @@ describe('getOtelAttributesField', () => {
     expect(getOtelAttributesField(log, true)).toEqual('vcs_ref_head_name=main field=value');
   });
 
+  test('Correctly matches excluded labels', () => {
+    const log = createLogLine({
+      labels: {
+        aws_something: 'nope',
+        k8s_something: 'nope',
+        cluster: 'nope',
+        namespace: 'nope',
+        pod: 'nope',
+        cluster_1: 'yes',
+        namespace_2: 'yes',
+        pod_3: 'yes',
+        vcs_ref_head_name: 'main',
+        field: 'value',
+      },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getOtelAttributesField(log, true)).toEqual(
+      'cluster_1=yes namespace_2=yes pod_3=yes vcs_ref_head_name=main field=value'
+    );
+  });
+
   test('Removes new lines when wrapping is disabled', () => {
     const log = createLogLine({
       labels: {

--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -1,7 +1,7 @@
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../mocks/logRow';
 
-import { getDisplayedFieldsForLogs, getOtelFormattedBody, OTEL_PROBE_FIELD } from './formats';
+import { getDisplayedFieldsForLogs, OTEL_PROBE_FIELD } from './formats';
 
 describe('getDisplayedFieldsForLogs', () => {
   test('Does not return displayed fields if not an OTel log line', () => {
@@ -34,27 +34,5 @@ describe('getDisplayedFieldsForLogs', () => {
 
     expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
     expect(log.otelLanguage).toBe('unknown');
-  });
-});
-
-describe('getOtelFormattedBody', () => {
-  test('Does not modify non OTel logs', () => {
-    const log = createLogLine({ labels: { place: 'luna' }, entry: `place="luna" 1ms 3 KB` });
-    expect(getOtelFormattedBody(log)).toEqual(`place="luna" 1ms 3 KB`);
-  });
-
-  test('Returns an OTel augmented log line body', () => {
-    const log = createLogLine({
-      labels: {
-        severity_number: '1',
-        telemetry_sdk_language: 'php',
-        scope_name: 'scope',
-        aws_ignore: 'ignored',
-        key: 'value',
-        otel: 'otel',
-      },
-      entry: `place="luna" 1ms 3 KB`,
-    });
-    expect(getOtelFormattedBody(log)).toEqual(`place="luna" 1ms 3 KB key=value otel=otel`);
   });
 });

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -1,7 +1,7 @@
 import { CoreApp, LogRowModel } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
-import { LogListModel } from '../panel/processing';
+import { LogListModel, NEWLINES_REGEX } from '../panel/processing';
 
 /**
  * The presence of this field along log fields determines OTel origin.
@@ -68,7 +68,7 @@ export function getDefaultOTelDisplayFormat() {
 }
 
 const OTEL_RESOURCE_ATTRS_REGEX =
-  /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_)/;
+  /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_|cluster$|namespace$|pod$)/;
 const OTEL_LOG_FIELDS_REGEX =
   /^(flags|observed_timestamp|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -74,14 +74,20 @@ const OTEL_LOG_FIELDS_REGEX =
 
 export const OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
 
-export function getOtelAttributesField(log: LogListModel) {
+export function getOtelAttributesField(log: LogListModel, wrapLogMessage: boolean) {
   const additionalFields = Object.keys(log.labels).filter(
     (label) =>
       !OTEL_RESOURCE_ATTRS_REGEX.test(label) &&
       !OTEL_LOG_FIELDS_REGEX.test(label) &&
       label !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME
   );
-  return additionalFields.map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : '')).join(' ');
+  const attributes = additionalFields
+    .map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : ''))
+    .join(' ');
+  if (!wrapLogMessage) {
+    return attributes.replace(NEWLINES_REGEX, '');
+  }
+  return attributes;
 }
 
 export function isSupportedApp(app: CoreApp) {

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -8,7 +8,8 @@ import { LogListModel, NEWLINES_REGEX } from '../panel/processing';
  */
 export const OTEL_PROBE_FIELD = 'severity_number';
 const OTEL_LANGUAGE_UNKNOWN = 'unknown';
-export function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
+
+function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
   const languagesSet = new Set<string>();
   logs.forEach((log) => {
     const lang = identifyOTelLanguage(log);
@@ -28,7 +29,7 @@ export function identifyOTelLanguage(log: LogListModel | LogRowModel): string | 
     : undefined;
 }
 
-export function getDisplayedFieldsForLanguages(logs: LogListModel[] | LogRowModel[], languages: string[]) {
+function getDisplayedFieldsForLanguages(logs: LogListModel[] | LogRowModel[], languages: string[]) {
   const displayedFields: string[] = [];
 
   languages.forEach((language) => {

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -61,7 +61,7 @@ export function getDefaultOTelDisplayFormat() {
 const OTEL_RESOURCE_ATTRS_REGEX =
   /^(aws_|cloud_|cloudfoundry_|container_|deployment_|faas_|gcp_|host_|k8s_|os_|process_|service_|telemetry_)/;
 const OTEL_LOG_FIELDS_REGEX =
-  /^(flags|observed_timestamp|scope_name|severity_number|severity_text|span_id|trace_id|detected_level)$/;
+  /^(flags|observed_timestamp|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 
 export const LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
 

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -55,7 +55,7 @@ export function getDisplayFormatForLanguage(language: string) {
 }
 
 export function getDefaultOTelDisplayFormat() {
-  return ['scope_name', 'thread_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME];
+  return ['thread_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME, LOG_LINE_ATTRIBUTES_FIELD_NAME];
 }
 
 const OTEL_RESOURCE_ATTRS_REGEX =
@@ -63,16 +63,14 @@ const OTEL_RESOURCE_ATTRS_REGEX =
 const OTEL_LOG_FIELDS_REGEX =
   /^(flags|observed_timestamp|scope_name|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 
-export function getOtelFormattedBody(log: LogListModel) {
+export const LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
+
+export function getOtelAttributesField(log: LogListModel) {
   if (!log.otelLanguage) {
     return log.raw;
   }
   const additionalFields = Object.keys(log.labels).filter(
-    (label) => !OTEL_RESOURCE_ATTRS_REGEX.test(label) && !OTEL_LOG_FIELDS_REGEX.test(label)
+    (label) => !OTEL_RESOURCE_ATTRS_REGEX.test(label) && !OTEL_LOG_FIELDS_REGEX.test(label) && label !== LOG_LINE_ATTRIBUTES_FIELD_NAME,
   );
-  return (
-    log.raw +
-    ' ' +
-    additionalFields.map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : '')).join(' ')
-  );
+  return additionalFields.map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : '')).join(' ');
 }

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -1,4 +1,4 @@
-import { LogRowModel } from '@grafana/data';
+import { CoreApp, LogRowModel } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogListModel } from '../panel/processing';
@@ -55,7 +55,13 @@ export function getDisplayFormatForLanguage(language: string) {
 }
 
 export function getDefaultOTelDisplayFormat() {
-  return ['thread_name', 'exception_type', 'exception_message', LOG_LINE_BODY_FIELD_NAME, LOG_LINE_ATTRIBUTES_FIELD_NAME];
+  return [
+    'thread_name',
+    'exception_type',
+    'exception_message',
+    LOG_LINE_BODY_FIELD_NAME,
+    LOG_LINE_ATTRIBUTES_FIELD_NAME,
+  ];
 }
 
 const OTEL_RESOURCE_ATTRS_REGEX =
@@ -70,7 +76,14 @@ export function getOtelAttributesField(log: LogListModel) {
     return log.raw;
   }
   const additionalFields = Object.keys(log.labels).filter(
-    (label) => !OTEL_RESOURCE_ATTRS_REGEX.test(label) && !OTEL_LOG_FIELDS_REGEX.test(label) && label !== LOG_LINE_ATTRIBUTES_FIELD_NAME,
+    (label) =>
+      !OTEL_RESOURCE_ATTRS_REGEX.test(label) &&
+      !OTEL_LOG_FIELDS_REGEX.test(label) &&
+      label !== LOG_LINE_ATTRIBUTES_FIELD_NAME
   );
   return additionalFields.map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : '')).join(' ');
+}
+
+export function isSupportedApp(app: CoreApp) {
+  return app !== CoreApp.Dashboard && app !== CoreApp.PanelEditor && app !== CoreApp.PanelViewer;
 }

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -41,7 +41,10 @@ export function getDisplayedFieldsForLanguages(logs: LogListModel[] | LogRowMode
   });
 
   return displayedFields.filter(
-    (field) => field === LOG_LINE_BODY_FIELD_NAME || logs.some((log) => log.labels[field] !== undefined)
+    (field) =>
+      field === LOG_LINE_BODY_FIELD_NAME ||
+      field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME ||
+      logs.some((log) => log.labels[field] !== undefined)
   );
 }
 
@@ -72,9 +75,6 @@ const OTEL_LOG_FIELDS_REGEX =
 export const OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
 
 export function getOtelAttributesField(log: LogListModel) {
-  if (!log.otelLanguage) {
-    return log.raw;
-  }
   const additionalFields = Object.keys(log.labels).filter(
     (label) =>
       !OTEL_RESOURCE_ATTRS_REGEX.test(label) &&

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -60,7 +60,7 @@ export function getDefaultOTelDisplayFormat() {
     'exception_type',
     'exception_message',
     LOG_LINE_BODY_FIELD_NAME,
-    LOG_LINE_ATTRIBUTES_FIELD_NAME,
+    OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
   ];
 }
 
@@ -69,7 +69,7 @@ const OTEL_RESOURCE_ATTRS_REGEX =
 const OTEL_LOG_FIELDS_REGEX =
   /^(flags|observed_timestamp|severity_number|severity_text|span_id|trace_id|detected_level)$/;
 
-export const LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
+export const OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME = '___OTEL_LOG_ATTRIBUTES___';
 
 export function getOtelAttributesField(log: LogListModel) {
   if (!log.otelLanguage) {
@@ -79,7 +79,7 @@ export function getOtelAttributesField(log: LogListModel) {
     (label) =>
       !OTEL_RESOURCE_ATTRS_REGEX.test(label) &&
       !OTEL_LOG_FIELDS_REGEX.test(label) &&
-      label !== LOG_LINE_ATTRIBUTES_FIELD_NAME
+      label !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME
   );
   return additionalFields.map((field) => (log.labels[field] ? `${field}=${log.labels[field]}` : '')).join(' ');
 }

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -1,4 +1,4 @@
-import { CoreApp, LogRowModel } from '@grafana/data';
+import { LogRowModel } from '@grafana/data';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogListModel, NEWLINES_REGEX } from '../panel/processing';
@@ -89,8 +89,4 @@ export function getOtelAttributesField(log: LogListModel, wrapLogMessage: boolea
     return attributes.replace(NEWLINES_REGEX, '');
   }
   return attributes;
-}
-
-export function isSupportedApp(app: CoreApp) {
-  return app !== CoreApp.Dashboard && app !== CoreApp.PanelEditor && app !== CoreApp.PanelViewer;
 }

--- a/public/app/features/logs/components/panel/HighlightedLogRenderer.test.tsx
+++ b/public/app/features/logs/components/panel/HighlightedLogRenderer.test.tsx
@@ -34,7 +34,7 @@ describe('HighlightedLogRenderer', () => {
       }
     );
 
-    const { container } = render(<HighlightedLogRenderer log={log} />);
+    const { container } = render(<HighlightedLogRenderer tokens={log.highlightedBodyTokens} />);
 
     expect(container.innerHTML).toEqual(log.highlightedBody);
   });
@@ -177,7 +177,7 @@ describe('HighlightedLogRenderer', () => {
       }
     );
 
-    const { container } = render(<HighlightedLogRenderer log={log} />);
+    const { container } = render(<HighlightedLogRenderer tokens={log.highlightedBodyTokens} />);
 
     expect(container.innerHTML).toEqual(log.highlightedBody);
   });
@@ -201,7 +201,7 @@ describe('HighlightedLogRenderer', () => {
       }
     );
 
-    const { container } = render(<HighlightedLogRenderer log={log} />);
+    const { container } = render(<HighlightedLogRenderer tokens={log.highlightedBodyTokens} />);
 
     expect(container.innerHTML).toEqual(log.highlightedBody);
   });

--- a/public/app/features/logs/components/panel/HighlightedLogRenderer.tsx
+++ b/public/app/features/logs/components/panel/HighlightedLogRenderer.tsx
@@ -1,16 +1,16 @@
 import { Token } from 'prismjs';
+import { memo } from 'react';
 
-import { LogListModel } from './processing';
-
-export const HighlightedLogRenderer = ({ log }: { log: LogListModel }) => {
+export const HighlightedLogRenderer = memo(({ tokens }: { tokens: Array<string | Token> }) => {
   return (
     <>
-      {log.highlightedBodyTokens.map((token, i) => (
+      {tokens.map((token, i) => (
         <LogToken token={token} key={i} />
       ))}
     </>
   );
-};
+});
+HighlightedLogRenderer.displayName = 'HighlightedLogRenderer';
 
 const LogToken = ({ token }: { token: Token | string }) => {
   if (typeof token === 'string') {

--- a/public/app/features/logs/components/panel/HighlightedLogRenderer.tsx
+++ b/public/app/features/logs/components/panel/HighlightedLogRenderer.tsx
@@ -12,7 +12,7 @@ export const HighlightedLogRenderer = memo(({ tokens }: { tokens: Array<string |
 });
 HighlightedLogRenderer.displayName = 'HighlightedLogRenderer';
 
-const LogToken = ({ token }: { token: Token | string }) => {
+const LogToken = memo(({ token }: { token: Token | string }) => {
   if (typeof token === 'string') {
     return token;
   }
@@ -30,4 +30,5 @@ const LogToken = ({ token }: { token: Token | string }) => {
       {typeof token.content === 'string' ? token.content : <LogToken token={token.content} />}
     </span>
   );
-};
+});
+LogToken.displayName = 'LogToken';

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -2,10 +2,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, createTheme, getDefaultTimeRange, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { config } from '@grafana/runtime';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../mocks/logRow';
-import { OTEL_PROBE_FIELD } from '../otel/formats';
+import { getDisplayedFieldsForLogs, OTEL_PROBE_FIELD } from '../otel/formats';
 
 import { getGridTemplateColumns, getStyles, LogLine, Props } from './LogLine';
 import { LogListFontSize } from './LogList';
@@ -14,7 +15,6 @@ import { LogListSearchContext } from './LogListSearchContext';
 import { defaultProps, defaultValue } from './__mocks__/LogListContext';
 import { LogListModel } from './processing';
 import { LogLineVirtualization } from './virtualization';
-import { config } from '@grafana/runtime';
 
 jest.mock('@grafana/assistant', () => ({
   ...jest.requireActual('@grafana/assistant'),
@@ -280,13 +280,14 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
         labels: { [OTEL_PROBE_FIELD]: '1', service: 'some service' },
         entry: `place="luna" 1ms 3 KB`,
       });
+      const displayedFields = getDisplayedFieldsForLogs([log]);
 
       render(
-        <LogListContextProvider {...contextProps}>
-          <LogLine {...defaultProps} log={log} />
+        <LogListContextProvider {...contextProps} displayedFields={displayedFields}>
+          <LogLine {...defaultProps} displayedFields={displayedFields} log={log} />
         </LogListContextProvider>
       );
-      expect(screen.getByText('service')).toBeInTheDocument();
+      expect(screen.getByText('service=')).toBeInTheDocument();
       expect(screen.getByText('some service')).toBeInTheDocument();
 
       expect(screen.getByText('place')).toBeInTheDocument();

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -444,7 +444,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
 
   return (
     <span className="field log-syntax-highlight">
-      <HighlightedLogRenderer log={log} />
+      <HighlightedLogRenderer tokens={log.highlightedBodyTokens} />
     </span>
   );
 };

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -20,6 +20,7 @@ import { Button, Icon, Tooltip } from '@grafana/ui';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { LogLabels } from '../LogLabels';
 import { LogMessageAnsi } from '../LogMessageAnsi';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { HighlightedLogRenderer } from './HighlightedLogRenderer';
 import { InlineLogLineDetails } from './LogLineDetails';
@@ -386,10 +387,18 @@ const DisplayedFields = ({
     return searchWords;
   }, [log.searchWords, log.uid, matchingUids, search]);
 
-  return displayedFields.map((field) =>
-    field === LOG_LINE_BODY_FIELD_NAME ? (
-      <LogLineBody log={log} key={field} styles={styles} />
-    ) : (
+  return displayedFields.map((field) => {
+    if (field === LOG_LINE_BODY_FIELD_NAME) {
+      return <LogLineBody log={log} key={field} styles={styles} />;
+    }
+    if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+      return (
+        <span className="field log-syntax-highlight" title={getNormalizedFieldName(field)} key={field}>
+          <HighlightedLogRenderer tokens={log.highlightedLogAttributesTokens} />
+        </span>
+      );
+    }
+    return (
       <span className="field" title={getNormalizedFieldName(field)} key={field}>
         {searchWords ? (
           <Highlighter
@@ -402,8 +411,8 @@ const DisplayedFields = ({
           log.getDisplayedFieldValue(field)
         )}
       </span>
-    )
-  );
+    );
+  });
 };
 
 const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles }) => {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -375,6 +375,7 @@ const DisplayedFields = ({
   styles: LogLineStyles;
 }) => {
   const { matchingUids, search } = useLogListSearchContext();
+  const { syntaxHighlighting } = useLogListContext();
 
   const searchWords = useMemo(() => {
     const searchWords = log.searchWords && log.searchWords[0] ? log.searchWords.slice() : [];
@@ -391,7 +392,7 @@ const DisplayedFields = ({
     if (field === LOG_LINE_BODY_FIELD_NAME) {
       return <LogLineBody log={log} key={field} styles={styles} />;
     }
-    if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+    if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME && syntaxHighlighting) {
       return (
         <span className="field log-syntax-highlight" title={getNormalizedFieldName(field)} key={field}>
           <HighlightedLogRenderer tokens={log.highlightedLogAttributesTokens} />

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -26,7 +26,7 @@ import { InlineLogLineDetails } from './LogLineDetails';
 import { LogLineMenu } from './LogLineMenu';
 import { useLogIsPermalinked, useLogIsPinned, useLogListContext } from './LogListContext';
 import { useLogListSearchContext } from './LogListSearchContext';
-import { LogListModel } from './processing';
+import { getNormalizedFieldName, LogListModel } from './processing';
 import {
   FIELD_GAP_MULTIPLIER,
   getLogLineDOMHeight,
@@ -390,7 +390,7 @@ const DisplayedFields = ({
     field === LOG_LINE_BODY_FIELD_NAME ? (
       <LogLineBody log={log} key={field} styles={styles} />
     ) : (
-      <span className="field" title={field} key={field}>
+      <span className="field" title={getNormalizedFieldName(field)} key={field}>
         {searchWords ? (
           <Highlighter
             textToHighlight={log.getDisplayedFieldValue(field)}

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -7,6 +7,7 @@ import { t } from '@grafana/i18n';
 import { Card, IconButton, useStyles2 } from '@grafana/ui';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { LogLineDetailsMode } from './LogLineDetails';
 import { useLogListContext } from './LogListContext';
@@ -99,7 +100,7 @@ const DisplayedField = ({
       <Card noMargin className={styles.fieldCard}>
         <div className={styles.fieldWrapper}>
           <div className={styles.field}>
-            {field === LOG_LINE_BODY_FIELD_NAME ? t('logs.log-line-details.log-line-field', 'Log line') : field}
+            {getNormalizedFieldName(field)}
           </div>
           {displayedFields.length > 1 && (
             <>
@@ -148,3 +149,12 @@ const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
     flex: 1,
   }),
 });
+
+export function getNormalizedFieldName(field: string) {
+  if (field === LOG_LINE_BODY_FIELD_NAME) {
+    return t('logs.log-line-details.log-line-field', 'Log line');
+  } else if (field === LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+    return t('logs.log-line-details.log-attributes-field', 'Log attributes');
+  }
+  return field;
+}

--- a/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsDisplayedFields.tsx
@@ -6,12 +6,10 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Card, IconButton, useStyles2 } from '@grafana/ui';
 
-import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
-import { LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
-
 import { LogLineDetailsMode } from './LogLineDetails';
 import { useLogListContext } from './LogListContext';
 import { reportInteractionOnce } from './analytics';
+import { getNormalizedFieldName } from './processing';
 
 export const LogLineDetailsDisplayedFields = () => {
   const { displayedFields, setDisplayedFields } = useLogListContext();
@@ -99,9 +97,7 @@ const DisplayedField = ({
     <div ref={provided.innerRef} {...provided.draggableProps} {...provided.dragHandleProps}>
       <Card noMargin className={styles.fieldCard}>
         <div className={styles.fieldWrapper}>
-          <div className={styles.field}>
-            {getNormalizedFieldName(field)}
-          </div>
+          <div className={styles.field}>{getNormalizedFieldName(field)}</div>
           {displayedFields.length > 1 && (
             <>
               <IconButton
@@ -149,12 +145,3 @@ const getStyles = (theme: GrafanaTheme2, detailsMode: LogLineDetailsMode) => ({
     flex: 1,
   }),
 });
-
-export function getNormalizedFieldName(field: string) {
-  if (field === LOG_LINE_BODY_FIELD_NAME) {
-    return t('logs.log-line-details.log-line-field', 'Log line');
-  } else if (field === LOG_LINE_ATTRIBUTES_FIELD_NAME) {
-    return t('logs.log-line-details.log-attributes-field', 'Log attributes');
-  }
-  return field;
-}

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -14,9 +14,8 @@ import { LogLabelStats } from '../LogLabelStats';
 import { FieldDef } from '../logParser';
 import { LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
-import { getNormalizedFieldName } from './LogLineDetailsDisplayedFields';
 import { useLogListContext } from './LogListContext';
-import { LogListModel } from './processing';
+import { LogListModel, getNormalizedFieldName } from './processing';
 
 interface LogLineDetailsFieldsProps {
   disableActions?: boolean;
@@ -317,7 +316,9 @@ export const LogLineDetailsField = ({
             />
           </div>
         )}
-        <div className={styles.label}>{singleKey ? getNormalizedFieldName(keys[0]) : <MultipleValue values={keys} />}</div>
+        <div className={styles.label}>
+          {singleKey ? getNormalizedFieldName(keys[0]) : <MultipleValue values={keys} />}
+        </div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>
             {singleValue ? (

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -12,7 +12,9 @@ import { logRowToSingleRowDataFrame } from '../../logsModel';
 import { calculateLogsLabelStats, calculateStats } from '../../utils';
 import { LogLabelStats } from '../LogLabelStats';
 import { FieldDef } from '../logParser';
+import { LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
+import { getNormalizedFieldName } from './LogLineDetailsDisplayedFields';
 import { useLogListContext } from './LogListContext';
 import { LogListModel } from './processing';
 
@@ -258,12 +260,14 @@ export const LogLineDetailsField = ({
   const singleKey = keys.length === 1;
   const singleValue = values.length === 1;
 
+  const fieldSupportsFilters = keys[0] !== LOG_LINE_ATTRIBUTES_FIELD_NAME;
+
   return (
     <>
       <div className={styles.row}>
         {!disableActions && (
           <div className={styles.actions}>
-            {onClickFilterLabel && (
+            {onClickFilterLabel && fieldSupportsFilters && (
               <AsyncIconButton
                 name="search-plus"
                 onClick={filterLabel}
@@ -272,7 +276,7 @@ export const LogLineDetailsField = ({
                 tooltipSuffix={refIdTooltip}
               />
             )}
-            {onClickFilterOutLabel && (
+            {onClickFilterOutLabel && fieldSupportsFilters && (
               <IconButton
                 name="search-minus"
                 tooltip={
@@ -313,7 +317,7 @@ export const LogLineDetailsField = ({
             />
           </div>
         )}
-        <div className={styles.label}>{singleKey ? keys[0] : <MultipleValue values={keys} />}</div>
+        <div className={styles.label}>{singleKey ? getNormalizedFieldName(keys[0]) : <MultipleValue values={keys} />}</div>
         <div className={styles.value}>
           <div className={styles.valueContainer}>
             {singleValue ? (

--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -12,7 +12,7 @@ import { logRowToSingleRowDataFrame } from '../../logsModel';
 import { calculateLogsLabelStats, calculateStats } from '../../utils';
 import { LogLabelStats } from '../LogLabelStats';
 import { FieldDef } from '../logParser';
-import { LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { useLogListContext } from './LogListContext';
 import { LogListModel, getNormalizedFieldName } from './processing';
@@ -259,7 +259,7 @@ export const LogLineDetailsField = ({
   const singleKey = keys.length === 1;
   const singleValue = values.length === 1;
 
-  const fieldSupportsFilters = keys[0] !== LOG_LINE_ATTRIBUTES_FIELD_NAME;
+  const fieldSupportsFilters = keys[0] !== OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME;
 
   return (
     <>

--- a/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsLog.tsx
@@ -33,7 +33,9 @@ export const LogLineDetailsLog = memo(({ log: originalLog, syntaxHighlighting }:
             <>
               {!syntaxHighlighting && <div className="field no-highlighting">{log.body}</div>}
               {syntaxHighlighting && (
-                <div className="field log-syntax-highlight">{<HighlightedLogRenderer log={log} />}</div>
+                <div className="field log-syntax-highlight">
+                  {<HighlightedLogRenderer tokens={log.highlightedBodyTokens} />}
+                </div>
               )}
             </>
           )}

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -13,11 +13,11 @@ import {
 import { config, reportInteraction } from '@grafana/runtime';
 
 import { disablePopoverMenu, enablePopoverMenu, isPopoverMenuDisabled } from '../../utils';
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogRow } from '../mocks/logRow';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 import { LogList, Props } from './LogList';
-import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
-import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 jest.mock('@grafana/assistant', () => ({
   ...jest.requireActual('@grafana/assistant'),

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -242,10 +242,16 @@ describe('LogList', () => {
     test('Reports the default displayed fields for non-OTel logs', () => {
       config.featureToggles.otelLogsFormatting = true;
       const onLogOptionsChange = jest.fn();
+      const setDisplayedFields = jest.fn();
 
-      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} />);
+      render(
+        <LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} setDisplayedFields={setDisplayedFields} />
+      );
       expect(screen.getByText('log message 1')).toBeInTheDocument();
       expect(onLogOptionsChange).toHaveBeenCalledWith('defaultDisplayedFields', []);
+
+      // No fields to display, no call
+      expect(setDisplayedFields).not.toHaveBeenCalled();
 
       config.featureToggles.otelLogsFormatting = originalState;
     });
@@ -253,14 +259,24 @@ describe('LogList', () => {
     test('Reports the default OTel displayed fields', () => {
       config.featureToggles.otelLogsFormatting = true;
       const onLogOptionsChange = jest.fn();
+      const setDisplayedFields = jest.fn();
+
       const logs = [createLogRow({ uid: '1', labels: { [OTEL_PROBE_FIELD]: '1' } })];
 
-      render(<LogList {...defaultProps} logs={logs} onLogOptionsChange={onLogOptionsChange} />);
+      render(
+        <LogList
+          {...defaultProps}
+          logs={logs}
+          onLogOptionsChange={onLogOptionsChange}
+          setDisplayedFields={setDisplayedFields}
+        />
+      );
       expect(screen.getByText('log message 1')).toBeInTheDocument();
       expect(onLogOptionsChange).toHaveBeenCalledWith('defaultDisplayedFields', [
         LOG_LINE_BODY_FIELD_NAME,
         OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
       ]);
+      expect(setDisplayedFields).toHaveBeenCalledWith([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
 
       config.featureToggles.otelLogsFormatting = originalState;
     });

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -233,7 +233,9 @@ describe('LogList', () => {
       const onLogOptionsChange = jest.fn();
       const setDisplayedFields = jest.fn();
 
-      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} setDisplayedFields={setDisplayedFields} />);
+      render(
+        <LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} setDisplayedFields={setDisplayedFields} />
+      );
       expect(screen.getByText('log message 1')).toBeInTheDocument();
       expect(onLogOptionsChange).not.toHaveBeenCalled();
       expect(setDisplayedFields).not.toHaveBeenCalled();

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -16,6 +16,8 @@ import { disablePopoverMenu, enablePopoverMenu, isPopoverMenuDisabled } from '..
 import { createLogRow } from '../mocks/logRow';
 
 import { LogList, Props } from './LogList';
+import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 jest.mock('@grafana/assistant', () => ({
   ...jest.requireActual('@grafana/assistant'),
@@ -221,6 +223,47 @@ describe('LogList', () => {
 
     expect(screen.queryByText('info')).not.toBeInTheDocument();
     expect(screen.getByText('debug')).toBeInTheDocument();
+  });
+
+  describe('OTel log lines', () => {
+    const originalState = config.featureToggles.otelLogsFormatting;
+
+    test('Does not perform OTel-related actions when the flag is disabled', () => {
+      config.featureToggles.otelLogsFormatting = false;
+      const onLogOptionsChange = jest.fn();
+
+      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} />);
+      expect(screen.getByText('log message 1')).toBeInTheDocument();
+      expect(onLogOptionsChange).not.toHaveBeenCalled();
+
+      config.featureToggles.otelLogsFormatting = originalState;
+    });
+
+    test('Reports the default displayed fields for non-OTel logs', () => {
+      config.featureToggles.otelLogsFormatting = true;
+      const onLogOptionsChange = jest.fn();
+
+      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} />);
+      expect(screen.getByText('log message 1')).toBeInTheDocument();
+      expect(onLogOptionsChange).toHaveBeenCalledWith('defaultDisplayedFields', []);
+
+      config.featureToggles.otelLogsFormatting = originalState;
+    });
+
+    test('Reports the default OTel displayed fields', () => {
+      config.featureToggles.otelLogsFormatting = true;
+      const onLogOptionsChange = jest.fn();
+      const logs = [createLogRow({ uid: '1', labels: { [OTEL_PROBE_FIELD]: '1' } })];
+
+      render(<LogList {...defaultProps} logs={logs} onLogOptionsChange={onLogOptionsChange} />);
+      expect(screen.getByText('log message 1')).toBeInTheDocument();
+      expect(onLogOptionsChange).toHaveBeenCalledWith('defaultDisplayedFields', [
+        LOG_LINE_BODY_FIELD_NAME,
+        OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+      ]);
+
+      config.featureToggles.otelLogsFormatting = originalState;
+    });
   });
 
   describe('Popover menu', () => {

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -231,10 +231,12 @@ describe('LogList', () => {
     test('Does not perform OTel-related actions when the flag is disabled', () => {
       config.featureToggles.otelLogsFormatting = false;
       const onLogOptionsChange = jest.fn();
+      const setDisplayedFields = jest.fn();
 
-      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} />);
+      render(<LogList {...defaultProps} onLogOptionsChange={onLogOptionsChange} setDisplayedFields={setDisplayedFields} />);
       expect(screen.getByText('log message 1')).toBeInTheDocument();
       expect(onLogOptionsChange).not.toHaveBeenCalled();
+      expect(setDisplayedFields).not.toHaveBeenCalled();
 
       config.featureToggles.otelLogsFormatting = originalState;
     });

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -19,12 +19,9 @@ import {
   TimeRange,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { ConfirmModal, Icon, PopoverContent, useStyles2, useTheme2 } from '@grafana/ui';
 import { PopoverMenu } from 'app/features/explore/Logs/PopoverMenu';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
-
-import { getDisplayedFieldsForLogs } from '../otel/formats';
 
 import { InfiniteScrollMode, InfiniteScroll, LoadMoreLogsType } from './InfiniteScroll';
 import { getGridTemplateColumns, LogLineTimestampResolution } from './LogLine';
@@ -239,7 +236,7 @@ const LogListComponent = ({
 }: LogListComponentProps) => {
   const {
     app,
-    displayedFields: contextDisplayedFields,
+    displayedFields,
     dedupStrategy,
     detailsMode,
     filterLevels,
@@ -267,18 +264,6 @@ const LogListComponent = ({
   const wrapperRef = useRef<HTMLDivElement | null>(null);
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const virtualization = useMemo(() => new LogLineVirtualization(theme, fontSize), [theme, fontSize]);
-  
-  const displayedFields = useMemo(() => {
-    if (contextDisplayedFields.length > 0 || !config.featureToggles.otelLogsFormatting) {
-      return contextDisplayedFields;
-    }
-    const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
-    if (otelDisplayedFields.length) {
-      return otelDisplayedFields;
-    }
-    return contextDisplayedFields;
-  }, [contextDisplayedFields, logs]);
-
   const dimensions = useMemo(
     () =>
       wrapLogMessage

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -66,7 +66,7 @@ export interface Props {
   onClickFilterOutString?: (value: string, refId?: string) => void;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  onLogOptionsChange?: (option: LogListControlOptions, value: string | boolean | string[]) => void;
+  onLogOptionsChange?: (option: LogListOptions, value: string | boolean | string[]) => void;
   onLogLineHover?: (row?: LogRowModel) => void;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;
@@ -90,7 +90,7 @@ export interface Props {
 
 export type LogListFontSize = 'default' | 'small';
 
-export type LogListControlOptions = keyof LogListState | 'wrapLogMessage' | 'prettifyLogMessage';
+export type LogListOptions = keyof LogListState | 'wrapLogMessage' | 'prettifyLogMessage' | 'defaultDisplayedFields';
 
 type LogListComponentProps = Omit<
   Props,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -78,6 +78,11 @@ export interface Props {
   prettifyJSON?: boolean;
   setDisplayedFields?: (displayedFields: string[]) => void;
   showControls: boolean;
+  /**
+   * Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata
+   * @alpha
+   */
+  showLogAttributes?: boolean;
   showTime: boolean;
   showUniqueLabels?: boolean;
   sortOrder: LogsSortOrder;
@@ -148,6 +153,7 @@ export const LogList = ({
   prettifyJSON = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.prettifyLogMessage`, true) : true,
   setDisplayedFields,
   showControls,
+  showLogAttributes,
   showTime,
   showUniqueLabels,
   sortOrder,
@@ -193,6 +199,7 @@ export const LogList = ({
       prettifyJSON={prettifyJSON}
       setDisplayedFields={setDisplayedFields}
       showControls={showControls}
+      showLogAttributes={showLogAttributes}
       showTime={showTime}
       showUniqueLabels={showUniqueLabels}
       sortOrder={sortOrder}

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -295,7 +295,7 @@ export const LogListContextProvider = ({
       displayedFields.length > 0 ||
       !config.featureToggles.otelLogsFormatting ||
       !setDisplayedFields ||
-      isSupportedApp(app)
+      !isSupportedApp(app)
     ) {
       return;
     }

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -28,7 +28,7 @@ import { config, getDataSourceSrv } from '@grafana/runtime';
 import { PopoverContent } from '@grafana/ui';
 
 import { checkLogsError, checkLogsSampled, downloadLogs as download, DownloadFormat } from '../../utils';
-import { getDisplayedFieldsForLogs } from '../otel/formats';
+import { getDisplayedFieldsForLogs, isSupportedApp } from '../otel/formats';
 
 import { LogLineTimestampResolution } from './LogLine';
 import { LogLineDetailsMode } from './LogLineDetails';
@@ -291,14 +291,20 @@ export const LogListContextProvider = ({
 
   // OTel displayed fields
   useEffect(() => {
-    if (displayedFields.length > 0 || !config.featureToggles.otelLogsFormatting || !setDisplayedFields) {
+    if (
+      displayedFields.length > 0 ||
+      !config.featureToggles.otelLogsFormatting ||
+      !setDisplayedFields ||
+      isSupportedApp(app)
+    ) {
       return;
     }
     const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
+    console.log(otelDisplayedFields);
     if (otelDisplayedFields.length) {
       setDisplayedFields(otelDisplayedFields);
     }
-  }, [displayedFields.length, logs, setDisplayedFields]);
+  }, [app, displayedFields.length, logs, setDisplayedFields]);
 
   // Sync state
   useEffect(() => {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -24,10 +24,11 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { PopoverContent } from '@grafana/ui';
 
 import { checkLogsError, checkLogsSampled, downloadLogs as download, DownloadFormat } from '../../utils';
+import { getDisplayedFieldsForLogs } from '../otel/formats';
 
 import { LogLineTimestampResolution } from './LogLine';
 import { LogLineDetailsMode } from './LogLineDetails';
@@ -287,6 +288,17 @@ export const LogListContextProvider = ({
     // Just once
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  // OTel displayed fields
+  useEffect(() => {
+    if (displayedFields.length > 0 || !config.featureToggles.otelLogsFormatting || !setDisplayedFields) {
+      return;
+    }
+    const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
+    if (otelDisplayedFields.length) {
+      setDisplayedFields(otelDisplayedFields);
+    }
+  }, [displayedFields.length, logs, setDisplayedFields]);
 
   // Sync state
   useEffect(() => {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -24,11 +24,10 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { getDataSourceSrv } from '@grafana/runtime';
 import { PopoverContent } from '@grafana/ui';
 
 import { checkLogsError, checkLogsSampled, downloadLogs as download, DownloadFormat } from '../../utils';
-import { getDisplayedFieldsForLogs } from '../otel/formats';
 
 import { LogLineTimestampResolution } from './LogLine';
 import { LogLineDetailsMode } from './LogLineDetails';
@@ -288,17 +287,6 @@ export const LogListContextProvider = ({
     // Just once
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  // OTel displayed fields
-  useEffect(() => {
-    if (displayedFields.length > 0 || !config.featureToggles.otelLogsFormatting || !setDisplayedFields) {
-      return;
-    }
-    const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
-    if (otelDisplayedFields.length) {
-      setDisplayedFields(otelDisplayedFields);
-    }
-  }, [displayedFields.length, logs, setDisplayedFields]);
 
   // Sync state
   useEffect(() => {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -33,7 +33,7 @@ import { getDisplayedFieldsForLogs, isSupportedApp } from '../otel/formats';
 import { LogLineTimestampResolution } from './LogLine';
 import { LogLineDetailsMode } from './LogLineDetails';
 import { GetRowContextQueryFn, LogLineMenuCustomItem } from './LogLineMenu';
-import { LogListControlOptions, LogListFontSize } from './LogList';
+import { LogListOptions, LogListFontSize } from './LogList';
 import { reportInteractionOnce } from './analytics';
 import { LogListModel } from './processing';
 import { getScrollbarWidth, LOG_LIST_CONTROLS_WIDTH, LOG_LIST_MIN_WIDTH } from './virtualization';
@@ -176,7 +176,7 @@ export interface Props {
   onClickFilterOutString?: (value: string, refId?: string) => void;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
-  onLogOptionsChange?: (option: LogListControlOptions, value: string | boolean | string[]) => void;
+  onLogOptionsChange?: (option: LogListOptions, value: string | boolean | string[]) => void;
   onLogLineHover?: (row?: LogRowModel) => void;
   onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onPinLine?: (row: LogRowModel) => void;
@@ -289,6 +289,8 @@ export const LogListContextProvider = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const otelDisplayedFields = useMemo(() => getDisplayedFieldsForLogs(logs), [logs]);
+
   // OTel displayed fields
   useEffect(() => {
     if (
@@ -299,11 +301,16 @@ export const LogListContextProvider = ({
     ) {
       return;
     }
-    const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
     if (otelDisplayedFields.length) {
       setDisplayedFields(otelDisplayedFields);
     }
-  }, [app, displayedFields.length, logs, setDisplayedFields]);
+  }, [app, displayedFields.length, otelDisplayedFields, setDisplayedFields]);
+
+  useEffect(() => {
+    if (config.featureToggles.otelLogsFormatting) {
+      onLogOptionsChange?.('defaultDisplayedFields', otelDisplayedFields);
+    }
+  }, [onLogOptionsChange, otelDisplayedFields]);
 
   // Sync state
   useEffect(() => {

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -300,7 +300,6 @@ export const LogListContextProvider = ({
       return;
     }
     const otelDisplayedFields = getDisplayedFieldsForLogs(logs);
-    console.log(otelDisplayedFields);
     if (otelDisplayedFields.length) {
       setDisplayedFields(otelDisplayedFields);
     }

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -300,6 +300,12 @@ export const LogListContextProvider = ({
 
   // OTel displayed fields
   useEffect(() => {
+    if (config.featureToggles.otelLogsFormatting && showLogAttributes !== false) {
+      onLogOptionsChange?.('defaultDisplayedFields', otelDisplayedFields);
+    }
+  }, [onLogOptionsChange, otelDisplayedFields, showLogAttributes]);
+
+  useEffect(() => {
     if (displayedFields.length > 0 || !setDisplayedFields) {
       return;
     }
@@ -307,12 +313,6 @@ export const LogListContextProvider = ({
       setDisplayedFields(otelDisplayedFields);
     }
   }, [displayedFields.length, otelDisplayedFields, setDisplayedFields]);
-
-  useEffect(() => {
-    if (config.featureToggles.otelLogsFormatting && showLogAttributes !== false) {
-      onLogOptionsChange?.('defaultDisplayedFields', otelDisplayedFields);
-    }
-  }, [onLogOptionsChange, otelDisplayedFields, showLogAttributes]);
 
   // Sync state
   useEffect(() => {

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -3,11 +3,11 @@ import { config } from '@grafana/runtime';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine, createLogRow } from '../mocks/logRow';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 import { LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
 import { LogLineVirtualization } from './virtualization';
-import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 describe('preProcessLogs', () => {
   let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -7,6 +7,7 @@ import { createLogLine, createLogRow } from '../mocks/logRow';
 import { LogListFontSize } from './LogList';
 import { LogListModel, preProcessLogs } from './processing';
 import { LogLineVirtualization } from './virtualization';
+import { OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME, OTEL_PROBE_FIELD } from '../otel/formats';
 
 describe('preProcessLogs', () => {
   let logFmtLog: LogRowModel, nginxLog: LogRowModel, jsonLog: LogRowModel;
@@ -237,6 +238,67 @@ describe('preProcessLogs', () => {
       expect(logListModel.body).toBeDefined(); // Triggers parsing
       expect(logListModel.isJSON).toBe(false);
     });
+
+    describe('OTel logs', () => {
+      const originalState = config.featureToggles.otelLogsFormatting;
+
+      test('Does not create the OTel attribute field when not enabled', () => {
+        config.featureToggles.otelLogsFormatting = false;
+
+        const logListModel = createLogLine(
+          { entry: 'the log' },
+          {
+            escape: false,
+            order: LogsSortOrder.Descending,
+            timeZone: 'browser',
+            wrapLogMessage: true, // wrapped
+            prettifyJSON: true,
+          }
+        );
+        expect(logListModel.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]).toBeUndefined();
+        expect(logListModel.highlightedLogAttributesTokens).toHaveLength(0);
+
+        config.featureToggles.otelLogsFormatting = originalState;
+      });
+
+      test('Does not create the OTel attribute field when is not an OTel log', () => {
+        config.featureToggles.otelLogsFormatting = false;
+
+        const logListModel = createLogLine(
+          { entry: 'the log', labels: {} },
+          {
+            escape: false,
+            order: LogsSortOrder.Descending,
+            timeZone: 'browser',
+            wrapLogMessage: true, // wrapped
+            prettifyJSON: true,
+          }
+        );
+        expect(logListModel.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]).toBeUndefined();
+        expect(logListModel.highlightedLogAttributesTokens).toHaveLength(0);
+
+        config.featureToggles.otelLogsFormatting = originalState;
+      });
+
+      test('Generates and highlights an OTel log line attributes field', () => {
+        config.featureToggles.otelLogsFormatting = true;
+
+        const logListModel = createLogLine(
+          { entry: 'the log', labels: { [OTEL_PROBE_FIELD]: '1', field: 'value' } },
+          {
+            escape: false,
+            order: LogsSortOrder.Descending,
+            timeZone: 'browser',
+            wrapLogMessage: true, // wrapped
+            prettifyJSON: true,
+          }
+        );
+        expect(logListModel.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]).toEqual('field=value');
+        expect(logListModel.highlightedLogAttributesTokens).toHaveLength(2);
+
+        config.featureToggles.otelLogsFormatting = originalState;
+      });
+    });
   });
 
   test('Orders logs', () => {
@@ -438,45 +500,5 @@ describe('preProcessLogs', () => {
       expect(longLog.collapsed).toBe(false);
       expect(longLog.body).toBe(entry);
     });
-  });
-});
-
-describe('OTel logs', () => {
-  let originalOtelLogsFormatting = config.featureToggles.otelLogsFormatting;
-  afterAll(() => {
-    config.featureToggles.otelLogsFormatting = originalOtelLogsFormatting;
-  });
-
-  test('Requires a feature flag', () => {
-    const log = createLogLine({
-      labels: {
-        severity_number: '1',
-        telemetry_sdk_language: 'php',
-        scope_name: 'scope',
-        aws_ignore: 'ignored',
-        key: 'value',
-        otel: 'otel',
-      },
-      entry: `place="luna" 1ms 3 KB`,
-    });
-    expect(log.otelLanguage).toBeDefined();
-    expect(log.body).toEqual(`place="luna" 1ms 3 KB`);
-  });
-
-  test('Augments OTel log lines', () => {
-    config.featureToggles.otelLogsFormatting = true;
-    const log = createLogLine({
-      labels: {
-        severity_number: '1',
-        telemetry_sdk_language: 'php',
-        scope_name: 'scope',
-        aws_ignore: 'ignored',
-        key: 'value',
-        otel: 'otel',
-      },
-      entry: `place="luna" 1ms 3 KB`,
-    });
-    expect(log.otelLanguage).toBeDefined();
-    expect(log.body).toEqual(`place="luna" 1ms 3 KB key=value otel=otel`);
   });
 });

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -18,7 +18,7 @@ import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 import { checkLogsError, checkLogsSampled, escapeUnescapedString, sortLogRows } from '../../utils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { FieldDef, getAllFields } from '../logParser';
-import { identifyOTelLanguage, getOtelAttributesField, LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
+import { identifyOTelLanguage, getOtelAttributesField, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { generateLogGrammar, generateTextMatchGrammar } from './grammar';
 import { LogLineVirtualization } from './virtualization';
@@ -117,7 +117,7 @@ export class LogListModel implements LogRowModel {
     this.raw = raw;
 
     if (config.featureToggles.otelLogsFormatting) {
-      this.labels[LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this);
+      this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this);
     }
   }
 
@@ -344,7 +344,7 @@ export function getLevelsFromLogs(logs: LogListModel[]) {
 export function getNormalizedFieldName(field: string) {
   if (field === LOG_LINE_BODY_FIELD_NAME) {
     return t('logs.log-line-details.log-line-field', 'Log line');
-  } else if (field === LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+  } else if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME) {
     return t('logs.log-line-details.log-attributes-field', 'Log attributes');
   }
   return field;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -116,7 +116,7 @@ export class LogListModel implements LogRowModel {
     }
     this.raw = raw;
 
-    if (config.featureToggles.otelLogsFormatting) {
+    if (config.featureToggles.otelLogsFormatting && this.otelLanguage) {
       this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this);
     }
   }

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -190,6 +190,9 @@ export class LogListModel implements LogRowModel {
   get highlightedLogAttributesTokens() {
     if (this._highlightedLogAttributesTokens === undefined) {
       const attributes = this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] ?? '';
+      if (!attributes) {
+        return [];
+      }
       this._grammar = this._grammar ?? generateLogGrammar(this);
       const extraGrammar = generateTextMatchGrammar(this.searchWords, this._currentSearch);
       this._highlightedLogAttributesTokens = Prism.tokenize(attributes, { ...extraGrammar, ...this._grammar });

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -118,7 +118,7 @@ export class LogListModel implements LogRowModel {
     this.raw = raw;
 
     if (config.featureToggles.otelLogsFormatting && this.otelLanguage) {
-      this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this, this._wrapLogMessage);
+      this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this, wrapLogMessage);
     }
   }
 

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -17,7 +17,7 @@ import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 import { checkLogsError, checkLogsSampled, escapeUnescapedString, sortLogRows } from '../../utils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { FieldDef, getAllFields } from '../logParser';
-import { identifyOTelLanguage, getOtelFormattedBody } from '../otel/formats';
+import { identifyOTelLanguage, getOtelAttributesField, LOG_LINE_ATTRIBUTES_FIELD_NAME } from '../otel/formats';
 
 import { generateLogGrammar, generateTextMatchGrammar } from './grammar';
 import { LogLineVirtualization } from './virtualization';
@@ -114,6 +114,10 @@ export class LogListModel implements LogRowModel {
       raw = escapeUnescapedString(raw);
     }
     this.raw = raw;
+
+    if (config.featureToggles.otelLogsFormatting) {
+      this.labels[LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this);
+    }
   }
 
   clone() {
@@ -137,7 +141,7 @@ export class LogListModel implements LogRowModel {
           this.raw = reStringified;
         }
       } catch (error) {}
-      const raw = config.featureToggles.otelLogsFormatting && this.otelLanguage ? getOtelFormattedBody(this) : this.raw;
+      const raw = this.raw;
       this._body = this.collapsed
         ? raw.substring(0, this._virtualization?.getTruncationLength(null) ?? TRUNCATION_DEFAULT_LENGTH)
         : raw;

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -189,7 +189,6 @@ export class LogListModel implements LogRowModel {
 
   get highlightedLogAttributesTokens() {
     if (this._highlightedLogAttributesTokens === undefined) {
-      // Body is accessed first to trigger the getter code before generateLogGrammar()
       const attributes = this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] ?? '';
       this._grammar = this._grammar ?? generateLogGrammar(this);
       const extraGrammar = generateTextMatchGrammar(this.searchWords, this._currentSearch);

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -11,6 +11,7 @@ import {
   LogsSortOrder,
   systemDateFormats,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
@@ -338,4 +339,13 @@ export function getLevelsFromLogs(logs: LogListModel[]) {
     levels.add(log.logLevel);
   }
   return Array.from(levels).filter((level) => level != null);
+}
+
+export function getNormalizedFieldName(field: string) {
+  if (field === LOG_LINE_BODY_FIELD_NAME) {
+    return t('logs.log-line-details.log-line-field', 'Log line');
+  } else if (field === LOG_LINE_ATTRIBUTES_FIELD_NAME) {
+    return t('logs.log-line-details.log-attributes-field', 'Log attributes');
+  }
+  return field;
 }

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -360,7 +360,7 @@ export function getNormalizedFieldName(field: string) {
   if (field === LOG_LINE_BODY_FIELD_NAME) {
     return t('logs.log-line-details.log-line-field', 'Log line');
   } else if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME) {
-    return t('logs.log-line-details.log-attributes-field', 'Log attributes');
+    return t('logs.log-line-details.log-attributes-field', 'OTel attributes');
   }
   return field;
 }

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -114,7 +114,7 @@ interface LogsPanelProps extends PanelProps<Options> {
    * controlsStorageKey?: string
    *
    * If controls are enabled, this function is called when a change is made in one of the options from the controls.
-   * onLogOptionsChange?: (option: LogListControlOptions, value: string | boolean | string[]) => void;
+   * onLogOptionsChange?: (option: LogListOptions, value: string | boolean | string[]) => void;
    *
    * When the feature toggle newLogsPanel is enabled, you can pass extra options to the LogLineMenu component.
    * These options are an array of items with { label, onClick } or { divider: true } for dividers.

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -47,6 +47,7 @@ import { LogLabels } from '../../../features/logs/components/LogLabels';
 import { LogRows } from '../../../features/logs/components/LogRows';
 import { COMMON_LABELS, dataFrameToLogsModel, dedupLogRows } from '../../../features/logs/logsModel';
 
+import type { Options } from './panelcfg.gen';
 import {
   GetFieldLinksFn,
   isCoreApp,
@@ -63,7 +64,6 @@ import {
   isReactNodeArray,
   isSetDisplayedFields,
   onNewLogsReceivedType,
-  Options,
 } from './types';
 import { useDatasourcesFromTargets } from './useDatasourcesFromTargets';
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -128,6 +128,11 @@ interface LogsPanelProps extends PanelProps<Options> {
    *
    * When showing timestamps, toggle between showing nanoseconds or milliseconds.
    * timestampResolution?: 'ms' | 'ns'
+   *
+   * Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.
+   * Requires the `otelLogsFormatting`.
+   * @alpha
+   * showLogAttributes?: boolean
    */
 }
 interface LogsPermalinkUrlState {
@@ -170,6 +175,7 @@ export const LogsPanel = ({
     detailsMode: detailsModeProp,
     noInteractions,
     timestampResolution,
+    showLogAttributes,
     ...options
   },
   height,
@@ -609,6 +615,7 @@ export const LogsPanel = ({
               prettifyJSON={prettifyLogMessage}
               setDisplayedFields={setDisplayedFieldsFn}
               showControls={Boolean(showControls)}
+              showLogAttributes={showLogAttributes}
               showTime={showTime}
               showUniqueLabels={showLabels}
               sortOrder={sortOrder}

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -119,6 +119,19 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
       defaultValue: false,
     });
 
+    if (config.featureToggles.otelLogsFormatting) {
+      builder.addBooleanSwitch({
+        path: 'showLogAttributes',
+        name: t('logs.show-log-attributes', 'Display log attributes for OTel logs'),
+        category,
+        description: t(
+          'logs.description-show-log-attributes',
+          'Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.'
+        ),
+        defaultValue: true,
+      });
+    }
+
     if (config.featureToggles.newLogsPanel) {
       builder
         .addBooleanSwitch({

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -40,6 +40,7 @@ composableKinds: PanelCfg: {
 					dedupStrategy:            common.LogsDedupStrategy
 					enableInfiniteScrolling?: bool
 					noInteractions?:          bool
+					showLogAttributes?:       bool
 					fontSize?:                "default" | "small"                  @cuetsy(kind="enum", memberNames="default|small")
 					detailsMode?:             "inline" | "sidebar"                  @cuetsy(kind="enum", memberNames="inline|sidebar")
 					timestampResolution?:     "ms" | "ns"                  @cuetsy(kind="enum", memberNames="ms|ns")

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -39,6 +39,7 @@ export interface Options {
   showCommonLabels: boolean;
   showControls?: boolean;
   showLabels: boolean;
+  showLogAttributes?: boolean;
   showLogContextToggle: boolean;
   showTime: boolean;
   sortOrder: common.LogsSortOrder;

--- a/public/app/plugins/panel/logs/suggestions.ts
+++ b/public/app/plugins/panel/logs/suggestions.ts
@@ -1,7 +1,7 @@
 import { VisualizationSuggestionsBuilder, VisualizationSuggestionScore } from '@grafana/data';
 import { SuggestionName } from 'app/types/suggestions';
 
-import { Options } from './types';
+import { Options } from './panelcfg.gen';
 
 export class LogsPanelSuggestionsSupplier {
   getSuggestionsForData(builder: VisualizationSuggestionsBuilder) {

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 
 import { CoreApp, DataFrame, Field, LinkModel, ScopedVars } from '@grafana/data';
 import { LogLineMenuCustomItem } from 'app/features/logs/components/panel/LogLineMenu';
-import { LogListControlOptions } from 'app/features/logs/components/panel/LogList';
+import { LogListOptions } from 'app/features/logs/components/panel/LogList';
 
 export type { Options } from './panelcfg.gen';
 
@@ -14,7 +14,7 @@ type filterLabelActiveType = (key: string, value: string, refId?: string) => Pro
 type onClickShowFieldType = (value: string) => void;
 type onClickHideFieldType = (value: string) => void;
 export type onNewLogsReceivedType = (allLogs: DataFrame[], newLogs: DataFrame[]) => void;
-type onLogOptionsChangeType = (option: LogListControlOptions, value: string | boolean | string[]) => void;
+type onLogOptionsChangeType = (option: LogListOptions, value: string | boolean | string[]) => void;
 type setDisplayedFieldsType = (fields: string[]) => void;
 
 export type GetFieldLinksFn = (

--- a/public/app/plugins/panel/logs/types.ts
+++ b/public/app/plugins/panel/logs/types.ts
@@ -4,8 +4,6 @@ import { CoreApp, DataFrame, Field, LinkModel, ScopedVars } from '@grafana/data'
 import { LogLineMenuCustomItem } from 'app/features/logs/components/panel/LogLineMenu';
 import { LogListOptions } from 'app/features/logs/components/panel/LogList';
 
-export type { Options } from './panelcfg.gen';
-
 type onClickFilterLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterOutLabelType = (key: string, value: string, frame?: DataFrame) => void;
 type onClickFilterValueType = (value: string, refId?: string) => void;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9496,9 +9496,6 @@
       "collapse": "Collapse labels",
       "expand": "Expand labels"
     },
-    "log-labels-list": {
-      "log-line": "log line"
-    },
     "log-line": {
       "has-error": "Has errors",
       "is-sampled": "Is sampled",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7054,7 +7054,6 @@
         "deduplication-count": "Deduplication count",
         "showing-only-selected-fields": "Showing only selected fields"
       },
-      "reset-displayed-fields": "Reset displayed fields",
       "show-original-line": "Show original line"
     },
     "logs-sample-panel": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9538,6 +9538,7 @@
       "inline-mode": "Display inline",
       "link-value-tooltip": "Link value",
       "links-section": "Links",
+      "log-attributes-field": "Log attributes",
       "log-line-field": "Log line",
       "log-line-section": "Log line",
       "move-displayed-field-down": "Move down",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9446,6 +9446,7 @@
     "description-enable-infinite-scrolling": "Experimental. Request more results by scrolling to the bottom of the logs list.",
     "description-enable-logs-highlighting": "Use a predefined coloring scheme to highlight relevant parts of the log lines",
     "description-show-controls": "Display controls to jump to the last or first log line, and filters by log level",
+    "description-show-log-attributes": "Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.",
     "fields": {
       "type": {
         "loki": {
@@ -9742,6 +9743,7 @@
       "line-contains": "Add as line contains filter",
       "line-contains-not": "Add as line does not contain filter"
     },
+    "show-log-attributes": "Display log attributes for OTel logs",
     "timestamp-format": "Timestamp resolution",
     "un-themed-log-details": {
       "aria-label-data-links": "Data links",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7054,6 +7054,7 @@
         "deduplication-count": "Deduplication count",
         "showing-only-selected-fields": "Showing only selected fields"
       },
+      "reset-displayed-fields": "Reset displayed fields",
       "show-original-line": "Show original line"
     },
     "logs-sample-panel": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9536,7 +9536,7 @@
       "inline-mode": "Display inline",
       "link-value-tooltip": "Link value",
       "links-section": "Links",
-      "log-attributes-field": "Log attributes",
+      "log-attributes-field": "OTel attributes",
       "log-line-field": "Log line",
       "log-line-section": "Log line",
       "move-displayed-field-down": "Move down",


### PR DESCRIPTION
Part of #101083 

- Moved attributes out of the log line and into a new field called "Log attributes".
  - Added support to parse and highlight this displayed field.
- Added `cluster`, `namespace`, and `pod` to the excluded "Log attributes".
- Removed `scope_name` from the default displayed fields.
- Implemented "default displayed fields", to represent the fields to be shown by default for a given set of logs.
- General cleanup and improvements, such as type renames, and effect cleanup.
- Drilldown Logs PR: https://github.com/grafana/logs-drilldown/pull/1554
-  [x] Update testing coverage

### How to test

#### `otelLogsFormatting` disabled

Nothing should change, and that includes not introducing regressions.

#### `otelLogsFormatting` enabled

Requires finding an OTel logs source, such as `{service_name="flux-commit-tracker"}` in OPS. For the frontend, OTel log lines are those that contains a `severity_number` metadata field.

When OTel logs are found, the formatting code will try to come up with a set of fields to show by default. The candidate fields are the following: 

https://github.com/grafana/grafana/blob/8c7081109a605c49a2885147f6eb131d1a5d0d50/public/app/features/logs/components/otel/formats.ts#L60-L68

If any log line contains them, they will be shown by default, becoming the "default displayed fields". The minimum displayed fields for all OTel log lines are going to be: the log line, and the new log attributes field.

This will also be the default state for OTel logs, so the "Show original button" should not be displayed, unless the user changes the displayed fields, in which case this button, when clicked, resets to the original state.

<img width="153" height="46" alt="imagen" src="https://github.com/user-attachments/assets/6decc6dc-c7da-42d7-83a3-77cdee8e1a68" />

This new "log attributes" field should also be highlighted in the same way the log line body is highlighted. What we're changing with this PR is that instead of modifying the original log line, the augmented part goes to a new field.

<img width="951" height="81" alt="imagen" src="https://github.com/user-attachments/assets/a6027c46-dffa-4194-8f89-3093c27c9ec4" />
