### PR TITLE
RepositoryStatusPage: Card grid layout for small screen fix

### DIFF
--- a/public/app/features/provisioning/Repository/RepositoryActions.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryActions.tsx
@@ -25,7 +25,7 @@ export function RepositoryActions({ repository }: RepositoryActionsProps) {
   const isReadOnlyRepo = getIsReadOnlyWorkflows(repository.spec?.workflows);
 
   return (
-    <Stack>
+    <Stack wrap="wrap">
       {isReadOnlyRepo && <Badge color="darkgrey" text={t('folder-repo.read-only-badge', 'Read only')} />}
       <StatusBadge repo={repository} />
       {repoHref && (

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -52,7 +53,7 @@ export function RepositoryOverview({ repo }: { repo: Repository }) {
   return (
     <Box padding={2}>
       <Stack direction="column" gap={2}>
-        <Grid columns={columns} gap={2}>
+        <Grid columns={{ xs: 1, sm: 2, lg: columns }} gap={2}>
           <div className={styles.cardContainer}>
             <Card noMargin className={styles.card}>
               <Card.Heading>
@@ -271,7 +272,7 @@ function getFolderURL(repo: Repository) {
   return '/dashboards';
 }
 
-const getStyles = () => {
+const getStyles = (theme: GrafanaTheme2) => {
   return {
     cardContainer: css({
       height: '100%',
@@ -285,6 +286,7 @@ const getStyles = () => {
       marginTop: 'auto',
     }),
     labelColumn: css({
+      minWidth: theme.spacing(10),
       gridColumn: 'span 3',
     }),
     valueColumn: css({


### PR DESCRIPTION
**What is this feature?**

`RepositoryStatusPgae`: Small screen responsive style fix to prevent text content overlap. 

<img width="973" height="722" alt="image" src="https://github.com/user-attachments/assets/8b8c783d-52b1-4970-92b4-215222c7a5ef" />
<img width="234" height="358" alt="image" src="https://github.com/user-attachments/assets/2742e0db-9db8-4a92-850f-977cd436caf0" />


**Why do we need this feature?**

Better UX

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/548

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
