### PR TITLE
fix: bump context deadline for integration tests while backend initialization

### DIFF
--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -72,7 +72,7 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, backend)
-			err = backend.Init(testutil.NewDefaultTestContext(t))
+			err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
 			require.NoError(t, err)
 			return backend
 		}, nil)
@@ -91,7 +91,7 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 			})
 			require.NoError(t, err)
 			require.NotNil(t, backend)
-			err = backend.Init(testutil.NewDefaultTestContext(t))
+			err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
 			require.NoError(t, err)
 			return backend
 		}, nil)

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -49,7 +49,7 @@ func TestIntegrationStorageServer(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, backend)
-		err = backend.Init(testutil.NewDefaultTestContext(t))
+		err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
 		require.NoError(t, err)
 		return backend
 	})


### PR DESCRIPTION
I came across the below error multiple times yesterday, this is just a quick fix regarding the context timeouts.

```
--- FAIL: TestIntegrationSQLStorageBackend (7.56s)
    --- FAIL: TestIntegrationSQLStorageBackend/IsHA_(polling_notifier) (2.59s)
        storage_backend.go:68: Running tests with namespace prefix: test-7d907f3c-8
        integration_test.go:79: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/storage/unified/sql/test/integration_test.go:79
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/storage/unified/testing/storage_backend.go:93
            	Error:      	Received unexpected error:
            	            	initialize resource DB: run migrations: migration failed (id = create table resource_version, index: 0): context deadline exceeded
            	Test:       	TestIntegrationSQLStorageBackend/IsHA_(polling_notifier)
```