### PR TITLE
fix (unified-storage): search returning empty results when query includes small term

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1182,7 +1182,6 @@ func removeSmallTerms(query string) string {
 	}
 
 	return strings.Join(validWords, " ")
-
 }
 
 func (b *bleveIndex) stopUpdaterAndCloseIndex() error {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1172,7 +1172,7 @@ func removeSmallTerms(query string) string {
 	validWords := make([]string, 0, len(words))
 
 	for _, word := range words {
-		if len(strings.TrimSpace(word)) >= EDGE_NGRAM_MIN_TOKEN {
+		if len(word) >= EDGE_NGRAM_MIN_TOKEN {
 			validWords = append(validWords, word)
 		}
 	}

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -192,6 +192,22 @@ func TestCanSearchByTitle(t *testing.T) {
 			checkSearchQuery(t, index, newQueryByTitle(fmt.Sprintf(`foo%d%s`, i, v)), []string{name})
 		}
 	})
+
+	t.Run("title search will ignore terms < 3 characters unless it is exact match", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "new dashboard",
+			"name2": "new dash",
+			"name3": "new",
+		})
+
+		// matches everything
+		checkSearchQuery(t, index, newTestQuery("new"), []string{"name3", "name2", "name1"})
+		// ignore terms shorter than 3 chars
+		checkSearchQuery(t, index, newTestQuery("new d"), []string{"name3", "name2", "name1"})
+		// include terms shorter that are exactly 3 chars
+		checkSearchQuery(t, index, newTestQuery("new das"), []string{"name2", "name1"})
+	})
 }
 
 func newTestQuery(query string) *resourcepb.ResourceSearchRequest {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -193,7 +193,7 @@ func TestCanSearchByTitle(t *testing.T) {
 		}
 	})
 
-	t.Run("title search will ignore terms < 3 characters unless it is exact match", func(t *testing.T) {
+	t.Run("title search will ignore terms < 3 characters", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{
 			"name1": "new dashboard",

--- a/pkg/storage/unified/search/custom_analyzers.go
+++ b/pkg/storage/unified/search/custom_analyzers.go
@@ -10,6 +10,7 @@ import (
 )
 
 const TITLE_ANALYZER = "title_analyzer"
+const EDGE_NGRAM_MIN_TOKEN = 3.0
 
 func RegisterCustomAnalyzers(mapper *mapping.IndexMappingImpl) error {
 	return registerTitleAnalyzer(mapper)
@@ -22,7 +23,7 @@ func registerTitleAnalyzer(mapper *mapping.IndexMappingImpl) error {
 	// Define an N-Gram tokenizer (for substring search)
 	edgeNgramTokenFilter := map[string]interface{}{
 		"type": edgengram.Name,
-		"min":  3.0,
+		"min":  EDGE_NGRAM_MIN_TOKEN,
 		"max":  10.0,
 		"back": edgengram.FRONT,
 	}


### PR DESCRIPTION
closes https://github.com/grafana/search-and-storage-team/issues/509

after we introduced [this change](https://github.com/grafana/grafana/pull/110672/files#diff-284e8a32b46a74f9d10caebfb3b5cbe7ae2d44688be503d35b1baf225b5aab3aR1086), it broke searches that includes at least one term < 3 characters. 

For example, if you search for "new da" it will always return empty results, even if you have a dashboard titled "new dashboard"