### PR TITLE
Devenv: expose internal faro.receiver server

### DIFF
--- a/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
+++ b/devenv/docker/blocks/self-instrumentation/docker-compose.yaml
@@ -42,6 +42,7 @@
       - --stability.level=experimental # Enable all functionality
     ports:
       - '12345:12345'
+      - '12347:12347'
     volumes:
       - ./docker/blocks/self-instrumentation/config.alloy:/etc/alloy/config.alloy
       - ../data/log:/var/log/grafana:ro # Mount Grafana logs directory


### PR DESCRIPTION
**What is this feature?**

This pull request makes a minor update to the `devenv/docker/blocks/self-instrumentation/docker-compose.yaml` file by exposing an additional port for the service.

* Added port `12347:12347` to the list of exposed ports in the Docker Compose configuration.

**Why do we need this feature?**

So it works for local Grafana 

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
