### PR TITLE
Dashboard: skip deletion validation on standalone mode

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -58,6 +58,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 var (
@@ -280,7 +281,7 @@ func (b *DashboardsAPIBuilder) validateDelete(ctx context.Context, a admission.A
 	}
 
 	// HACK: deletion validation currently doesn't work for the standalone case. So we currently skip it.
-	if b.isStandalone && b.dashboardProvisioningService == nil {
+	if b.isStandalone && util.IsInterfaceNil(b.dashboardProvisioningService) {
 		return nil
 	}
 

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -274,14 +274,14 @@ func (b *DashboardsAPIBuilder) validateDelete(ctx context.Context, a admission.A
 		return nil
 	}
 
-	// HACK: deletion validation currently doesn't work for the standalone case. So we currently skip it.
-	if b.isStandalone {
-		return nil
-	}
-
 	nsInfo, err := claims.ParseNamespace(a.GetNamespace())
 	if err != nil {
 		return fmt.Errorf("%v: %w", "failed to parse namespace", err)
+	}
+
+	// HACK: deletion validation currently doesn't work for the standalone case. So we currently skip it.
+	if b.isStandalone && b.dashboardProvisioningService == nil {
+		return nil
 	}
 
 	// The name of the resource is the dashboard UID

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -274,6 +274,11 @@ func (b *DashboardsAPIBuilder) validateDelete(ctx context.Context, a admission.A
 		return nil
 	}
 
+	// HACK: deletion validation currently doesn't work for the standalone case. So we currently skip it.
+	if b.isStandalone {
+		return nil
+	}
+
 	nsInfo, err := claims.ParseNamespace(a.GetNamespace())
 	if err != nil {
 		return fmt.Errorf("%v: %w", "failed to parse namespace", err)


### PR DESCRIPTION
**What is this feature?**

When dashboard API is deployed as a standalone service, dashboard deletion is not currently working, as it panics on deletion validation. 
To currently support it, we're adding an hack that skips validation until we have a proper solution, to ease provisioning e2e testing. 

**Note**: this is part of what @charandas did in https://github.com/grafana/grafana/pull/110893 - I'm extracting that work here to better isolate PRs. 

**Why do we need this feature?**

So that we're able to delete resources managed by standalone dashboard API. 

**Who is this feature for?**

Users of GitSync feature

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/541 (skips this panic - but we need some more work on it)
Part of https://github.com/grafana/git-ui-sync-project/issues/535 (makes finalizer on deleting resources work)

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
