### PR TITLE
Chore: prevents imports from grafana packages in i18n

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -548,4 +548,24 @@ module.exports = [
       'no-barrel-files/no-barrel-files': 'error',
     },
   },
+
+  {
+    // @grafana/i18n shouldn't import from our 'library' NPM packages
+    name: 'grafana/packages-that-i18n-cant-import',
+    files: ['packages/grafana-i18n/**/*.{ts,tsx}'],
+    ignores: [],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        withBaseRestrictedImportsConfig({
+          patterns: [
+            {
+              group: ['@grafana/*'],
+              message: "'@grafana/* packages' should not be imported in @grafana/i18n",
+            },
+          ],
+        }),
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
**What is this feature?**

This pull request adds a new ESLint configuration to enforce import restrictions for the `@grafana/i18n` package. The main change ensures that `@grafana/i18n` cannot import from other `@grafana/*` library packages, helping to maintain proper dependency boundaries.
| Before | After |
|-----|-----|
|<img width="381" height="47" alt="image" src="https://github.com/user-attachments/assets/3649ebab-fc82-42c3-b13d-c81dc1c5cfcc" />|<img width="1295" height="198" alt="image" src="https://github.com/user-attachments/assets/b7a0d8a0-cec8-4e56-90aa-ba45705b5de5" />|
|<img width="748" height="48" alt="image" src="https://github.com/user-attachments/assets/5f9e3a40-4b38-4817-a68e-73374940474d" />|<img width="748" height="95" alt="image" src="https://github.com/user-attachments/assets/a6705293-1940-45f6-b126-27b89b9a1e12" />|


**Why do we need this feature?**

So we can keep i18n dependency free

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
