### PR TITLE
Graphite: Type updates

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4093,33 +4093,9 @@
       "count": 3
     }
   },
-  "public/app/plugins/datasource/graphite/datasource.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 3
-    },
-    "@typescript-eslint/no-explicit-any": {
-      "count": 8
-    }
-  },
-  "public/app/plugins/datasource/graphite/gfunc.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 2
-    },
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "public/app/plugins/datasource/graphite/graphite_query.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
     "@typescript-eslint/no-explicit-any": {
-      "count": 9
-    }
-  },
-  "public/app/plugins/datasource/graphite/lexer.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 3
+      "count": 7
     }
   },
   "public/app/plugins/datasource/graphite/migrations.ts": {
@@ -4145,16 +4121,6 @@
   "public/app/plugins/datasource/graphite/state/store.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2
-    }
-  },
-  "public/app/plugins/datasource/graphite/types.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
-  "public/app/plugins/datasource/graphite/utils.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/influxdb/components/editor/annotation/AnnotationEditor.tsx": {

--- a/public/app/plugins/datasource/graphite/datasource_integration.test.ts
+++ b/public/app/plugins/datasource/graphite/datasource_integration.test.ts
@@ -1,12 +1,51 @@
 import { of } from 'rxjs';
 
+import { PluginType } from '@grafana/data';
 import { BackendSrv, getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
 import { GraphiteDatasource } from './datasource';
+import { GraphiteType } from './types';
 
 interface Context {
   ds: GraphiteDatasource;
 }
+
+const instanceSettings = {
+  id: 1,
+  uid: 'graphiteUid',
+  type: 'graphite',
+  readOnly: false,
+  access: 'proxy' as 'proxy',
+  meta: {
+    id: '1',
+    name: 'graphite',
+    type: PluginType.datasource,
+    info: {
+      description: 'Graphite datasource',
+      author: {
+        name: 'Grafana Labs',
+        url: 'https://grafana.com',
+      },
+      keywords: ['graphite', 'datasource'],
+      links: [],
+      logos: {
+        large: '',
+        small: '',
+      },
+      screenshots: [],
+      updated: '',
+      version: '',
+    },
+    module: '',
+    baseUrl: '',
+  },
+  url: '/api/datasources/proxy/1',
+  name: 'graphiteProd',
+  jsonData: {
+    rollupIndicatorEnabled: true,
+    graphiteType: GraphiteType.Default,
+  },
+};
 
 let origBackendSrv: BackendSrv;
 describe('graphiteDatasource integration with backendSrv and fetch', () => {
@@ -15,13 +54,7 @@ describe('graphiteDatasource integration with backendSrv and fetch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     origBackendSrv = getBackendSrv();
-    const instanceSettings = {
-      url: '/api/datasources/proxy/1',
-      name: 'graphiteProd',
-      jsonData: {
-        rollupIndicatorEnabled: true,
-      },
-    };
+
     const ds = new GraphiteDatasource(instanceSettings);
     ctx = { ds };
   });

--- a/public/app/plugins/datasource/graphite/gfunc.ts
+++ b/public/app/plugins/datasource/graphite/gfunc.ts
@@ -10,6 +10,9 @@ export type ParamDef = {
   multiple?: boolean;
   optional?: boolean;
   version?: string;
+  required?: boolean;
+  default?: string | number;
+  suggestions?: string[];
 };
 
 export interface FuncDef {
@@ -25,6 +28,7 @@ export interface FuncDef {
    * True if the function was not found on the list of available function descriptions.
    */
   unknown?: boolean;
+  group?: string;
 }
 
 export type FuncDefs = {
@@ -34,12 +38,17 @@ export type FuncDefs = {
 const index: FuncDefs = {};
 
 function addFuncDef(funcDef: Partial<FuncDef> & { name: string; category: string }) {
-  funcDef.params = funcDef.params || [];
-  funcDef.defaultParams = funcDef.defaultParams || [];
+  funcDef.params = funcDef.params ?? [];
+  funcDef.defaultParams = funcDef.defaultParams ?? [];
 
-  index[funcDef.name] = funcDef as FuncDef;
+  const updatedFuncDef: FuncDef = {
+    ...funcDef,
+    params: funcDef.params || [],
+    defaultParams: funcDef.defaultParams || [],
+  };
+  index[funcDef.name] = updatedFuncDef;
   if (funcDef.shortName) {
-    index[funcDef.shortName] = funcDef as FuncDef;
+    index[funcDef.shortName] = updatedFuncDef;
   }
 }
 
@@ -1147,7 +1156,7 @@ function getFuncDefs(graphiteVersion: string, idx?: FuncDefs | null): FuncDefs {
 }
 
 // parse response from graphite /functions endpoint into internal format
-function parseFuncDefs(rawDefs: any): FuncDefs {
+function parseFuncDefs(rawDefs: Record<string, FuncDef>): FuncDefs {
   const funcDefs: FuncDefs = {};
 
   forEach(rawDefs || {}, (funcDef, funcName) => {

--- a/public/app/plugins/datasource/graphite/graphite_query.ts
+++ b/public/app/plugins/datasource/graphite/graphite_query.ts
@@ -6,7 +6,7 @@ import { TemplateSrv } from '@grafana/runtime';
 import { GraphiteDatasource } from './datasource';
 import { FuncInstance } from './gfunc';
 import { AstNode, Parser } from './parser';
-import { GraphiteSegment } from './types';
+import { GraphiteQuery as GraphiteQueryType, GraphiteSegment } from './types';
 import { arrayMove } from './utils';
 
 export type GraphiteTagOperator = '=' | '=~' | '!=' | '!=~';
@@ -41,7 +41,12 @@ export default class GraphiteQuery {
   templateSrv: TemplateSrv | undefined;
   scopedVars?: ScopedVars;
 
-  constructor(datasource: GraphiteDatasource, target: any, templateSrv?: TemplateSrv, scopedVars?: ScopedVars) {
+  constructor(
+    datasource: GraphiteDatasource,
+    target: GraphiteTarget,
+    templateSrv?: TemplateSrv,
+    scopedVars?: ScopedVars
+  ) {
     this.datasource = datasource;
     this.target = target;
     this.templateSrv = templateSrv;
@@ -206,7 +211,7 @@ export default class GraphiteQuery {
     return reduce(this.functions, wrapFunction, metricPath);
   }
 
-  updateModelTarget(targets: any) {
+  updateModelTarget(targets: GraphiteQueryType[]) {
     if (!this.target.textEditor) {
       this.target.target = this.generateQueryString();
     }
@@ -285,7 +290,7 @@ export default class GraphiteQuery {
           if (tag.length === 3) {
             return {
               key: tag[0],
-              operator: tag[1] as GraphiteTagOperator,
+              operator: tag[1],
               value: tag[2],
             };
           }

--- a/public/app/plugins/datasource/graphite/lexer.ts
+++ b/public/app/plugins/datasource/graphite/lexer.ts
@@ -87,12 +87,23 @@ for (let i = 0; i < 128; i++) {
 
 const identifierPartTable = identifierStartTable;
 
+type ScanReturnType = null | ScanReturn;
+interface ScanReturn {
+  type: string;
+  value: string;
+  base?: number;
+  isMalformed?: boolean;
+  pos?: number;
+  isUnclosed?: boolean;
+  quote?: string;
+}
+
 export class Lexer {
-  input: any;
+  input: string;
   char: number;
   from: number;
 
-  constructor(expression: any) {
+  constructor(expression: string) {
     this.input = expression;
     this.char = 1;
     this.from = 1;
@@ -150,7 +161,7 @@ export class Lexer {
     return null;
   }
 
-  scanTemplateSequence() {
+  scanTemplateSequence(): ScanReturnType {
     if (this.peek() === '[' && this.peek(1) === '[') {
       return {
         type: 'templateStart',
@@ -176,7 +187,7 @@ export class Lexer {
    * to Identifier this method can also produce BooleanLiteral
    * (true/false) and NullLiteral (null).
    */
-  scanIdentifier() {
+  scanIdentifier(): ScanReturnType {
     let id = '';
     let index = 0;
     let type, char;
@@ -334,7 +345,7 @@ export class Lexer {
    * This method's implementation was heavily influenced by the
    * scanNumericLiteral function in the Esprima parser's source code.
    */
-  scanNumericLiteral(): any {
+  scanNumericLiteral(): ScanReturnType {
     let index = 0;
     let value = '';
     const length = this.input.length;
@@ -551,7 +562,7 @@ export class Lexer {
     return false;
   }
 
-  scanPunctuator() {
+  scanPunctuator(): ScanReturnType {
     const ch1 = this.peek();
 
     if (this.isPunctuator(ch1)) {
@@ -576,7 +587,7 @@ export class Lexer {
    *   var str = "hello\
    *   world";
    */
-  scanStringLiteral() {
+  scanStringLiteral(): ScanReturnType {
     const quote = this.peek();
 
     // String must start with a quote.

--- a/public/app/plugins/datasource/graphite/types.ts
+++ b/public/app/plugins/datasource/graphite/types.ts
@@ -1,6 +1,6 @@
 import { DataQueryRequest, DataSourceJsonData, TimeRange } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, TimeZone } from '@grafana/schema';
 
 import { GraphiteDatasource } from './datasource';
 
@@ -21,10 +21,28 @@ export interface GraphiteQuery extends DataQuery {
 }
 
 export interface GraphiteOptions extends DataSourceJsonData {
-  graphiteVersion: string;
+  graphiteVersion?: string;
   graphiteType: GraphiteType;
   rollupIndicatorEnabled?: boolean;
-  importConfiguration: GraphiteQueryImportConfiguration;
+  importConfiguration?: GraphiteQueryImportConfiguration;
+}
+
+// Used for the frontend render request
+export interface GraphiteQueryParameters {
+  from: string | number;
+  until: string | number;
+  targets: GraphiteQuery[];
+  format: string;
+  cacheTimeout?: string | number;
+  maxDataPoints?: number;
+}
+
+export interface GraphiteAPIOptions {
+  requestId?: string;
+  range?: TimeRange;
+  timezone?: TimeZone;
+  limit?: number;
+  searchFilter?: string;
 }
 
 export enum GraphiteType {
@@ -33,7 +51,7 @@ export enum GraphiteType {
 }
 
 export interface MetricTankRequestMeta {
-  [key: string]: any;
+  [key: string]: Record<string, number>;
 }
 
 export interface MetricTankSeriesMeta {
@@ -91,7 +109,7 @@ export type GraphiteTag = {
 };
 
 export type GraphiteQueryEditorDependencies = {
-  target: any;
+  target: string;
   datasource: GraphiteDatasource;
   range?: TimeRange;
   templateSrv: TemplateSrv;

--- a/public/app/plugins/datasource/graphite/utils.test.ts
+++ b/public/app/plugins/datasource/graphite/utils.test.ts
@@ -39,6 +39,7 @@ describe('Graphite utils', () => {
       data: {
         message: SAMPLE_500_PAGE,
       },
+      config: { url: '' },
     };
 
     expect(reduceError(error)).toMatchObject({
@@ -54,6 +55,7 @@ describe('Graphite utils', () => {
       data: {
         message: 'ERROR MESSAGE',
       },
+      config: { url: '' },
     };
 
     expect(reduceError(error)).toMatchObject({
@@ -69,6 +71,7 @@ describe('Graphite utils', () => {
       data: {
         message: 'ERROR MESSAGE',
       },
+      config: { url: '' },
     };
 
     expect(reduceError(error)).toMatchObject({

--- a/public/app/plugins/datasource/graphite/utils.ts
+++ b/public/app/plugins/datasource/graphite/utils.ts
@@ -1,5 +1,7 @@
 import { last } from 'lodash';
 
+import { FetchError, isFetchError } from '@grafana/runtime';
+
 import { GraphiteParserError } from './types';
 
 /**
@@ -8,8 +10,8 @@ import { GraphiteParserError } from './types';
  * This function removes all HTML tags and keeps only the last line from the stack
  * trace which should be the most meaningful.
  */
-export function reduceError(error: any) {
-  if (error && error.status === 500 && error.data?.message?.startsWith('<body')) {
+export function reduceError(error: FetchError | { message: string }): typeof error {
+  if (error && isFetchError(error) && error.status === 500 && error.data?.message?.startsWith('<body')) {
     // Remove all HTML tags and take the last line from the stack trace
     const newMessage = last<string>(
       error.data.message


### PR DESCRIPTION
Some general clean up on the Graphite data source as a part of grafana/data-sources#607.

I've done the following: 

- Improve type definitions
- Remove `any`
- Remove type assertions

There are still some assertions and `any`'s that would require more work.