### PR TITLE
Logs Panel: Add unique labels support for dashboards

### DIFF
--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -165,6 +165,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     button: css({
       height: theme.spacing(2.75),
-    })
+    }),
   };
 };

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -68,6 +68,7 @@ export const LogLabels = memo(
             size="sm"
             fill="outline"
             variant="secondary"
+            className={styles.button}
             aria-label={t('logs.log-labels.expand', 'Expand labels')}
             onClick={() => {
               setDisplayAll(true);
@@ -83,6 +84,7 @@ export const LogLabels = memo(
             size="sm"
             fill="outline"
             variant="secondary"
+            className={styles.button}
             aria-label={t('logs.log-labels.collapse', 'Collapse labels')}
             onClick={() => {
               setDisplayAll(false);
@@ -161,5 +163,8 @@ const getStyles = (theme: GrafanaTheme2) => {
       textOverflow: 'ellipsis',
       overflow: 'hidden',
     }),
+    button: css({
+      height: theme.spacing(2.75),
+    })
   };
 };

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -137,7 +137,7 @@ LogLabel.displayName = 'LogLabel';
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     logsLabels: css({
-      display: 'flex',
+      display: 'inline-flex',
       flexWrap: 'wrap',
       fontSize: theme.typography.size.xs,
       alignItems: 'center',

--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -613,4 +613,34 @@ describe('getGridTemplateColumns', () => {
       )
     ).toBe('23px 4px 4px 20px');
   });
+
+  test('Gets the template columns with unique labels', () => {
+    expect(
+      getGridTemplateColumns(
+        [
+          {
+            field: 'timestamp',
+            width: 23,
+          },
+          {
+            field: 'level',
+            width: 4,
+          },
+          {
+            field: 'unique-labels',
+            width: 0,
+          },
+          {
+            field: 'field',
+            width: 4,
+          },
+          {
+            field: LOG_LINE_BODY_FIELD_NAME,
+            width: 20,
+          },
+        ],
+        ['field']
+      )
+    ).toBe('23px 4px max-content 4px 20px');
+  });
 });

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -163,7 +163,7 @@ const LogLineComponent = memo(
         if (frameId) {
           cancelAnimationFrame(frameId);
         }
-      }
+      };
     }, [handleLogLineResize]);
 
     useEffect(() => {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -148,6 +148,7 @@ const LogLineComponent = memo(
     });
 
     useLayoutEffect(() => {
+      handleLogLineResize();
     }, [detailsMode, handleLogLineResize]);
 
     useEffect(() => {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -18,6 +18,7 @@ import { t } from '@grafana/i18n';
 import { Button, Icon, Tooltip } from '@grafana/ui';
 
 import { LOG_LINE_BODY_FIELD_NAME } from '../LogDetailsBody';
+import { LogLabels } from '../LogLabels';
 import { LogMessageAnsi } from '../LogMessageAnsi';
 
 import { HighlightedLogRenderer } from './HighlightedLogRenderer';
@@ -33,7 +34,6 @@ import {
   LogLineVirtualization,
   DEFAULT_LINE_HEIGHT,
 } from './virtualization';
-import { LogLabels } from '../LogLabels';
 
 export interface Props {
   displayedFields: string[];

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -149,11 +149,21 @@ const LogLineComponent = memo(
       if (!logLineRef.current) {
         return;
       }
-      const observer = new ResizeObserver(() => {
-        handleLogLineResize();
-      });
+      let frameId: number;
+      const handleResize = () => {
+        if (frameId) {
+          cancelAnimationFrame(frameId);
+        }
+        frameId = requestAnimationFrame(() => handleLogLineResize());
+      };
+      const observer = new ResizeObserver(handleResize);
       observer.observe(logLineRef.current);
-      return () => observer.disconnect();
+      return () => {
+        observer.disconnect();
+        if (frameId) {
+          cancelAnimationFrame(frameId);
+        }
+      }
     }, [handleLogLineResize]);
 
     useEffect(() => {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -277,6 +277,12 @@ interface LogProps {
 
 const Log = memo(
   ({ displayedFields, log, showTime, showUniqueLabels, styles, timestampResolution, wrapLogMessage }: LogProps) => {
+    const handleLabelsToggle = useCallback(
+      (expanded: boolean) => {
+        log.uniqueLabelsExpanded = expanded;
+      },
+      [log]
+    );
     return (
       <>
         {showTime && (
@@ -292,7 +298,13 @@ const Log = memo(
         )}
         {showUniqueLabels && log.uniqueLabels && (
           <span className="field">
-            <LogLabels labels={log.uniqueLabels} addTooltip={true} displayMax={5} />
+            <LogLabels
+              addTooltip={true}
+              displayAll={log.uniqueLabelsExpanded}
+              displayMax={5}
+              labels={log.uniqueLabels}
+              onDisplayMaxToggle={handleLabelsToggle}
+            />
           </span>
         )}
         {displayedFields.length > 0 ? (

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -142,14 +142,19 @@ const LogLineComponent = memo(
     }, [height, index, log.collapsed, log.uid, onOverflow, virtualization]);
 
     useLayoutEffect(() => {
-      if (wrapLogMessage) {
-        handleLogLineResize();
-      }
-    });
+      handleLogLineResize();
+    }, [handleLogLineResize, detailsMode]);
 
     useLayoutEffect(() => {
-      handleLogLineResize();
-    }, [detailsMode, handleLogLineResize]);
+      if (!logLineRef.current) {
+        return;
+      }
+      const observer = new ResizeObserver(() => {
+        handleLogLineResize();
+      });
+      observer.observe(logLineRef.current);
+      return () => observer.disconnect();
+    }, [handleLogLineResize]);
 
     useEffect(() => {
       if (!wrapLogMessage) {

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -33,6 +33,7 @@ import {
   LogLineVirtualization,
   DEFAULT_LINE_HEIGHT,
 } from './virtualization';
+import { LogLabels } from '../LogLabels';
 
 export interface Props {
   displayedFields: string[];
@@ -118,6 +119,7 @@ const LogLineComponent = memo(
       fontSize,
       hasLogsWithErrors,
       hasSampledLogs,
+      showUniqueLabels,
       timestampResolution,
       onLogLineHover,
     } = useLogListContext();
@@ -280,6 +282,7 @@ const LogLineComponent = memo(
             logs={logs}
             log={log}
             onResize={handleLogLineResize}
+            timeRange={timeRange}
             timeZone={timeZone}
           />
         )}

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -451,7 +451,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
 
 export function getGridTemplateColumns(dimensions: LogFieldDimension[], displayedFields: string[]) {
   const columns = dimensions
-    .map((dimension) => (dimension.width > 0 ? `${dimension.width}px` : 'fit-content(50%)'))
+    .map((dimension) => (dimension.width > 0 ? `${dimension.width}px` : 'max-content'))
     .join(' ');
   const logLineWidth = displayedFields.length > 0 ? '' : ' 1fr';
   return `${columns}${logLineWidth}`;

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -64,7 +64,6 @@ const setup = (
     containerElement: document.createElement('div'),
     focusLogLine: jest.fn(),
     logs,
-    onResize: jest.fn(),
     timeRange: getDefaultTimeRange(),
     timeZone: 'browser',
     showControls: true,
@@ -613,7 +612,6 @@ describe('LogLineDetails', () => {
         timeRange: getDefaultTimeRange(),
         timeZone: 'browser',
         showControls: true,
-        onResize: jest.fn(),
       };
 
       const contextData: LogListContextData = {

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -19,14 +19,13 @@ export interface Props {
   logs: LogListModel[];
   timeRange: TimeRange;
   timeZone: string;
-  onResize(): void;
   showControls: boolean;
 }
 
 export type LogLineDetailsMode = 'inline' | 'sidebar';
 
 export const LogLineDetails = memo(
-  ({ containerElement, focusLogLine, logs, timeRange, timeZone, onResize, showControls }: Props) => {
+  ({ containerElement, focusLogLine, logs, timeRange, timeZone, showControls }: Props) => {
     const { detailsWidth, noInteractions, setDetailsWidth } = useLogListContext();
     const styles = useStyles2(getStyles, 'sidebar', showControls);
     const dragStyles = useStyles2(getDragStyles);
@@ -36,8 +35,7 @@ export const LogLineDetails = memo(
       if (containerRef.current) {
         setDetailsWidth(containerRef.current.clientWidth);
       }
-      onResize();
-    }, [onResize, setDetailsWidth]);
+    }, [setDetailsWidth]);
 
     const reportResize = useCallback(() => {
       if (containerRef.current && !noInteractions) {
@@ -144,12 +142,11 @@ LogLineDetailsTabs.displayName = 'LogLineDetailsTabs';
 export interface InlineLogLineDetailsProps {
   log: LogListModel;
   logs: LogListModel[];
-  onResize(): void;
   timeRange: TimeRange;
   timeZone: string;
 }
 
-export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, timeZone }: InlineLogLineDetailsProps) => {
+export const InlineLogLineDetails = memo(({ logs, log, timeRange, timeZone }: InlineLogLineDetailsProps) => {
   const { app, detailsWidth, noInteractions } = useLogListContext();
   const styles = useStyles2(getStyles, 'inline');
   const scrollRef = useRef<HTMLDivElement | null>(null);
@@ -162,14 +159,6 @@ export const InlineLogLineDetails = memo(({ logs, log, onResize, timeRange, time
       });
     }
   }, [app, noInteractions]);
-
-  useEffect(() => {
-    function handleResize() {
-      onResize();
-    }
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
-  }, [onResize]);
 
   const saveScroll = useCallback(() => {
     saveDetailsScrollPosition(log, scrollRef.current?.scrollTop ?? 0);

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -149,7 +149,7 @@ export const LogList = ({
   setDisplayedFields,
   showControls,
   showTime,
-  showUniqueLabels = true,
+  showUniqueLabels,
   sortOrder,
   syntaxHighlighting = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.syntaxHighlighting`, true) : true,
   timeRange,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -405,10 +405,6 @@ const LogListComponent = ({
     [handleTextSelection, toggleDetails]
   );
 
-  const handleLogDetailsResize = useCallback(() => {
-    debouncedResetAfterIndex(0);
-  }, [debouncedResetAfterIndex]);
-
   const focusLogLine = useCallback(
     (log: LogListModel) => {
       const index = filteredLogs.findIndex((filteredLog) => filteredLog.uid === log.uid);
@@ -434,7 +430,6 @@ const LogListComponent = ({
           logs={filteredLogs}
           timeRange={timeRange}
           timeZone={timeZone}
-          onResize={handleLogDetailsResize}
           showControls={showControls}
         />
       )}

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -149,7 +149,7 @@ export const LogList = ({
   setDisplayedFields,
   showControls,
   showTime,
-  showUniqueLabels,
+  showUniqueLabels = true,
   sortOrder,
   syntaxHighlighting = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.syntaxHighlighting`, true) : true,
   timeRange,

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -79,6 +79,7 @@ export interface Props {
   setDisplayedFields?: (displayedFields: string[]) => void;
   showControls: boolean;
   showTime: boolean;
+  showUniqueLabels?: boolean;
   sortOrder: LogsSortOrder;
   timeRange: TimeRange;
   timestampResolution?: LogLineTimestampResolution;
@@ -148,6 +149,7 @@ export const LogList = ({
   setDisplayedFields,
   showControls,
   showTime,
+  showUniqueLabels,
   sortOrder,
   syntaxHighlighting = logOptionsStorageKey ? store.getBool(`${logOptionsStorageKey}.syntaxHighlighting`, true) : true,
   timeRange,
@@ -192,6 +194,7 @@ export const LogList = ({
       setDisplayedFields={setDisplayedFields}
       showControls={showControls}
       showTime={showTime}
+      showUniqueLabels={showUniqueLabels}
       sortOrder={sortOrder}
       syntaxHighlighting={syntaxHighlighting}
       timestampResolution={timestampResolution}
@@ -247,6 +250,7 @@ const LogListComponent = ({
     prettifyJSON,
     showDetails,
     showTime,
+    showUniqueLabels,
     sortOrder,
     timestampResolution,
     toggleDetails,
@@ -264,8 +268,13 @@ const LogListComponent = ({
     () =>
       wrapLogMessage
         ? []
-        : virtualization.calculateFieldDimensions(processedLogs, displayedFields, timestampResolution),
-    [displayedFields, processedLogs, timestampResolution, virtualization, wrapLogMessage]
+        : virtualization.calculateFieldDimensions(
+            processedLogs,
+            displayedFields,
+            timestampResolution,
+            showUniqueLabels
+          ),
+    [displayedFields, processedLogs, showUniqueLabels, timestampResolution, virtualization, wrapLogMessage]
   );
   const styles = useStyles2(getStyles, dimensions, displayedFields, { showTime });
   const widthContainer = wrapperRef.current ?? containerElement;

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -334,9 +334,7 @@ export const LogListContextProvider = ({
 
   // Sync details mode
   useEffect(() => {
-    if (detailsModeProp) {
-      setDetailsMode(detailsModeProp);
-    }
+    setDetailsMode(detailsModeProp);
   }, [detailsModeProp]);
 
   // Sync font size

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -334,7 +334,9 @@ export const LogListContextProvider = ({
 
   // Sync details mode
   useEffect(() => {
-    setDetailsMode(detailsModeProp);
+    if (detailsModeProp) {
+      setDetailsMode(detailsModeProp);
+    }
   }, [detailsModeProp]);
 
   // Sync font size

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -53,6 +53,7 @@ export class LogListModel implements LogRowModel {
   timeUtc: string;
   uid: string;
   uniqueLabels: Labels | undefined;
+  uniqueLabelsExpanded = false;
 
   private _body: string | undefined = undefined;
   private _currentSearch: string | undefined = undefined;

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -326,40 +326,6 @@ export interface LogFieldDimension {
   width: number;
 }
 
-export function hasUnderOrOverflow(
-  virtualization: LogLineVirtualization,
-  element: HTMLDivElement,
-  calculatedHeight?: number,
-  collapsed?: boolean
-): number | null {
-  if (collapsed !== undefined && calculatedHeight) {
-    calculatedHeight -= virtualization.getLineHeight();
-  }
-  const inlineDetails = element.parentElement
-    ? Array.from(element.parentElement.children).filter((element) =>
-        element.classList.contains('log-line-inline-details')
-      )
-    : undefined;
-  const detailsHeight = inlineDetails?.length ? inlineDetails[0].clientHeight : 0;
-
-  // Line overflows container
-  let measuredHeight = element.scrollHeight + detailsHeight;
-  const height = calculatedHeight ?? element.clientHeight;
-  if (measuredHeight > height) {
-    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
-  }
-
-  // Line is smaller than container
-  const child = element.children[1];
-  measuredHeight = child.clientHeight + detailsHeight;
-  if (child instanceof HTMLDivElement && measuredHeight < height) {
-    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
-  }
-
-  // No overflow or undermeasurement
-  return null;
-}
-
 const logLineMenuIconWidth = 24;
 const scrollBarWidth = getScrollbarWidth();
 

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -182,7 +182,8 @@ export class LogLineVirtualization {
   calculateFieldDimensions = (
     logs: LogListModel[],
     displayedFields: string[] = [],
-    timestampResolution: LogLineTimestampResolution
+    timestampResolution: LogLineTimestampResolution,
+    showUniqueLabels?: boolean
   ) => {
     if (!logs.length) {
       return [];
@@ -214,6 +215,12 @@ export class LogLineVirtualization {
         width: levelWidth,
       },
     ];
+    if (showUniqueLabels) {
+      dimensions.push({
+        field: 'unique-labels',
+        width: 0,
+      });
+    }
     for (const field in fieldWidths) {
       dimensions.push({
         field,

--- a/public/app/features/logs/components/panel/virtualization.ts
+++ b/public/app/features/logs/components/panel/virtualization.ts
@@ -326,6 +326,40 @@ export interface LogFieldDimension {
   width: number;
 }
 
+export function getLogLineDOMHeight(
+  virtualization: LogLineVirtualization,
+  element: HTMLDivElement,
+  calculatedHeight?: number,
+  collapsed?: boolean
+): number | null {
+  if (collapsed !== undefined && calculatedHeight) {
+    calculatedHeight -= virtualization.getLineHeight();
+  }
+  const inlineDetails = element.parentElement
+    ? Array.from(element.parentElement.children).filter((element) =>
+        element.classList.contains('log-line-inline-details')
+      )
+    : undefined;
+  const detailsHeight = inlineDetails?.length ? inlineDetails[0].clientHeight : 0;
+
+  // Line overflows container
+  let measuredHeight = element.scrollHeight + detailsHeight;
+  const height = calculatedHeight ?? element.clientHeight;
+  if (measuredHeight > height) {
+    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
+  }
+
+  // Line is smaller than container
+  const child = element.children[1];
+  measuredHeight = child.clientHeight + detailsHeight;
+  if (child instanceof HTMLDivElement && measuredHeight < height) {
+    return collapsed !== undefined ? measuredHeight + virtualization.getLineHeight() : measuredHeight;
+  }
+
+  // No overflow or undermeasurement
+  return null;
+}
+
 const logLineMenuIconWidth = 24;
 const scrollBarWidth = getScrollbarWidth();
 

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -610,6 +610,7 @@ export const LogsPanel = ({
               setDisplayedFields={setDisplayedFieldsFn}
               showControls={Boolean(showControls)}
               showTime={showTime}
+              showUniqueLabels={showLabels}
               sortOrder={sortOrder}
               logOptionsStorageKey={storageKey}
               syntaxHighlighting={syntaxHighlighting}

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -22,7 +22,6 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
         name: t('logs.name-unique-labels', 'Unique labels'),
         category,
         description: '',
-        defaultValue: false,
       });
 
     if (!config.featureToggles.newLogsPanel) {

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -9,30 +9,30 @@ import { LogsPanelSuggestionsSupplier } from './suggestions';
 export const plugin = new PanelPlugin<Options>(LogsPanel)
   .setPanelOptions((builder, context) => {
     const category = [t('logs.category-logs', 'Logs')];
-    builder.addBooleanSwitch({
-      path: 'showTime',
-      name: t('logs.name-time', 'Show timestamps'),
-      category,
-      description: '',
-      defaultValue: false,
-    });
+    builder
+      .addBooleanSwitch({
+        path: 'showTime',
+        name: t('logs.name-time', 'Show timestamps'),
+        category,
+        description: '',
+        defaultValue: false,
+      })
+      .addBooleanSwitch({
+        path: 'showLabels',
+        name: t('logs.name-unique-labels', 'Unique labels'),
+        category,
+        description: '',
+        defaultValue: false,
+      });
 
     if (!config.featureToggles.newLogsPanel) {
-      builder
-        .addBooleanSwitch({
-          path: 'showLabels',
-          name: t('logs.name-unique-labels', 'Unique labels'),
-          category,
-          description: '',
-          defaultValue: false,
-        })
-        .addBooleanSwitch({
-          path: 'showCommonLabels',
-          name: t('logs.name-common-labels', 'Common labels'),
-          category,
-          description: '',
-          defaultValue: false,
-        });
+      builder.addBooleanSwitch({
+        path: 'showCommonLabels',
+        name: t('logs.name-common-labels', 'Common labels'),
+        category,
+        description: '',
+        defaultValue: false,
+      });
     } else if (context.options?.showTime) {
       builder.addRadio({
         path: 'timestampResolution',


### PR DESCRIPTION
Part of #99075

Changes in this PR:
- Updates the method to detect and report log line overflow (estimated size !== real size) 
- Removes debounces to improve jittering when resizing log-related components or the browser window.

### How to test

#### Unique labels

In a dashboard, edit a log panel, enable unique labels

Expectation: the panel should show up to 5 unique labels, and a button to expand if there are more. There should not be visual errors in the rendered logs.

#### Overflow and debounce changes

In a dashboard/Drilldown Logs/Explore, resizing the browser window, log details, etc, should properly re-render the logs with less jittering and no extra/missing space.