### PR TITLE
Prometheus: Fix ad hoc filters when using explore table column filtering

### DIFF
--- a/packages/grafana-prometheus/src/add_label_to_query.test.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.test.ts
@@ -71,7 +71,7 @@ describe('addLabelToQuery()', () => {
       'foo{x="yy", bar="baz"}'
     );
     expect(addLabelToQuery(addLabelToQuery('foo{x="yy"}', 'bar', 'baz', '='), 'bar', 'baz', '!=')).toBe(
-      'foo{x="yy", bar="baz"}'
+      'foo{x="yy", bar!="baz"}'
     );
   });
 

--- a/packages/grafana-prometheus/src/add_label_to_query.test.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.test.ts
@@ -66,6 +66,15 @@ describe('addLabelToQuery()', () => {
     );
   });
 
+  it('should modify existing labels if the operator is different', () => {
+    expect(addLabelToQuery(addLabelToQuery('foo{x="yy"}', 'bar', 'baz', '!='), 'bar', 'baz', '=')).toBe(
+      'foo{x="yy", bar="baz"}'
+    );
+    expect(addLabelToQuery(addLabelToQuery('foo{x="yy"}', 'bar', 'baz', '='), 'bar', 'baz', '!=')).toBe(
+      'foo{x="yy", bar="baz"}'
+    );
+  });
+
   it('should not remove filters', () => {
     expect(addLabelToQuery('{x="y"} |="yy"', 'bar', 'baz')).toBe('{x="y", bar="baz"} |="yy"');
     expect(addLabelToQuery('{x="y"} |="yy" !~"xx"', 'bar', 'baz')).toBe('{x="y", bar="baz"} |="yy" !~"xx"');

--- a/packages/grafana-prometheus/src/add_label_to_query.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.ts
@@ -79,8 +79,17 @@ function addFilter(
     const start = query.substring(prev, match.from);
     const end = isLast ? query.substring(match.to) : '';
 
-    if (!labelExists(match.query.labels, filter)) {
+    const labelToMatch = labelExists(match.query.labels, filter);
+    if (labelToMatch) {
+      // if label exists, check the operator, if it is different, update it.
       // We don't want to add duplicate labels.
+      if (!labelOperatorMatches(labelToMatch, filter)) {
+        match.query.labels = match.query.labels.map((label) =>
+          label.label === filter.label && label.value === filter.value ? filter : label
+        );
+      }
+    } else {
+      // label does not exist, add as is.
       match.query.labels.push(filter);
     }
     const newLabels = renderQuery(match.query);
@@ -97,4 +106,8 @@ function addFilter(
  */
 function labelExists(labels: QueryBuilderLabelFilter[], filter: QueryBuilderLabelFilter) {
   return labels.find((label) => label.label === filter.label && label.value === filter.value);
+}
+
+function labelOperatorMatches(label: QueryBuilderLabelFilter, filter: QueryBuilderLabelFilter) {
+  return label.op === filter.op;
 }

--- a/packages/grafana-prometheus/src/add_label_to_query.ts
+++ b/packages/grafana-prometheus/src/add_label_to_query.ts
@@ -83,7 +83,7 @@ function addFilter(
     if (labelToMatch) {
       // if label exists, check the operator, if it is different, update it.
       // We don't want to add duplicate labels.
-      if (!labelOperatorMatches(labelToMatch, filter)) {
+      if (labelToMatch.op !== filter.op) {
         match.query.labels = match.query.labels.map((label) =>
           label.label === filter.label && label.value === filter.value ? filter : label
         );
@@ -106,8 +106,4 @@ function addFilter(
  */
 function labelExists(labels: QueryBuilderLabelFilter[], filter: QueryBuilderLabelFilter) {
   return labels.find((label) => label.label === filter.label && label.value === filter.value);
-}
-
-function labelOperatorMatches(label: QueryBuilderLabelFilter, filter: QueryBuilderLabelFilter) {
-  return label.op === filter.op;
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the way we handle ad hoc filtering on tables for Prometheus Datasource when used in Explore. 

**Why do we need this feature?**

When using + / - from table view in Explore, if a label had already been added as a filter, changing the operator on the same label key and value (+ -> - or - -> +) had no effect, essentially making the first filter applied the only one that worked. 

With this change, we keep the logic to only add non duplicate label / value filters, but considering the operator as well on top of label key / value values so that if the operator needs to be changed, we change it instead of ignoring it:


https://github.com/user-attachments/assets/2d5088fb-af28-406f-b0c7-f881c553c92a


**Who is this feature for?**

Prometheus users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #65894 