### PR TITLE
Graphite: Migrate query endpoint entirely to backend

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4093,14 +4093,9 @@
       "count": 3
     }
   },
-  "public/app/plugins/datasource/graphite/datasource.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 3
-    }
-  },
   "public/app/plugins/datasource/graphite/datasource.ts": {
     "@typescript-eslint/consistent-type-assertions": {
-      "count": 4
+      "count": 3
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 8

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -32,10 +32,11 @@ func TestProcessQuery(t *testing.T) {
 				}`),
 			},
 		}
-		target, jsonModel, err := service.processQuery(queries[0])
+		target, jsonModel, isMetricTank, err := service.processQuery(queries[0])
 		assert.NoError(t, err)
 		assert.Nil(t, jsonModel)
 		assert.Equal(t, "app.grafana.*.dashboards.views.1M.count", target)
+		assert.False(t, isMetricTank)
 	})
 
 	t.Run("Returns if target is empty", func(t *testing.T) {
@@ -48,10 +49,26 @@ func TestProcessQuery(t *testing.T) {
 			},
 		}
 		emptyQuery := GraphiteQuery{Target: ""}
-		target, jsonModel, err := service.processQuery(queries[0])
+		target, jsonModel, isMetricTank, err := service.processQuery(queries[0])
 		assert.NoError(t, err)
 		assert.Equal(t, &emptyQuery, jsonModel)
 		assert.Equal(t, "", target)
+		assert.False(t, isMetricTank)
+	})
+
+	t.Run("Returns isMetricTank value", func(t *testing.T) {
+		queries := []backend.DataQuery{
+			{
+				RefID: "A",
+				JSON: []byte(`{
+					"target": "app.grafana.*.dashboards.views.1M.count",
+					"isMetricTank": true
+				}`),
+			},
+		}
+		_, _, isMetricTank, err := service.processQuery(queries[0])
+		assert.NoError(t, err)
+		assert.True(t, isMetricTank)
 	})
 
 	t.Run("QueryData with no valid queries returns bad request response", func(t *testing.T) {

--- a/pkg/tsdb/graphite/types.go
+++ b/pkg/tsdb/graphite/types.go
@@ -27,6 +27,7 @@ type GraphiteQuery struct {
 	TargetFull      string   `json:"targetFull,omitempty"`
 	Tags            []string `json:"tags,omitempty"`
 	FromAnnotations *bool    `json:"fromAnnotations,omitempty"`
+	IsMetricTank    bool     `json:"isMetricTank,omitempty"`
 }
 
 type GraphiteEventsRequest struct {

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -371,17 +371,14 @@ export class GraphiteDatasource
     return this.frontendQuery(options, originalTargetMap, formattedRefIdsMap);
   }
 
-  addTracingHeaders(
-    httpOptions: BackendSrvRequest,
-    options: { dashboardId?: number; panelId?: number; panelPluginId?: string }
-  ) {
-    const proxyMode = !this.url.match(/^http/);
+  addTracingHeaders(httpOptions: BackendSrvRequest, options: Partial<DataQueryRequest<GraphiteQuery>>) {
+    const proxyMode = !this.url?.match(/^http/);
     if (!httpOptions.headers) {
       httpOptions.headers = {};
     }
     if (proxyMode) {
-      if (options.dashboardId) {
-        httpOptions.headers['X-Dashboard-Id'] = options.dashboardId;
+      if (options.dashboardUID) {
+        httpOptions.headers['X-Dashboard-Id'] = options.dashboardUID;
       }
       if (options.panelId) {
         httpOptions.headers['X-Panel-Id'] = options.panelId;

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -285,7 +285,7 @@ export class GraphiteDatasource
 
     const seriesReferenceRegex = /\#([A-Z])/g;
 
-    function nestedSeriesRegexReplacer(match: string, g1: string | number) {
+    function nestedSeriesRegexReplacer(match: string, g1: string) {
       // Handle the case where a query references itself to prevent infinite recursion
       if (target.refId === g1) {
         return referenceTargets[g1] || match;
@@ -1141,7 +1141,7 @@ export class GraphiteDatasource
 
     const regex = /\#([A-Z])/g;
 
-    function nestedSeriesRegexReplacer(match: string, g1: string | number) {
+    function nestedSeriesRegexReplacer(match: string, g1: string) {
       // Handle the case where a query references itself to prevent infinite recursion
       if (target.refId === g1) {
         return targets[g1] || match;

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -47,7 +47,6 @@ import {
   GraphiteOptions,
   GraphiteQuery,
   GraphiteQueryImportConfiguration,
-  GraphiteQueryRequest,
   GraphiteQueryType,
   GraphiteType,
   MetricTankRequestMeta,
@@ -201,48 +200,35 @@ export class GraphiteDatasource
     };
   }
 
-  query(options: DataQueryRequest<GraphiteQuery>): Observable<DataQueryResponse> {
-    if (options.targets.some((target: GraphiteQuery) => target.fromAnnotations)) {
-      const streams: Array<Observable<DataQueryResponse>> = [];
-
-      for (const target of options.targets) {
-        streams.push(
-          new Observable((subscriber) => {
-            this.annotationEvents(options.range, target)
-              .then((events) => subscriber.next({ data: [toDataFrame(events)] }))
-              .catch((ex) => subscriber.error(new Error(ex)))
-              .finally(() => subscriber.complete());
-          })
-        );
-      }
-
-      return merge(...streams);
+  filterQuery(item: GraphiteQuery): boolean {
+    if (!item.target && !item.fromAnnotations) {
+      return false;
     }
 
-    // Use this object to map the sanitised refID to the original
-    const formattedRefIdsMap: { [key: string]: string } = {};
-    // Use this object to map the original refID to the original target
-    const originalTargetMap: { [key: string]: string } = {};
-    for (const target of options.targets) {
-      // Sanitise the refID otherwise the Graphite query will fail
-      const formattedRefId = target.refId.replaceAll(' ', '_');
-      formattedRefIdsMap[formattedRefId] = target.refId;
-      // Track the original target to ensure if we need to interpolate a series, we interpolate using the original target
-      // rather than the target wrapped in aliasSub e.g.:
-      // Suppose a query has three targets: A: metric1 B: sumSeries(#A) and C: asPercent(#A, #B)
-      // We want the targets to be interpolated to: A: aliasSub(metric1, "(^.*$)", "\\1 A"), B: aliasSub(sumSeries(metric1), "(^.*$)", "\\1 B") and C: asPercent(metric1, sumSeries(metric1))
-      originalTargetMap[target.refId] = target.target || '';
-      // Use aliasSub to include the refID in the response series name. This allows us to set the refID on the frame.
-      const updatedTarget = `aliasSub(${target.target}, "(^.*$)", "\\1 ${formattedRefId}")`;
-      target.target = updatedTarget;
-    }
+    return true;
+  }
 
+  // Note that we do not omit queries with the hide flag set to true to avoid breaking nested series replacement
+  // e.g. sumSeries(#A) where A is hidden
+  applyTemplateVariables(target: GraphiteQuery, scopedVars: ScopedVars) {
+    return {
+      ...target,
+      target: this.templateSrv.replace(target.target ?? '', scopedVars),
+      targetFull: this.templateSrv.replace(target.targetFull ?? '', scopedVars),
+    };
+  }
+
+  frontendQuery(
+    options: DataQueryRequest<GraphiteQuery>,
+    originalTargetMap: { [key: string]: string },
+    formattedRefIdsMap: { [key: string]: string }
+  ): Observable<DataQueryResponse> {
     // handle the queries here
     const graphOptions = {
       from: this.translateTime(options.range.from, false, options.timezone),
       until: this.translateTime(options.range.to, true, options.timezone),
       targets: options.targets,
-      format: (options as GraphiteQueryRequest).format,
+      format: 'json',
       cacheTimeout: options.cacheTimeout || this.cacheTimeout,
       maxDataPoints: options.maxDataPoints,
     };
@@ -274,6 +260,115 @@ export class GraphiteDatasource
     return this.doGraphiteRequest(httpOptions).pipe(
       map((result) => this.convertResponseToDataFrames(result, formattedRefIdsMap))
     );
+  }
+
+  backendBuildGraphiteQueries(
+    options: DataQueryRequest<GraphiteQuery>,
+    originalTargetMap: { [key: string]: string }
+  ): GraphiteQuery[] {
+    const referenceTargets: Record<string, string> = {};
+    const finalTargets: GraphiteQuery[] = [];
+    let target: GraphiteQuery, targetValue, i;
+
+    for (i = 0; i < options.targets.length; i++) {
+      target = options.targets[i];
+      if (!target.target) {
+        continue;
+      }
+
+      if (!target.refId) {
+        target.refId = this._seriesRefLetters[i];
+      }
+
+      referenceTargets[target.refId] = target.target;
+    }
+
+    const seriesReferenceRegex = /\#([A-Z])/g;
+
+    function nestedSeriesRegexReplacer(match: string, g1: string | number) {
+      // Handle the case where a query references itself to prevent infinite recursion
+      if (target.refId === g1) {
+        return referenceTargets[g1] || match;
+      }
+
+      // Recursively replace all nested series references
+      return originalTargetMap[g1].replace(seriesReferenceRegex, nestedSeriesRegexReplacer) || match;
+    }
+
+    for (i = 0; i < options.targets.length; i++) {
+      const targetClone = { ...options.targets[i] };
+      target = options.targets[i];
+      if (!targetClone.target) {
+        continue;
+      }
+
+      targetValue = this.templateSrv.replace(
+        referenceTargets[target.refId].replace(seriesReferenceRegex, nestedSeriesRegexReplacer),
+        options.scopedVars
+      );
+
+      targetClone.target = targetValue;
+      if (this.isMetricTank) {
+        targetClone.isMetricTank = true;
+      }
+
+      if (!targetClone.hide) {
+        finalTargets.push(targetClone);
+      }
+    }
+
+    return finalTargets;
+  }
+
+  query(options: DataQueryRequest<GraphiteQuery>): Observable<DataQueryResponse> {
+    if (options.targets.some((target: GraphiteQuery) => target.fromAnnotations)) {
+      const streams: Array<Observable<DataQueryResponse>> = [];
+
+      for (const target of options.targets) {
+        streams.push(
+          new Observable((subscriber) => {
+            this.annotationEvents(options.range, target)
+              .then((events) => subscriber.next({ data: [toDataFrame(events)] }))
+              .catch((ex) => subscriber.error(new Error(ex)))
+              .finally(() => subscriber.complete());
+          })
+        );
+      }
+
+      return merge(...streams);
+    }
+
+    // Use this object to map the sanitised refID to the original
+    const formattedRefIdsMap: { [key: string]: string } = {};
+    // Use this object to map the original refID to the original target
+    const originalTargetMap: { [key: string]: string } = {};
+    for (const target of options.targets) {
+      // Sanitise the refID otherwise the Graphite query will fail
+      const formattedRefId = target.refId.replaceAll(' ', '_');
+      formattedRefIdsMap[formattedRefId] = target.refId;
+      // Track the original target to ensure if we need to interpolate a series, we interpolate using the original target
+      // rather than the target wrapped in aliasSub e.g.:
+      // Suppose a query has three targets: A: metric1 B: sumSeries(#A) and C: asPercent(#A, #B)
+      // We want the targets to be interpolated to: A: aliasSub(metric1, "(^.*$)", "\\1 A"), B: aliasSub(sumSeries(metric1), "(^.*$)", "\\1 B") and C: asPercent(metric1, sumSeries(metric1))
+      originalTargetMap[target.refId] = target.target || '';
+
+      // We only need to alias queries in frontend mode
+      if (!config.featureToggles.graphiteBackendMode) {
+        // Use aliasSub to include the refID in the response series name. This allows us to set the refID on the frame.
+        const updatedTarget = `aliasSub(${target.target}, "(^.*$)", "\\1 ${formattedRefId}")`;
+        target.target = updatedTarget;
+      }
+    }
+
+    if (config.featureToggles.graphiteBackendMode) {
+      const graphiteQueries = this.backendBuildGraphiteQueries(options, originalTargetMap);
+
+      options.targets = graphiteQueries;
+
+      return super.query(options);
+    }
+
+    return this.frontendQuery(options, originalTargetMap, formattedRefIdsMap);
   }
 
   addTracingHeaders(
@@ -660,6 +755,9 @@ export class GraphiteDatasource
     let result: MetricFindValue[];
 
     if (queryType === GraphiteQueryType.Value) {
+      if (!data.data || data.data.length === 0) {
+        return Promise.resolve([]);
+      }
       result = data.data[0].fields[1].values
         .filter((f?: number) => !!f)
         .map((v: number) => ({
@@ -1014,6 +1112,7 @@ export class GraphiteDatasource
       );
   }
 
+  // Can be removed when the frontend query path is removed
   buildGraphiteParams(options: any, originalTargetMap: { [key: string]: string }, scopedVars?: ScopedVars): string[] {
     const graphiteOptions = ['from', 'until', 'rawData', 'format', 'maxDataPoints', 'cacheTimeout'];
     const cleanOptions = [],

--- a/public/app/plugins/datasource/graphite/types.ts
+++ b/public/app/plugins/datasource/graphite/types.ts
@@ -17,6 +17,7 @@ export interface GraphiteQuery extends DataQuery {
   targetFull?: string;
   tags?: string[];
   fromAnnotations?: boolean;
+  isMetricTank?: boolean;
 }
 
 export interface GraphiteOptions extends DataSourceJsonData {


### PR DESCRIPTION
This PR ensures that queries can be executed against the backend logic correctly.

I've added support in the backend for the `metricTank` property to ensure any queries are correctly supported. I've also added support for the `filterQuery` and `applyTemplateVariables` methods. The frontend path for querying has been separated from the backend path to allow us to easily remove this in the future. 

All logic related to nested series name replacement and template variable replacement has remained and the appropriate tests have been replicated for the backend path to ensure there are no regressions.

I've updated and expanded the tests accordingly.

Part of grafana/data-sources#607

Fixes grafana/grafana#109810