### PR TITLE
Chore: Fix @grafana/alerting package repo

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -14,7 +14,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+http://github.com/grafana/grafana.git",
+    "url": "http://github.com/grafana/grafana.git",
     "directory": "packages/grafana-alerting"
   },
   "main": "src/index.ts",


### PR DESCRIPTION
The `@grafana/alerting` package.json has an inconsistent `repository.url` property from all our other packages, and is in the incorrect format for provenance statements for npm trusted publishing.

See https://github.com/grafana/grafana/actions/runs/17639590086/job/50124927718#step:7:144

> npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@grafana%2falerting - Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "git+http://github.com/grafana/grafana.git", expected to match "https://github.com/grafana/grafana" from provenance 