### PR TITLE
Alerting: Update alert_rule table to fix paginated results

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -158,4 +158,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.AddStateFiredAtColumn(mg)
 
 	ualert.CollateAlertRuleGroup(mg)
+
+	ualert.AddAlertRuleGroupIndexMigration(mg)
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -156,4 +156,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.DropTitleUniqueIndexMigration(mg)
 
 	ualert.AddStateFiredAtColumn(mg)
+
+	ualert.CollateAlertRuleGroup(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation.go
@@ -1,0 +1,9 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// CollateAlertRuleGroup ensures that rule_group column collates.
+func CollateAlertRuleGroup(mg *migrator.Migrator) {
+	mg.AddMigration("ensure rule_group column is case sensitive in returned results", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_as_cs NOT NULL;"))
+}

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_group_index.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_group_index.go
@@ -1,0 +1,14 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// AddAlertRuleGroupIndexMigration adds an index on org_id, namespace_uid, rule_group, and rule_group_idx columns to alert_rule table.
+func AddAlertRuleGroupIndexMigration(mg *migrator.Migrator) {
+	mg.AddMigration("add index in alert_rule on org_id, namespace_uid, rule_group and rule_group_idx columns", migrator.NewAddIndexMigration(
+		migrator.Table{Name: "alert_rule"},
+		&migrator.Index{
+			Name: "IDX_alert_rule_org_id_namespace_uid_rule_group_rule_group_idx",
+			Cols: []string{"org_id", "namespace_uid", "rule_group", "rule_group_idx"},
+		},
+	))
+}


### PR DESCRIPTION
**What is this feature?**

This adds an index for the order by clauses used with the paginated lists and corrects the collation of the `rule_group` column.

**Why do we need this feature?**

It improves performance of list queries and ensures the correctness when working with `mysql` in which our table creation defaults to case-insensitve collation.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
