### PR TITLE
[release-12.0.5] Fix: Fix redirection after login when Grafana is served from subpath

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -436,13 +436,18 @@ function handleRedirectTo(): void {
   }
 
   window.sessionStorage.removeItem(RedirectToUrlKey);
-  const decodedRedirectTo = decodeURIComponent(redirectTo);
+  let decodedRedirectTo = decodeURIComponent(redirectTo);
   if (decodedRedirectTo.startsWith('/goto/')) {
     // In this case there should be a request to the backend
+    if (config.appSubUrl && !decodedRedirectTo.startsWith(config.appSubUrl)) {
+      decodedRedirectTo = config.appSubUrl + decodedRedirectTo;
+    }
     window.location.replace(decodedRedirectTo);
-  } else {
-    locationService.replace(decodedRedirectTo);
+    return;
   }
+  // Ensure that the appsuburl is stripped from the redirect to in case of a frontend redirect
+  const stripped = locationUtil.stripBaseFromUrl(decodedRedirectTo);
+  locationService.replace(stripped);
 }
 
 export default new GrafanaApp();


### PR DESCRIPTION
Backport ccc87a03f0ec70eb28f9ce49221834718abeca7d from #110889

---

**What is this feature?**
Fixes the redirection after login when Grafana is served from subpath.

**Why do we need this feature?**
To correctly redirect user when Grafana is served from subpath.

**Who is this feature for?**
Users who serve Grafana on a sub path.

**Which issue(s) does this PR fix?**:

Possibly fixes #108875
Fixes #106234

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
