### PR TITLE
Unistore: Add validation for resource names

### DIFF
--- a/pkg/apiserver/storage/testing/watcher_tests.go
+++ b/pkg/apiserver/storage/testing/watcher_tests.go
@@ -684,7 +684,7 @@ func RunTestClusterScopedWatch(ctx context.Context, t *testing.T, store storage.
 			currentObjs := map[string]*example.Pod{}
 			for _, watchTest := range tt.watchTests {
 				out := &example.Pod{}
-				key := "pods/" + watchTest.obj.Name
+				key := "pods/ns-1/" + watchTest.obj.Name
 				err := store.GuaranteedUpdate(ctx, key, out, true, nil, storage.SimpleUpdate(
 					func(runtime.Object) (runtime.Object, error) {
 						obj := watchTest.obj.DeepCopy()
@@ -1607,15 +1607,15 @@ func clusterScopedNodeNameAttrFunc(obj runtime.Object) (labels.Set, fields.Set, 
 }
 
 func basePod(podName string) *example.Pod {
-	return baseNamespacedPod(podName, "")
+	return baseNamespacedPod(podName, "ns-1")
 }
 
 func basePodUpdated(podName string) *example.Pod {
-	return baseNamespacedPodUpdated(podName, "")
+	return baseNamespacedPodUpdated(podName, "ns-1")
 }
 
 func basePodAssigned(podName, nodeName string) *example.Pod {
-	return baseNamespacedPodAssigned(podName, "", nodeName)
+	return baseNamespacedPodAssigned(podName, "ns-1", nodeName)
 }
 
 func baseNamespacedPod(podName, namespace string) *example.Pod {

--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -170,6 +170,18 @@ func (s *server) BulkProcess(stream resourcepb.BulkStore_BulkProcessServer) erro
 		})
 	}
 
+	// Verify all request keys are valid
+	for _, k := range settings.Collection {
+		if r := verifyRequestKey(k); r != nil {
+			return sendAndClose(&resourcepb.BulkResponse{
+				Error: &resourcepb.ErrorResult{
+					Message: fmt.Sprintf("invalid request key: %s", r.Message),
+					Code:    http.StatusBadRequest,
+				},
+			})
+		}
+	}
+
 	if settings.RebuildCollection {
 		for _, k := range settings.Collection {
 			// Can we delete the whole collection

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
@@ -16,6 +17,18 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	}
 	if key.Resource == "" {
 		return NewBadRequestError("request key is missing resource")
+	}
+	if !util.IsValidShortUID(key.Name) {
+		return NewBadRequestError(fmt.Sprintf("name '%s' is invalid", key.Name))
+	}
+	if !validNameRegex.MatchString(key.Namespace) {
+		return NewBadRequestError(fmt.Sprintf("namespace '%s' is invalid", key.Namespace))
+	}
+	if !validNameRegex.MatchString(key.Group) {
+		return NewBadRequestError(fmt.Sprintf("group '%s' is invalid", key.Group))
+	}
+	if !validNameRegex.MatchString(key.Resource) {
+		return NewBadRequestError(fmt.Sprintf("resource '%s' is invalid", key.Resource))
 	}
 	return nil
 }

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -20,13 +20,13 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	if err := validateName(key.Name); err != nil {
 		return NewBadRequestError(fmt.Sprintf("name '%s' is invalid: '%s'", key.Name, err))
 	}
-	if err := validateName(key.Namespace); err != nil {
+	if err := validateQualifiedName(key.Namespace); err != nil {
 		return NewBadRequestError(fmt.Sprintf("namespace '%s' is invalid: '%s'", key.Namespace, err))
 	}
-	if err := validateName(key.Group); err != nil {
+	if err := validateQualifiedName(key.Group); err != nil {
 		return NewBadRequestError(fmt.Sprintf("group '%s' is invalid: '%s'", key.Group, err))
 	}
-	if err := validateName(key.Resource); err != nil {
+	if err := validateQualifiedName(key.Resource); err != nil {
 		return NewBadRequestError(fmt.Sprintf("resource '%s' is invalid: '%s'", key.Resource, err))
 	}
 	return nil

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/util"
 )
 
 func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
@@ -18,7 +17,7 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	if key.Resource == "" {
 		return NewBadRequestError("request key is missing resource")
 	}
-	if err := util.ValidateUID(key.Name); err != nil {
+	if err := validateName(key.Name); err != nil {
 		return NewBadRequestError(fmt.Sprintf("name '%s' is invalid: '%s'", key.Name, err))
 	}
 	if err := validateName(key.Namespace); err != nil {

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -18,17 +18,17 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	if key.Resource == "" {
 		return NewBadRequestError("request key is missing resource")
 	}
-	if !util.IsValidShortUID(key.Name) {
-		return NewBadRequestError(fmt.Sprintf("name '%s' is invalid", key.Name))
+	if err := util.ValidateUID(key.Name); err != nil {
+		return NewBadRequestError(fmt.Sprintf("name '%s' is invalid: '%s'", key.Name, err))
 	}
-	if !validNameRegex.MatchString(key.Namespace) {
-		return NewBadRequestError(fmt.Sprintf("namespace '%s' is invalid", key.Namespace))
+	if err := validateName(key.Namespace); err != nil {
+		return NewBadRequestError(fmt.Sprintf("namespace '%s' is invalid: '%s'", key.Namespace, err))
 	}
-	if !validNameRegex.MatchString(key.Group) {
-		return NewBadRequestError(fmt.Sprintf("group '%s' is invalid", key.Group))
+	if err := validateName(key.Group); err != nil {
+		return NewBadRequestError(fmt.Sprintf("group '%s' is invalid: '%s'", key.Group, err))
 	}
-	if !validNameRegex.MatchString(key.Resource) {
-		return NewBadRequestError(fmt.Sprintf("resource '%s' is invalid", key.Resource))
+	if err := validateName(key.Resource); err != nil {
+		return NewBadRequestError(fmt.Sprintf("resource '%s' is invalid: '%s'", key.Resource, err))
 	}
 	return nil
 }

--- a/pkg/storage/unified/resource/keys_test.go
+++ b/pkg/storage/unified/resource/keys_test.go
@@ -1,6 +1,8 @@
 package resource
 
 import (
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -64,5 +66,118 @@ func TestSearchIDKeys(t *testing.T) {
 		if err == nil {
 			require.Equal(t, test.expected, tmp, test.input)
 		}
+	}
+}
+
+func TestVerifyRequestKey(t *testing.T) {
+	validGroup := "group.grafana.app"
+	validResource := "resource"
+	validNamespace := "default"
+	validName := "fdgsv37qslr0ga"
+	validLegacyUID := "f8cc010c-ee72-4681-89d2-d46e1bd47d33"
+
+	invalidGroup := "group.~~~~~grafana.app"
+	invalidResource := "##resource"
+	invalidNamespace := "(((((default"
+	invalidName := "    " // only spaces
+
+	namespaceTooLong := strings.Repeat("a", MaxQualifiedNameLength+1)
+	nameTooLong := strings.Repeat("a", 300)
+
+	tests := []struct {
+		name         string
+		input        *resourcepb.ResourceKey
+		expectedCode int32
+	}{
+		{
+			name: "no error when all fields are set and valid",
+			input: &resourcepb.ResourceKey{
+				Namespace: validNamespace,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      validName,
+			},
+		},
+		{
+			name: "invalid namespace returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: invalidNamespace,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      validName,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "invalid group returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: validNamespace,
+				Group:     invalidGroup,
+				Resource:  validResource,
+				Name:      validName,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "invalid resource returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: validNamespace,
+				Group:     validGroup,
+				Resource:  invalidResource,
+				Name:      validName,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "invalid name returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: validNamespace,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      invalidName,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "valid legacy UID returns no error",
+			input: &resourcepb.ResourceKey{
+				Namespace: validNamespace,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      validLegacyUID,
+			},
+		},
+		{
+			name: "namespace too long returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: namespaceTooLong,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      validName,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name: "name too long returns error",
+			input: &resourcepb.ResourceKey{
+				Namespace: namespaceTooLong,
+				Group:     validGroup,
+				Resource:  validResource,
+				Name:      nameTooLong,
+			},
+			expectedCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := verifyRequestKey(test.input)
+			if test.expectedCode == 0 {
+				require.Nil(t, err)
+				return
+			}
+
+			require.Equal(t, test.expectedCode, err.Code)
+		})
 	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -626,6 +626,10 @@ func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*re
 	ctx, span := s.tracer.Start(ctx, "storage_server.Create")
 	defer span.End()
 
+	if r := verifyRequestKey(req.Key); r != nil {
+		return nil, fmt.Errorf("invalid request key: %s", r.Message)
+	}
+
 	rsp := &resourcepb.CreateResponse{}
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -296,6 +296,38 @@ func TestSimpleServer(t *testing.T) {
 
 		require.NoError(t, err)
 		require.NotNil(t, created)
+
+		// legacy name - also valid
+		key = &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr", // can be anything :(
+			Namespace: "default",
+			Name:      "IvIsO_YGz",
+		}
+
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, created)
+
+		// legacy name - also valid
+		key = &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr", // can be anything :(
+			Namespace: "default",
+			Name:      "_IvIsOYGz",
+		}
+
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, created)
 	})
 
 	t.Run("playlist update optimistic concurrency check", func(t *testing.T) {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -195,7 +195,7 @@ func TestSimpleServer(t *testing.T) {
 		require.Len(t, all.Items, 0) // empty
 	})
 
-	t.Run("playlist FAIL CRUD paths", func(t *testing.T) {
+	t.Run("playlist FAIL CRUD paths due to invalid key", func(t *testing.T) {
 		raw := []byte(`{
     		"apiVersion": "playlist.grafana.app/v0alpha1",
 			"kind": "Playlist",
@@ -221,14 +221,60 @@ func TestSimpleServer(t *testing.T) {
 			}
 		}`)
 
+		// invalid group
 		key := &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app###",
+			Resource:  "rrrr###", // can be anything :(
+			Namespace: "default",
+			Name:      "fdgsv37qslr0ga",
+		}
+
+		created, err := server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+		require.Error(t, err)
+		require.Nil(t, created)
+
+		// invalid resource
+		key = &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr###", // can be anything :(
+			Namespace: "default",
+			Name:      "fdgsv37qslr0ga",
+		}
+
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+		require.Error(t, err)
+		require.Nil(t, created)
+
+		// invalid namespace
+		key = &resourcepb.ResourceKey{
 			Group:     "playlist.grafana.app",
 			Resource:  "rrrr", // can be anything :(
 			Namespace: "default###",
 			Name:      "fdgsv37qslr0ga",
 		}
 
-		created, err := server.Create(ctx, &resourcepb.CreateRequest{
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+		require.Error(t, err)
+		require.Nil(t, created)
+
+		// invalid name
+		key = &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr", // can be anything :(
+			Namespace: "default",
+			Name:      "fdgsv37qslr0g###",
+		}
+
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
 			Value: raw,
 			Key:   key,
 		})

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -195,6 +195,47 @@ func TestSimpleServer(t *testing.T) {
 		require.Len(t, all.Items, 0) // empty
 	})
 
+	t.Run("playlist FAIL CRUD paths", func(t *testing.T) {
+		raw := []byte(`{
+    		"apiVersion": "playlist.grafana.app/v0alpha1",
+			"kind": "Playlist",
+			"metadata": {
+				"name": "fdgsv37#qslr0ga",
+				"uid": "xyz",
+				"namespace": "default",
+				"annotations": {
+					"grafana.app/repoName": "elsewhere",
+					"grafana.app/repoPath": "path/to/item",
+					"grafana.app/repoTimestamp": "2024-02-02T00:00:00Z"
+				}
+			},
+			"spec": {
+				"title": "hello",
+				"interval": "5m",
+				"items": [
+					{
+						"type": "dashboard_by_uid",
+						"value": "vmie2cmWz"
+					}
+				]
+			}
+		}`)
+
+		key := &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr", // can be anything :(
+			Namespace: "default###",
+			Name:      "fdgsv37qslr0ga",
+		}
+
+		created, err := server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+		require.Error(t, err)
+		require.Nil(t, created)
+	})
+
 	t.Run("playlist update optimistic concurrency check", func(t *testing.T) {
 		raw := []byte(`{
     	"apiVersion": "playlist.grafana.app/v0alpha1",

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -224,7 +224,7 @@ func TestSimpleServer(t *testing.T) {
 		// invalid group
 		key := &resourcepb.ResourceKey{
 			Group:     "playlist.grafana.app###",
-			Resource:  "rrrr###", // can be anything :(
+			Resource:  "rrrr", // can be anything :(
 			Namespace: "default",
 			Name:      "fdgsv37qslr0ga",
 		}
@@ -278,8 +278,22 @@ func TestSimpleServer(t *testing.T) {
 			Value: raw,
 			Key:   key,
 		})
-		require.Error(t, err)
-		require.Nil(t, created)
+
+		// legacy name - valid
+		key = &resourcepb.ResourceKey{
+			Group:     "playlist.grafana.app",
+			Resource:  "rrrr", // can be anything :(
+			Namespace: "default",
+			Name:      "2c7e5361-7360-4d2a-ae45-5e79bba458d6",
+		}
+
+		created, err = server.Create(ctx, &resourcepb.CreateRequest{
+			Value: raw,
+			Key:   key,
+		})
+
+		require.NoError(t, err)
+		require.NotNil(t, created)
 	})
 
 	t.Run("playlist update optimistic concurrency check", func(t *testing.T) {

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -278,6 +278,8 @@ func TestSimpleServer(t *testing.T) {
 			Value: raw,
 			Key:   key,
 		})
+		require.Error(t, err)
+		require.Nil(t, created)
 
 		// legacy name - valid
 		key = &resourcepb.ResourceKey{

--- a/pkg/storage/unified/resource/validation.go
+++ b/pkg/storage/unified/resource/validation.go
@@ -1,10 +1,14 @@
 package resource
 
 import (
+	"fmt"
 	"regexp"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
+
+const MaxQualifiedNameLength = 40
 
 var validNameCharPattern = `a-zA-Z0-9:\-\_\.`
 var validNamePattern = regexp.MustCompile(`^[` + validNameCharPattern + `]*$`).MatchString
@@ -22,5 +26,21 @@ func validateName(name string) *resourcepb.ErrorResult {
 	// In standard k8s, it must not start with a number
 	// however that would force us to update many many many existing resources
 	// so we will be slightly more lenient than standard k8s
+	return nil
+}
+
+func validateQualifiedName(value string) *resourcepb.ErrorResult {
+	if len(value) == 0 {
+		return NewBadRequestError("value is too short")
+	}
+	if len(value) > MaxQualifiedNameLength {
+		return NewBadRequestError("value is too long")
+	}
+
+	err := validation.IsQualifiedName(value)
+	if len(err) > 0 {
+		return NewBadRequestError(fmt.Sprintf("name is not a valid qualified name: %+v", err))
+	}
+
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Unistore: add validation for key attributes (name, namespace, group, resource). Validation checks for size and valid characters.

**Why do we need this feature?**

We need to be able to validate a key before storing it in the Resource Server 

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:
related to https://github.com/grafana/search-and-storage-team/issues/475

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
