### PR TITLE
Chore: Removes remaining occurrences of angular_support_enabled

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -439,9 +439,6 @@ content_security_policy_report_only = false
 # $ROOT_PATH is server.root_url without the protocol.
 content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
-# Controls if old angular plugins are supported or not.
-angular_support_enabled = false
-
 # The CSRF check will be executed even if the request has no login cookie.
 csrf_always_check = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -432,9 +432,6 @@
 # $ROOT_PATH is server.root_url without the protocol.
 ;content_security_policy_report_only_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self';"""
 
-# Controls if old angular plugins are supported or not.
-;angular_support_enabled = false
-
 # List of additional allowed URLs to pass by the CSRF check, separated by spaces. Suggested when authentication comes from an IdP.
 ;csrf_trusted_origins = example.com
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -792,20 +792,6 @@ The following example limits access to the backend of a single plugin:
 
 `actions_allow_post_url=/api/plugins/grafana-special-app`
 
-<hr />
-
-#### `angular_support_enabled`
-
-This is set to false by default, meaning that the angular framework and support components aren't loaded.
-This means that all [plugins](../../developers/angular_deprecation/angular-plugins/) and core features that depend on angular support won't work.
-
-The core features that depend on angular are:
-
-- Old graph panel
-- Old table panel
-
-These features each have supported alternatives, and we recommend using them.
-
 #### `csrf_trusted_origins`
 
 List of additional allowed URLs to pass by the CSRF check. Suggested when authentication comes from an IdP.


### PR DESCRIPTION
**What is this feature?**

This pull request removes remaining occurrences of `angular_support_enabled` from the codebase and documentation.

**Why do we need this feature?**

To keep docs and examples up to date

**Who is this feature for?**

Users trying to configure Grafana

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #111300

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
