### PR TITLE
TimeComparison: Ensure dashboardScene is enabled

### DIFF
--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -18,7 +18,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     commonOptionsBuilder.addTooltipOptions(builder, false, true, optsWithHideZeros);
     commonOptionsBuilder.addLegendOptions(builder);
 
-    if (config.featureToggles.timeComparison) {
+    if (config.featureToggles.timeComparison && config.featureToggles.dashboardScene) {
       commonOptionsBuilder.addTimeCompareOption(builder);
     }
 


### PR DESCRIPTION
The time comparison options should not be exposed if dashboardScene is false.