### PR TITLE
fix: introduce an init lock for the storage backend integration tests

### DIFF
--- a/pkg/storage/unified/sql/test/benchmark_test.go
+++ b/pkg/storage/unified/sql/test/benchmark_test.go
@@ -1,38 +1,13 @@
 package test
 
 import (
-	"context"
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/unified/resource"
-	"github.com/grafana/grafana/pkg/storage/unified/sql"
-	"github.com/grafana/grafana/pkg/storage/unified/sql/db/dbimpl"
 	test "github.com/grafana/grafana/pkg/storage/unified/testing"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
-
-func newTestBackend(b testing.TB) resource.StorageBackend {
-	dbstore := db.InitTestDB(b)
-	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-	require.NoError(b, err)
-	require.NotNil(b, eDB)
-
-	backend, err := sql.NewBackend(sql.BackendOptions{
-		DBProvider:              eDB,
-		IsHA:                    true,
-		SimulatedNetworkLatency: 2 * time.Millisecond, // to simulate some network latency
-	})
-	require.NoError(b, err)
-	require.NotNil(b, backend)
-	err = backend.Init(context.Background())
-	require.NoError(b, err)
-	return backend
-}
 
 func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
@@ -40,5 +15,5 @@ func TestIntegrationBenchmarkSQLStorageBackend(t *testing.T) {
 	if db.IsTestDbSQLite() {
 		opts.Concurrency = 1 // to avoid SQLite database is locked error
 	}
-	test.BenchmarkStorageBackend(t, newTestBackend(t), opts)
+	test.BenchmarkStorageBackend(t, newTestBackend(t, true, 2*time.Millisecond), opts)
 }

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -72,7 +72,7 @@ func TestIntegrationStorageServer(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	unitest.RunStorageServerTest(t, func(ctx context.Context) resource.StorageBackend {
-		return newTestBackend(t, false, 0)
+		return newTestBackend(t, true, 0)
 	})
 }
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -36,6 +36,34 @@ import (
 // This prevents race conditions where multiple tests try to alter the same table simultaneously.
 var initMutex = &sync.Mutex{}
 
+// newTestBackend creates a fresh database and backend for a test.
+// It uses a mutex to ensure the entire initialization and migration
+// process is atomic and does not race with other parallel tests.
+func newTestBackend(t *testing.T, isHA bool, simulatedNetworkLatency time.Duration) resource.StorageBackend {
+	// Lock to ensure the entire init block is atomic.
+	initMutex.Lock()
+	// Unlock once the function returns the initialized backend.
+	defer initMutex.Unlock()
+
+	dbstore := db.InitTestDB(t)
+	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
+	require.NoError(t, err)
+	require.NotNil(t, eDB)
+
+	backend, err := sql.NewBackend(sql.BackendOptions{
+		DBProvider:              eDB,
+		IsHA:                    isHA,
+		SimulatedNetworkLatency: simulatedNetworkLatency,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, backend)
+
+	// Use a context with a reasonable timeout for migrations.
+	err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
+	require.NoError(t, err)
+	return backend
+}
+
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }
@@ -44,23 +72,7 @@ func TestIntegrationStorageServer(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	unitest.RunStorageServerTest(t, func(ctx context.Context) resource.StorageBackend {
-		initMutex.Lock()
-		defer initMutex.Unlock()
-
-		dbstore := db.InitTestDB(t)
-		eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-		require.NoError(t, err)
-		require.NotNil(t, eDB)
-
-		backend, err := sql.NewBackend(sql.BackendOptions{
-			DBProvider: eDB,
-			IsHA:       true,
-		})
-		require.NoError(t, err)
-		require.NotNil(t, backend)
-		err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
-		require.NoError(t, err)
-		return backend
+		return newTestBackend(t, false, 0)
 	})
 }
 
@@ -70,45 +82,13 @@ func TestIntegrationSQLStorageBackend(t *testing.T) {
 
 	t.Run("IsHA (polling notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			initMutex.Lock()
-			defer initMutex.Unlock()
-
-			dbstore := db.InitTestDB(t)
-			eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-			require.NoError(t, err)
-			require.NotNil(t, eDB)
-
-			backend, err := sql.NewBackend(sql.BackendOptions{
-				DBProvider: eDB,
-				IsHA:       true,
-			})
-			require.NoError(t, err)
-			require.NotNil(t, backend)
-			err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
-			require.NoError(t, err)
-			return backend
+			return newTestBackend(t, true, 0)
 		}, nil)
 	})
 
 	t.Run("NotHA (in process notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			initMutex.Lock()
-			defer initMutex.Unlock()
-
-			dbstore := db.InitTestDB(t)
-			eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-			require.NoError(t, err)
-			require.NotNil(t, eDB)
-
-			backend, err := sql.NewBackend(sql.BackendOptions{
-				DBProvider: eDB,
-				IsHA:       false,
-			})
-			require.NoError(t, err)
-			require.NotNil(t, backend)
-			err = backend.Init(testutil.NewTestContext(t, time.Now().Add(1*time.Minute)))
-			require.NoError(t, err)
-			return backend
+			return newTestBackend(t, false, 0)
 		}, nil)
 	})
 }
@@ -133,20 +113,10 @@ func TestIntegrationSearchAndStorage(t *testing.T) {
 	t.Cleanup(search.CloseAllIndexes)
 
 	// Create a new resource backend
-	dbstore := db.InitTestDB(t)
-	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
-	require.NoError(t, err)
-	require.NotNil(t, eDB)
-
-	storage, err := sql.NewBackend(sql.BackendOptions{
-		DBProvider: eDB,
-		IsHA:       false,
-	})
-	require.NoError(t, err)
+	storage := newTestBackend(t, false, 0)
 	require.NotNil(t, storage)
 
-	err = storage.Init(ctx)
-	require.NoError(t, err)
+	// Run the shared storage and search tests
 	unitest.RunTestSearchAndStorage(t, ctx, storage, search)
 }
 


### PR DESCRIPTION
This effort stems from the failing migrations when running the integration tests. We encounter the following error `initialize resource DB: run migrations: migration failed (id = Add column folder in resource): SQL logic error: duplicate column name: folder (1)` on an intermittent basis. This might not suffice in getting rid of the structural problems existing with the migrations but at least it would be a nice step forward in minimizing the issues that could arise from a potential race condition scenario present in the integration tests.

**Ticket:** https://github.com/grafana/search-and-storage-team/issues/487