### PR TITLE
Make alerting team a sole owner of alerting tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,7 +187,7 @@
 /pkg/setting/ @grafana/grafana-backend-services-squad
 /pkg/tests/ @grafana/grafana-backend-services-squad
 /pkg/tests/apis/ @grafana/grafana-app-platform-squad
-/pkg/tests/apis/alerting @grafana/grafana-app-platform-squad @grafana/alerting-backend
+/pkg/tests/apis/alerting @grafana/alerting-backend
 /pkg/tests/apis/features @grafana/grafana-backend-services-squad
 /pkg/tests/apis/folder @grafana/grafana-search-and-storage
 /pkg/tests/apis/iam @grafana/identity-access-team


### PR DESCRIPTION
Removes platform squad from alerting tests codeowners