### PR TITLE
Provisioning: Fix settings panic

### DIFF
--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -156,10 +156,15 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	legacyStorage := false
+	if b.storageStatus != nil {
+		legacyStorage = dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, b.storageStatus)
+	}
+
 	settings := provisioning.RepositoryViewList{
 		Items: make([]provisioning.RepositoryView, len(all)),
 		// FIXME: this shouldn't be here in provisioning but at the dual writer or something about the storage
-		LegacyStorage:            dualwrite.IsReadingLegacyDashboardsAndFolders(ctx, b.storageStatus),
+		LegacyStorage:            legacyStorage,
 		AvailableRepositoryTypes: b.repoFactory.Types(),
 	}
 


### PR DESCRIPTION
**Why do we need this feature?**

When initialized with unified storage only, the `storageStatus` will be nil. This fixes a panic that would then occur from that:


```
ERROR[09-11|11:36:21] apiserver panic'd                        logger=grafana-apiserver method=GET URI=/apis/provisioning.grafana.app/v0alpha1/namespaces/default/settings auditID=c61c8518-03f4-428b-854f-3cf0426fc913
ERROR[09-11|11:36:22] Observed a panic                         logger=grafana-apiserver panic="runtime error: invalid memory address or nil pointer dereference\ngoroutine 1260 [running]:\nk8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1.1()\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:110 +0xb0\npanic({0x10d97c3e0?, 0x116eb7f70?})\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/runtime/panic.go:783 +0x120\ngithub.com/grafana/grafana/pkg/storage/legacysql/dualwrite.IsReadingLegacyDashboardsAndFolders({0x10ef70df0, 0x14001654cb0}, {0x0, 0x0})\n\t/Users/rjimenez/workspace/grafana/pkg/storage/legacysql/dualwrite/utils.go:13 +0x28\ngithub.com/grafana/grafana/pkg/registry/apis/provisioning.(*APIBuilder).handleSettings(0x140026cc2c0, {0x10ef47880, 0x140004e14e0}, 0x14002fbb7c0)\n\t/Users/rjimenez/workspace/grafana/pkg/registry/apis/provisioning/routes.go:162 +0x11c\nnet/http.HandlerFunc.ServeHTTP(0x14002fbb680?, {0x10ef47880?, 0x140004e14e0?}, 0x14002fbb680?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/registry/apis/provisioning.(*APIBuilder).GetAPIRoutes.WithTimeoutFunc.WithTimeout.func2({0x10ef47880, 0x140004e14e0}, 0x14002fbb680)\n\t/Users/rjimenez/workspace/grafana/pkg/registry/apis/provisioning/timeout.go:14 +0x8c\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e14e0?}, 0x10cb37c10?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nnet/http.HandlerFunc.ServeHTTP(0x14002fbb540?, {0x10ef47880?, 0x140004e14e0?}, 0x102f32c78?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/gorilla/mux.(*Router).ServeHTTP(0x140011c6b40, {0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/github.com/gorilla/mux/mux.go:212 +0x18c\ngithub.com/grafana/grafana/pkg/services/apiserver/builder.(*requestHandler).ServeHTTP(0x0?, {0x10ef47880?, 0x140004e14e0?}, 0x0?)\n\t/Users/rjimenez/workspace/grafana/pkg/services/apiserver/builder/request_handler.go:85 +0x28\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.WithTracingHTTPLoggingAttributes.1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/pkg/apiserver/endpoints/filters/tracing_log.go:24 +0x1d4\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e14e0?}, 0x103e74074?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.WithRequester.3({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/pkg/apiserver/endpoints/filters/requester.go:21 +0x360\nnet/http.HandlerFunc.ServeHTTP(0x10cb57778?, {0x10ef47880?, 0x140004e14e0?}, 0x106f8d6b8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func22({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x108\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e14e0?}, 0x4?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filters.withAuthorization.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/authorization.go:84 +0x3cc\nnet/http.HandlerFunc.ServeHTTP(0x10df642c0?, {0x10ef47880?, 0x140004e14e0?}, 0x10efa2c30?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x130\nnet/http.HandlerFunc.ServeHTTP(0x11708dea0?, {0x10ef47880?, 0x140004e14e0?}, 0x0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server/filters.WithMaxInFlightLimit.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/maxinflight.go:196 +0x214\nnet/http.HandlerFunc.ServeHTTP(0x10cb57778?, {0x10ef47880?, 0x140004e14e0?}, 0x106f8d358?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func24({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x108\nnet/http.HandlerFunc.ServeHTTP(0x14001914840?, {0x10ef47880?, 0x140004e14e0?}, 0x0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithImpersonation.func4({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/impersonation.go:50 +0x134\nnet/http.HandlerFunc.ServeHTTP(0x14001440788?, {0x10ef47880?, 0x140004e14e0?}, 0x102e594e8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x130\nnet/http.HandlerFunc.ServeHTTP(0x10cb57778?, {0x10ef47880?, 0x140004e14e0?}, 0x106f8bdd8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func25({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x108\nnet/http.HandlerFunc.ServeHTTP(0x140014409b8?, {0x10ef47880?, 0x140004e14e0?}, 0x14001e4bce0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:84 +0x130\nnet/http.HandlerFunc.ServeHTTP(0x10cb57778?, {0x10ef47880?, 0x140004e14e0?}, 0x106f8b0a8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.TrackCompleted.trackCompleted.func27({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:110 +0x108\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e14e0?}, 0x10cb37c10?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filters.withAuthentication.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb400)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/authentication.go:123 +0x550\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e14e0?}, 0x10cb57778?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/endpoints/filterlatency.trackStarted.func1({0x10ef47880, 0x140004e14e0}, 0x14002fbb180)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filterlatency/filterlatency.go:94 +0x290\nnet/http.HandlerFunc.ServeHTTP(0x14002fbb040?, {0x10ef47880?, 0x140004e14e0?}, 0x14000748960?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWarningRecorder.func11({0x10ef47880, 0x140004e14e0}, 0x14002fbb040)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/warning.go:35 +0xb4\nnet/http.HandlerFunc.ServeHTTP(0x14001046740?, {0x10ef47880?, 0x140004e14e0?}, 0x102e78964?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP.func1()\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:115 +0x54\ncreated by k8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP in goroutine 1259\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:101 +0x144\n" stacktrace="goroutine 1259 [running]:\nk8s.io/apimachinery/pkg/util/runtime.logPanic({0x10ef70750, 0x1171d22e0}, {0x10d40b2c0, 0x140018b16e0})\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:132 +0x94\nk8s.io/apimachinery/pkg/util/runtime.handleCrash({0x10ef70750, 0x1171d22e0}, {0x10d40b2c0, 0x140018b16e0}, {0x1400106cb18, 0x1, 0x1400106caf8?})\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:107 +0xdc\nk8s.io/apimachinery/pkg/util/runtime.HandleCrash({0x1400106cb60, 0x1, 0x140016b0380?})\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:64 +0x164\npanic({0x10d40b2c0?, 0x140018b16e0?})\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/runtime/panic.go:783 +0x120\nk8s.io/apiserver/pkg/server/filters.(*timeoutHandler).ServeHTTP(0x1400123f2a8, {0x10ef47880, 0x140004e13a0}, 0xdf8475800?)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/timeout.go:121 +0x270\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestDeadline.withRequestDeadline.func28({0x10ef47880, 0x140004e13a0}, 0x14002fbadc0)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/request_deadline.go:100 +0x188\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef47880?, 0x140004e13a0?}, 0x10d55dee0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithWaitGroup.withWaitGroup.func29({0x10ef47880, 0x140004e13a0}, 0x14002fbadc0)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/waitgroup.go:86 +0x134\nnet/http.HandlerFunc.ServeHTTP(0x140019143f0?, {0x10ef47880?, 0x140004e13a0?}, 0x10b39df79?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithCacheControl.func14({0x10ef47880, 0x140004e13a0}, 0x14002fbadc0)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/cachecontrol.go:31 +0xa4\nnet/http.HandlerFunc.ServeHTTP(0x1175905c0?, {0x10ef47880?, 0x140004e13a0?}, 0x140004e13a0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithHTTPLogging.WithLogging.withLogging.func35({0x10ef47880, 0x140004e13a0}, 0x14002fbadc0)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/httplog/httplog.go:112 +0x70\nnet/http.HandlerFunc.ServeHTTP(0x10ef73288?, {0x10ef47880?, 0x140004e13a0?}, 0x14002fbac80?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithLatencyTrackers.func16({0x10ef50200, 0x140007487d0}, 0x14002fbac80)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/webhook_duration.go:56 +0x110\nnet/http.HandlerFunc.ServeHTTP(0x14002fbab40?, {0x10ef50200?, 0x140007487d0?}, 0x102e0d1dc?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestInfo.func18({0x10ef50200, 0x140007487d0}, 0x14002fbab40)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/requestinfo.go:39 +0xfc\nnet/http.HandlerFunc.ServeHTTP(0x14002fbaa00?, {0x10ef50200?, 0x140007487d0?}, 0xf4e6ef4b55?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithRequestReceivedTimestamp.withRequestReceivedTimestampWithClock.func32({0x10ef50200, 0x140007487d0}, 0x14002fbaa00)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/request_received_time.go:38 +0xa4\nnet/http.HandlerFunc.ServeHTTP(0x14000781808?, {0x10ef50200?, 0x140007487d0?}, 0x102e0d1dc?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithMuxAndDiscoveryComplete.func19({0x10ef50200?, 0x140007487d0?}, 0x14002fbaa00?)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/mux_discovery_complete.go:52 +0xcc\nnet/http.HandlerFunc.ServeHTTP(0x64492d7469647541?, {0x10ef50200?, 0x140007487d0?}, 0x8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithPanicRecovery.withPanicRecovery.func33({0x10ef50200, 0x140007487d0}, 0x14002fbaa00)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/filters/wrap.go:73 +0xc4\nnet/http.HandlerFunc.ServeHTTP(0x140019143f0?, {0x10ef50200?, 0x140007487d0?}, 0x14001e4f980?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.DefaultBuildHandlerChain.WithAuditInit.withAuditInit.func34({0x10ef50200, 0x140007487d0}, 0x14002fba8c0)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/endpoints/filters/audit_init.go:63 +0x108\nnet/http.HandlerFunc.ServeHTTP(0x14002fba000?, {0x10ef50200?, 0x140007487d0?}, 0x117184bc0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).withPreAuthGrafanaContextMiddleware.(*ContextHandler).Middleware.func1({0x10ef50200, 0x140007487d0}, 0x14002fba000)\n\t/Users/rjimenez/workspace/grafana/pkg/services/contexthandler/contexthandler.go:98 +0xa0\nnet/http.HandlerFunc.ServeHTTP(0x14000fc9bc0?, {0x10ef50200?, 0x140007487d0?}, 0x140016b9e00?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.withPreAuthMacaronMiddleware.EmptyMacaronMiddleware.7({0x10ef50200, 0x140007487d0}, 0x140016b9e00)\n\t/Users/rjimenez/workspace/grafana/pkg/web/macaron.go:149 +0x64\nnet/http.HandlerFunc.ServeHTTP(0x140016b9cc0?, {0x10ef50200?, 0x140007487d0?}, 0x0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.WithAcceptHeader.4({0x10ef50200, 0x140007487d0}, 0x140016b9cc0)\n\t/Users/rjimenez/workspace/grafana/pkg/apiserver/endpoints/filters/accept.go:13 +0x9c\nnet/http.HandlerFunc.ServeHTTP(0x140007db658?, {0x10ef50200?, 0x140007487d0?}, 0x1400199b740?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.WithPathRewriters.5({0x10ef50200, 0x140007487d0}, 0x140016b9cc0)\n\t/Users/rjimenez/workspace/grafana/pkg/apiserver/endpoints/filters/path_rewriter.go:29 +0xdc\nnet/http.HandlerFunc.ServeHTTP(0x140014134d0?, {0x10ef50200?, 0x140007487d0?}, 0x0?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/component-base/tracing.WithTracing.func1({0x10ef50200?, 0x140007487d0?}, 0x140016b9cc0?)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/component-base/tracing/utils.go:106 +0x188\nnet/http.HandlerFunc.ServeHTTP(0x10ef70d48?, {0x10ef50200?, 0x140007487d0?}, 0x10cb57778?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.(*middleware).serveHTTP(0x140019efb00, {0x10ef4c480, 0x140023cc940}, 0x140016b9b80, {0x10eeacac0, 0x14001352c90})\n\t/Users/rjimenez/workspace/grafana/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:180 +0xf84\ngo.opentelemetry.io/contrib/instrumentation/net/http/otelhttp.NewMiddleware.func1.1({0x10ef4c480?, 0x140023cc940?}, 0x14001440ca8?)\n\t/Users/rjimenez/workspace/grafana/vendor/go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp/handler.go:67 +0x3c\nnet/http.HandlerFunc.ServeHTTP(0x140016b9a40?, {0x10ef4c480?, 0x140023cc940?}, 0x14000fc9110?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\ngithub.com/grafana/grafana/pkg/extensions/apiserver.(*apiFactory).GetBuildHandlerChainFunc.func1.WithExtractJaegerTrace.6({0x10ef4c480, 0x140023cc940}, 0x140016b9a40)\n\t/Users/rjimenez/workspace/grafana/pkg/apiserver/endpoints/filters/jaeger_tracing.go:15 +0x7c\nnet/http.HandlerFunc.ServeHTTP(0x140010464d8?, {0x10ef4c480?, 0x140023cc940?}, 0x102f1c100?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:2322 +0x38\nk8s.io/apiserver/pkg/server.(*APIServerHandler).ServeHTTP(0x1d?, {0x10ef4c480?, 0x140023cc940?}, 0x10335a134?)\n\t/Users/rjimenez/workspace/grafana/vendor/k8s.io/apiserver/pkg/server/handler.go:188 +0x2c\nnet/http.serverHandler.ServeHTTP({0x1171d22e0?}, {0x10ef4c480?, 0x140023cc940?}, 0xa8000000a8?)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:3340 +0xb0\nnet/http.initALPNRequest.ServeHTTP({{0x10ef70d48?, 0x140019a4bd0?}, 0x140018dc008?, {0x14001847100?}}, {0x10ef4c480, 0x140023cc940}, 0x140016b9a40)\n\t/opt/homebrew/Cellar/go/1.25.0/libexec/src/net/http/server.go:4013 +0x1a8\ngolang.org/x/net/http2.(*serverConn).runHandler(0x1171d22e0?, 0x0?, 0x0?, 0x140010467b0?)\n\t/Users/rjimenez/workspace/grafana/vendor/golang.org/x/net/http2/server.go:2433 +0xdc\ncreated by golang.org/x/net/http2.(*serverConn).scheduleHandler in goroutine 1362\n\t/Users/rjimenez/workspace/grafana/vendor/golang.org/x/net/http2/server.go:2367 +0x1dc\n"
ERROR[09-11|11:36:22] apiserver panic'd                        logger=grafana-apiserver method=GET URI=/apis/provisioning.grafana.app/v0alpha1/namespaces/default/settings auditID=40584dbc-5191-45a0-8171-7bdf28cf51cd


```

**Which issue(s) does this PR fix?**:

Closes https://github.com/grafana/git-ui-sync-project/issues/546
