### PR TITLE
unified-storage: Unified search wildcard exception

### DIFF
--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -207,6 +207,19 @@ func TestCanSearchByTitle(t *testing.T) {
 		// include terms shorter that are exactly 3 chars
 		checkSearchQuery(t, index, newTestQuery("new das"), []string{"name2", "name1"})
 	})
+
+	t.Run("title search will use wildcard match when using a single term", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "new dashboard",
+			"name2": "new dash",
+			"name3": "somedash",
+		})
+
+		checkSearchQuery(t, index, newTestQuery("das"), []string{"name1", "name2", "name3"})
+		checkSearchQuery(t, index, newTestQuery("ome"), []string{"name3"})
+		checkSearchQuery(t, index, newTestQuery("new das"), []string{"name2", "name1"})
+	})
 }
 
 func newTestQuery(query string) *resourcepb.ResourceSearchRequest {


### PR DESCRIPTION
for https://github.com/grafana/search-and-storage-team/issues/500

current legacy sql relies heavily on these kinds of matches. we used to have that but removed on https://github.com/grafana/grafana/pull/101441 due to performance issues.

I propose we give it a try again, with a couple of constraints: only against the title of the document, and only if there is exactly one term in the original query (unless it's forced with a `*`)