### PR TITLE
Dashboard Migrations: Report metrics when migration fails

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/metrics.go
+++ b/apps/dashboard/pkg/migration/conversion/metrics.go
@@ -209,6 +209,6 @@ func withConversionMetrics(sourceVersionAPI, targetVersionAPI string, conversion
 			logger.Debug("Dashboard conversion succeeded", successLogFields...)
 		}
 
-		return err
+		return nil
 	}
 }

--- a/apps/dashboard/pkg/migration/conversion/v0.go
+++ b/apps/dashboard/pkg/migration/conversion/v0.go
@@ -36,7 +36,7 @@ func Convert_V0_to_V1(in *dashv0.Dashboard, out *dashv1.Dashboard, scope convers
 	if err != nil {
 		out.Status.Conversion.Failed = true
 		out.Status.Conversion.Error = ptr.To(err.Error())
-		return nil
+		return schemaversion.NewMigrationError(err.Error(), schemaversion.GetSchemaVersion(in.Spec.Object), schemaversion.LATEST_VERSION, "Convert_V0_to_V1")
 	}
 
 	// a background service identity is used here because the user who is reading the specific dashboard
@@ -47,7 +47,7 @@ func Convert_V0_to_V1(in *dashv0.Dashboard, out *dashv1.Dashboard, scope convers
 	if err := migration.Migrate(ctx, out.Spec.Object, schemaversion.LATEST_VERSION); err != nil {
 		out.Status.Conversion.Failed = true
 		out.Status.Conversion.Error = ptr.To(err.Error())
-		return nil
+		return schemaversion.NewMigrationError(err.Error(), schemaversion.GetSchemaVersion(in.Spec.Object), schemaversion.LATEST_VERSION, "Convert_V0_to_V1")
 	}
 
 	return nil


### PR DESCRIPTION
This ensures that migration failures are reported. Currently, when [withConversionMetrics](https://github.com/grafana/grafana/blob/24f82dc20d7e5074a9cb81f71257be7d72de4fff/apps/dashboard/pkg/migration/conversion/metrics.go#L68) runs, it runs [conversionFunc](https://github.com/grafana/grafana/blob/24f82dc20d7e5074a9cb81f71257be7d72de4fff/apps/dashboard/pkg/migration/conversion/metrics.go#L114), but when that function runs, e.g., `Convert_V0_to_V1`, we are always returning nil. With this fix, we will be able to see `grafana_dashboard_migration_conversion_failure_total` metric. 

@dprokop @ivanortegaalba I understand that this will create a bit of noise because we will see minimum schema version errors, but I don't see any other way to get the failure metric. 

If we still want to return the error through withConversionMetrics, this will result in a response 500, so we need to decide if we want to do this or just have these errors in the status field, but still return a valid, although not properly converted dashboard.  

<img width="1897" height="304" alt="Screenshot 2025-09-16 at 4 25 13 PM" src="https://github.com/user-attachments/assets/1cad581e-9315-45b7-89b2-717ac60762d4" />


Please check that:
- [ ] It works as expected from a user's perspective.
