### PR TITLE
Chore: fixes detect breaking changes script on new packages

### DIFF
--- a/scripts/check-breaking-changes.sh
+++ b/scripts/check-breaking-changes.sh
@@ -34,6 +34,11 @@ while IFS=" " read -r -a package; do
     continue
   fi
 
+  # Skip packages that don't exist in the base (packages introduced in PR)
+  if [[ ! -f "./base/@$PACKAGE_PATH.tgz" ]]; then
+    continue
+  fi
+
   # Extract the npm package tarballs into separate directories e.g. ./base/@grafana-data.tgz -> ./base/grafana-data/
   mkdir "$PREV"
   tar -xf "./base/@$PACKAGE_PATH.tgz" --strip-components=1 -C "$PREV"


### PR DESCRIPTION
**What is this feature?**

This pull request introduces a small but important improvement to the `scripts/check-breaking-changes.sh` script. The change ensures that the script skips packages that are newly introduced in the pull request and do not exist in the base branch, preventing errors during the breaking changes check.

| Before this fix GH run | After this fix GH run |
|-----|-----|
|https://github.com/grafana/grafana/actions/runs/17589509221/job/49966760979|https://github.com/grafana/grafana/actions/runs/17636713365/job/50114639723|

**Why do we need this feature?**

https://github.com/grafana/levitate/issues/964

**Who is this feature for?**

Plugin platform maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/levitate/issues/964

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
