### PR TITLE
fix(unified-storage): track mode 5 correctly

### DIFF
--- a/pkg/services/apiserver/appinstaller/storage.go
+++ b/pkg/services/apiserver/appinstaller/storage.go
@@ -58,6 +58,7 @@ func NewDualWriter(
 
 	// Force using storage only -- regardless of internal synchronization state
 	if mode == grafanarest.Mode5 {
+		builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode, grafanarest.Mode5)
 		return storage, nil
 	}
 

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -317,6 +317,7 @@ func InstallAPIs(
 
 			// Force using storage only -- regardless of internal synchronization state
 			if mode == grafanarest.Mode5 {
+				builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, mode, grafanarest.Mode5)
 				return storage, nil
 			}
 


### PR DESCRIPTION
This PR fixes that we don't record mode 5 in the `unified_storage_dual_writer_current_mode` metric. As we return early before the record call in mode 5, we need to do it in the if condition.