### PR TITLE
CI: Fix path to scripts in release-npm.yml workflow

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -59,6 +59,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: false
 
       - name: Verify commit is in workflow HEAD
         env:

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Verify commit is in workflow HEAD
         env:
           GIT_COMMIT: ${{ github.event.inputs.grafana_commit }}
-        run: ./github/workflows/scripts/validate-commit-in-head.sh
+        run: ./.github/workflows/scripts/validate-commit-in-head.sh
         shell: bash
 
       - name: Map version type to NPM tag
@@ -71,7 +71,7 @@ jobs:
         env:
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
         run: |
-          TAG=$(./github/workflows/scripts/determine-npm-tag.sh)
+          TAG=$(./.github/workflows/scripts/determine-npm-tag.sh)
           echo "NPM_TAG=$TAG" >> "$GITHUB_OUTPUT"
         shell: bash
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -97,9 +97,11 @@ jobs:
         run: yarn run packages:typecheck
 
       - name: Version, build, and pack packages
+        env:
+          VERSION: ${{ github.event.inputs.version }}
         run: |
           yarn run packages:build
-          yarn lerna version "$PACKAGES_VERSION" \
+          yarn lerna version "$VERSION" \
             --exact \
             --no-git-tag-version \
             --no-push \

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -59,7 +59,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
-          fetch-depth: 0
+          fetch-depth: 100
           fetch-tags: false
 
       - name: Verify commit is in workflow HEAD

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -88,7 +88,7 @@ jobs:
           ref: ${{ github.event.inputs.grafana_commit }}
 
       - name: Setup Node
-        uses: ./github/actions/setup-node
+        uses: ./.github/actions/setup-node
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -72,6 +72,7 @@ jobs:
         id: npm-tag
         env:
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
+          REFERENCE_PKG: "@grafana/runtime"
         run: |
           TAG=$(./.github/workflows/scripts/determine-npm-tag.sh)
           echo "NPM_TAG=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -90,6 +90,10 @@ jobs:
       - name: Setup Node
         uses: ./.github/actions/setup-node
 
+      # Trusted Publishing is only available in npm v11.5.1 and later
+      - name: Update npm
+        run: npm install -g npm@^11.5.1
+
       - name: Install dependencies
         run: yarn install --immutable
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -62,6 +62,8 @@ jobs:
           fetch-depth: 100
           fetch-tags: false
 
+      # this will fail with "{commit} is not a valid commit" if the commit is valid but
+      # not in the last 100 commits.
       - name: Verify commit is in workflow HEAD
         env:
           GIT_COMMIT: ${{ github.event.inputs.grafana_commit }}
@@ -71,6 +73,7 @@ jobs:
       - name: Map version type to NPM tag
         id: npm-tag
         env:
+          VERSION: ${{ github.event.inputs.version }}
           VERSION_TYPE: ${{ github.event.inputs.version_type }}
           REFERENCE_PKG: "@grafana/runtime"
         run: |


### PR DESCRIPTION
Fixes a number of problems in the npm publish github workflow:

 - Fixes the missing `.` in `.github` in a bunch of script paths
 - `validate-commit-in-head.sh` doesn't work in a shallow clone if the commit was not fetched, so set the fetch depth to 100 which "should work"
 - Fixed `determine-npm-tag.sh` not having its required environment variables passed in
 - Fixed forgetting to install the right version of npm
 - Fixed not passing the version in to `yarn lerna version` through env var