### PR TITLE
Chore: Remove some unnecessary suppressions

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,14 +1,4 @@
 {
-  "apps/dashboard/tshack/v0alpha1_spec_gen.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "apps/dashboard/tshack/v1alpha1_spec_gen.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "e2e/cypress/support/commands.js": {
     "no-restricted-syntax": {
       "count": 1
@@ -370,11 +360,6 @@
   "packages/grafana-data/src/vector/FunctionalVector.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 9
-    }
-  },
-  "packages/grafana-data/test/helpers/pluginMocks.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
     }
   },
   "packages/grafana-e2e-selectors/src/resolver.ts": {
@@ -2338,11 +2323,6 @@
       "count": 10
     }
   },
-  "public/app/features/dashboard-scene/v2schema/test-helpers.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 3
-    }
-  },
   "public/app/features/dashboard/api/ResponseTransformers.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 4
@@ -3310,9 +3290,6 @@
     }
   },
   "public/app/features/query/state/DashboardQueryRunner/testHelpers.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
     "@typescript-eslint/no-explicit-any": {
       "count": 2
     }
@@ -3411,11 +3388,6 @@
   "public/app/features/templating/templateProxies.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
-    }
-  },
-  "public/app/features/templating/template_srv.mock.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 4
     }
   },
   "public/app/features/templating/template_srv.ts": {
@@ -4042,11 +4014,6 @@
     }
   },
   "public/app/plugins/datasource/elasticsearch/hooks/useStatelessReducer.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/datasource/elasticsearch/test-helpers/render.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
     }

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,8 +27,12 @@ const commonTestIgnores = [
   '**/mocks/**/*.{ts,tsx}',
   '**/public/test/**',
   '**/mocks.{ts,tsx}',
-  '**/spec/**/*.{ts,tsx}',
+  '**/*.mock.{ts,tsx}',
+  '**/{test-helpers,testHelpers}.{ts,tsx}',
+  '**/{spec,test-helpers}/**/*.{ts,tsx}',
 ];
+
+const generatedFiles = ['**/*.gen.ts', '**/*_gen.ts'];
 
 const enterpriseIgnores = ['public/app/extensions/**/*', 'e2e/extensions/**/*'];
 
@@ -92,7 +96,7 @@ module.exports = [
       '.github',
       '.yarn',
       '**/.*', // dotfiles aren't ignored by default in FlatConfig
-      '**/*.gen.ts',
+      ...generatedFiles,
       '**/build/',
       '**/compiled/',
       '**/dist/',

--- a/packages/grafana-data/test/helpers/pluginMocks.ts
+++ b/packages/grafana-data/test/helpers/pluginMocks.ts
@@ -92,5 +92,6 @@ export function getMockPlugin(overrides?: Partial<PluginMeta>): PluginMeta {
     module: 'path/to/module',
   };
 
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   return defaultsDeep(overrides || {}, defaults) as PluginMeta;
 }


### PR DESCRIPTION
**What is this feature?**
Removes some unneeded suppressions from ESLint

**Why do we need this feature?**
These issues were happening inside test, mock or generated files, and we don't care about some eslint rules within those places
