### PR TITLE
Use concurrent informer for iam-folder-reconciler

### DIFF
--- a/apps/iam/cmd/operator/config.go
+++ b/apps/iam/cmd/operator/config.go
@@ -31,7 +31,8 @@ type WebhookServerConfig struct {
 }
 
 type FolderReconcilerConfig struct {
-	Namespace string
+	Namespace            string
+	MaxConcurrentWorkers uint64
 }
 
 func LoadConfigFromEnv() (*Config, error) {
@@ -115,6 +116,16 @@ func LoadConfigFromEnv() (*Config, error) {
 	cfg.ZanzanaClient.ServerCertFile = os.Getenv("ZANZANA_SERVER_CERT_FILE")
 
 	cfg.FolderReconciler.Namespace = os.Getenv("FOLDER_RECONCILER_NAMESPACE")
+	maxConcurrentWorkersStr := os.Getenv("FOLDER_RECONCILER_MAX_CONCURRENT_WORKERS")
+	if maxConcurrentWorkersStr == "" {
+		cfg.FolderReconciler.MaxConcurrentWorkers = 20
+	} else {
+		maxConcurrentWorkers, err := strconv.ParseUint(maxConcurrentWorkersStr, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid FOLDER_RECONCILER_MAX_CONCURRENT_WORKERS '%s': %w", maxConcurrentWorkersStr, err)
+		}
+		cfg.FolderReconciler.MaxConcurrentWorkers = maxConcurrentWorkers
+	}
 
 	return &cfg, nil
 }

--- a/apps/iam/cmd/operator/main.go
+++ b/apps/iam/cmd/operator/main.go
@@ -69,6 +69,9 @@ func main() {
 	appCfg := app.AppConfig{
 		ZanzanaClientCfg:          cfg.ZanzanaClient,
 		FolderReconcilerNamespace: cfg.FolderReconciler.Namespace,
+		InformerConfig: app.InformerConfig{
+			MaxConcurrentWorkers: cfg.FolderReconciler.MaxConcurrentWorkers,
+		},
 	}
 
 	// Run

--- a/pkg/operators/iam/zanzana_folder_reconciler.go
+++ b/pkg/operators/iam/zanzana_folder_reconciler.go
@@ -106,6 +106,8 @@ func buildIAMConfigFromSettings(cfg *setting.Cfg) (*iamConfig, error) {
 	}
 	iamCfg.AppConfig.ZanzanaClientCfg.URL = zanzanaURL
 
+	iamCfg.AppConfig.InformerConfig.MaxConcurrentWorkers = operatorSec.Key("max_concurrent_workers").MustUint64(20)
+
 	folderAppURL := operatorSec.Key("folder_app_url").MustString("")
 	if folderAppURL == "" {
 		return nil, fmt.Errorf("folder_app_url is required in [operator] section")


### PR DESCRIPTION
The operator could take a very long time (on the order of hours/10's of hours) to process sync events due to the `DefaultInformer` being single-threaded.

This PR addresses that by using a `ConcurrentInformer` with a configurable number of workers. The business logic is quite simple and limited by network latency. Because of this, I have chosen a conservative, 20, number of workers to test out it's performance, but we can easily tune this in the future by changing the config.