### PR TITLE
datasources: querier: deduplicate logging code

### DIFF
--- a/pkg/registry/apis/query/client/instance_provider.go
+++ b/pkg/registry/apis/query/client/instance_provider.go
@@ -21,6 +21,7 @@ type singleTenantInstanceProvider struct {
 type singleTenantInstance struct {
 	client       clientapi.QueryDataClient
 	instanceConf clientapi.InstanceConfigurationSettings
+	logger       log.Logger
 }
 
 func (t *singleTenantInstance) GetDataSourceClient(_ context.Context, _ data.DataSourceRef) (clientapi.QueryDataClient, error) {
@@ -43,10 +44,11 @@ func NewSingleTenantInstanceProvider(cfg *setting.Cfg, features featuremgmt.Feat
 	}
 }
 
-func (s *singleTenantInstanceProvider) GetInstance(_ context.Context, _ map[string]string) (clientapi.Instance, error) {
+func (s *singleTenantInstanceProvider) GetInstance(_ context.Context, logger log.Logger, _ map[string]string) (clientapi.Instance, error) {
 	return &singleTenantInstance{
 		client:       s.client,
 		instanceConf: s.instanceConf,
+		logger:       logger,
 	}, nil
 }
 
@@ -54,9 +56,8 @@ func (s *singleTenantInstance) GetSettings() clientapi.InstanceConfigurationSett
 	return s.instanceConf
 }
 
-func (s *singleTenantInstance) GetLogger(parent log.Logger) log.Logger {
-	// currently we do not add any extra info
-	return parent.New()
+func (s *singleTenantInstance) GetLogger() log.Logger {
+	return s.logger
 }
 
 func (s *singleTenantInstance) ReportMetrics() {

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -33,10 +33,10 @@ type Instance interface {
 	GetDataSourceClient(ctx context.Context, ref data.DataSourceRef) (QueryDataClient, error)
 	// fetch information on the grafana instance (e.g. feature toggles)
 	GetSettings() InstanceConfigurationSettings
-	GetLogger(parent log.Logger) log.Logger
-	ReportMetrics() // some metrics are only reported at the end
+	GetLogger() log.Logger // returns the instance's logger. this logs instance-specific data too
+	ReportMetrics()        // some metrics are only reported at the end
 }
 
 type InstanceProvider interface {
-	GetInstance(ctx context.Context, headers map[string]string) (Instance, error)
+	GetInstance(ctx context.Context, logger log.Logger, headers map[string]string) (Instance, error)
 }

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -277,7 +277,7 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	headers := ExtractKnownHeaders(httpreq.Header)
 
-	instance, err := b.instanceProvider.GetInstance(ctx, headers)
+	instance, err := b.instanceProvider.GetInstance(ctx, connectLogger, headers)
 	if err != nil {
 		connectLogger.Error("failed to get instance configuration settings", "err", err)
 		responder.Error(err)
@@ -286,7 +286,7 @@ func handleQuery(ctx context.Context, raw query.QueryDataRequest, b QueryAPIBuil
 
 	instanceConfig := instance.GetSettings()
 
-	dsQuerierLoggerWithSlug := instance.GetLogger(connectLogger)
+	dsQuerierLoggerWithSlug := instance.GetLogger()
 
 	qsDsClientBuilder := dsquerierclient.NewQsDatasourceClientBuilderWithInstance(
 		instance,

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -259,11 +259,13 @@ func (m *mockResponder) Error(err error) {
 
 type mockClient struct {
 	stubbedFrame *data.Frame
+	logger       log.Logger
 }
 
-func (m mockClient) GetInstance(ctx context.Context, headers map[string]string) (clientapi.Instance, error) {
+func (m mockClient) GetInstance(ctx context.Context, logger log.Logger, headers map[string]string) (clientapi.Instance, error) {
 	mclient := mockClient{
 		stubbedFrame: m.stubbedFrame,
+		logger:       logger,
 	}
 	return mclient, nil
 }
@@ -271,8 +273,8 @@ func (m mockClient) GetInstance(ctx context.Context, headers map[string]string) 
 func (m mockClient) ReportMetrics() {
 }
 
-func (m mockClient) GetLogger(parent log.Logger) log.Logger {
-	return parent.New()
+func (m mockClient) GetLogger() log.Logger {
+	return m.logger
 }
 
 func (m mockClient) GetDataSourceClient(ctx context.Context, ref dataapi.DataSourceRef) (clientapi.QueryDataClient, error) {


### PR DESCRIPTION
before i add more attributes to logs (`dashboard_uid` for example), i wanted to simplify our logging code