### PR TITLE
Provisioning: Skip test while being looked at

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -20,6 +20,8 @@ import (
 )
 
 func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
+	// TODO: fix
+	t.Skip("Skipping this test while being worked on")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)


### PR DESCRIPTION
Something that was merged into main before this: https://github.com/grafana/grafana/pull/111209 is making this test fail. Skipping for now while I look into it, it is consistently failing