### PR TITLE
OTel: support unknown languages

### DIFF
--- a/public/app/features/logs/components/otel/formats.test.ts
+++ b/public/app/features/logs/components/otel/formats.test.ts
@@ -1,7 +1,7 @@
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
 import { createLogLine } from '../mocks/logRow';
 
-import { getDisplayedFieldsForLogs, getOtelFormattedBody } from './formats';
+import { getDisplayedFieldsForLogs, getOtelFormattedBody, OTEL_PROBE_FIELD } from './formats';
 
 describe('getDisplayedFieldsForLogs', () => {
   test('Does not return displayed fields if not an OTel log line', () => {
@@ -10,19 +10,30 @@ describe('getDisplayedFieldsForLogs', () => {
     expect(getDisplayedFieldsForLogs([log])).toEqual([]);
   });
 
-  test('Does not return displayed fields if telemetry_sdk_language is empty', () => {
-    const log = createLogLine({ labels: { severity_number: '1' }, entry: `place="luna" 1ms 3 KB` });
+  test('Does not return displayed fields if the OTel probe field is not present', () => {
+    const log = createLogLine({ labels: { severity_level: '1' }, entry: `place="luna" 1ms 3 KB` });
 
     expect(getDisplayedFieldsForLogs([log])).toEqual([]);
   });
 
-  test('Does not return displayed fields if telemetry_sdk_language is empty', () => {
+  test('Returns displayed fields if the OTel probe field is present', () => {
     const log = createLogLine({
-      labels: { severity_number: '1', telemetry_sdk_language: 'php', scope_name: 'scope' },
+      labels: { [OTEL_PROBE_FIELD]: '1', telemetry_sdk_language: 'php', scope_name: 'scope' },
       entry: `place="luna" 1ms 3 KB`,
     });
 
     expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
+    expect(log.otelLanguage).toBe('php');
+  });
+
+  test('Returns displayed fields if the OTel probe field is present and the language unknown', () => {
+    const log = createLogLine({
+      labels: { [OTEL_PROBE_FIELD]: '1', scope_name: 'scope' },
+      entry: `place="luna" 1ms 3 KB`,
+    });
+
+    expect(getDisplayedFieldsForLogs([log])).toEqual(['scope_name', LOG_LINE_BODY_FIELD_NAME]);
+    expect(log.otelLanguage).toBe('unknown');
   });
 });
 

--- a/public/app/features/logs/components/otel/formats.ts
+++ b/public/app/features/logs/components/otel/formats.ts
@@ -6,7 +6,8 @@ import { LogListModel } from '../panel/processing';
 /**
  * The presence of this field along log fields determines OTel origin.
  */
-const OTEL_PROBE_FIELD = 'severity_number';
+export const OTEL_PROBE_FIELD = 'severity_number';
+const OTEL_LANGUAGE_UNKNOWN = 'unknown';
 export function identifyOTelLanguages(logs: LogListModel[] | LogRowModel[]): string[] {
   const languagesSet = new Set<string>();
   logs.forEach((log) => {
@@ -22,8 +23,8 @@ export function identifyOTelLanguage(log: LogListModel | LogRowModel): string | 
   if ('otelLanguage' in log && log.otelLanguage) {
     return log.otelLanguage;
   }
-  return log.labels[OTEL_PROBE_FIELD] !== undefined && log.labels.telemetry_sdk_language
-    ? log.labels.telemetry_sdk_language
+  return log.labels[OTEL_PROBE_FIELD] !== undefined
+    ? (log.labels.telemetry_sdk_language ?? OTEL_LANGUAGE_UNKNOWN)
     : undefined;
 }
 


### PR DESCRIPTION
Follow up of https://github.com/grafana/grafana/pull/108170 part of https://github.com/grafana/grafana/issues/101083

We no longer require `telemetry_sdk_language` to be defined to trigger OTel treatment of log lines.

Example.

Original log line:

<img width="801" height="41" alt="imagen" src="https://github.com/user-attachments/assets/008800f7-1524-4745-9dbb-4567c18e6cde" />

OTel log line:

<img width="1475" height="71" alt="imagen" src="https://github.com/user-attachments/assets/a130fb58-c2af-479e-b319-b794888b8766" />

Requires `otelLogsFormatting` enabled.
Requires `newLogsPanel` enabled.

### How to test

With the feature flags enabled, if `severity_number` is defined, the log line will be treated as OTel, adding extra fields by default, such as `scope_name`, and the log line body is complemented with extra attributes taken from the log labels.

Example: `{service_name="flux-commit-tracker"}` in OPS.