### PR TITLE
Provisioning: Add back most integration tests; skip flaky ones

### DIFF
--- a/pkg/tests/apis/provisioning/exportjob_test.go
+++ b/pkg/tests/apis/provisioning/exportjob_test.go
@@ -17,6 +17,9 @@ import (
 )
 
 func TestIntegrationProvisioning_ExportUnifiedToRepository(t *testing.T) {
+	// TODO: fix flaky test
+	t.Skip("skipping flaky test")
+
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -109,6 +109,9 @@ func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_MoveResources(t *testing.T) {
+	// TODO: fix flaky test
+	t.Skip("skipping flaky test")
+
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)
@@ -399,6 +402,9 @@ func TestIntegrationProvisioning_MoveResources(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
+	// TODO: fix flaky test
+	t.Skip("skipping flaky test")
+
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)

--- a/pkg/tests/apis/provisioning/helper_test.go
+++ b/pkg/tests/apis/provisioning/helper_test.go
@@ -36,11 +36,11 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/tests/testsuite"
 )
 
 func TestMain(m *testing.M) {
-	// TODO: Tests are flaky, so skip them for now
-	//testsuite.Run(m)
+	testsuite.Run(m)
 }
 
 type provisioningTestHelper struct {

--- a/pkg/tests/apis/provisioning/pulljob_test.go
+++ b/pkg/tests/apis/provisioning/pulljob_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestIntegrationProvisioning_PullJobOwnershipProtection(t *testing.T) {
+	// TODO: fix flaky test
+	t.Skip("skipping flaky test")
+
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -382,6 +382,9 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 }
 
 func TestIntegrationProvisioning_RepositoryLimits(t *testing.T) {
+	// TODO: fix flaky test
+	t.Skip("skipping flaky test")
+
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/111128, and instead went through ci failures from the past day and skipped all flaky tests from those. Will go through each individually to see what is going on. For now, get some coverage back

Relates to https://github.com/grafana/git-ui-sync-project/issues/442