### PR TITLE
Table: Use higher contrast color for Tooltip from Field chip

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -228,10 +228,7 @@ export const getTooltipStyles = (theme: GrafanaTheme2, textAlign: TextAlign) => 
     [textAlign === 'right' ? 'right' : 'left']: theme.spacing(0.25),
     width: theme.spacing(1.75),
     height: theme.spacing(1.75),
-    background: caretTriangle(textAlign === 'right' ? 'right' : 'left', theme.colors.border.medium),
-    '&:hover, &[aria-pressed=true]': {
-      background: caretTriangle(textAlign === 'right' ? 'right' : 'left', theme.colors.border.strong),
-    },
+    background: caretTriangle(textAlign === 'right' ? 'right' : 'left', theme.colors.border.strong),
   }),
 });
 


### PR DESCRIPTION
Relates to https://github.com/grafana/hyperion-planning/issues/415

*Note: now, when hovering the chip, there's no change, because now we're using the "heaviest" border color all the time*

### Before

<img width="310" height="126" alt="Screenshot 2025-09-11 at 11 47 41 AM" src="https://github.com/user-attachments/assets/9665327d-ed6b-4907-bed5-57e8544ae12c" />
<img width="315" height="114" alt="Screenshot 2025-09-11 at 11 47 32 AM" src="https://github.com/user-attachments/assets/e9774431-2805-49fa-8df0-f7cbe21949b5" />

### After

<img width="307" height="114" alt="Screenshot 2025-09-11 at 11 47 07 AM" src="https://github.com/user-attachments/assets/95b662b0-32af-4f07-acc7-fe008113cebd" />
<img width="321" height="122" alt="Screenshot 2025-09-11 at 11 47 18 AM" src="https://github.com/user-attachments/assets/265dbb04-b14a-418b-8540-2e927f1601d2" />