### PR TITLE
Chore: Add separate "open keyboard shortcuts" event 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -638,6 +638,7 @@
 /packages/grafana-runtime/src/components/PluginPage.tsx @grafana/grafana-search-navigate-organise
 /packages/grafana-runtime/src/components/QueryEditorWithMigration* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /packages/grafana-runtime/src/config.ts @grafana/grafana-frontend-platform
+/packages/grafana-runtime/src/events.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/ @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/services/pluginExtensions @grafana/plugins-platform-frontend
 /packages/grafana-runtime/src/services/CorrelationsService.ts @grafana/datapro

--- a/packages/grafana-runtime/src/events.ts
+++ b/packages/grafana-runtime/src/events.ts
@@ -1,0 +1,6 @@
+import { BusEventBase } from '@grafana/data';
+
+/** Publish this event to open keyboard shortcuts modal */
+export class OpenKeyboardShortcutsModalEvent extends BusEventBase {
+  static type = 'open-keyboard-shortcuts-modal';
+}

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -6,6 +6,7 @@
 export * from './services';
 export * from './config';
 export * from './analytics/types';
+export * from './events';
 export { loadPluginCss, type PluginCssOptions, setPluginImportUtils, getPluginImportUtils } from './utils/plugin';
 export { reportMetaAnalytics, reportInteraction, reportPageview, reportExperimentView } from './analytics/utils';
 export { featureEnabled } from './utils/licensing';

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -2,14 +2,12 @@ import { useEffect } from 'react';
 
 import { NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { config, reportInteraction } from '@grafana/runtime';
+import { config, OpenKeyboardShortcutsModalEvent, reportInteraction } from '@grafana/runtime';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 
-import { ShowModalReactEvent } from '../../../../types/events';
 import appEvents from '../../../app_events';
 import { getFooterLinks } from '../../Footer/Footer';
-import { HelpModal } from '../../help/HelpModal';
 
 import { DOCK_MENU_BUTTON_ID, MEGA_MENU_HEADER_TOGGLE_ID } from './MegaMenuHeader';
 
@@ -17,9 +15,6 @@ export const enrichHelpItem = (helpItem: NavModelItem) => {
   let menuItems = helpItem.children || [];
 
   if (helpItem.id === 'help') {
-    const onOpenShortcuts = () => {
-      appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
-    };
     helpItem.children = [
       ...menuItems,
       ...getFooterLinks(),
@@ -28,7 +23,7 @@ export const enrichHelpItem = (helpItem: NavModelItem) => {
         id: 'keyboard-shortcuts',
         text: t('nav.help/keyboard-shortcuts', 'Keyboard shortcuts'),
         icon: 'keyboard',
-        onClick: onOpenShortcuts,
+        onClick: () => appEvents.publish(new OpenKeyboardShortcutsModalEvent()),
       },
     ];
   }

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.test.tsx
@@ -1,0 +1,47 @@
+import { KBarProvider } from 'kbar';
+import { render, screen } from 'test/test-utils';
+
+import { setAppEvents } from '@grafana/runtime';
+import { ModalRoot } from '@grafana/ui';
+import appEvents from 'app/core/app_events';
+
+import { SingleTopBar } from './SingleTopBar';
+
+describe('SingleTopBar', () => {
+  beforeEach(() => {
+    setAppEvents(appEvents);
+  });
+
+  it('renders help menu and allows opening keyboard shortcuts modal', async () => {
+    const { user } = render(
+      <KBarProvider>
+        <SingleTopBar
+          onToggleKioskMode={() => {}}
+          onToggleMegaMenu={() => {}}
+          showToolbarLevel={false}
+          sectionNav={{
+            text: 'Section',
+          }}
+          pageNav={{
+            text: 'Page',
+          }}
+        />
+        <ModalRoot />
+      </KBarProvider>,
+      {
+        preloadedState: {
+          navIndex: {
+            help: {
+              text: 'Help',
+              id: 'help',
+            },
+          },
+        },
+      }
+    );
+    expect(screen.getByRole('button', { name: /Open menu/i })).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: /help/i }));
+    await user.click(await screen.findByText(/keyboard shortcuts/i));
+    expect(await screen.findByRole('dialog', { name: /shortcuts/i })).toBeInTheDocument();
+  });
+});

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -5,12 +5,12 @@ import { memo } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { OpenKeyboardShortcutsModalEvent, ScopesContextValue } from '@grafana/runtime';
+import { getAppEvents, OpenKeyboardShortcutsModalEvent, ScopesContextValue } from '@grafana/runtime';
 import { Dropdown, Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
 import { useGrafana } from 'app/core/context/GrafanaContext';
-import { appEvents, contextSrv } from 'app/core/core';
+import { contextSrv } from 'app/core/core';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { ShowModalReactEvent } from 'app/types/events';
@@ -67,10 +67,12 @@ export const SingleTopBar = memo(function SingleTopBar({
   const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav, homeNav);
   const unifiedHistoryEnabled = config.featureToggles.unifiedHistory;
   const isSmallScreen = !useMediaQueryMinWidth('sm');
+  const appEvents = getAppEvents();
 
-  // Subscribe to separate shortcuts events so that plugins and other places can
+  // Subscribe to separate shortcuts event so that plugins and other places can
   // open the keyboard shortcuts modal, without having to have access to the necessary components
-  appEvents.subscribe(OpenKeyboardShortcutsModalEvent, () => {
+  // This is using optional chaining to avoid lots of tests breaking
+  appEvents?.subscribe(OpenKeyboardShortcutsModalEvent, () => {
     appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
   });
 

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -5,12 +5,12 @@ import { memo } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { getAppEvents, OpenKeyboardShortcutsModalEvent, ScopesContextValue } from '@grafana/runtime';
+import { OpenKeyboardShortcutsModalEvent, ScopesContextValue } from '@grafana/runtime';
 import { Dropdown, Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
 import { useGrafana } from 'app/core/context/GrafanaContext';
-import { contextSrv } from 'app/core/core';
+import { appEvents, contextSrv } from 'app/core/core';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { ShowModalReactEvent } from 'app/types/events';
@@ -68,7 +68,6 @@ export const SingleTopBar = memo(function SingleTopBar({
   const unifiedHistoryEnabled = config.featureToggles.unifiedHistory;
   const isSmallScreen = !useMediaQueryMinWidth('sm');
 
-  const appEvents = getAppEvents();
   // Subscribe to separate shortcuts events so that plugins and other places can
   // open the keyboard shortcuts modal, without having to have access to the necessary components
   appEvents.subscribe(OpenKeyboardShortcutsModalEvent, () => {

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -5,7 +5,7 @@ import { memo } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { ScopesContextValue } from '@grafana/runtime';
+import { getAppEvents, OpenKeyboardShortcutsModalEvent, ScopesContextValue } from '@grafana/runtime';
 import { Dropdown, Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
@@ -13,11 +13,13 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { contextSrv } from 'app/core/core';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
+import { ShowModalReactEvent } from 'app/types/events';
 import { useSelector } from 'app/types/store';
 
 import { Branding } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
+import { HelpModal } from '../../help/HelpModal';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
 import { HistoryContainer } from '../History/HistoryContainer';
 import { enrichHelpItem } from '../MegaMenu/utils';
@@ -65,6 +67,13 @@ export const SingleTopBar = memo(function SingleTopBar({
   const breadcrumbs = buildBreadcrumbs(sectionNav, pageNav, homeNav);
   const unifiedHistoryEnabled = config.featureToggles.unifiedHistory;
   const isSmallScreen = !useMediaQueryMinWidth('sm');
+
+  const appEvents = getAppEvents();
+  // Subscribe to separate shortcuts events so that plugins and other places can
+  // open the keyboard shortcuts modal, without having to have access to the necessary components
+  appEvents.subscribe(OpenKeyboardShortcutsModalEvent, () => {
+    appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
+  });
 
   return (
     <>

--- a/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
@@ -2,8 +2,11 @@ import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
+import { getAppEvents, OpenKeyboardShortcutsModalEvent } from '@grafana/runtime';
 import { Menu, MenuItem, useStyles2 } from '@grafana/ui';
+import { ShowModalReactEvent } from 'app/types/events';
 
+import { HelpModal } from '../../help/HelpModal';
 import { enrichWithInteractionTracking } from '../MegaMenu/utils';
 
 export interface TopNavBarMenuProps {
@@ -14,6 +17,12 @@ export interface TopNavBarMenuProps {
 export function TopNavBarMenu({ node: nodePlain, children }: TopNavBarMenuProps) {
   const styles = useStyles2(getStyles);
   const node = enrichWithInteractionTracking(cloneDeep(nodePlain), false);
+  const appEvents = getAppEvents();
+  // Subscribe to separate shortcuts events so that plugins and other places can
+  // open the keyboard shortcuts modal, without having to have access to the necessary components
+  appEvents.subscribe(OpenKeyboardShortcutsModalEvent, () => {
+    appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
+  });
 
   if (!node) {
     return null;

--- a/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopNavBarMenu.tsx
@@ -2,11 +2,8 @@ import { css } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
-import { getAppEvents, OpenKeyboardShortcutsModalEvent } from '@grafana/runtime';
 import { Menu, MenuItem, useStyles2 } from '@grafana/ui';
-import { ShowModalReactEvent } from 'app/types/events';
 
-import { HelpModal } from '../../help/HelpModal';
 import { enrichWithInteractionTracking } from '../MegaMenu/utils';
 
 export interface TopNavBarMenuProps {
@@ -17,12 +14,6 @@ export interface TopNavBarMenuProps {
 export function TopNavBarMenu({ node: nodePlain, children }: TopNavBarMenuProps) {
   const styles = useStyles2(getStyles);
   const node = enrichWithInteractionTracking(cloneDeep(nodePlain), false);
-  const appEvents = getAppEvents();
-  // Subscribe to separate shortcuts events so that plugins and other places can
-  // open the keyboard shortcuts modal, without having to have access to the necessary components
-  appEvents.subscribe(OpenKeyboardShortcutsModalEvent, () => {
-    appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
-  });
 
   if (!node) {
     return null;

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,5 +1,5 @@
 import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent, locationUtil } from '@grafana/data';
-import { LocationService } from '@grafana/runtime';
+import { LocationService, OpenKeyboardShortcutsModalEvent, config } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
@@ -19,7 +19,6 @@ import {
   PasteTimeEvent,
 } from '../../types/events';
 import { AppChromeService } from '../components/AppChrome/AppChromeService';
-import { HelpModal } from '../components/help/HelpModal';
 import { contextSrv } from '../core';
 import { RouteDescriptor } from '../navigation/types';
 
@@ -117,7 +116,7 @@ export class KeybindingSrv {
   }
 
   private showHelpModal() {
-    appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
+    appEvents.publish(new OpenKeyboardShortcutsModalEvent());
   }
 
   private exit() {

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,5 +1,5 @@
 import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent, locationUtil } from '@grafana/data';
-import { LocationService, OpenKeyboardShortcutsModalEvent, config } from '@grafana/runtime';
+import { LocationService, OpenKeyboardShortcutsModalEvent } from '@grafana/runtime';
 import appEvents from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';


### PR DESCRIPTION
**What is this feature?**
Adds a separate event that can be emitted elsewhere, to allow for opening the keyboard shortcuts modal. 

**Why do we need this feature?**
This means that a plugin can open the modal without having to import and use the modal. They can emit the `OpenKeyboardShortcutsModalEvent` event instead, and core is listening for this event and then handles the modal logic

**Who is this feature for?**
Pathfinder/plugins, see https://github.com/grafana/grafana/pull/110592
