### PR TITLE
TimeSeries: Simplify time comparison styling

### DIFF
--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -1,4 +1,3 @@
-import { getFieldSeriesColor } from '../field/fieldColor';
 import { GrafanaTheme2 } from '../themes/types';
 import { DataFrame, Field, FieldType } from '../types/dataFrame';
 import { TimeRange } from '../types/time';
@@ -155,26 +154,13 @@ export function alignTimeRangeCompareData(series: DataFrame, diff: number, theme
 
     // Apply visual styling for comparison series
     if (field.type === FieldType.number || field.type === FieldType.boolean || field.type === FieldType.enum) {
-      const seriesColor = getFieldSeriesColor(field, theme).color;
-      const lineStyle = field.config.custom?.lineStyle;
-      const isSolid = !lineStyle?.fill || lineStyle.fill === 'solid';
-
-      if (isSolid) {
-        field.config.custom = {
-          ...(field.config.custom ?? {}),
-          lineStyle: {
-            fill: 'dash',
-            dash: [5, 5],
-          },
-        };
-      } else {
-        // For already dashed/dotted lines, reduce opacity
-        const tinycolor = require('tinycolor2');
-        field.config.color = {
-          mode: 'fixed',
-          fixedColor: tinycolor(seriesColor).setAlpha(0.5).toString(),
-        };
-      }
+      field.config.custom = {
+        ...(field.config.custom ?? {}),
+        lineStyle: {
+          fill: 'dash',
+          dash: [1, 5, 4, 5],
+        },
+      };
     }
   });
 }

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -157,7 +157,6 @@ export function alignTimeRangeCompareData(series: DataFrame, diff: number, theme
       field.config.custom = {
         ...(field.config.custom ?? {}),
         lineStyle: {
-          fill: 'dash',
           dash: [1, 5, 4, 5],
         },
       };

--- a/packages/grafana-data/src/dataframe/utils.ts
+++ b/packages/grafana-data/src/dataframe/utils.ts
@@ -157,6 +157,7 @@ export function alignTimeRangeCompareData(series: DataFrame, diff: number, theme
       field.config.custom = {
         ...(field.config.custom ?? {}),
         lineStyle: {
+          fill: 'dash',
           dash: [1, 5, 4, 5],
         },
       };


### PR DESCRIPTION
This PR simplifies comparison line styling, making the comparison line style consistent with the pattern `[1, 5, 4, 5]` for all line types so that the user can become better accustomed to a consistent visual representation.

Before:
solid
<img width="1577" height="655" alt="image" src="https://github.com/user-attachments/assets/e9a92a9b-c9fb-4a57-93d9-9b6387787ac5" />

dash
<img width="1579" height="639" alt="image" src="https://github.com/user-attachments/assets/81328e21-1230-44ed-b6e7-254857070687" />

dots
<img width="1574" height="638" alt="image" src="https://github.com/user-attachments/assets/fa20df51-4005-4c73-bd81-61a3061f829c" />


After:
solid
<img width="1572" height="641" alt="image" src="https://github.com/user-attachments/assets/b96a90ac-8d11-4aec-80c2-e7bf1d65e7b7" />

dash
<img width="1575" height="634" alt="image" src="https://github.com/user-attachments/assets/a9b03174-4969-439d-875e-8539c83a6db7" />

dots
<img width="1583" height="635" alt="image" src="https://github.com/user-attachments/assets/72c98d5b-66fe-44eb-b799-0a049981f042" />
