### PR TITLE
Alerting: Fix rule matching when queries contain comments

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-id.ts
+++ b/public/app/features/alerting/unified/utils/rule-id.ts
@@ -307,6 +307,13 @@ export function getPromRuleFingerprint(rule: Rule, includeQuery: boolean) {
 
 // there can be slight differences in how prom & ruler render a query, this will hash them accounting for the differences
 export function hashQuery(query: string) {
+  // remove comments
+  query = query
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'))
+    .join('\n');
+
   // one of them might be wrapped in parens
   if (query.length > 1 && query[0] === '(' && query[query.length - 1] === ')') {
     query = query.slice(1, -1);


### PR DESCRIPTION
# Fix rule matching when expressions contain comments

  Fixed rule matching logic to properly handle comments in Prometheus expressions. When multiple rules have identical names and labels,
   the system falls back to query comparison, but the `hashQuery` function wasn't stripping comments, causing mismatches between ruler
  rules (with comments) and Prometheus rules (without comments).

  ## What's Fixed
  - **`hashQuery()` function**: Now properly strips comment lines starting with `#` before normalizing queries
  - Ensures ruler rules with comments can match their corresponding Prometheus rules without comments
  - Fixes real-world scenarios where identical rules fail to match due to comment differences

  ## Tests Added
  - 3 comprehensive test cases covering `getMatchingRulerRule`, `getMatchingPromRule`, and `matchRulesGroup`
  - Tests use realistic PromQL expressions with comments (production/staging fallback pattern)
  - All tests force query-level comparison by having multiple rules with identical names and labels
  - Validates the fix works correctly and provides regression coverage

Fixes https://github.com/grafana/support-escalations/issues/18345

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
