### PR TITLE
CI: Send notification in PR when release-build is started

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -286,3 +286,52 @@ jobs:
       version: ${{ needs.setup.outputs.version }}
       build_id: ${{ github.run_id }}
       version_type: "canary"
+
+  # notify-pr creates (or updates) a comment in a pull request to link to this workflow where the release artifacts are
+  # being built.
+  notify-pr:
+    runs-on: ubuntu-x64-small
+    permissions:
+      contents: read
+      id-token: write
+    needs:
+      - setup
+    steps:
+      - id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+          repositories: '["grafana"]'
+          permissions: '{"issues": "write", "pull_requests": "write", "contents": "read"}'
+      - name: Find PR
+        env:
+          GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
+        run: echo "ISSUE_NUMBER=$(gh api "/repos/grafana/grafana/commits/${GRAFANA_COMMIT}/pulls" | jq -r '.[0].number')" >> "$GITHUB_ENV"
+      - name: Find Comment
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        id: fc
+        with:
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          comment-author: 'grafana-delivery-bot[bot]'
+          body-includes: GitHub Actions Build
+          token: ${{ steps.generate_token.outputs.token }}
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ env.ISSUE_NUMBER }}
+          body: |
+            :rocket: Your submission is now being built and packaged.
+
+            - [GitHub Actions Build](https://github.com/grafana/grafana/actions/runs/${{ github.run_id }})
+            - Version: ${{ needs.setup.outputs.version }}
+          edit-mode: replace


### PR DESCRIPTION
When a PR is merged to main, it can be hard to identify the build process that is building the release candidate.

This change should make it a little clearer.