### PR TITLE
Dynamic Dashboards: Expand dashboard save and create tracking

### DIFF
--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -2,7 +2,7 @@ import { useAsyncFn } from 'react-use';
 
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { locationService, reportInteraction } from '@grafana/runtime';
+import { locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import appEvents from 'app/core/app_events';
@@ -15,6 +15,8 @@ import { useDispatch } from 'app/types/store';
 
 import { updateDashboardUidLastUsedDatasource } from '../../dashboard/utils/dashboard';
 import { DashboardScene } from '../scene/DashboardScene';
+import { DashboardInteractions } from '../utils/interactions';
+import { trackDashboardSceneCreatedOrSaved } from '../utils/tracking';
 
 export function useSaveDashboard(isCopy = false) {
   const dispatch = useDispatch();
@@ -62,18 +64,15 @@ export function useSaveDashboard(isCopy = false) {
         appEvents.publish(new DashboardSavedEvent());
         notifyApp.success(t('dashboard-scene.use-save-dashboard.message-dashboard-saved', 'Dashboard saved'));
 
-        //Update local storage dashboard to handle things like last used datasource
+         
         updateDashboardUidLastUsedDatasource(resultData.uid);
 
         if (isCopy) {
-          reportInteraction('grafana_dashboard_copied', {
-            name: saveModel.title,
-            url: resultData.url,
-          });
+          DashboardInteractions.dashboardCopied({ name: saveModel.title || '', url: resultData.url });
         } else {
-          reportInteraction(`grafana_dashboard_${options.isNew ? 'created' : 'saved'}`, {
-            name: saveModel.title,
-            url: resultData.url,
+          trackDashboardSceneCreatedOrSaved(options.isNew ? 'created' : 'saved', scene, {
+            name: saveModel.title || '',
+            url: resultData.url || '',
           });
         }
 

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -64,7 +64,6 @@ export function useSaveDashboard(isCopy = false) {
         appEvents.publish(new DashboardSavedEvent());
         notifyApp.success(t('dashboard-scene.use-save-dashboard.message-dashboard-saved', 'Dashboard saved'));
 
-         
         updateDashboardUidLastUsedDatasource(resultData.uid);
 
         if (isCopy) {

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -12,7 +12,6 @@ import {
   defaultSpec as defaultDashboardV2Spec,
   defaultDataQueryKind,
   defaultPanelSpec,
-  defaultTimeSettingsSpec,
   GridLayoutKind,
   PanelKind,
   PanelSpec,
@@ -27,11 +26,11 @@ import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { DashboardScene } from '../scene/DashboardScene';
 import { transformSaveModelToScene } from '../serialization/transformSaveModelToScene';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
+import { getTestDashboardSceneFromSaveModel } from '../utils/test-utils';
 import { findVizPanelByKey } from '../utils/utils';
 
 import { V1DashboardSerializer, V2DashboardSerializer } from './DashboardSceneSerializer';
-import { getPanelElement, transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
-import { transformSceneToSaveModelSchemaV2 } from './transformSceneToSaveModelSchemaV2';
+import { getPanelElement } from './transformSaveModelSchemaV2ToScene';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -1478,87 +1477,5 @@ function setup(override: Partial<Dashboard> = {}) {
 }
 
 function setupV2(spec?: Partial<DashboardV2Spec>) {
-  const dashboard = transformSaveModelSchemaV2ToScene({
-    kind: 'DashboardWithAccessInfo',
-    spec: {
-      ...defaultDashboardV2Spec(),
-      title: 'hello',
-      timeSettings: {
-        ...defaultTimeSettingsSpec(),
-        autoRefresh: '10s',
-        from: 'now-1h',
-        to: 'now',
-      },
-      elements: {
-        'panel-1': {
-          kind: 'Panel',
-          spec: {
-            ...defaultPanelSpec(),
-            id: 1,
-            title: 'Panel 1',
-          },
-        },
-      },
-      layout: {
-        kind: 'GridLayout',
-        spec: {
-          items: [
-            {
-              kind: 'GridLayoutItem',
-              spec: {
-                x: 0,
-                y: 0,
-                width: 12,
-                height: 8,
-                element: {
-                  kind: 'ElementReference',
-                  name: 'panel-1',
-                },
-              },
-            },
-          ],
-        },
-      },
-      variables: [
-        {
-          kind: 'CustomVariable',
-          spec: {
-            name: 'app',
-            label: 'Query Variable',
-            description: 'A query variable',
-            skipUrlSync: false,
-            hide: 'dontHide',
-            options: [],
-            multi: false,
-            current: {
-              text: 'app1',
-              value: 'app1',
-            },
-            query: 'app1',
-            allValue: '',
-            includeAll: false,
-            allowCustomValue: true,
-          },
-        },
-      ],
-      ...spec,
-    },
-    apiVersion: 'v1',
-    metadata: {
-      name: 'dashboard-test',
-      resourceVersion: '1',
-      creationTimestamp: '2023-01-01T00:00:00Z',
-    },
-    access: {
-      canEdit: true,
-      canSave: true,
-      canStar: true,
-      canShare: true,
-    },
-  });
-
-  const initialSaveModel = transformSceneToSaveModelSchemaV2(dashboard);
-  dashboard.setInitialSaveModel(initialSaveModel);
-
-  return dashboard;
+  return getTestDashboardSceneFromSaveModel(spec);
 }

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -1,4 +1,5 @@
 import { config, reportInteraction } from '@grafana/runtime';
+import { DashboardCreatedProps } from 'app/features/dashboard-scene/utils/tracking';
 
 let isScenesContextSet = false;
 
@@ -6,6 +7,14 @@ export const DashboardInteractions = {
   // Dashboard interactions:
   dashboardInitialized: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('init_dashboard_completed', { ...properties });
+  },
+
+  dashboardCopied: (properties: DashboardCreatedProps) => {
+    reportInteraction('grafana_dashboard_copied', properties);
+  },
+
+  dashboardCreatedOrSaved: (name: 'created' | 'saved', properties: DashboardCreatedProps) => {
+    reportDashboardInteraction(name, properties);
   },
 
   // grafana_dashboards_edit_button_clicked

--- a/public/app/features/dashboard-scene/utils/test-utils.ts
+++ b/public/app/features/dashboard-scene/utils/test-utils.ts
@@ -12,6 +12,12 @@ import {
   TestVariable,
   VizPanel,
 } from '@grafana/scenes';
+import {
+  defaultTimeSettingsSpec,
+  defaultPanelSpec,
+  Spec as DashboardV2Spec,
+  defaultSpec as defaultDashboardV2Spec,
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardLoaderSrv, setDashboardLoaderSrv } from 'app/features/dashboard/services/DashboardLoaderSrv';
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from 'app/features/variables/constants';
 import { DashboardDTO } from 'app/types/dashboard';
@@ -20,6 +26,8 @@ import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { DashboardGridItem, RepeatDirection } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowRepeaterBehavior } from '../scene/layout-default/RowRepeaterBehavior';
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
+import { transformSceneToSaveModelSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
 
 export function setupLoadDashboardMock(rsp: DeepPartial<DashboardDTO>, spy?: jest.Mock) {
   const loadDashboardMock = (spy || jest.fn()).mockResolvedValue(rsp);
@@ -216,4 +224,90 @@ export function buildPanelRepeaterScene(options: SceneOptions, source?: VizPanel
   });
 
   return { scene, repeater: withRepeat, row, variable: panelRepeatVariable };
+}
+
+export function getTestDashboardSceneFromSaveModel(spec?: Partial<DashboardV2Spec>) {
+  const dashboard = transformSaveModelSchemaV2ToScene({
+    kind: 'DashboardWithAccessInfo',
+    spec: {
+      ...defaultDashboardV2Spec(),
+      title: 'hello',
+      timeSettings: {
+        ...defaultTimeSettingsSpec(),
+        autoRefresh: '10s',
+        from: 'now-1h',
+        to: 'now',
+      },
+      elements: {
+        'panel-1': {
+          kind: 'Panel',
+          spec: {
+            ...defaultPanelSpec(),
+            id: 1,
+            title: 'Panel 1',
+          },
+        },
+      },
+      layout: {
+        kind: 'GridLayout',
+        spec: {
+          items: [
+            {
+              kind: 'GridLayoutItem',
+              spec: {
+                x: 0,
+                y: 0,
+                width: 12,
+                height: 8,
+                element: {
+                  kind: 'ElementReference',
+                  name: 'panel-1',
+                },
+              },
+            },
+          ],
+        },
+      },
+      variables: [
+        {
+          kind: 'CustomVariable',
+          spec: {
+            name: 'app',
+            label: 'Query Variable',
+            description: 'A query variable',
+            skipUrlSync: false,
+            hide: 'dontHide',
+            options: [],
+            multi: false,
+            current: {
+              text: 'app1',
+              value: 'app1',
+            },
+            query: 'app1',
+            allValue: '',
+            includeAll: false,
+            allowCustomValue: true,
+          },
+        },
+      ],
+      ...spec,
+    },
+    apiVersion: 'v1',
+    metadata: {
+      name: 'dashboard-test',
+      resourceVersion: '1',
+      creationTimestamp: '2023-01-01T00:00:00Z',
+    },
+    access: {
+      canEdit: true,
+      canSave: true,
+      canStar: true,
+      canShare: true,
+    },
+  });
+
+  const initialSaveModel = transformSceneToSaveModelSchemaV2(dashboard);
+  dashboard.setInitialSaveModel(initialSaveModel);
+
+  return dashboard;
 }

--- a/public/app/features/dashboard-scene/utils/tracking.test.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.test.ts
@@ -1,0 +1,52 @@
+import { getPanelPlugin } from '@grafana/data/test';
+import { reportInteraction, setPluginImportUtils } from '@grafana/runtime';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import nestedDashboard from '../serialization/testfiles/nested_dashboard.json';
+import { getTestDashboardSceneFromSaveModel } from '../utils/test-utils';
+
+import { trackDashboardSceneCreatedOrSaved } from './tracking';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportInteraction: jest.fn(),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      dashboardNewLayouts: true,
+    },
+  },
+}));
+
+// mock useSaveDashboardMutation
+jest.mock('app/features/browse-dashboards/api/browseDashboardsAPI', () => ({
+  useSaveDashboardMutation: () => [() => Promise.resolve({ data: { version: 2, uid: 'new-uid' } })],
+}));
+
+setPluginImportUtils({
+  importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
+  getPanelPluginFromCache: (id: string) => undefined,
+});
+
+export function buildTestScene() {
+  const dashboard = getTestDashboardSceneFromSaveModel(nestedDashboard as Partial<DashboardV2Spec>);
+  return dashboard;
+}
+
+describe('dashboard tracking', () => {
+  describe('save v2 dashboard tracking', () => {
+    it('should call report interaction with correct parameters when saving a new dashboard', async () => {
+      const scene = buildTestScene();
+      trackDashboardSceneCreatedOrSaved('created', scene, { name: 'new dashboard', url: 'new-uid' });
+      expect(reportInteraction).toHaveBeenCalledWith('dashboards_created', {
+        isDynamicDashboard: true,
+        name: 'new dashboard',
+        url: 'new-uid',
+        numPanels: 6,
+        conditionalRenderRules: 3,
+        autoLayout: 3,
+        customGridLayout: 2,
+      });
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -18,27 +18,18 @@ export interface DashboardCreatedProps {
   [key: string]: unknown;
 }
 
-export function isV2TrackingInfo(
-  t: DashboardTrackingInfo & DashboardV2TrackingInfo
-): t is DashboardV2TrackingInfo & DashboardTrackingInfo {
-  return 'autoLayoutCount' in t;
-}
-
 export function trackDashboardSceneCreatedOrSaved(
   name: 'created' | 'saved',
   dashboard: DashboardScene,
   initialProperties: DashboardCreatedProps
 ) {
   const trackingInformation = dashboard.getTrackingInformation();
-  const v2TrackingFields =
-    trackingInformation && isV2TrackingInfo(trackingInformation)
-      ? {
-          numPanels: trackingInformation.panels_count,
-          conditionalRenderRules: trackingInformation.conditionalRenderRulesCount,
-          autoLayout: trackingInformation.autoLayoutCount,
-          customGridLayout: trackingInformation.customGridLayoutCount,
-        }
-      : {};
+  const v2TrackingFields = {
+    numPanels: trackingInformation?.panels_count,
+    conditionalRenderRules: trackingInformation?.conditionalRenderRulesCount,
+    autoLayout: trackingInformation?.autoLayoutCount,
+    customGridLayout: trackingInformation?.customGridLayoutCount,
+  };
 
   DashboardInteractions.dashboardCreatedOrSaved(name, {
     ...initialProperties,

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -17,10 +17,6 @@ export function trackDashboardSceneLoaded(dashboard: DashboardScene, duration?: 
   });
 }
 
-export function trackDashboardCreatedOrSaved(name: 'created' | 'saved', trackingProps: DashboardCreatedProps) {
-  DashboardInteractions.dashboardCreatedOrSaved(name, trackingProps);
-}
-
 export const trackDeleteDashboardElement = (element: EditableDashboardElementInfo) => {
   switch (element?.typeName) {
     case 'Row':

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -3,6 +3,7 @@ import { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
 import { EditableDashboardElementInfo } from 'app/features/dashboard-scene/scene/types/EditableDashboardElement';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
+import { DashboardCreatedProps } from 'app/features/dashboard-scene/utils/tracking';
 
 import { DashboardModel } from '../state/DashboardModel';
 
@@ -37,6 +38,10 @@ export function trackDashboardSceneLoaded(dashboard: DashboardScene, duration?: 
     isScene: true,
     ...trackingInformation,
   });
+}
+
+export function trackDashboardCreatedOrSaved(name: 'created' | 'saved', trackingProps: DashboardCreatedProps) {
+  DashboardInteractions.dashboardCreatedOrSaved(name, trackingProps);
 }
 
 export const trackDeleteDashboardElement = (element: EditableDashboardElementInfo) => {


### PR DESCRIPTION
Blocked by https://github.com/grafana/grafana/pull/111102 since it depends on some types and utils there (`getTrackingInformation` primarily)

Implements `expand dashboards_created/saved` from https://github.com/grafana/grafana/issues/110090

isDynamicDashboard prop to specify feature toggle value
numPanels : # of panels of dashboard
conditionalRenderRules: # of conditional rendering rules
‘autoLayout’ : number of auto layout sections in dashboard
‘customGridLayout’ : number of custom grid layout sections in dashboard

- moved the `setupV2` to test utils
- calls DashboardInteractions.dashboardCopied instead of reportInteraction directly, so we have all tracking functions documented in `interactions.ts`
- 