### PR TITLE
Azure: Disable E2E tests on main

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -323,7 +323,7 @@ jobs:
           retention-days: 1
 
   run-azure-monitor-e2e:
-    if: needs.detect-changes.outputs.cloud_plugins_changed == 'true' && github.event.pull_request.head.repo.fork == false
+    if: needs.detect-changes.outputs.cloud_plugins_changed == 'true' && github.event.pull_request.head.repo.fork == false && github.event_name == 'pull_request'
     runs-on: ubuntu-x64-large
     needs:
       - build-grafana


### PR DESCRIPTION
These E2E tests should only run on Azure Monitor changes. They do not need to run for every main commit.