### PR TITLE
Testing: Tidy up alerting handlers in default mock worker setup

### DIFF
--- a/public/app/dev-utils.ts
+++ b/public/app/dev-utils.ts
@@ -27,7 +27,7 @@ export const potentiallySetupMockApi = async () => {
     const { default: worker } = await import('@grafana/test-utils/worker');
 
     // TODO: Generalise and move Alerting handlers into @grafana/test-utils or @grafana/alerting package
-    const { default: alertingHandlers } = await import('./features/alerting/unified/mocks/server/all-handlers');
+    const { alertingHandlers } = await import('./features/alerting/unified/mocks/server/all-handlers');
     worker.use(...alertingHandlers);
 
     worker.start({ onUnhandledRequest: 'bypass' });

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -21,30 +21,40 @@ import searchHandlers from 'app/features/alerting/unified/mocks/server/handlers/
 import silenceHandlers from 'app/features/alerting/unified/mocks/server/handlers/silences';
 
 /**
- * Array of all mock handlers that are required across Alerting tests
- * @deprecated Move to `@grafana/test-utils` instead
+ * All alerting-specific handlers that are required across tests
+ * @deprecated Move to `@grafana/alerting/testing` instead
  */
-const allHandlers = [
-  ...accessControlHandlers,
+export const alertingHandlers = [
   ...alertNotifierHandlers,
   ...grafanaRulerHandlers,
   ...mimirRulerHandlers,
   ...alertmanagerHandlers,
-  ...datasourcesHandlers,
-  ...evalHandlers,
-  ...folderHandlers,
-  ...pluginsHandlers,
-  ...provisioningHandlers,
   ...silenceHandlers,
-  ...searchHandlers,
-
-  ...allPluginHandlers,
+  ...provisioningHandlers,
 
   // Kubernetes-style handlers
   ...timeIntervalK8sHandlers,
   ...receiverK8sHandlers,
   ...templatesK8sHandlers,
   ...routingTreeK8sHandlers,
+];
+
+/**
+ * Array of all mock handlers that are required across Alerting tests,
+ * including some re-defined behaviour for handlers that are defined in `@grafana/test-utils`
+ *
+ * @deprecated Move to or use inbuilt handlers from `@grafana/test-utils` instead
+ */
+const allHandlers = [
+  ...alertingHandlers,
+  ...folderHandlers,
+  ...searchHandlers,
+
+  ...accessControlHandlers,
+  ...allPluginHandlers,
+  ...datasourcesHandlers,
+  ...evalHandlers,
+  ...pluginsHandlers,
 ];
 
 export default allHandlers;

--- a/public/app/features/alerting/unified/mocks/server/handlers/folders.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/folders.ts
@@ -52,6 +52,7 @@ const listFoldersHandler = (folders = DEFAULT_FOLDERS) =>
     return HttpResponse.json(strippedFolders);
   });
 
+/** @deprecated Move to or use inbuilt handlers from `@grafana/test-utils` instead */
 const handlers = [listFoldersHandler(), getFolderHandler()];
 
 export default handlers;

--- a/public/app/features/alerting/unified/mocks/server/handlers/search.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/search.ts
@@ -29,6 +29,7 @@ const defaultSearchResponse = [
 export const searchHandler = (response = defaultSearchResponse) =>
   http.get(`/api/search`, () => HttpResponse.json(response));
 
+/** @deprecated Move to or use inbuilt handlers from `@grafana/test-utils` instead */
 const handlers = [searchHandler()];
 
 export default handlers;

--- a/public/test/mock-api/worker.ts
+++ b/public/test/mock-api/worker.ts
@@ -1,5 +1,0 @@
-import { setupWorker } from 'msw/browser';
-
-import allAlertingHandlers from 'app/features/alerting/unified/mocks/server/all-handlers';
-
-export default setupWorker(...allAlertingHandlers);


### PR DESCRIPTION
**What is this feature?**
Splits the alerting MSW handlers out so that the browser worker that can be used for testing, doesn't include the specific overridden behaviour for some endpoints.

**Why do we need this feature?**
Some of the endpoints that were defined in the alerting test handlers were re-defining handlers that exist in `@grafan/test-utils`. This means that things like folders and search endpoints were being overridden by (slightly incomplete) different implementations of the API

This splits the alerting ones out into
* alerting specific handlers
* handlers that are defining bespoke logic for other general purpose endpoints, but haven't yet made it into `@grafana/test-utils`

**Who is this feature for?**
UI devs