### PR TITLE
SaveProvisionedDashboardForm: Bug fix dashboard tag changes is not persist

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -154,6 +154,7 @@ export function SaveProvisionedDashboardForm({
       isNew,
       title,
       description,
+      copyTags: true,
     });
 
     createOrUpdateFile({


### PR DESCRIPTION
**What is this feature?**

Bug fix: When applying tag changes to existing dashboard, changes is not persist. 
Root cause: The save operation did not copy tags to the request body sent to the backend, causing tag modifications to be lost.  


**After fix:**  
https://github.com/user-attachments/assets/48bfd37c-a528-44aa-b781-31d758cb13e3

Before fix:  

https://github.com/user-attachments/assets/1ccb0363-4162-42e0-bbfd-63eab9319b34


**Why do we need this feature?**

To have tag changes properly apply

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/543

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
