### PR TITLE
Alerting: Add support for vanilla `rule_name[]` query params

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -192,11 +192,19 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         excludeAlerts,
       }) => {
         const queryParams: Record<string, string | undefined> = {
-          rule_group: groupName,
-          rule_name: ruleName,
           dashboard_uid: dashboardUid, // Supported only by Grafana managed rules
           panel_id: panelId?.toString(), // Supported only by Grafana managed rules
         };
+
+        if (groupName) {
+          queryParams[PrometheusAPIFilters.RuleGroup] = groupName;
+          queryParams[PrometheusAPIFilters.RuleGroupVanilla] = groupName;
+        }
+
+        if (ruleName) {
+          queryParams[PrometheusAPIFilters.RuleName] = ruleName;
+          queryParams[PrometheusAPIFilters.RuleNameVanilla] = ruleName;
+        }
 
         if (namespace) {
           if (isGrafanaRulesSource(ruleSourceName)) {


### PR DESCRIPTION
**What is this feature?**

Prior to this PR, we only supported the Mimir-based `rule_name` query param – this meant that vanilla Prometheus wasn't supported when using the `/find` page of Alerting where we try to find the rule identifier by rule name.

**Special notes for your reviewer:**

I've also added support for the `rule_group[]` parameter even though we don't appear to really be using that one in the `/find` page.