### PR TITLE
Logs Panel: Fix setting default details mode

### DIFF
--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -203,7 +203,7 @@ export const LogListContextProvider = ({
   enableLogDetails,
   logOptionsStorageKey,
   detailsMode: detailsModeProp = logOptionsStorageKey
-    ? store.get(`${logOptionsStorageKey}.detailsMode`) ?? getDefaultDetailsMode(containerElement)
+    ? (store.get(`${logOptionsStorageKey}.detailsMode`) ?? getDefaultDetailsMode(containerElement))
     : getDefaultDetailsMode(containerElement),
   dedupStrategy,
   displayedFields,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -203,7 +203,7 @@ export const LogListContextProvider = ({
   enableLogDetails,
   logOptionsStorageKey,
   detailsMode: detailsModeProp = logOptionsStorageKey
-    ? store.get(`${logOptionsStorageKey}.detailsMode`)
+    ? store.get(`${logOptionsStorageKey}.detailsMode`) || getDefaultDetailsMode(containerElement)
     : getDefaultDetailsMode(containerElement),
   dedupStrategy,
   displayedFields,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -203,7 +203,7 @@ export const LogListContextProvider = ({
   enableLogDetails,
   logOptionsStorageKey,
   detailsMode: detailsModeProp = logOptionsStorageKey
-    ? store.get(`${logOptionsStorageKey}.detailsMode`) || getDefaultDetailsMode(containerElement)
+    ? store.get(`${logOptionsStorageKey}.detailsMode`) ?? getDefaultDetailsMode(containerElement)
     : getDefaultDetailsMode(containerElement),
   dedupStrategy,
   displayedFields,

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -334,7 +334,9 @@ export const LogListContextProvider = ({
 
   // Sync details mode
   useEffect(() => {
-    setDetailsMode(detailsModeProp);
+    if (detailsModeProp) {
+      setDetailsMode(detailsModeProp);
+    }
   }, [detailsModeProp]);
 
   // Sync font size


### PR DESCRIPTION
fixes: https://github.com/grafana/grafana/issues/111252

I have never set display mode added in https://github.com/grafana/grafana/pull/107718:

<img width="692" height="177" alt="Screenshot 2025-09-17 at 15 39 58" src="https://github.com/user-attachments/assets/11c415bd-5fd9-4dd1-8b7f-45384ec94c78" />

I think that's why I also didn't have grafana.explore.logs.detailsMode in local storage ever set. After adding https://github.com/grafana/grafana/pull/110276 and https://github.com/grafana/grafana/pull/111163 it may be now be set to `undefined` in runtime causing no details being showed up on click.


