### PR TITLE
Azure: Fix possible nil pointer dereference

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -128,7 +128,11 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 		req.URL.RawQuery = queryParams.Encode()
 		resp, err := cli.Do(req)
 		if err != nil {
-			return nil, writeErrorResponse(rw, resp.StatusCode, fmt.Sprintf("failed to fetch metadata: %s", err))
+			statusCode := http.StatusInternalServerError
+			if resp != nil {
+				statusCode = resp.StatusCode
+			}
+			return nil, writeErrorResponse(rw, statusCode, fmt.Sprintf("failed to fetch metadata: %s", err))
 		}
 
 		defer func() {

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -132,7 +132,7 @@ func (e *AzureLogAnalyticsDatasource) ResourceRequest(rw http.ResponseWriter, re
 			if resp != nil {
 				statusCode = resp.StatusCode
 			}
-			return nil, writeErrorResponse(rw, statusCode, fmt.Sprintf("failed to fetch metadata: %s", err))
+			return nil, writeErrorResponse(rw, statusCode, fmt.Sprintf("failed to fetch metadata: %v", err))
 		}
 
 		defer func() {


### PR DESCRIPTION
I've noticed some `nil` pointer dereferences in E2E tests (e.g. [here](https://github.com/grafana/grafana/actions/runs/17687245447/job/50274998395)) which I think is possible due to response being `nil`.

This check should prevent that from being hit.