### PR TITLE
TimeComparison: Ensure headerActions are activated

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -15,6 +15,7 @@ import {
   SceneQueryRunner,
   sceneUtils,
   VizPanel,
+  isSceneObject,
 } from '@grafana/scenes';
 import { Panel } from '@grafana/schema/dist/esm/index.gen';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
@@ -94,6 +95,16 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     );
 
     const deactivateParents = activateSceneObjectAndParentTree(panel);
+
+    // Ensure headerActions are activated
+    const headerActions = panel.state.headerActions;
+    if (headerActions) {
+      (Array.isArray(headerActions) ? headerActions : [headerActions]).forEach((action) => {
+        if (isSceneObject(action)) {
+          action.activate();
+        }
+      });
+    }
 
     this.waitForPlugin();
 


### PR DESCRIPTION
For TimeComparison in panel header actions for Time Series, we need to be sure that it is activated properly when panel editor toggles table view on and off.

FF = `timeComparison`

Before:
![Sep-17-2025 00-34-30](https://github.com/user-attachments/assets/ae9cda27-18a8-48c9-aa97-7dccde714dc1)

After:
![Sep-17-2025 00-31-07](https://github.com/user-attachments/assets/58d5790d-0b7f-40ed-9a87-0a606be71081)


Fixes https://github.com/grafana/grafana/issues/110574