### PR TITLE
`grafana-iam`: Fix context for identity store queries to work

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -99,7 +99,8 @@ func (s *ResourcePermSqlBackend) ListIterator(ctx context.Context, req *resource
 		Continue: token.offset,
 	}
 
-	dbHelper, err := s.dbProvider(request.WithNamespace(ctx, ns.Value))
+	ctx = request.WithNamespace(ctx, ns.Value)
+	dbHelper, err := s.dbProvider(ctx)
 	if err != nil {
 		logger := s.logger.FromContext(ctx)
 		logger.Error("Failed to get database helper", "error", err)
@@ -148,7 +149,8 @@ func (s *ResourcePermSqlBackend) ReadResource(ctx context.Context, req *resource
 		return rsp
 	}
 
-	dbHelper, err := s.dbProvider(request.WithNamespace(ctx, ns.Value))
+	ctx = request.WithNamespace(ctx, ns.Value)
+	dbHelper, err := s.dbProvider(ctx)
 	if err != nil {
 		// Hide the error from the user, but log it
 		logger := s.logger.FromContext(ctx)
@@ -232,7 +234,8 @@ func (s *ResourcePermSqlBackend) WriteEvent(ctx context.Context, event resource.
 		return 0, apierrors.NewBadRequest(fmt.Sprintf("invalid key %q: %v", event.Key, err.Error()))
 	}
 
-	dbHelper, err := s.dbProvider(request.WithNamespace(ctx, ns.Value))
+	ctx = request.WithNamespace(ctx, ns.Value)
+	dbHelper, err := s.dbProvider(ctx)
 	if err != nil {
 		// Hide the error from the user, but log it
 		logger := s.logger.FromContext(ctx)


### PR DESCRIPTION
This PR sets the namespace in the context for DB queries made by the identity store to work.