### PR TITLE
Prometheus: Improve indication of labels loading when using metrics browser.

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/LabelSelector.tsx
@@ -2,17 +2,18 @@ import { useMemo, useState } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { BrowserLabel as PromLabel, Input, Label, useStyles2 } from '@grafana/ui';
+import { BrowserLabel as PromLabel, Input, Label, useStyles2, Spinner } from '@grafana/ui';
 
 import { METRIC_LABEL } from '../../constants';
 
 import { useMetricsBrowser } from './MetricsBrowserContext';
-import { getStylesLabelSelector } from './styles';
+import { getStylesLabelSelector, getStylesMetricsBrowser } from './styles';
 
 export function LabelSelector() {
   const styles = useStyles2(getStylesLabelSelector);
+  const sharedStyles = useStyles2(getStylesMetricsBrowser);
   const [labelSearchTerm, setLabelSearchTerm] = useState('');
-  const { labelKeys, selectedLabelKeys, onLabelKeyClick } = useMetricsBrowser();
+  const { labelKeys, isLoadingLabelKeys, selectedLabelKeys, onLabelKeyClick } = useMetricsBrowser();
 
   const filteredLabelKeys = useMemo(() => {
     return labelKeys.filter(
@@ -44,24 +45,29 @@ export function LabelSelector() {
         />
       </div>
       {/* Using fixed height here to prevent jumpy layout */}
-      <div className={styles.list} style={{ height: 120 }}>
-        {filteredLabelKeys.map((label) => (
-          <PromLabel
-            key={label}
-            name={label}
-            loading={false}
-            active={selectedLabelKeys.includes(label)}
-            hidden={false}
-            facets={undefined}
-            onClick={(name: string) => {
-              // Resetting search to prevent empty results
-              setLabelSearchTerm('');
-              onLabelKeyClick(name);
-            }}
-            searchTerm={labelSearchTerm}
-          />
-        ))}
-      </div>
+      {isLoadingLabelKeys ? (
+        <div className={sharedStyles.spinner}>
+          <Spinner size="xl" />
+        </div>
+      ) : (
+        <div className={styles.list} style={{ height: 120 }}>
+          {filteredLabelKeys.map((label) => (
+            <PromLabel
+              key={label}
+              name={label}
+              active={selectedLabelKeys.includes(label)}
+              hidden={false}
+              facets={undefined}
+              onClick={(name: string) => {
+                // Resetting search to prevent empty results
+                setLabelSearchTerm('');
+                onLabelKeyClick(name);
+              }}
+              searchTerm={labelSearchTerm}
+            />
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/MetricsBrowserContext.tsx
@@ -33,6 +33,8 @@ interface MetricsBrowserContextType {
   // Data and selection state
   metrics: Metric[];
   labelKeys: string[];
+  isLoadingLabelKeys: boolean;
+  isLoadingLabelValues: boolean;
   labelValues: Record<string, string[]>;
   selectedMetric: string;
   selectedLabelKeys: string[];
@@ -78,6 +80,8 @@ export function MetricsBrowserProvider({
     validationStatus,
     metrics,
     labelKeys,
+    isLoadingLabelKeys,
+    isLoadingLabelValues,
     labelValues,
     selectedMetric,
     selectedLabelKeys,
@@ -109,6 +113,8 @@ export function MetricsBrowserProvider({
       getSelector,
       metrics,
       labelKeys,
+      isLoadingLabelKeys,
+      isLoadingLabelValues,
       labelValues,
       selectedMetric,
       selectedLabelKeys,
@@ -128,16 +134,18 @@ export function MetricsBrowserProvider({
       setSeriesLimit,
       validationStatus,
       onChange,
-      metrics,
       getSelector,
+      metrics,
       labelKeys,
+      isLoadingLabelKeys,
+      isLoadingLabelValues,
       labelValues,
       selectedMetric,
       selectedLabelKeys,
       selectedLabelValues,
+      handleSelectedMetricChange,
       handleSelectedLabelKeyChange,
       handleSelectedLabelValueChange,
-      handleSelectedMetricChange,
       handleValidation,
       handleClear,
     ]

--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -3,17 +3,20 @@ import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
-import { BrowserLabel as PromLabel, Input, Label, useStyles2 } from '@grafana/ui';
+import { BrowserLabel as PromLabel, Input, Label, useStyles2, Spinner } from '@grafana/ui';
 
 import { LIST_ITEM_SIZE } from '../../constants';
 
 import { useMetricsBrowser } from './MetricsBrowserContext';
-import { getStylesValueSelector } from './styles';
+import { getStylesMetricsBrowser, getStylesValueSelector } from './styles';
 
 export function ValueSelector() {
   const styles = useStyles2(getStylesValueSelector);
+  const sharedStyles = useStyles2(getStylesMetricsBrowser);
+
   const [valueSearchTerm, setValueSearchTerm] = useState('');
-  const { labelValues, selectedLabelValues, onLabelValueClick, onLabelKeyClick } = useMetricsBrowser();
+  const { labelValues, selectedLabelValues, isLoadingLabelValues, onLabelValueClick, onLabelKeyClick } =
+    useMetricsBrowser();
 
   return (
     <div className={styles.section}>
@@ -38,63 +41,62 @@ export function ValueSelector() {
           data-testid={selectors.components.DataSource.Prometheus.queryEditor.code.metricsBrowser.labelValuesFilter}
         />
       </div>
-      <div className={styles.valueListArea}>
-        {Object.entries(labelValues).map(([lk, lv]) => {
-          if (!lk || !lv) {
-            console.error('label values are empty:', { lk, lv });
-            return null;
-          }
-          return (
-            <div
-              role="list"
-              key={lk}
-              aria-label={t(
-                'grafana-prometheus.components.value-selector.aria-label-values-for',
-                'Values for {{labelKey}}',
-                {
-                  labelKey: lk,
-                }
-              )}
-              className={styles.valueListWrapper}
-            >
-              <div className={styles.valueTitle}>
-                <PromLabel
-                  name={lk}
-                  loading={false}
-                  active={true}
-                  hidden={false}
-                  facets={lv.length}
-                  onClick={onLabelKeyClick}
-                />
-              </div>
-              <FixedSizeList
-                height={Math.min(200, LIST_ITEM_SIZE * (lv.length || 0))}
-                itemCount={lv.length || 0}
-                itemSize={28}
-                itemKey={(i) => lv[i]}
-                width={200}
-                className={styles.valueList}
+      {isLoadingLabelValues ? (
+        <div className={sharedStyles.spinner}>
+          <Spinner size="xl" />
+        </div>
+      ) : (
+        <div className={styles.valueListArea}>
+          {Object.entries(labelValues).map(([lk, lv]) => {
+            if (!lk || !lv) {
+              console.error('label values are empty:', { lk, lv });
+              return null;
+            }
+            return (
+              <div
+                role="list"
+                key={lk}
+                aria-label={t(
+                  'grafana-prometheus.components.value-selector.aria-label-values-for',
+                  'Values for {{labelKey}}',
+                  {
+                    labelKey: lk,
+                  }
+                )}
+                className={styles.valueListWrapper}
               >
-                {({ index, style }) => {
-                  const value = lv[index];
-                  const isSelected = selectedLabelValues[lk]?.includes(value);
-                  return (
-                    <div style={style}>
-                      <PromLabel
-                        name={value}
-                        value={value}
-                        active={isSelected}
-                        onClick={(name) => onLabelValueClick(lk, name, !isSelected)}
-                        searchTerm={valueSearchTerm}
-                      />
-                    </div>
-                  );
-                }}
-              </FixedSizeList>
-            </div>
-          );
-        })}
-      </div>
+                <div className={styles.valueTitle}>
+                  <PromLabel name={lk} active={true} hidden={false} facets={lv.length} onClick={onLabelKeyClick} />
+                </div>
+                <FixedSizeList
+                  height={Math.min(200, LIST_ITEM_SIZE * (lv.length || 0))}
+                  itemCount={lv.length || 0}
+                  itemSize={28}
+                  itemKey={(i) => lv[i]}
+                  width={200}
+                  className={styles.valueList}
+                >
+                  {({ index, style }) => {
+                    const value = lv[index];
+                    const isSelected = selectedLabelValues[lk]?.includes(value);
+                    return (
+                      <div style={style}>
+                        <PromLabel
+                          name={value}
+                          value={value}
+                          active={isSelected}
+                          onClick={(name) => onLabelValueClick(lk, name, !isSelected)}
+                          searchTerm={valueSearchTerm}
+                        />
+                      </div>
+                    );
+                  }}
+                </FixedSizeList>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/grafana-prometheus/src/components/metrics-browser/styles.ts
+++ b/packages/grafana-prometheus/src/components/metrics-browser/styles.ts
@@ -8,6 +8,12 @@ export const getStylesMetricsBrowser = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(1),
     width: '100%',
   }),
+  spinner: css({
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    height: 120,
+  }),
 });
 
 export const getStylesMetricSelector = (theme: GrafanaTheme2) => ({

--- a/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/shared/QueryBuilderHints.tsx
@@ -92,6 +92,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     hint: css({
       marginRight: theme.spacing(1),
+      marginBottom: theme.spacing(1),
     }),
   };
 };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds a spinner to Prometheus' metrics browser to make it clear when Label keys or values are being loaded:



https://github.com/user-attachments/assets/0e47218d-6d1d-4a62-9294-238f2c23874d

Also adds a small margin bottom to hints so that they do not overlap when zoomed in:

Before:

<img width="730" height="577" alt="Screenshot 2025-08-28 at 11 49 29 AM" src="https://github.com/user-attachments/assets/70d4236c-8c1c-4ebf-9142-35234fb2a4fb" />

After:

<img width="754" height="446" alt="Screenshot 2025-08-28 at 12 23 24 PM" src="https://github.com/user-attachments/assets/e4f27992-bb24-426a-acbb-f8e36da62e9f" />



**Why do we need this feature?**

To help make it clear that something is loading. Before, metrics with a lot of labels, did not have any UI indication that something was being loaded which could make it confusing as to what is going on.

**Who is this feature for?**

Prometheus users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #83214 


