### PR TITLE
Alerting: Fix start with unified_alerting disabled

### DIFF
--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -2,7 +2,6 @@ package rules
 
 import (
 	"context"
-	"fmt"
 
 	restclient "k8s.io/client-go/rest"
 
@@ -40,7 +39,7 @@ func RegisterAppInstaller(
 	ng *ngalert.AlertNG,
 ) (*AlertingRulesAppInstaller, error) {
 	if ng.IsDisabled() {
-		return nil, fmt.Errorf("alerting rules app installer cannot be registered when ngalert is disabled")
+		return nil, nil
 	}
 
 	installer := &AlertingRulesAppInstaller{

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/apps/alerting/rules/pkg/apis"
 	rulesApp "github.com/grafana/grafana/apps/alerting/rules/pkg/app"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/alertrule"
 	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules/recordingrule"
 	"github.com/grafana/grafana/pkg/services/apiserver/appinstaller"
@@ -39,6 +40,7 @@ func RegisterAppInstaller(
 	ng *ngalert.AlertNG,
 ) (*AlertingRulesAppInstaller, error) {
 	if ng.IsDisabled() {
+		log.New("app-registry").Info("Skipping Kubernetes Alerting Rules apiserver (rules.alerting.grafana.app): Unified Alerting is disabled")
 		return nil, nil
 	}
 

--- a/pkg/registry/apps/alerting/rules/register_test.go
+++ b/pkg/registry/apps/alerting/rules/register_test.go
@@ -1,0 +1,39 @@
+package rules
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/services/ngalert"
+	"github.com/grafana/grafana/pkg/setting"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegisterAppInstaller_UnifiedAlertingEnabled(t *testing.T) {
+	tests := []struct {
+		name            string
+		enabled         bool
+		expectInstaller bool
+	}{
+		{name: "unified_alerting disabled returns nil installer", enabled: false, expectInstaller: false},
+		{name: "unified_alerting enabled returns installer", enabled: true, expectInstaller: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			enabled := tt.enabled
+			cfg := &setting.Cfg{UnifiedAlerting: setting.UnifiedAlertingSettings{Enabled: &enabled}}
+			ng := &ngalert.AlertNG{Cfg: cfg}
+
+			inst, err := RegisterAppInstaller(cfg, ng)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.expectInstaller {
+				require.NotNil(t, inst)
+			} else {
+				require.Nil(t, inst)
+			}
+		})
+	}
+}

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -37,7 +37,7 @@ func ProvideAppInstallers(
 	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesShortURLs) {
 		installers = append(installers, shorturlAppInstaller)
 	}
-	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAlertingRules) {
+	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAlertingRules) && rulesAppInstaller != nil {
 		installers = append(installers, rulesAppInstaller)
 	}
 	return installers

--- a/pkg/registry/apps/apps_test.go
+++ b/pkg/registry/apps/apps_test.go
@@ -1,0 +1,41 @@
+package appregistry
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/registry/apps/alerting/rules"
+	"github.com/grafana/grafana/pkg/registry/apps/playlist"
+	"github.com/grafana/grafana/pkg/registry/apps/plugins"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProvideAppInstallers_Table(t *testing.T) {
+	playlistInstaller := &playlist.PlaylistAppInstaller{}
+	pluginsInstaller := &plugins.PluginsAppInstaller{}
+	rulesInstaller := &rules.AlertingRulesAppInstaller{}
+
+	tests := []struct {
+		name           string
+		flags          []any
+		rulesInst      *rules.AlertingRulesAppInstaller
+		expectRulesApp bool
+	}{
+		{name: "no flags", flags: nil, rulesInst: nil, expectRulesApp: false},
+		{name: "rules flag without installer", flags: []any{featuremgmt.FlagKubernetesAlertingRules}, rulesInst: nil, expectRulesApp: false},
+		{name: "rules flag with installer", flags: []any{featuremgmt.FlagKubernetesAlertingRules}, rulesInst: rulesInstaller, expectRulesApp: true},
+		{name: "rules installer without flag", flags: nil, rulesInst: rulesInstaller, expectRulesApp: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features := featuremgmt.WithFeatures(tt.flags...)
+			got := ProvideAppInstallers(features, playlistInstaller, pluginsInstaller, nil, tt.rulesInst)
+			if tt.expectRulesApp {
+				require.Contains(t, got, tt.rulesInst)
+			} else {
+				require.NotContains(t, got, tt.rulesInst)
+			}
+		})
+	}
+}


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/106859 a new alerting rules app installer (Kubernetes Rules API) was introduced, but it broke starting Grafana with [unified_alerting] `enabled = false`. This PR fixes this.