### PR TITLE
Fix State Timeline panel error when all series are hidden

### DIFF
--- a/public/app/core/components/TimelineChart/utils.test.ts
+++ b/public/app/core/components/TimelineChart/utils.test.ts
@@ -563,3 +563,97 @@ describe('hasSpecialMappedValue', () => {
     expect(hasSpecialMappedValue(field, valueMatch)).toEqual(expected);
   });
 });
+
+describe('prepareTimelineFields with hidden series', () => {
+  it('should return empty warn when all non-time fields are hidden via hideFrom.viz', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+          { 
+            name: 'value1', 
+            type: FieldType.number, 
+            values: [10, 20, 30],
+            config: {
+              custom: {
+                hideFrom: { viz: true }
+              }
+            }
+          },
+          { 
+            name: 'value2', 
+            type: FieldType.string, 
+            values: ['a', 'b', 'c'],
+            config: {
+              custom: {
+                hideFrom: { viz: true }
+              }
+            }
+          },
+        ],
+      }),
+    ];
+
+    const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
+    
+    expect(result.warn).toBe('');
+    expect(result.frames).toBeUndefined();
+  });
+
+  it('should return frames when some fields are visible', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+          { 
+            name: 'value1', 
+            type: FieldType.number, 
+            values: [10, 20, 30],
+            config: {
+              custom: {
+                hideFrom: { viz: true }
+              }
+            }
+          },
+          { 
+            name: 'value2', 
+            type: FieldType.string, 
+            values: ['a', 'b', 'c'],
+            config: {
+              custom: {
+                hideFrom: { viz: false }
+              }
+            }
+          },
+        ],
+      }),
+    ];
+
+    const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
+    
+    expect(result.warn).toBeUndefined();
+    expect(result.frames).toBeDefined();
+    expect(result.frames).toHaveLength(1);
+  });
+
+  it('should return frames when fields have no hideFrom config', () => {
+    const frames = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+          { 
+            name: 'value1', 
+            type: FieldType.number, 
+            values: [10, 20, 30]
+          },
+        ],
+      }),
+    ];
+
+    const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
+    
+    expect(result.warn).toBeUndefined();
+    expect(result.frames).toBeDefined();
+    expect(result.frames).toHaveLength(1);
+  });
+});

--- a/public/app/core/components/TimelineChart/utils.test.ts
+++ b/public/app/core/components/TimelineChart/utils.test.ts
@@ -570,32 +570,32 @@ describe('prepareTimelineFields with hidden series', () => {
       toDataFrame({
         fields: [
           { name: 'time', type: FieldType.time, values: [1, 2, 3] },
-          { 
-            name: 'value1', 
-            type: FieldType.number, 
+          {
+            name: 'value1',
+            type: FieldType.number,
             values: [10, 20, 30],
             config: {
               custom: {
-                hideFrom: { viz: true }
-              }
-            }
+                hideFrom: { viz: true },
+              },
+            },
           },
-          { 
-            name: 'value2', 
-            type: FieldType.string, 
+          {
+            name: 'value2',
+            type: FieldType.string,
             values: ['a', 'b', 'c'],
             config: {
               custom: {
-                hideFrom: { viz: true }
-              }
-            }
+                hideFrom: { viz: true },
+              },
+            },
           },
         ],
       }),
     ];
 
     const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
-    
+
     expect(result.warn).toBe('');
     expect(result.frames).toBeUndefined();
   });
@@ -605,32 +605,32 @@ describe('prepareTimelineFields with hidden series', () => {
       toDataFrame({
         fields: [
           { name: 'time', type: FieldType.time, values: [1, 2, 3] },
-          { 
-            name: 'value1', 
-            type: FieldType.number, 
+          {
+            name: 'value1',
+            type: FieldType.number,
             values: [10, 20, 30],
             config: {
               custom: {
-                hideFrom: { viz: true }
-              }
-            }
+                hideFrom: { viz: true },
+              },
+            },
           },
-          { 
-            name: 'value2', 
-            type: FieldType.string, 
+          {
+            name: 'value2',
+            type: FieldType.string,
             values: ['a', 'b', 'c'],
             config: {
               custom: {
-                hideFrom: { viz: false }
-              }
-            }
+                hideFrom: { viz: false },
+              },
+            },
           },
         ],
       }),
     ];
 
     const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
-    
+
     expect(result.warn).toBeUndefined();
     expect(result.frames).toBeDefined();
     expect(result.frames).toHaveLength(1);
@@ -641,17 +641,17 @@ describe('prepareTimelineFields with hidden series', () => {
       toDataFrame({
         fields: [
           { name: 'time', type: FieldType.time, values: [1, 2, 3] },
-          { 
-            name: 'value1', 
-            type: FieldType.number, 
-            values: [10, 20, 30]
+          {
+            name: 'value1',
+            type: FieldType.number,
+            values: [10, 20, 30],
           },
         ],
       }),
     ];
 
     const result = prepareTimelineFields(frames, true, { from: 0, to: 100 } as any, {} as any);
-    
+
     expect(result.warn).toBeUndefined();
     expect(result.frames).toBeDefined();
     expect(result.frames).toHaveLength(1);

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -446,6 +446,17 @@ export function prepareTimelineFields(
     return { warn: t('timeline.missing-field.all', 'No graphable fields') };
   }
 
+  // Check if all non-time fields are hidden from visualization
+  const hasVisibleFields = frames.some((frame) => 
+    frame.fields.some((field) => 
+      field.type !== FieldType.time && !field.config.custom?.hideFrom?.viz
+    )
+  );
+
+  if (!hasVisibleFields) {
+    return { warn: '' }; // Return empty warn to show default "No data" message
+  }
+
   return { frames };
 }
 

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -447,10 +447,8 @@ export function prepareTimelineFields(
   }
 
   // Check if all non-time fields are hidden from visualization
-  const hasVisibleFields = frames.some((frame) => 
-    frame.fields.some((field) => 
-      field.type !== FieldType.time && !field.config.custom?.hideFrom?.viz
-    )
+  const hasVisibleFields = frames.some((frame) =>
+    frame.fields.some((field) => field.type !== FieldType.time && !field.config.custom?.hideFrom?.viz)
   );
 
   if (!hasVisibleFields) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Add check in prepareTimelineFields to detect when all non-time fields are hidden via hideFrom.viz
- Return empty warn message to show default 'No data' instead of error
- Add comprehensive test cases covering hidden series scenarios


**Which issue(s) does this PR fix?**:

Fixes #111073

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
