### PR TITLE
CloudMigration: fix flacky test

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -176,7 +176,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusPendingProcessing), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot processing", func(t *testing.T) {
@@ -200,7 +200,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot finished", func(t *testing.T) {
@@ -224,7 +224,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot canceled", func(t *testing.T) {
@@ -248,7 +248,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusCanceled), time.Second, 10*time.Millisecond)
-		require.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		require.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot error", func(t *testing.T) {
@@ -272,7 +272,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
-		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() > 1)
+		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot unknown", func(t *testing.T) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -176,7 +176,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusPendingProcessing), time.Second, 10*time.Millisecond)
-		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
+		require.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot processing", func(t *testing.T) {
@@ -200,7 +200,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusProcessing), time.Second, 10*time.Millisecond)
-		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
+		require.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot finished", func(t *testing.T) {
@@ -224,7 +224,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusFinished), time.Second, 10*time.Millisecond)
-		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
+		require.True(t, gmsClientFake.GetSnapshotStatusCallCount() >= 1)
 	})
 
 	t.Run("test case: gms snapshot canceled", func(t *testing.T) {

--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -272,7 +272,7 @@ func Test_GetSnapshotStatusFromGMS(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Eventually(t, checkStatusSync(ctx, s, snapshotUID, sessionUID, cloudmigration.SnapshotStatusError), time.Second, 10*time.Millisecond)
-		assert.Equal(t, 1, gmsClientFake.GetSnapshotStatusCallCount())
+		assert.True(t, gmsClientFake.GetSnapshotStatusCallCount() > 1)
 	})
 
 	t.Run("test case: gms snapshot unknown", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes flaky tests in the cloud migration service by replacing exact call count assertions with minimum call count assertions. The tests were failing intermittently because they expected exactly one call to the GetSnapshotStatus method, but the asynchronous nature of the status sync process could result in multiple calls.

