### PR TITLE
Stop background tasks and when stopping bleve backend.

### DIFF
--- a/pkg/storage/unified/search/bleve_integration_test.go
+++ b/pkg/storage/unified/search/bleve_integration_test.go
@@ -24,7 +24,7 @@ func TestBleveSearchBackend(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, backend)
 
-		t.Cleanup(backend.CloseAllIndexes)
+		t.Cleanup(backend.Stop)
 
 		return backend
 	}, &unitest.TestOptions{
@@ -49,7 +49,7 @@ func TestSearchBackendBenchmark(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, backend)
 
-	t.Cleanup(backend.CloseAllIndexes)
+	t.Cleanup(backend.Stop)
 
 	unitest.BenchmarkSearchBackend(t, backend, opts)
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -250,7 +250,7 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, batchSize
 	}, tracing.NewNoopTracerService(), nil)
 	require.NoError(t, err)
 
-	t.Cleanup(backend.CloseAllIndexes)
+	t.Cleanup(backend.Stop)
 
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
 

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -110,7 +110,7 @@ func TestIntegrationSearchAndStorage(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, search)
 
-	t.Cleanup(search.CloseAllIndexes)
+	t.Cleanup(search.Stop)
 
 	// Create a new resource backend
 	storage := newTestBackend(t, false, 0)


### PR DESCRIPTION
This PR improves bleve backend to stop background metrics updater when backend is asked to Stop. This allows us to remove a function from goroutines leak check.