### PR TITLE
Dashboards: Remove the `showInControlsMenu` prop from the variable models

### DIFF
--- a/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/kinds/v2beta1/dashboard_spec.cue
@@ -770,7 +770,6 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort
@@ -783,7 +782,6 @@ QueryVariableSpec: {
 	allowCustomValue: bool | *true
 	staticOptions?: [...VariableOption]
 	staticOptionsOrder?: "before" | "after" | "sorted"
-	showInControlsMenu?: bool
 }
 
 // Query variable kind
@@ -804,7 +802,6 @@ TextVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Text variable kind
@@ -825,7 +822,6 @@ ConstantVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Constant variable kind
@@ -853,7 +849,6 @@ DatasourceVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Datasource variable kind
@@ -879,7 +874,6 @@ IntervalVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Interval variable kind
@@ -902,7 +896,6 @@ CustomVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Custom variable kind
@@ -925,7 +918,6 @@ GroupByVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Group variable kind
@@ -949,7 +941,6 @@ AdhocVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Define the MetricFindValue type

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec.cue
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec.cue
@@ -774,7 +774,6 @@ QueryVariableSpec: {
 	refresh:      VariableRefresh
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 	query:        DataQueryKind
 	regex:        string | *""
 	sort:         VariableSort
@@ -787,7 +786,6 @@ QueryVariableSpec: {
 	allowCustomValue: bool | *true
 	staticOptions?: [...VariableOption]
 	staticOptionsOrder?: "before" | "after" | "sorted"
-	showInControlsMenu?: bool
 }
 
 // Query variable kind
@@ -808,7 +806,6 @@ TextVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Text variable kind
@@ -829,7 +826,6 @@ ConstantVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Constant variable kind
@@ -857,7 +853,6 @@ DatasourceVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Datasource variable kind
@@ -883,7 +878,6 @@ IntervalVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Interval variable kind
@@ -906,7 +900,6 @@ CustomVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Custom variable kind
@@ -929,7 +922,6 @@ GroupByVariableSpec: {
 	hide:         VariableHide
 	skipUrlSync:  bool | *false
 	description?: string
-	showInControlsMenu?: bool
 }
 
 // Group variable kind
@@ -953,7 +945,6 @@ AdhocVariableSpec: {
 	skipUrlSync:  bool | *false
 	description?: string
 	allowCustomValue: bool | *true
-	showInControlsMenu?: bool
 }
 
 // Define the MetricFindValue type

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec_gen.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/dashboard_spec_gen.go
@@ -1322,7 +1322,6 @@ type DashboardQueryVariableSpec struct {
 	Refresh            DashboardVariableRefresh                      `json:"refresh"`
 	SkipUrlSync        bool                                          `json:"skipUrlSync"`
 	Description        *string                                       `json:"description,omitempty"`
-	ShowInControlsMenu *bool                                         `json:"showInControlsMenu,omitempty"`
 	Query              DashboardDataQueryKind                        `json:"query"`
 	Regex              string                                        `json:"regex"`
 	Sort               DashboardVariableSort                         `json:"sort"`
@@ -1450,14 +1449,13 @@ func NewDashboardTextVariableKind() *DashboardTextVariableKind {
 // Text variable specification
 // +k8s:openapi-gen=true
 type DashboardTextVariableSpec struct {
-	Name               string                  `json:"name"`
-	Current            DashboardVariableOption `json:"current"`
-	Query              string                  `json:"query"`
-	Label              *string                 `json:"label,omitempty"`
-	Hide               DashboardVariableHide   `json:"hide"`
-	SkipUrlSync        bool                    `json:"skipUrlSync"`
-	Description        *string                 `json:"description,omitempty"`
-	ShowInControlsMenu *bool                   `json:"showInControlsMenu,omitempty"`
+	Name        string                  `json:"name"`
+	Current     DashboardVariableOption `json:"current"`
+	Query       string                  `json:"query"`
+	Label       *string                 `json:"label,omitempty"`
+	Hide        DashboardVariableHide   `json:"hide"`
+	SkipUrlSync bool                    `json:"skipUrlSync"`
+	Description *string                 `json:"description,omitempty"`
 }
 
 // NewDashboardTextVariableSpec creates a new DashboardTextVariableSpec object.
@@ -1496,14 +1494,13 @@ func NewDashboardConstantVariableKind() *DashboardConstantVariableKind {
 // Constant variable specification
 // +k8s:openapi-gen=true
 type DashboardConstantVariableSpec struct {
-	Name               string                  `json:"name"`
-	Query              string                  `json:"query"`
-	Current            DashboardVariableOption `json:"current"`
-	Label              *string                 `json:"label,omitempty"`
-	Hide               DashboardVariableHide   `json:"hide"`
-	SkipUrlSync        bool                    `json:"skipUrlSync"`
-	Description        *string                 `json:"description,omitempty"`
-	ShowInControlsMenu *bool                   `json:"showInControlsMenu,omitempty"`
+	Name        string                  `json:"name"`
+	Query       string                  `json:"query"`
+	Current     DashboardVariableOption `json:"current"`
+	Label       *string                 `json:"label,omitempty"`
+	Hide        DashboardVariableHide   `json:"hide"`
+	SkipUrlSync bool                    `json:"skipUrlSync"`
+	Description *string                 `json:"description,omitempty"`
 }
 
 // NewDashboardConstantVariableSpec creates a new DashboardConstantVariableSpec object.
@@ -1542,21 +1539,20 @@ func NewDashboardDatasourceVariableKind() *DashboardDatasourceVariableKind {
 // Datasource variable specification
 // +k8s:openapi-gen=true
 type DashboardDatasourceVariableSpec struct {
-	Name               string                    `json:"name"`
-	PluginId           string                    `json:"pluginId"`
-	Refresh            DashboardVariableRefresh  `json:"refresh"`
-	Regex              string                    `json:"regex"`
-	Current            DashboardVariableOption   `json:"current"`
-	Options            []DashboardVariableOption `json:"options"`
-	Multi              bool                      `json:"multi"`
-	IncludeAll         bool                      `json:"includeAll"`
-	AllValue           *string                   `json:"allValue,omitempty"`
-	Label              *string                   `json:"label,omitempty"`
-	Hide               DashboardVariableHide     `json:"hide"`
-	SkipUrlSync        bool                      `json:"skipUrlSync"`
-	Description        *string                   `json:"description,omitempty"`
-	AllowCustomValue   bool                      `json:"allowCustomValue"`
-	ShowInControlsMenu *bool                     `json:"showInControlsMenu,omitempty"`
+	Name             string                    `json:"name"`
+	PluginId         string                    `json:"pluginId"`
+	Refresh          DashboardVariableRefresh  `json:"refresh"`
+	Regex            string                    `json:"regex"`
+	Current          DashboardVariableOption   `json:"current"`
+	Options          []DashboardVariableOption `json:"options"`
+	Multi            bool                      `json:"multi"`
+	IncludeAll       bool                      `json:"includeAll"`
+	AllValue         *string                   `json:"allValue,omitempty"`
+	Label            *string                   `json:"label,omitempty"`
+	Hide             DashboardVariableHide     `json:"hide"`
+	SkipUrlSync      bool                      `json:"skipUrlSync"`
+	Description      *string                   `json:"description,omitempty"`
+	AllowCustomValue bool                      `json:"allowCustomValue"`
 }
 
 // NewDashboardDatasourceVariableSpec creates a new DashboardDatasourceVariableSpec object.
@@ -1601,19 +1597,18 @@ func NewDashboardIntervalVariableKind() *DashboardIntervalVariableKind {
 // Interval variable specification
 // +k8s:openapi-gen=true
 type DashboardIntervalVariableSpec struct {
-	Name               string                    `json:"name"`
-	Query              string                    `json:"query"`
-	Current            DashboardVariableOption   `json:"current"`
-	Options            []DashboardVariableOption `json:"options"`
-	Auto               bool                      `json:"auto"`
-	AutoMin            string                    `json:"auto_min"`
-	AutoCount          int64                     `json:"auto_count"`
-	Refresh            DashboardVariableRefresh  `json:"refresh"`
-	Label              *string                   `json:"label,omitempty"`
-	Hide               DashboardVariableHide     `json:"hide"`
-	SkipUrlSync        bool                      `json:"skipUrlSync"`
-	Description        *string                   `json:"description,omitempty"`
-	ShowInControlsMenu *bool                     `json:"showInControlsMenu,omitempty"`
+	Name        string                    `json:"name"`
+	Query       string                    `json:"query"`
+	Current     DashboardVariableOption   `json:"current"`
+	Options     []DashboardVariableOption `json:"options"`
+	Auto        bool                      `json:"auto"`
+	AutoMin     string                    `json:"auto_min"`
+	AutoCount   int64                     `json:"auto_count"`
+	Refresh     DashboardVariableRefresh  `json:"refresh"`
+	Label       *string                   `json:"label,omitempty"`
+	Hide        DashboardVariableHide     `json:"hide"`
+	SkipUrlSync bool                      `json:"skipUrlSync"`
+	Description *string                   `json:"description,omitempty"`
 }
 
 // NewDashboardIntervalVariableSpec creates a new DashboardIntervalVariableSpec object.
@@ -1657,19 +1652,18 @@ func NewDashboardCustomVariableKind() *DashboardCustomVariableKind {
 // Custom variable specification
 // +k8s:openapi-gen=true
 type DashboardCustomVariableSpec struct {
-	Name               string                    `json:"name"`
-	Query              string                    `json:"query"`
-	Current            DashboardVariableOption   `json:"current"`
-	Options            []DashboardVariableOption `json:"options"`
-	Multi              bool                      `json:"multi"`
-	IncludeAll         bool                      `json:"includeAll"`
-	AllValue           *string                   `json:"allValue,omitempty"`
-	Label              *string                   `json:"label,omitempty"`
-	Hide               DashboardVariableHide     `json:"hide"`
-	SkipUrlSync        bool                      `json:"skipUrlSync"`
-	Description        *string                   `json:"description,omitempty"`
-	AllowCustomValue   bool                      `json:"allowCustomValue"`
-	ShowInControlsMenu *bool                     `json:"showInControlsMenu,omitempty"`
+	Name             string                    `json:"name"`
+	Query            string                    `json:"query"`
+	Current          DashboardVariableOption   `json:"current"`
+	Options          []DashboardVariableOption `json:"options"`
+	Multi            bool                      `json:"multi"`
+	IncludeAll       bool                      `json:"includeAll"`
+	AllValue         *string                   `json:"allValue,omitempty"`
+	Label            *string                   `json:"label,omitempty"`
+	Hide             DashboardVariableHide     `json:"hide"`
+	SkipUrlSync      bool                      `json:"skipUrlSync"`
+	Description      *string                   `json:"description,omitempty"`
+	AllowCustomValue bool                      `json:"allowCustomValue"`
 }
 
 // NewDashboardCustomVariableSpec creates a new DashboardCustomVariableSpec object.
@@ -1707,16 +1701,15 @@ func NewDashboardGroupByVariableKind() *DashboardGroupByVariableKind {
 // GroupBy variable specification
 // +k8s:openapi-gen=true
 type DashboardGroupByVariableSpec struct {
-	Name               string                    `json:"name"`
-	DefaultValue       *DashboardVariableOption  `json:"defaultValue,omitempty"`
-	Current            DashboardVariableOption   `json:"current"`
-	Options            []DashboardVariableOption `json:"options"`
-	Multi              bool                      `json:"multi"`
-	Label              *string                   `json:"label,omitempty"`
-	Hide               DashboardVariableHide     `json:"hide"`
-	SkipUrlSync        bool                      `json:"skipUrlSync"`
-	Description        *string                   `json:"description,omitempty"`
-	ShowInControlsMenu *bool                     `json:"showInControlsMenu,omitempty"`
+	Name         string                    `json:"name"`
+	DefaultValue *DashboardVariableOption  `json:"defaultValue,omitempty"`
+	Current      DashboardVariableOption   `json:"current"`
+	Options      []DashboardVariableOption `json:"options"`
+	Multi        bool                      `json:"multi"`
+	Label        *string                   `json:"label,omitempty"`
+	Hide         DashboardVariableHide     `json:"hide"`
+	SkipUrlSync  bool                      `json:"skipUrlSync"`
+	Description  *string                   `json:"description,omitempty"`
 }
 
 // NewDashboardGroupByVariableSpec creates a new DashboardGroupByVariableSpec object.
@@ -1758,16 +1751,15 @@ func NewDashboardAdhocVariableKind() *DashboardAdhocVariableKind {
 // Adhoc variable specification
 // +k8s:openapi-gen=true
 type DashboardAdhocVariableSpec struct {
-	Name               string                           `json:"name"`
-	BaseFilters        []DashboardAdHocFilterWithLabels `json:"baseFilters"`
-	Filters            []DashboardAdHocFilterWithLabels `json:"filters"`
-	DefaultKeys        []DashboardMetricFindValue       `json:"defaultKeys"`
-	Label              *string                          `json:"label,omitempty"`
-	Hide               DashboardVariableHide            `json:"hide"`
-	SkipUrlSync        bool                             `json:"skipUrlSync"`
-	Description        *string                          `json:"description,omitempty"`
-	AllowCustomValue   bool                             `json:"allowCustomValue"`
-	ShowInControlsMenu *bool                            `json:"showInControlsMenu,omitempty"`
+	Name             string                           `json:"name"`
+	BaseFilters      []DashboardAdHocFilterWithLabels `json:"baseFilters"`
+	Filters          []DashboardAdHocFilterWithLabels `json:"filters"`
+	DefaultKeys      []DashboardMetricFindValue       `json:"defaultKeys"`
+	Label            *string                          `json:"label,omitempty"`
+	Hide             DashboardVariableHide            `json:"hide"`
+	SkipUrlSync      bool                             `json:"skipUrlSync"`
+	Description      *string                          `json:"description,omitempty"`
+	AllowCustomValue bool                             `json:"allowCustomValue"`
 }
 
 // NewDashboardAdhocVariableSpec creates a new DashboardAdhocVariableSpec object.

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/zz_generated.openapi.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/zz_generated.openapi.go
@@ -635,12 +635,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardAdhocVariableSpec(ref common.Ref
 							Format:  "",
 						},
 					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 				},
 				Required: []string{"name", "baseFilters", "filters", "defaultKeys", "hide", "skipUrlSync", "allowCustomValue"},
 			},
@@ -1326,12 +1320,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardConstantVariableSpec(ref common.
 							Format: "",
 						},
 					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 				},
 				Required: []string{"name", "query", "current", "hide", "skipUrlSync"},
 			},
@@ -1497,12 +1485,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardCustomVariableSpec(ref common.Re
 							Default: false,
 							Type:    []string{"boolean"},
 							Format:  "",
-						},
-					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
 						},
 					},
 				},
@@ -1895,12 +1877,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardDatasourceVariableSpec(ref commo
 							Default: false,
 							Type:    []string{"boolean"},
 							Format:  "",
-						},
-					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
 						},
 					},
 				},
@@ -2593,12 +2569,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardGroupByVariableSpec(ref common.R
 							Format: "",
 						},
 					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
-							Format: "",
-						},
-					},
 				},
 				Required: []string{"name", "current", "options", "multi", "hide", "skipUrlSync"},
 			},
@@ -2811,12 +2781,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardIntervalVariableSpec(ref common.
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -3592,12 +3556,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardQueryVariableSpec(ref common.Ref
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},
@@ -4442,12 +4400,6 @@ func schema_pkg_apis_dashboard_v2beta1_DashboardTextVariableSpec(ref common.Refe
 					"description": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"string"},
-							Format: "",
-						},
-					},
-					"showInControlsMenu": {
-						SchemaProps: spec.SchemaProps{
-							Type:   []string{"boolean"},
 							Format: "",
 						},
 					},

--- a/packages/grafana-data/src/types/templateVars.ts
+++ b/packages/grafana-data/src/types/templateVars.ts
@@ -187,7 +187,6 @@ export interface BaseVariableModel {
   error: any | null;
   description: string | null;
   usedInRepeat?: boolean;
-  showInControlsMenu?: boolean;
 }
 
 export interface SnapshotVariableModel extends VariableWithOptions {

--- a/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2beta1/types.spec.gen.ts
@@ -1076,7 +1076,6 @@ export interface QueryVariableSpec {
 	refresh: VariableRefresh;
 	skipUrlSync: boolean;
 	description?: string;
-	showInControlsMenu?: boolean;
 	query: DataQueryKind;
 	regex: string;
 	sort: VariableSort;
@@ -1171,7 +1170,6 @@ export interface TextVariableSpec {
 	hide: VariableHide;
 	skipUrlSync: boolean;
 	description?: string;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultTextVariableSpec = (): TextVariableSpec => ({
@@ -1202,7 +1200,6 @@ export interface ConstantVariableSpec {
 	hide: VariableHide;
 	skipUrlSync: boolean;
 	description?: string;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultConstantVariableSpec = (): ConstantVariableSpec => ({
@@ -1240,7 +1237,6 @@ export interface DatasourceVariableSpec {
 	skipUrlSync: boolean;
 	description?: string;
 	allowCustomValue: boolean;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultDatasourceVariableSpec = (): DatasourceVariableSpec => ({
@@ -1282,7 +1278,6 @@ export interface IntervalVariableSpec {
 	hide: VariableHide;
 	skipUrlSync: boolean;
 	description?: string;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultIntervalVariableSpec = (): IntervalVariableSpec => ({
@@ -1323,7 +1318,6 @@ export interface CustomVariableSpec {
 	skipUrlSync: boolean;
 	description?: string;
 	allowCustomValue: boolean;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultCustomVariableSpec = (): CustomVariableSpec => ({
@@ -1365,7 +1359,6 @@ export interface GroupByVariableSpec {
 	hide: VariableHide;
 	skipUrlSync: boolean;
 	description?: string;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultGroupByVariableSpec = (): GroupByVariableSpec => ({
@@ -1404,7 +1397,6 @@ export interface AdhocVariableSpec {
 	skipUrlSync: boolean;
 	description?: string;
 	allowCustomValue: boolean;
-	showInControlsMenu?: boolean;
 }
 
 export const defaultAdhocVariableSpec = (): AdhocVariableSpec => ({


### PR DESCRIPTION
### What changed?
With https://github.com/grafana/grafana/pull/111245 we transitioned to use the `hide` property for displaying variables in the dashboard controls drop-down menu. This PR is removing the `showInControlsMenu` prop from variable model definitions, as it's no longer needed.

**Scenes counterpart PR:** https://github.com/grafana/scenes/pull/1249