### PR TITLE
Schema V2 Dashboard Import: Don't include built in ds in inputs

### DIFF
--- a/public/app/features/manage-dashboards/state/actions.test.ts
+++ b/public/app/features/manage-dashboards/state/actions.test.ts
@@ -41,7 +41,7 @@ jest.mock('@grafana/runtime', () => ({
           uid: string;
           name: string;
           type: string;
-          meta: { id: string };
+          meta: { id: string; builtIn?: boolean };
         };
       } = {
         prometheus: {
@@ -56,18 +56,21 @@ jest.mock('@grafana/runtime', () => ({
           type: 'loki',
           meta: { id: 'loki' },
         },
+        // grafana datasource is what we call "-- Grafana --" datasource and it's returned
+        // from datasourceSrv with meta: {builtIn: true}
         grafana: {
           uid: 'grafana-uid',
           name: 'Grafana',
           type: 'grafana',
-          meta: { id: 'grafana' },
+          meta: { id: 'grafana', builtIn: true },
         },
-        // "datasource" type is what we call "--Dashboard--" datasource
+        // "datasource" type is what we call "-- Dashboard --" datasource and it's returned
+        // from datasourceSrv with meta: {builtIn: true}
         datasource: {
           uid: '--Dashboard--',
           name: '--Dashboard--',
           type: 'datasource',
-          meta: { id: 'dashboard' },
+          meta: { id: 'dashboard', builtIn: true },
         },
       };
       return dsListTypeDSMock[dsType.type];
@@ -982,7 +985,8 @@ describe('processV2Datasources', () => {
 
 describe('processV2DatasourceInput', () => {
   // should not map grafana datasource input or dashboard datasource input
-  it('Should not map grafana datasource input', async () => {
+  // grafana datasource input is built in and
+  it('Should not map grafana datasource input (built in)', async () => {
     const queryVariable = {
       kind: 'QueryVariable',
       spec: {
@@ -1004,7 +1008,7 @@ describe('processV2DatasourceInput', () => {
     expect(result).toEqual({});
   });
 
-  it('Should not map dashboard datasource input', async () => {
+  it('Should not map dashboard datasource input (built in)', async () => {
     // create a panel with dashboard datasource input
     const panelQuery = {
       kind: 'PanelQuery',

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -310,20 +310,15 @@ export async function processV2DatasourceInput(
   spec: PanelQueryKind['spec'] | QueryVariableKind['spec'] | AnnotationQueryKind['spec'],
   inputs: Record<string, DataSourceInput> = {}
 ) {
-  const datasourceRef = spec.query.datasource;
   let dataSourceInput: DataSourceInput | undefined;
   const dsType = spec.query.group;
 
-  if (!datasourceRef) {
-    // if dsType is grafana, it means we are using a built-in annotation or default grafana datasource, in those
-    // cases we don't need to map it
-    // "datasource" type is what we call "--Dashboard--" datasource <.-.>
-    if (dsType === 'grafana' || dsType === 'datasource') {
-      return inputs;
-    }
+  const datasource = await getDatasourceSrv().get({ type: dsType });
+
+  if (datasource.meta?.builtIn) {
+    return inputs;
   }
 
-  const datasource = await getDatasourceSrv().get({ type: dsType });
   if (datasource) {
     dataSourceInput = {
       name: datasource.name,


### PR DESCRIPTION
Fixes the issue where in some cases during import selection, input for built-in datasources was required. We had this check in place, but it wasn't robust enough because it was only applied to kinds without datasourceRef, and annotations can have a datasourceRef but still rely on a built-in datasource. With this fix, we dynamically check for this through datasourceSrv, aligning with our [current approach for V1 dashboards](https://github.com/grafana/grafana/blob/e34b90a024b3e15a047fed45ee32c03ffb720f7c/public/app/features/dashboard-scene/scene/export/exporters.ts#L139).   

Fixes: https://github.com/grafana/grafana/issues/109118