### PR TITLE
[release-12.1.2] docs: clarify that data links must use variable names, not labels

### DIFF
--- a/docs/sources/panels-visualizations/configure-data-links/index.md
+++ b/docs/sources/panels-visualizations/configure-data-links/index.md
@@ -278,6 +278,17 @@ When linking to another dashboard that uses template variables, select variable 
 
 If you want to add all of the current dashboard's variables to the URL, then use `${__all_variables}`.
 
+When you link to another dashboard, ensure that:
+
+- The target dashboard has the same variable name. If it doesn't (for example, `server` in the source dashboard and `host` in the target), you must align them or explicitly map values (for example, `&var-host=${server}`).
+- You use the variable _name_, and not the label. Labels are only used as display text and aren't recognized in URLs.
+
+For example, if you have a variable with the name `var-server` and the label `ChooseYourServer`, you must use `var-server` in the URL, as shown in the following table:
+
+| Correct link                                   | Incorrect link                                           |
+| ---------------------------------------------- | -------------------------------------------------------- |
+| `/d/xxxx/dashboard-b?orgId=1&var-server=web02` | `/d/xxxx/dashboard-b?orgId=1&var-ChooseYourServer=web02` |
+
 ## Add data links or actions {#add-a-data-link}
 
 The following tasks describe how to configure data links and actions.
@@ -296,9 +307,7 @@ To add a data link, follow these steps:
    This is a human-readable label for the link displayed in the UI. This is a required field.
 
 1. Enter the **URL** to which you want to link.
-
-   To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables. This is a required field.
-
+1. (Optional) To add a data link variable, click in the **URL** field and enter `$` or press Ctrl+Space or Cmd+Space to see a list of available variables.
 1. If you want the link to open in a new tab, toggle the **Open in a new tab** switch.
 1. If you want the data link to open with a single click on the visualization, toggle the **One click** switch.
 


### PR DESCRIPTION
Backport 0b1e640b03ba706d415e6f281e9dc94e4436ceea from #110077

---

### What this PR does
This PR improves the Configure data links and actions documentation by clarifying that data links must use the variable name, not the label.

- Added a new section "Variable names vs. labels"
- Included a comparison table with correct vs. incorrect examples
- Added a note on aligning/mapping variable names across dashboards

### Why this is needed
Previously, the docs didn’t explain that labels are not recognized in URLs.  
This caused confusion and broken links. The update makes this explicit.

### Screenshot
<img width="1440" height="900" alt="Screenshot 2025-08-23 at 7 48 41 PM" src="https://github.com/user-attachments/assets/667227fa-185b-457b-9a8b-fccf1b98d0ef" />

### Checklist
- [x] Tested locally with `make docs`
- [x] Section follows Grafana docs style guide
- [x] Added table + note for clarity

Closes #44475
