### PR TITLE
Provisioning: check finalizers when validating Repository object

### DIFF
--- a/apps/provisioning/pkg/repository/finalizers.go
+++ b/apps/provisioning/pkg/repository/finalizers.go
@@ -1,0 +1,10 @@
+package repository
+
+// RemoveOrphanResourcesFinalizer removes everything this repo created
+const RemoveOrphanResourcesFinalizer = "remove-orphan-resources"
+
+// ReleaseOrphanResourcesFinalizer removes the metadata for anything this repo created
+const ReleaseOrphanResourcesFinalizer = "release-orphan-resources"
+
+// CleanFinalizer calls the "OnDelete" function for resource
+const CleanFinalizer = "cleanup"

--- a/apps/provisioning/pkg/repository/test.go
+++ b/apps/provisioning/pkg/repository/test.go
@@ -84,6 +84,17 @@ func ValidateRepository(repo Repository) field.ErrorList {
 		}
 	}
 
+	if slices.Contains(cfg.Finalizers, RemoveOrphanResourcesFinalizer) &&
+		slices.Contains(cfg.Finalizers, ReleaseOrphanResourcesFinalizer) {
+		list = append(list,
+			field.Invalid(
+				field.NewPath("medatada", "finalizers"),
+				cfg.Finalizers,
+				"cannot have both remove and release orphan resources finalizers",
+			),
+		)
+	}
+
 	return list
 }
 

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -19,15 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
 
-// RemoveOrphanResourcesFinalizer removes everything this repo created
-const RemoveOrphanResourcesFinalizer = "remove-orphan-resources"
-
-// ReleaseOrphanResourcesFinalizer removes the metadata for anything this repo created
-const ReleaseOrphanResourcesFinalizer = "release-orphan-resources"
-
-// CleanFinalizer calls the "OnDelete" function for resource
-const CleanFinalizer = "cleanup"
-
 type finalizer struct {
 	lister        resources.ResourceLister
 	clientFactory resources.ClientFactory
@@ -41,7 +32,7 @@ func (f *finalizer) process(ctx context.Context,
 
 	for _, finalizer := range finalizers {
 		switch finalizer {
-		case CleanFinalizer:
+		case repository.CleanFinalizer:
 			// NOTE: the controller loop will never get run unless a finalizer is set
 			hooks, ok := repo.(repository.Hooks)
 			if ok {
@@ -50,7 +41,7 @@ func (f *finalizer) process(ctx context.Context,
 				}
 			}
 
-		case ReleaseOrphanResourcesFinalizer:
+		case repository.ReleaseOrphanResourcesFinalizer:
 			err := f.processExistingItems(ctx, repo.Config(),
 				func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error {
 					patchAnnotations, err := getPatchedAnnotations(item)
@@ -67,7 +58,7 @@ func (f *finalizer) process(ctx context.Context,
 				return err
 			}
 
-		case RemoveOrphanResourcesFinalizer:
+		case repository.RemoveOrphanResourcesFinalizer:
 			err := f.processExistingItems(ctx, repo.Config(),
 				func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error {
 					return client.Delete(ctx, item.Name, v1.DeleteOptions{})

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -485,8 +485,8 @@ func (b *APIBuilder) Mutate(ctx context.Context, a admission.Attributes, o admis
 	// This is called on every update, so be careful to only add the finalizer for create
 	if len(r.Finalizers) == 0 && a.GetOperation() == admission.Create {
 		r.Finalizers = []string{
-			controller.RemoveOrphanResourcesFinalizer,
-			controller.CleanFinalizer,
+			repository.RemoveOrphanResourcesFinalizer,
+			repository.CleanFinalizer,
 		}
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR updates the Repository object validation to also check on finalisers.
There are two of them which are mutually exclusive, therefore we should check if both are present and error in that case.

**Why do we need this feature?**

To correctly handle finalisers when deleting repos. 

**Who is this feature for?**

Users of GitSync feature

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/535

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
