### PR TITLE
Accessibility: enable responsive reflow of variables in dashboard edit

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -152,10 +152,10 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
         {editPanel && <PanelEditControls panelEditor={editPanel} />}
       </Stack>
       {!hideTimeControls && (
-        <Stack justifyContent="flex-end">
+        <div className={cx(styles.timeControls, editPanel && styles.timeControlsWrap)}>
           <timePicker.Component model={timePicker} />
           <refreshPicker.Component model={refreshPicker} />
-        </Stack>
+        </div>
       )}
       {(hasControlMenuVariables || hasControlMenuLinks) && (
         <Stack>
@@ -198,12 +198,22 @@ function getStyles(theme: GrafanaTheme2) {
       },
     }),
     controlsPanelEdit: css({
+      flexWrap: 'wrap-reverse',
       // In panel edit we do not need any right padding as the splitter is providing it
       paddingRight: 0,
     }),
     embedded: css({
       background: 'unset',
       position: 'unset',
+    }),
+    timeControls: css({
+      display: 'flex',
+      justifyContent: 'flex-end',
+      gap: theme.spacing(1),
+    }),
+    timeControlsWrap: css({
+      flexWrap: 'wrap',
+      marginLeft: 'auto',
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

This is the unrevert of https://github.com/grafana/grafana/pull/110684 with changes to only have the new variable reflow in dashboard edit, not dashboard view.

With variable reflow in edit:

<img width="982" height="598" alt="image" src="https://github.com/user-attachments/assets/96dd8ab9-e008-4b67-9f57-466afc9e05ca" />

Without variable reflow in view:

<img width="982" height="598" alt="image" src="https://github.com/user-attachments/assets/fbc64c2b-de07-4ee0-b2f8-e9ec55f98c15" />

**Why do we need this feature?**

Having variable in dashboard edit very quickly leads to the flex box overflowing and the time range picker and refresh dropdown being forced behind the edit sidebar. That's an accessibility issues for users zoomed in and on smaller screens.

**Who is this feature for?**

Users on smaller screens or zoomed in (or with a lot of dashboard variables)

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/107127

**Special notes for your reviewer:**

the `timeControls` styles on a div are exactly equivalent to `<Stack justifyContent="flex-end">`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
