### PR TITLE
E2E: Add table selectors

### DIFF
--- a/devenv/dev-dashboards/panel-table/table_tests.json
+++ b/devenv/dev-dashboards/panel-table/table_tests.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": { "type": "datasource", "uid": "grafana" },
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",
@@ -13,76 +13,123 @@
     ]
   },
   "editable": true,
-  "gnetId": null,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
+  "id": 42,
   "links": [],
   "panels": [
     {
-      "columns": [],
-      "datasource": {
-        "type": "grafana-testdata-datasource"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 0,
-        "y": 0
-      },
-      "id": 3,
-      "links": [],
-      "pageSize": 10,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
+      "datasource": { "type": "grafana-testdata-datasource", "uid": "PD8C576611E62080A" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "custom": {
+            "align": "auto",
+            "cellOptions": { "type": "auto" },
+            "footer": { "reducers": [] },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          }
         },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 7,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
+      "targets": [
         {
-          "alias": "",
-          "colorMode": "cell",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorCell",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "currencyUSD"
-        },
-        {
-          "alias": "",
-          "colorMode": "value",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorValue",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "Bps"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
-          "unit": "short"
+          "csvContent": "Metric,Value,Stat\ncpu,20,average\ndropped_bytes,10,mean\ncpu_utilization,70,mean\n\n",
+          "refId": "A",
+          "scenarioId": "csv_content"
         }
       ],
+      "title": "New panel",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "cellOptions": { "type": "auto" }, "footer": { "reducers": [] }, "inspect": false },
+          "decimals": 2,
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [
+              { "id": "displayName", "value": "Time" },
+              { "id": "unit", "value": "time: YYYY-MM-DD HH:mm:ss" },
+              { "id": "custom.align" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorCell" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorValue" },
+            "properties": [
+              { "id": "unit", "value": "Bps" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 11, "w": 12, "x": 0, "y": 0 },
+      "id": 3,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "alias": "server1",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "expr": "",
           "format": "table",
           "intervalFactor": 1,
@@ -92,94 +139,92 @@
         },
         {
           "alias": "server2",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "refId": "B",
           "scenarioId": "csv_metric_values",
           "stringInput": "1,20,90,30,5,0"
         }
       ],
       "title": "Time series to rows (2 pages)",
-      "transform": "timeseries_to_rows",
+      "transformations": [{ "id": "seriesToRows", "options": { "reducers": [] } }],
       "type": "table"
     },
     {
-      "columns": [
-        {
-          "text": "Avg",
-          "value": "avg"
-        },
-        {
-          "text": "Max",
-          "value": "max"
-        },
-        {
-          "text": "Current",
-          "value": "current"
-        }
-      ],
-      "datasource": {
-        "type": "grafana-testdata-datasource"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 11,
-        "w": 12,
-        "x": 12,
-        "y": 0
-      },
-      "id": 4,
-      "links": [],
-      "pageSize": 10,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "cell",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "cellOptions": { "type": "auto" }, "footer": { "reducers": [] }, "inspect": false },
           "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorCell",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "currencyUSD"
-        },
-        {
-          "alias": "",
-          "colorMode": "value",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorValue",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "Bps"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          },
           "unit": "short"
-        }
-      ],
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [
+              { "id": "displayName", "value": "Time" },
+              { "id": "unit", "value": "time: YYYY-MM-DD HH:mm:ss" },
+              { "id": "custom.align" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorCell" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorValue" },
+            "properties": [
+              { "id": "unit", "value": "Bps" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 11, "w": 12, "x": 12, "y": 0 },
+      "id": 4,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "alias": "server1",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "expr": "",
           "format": "table",
           "intervalFactor": 1,
@@ -189,69 +234,74 @@
         },
         {
           "alias": "server2",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "refId": "B",
           "scenarioId": "csv_metric_values",
           "stringInput": "1,20,90,30,5,0"
         }
       ],
       "title": "Time series aggregations",
-      "transform": "timeseries_aggregations",
+      "transformations": [
+        { "id": "reduce", "options": { "includeTimeField": false, "reducers": ["mean", "max", "lastNotNull"] } }
+      ],
       "type": "table"
     },
     {
-      "columns": [],
-      "datasource": {
-        "type": "grafana-testdata-datasource"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 7,
-        "w": 24,
-        "x": 0,
-        "y": 11
-      },
-      "id": 5,
-      "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "row",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "cellOptions": { "type": "auto" }, "footer": { "reducers": [] }, "inspect": false },
           "decimals": 2,
-          "mappingType": 1,
-          "pattern": "/Color/",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "currencyUSD"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          },
           "unit": "short"
-        }
-      ],
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [
+              { "id": "displayName", "value": "Time" },
+              { "id": "unit", "value": "time: YYYY-MM-DD HH:mm:ss" },
+              { "id": "custom.align" }
+            ]
+          },
+          {
+            "matcher": { "id": "byRegexp", "options": "/Color/" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 24, "x": 0, "y": 11 },
+      "id": 5,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "alias": "ColorValue",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "expr": "",
           "format": "table",
           "intervalFactor": 1,
@@ -261,75 +311,85 @@
         }
       ],
       "title": "color row by threshold",
-      "transform": "timeseries_to_columns",
+      "transformations": [{ "id": "seriesToColumns", "options": { "reducers": [] } }],
       "type": "table"
     },
     {
-      "columns": [],
-      "datasource": {
-        "type": "grafana-testdata-datasource"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 18
-      },
-      "id": 2,
-      "links": [],
-      "pageSize": null,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "cell",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "cellOptions": { "type": "auto" }, "footer": { "reducers": [] }, "inspect": false },
           "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorCell",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "currencyUSD"
-        },
-        {
-          "alias": "",
-          "colorMode": "value",
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "ColorValue",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "Bps"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          },
           "unit": "short"
-        }
-      ],
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [
+              { "id": "displayName", "value": "Time" },
+              { "id": "unit", "value": "time: YYYY-MM-DD HH:mm:ss" },
+              { "id": "custom.align" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorCell" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorValue" },
+            "properties": [
+              { "id": "unit", "value": "Bps" },
+              { "id": "decimals", "value": 2 },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.9)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.89)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.97)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 18 },
+      "id": 2,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "alias": "ColorValue",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "expr": "",
           "format": "table",
           "intervalFactor": 1,
@@ -339,87 +399,94 @@
         },
         {
           "alias": "ColorCell",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "refId": "B",
           "scenarioId": "csv_metric_values",
           "stringInput": "5,1,2,3,4,5,10,20"
         }
       ],
       "title": "Column style thresholds & units",
-      "transform": "timeseries_to_columns",
+      "transformations": [{ "id": "seriesToColumns", "options": { "reducers": [] } }],
       "type": "table"
     },
     {
-      "columns": [],
-      "datasource": {
-        "type": "grafana-testdata-datasource"
-      },
-      "fontSize": "100%",
-      "gridPos": {
-        "h": 10,
-        "w": 24,
-        "x": 0,
-        "y": 26
-      },
-      "id": 6,
-      "links": [],
-      "pageSize": 20,
-      "scroll": true,
-      "showHeader": true,
-      "sort": {
-        "col": 0,
-        "desc": true
-      },
-      "styles": [
-        {
-          "alias": "Time",
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "Time",
-          "type": "date"
-        },
-        {
-          "alias": "",
-          "colorMode": "cell",
-          "colors": ["rgba(245, 54, 54, 0.5)", "rgba(237, 129, 40, 0.5)", "rgba(50, 172, 45, 0.5)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "cellOptions": { "type": "auto" }, "footer": { "reducers": [] }, "inspect": false },
           "decimals": 2,
-          "link": true,
-          "linkTargetBlank": true,
-          "linkTooltip": "",
-          "linkUrl": "http://www.grafana.com",
-          "mappingType": 1,
-          "pattern": "ColorCell",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "currencyUSD"
-        },
-        {
-          "alias": "",
-          "colorMode": "value",
-          "colors": ["rgba(245, 54, 54, 0.5)", "rgba(237, 129, 40, 0.5)", "rgba(50, 172, 45, 0.5)"],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "link": true,
-          "linkUrl": "http://www.grafana.com",
-          "mappingType": 1,
-          "pattern": "ColorValue",
-          "thresholds": ["5", "10"],
-          "type": "number",
-          "unit": "Bps"
-        },
-        {
-          "alias": "",
-          "colorMode": null,
-          "colors": ["rgba(245, 54, 54, 0.9)", "rgba(237, 129, 40, 0.89)", "rgba(50, 172, 45, 0.97)"],
-          "decimals": 2,
-          "pattern": "/.*/",
-          "thresholds": [],
-          "type": "number",
+          "displayName": "",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": 0 },
+              { "color": "red", "value": 80 }
+            ]
+          },
           "unit": "short"
-        }
-      ],
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "Time" },
+            "properties": [
+              { "id": "displayName", "value": "Time" },
+              { "id": "unit", "value": "time: YYYY-MM-DD HH:mm:ss" },
+              { "id": "custom.align" }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorCell" },
+            "properties": [
+              { "id": "unit", "value": "currencyUSD" },
+              { "id": "decimals", "value": 2 },
+              { "id": "links", "value": [{ "targetBlank": true, "title": "", "url": "http://www.grafana.com" }] },
+              { "id": "custom.cellOptions", "value": { "type": "color-background" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.5)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.5)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.5)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": { "id": "byName", "options": "ColorValue" },
+            "properties": [
+              { "id": "unit", "value": "Bps" },
+              { "id": "decimals", "value": 2 },
+              { "id": "links", "value": [{ "targetBlank": false, "title": "", "url": "http://www.grafana.com" }] },
+              { "id": "custom.cellOptions", "value": { "type": "color-text" } },
+              { "id": "custom.align" },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    { "color": "rgba(245, 54, 54, 0.5)", "value": 0 },
+                    { "color": "rgba(237, 129, 40, 0.5)", "value": 5 },
+                    { "color": "rgba(50, 172, 45, 0.5)", "value": 10 }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 26 },
+      "id": 6,
+      "options": { "cellHeight": "sm", "showHeader": true },
+      "pluginVersion": "11.5.0-pre",
       "targets": [
         {
           "alias": "ColorValue",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "expr": "",
           "format": "table",
           "intervalFactor": 1,
@@ -429,31 +496,26 @@
         },
         {
           "alias": "ColorCell",
+          "datasource": { "type": "grafana-testdata-datasource" },
           "refId": "B",
           "scenarioId": "csv_metric_values",
           "stringInput": "null,5,1,2,3,4,5,10,20"
         }
       ],
       "title": "Column style thresholds and links",
-      "transform": "timeseries_to_columns",
+      "transformations": [{ "id": "seriesToColumns", "options": { "reducers": [] } }],
       "type": "table"
     }
   ],
+  "preload": false,
   "refresh": false,
-  "schemaVersion": 16,
+  "schemaVersion": 42,
   "tags": ["gdev", "panel-tests", "table"],
-  "templating": {
-    "list": []
-  },
-  "time": {
-    "from": "now-1h",
-    "to": "now"
-  },
-  "timepicker": {
-    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"]
-  },
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
   "timezone": "browser",
   "title": "Panel Tests - Table",
   "uid": "pttable",
-  "version": 3
+  "version": 1
 }

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
@@ -4,102 +4,109 @@ import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
 
 const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
+const TABLE_TEST_PANEL_DASHBOARD = { uid: 'pttable' };
 
-test.describe(
-  'plugin-e2e-api-tests admin',
-  {
-    tag: ['@plugins'],
-  },
-  () => {
-    test.describe('panel edit page', () => {
-      test('table panel data assertions with provisioned dashboard', async ({ gotoPanelEditPage }) => {
-        const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
-        await expect(
-          panelEditPage.panel.locator,
-          formatExpectError('Could not locate panel in panel edit page')
-        ).toBeVisible();
-        await expect(
-          panelEditPage.panel.fieldNames,
-          formatExpectError('Could not locate header elements in table panel')
-        ).toContainText(['Field', 'Max', 'Mean', 'Last']);
-      });
-
-      test('table panel data assertions', async ({ panelEditPage }) => {
-        await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
-        await panelEditPage.datasource.set('gdev-testdata');
-        await panelEditPage.setVisualization('Table');
-        await panelEditPage.refreshPanel();
-        await expect(
-          panelEditPage.panel.locator,
-          formatExpectError('Could not locate panel in panel edit page')
-        ).toBeVisible();
-        await expect(
-          panelEditPage.panel.fieldNames,
-          formatExpectError('Could not locate header elements in table panel')
-        ).toContainText(['col1', 'col2']);
-        await expect(
-          panelEditPage.panel.locator.getByRole('gridcell'),
-          formatExpectError('Could not locate headers in table panel')
-        ).toContainText(['val1', 'val2', 'val3', 'val4']);
-      });
-
-      test('timeseries panel - table view assertions', async ({ panelEditPage }) => {
-        await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
-        await panelEditPage.datasource.set('gdev-testdata');
-        await panelEditPage.setVisualization('Time series');
-        await panelEditPage.refreshPanel();
-        await panelEditPage.toggleTableView();
-        await expect(
-          panelEditPage.panel.locator,
-          formatExpectError('Could not locate panel in panel edit page')
-        ).toBeVisible();
-        await expect(
-          panelEditPage.panel.fieldNames,
-          formatExpectError('Could not locate header elements in table panel')
-        ).toContainText(['col1', 'col2']);
-        await expect(
-          panelEditPage.panel.locator.getByRole('gridcell'),
-          formatExpectError('Could not locate data elements in table panel')
-        ).toContainText(['val1', 'val2', 'val3', 'val4']);
-      });
+test.describe('plugin-e2e-api-tests admin', { tag: ['@plugins'] }, () => {
+  test.describe('panel edit page', () => {
+    test('table panel data assertions with provisioned dashboard', async ({ gotoPanelEditPage }) => {
+      const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
+      await expect(
+        panelEditPage.panel.locator,
+        formatExpectError('Could not locate panel in panel edit page')
+      ).toBeVisible();
+      await expect(
+        panelEditPage.panel.fieldNames,
+        formatExpectError('Could not locate header elements in table panel')
+      ).toContainText(['Field', 'Max', 'Mean', 'Last']);
     });
 
-    test.describe('dashboard page', () => {
-      test('getting panel by title', async ({ gotoDashboardPage }) => {
-        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
-        await dashboardPage.goto();
-        const panel = await dashboardPage.getPanelByTitle('Colored background');
-        await expect(panel.fieldNames).toContainText(['Field', 'Max', 'Mean', 'Last']);
-      });
-
-      test('getting panel by id', async ({ gotoDashboardPage }) => {
-        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
-        await dashboardPage.goto();
-        const panel = await dashboardPage.getPanelByTitle('Colored background');
-        await expect(
-          panel.fieldNames,
-          formatExpectError('Could not locate header elements in table panel')
-        ).toContainText(['Field', 'Max', 'Mean', 'Last']);
-      });
+    test('table panel data assertions', async ({ panelEditPage }) => {
+      await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
+      await panelEditPage.datasource.set('gdev-testdata');
+      await panelEditPage.setVisualization('Table');
+      await panelEditPage.refreshPanel();
+      await expect(
+        panelEditPage.panel.locator,
+        formatExpectError('Could not locate panel in panel edit page')
+      ).toBeVisible();
+      await expect(
+        panelEditPage.panel.fieldNames,
+        formatExpectError('Could not locate header elements in table panel')
+      ).toContainText(['col1', 'col2']);
+      await expect(
+        panelEditPage.panel.locator.getByRole('gridcell'),
+        formatExpectError('Could not locate headers in table panel')
+      ).toContainText(['val1', 'val2', 'val3', 'val4']);
     });
 
-    test.describe('explore page', () => {
-      test('table panel', async ({ explorePage }) => {
-        const url =
-          'left=%7B"datasource":"grafana","queries":%5B%7B"queryType":"randomWalk","refId":"A","datasource":%7B"type":"datasource","uid":"grafana"%7D%7D%5D,"range":%7B"from":"1547161200000","to":"1576364400000"%7D%7D&orgId=1';
-        await explorePage.goto({
-          queryParams: new URLSearchParams(url),
-        });
-        await expect(
-          explorePage.timeSeriesPanel.locator,
-          formatExpectError('Could not locate time series panel in explore page')
-        ).toBeVisible();
-        await expect(
-          explorePage.tablePanel.locator,
-          formatExpectError('Could not locate table panel in explore page')
-        ).toBeVisible();
-        await expect(explorePage.tablePanel.fieldNames).toContainText(['time', 'A-series']);
-      });
+    test('timeseries panel - table view assertions', async ({ panelEditPage }) => {
+      await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
+      await panelEditPage.datasource.set('gdev-testdata');
+      await panelEditPage.setVisualization('Time series');
+      await panelEditPage.refreshPanel();
+      await panelEditPage.toggleTableView();
+      await expect(
+        panelEditPage.panel.locator,
+        formatExpectError('Could not locate panel in panel edit page')
+      ).toBeVisible();
+      await expect(
+        panelEditPage.panel.fieldNames,
+        formatExpectError('Could not locate header elements in table panel')
+      ).toContainText(['col1', 'col2']);
+      await expect(
+        panelEditPage.panel.locator.getByRole('gridcell'),
+        formatExpectError('Could not locate data elements in table panel')
+      ).toContainText(['val1', 'val2', 'val3', 'val4']);
     });
-  }
-);
+
+    test('get table headers', async ({ gotoPanelEditPage, selectors }) => {
+      const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
+      await expect(
+        panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.ColumnHeader)
+      ).toContainText(['Metric', 'Value', 'Stat']);
+    });
+
+    test('get table cells', async ({ gotoPanelEditPage, selectors }) => {
+      const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
+      await expect(
+        panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Cell)
+      ).toContainText(['cpu', '20', 'average', 'dropped_bytes', '10', 'mean']);
+    });
+  });
+
+  test.describe('dashboard page', () => {
+    test('getting panel by title', async ({ gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+      await dashboardPage.goto();
+      const panel = await dashboardPage.getPanelByTitle('Colored background');
+      await expect(panel.fieldNames).toContainText(['Field', 'Max', 'Mean', 'Last']);
+    });
+
+    test('getting panel by id', async ({ gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+      await dashboardPage.goto();
+      const panel = await dashboardPage.getPanelByTitle('Colored background');
+      await expect(
+        panel.fieldNames,
+        formatExpectError('Could not locate header elements in table panel')
+      ).toContainText(['Field', 'Max', 'Mean', 'Last']);
+    });
+  });
+
+  test.describe('explore page', () => {
+    test('table panel', async ({ explorePage }) => {
+      const url =
+        'left=%7B"datasource":"grafana","queries":%5B%7B"queryType":"randomWalk","refId":"A","datasource":%7B"type":"datasource","uid":"grafana"%7D%7D%5D,"range":%7B"from":"1547161200000","to":"1576364400000"%7D%7D&orgId=1';
+      await explorePage.goto({ queryParams: new URLSearchParams(url) });
+      await expect(
+        explorePage.timeSeriesPanel.locator,
+        formatExpectError('Could not locate time series panel in explore page')
+      ).toBeVisible();
+      await expect(
+        explorePage.tablePanel.locator,
+        formatExpectError('Could not locate table panel in explore page')
+      ).toBeVisible();
+      await expect(explorePage.tablePanel.fieldNames).toContainText(['time', 'A-series']);
+    });
+  });
+});

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
@@ -4,109 +4,116 @@ import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
 
 const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
-const TABLE_TEST_PANEL_DASHBOARD = { uid: 'pttable' };
 
-test.describe('plugin-e2e-api-tests admin', { tag: ['@plugins'] }, () => {
-  test.describe('panel edit page', () => {
-    test('table panel data assertions with provisioned dashboard', async ({ gotoPanelEditPage }) => {
-      const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
-      await expect(
-        panelEditPage.panel.locator,
-        formatExpectError('Could not locate panel in panel edit page')
-      ).toBeVisible();
-      await expect(
-        panelEditPage.panel.fieldNames,
-        formatExpectError('Could not locate header elements in table panel')
-      ).toContainText(['Field', 'Max', 'Mean', 'Last']);
+test.describe(
+  'plugin-e2e-api-tests admin',
+  {
+    tag: ['@plugins'],
+  },
+  () => {
+    test.describe('panel edit page', () => {
+      test('table panel data assertions with provisioned dashboard', async ({ gotoPanelEditPage }) => {
+        const panelEditPage = await gotoPanelEditPage({ dashboard: REACT_TABLE_DASHBOARD, id: '4' });
+        await expect(
+          panelEditPage.panel.locator,
+          formatExpectError('Could not locate panel in panel edit page')
+        ).toBeVisible();
+        await expect(
+          panelEditPage.panel.fieldNames,
+          formatExpectError('Could not locate header elements in table panel')
+        ).toContainText(['Field', 'Max', 'Mean', 'Last']);
+      });
+
+      test('table panel data assertions', async ({ panelEditPage }) => {
+        await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
+        await panelEditPage.datasource.set('gdev-testdata');
+        await panelEditPage.setVisualization('Table');
+        await panelEditPage.refreshPanel();
+        await expect(
+          panelEditPage.panel.locator,
+          formatExpectError('Could not locate panel in panel edit page')
+        ).toBeVisible();
+        await expect(
+          panelEditPage.panel.fieldNames,
+          formatExpectError('Could not locate header elements in table panel')
+        ).toContainText(['col1', 'col2']);
+        await expect(
+          panelEditPage.panel.locator.getByRole('gridcell'),
+          formatExpectError('Could not locate headers in table panel')
+        ).toContainText(['val1', 'val2', 'val3', 'val4']);
+      });
+
+      test('timeseries panel - table view assertions', async ({ panelEditPage }) => {
+        await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
+        await panelEditPage.datasource.set('gdev-testdata');
+        await panelEditPage.setVisualization('Time series');
+        await panelEditPage.refreshPanel();
+        await panelEditPage.toggleTableView();
+        await expect(
+          panelEditPage.panel.locator,
+          formatExpectError('Could not locate panel in panel edit page')
+        ).toBeVisible();
+        await expect(
+          panelEditPage.panel.fieldNames,
+          formatExpectError('Could not locate header elements in table panel')
+        ).toContainText(['col1', 'col2']);
+        await expect(
+          panelEditPage.panel.locator.getByRole('gridcell'),
+          formatExpectError('Could not locate data elements in table panel')
+        ).toContainText(['val1', 'val2', 'val3', 'val4']);
+      });
+
+      test('get table headers', async ({ gotoPanelEditPage, selectors }) => {
+        const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
+        await expect(
+          panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.ColumnHeader)
+        ).toContainText(['Metric', 'Value', 'Stat']);
+      });
+
+      test('get table cells', async ({ gotoPanelEditPage, selectors }) => {
+        const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
+        await expect(
+          panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Cell)
+        ).toContainText(['cpu', '20', 'average', 'dropped_bytes', '10', 'mean']);
+      });
     });
 
-    test('table panel data assertions', async ({ panelEditPage }) => {
-      await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
-      await panelEditPage.datasource.set('gdev-testdata');
-      await panelEditPage.setVisualization('Table');
-      await panelEditPage.refreshPanel();
-      await expect(
-        panelEditPage.panel.locator,
-        formatExpectError('Could not locate panel in panel edit page')
-      ).toBeVisible();
-      await expect(
-        panelEditPage.panel.fieldNames,
-        formatExpectError('Could not locate header elements in table panel')
-      ).toContainText(['col1', 'col2']);
-      await expect(
-        panelEditPage.panel.locator.getByRole('gridcell'),
-        formatExpectError('Could not locate headers in table panel')
-      ).toContainText(['val1', 'val2', 'val3', 'val4']);
+    test.describe('dashboard page', () => {
+      test('getting panel by title', async ({ gotoDashboardPage }) => {
+        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+        await dashboardPage.goto();
+        const panel = await dashboardPage.getPanelByTitle('Colored background');
+        await expect(panel.fieldNames).toContainText(['Field', 'Max', 'Mean', 'Last']);
+      });
+
+      test('getting panel by id', async ({ gotoDashboardPage }) => {
+        const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
+        await dashboardPage.goto();
+        const panel = await dashboardPage.getPanelByTitle('Colored background');
+        await expect(
+          panel.fieldNames,
+          formatExpectError('Could not locate header elements in table panel')
+        ).toContainText(['Field', 'Max', 'Mean', 'Last']);
+      });
     });
 
-    test('timeseries panel - table view assertions', async ({ panelEditPage }) => {
-      await panelEditPage.mockQueryDataResponse(successfulDataQuery, 200);
-      await panelEditPage.datasource.set('gdev-testdata');
-      await panelEditPage.setVisualization('Time series');
-      await panelEditPage.refreshPanel();
-      await panelEditPage.toggleTableView();
-      await expect(
-        panelEditPage.panel.locator,
-        formatExpectError('Could not locate panel in panel edit page')
-      ).toBeVisible();
-      await expect(
-        panelEditPage.panel.fieldNames,
-        formatExpectError('Could not locate header elements in table panel')
-      ).toContainText(['col1', 'col2']);
-      await expect(
-        panelEditPage.panel.locator.getByRole('gridcell'),
-        formatExpectError('Could not locate data elements in table panel')
-      ).toContainText(['val1', 'val2', 'val3', 'val4']);
+    test.describe('explore page', () => {
+      test('table panel', async ({ explorePage }) => {
+        const url =
+          'left=%7B"datasource":"grafana","queries":%5B%7B"queryType":"randomWalk","refId":"A","datasource":%7B"type":"datasource","uid":"grafana"%7D%7D%5D,"range":%7B"from":"1547161200000","to":"1576364400000"%7D%7D&orgId=1';
+        await explorePage.goto({
+          queryParams: new URLSearchParams(url),
+        });
+        await expect(
+          explorePage.timeSeriesPanel.locator,
+          formatExpectError('Could not locate time series panel in explore page')
+        ).toBeVisible();
+        await expect(
+          explorePage.tablePanel.locator,
+          formatExpectError('Could not locate table panel in explore page')
+        ).toBeVisible();
+        await expect(explorePage.tablePanel.fieldNames).toContainText(['time', 'A-series']);
+      });
     });
-
-    test('get table headers', async ({ gotoPanelEditPage, selectors }) => {
-      const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
-      await expect(
-        panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.ColumnHeader)
-      ).toContainText(['Metric', 'Value', 'Stat']);
-    });
-
-    test('get table cells', async ({ gotoPanelEditPage, selectors }) => {
-      const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
-      await expect(
-        panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Cell)
-      ).toContainText(['cpu', '20', 'average', 'dropped_bytes', '10', 'mean']);
-    });
-  });
-
-  test.describe('dashboard page', () => {
-    test('getting panel by title', async ({ gotoDashboardPage }) => {
-      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
-      await dashboardPage.goto();
-      const panel = await dashboardPage.getPanelByTitle('Colored background');
-      await expect(panel.fieldNames).toContainText(['Field', 'Max', 'Mean', 'Last']);
-    });
-
-    test('getting panel by id', async ({ gotoDashboardPage }) => {
-      const dashboardPage = await gotoDashboardPage(REACT_TABLE_DASHBOARD);
-      await dashboardPage.goto();
-      const panel = await dashboardPage.getPanelByTitle('Colored background');
-      await expect(
-        panel.fieldNames,
-        formatExpectError('Could not locate header elements in table panel')
-      ).toContainText(['Field', 'Max', 'Mean', 'Last']);
-    });
-  });
-
-  test.describe('explore page', () => {
-    test('table panel', async ({ explorePage }) => {
-      const url =
-        'left=%7B"datasource":"grafana","queries":%5B%7B"queryType":"randomWalk","refId":"A","datasource":%7B"type":"datasource","uid":"grafana"%7D%7D%5D,"range":%7B"from":"1547161200000","to":"1576364400000"%7D%7D&orgId=1';
-      await explorePage.goto({ queryParams: new URLSearchParams(url) });
-      await expect(
-        explorePage.timeSeriesPanel.locator,
-        formatExpectError('Could not locate time series panel in explore page')
-      ).toBeVisible();
-      await expect(
-        explorePage.tablePanel.locator,
-        formatExpectError('Could not locate table panel in explore page')
-      ).toBeVisible();
-      await expect(explorePage.tablePanel.fieldNames).toContainText(['time', 'A-series']);
-    });
-  });
-});
+  }
+);

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
@@ -70,13 +70,6 @@ test.describe(
           panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.ColumnHeader)
         ).toContainText(['Metric', 'Value', 'Stat']);
       });
-
-      test('get table cells', async ({ gotoPanelEditPage, selectors }) => {
-        const panelEditPage = await gotoPanelEditPage({ dashboard: TABLE_TEST_PANEL_DASHBOARD, id: '7' });
-        await expect(
-          panelEditPage.getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.Cell)
-        ).toContainText(['cpu', '20', 'average', 'dropped_bytes', '10', 'mean']);
-      });
     });
 
     test.describe('dashboard page', () => {

--- a/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
+++ b/e2e-playwright/plugin-e2e/plugin-e2e-api-tests/as-admin-user/panelDataAssertion.spec.ts
@@ -4,6 +4,7 @@ import { formatExpectError } from '../errors';
 import { successfulDataQuery } from '../mocks/queries';
 
 const REACT_TABLE_DASHBOARD = { uid: 'U_bZIMRMk' };
+const TABLE_TEST_PANEL_DASHBOARD = { uid: 'pttable' };
 
 test.describe(
   'plugin-e2e-api-tests admin',

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -488,6 +488,10 @@ export const versionedComponents = {
         },
       },
       TableNG: {
+        ColumnHeader: { '12.3.0': 'data-testid tableng column header' },
+        Cell: {
+          '12.3.0': 'data-testid tableng cell row',
+        },
         Filters: {
           HeaderButton: {
             '12.1.0': 'data-testid tableng header filter',

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -489,9 +489,6 @@ export const versionedComponents = {
       },
       TableNG: {
         ColumnHeader: { '12.3.0': 'data-testid tableng column header' },
-        Cell: {
-          '12.3.0': 'data-testid tableng cell row',
-        },
         Filters: {
           HeaderButton: {
             '12.1.0': 'data-testid tableng header filter',

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -24,7 +24,6 @@ import {
   FieldType,
   getDisplayProcessor,
 } from '@grafana/data';
-import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { FieldColorModeId, TableCellTooltipPlacement, TableFooterOptions } from '@grafana/schema';
 
@@ -520,7 +519,6 @@ export function TableNG(props: TableNGProps) {
             <Cell
               key={key}
               {...props}
-              data-testid={selectors.components.Panels.Visualization.TableNG.Cell}
               className={clsx(
                 props.className,
                 cellParentStyles,

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -24,6 +24,7 @@ import {
   FieldType,
   getDisplayProcessor,
 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { FieldColorModeId, TableCellTooltipPlacement, TableFooterOptions } from '@grafana/schema';
 
@@ -519,6 +520,7 @@ export function TableNG(props: TableNGProps) {
             <Cell
               key={key}
               {...props}
+              data-testid={selectors.components.Panels.Visualization.TableNG.Cell}
               className={clsx(
                 props.className,
                 cellParentStyles,

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -3,6 +3,7 @@ import React, { useEffect } from 'react';
 import { Column, SortDirection } from 'react-data-grid';
 
 import { Field, GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 
 import { useStyles2 } from '../../../../themes/ThemeContext';
 import { getFieldTypeIcon } from '../../../../types/icon';
@@ -55,7 +56,12 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
       {showTypeIcons && (
         <Icon className={styles.headerCellIcon} name={getFieldTypeIcon(field)} title={field?.type} size="sm" />
       )}
-      <span className={styles.headerCellLabel}>{getDisplayName(field)}</span>
+      <span
+        data-testid={selectors.components.Panels.Visualization.TableNG.ColumnHeader}
+        className={styles.headerCellLabel}
+      >
+        {getDisplayName(field)}
+      </span>
       {direction && (
         <Icon
           className={cx(styles.headerCellIcon, styles.headerSortIcon)}


### PR DESCRIPTION
**What is this feature?**

This PR adds proper e2e selectors to headers and cells rendered in the table panel. 

**Why do we need this feature?**

plugin-e2e uses the table panel heavily to assert on panel data. Currently, it's using the role attribute to locate table headers and cells. This is brittle so adding proper e2e selectors for these element should make plugin-e2e apis more future proof. 

See [example](https://github.com/grafana/plugin-tools/pull/2105) where plugin-e2e apis broke due to a change in the table markup. 

**Who is this feature for?**

Plugin developers and plugin api maintainers.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/plugin-tools/issues/2114

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
