### PR TITLE
[release-12.0.5] LDAP: Restore test user mapping functionality

### DIFF
--- a/public/app/features/admin/ldap/LdapSettingsPage.tsx
+++ b/public/app/features/admin/ldap/LdapSettingsPage.tsx
@@ -30,6 +30,7 @@ import { Loader } from 'app/features/plugins/admin/components/Loader';
 import { LdapPayload, MapKeyCertConfigured, StoreState } from 'app/types';
 
 import { LdapDrawerComponent } from './LdapDrawer';
+import { LdapTestDrawer } from './LdapTestDrawer';
 
 const appEvents = getAppEvents();
 
@@ -98,6 +99,8 @@ const emptySettings: LdapPayload = {
 export const LdapSettingsPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
+  const [isTestDrawerOpen, setIsTestDrawerOpen] = useState(false);
+  const [usernameParam, setUsernameParam] = useState<string | null>(null);
 
   const [isBindPasswordConfigured, setBindPasswordConfigured] = useState(false);
   const [mapKeyCertConfigured, setMapKeyCertConfigured] = useState<MapKeyCertConfigured>({
@@ -121,6 +124,10 @@ export const LdapSettingsPage = () => {
 
   useEffect(() => {
     async function init() {
+      const urlParams = new URLSearchParams(window.location.search);
+      const username = urlParams.get('username');
+      setUsernameParam(username);
+
       const payload = await getSettings();
       let serverConfig = emptySettings.settings.config.servers[0];
       if (payload.settings.config.servers?.length > 0) {
@@ -134,6 +141,10 @@ export const LdapSettingsPage = () => {
 
       reset(payload);
       setIsLoading(false);
+
+      if (username) {
+        setIsTestDrawerOpen(true);
+      }
     }
     init();
   }, [reset]);
@@ -415,6 +426,9 @@ export const LdapSettingsPage = () => {
                     <Button variant="secondary" onClick={handleSubmit(saveForm)}>
                       <Trans i18nKey="ldap-settings-page.buttons-section.save-button">Save</Trans>
                     </Button>
+                    <Button variant="secondary" onClick={() => setIsTestDrawerOpen(true)}>
+                      <Trans i18nKey="ldap-settings-page.buttons-section.test-button">Test</Trans>
+                    </Button>
                     <LinkButton href="/admin/authentication" variant="secondary">
                       <Trans i18nKey="ldap-settings-page.buttons-section.discard-button">Discard</Trans>
                     </LinkButton>
@@ -454,6 +468,9 @@ export const LdapSettingsPage = () => {
               />
             )}
           </form>
+          {isTestDrawerOpen && (
+            <LdapTestDrawer onClose={() => setIsTestDrawerOpen(false)} username={usernameParam || undefined} />
+          )}
         </FormProvider>
       </Page.Contents>
     </Page>

--- a/public/app/features/admin/ldap/LdapTestDrawer.tsx
+++ b/public/app/features/admin/ldap/LdapTestDrawer.tsx
@@ -1,13 +1,10 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { NavModelItem } from '@grafana/data';
 import { featureEnabled } from '@grafana/runtime';
-import { Alert, Button, Field, Input, Stack } from '@grafana/ui';
-import { Page } from 'app/core/components/Page/Page';
+import { Alert, Button, Drawer, Field, Input, LoadingPlaceholder, Stack, Text } from '@grafana/ui';
 import { contextSrv } from 'app/core/core';
 import { Trans, t } from 'app/core/internationalization';
-import { GrafanaRouteComponentProps } from 'app/core/navigation/types';
 import { AppNotificationSeverity, AccessControlAction } from 'app/types';
 import { useDispatch, useSelector } from 'app/types/store';
 
@@ -23,20 +20,16 @@ import { LdapConnectionStatus } from './LdapConnectionStatus';
 import { LdapSyncInfo } from './LdapSyncInfo';
 import { LdapUserInfo } from './LdapUserInfo';
 
-interface Props extends GrafanaRouteComponentProps<{}, { username?: string }> {}
+interface Props {
+  onClose: () => void;
+  username?: string;
+}
 
 interface FormModel {
   username: string;
 }
 
-const pageNav: NavModelItem = {
-  text: 'LDAP',
-  subTitle: `Verify your LDAP and user mapping configuration.`,
-  icon: 'book',
-  id: 'LDAP',
-};
-
-export const LdapPage = ({ queryParams }: Props) => {
+export const LdapTestDrawer = ({ onClose, username }: Props) => {
   const dispatch = useDispatch();
 
   const ldapConnectionInfo = useSelector((state) => state.ldap.connectionInfo);
@@ -60,22 +53,24 @@ export const LdapPage = ({ queryParams }: Props) => {
     };
 
     async function init() {
-      await dispatch(clearUserMappingInfo());
+      dispatch(clearUserMappingInfo());
       await fetchLDAPStatus();
 
-      if (queryParams.username) {
-        await fetchUserMapping(queryParams.username);
+      if (username) {
+        await fetchUserMapping(username);
       }
 
       setIsLoading(false);
     }
 
     init();
-  }, [dispatch, fetchUserMapping, queryParams]);
+  }, [dispatch, fetchUserMapping, username]);
 
-  const search = ({ username }: FormModel) => {
-    if (username) {
-      fetchUserMapping(username);
+  const search = (data: FormModel, event?: React.BaseSyntheticEvent) => {
+    event?.preventDefault();
+    event?.stopPropagation();
+    if (data.username) {
+      fetchUserMapping(data.username);
     }
   };
 
@@ -85,8 +80,14 @@ export const LdapPage = ({ queryParams }: Props) => {
 
   const canReadLDAPUser = contextSrv.hasPermission(AccessControlAction.LDAPUsersRead);
   return (
-    <Page navId="authentication" pageNav={pageNav}>
-      <Page.Contents isLoading={isLoading}>
+    <Drawer
+      title={t('admin.ldap.debug-title', 'LDAP Diagnostics')}
+      subtitle={t('admin.ldap.debug-subtitle', 'Verify your LDAP and user mapping configuration.')}
+      onClose={onClose}
+    >
+      {isLoading ? (
+        <LoadingPlaceholder text={t('admin.ldap.text-loading-ldap-status', 'Loading LDAP status...')} />
+      ) : (
         <Stack direction="column" gap={4}>
           {ldapError && ldapError.title && (
             <Alert title={ldapError.title} severity={AppNotificationSeverity.Error}>
@@ -100,37 +101,37 @@ export const LdapPage = ({ queryParams }: Props) => {
 
           {canReadLDAPUser && (
             <section>
-              <h3>
-                <Trans i18nKey="admin.ldap.test-mapping-heading">Test user mapping</Trans>
-              </h3>
-              <form onSubmit={handleSubmit(search)}>
-                <Field label={t('admin.ldap-page.label-username', 'Username')}>
-                  <Input
-                    {...register('username', { required: true })}
-                    width={34}
-                    id="username"
-                    type="text"
-                    defaultValue={queryParams.username}
-                    addonAfter={
-                      <Button variant="primary" type="submit">
+              <Stack direction="column" gap={2}>
+                <Text element="h3">
+                  <Trans i18nKey="admin.ldap.test-mapping-heading">Test user mapping</Trans>
+                </Text>
+                <form onSubmit={handleSubmit(search)}>
+                  <Field label={t('admin.ldap-page.label-username', 'Username')}>
+                    <Stack>
+                      <Input
+                        {...register('username', { required: true })}
+                        width={34}
+                        id="username"
+                        type="text"
+                        defaultValue={username}
+                      />
+                      <Button variant="secondary" type="submit">
                         <Trans i18nKey="admin.ldap.test-mapping-run-button">Run</Trans>
                       </Button>
-                    }
-                  />
-                </Field>
-              </form>
-              {userError && userError.title && (
-                <Alert title={userError.title} severity={AppNotificationSeverity.Error} onRemove={onClearUserError}>
-                  {userError.body}
-                </Alert>
-              )}
-              {ldapUser && <LdapUserInfo ldapUser={ldapUser} />}
+                    </Stack>
+                  </Field>
+                </form>
+                {userError && userError.title && (
+                  <Alert title={userError.title} severity={AppNotificationSeverity.Error} onRemove={onClearUserError}>
+                    {userError.body}
+                  </Alert>
+                )}
+                {ldapUser && <LdapUserInfo ldapUser={ldapUser} />}
+              </Stack>
             </section>
           )}
         </Stack>
-      </Page.Contents>
-    </Page>
+      )}
+    </Drawer>
   );
 };
-
-export default LdapPage;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -121,8 +121,11 @@
       "title": "Get Grafana Enterprise"
     },
     "ldap": {
+      "debug-subtitle": "Verify your LDAP and user mapping configuration.",
+      "debug-title": "LDAP Diagnostics",
       "test-mapping-heading": "Test user mapping",
-      "test-mapping-run-button": "Run"
+      "test-mapping-run-button": "Run",
+      "text-loading-ldap-status": "Loading LDAP status..."
     },
     "ldap-error-box": {
       "title-connection-error": "Connection error"
@@ -5089,7 +5092,8 @@
       "disable-button": "Disable",
       "discard-button": "Discard",
       "save-and-enable-button": "Save and enable",
-      "save-button": "Save"
+      "save-button": "Save",
+      "test-button": "Test"
     },
     "documentation": "documentation",
     "host": {


### PR DESCRIPTION
Backport 585b53bc7dba1925926a95e86aa8f1d45a2e74d6 from #110841

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR brings back the old LDAP debug page as a drawer in the LDAP SSO Settings page.

**Why do we need this feature?**

We need this feature to allow users to troubleshoot their LDAP connection and user mappings.

**Who is this feature for?**

This feature is for users of LDAP authentication.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #108784 

**Special notes for your reviewer:**

The old LDAP debug allowed `username` to be passed in as a query parameter. I'm not sure whether that feature was documented (I couldn't find it anywhere), but I kept it anyway.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
