### PR TITLE
Alerting: Fix incorrect time range display for queries with custom 'to' values

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { keyBy, startCase, uniqueId } from 'lodash';
 import * as React from 'react';
 
-import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, rangeUtil, urlUtil } from '@grafana/data';
+import { DataSourceInstanceSettings, GrafanaTheme2, PanelData, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { DataSourceRef } from '@grafana/schema';
@@ -25,6 +25,7 @@ import {
 import alertDef, { EvalFunction } from '../state/alertDef';
 
 import { Spacer } from './components/Spacer';
+import { TimeRangeLabel } from './components/TimeRangeLabel';
 import { WithReturnButton } from './components/WithReturnButton';
 import { ExpressionResult } from './components/expressions/Expression';
 import { ThresholdDefinition, getThresholdsForQueries } from './components/rule-editor/util';
@@ -123,12 +124,7 @@ export function QueryPreview({
   if (relativeTimeRange) {
     headerItems.push(
       <Text color="secondary" key="timerange">
-        <Trans
-          i18nKey="alerting.query-preview.relative-time-range"
-          values={{ from: rangeUtil.secondsToHms(relativeTimeRange.from) }}
-        >
-          <code>{'{{from}}'}</code> to now
-        </Trans>
+        <TimeRangeLabel relativeTimeRange={relativeTimeRange} />
       </Text>
     );
   }

--- a/public/app/features/alerting/unified/components/TimeRangeLabel.test.tsx
+++ b/public/app/features/alerting/unified/components/TimeRangeLabel.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from 'test/test-utils';
+
+import { TimeRangeLabel } from './TimeRangeLabel';
+
+describe('TimeRangeLabel', () => {
+  it('renders "to now" when to is 0', () => {
+    render(<TimeRangeLabel relativeTimeRange={{ from: 900, to: 0 }} />);
+
+    // 900 seconds -> 15m
+    expect(screen.getByText(/to now/i)).toBeInTheDocument();
+    expect(screen.getByText('15m')).toBeInTheDocument();
+  });
+
+  it('renders "to <to>" when to > 0', () => {
+    render(<TimeRangeLabel relativeTimeRange={{ from: 900, to: 60 }} />);
+
+    // 900 seconds -> 15m, 60 seconds -> 1m
+    const container = screen.getByText(/to/i).closest('span') || screen.getByText(/to/i).parentElement || document.body;
+    expect(container).toHaveTextContent(/15m to 1m/);
+  });
+});

--- a/public/app/features/alerting/unified/components/TimeRangeLabel.tsx
+++ b/public/app/features/alerting/unified/components/TimeRangeLabel.tsx
@@ -1,0 +1,32 @@
+import { RelativeTimeRange, rangeUtil } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+
+interface RuleTimeRangeLabelProps {
+  relativeTimeRange: RelativeTimeRange;
+}
+
+/**
+ * Displays a human-readable relative time range label like:
+ * - "15m to now" when to === 0 or not set
+ * - "15m to 1m" when to > 0
+ */
+export function TimeRangeLabel({ relativeTimeRange }: RuleTimeRangeLabelProps) {
+  const fromLabel = rangeUtil.secondsToHms(relativeTimeRange.from);
+  const toSeconds = relativeTimeRange.to ?? 0;
+  const toIsNow = !toSeconds || toSeconds <= 0;
+  const toLabel = toIsNow ? 'now' : rangeUtil.secondsToHms(toSeconds);
+
+  if (toIsNow) {
+    return (
+      <Trans i18nKey="alerting.rule-time-range-label.relative" values={{ from: fromLabel }}>
+        <code>{'{{from}}'}</code> to now
+      </Trans>
+    );
+  }
+
+  return (
+    <Trans i18nKey="alerting.rule-time-range-label.relative-with-to" values={{ from: fromLabel, to: toLabel }}>
+      <code>{'{{from}}'}</code> to <code>{'{{to}}'}</code>
+    </Trans>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 
-import { GrafanaTheme2, RelativeTimeRange, dateTime, getDefaultRelativeTimeRange, rangeUtil } from '@grafana/data';
+import { GrafanaTheme2, RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Icon, InlineField, RelativeTimeRangePicker, Toggletip, clearButtonStyles, useStyles2 } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { TimeRangeLabel } from '../TimeRangeLabel';
 
 import { AlertQueryOptions, MaxDataPointsOption, MinIntervalOption } from './QueryWrapper';
 
@@ -26,8 +28,6 @@ export const QueryOptions = ({
   const styles = useStyles2(getStyles);
 
   const [showOptions, setShowOptions] = useState(false);
-
-  const timeRange = query.relativeTimeRange ? rangeUtil.relativeToTimeRange(query.relativeTimeRange) : undefined;
 
   const separator = <span>, </span>;
 
@@ -58,7 +58,9 @@ export const QueryOptions = ({
       </Toggletip>
 
       <div className={styles.staticValues}>
-        <span>{dateTime(timeRange?.from).locale('en').fromNow(true)}</span>
+        <span>
+          <TimeRangeLabel relativeTimeRange={query.relativeTimeRange ?? getDefaultRelativeTimeRange()} />
+        </span>
 
         {queryOptions.maxDataPoints && (
           <>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2212,9 +2212,6 @@
       "max-data-points": "MD = {{maxDataPoints}}",
       "min-interval": "Min. Interval = {{minInterval}}"
     },
-    "query-preview": {
-      "relative-time-range": "<0>{{from}}</0> to now"
-    },
     "queryAndExpressionsStep": {
       "disableAdvancedOptions": {
         "text": "The selected queries and expressions cannot be converted to default. If you deactivate advanced options, your query and condition will be reset to default settings."
@@ -2559,6 +2556,10 @@
       "pending": "{{pendingStats}} pending",
       "recording": "{{recordingStats}} recording",
       "recovering": "{{recoveringStats}} recovering"
+    },
+    "rule-time-range-label": {
+      "relative": "<0>{{from}}</0> to now",
+      "relative-with-to": "<0>{{from}}</0> to <2>{{to}}</2>"
     },
     "rule-type-picker": {
       "grafana-managed": "Select &ldquo;Grafana managed&rdquo; unless you have a Mimir, Loki or Cortex data source with the Ruler API enabled."


### PR DESCRIPTION
## Problem
- Alert rules configured with `from=900, to=60` (15m to 1m) 
- UI incorrectly displayed `"15m to now"` instead of `"15m to 1m"`
- Alert preview displaying invalid state - Rule displays normal state but the preview shows firing

## Root Cause
1. UI components didn't support displaying custom `to` values
2. `widenRelativeTimeRanges()` automatically expanded time ranges and forced all queries to end at `now`

## Fix
1. **Removed time range widening** - UI now shows actual configured ranges
3. **New `TimeRangeLabel` component** - supports both `"15m to now"` and `"15m to 1m"` formats
4. **Consistent display** across rule viewer and query options

I removed `widenRelativeTimeRanges()` to fix the current issue. I believe we should address that functionality in another PR where we add `TimeRange` selector component and just allow users to set any time range they want

Fixes #https://github.com/grafana/support-escalations/issues/18328