### PR TITLE
Folders: Fix panic in unified storage only mode

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -143,6 +143,10 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	storage := map[string]rest.Storage{}
 
 	if b.ignoreLegacy {
+		opts.StorageOptsRegister(resourceInfo.GroupResource(), apistore.StorageOptions{
+			EnableFolderSupport:         true,
+			RequireDeprecatedInternalID: true})
+
 		store, err := grafanaregistry.NewRegistryStore(opts.Scheme, resourceInfo, opts.OptsGetter)
 		if err != nil {
 			return err
@@ -150,6 +154,7 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		storage[resourceInfo.StoragePath()] = store
 		apiGroupInfo.VersionedResourcesStorageMap[folders.VERSION] = storage
 		b.storage = storage[resourceInfo.StoragePath()].(grafanarest.Storage)
+		b.parents = newParentsGetter(store, folder.MaxNestedFolderDepth)
 		return nil
 	}
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes a panic that would happen in subfolders, when ignoreLegacy was true, because the parents function was not setup.

```
 curl -k -X POST https://localhost:6446/apis/folder.grafana.app/v1beta1/namespaces/default/folders -H 'Content-Type: application/json' -d '{"apiVersion": "folder.grafana.app/v1beta1", "kind": "Folder", "metadata": {"name": "test3","annotations": {"grafana.app/folder": "test"}},"spec": {"title": "testing3"}}'
{
  "kind": "Folder",
  "apiVersion": "folder.grafana.app/v1beta1",
  "metadata": {
    "name": "test3",
    "namespace": "default",
    "uid": "4d6774ff-435b-45ba-997b-1aa4792c9b45",
    "resourceVersion": "1757614566283722",
    "generation": 1,
    "creationTimestamp": "2025-09-11T18:16:06Z",
    "labels": {
      "grafana.app/deprecatedInternalID": "2634678707122176"
    },
    "annotations": {
      "grafana.app/createdBy": "anonymous:",
      "grafana.app/folder": "test"
    },
    "managedFields": [
      {
        "manager": "curl",
        "operation": "Update",
        "apiVersion": "folder.grafana.app/v1beta1",
        "time": "2025-09-11T18:16:06Z",
        "fieldsType": "FieldsV1",
        "fieldsV1": {
          "f:metadata": {
            "f:annotations": {
              ".": {},
              "f:grafana.app/folder": {}
            }
          },
          "f:spec": {
            "f:title": {}
          }
        }
      }
    ]
  },
  "spec": {
    "title": "testing3"
  },
  "status": {}
}%       
```


**Which issue(s) does this PR fix?**:

Fixes #https://github.com/grafana/git-ui-sync-project/issues/536

