### PR TITLE
Navigation: Add missing subpaths for navtree items

### DIFF
--- a/pkg/services/navtree/navtreeimpl/admin.go
+++ b/pkg/services/navtree/navtreeimpl/admin.go
@@ -76,7 +76,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Text:     "General",
 		SubTitle: "Manage default preferences and settings across Grafana",
 		Id:       navtree.NavIDCfgGeneral,
-		Url:      "/admin/general",
+		Url:      s.cfg.AppSubURL + "/admin/general",
 		Icon:     "shield",
 		Children: generalNodeLinks,
 	}
@@ -121,7 +121,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Text:     "Plugins and data",
 		SubTitle: "Install plugins and define the relationships between data",
 		Id:       navtree.NavIDCfgPlugins,
-		Url:      "/admin/plugins",
+		Url:      s.cfg.AppSubURL + "/admin/plugins",
 		Icon:     "shield",
 		Children: pluginsNodeLinks,
 	}
@@ -174,7 +174,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Text:     "Users and access",
 		SubTitle: "Configure access for individual users, teams, and service accounts",
 		Id:       navtree.NavIDCfgAccess,
-		Url:      "/admin/access",
+		Url:      s.cfg.AppSubURL + "/admin/access",
 		Icon:     "shield",
 		Children: accessNodeLinks,
 	}
@@ -201,7 +201,7 @@ func (s *ServiceImpl) getAdminNode(c *contextmodel.ReqContext) (*navtree.NavLink
 		Icon:       "cog",
 		SortWeight: navtree.WeightConfig,
 		Children:   configNodes,
-		Url:        "/admin",
+		Url:        s.cfg.AppSubURL + "/admin",
 	}
 
 	return configNode, nil

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -267,7 +267,7 @@ func (s *ServiceImpl) addHelpLinks(treeRoot *navtree.NavTreeRoot, c *contextmode
 			supportBundleNode := &navtree.NavLink{
 				Text:       "Support bundles",
 				Id:         "support-bundles",
-				Url:        "/support-bundles",
+				Url:        s.cfg.AppSubURL + "/support-bundles",
 				Icon:       "wrench",
 				SortWeight: navtree.WeightHelp,
 			}


### PR DESCRIPTION
**What is this feature?**

Adds in missing subpaths for navigation tree items.

**Why do we need this feature?**

Fixes issues with breadcrumbs items opening in new tab resulting in a 404.

**Which issue(s) does this PR fix?**:

Fixes #111199
