### PR TITLE
AutoGridItem: Reset repeatedPanels when disabling repeats

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -141,6 +141,10 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
   public setRepeatByVariable(variableName: string | undefined) {
     const stateUpdate: Partial<AutoGridItemState> = { variableName };
 
+    if (!variableName) {
+      stateUpdate.repeatedPanels = undefined;
+    }
+
     if (this.state.body.state.$variables) {
       this.state.body.setState({ $variables: undefined });
     }

--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -234,6 +234,10 @@ export class DashboardGridItem
   public setRepeatByVariable(variableName: string | undefined) {
     const stateUpdate: Partial<DashboardGridItemState> = { variableName };
 
+    if (!variableName) {
+      stateUpdate.repeatedPanels = undefined;
+    }
+
     if (variableName && !this.state.repeatDirection) {
       stateUpdate.repeatDirection = 'h';
     }


### PR DESCRIPTION
Issue: auto grid does not remove repeated panels when disabling repeats. 

Resetting `repeatedPanels` if `variableName` is empty for custom and auto grids.