### PR TITLE
Provisioning: Fix cleanup

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -539,7 +539,7 @@ func (r *DualReadWriter) authorizeCreateFolder(ctx context.Context, _ string) er
 func (r *DualReadWriter) deleteFolder(ctx context.Context, opts DualWriteOptions) (*ParsedResource, error) {
 	// if the ref is set, it is not the active branch, so just delete the files from the branch
 	// and do not delete the items from grafana itself
-	if r.shouldUpdateGrafanaDB(opts, nil) {
+	if !r.shouldUpdateGrafanaDB(opts, nil) {
 		err := r.repo.Delete(ctx, opts.Path, opts.Ref, opts.Message)
 		if err != nil {
 			return nil, fmt.Errorf("error deleting folder from repository: %w", err)

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -20,8 +20,6 @@ import (
 )
 
 func TestIntegrationProvisioning_DeleteResources(t *testing.T) {
-	// TODO: fix
-	t.Skip("Skipping this test while being worked on")
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)


### PR DESCRIPTION
**What is this feature?**

This PR fixes the provisioning cleanup.

In [this pr](https://github.com/grafana/grafana/commit/0248a393d7ac07d7d0a68bd0d91306d15c0e3a96#diff-aa926717306240b6fd01691d3e676a94abc327c410ef31d26862009e841e8a8aR542), a helper function was added, but for this particular check it should be not true rather than true (originally was `if opts.Ref != "" {`)