### PR TITLE
Table: Fix logic to calculate footer height

### DIFF
--- a/devenv/dev-dashboards/panel-table/table_footer.json
+++ b/devenv/dev-dashboards/panel-table/table_footer.json
@@ -1442,6 +1442,67 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "footer": {
+              "reducers": ["lastNotNull", "countAll"]
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "options": {
+        "cellHeight": "sm",
+        "showHeader": true
+      },
+      "pluginVersion": "12.2.0-pre",
+      "targets": [
+        {
+          "csvContent": "a,b\nfoo,bar\nbaz,bim\nbop,boop",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "No numeric fields",
+      "type": "table"
     }
   ],
   "preload": false,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -142,7 +142,7 @@ export function TableNG(props: TableNGProps) {
   const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
   const hasHeader = !noHeader;
   const hasFooter = useMemo(
-    () => visibleFields.some((field) => field.config?.custom?.footer?.reducers?.length ?? false),
+    () => visibleFields.some((field) => Boolean(field.config.custom?.footer?.reducers?.length)),
     [visibleFields]
   );
   const footerHeight = useMemo(

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -108,7 +108,6 @@ export function TableNG(props: TableNGProps) {
     enablePagination = false,
     enableSharedCrosshair = false,
     enableVirtualization,
-    fieldConfig,
     frozenColumns = 0,
     getActions = () => [],
     height,
@@ -125,12 +124,6 @@ export function TableNG(props: TableNGProps) {
     width,
   } = props;
 
-  const hasFooter = useMemo(
-    () => data.fields.some((field) => field.config?.custom?.footer?.reducers?.length ?? false),
-    [data.fields]
-  );
-  const footerHeight = hasFooter ? calculateFooterHeight(data, fieldConfig) : 0;
-
   const theme = useTheme2();
   const styles = useStyles2(getGridStyles, enablePagination, transparent);
   const panelContext = usePanelContext();
@@ -146,7 +139,16 @@ export function TableNG(props: TableNGProps) {
     [getActions, data, userCanExecuteActions]
   );
 
+  const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
   const hasHeader = !noHeader;
+  const hasFooter = useMemo(
+    () => visibleFields.some((field) => field.config?.custom?.footer?.reducers?.length ?? false),
+    [visibleFields]
+  );
+  const footerHeight = useMemo(
+    () => (hasFooter ? calculateFooterHeight(visibleFields) : 0),
+    [hasFooter, visibleFields]
+  );
 
   const resizeHandler = useColumnResize(onColumnResize);
 
@@ -173,7 +175,7 @@ export function TableNG(props: TableNGProps) {
   const [expandedRows, setExpandedRows] = useState(() => new Set<number>());
 
   // vt scrollbar accounting for column auto-sizing
-  const visibleFields = useMemo(() => getVisibleFields(data.fields), [data.fields]);
+
   const defaultRowHeight = useMemo(
     () => getDefaultRowHeight(theme, visibleFields, cellHeight),
     [theme, visibleFields, cellHeight]

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -46,6 +46,7 @@ import {
   getDefaultRowHeight,
   getDisplayName,
   predicateByName,
+  calculateFooterHeight,
 } from './utils';
 
 describe('TableNG utils', () => {
@@ -1377,6 +1378,35 @@ describe('TableNG utils', () => {
         { time: 1, value: 10 },
         { time: 2, value: 30 },
       ]);
+    });
+  });
+
+  describe('calculateFooterHeight', () => {
+    it('should return 0 if no footer is present', () => {
+      const frame = createDataFrame({
+        fields: [
+          { name: 'time', values: [1, 1, 2], nanos: [100, 99, 0] },
+          { name: 'value', values: [10, 20, 30] },
+        ],
+      });
+
+      expect(calculateFooterHeight(frame.fields)).toBe(0);
+    });
+
+    it('should return the height in pixels for the max reducers on a given field', () => {
+      const frame = createDataFrame({
+        fields: [
+          {
+            name: 'time',
+            values: [1, 1, 2],
+            nanos: [100, 99, 0],
+            config: { custom: { footer: { reducers: ['min', 'max', 'count'] } } },
+          },
+          { name: 'value', values: [10, 20, 30], config: { custom: { footer: { reducers: ['min'] } } } },
+        ],
+      });
+
+      expect(calculateFooterHeight(frame.fields)).toBe(78); // 3 reducers * 22px line height + 12px padding
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -848,7 +848,7 @@ export const processNestedTableRows = (
 export const calculateFooterHeight = (fields: Field[]): number => {
   let maxReducerCount = 0;
   for (const field of fields) {
-    maxReducerCount = Math.max(maxReducerCount, field.config?.custom?.footer?.reducers?.length ?? 0);
+    maxReducerCount = Math.max(maxReducerCount, field.config.custom?.footer?.reducers?.length ?? 0);
   }
 
   // Base height (+ padding) + height per reducer


### PR DESCRIPTION
Related to a customer issue.

The logic to calculate the height of a footer as originally written in #102948 has some shortcomings based on the updates in that PR, namely that any field with reducers can contribute to the height of the footer, not just numeric ones. Additionally, the `calculateFooterHeight` was unnecessarily taking fieldOverrides into account - any relevant overrides will already be applied to the field config by the time this util is run.

I've confirmed this fix with the Footer, 12.2 migration, and Kitchen Sink gdev dashboards, as well as the customer's debug dashboard which initially reproduced the issue. here's a simple repro dashboard as well - any dashboard which contains no numeric fields but which does contain reducers would see the issue.

<details>

<summary>Repro dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 1854,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "footer": {
              "reducers": [
                "lastNotNull",
                "countAll"
              ]
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "showHeader": true
      },
      "pluginVersion": "12.2.0-pre",
      "targets": [
        {
          "csvContent": "a,b\nfoo,bar\nbaz,bim\nbop,boop",
          "datasource": {
            "type": "grafana-testdata-datasource"
          },
          "refId": "A",
          "scenarioId": "csv_content"
        }
      ],
      "title": "New panel",
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Repro non-numeric footer height issue",
  "uid": "adz8mxg",
  "version": 1
}
```

</details>