### PR TITLE
Table: Restore previous footer behavior of reducers applying to filtered data

### DIFF
--- a/e2e-playwright/panels-suite/table-footer.spec.ts
+++ b/e2e-playwright/panels-suite/table-footer.spec.ts
@@ -11,7 +11,7 @@ const waitForTableLoad = async (loc: Page | Locator) => {
 };
 
 test.describe('Panels test: Table - Footer', { tag: ['@panels', '@table'] }, () => {
-  test('Footer unaffected by filtering', async ({ gotoDashboardPage, selectors, page }) => {
+  test('Footer affected by filtering', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '4' }),
@@ -51,7 +51,7 @@ test.describe('Panels test: Table - Footer', { tag: ['@panels', '@table'] }, () 
       dashboardPage
         .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Footer.Value)
         .nth(minColumnIdx)
-    ).toHaveText(minReducerValue);
+    ).not.toHaveText(minReducerValue);
   });
 
   test('Footer unaffected by sorting', async ({ gotoDashboardPage, selectors, page }) => {

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -677,7 +677,7 @@ export function TableNG(props: TableNGProps) {
           ),
           renderSummaryCell: () => (
             <SummaryCell
-              rows={rows}
+              rows={sortedRows}
               footers={footers}
               field={field}
               colIdx={i}
@@ -707,10 +707,11 @@ export function TableNG(props: TableNGProps) {
       maxRowHeight,
       numFrozenColsFullyInView,
       onCellFilterAdded,
+      rows,
       rowHeight,
       rowHeightFn,
-      rows,
       setFilter,
+      sortedRows,
       showTypeIcons,
       theme,
       timeRange,


### PR DESCRIPTION
After some customer feedback and a bit of soul-searching, it makes more sense to not rip this band-aid just yet, I think.

In TableNG, we were thinking of changing the default behavior of the table footer to apply reducers to the full dataset, instead of the filtered data. But given:

- the fact that you can just unfilter the table to get the same info, but the reverse isn't true, and
- the fact that there's no way to change the mode of the the footer filtering logic at this time,

we probably should not break this for this release. This PR reverses the behavior and goes back to applying reducers over the sorted + filtered data.