### PR TITLE
fix(folders): allow correct max depth on app platform

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/kube-openapi/pkg/spec3"
 
 	authlib "github.com/grafana/authlib/types"
+
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	"github.com/grafana/grafana/apps/iam/pkg/reconcilers"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -58,8 +58,9 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return fmt.Errorf("unable to create folder inside parent: %w", err)
 	}
 
-	// Can not create a folder that will be too deep
-	if len(parents.Items)+1 > maxDepth {
+	// Can not create a folder that will be too deep.
+	// We need to add +1 as we also have the root folder as part of the parents.
+	if len(parents.Items) > maxDepth+1 {
 		return fmt.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
 	}
 


### PR DESCRIPTION
In legacy grafana we allow a max depth of 4 for folders, which means that inside the first folder there can be 4 other folders nested. In total it will be 6 folders, as we have a pseudo folder (general, displayed as "Dashboards").

It looks like this:
<img width="347" height="40" alt="image" src="https://github.com/user-attachments/assets/fff095ad-9787-46a7-bfdc-92c8b368f3e2" />

When using unified storage, the check was wrong and would only allow for 2 folders nested. This PR fixes that. 

Interesting enough, the update check was already correct. So one could create in unified storage 2 nested folders and then just move the other two by using update. I made the tests more robust anyway.

Fixes https://github.com/grafana/search-and-storage-team/issues/503