### PR TITLE
Alerting: Add jitter support for periodic alert state storage to reduce database load spikes

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1453,6 +1453,10 @@ state_periodic_save_interval = 5m
 # If the feature flag 'alertingSaveStatePeriodic' is enabled, this is the size of the batch that is saved to the database at once.
 state_periodic_save_batch_size = 1
 
+# Enable jitter for periodic state saving to distribute database load over time.
+# When enabled, batches are spread across the save interval to prevent load spikes.
+state_periodic_save_jitter_enabled = false
+
 # Disables the smoothing of alert evaluations across their evaluation window.
 # Rules will evaluate in sync.
 disable_jitter = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1426,6 +1426,14 @@
 # If the feature flag 'alertingSaveStatePeriodic' is enabled, this is the size of the batch that is saved to the database at once.
 ;state_periodic_save_batch_size = 1
 
+# Enable jitter for periodic state saves to distribute database load over time.
+# When enabled, batches of alert instances are saved with calculated delays between them,
+# preventing all instances from being written to the database simultaneously.
+# This helps reduce database load spikes during periodic saves, especially beneficial
+# in environments with many alert instances or high database contention.
+# The jitter delays are distributed within 85% of the save interval to ensure completion before the next cycle.
+;state_periodic_save_jitter_enabled = false
+
 # Disables the smoothing of alert evaluations across their evaluation window.
 # Rules will evaluate in sync.
 ;disable_jitter = false

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -77,6 +77,32 @@ By default, it saves the states every 5 minutes to the database and on each shut
 can also be configured using the `state_periodic_save_interval` configuration flag. During this process, Grafana deletes all existing alert instances from the database and then writes the entire current set of instances back in batches in a single transaction.
 Configure the size of each batch using the `state_periodic_save_batch_size` configuration option.
 
+#### Jitter for periodic saves
+
+To further distribute database load, you can enable jitter for periodic state saves by setting `state_periodic_save_jitter_enabled = true`. When jitter is enabled, instead of saving all batches simultaneously, Grafana spreads the batch writes across a calculated time window of 85% of the save interval.
+
+**How jitter works:**
+- Calculates delays for each batch: `delay = (batchIndex * timeWindow) / (totalBatches - 1)`
+- Time window uses 85% of save interval for safety margin
+- Batches are evenly distributed across the time window
+- All operations occur within a single database transaction
+
+**Configuration example:**
+```ini
+[unified_alerting]
+state_periodic_save_jitter_enabled = true
+state_periodic_save_interval = 1m
+state_periodic_save_batch_size = 100
+```
+
+**Performance impact:**
+For 2000 alert instances with 1-minute interval and 100 batch size:
+- Creates 20 batches (2000 ÷ 100)
+- Spreads writes across 51 seconds (85% of 60s)
+- Batch writes occur every ~2.68 seconds
+
+This helps reduce database load spikes in environments with high alert cardinality by distributing writes over time rather than concentrating them at the beginning of each save cycle.
+
 The time it takes to write to the database periodically can be monitored using the `state_full_sync_duration_seconds` metric
 that is exposed by Grafana.
 

--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -82,12 +82,14 @@ Configure the size of each batch using the `state_periodic_save_batch_size` conf
 To further distribute database load, you can enable jitter for periodic state saves by setting `state_periodic_save_jitter_enabled = true`. When jitter is enabled, instead of saving all batches simultaneously, Grafana spreads the batch writes across a calculated time window of 85% of the save interval.
 
 **How jitter works:**
+
 - Calculates delays for each batch: `delay = (batchIndex * timeWindow) / (totalBatches - 1)`
 - Time window uses 85% of save interval for safety margin
 - Batches are evenly distributed across the time window
 - All operations occur within a single database transaction
 
 **Configuration example:**
+
 ```ini
 [unified_alerting]
 state_periodic_save_jitter_enabled = true
@@ -97,6 +99,7 @@ state_periodic_save_batch_size = 100
 
 **Performance impact:**
 For 2000 alert instances with 1-minute interval and 100 batch size:
+
 - Creates 20 batches (2000 ÷ 100)
 - Spreads writes across 51 seconds (85% of 60s)
 - Batch writes occur every ~2.68 seconds

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -369,19 +369,21 @@ func (ng *AlertNG) init() error {
 	ng.InstanceStore, ng.StartupInstanceReader = initInstanceStore(ng.store.SQLStore, ng.Log, ng.FeatureToggles)
 
 	stateManagerCfg := state.ManagerCfg{
-		Metrics:                    ng.Metrics.GetStateMetrics(),
-		ExternalURL:                appUrl,
-		DisableExecution:           !ng.Cfg.UnifiedAlerting.ExecuteAlerts,
-		InstanceStore:              ng.InstanceStore,
-		Images:                     ng.ImageService,
-		Clock:                      clk,
-		Historian:                  history,
-		MaxStateSaveConcurrency:    ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
-		StatePeriodicSaveBatchSize: ng.Cfg.UnifiedAlerting.StatePeriodicSaveBatchSize,
-		RulesPerRuleGroupLimit:     ng.Cfg.UnifiedAlerting.RulesPerRuleGroupLimit,
-		Tracer:                     ng.tracer,
-		Log:                        log.New("ngalert.state.manager"),
-		ResolvedRetention:          ng.Cfg.UnifiedAlerting.ResolvedAlertRetention,
+		Metrics:                        ng.Metrics.GetStateMetrics(),
+		ExternalURL:                    appUrl,
+		DisableExecution:               !ng.Cfg.UnifiedAlerting.ExecuteAlerts,
+		InstanceStore:                  ng.InstanceStore,
+		Images:                         ng.ImageService,
+		Clock:                          clk,
+		Historian:                      history,
+		MaxStateSaveConcurrency:        ng.Cfg.UnifiedAlerting.MaxStateSaveConcurrency,
+		StatePeriodicSaveBatchSize:     ng.Cfg.UnifiedAlerting.StatePeriodicSaveBatchSize,
+		StatePeriodicSaveJitterEnabled: ng.Cfg.UnifiedAlerting.StatePeriodicSaveJitterEnabled,
+		StatePeriodicSaveInterval:      ng.Cfg.UnifiedAlerting.StatePeriodicSaveInterval,
+		RulesPerRuleGroupLimit:         ng.Cfg.UnifiedAlerting.RulesPerRuleGroupLimit,
+		Tracer:                         ng.tracer,
+		Log:                            log.New("ngalert.state.manager"),
+		ResolvedRetention:              ng.Cfg.UnifiedAlerting.ResolvedAlertRetention,
 	}
 	statePersister := initStatePersister(ng.Cfg.UnifiedAlerting, stateManagerCfg, ng.FeatureToggles)
 	stateManager := state.NewManager(stateManagerCfg, statePersister)

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -72,6 +72,10 @@ type ManagerCfg struct {
 	// StatePeriodicSaveBatchSize controls the size of the alert instance batch that is saved periodically when the
 	// alertingSaveStatePeriodic feature flag is enabled.
 	StatePeriodicSaveBatchSize int
+	// StatePeriodicSaveInterval controls the interval for periodic state saves.
+	StatePeriodicSaveInterval time.Duration
+	// StatePeriodicSaveJitterEnabled enables jitter for periodic state saves to distribute database load.
+	StatePeriodicSaveJitterEnabled bool
 
 	RulesPerRuleGroupLimit int64
 

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
@@ -26,6 +27,8 @@ type InstanceWriter interface {
 	SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error
 	FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error
+	// FullSyncWithJitter performs a full sync with jitter delays between rule groups while maintaining atomicity.
+	FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error
 }
 
 type OrgReader interface {

--- a/pkg/services/ngalert/state/persist.go
+++ b/pkg/services/ngalert/state/persist.go
@@ -26,9 +26,10 @@ type InstanceWriter interface {
 	// SaveAlertInstancesForRule overwrites the state for the given rule.
 	SaveAlertInstancesForRule(ctx context.Context, key models.AlertRuleKeyWithGroup, instances []models.AlertInstance) error
 	DeleteAlertInstancesByRule(ctx context.Context, key models.AlertRuleKeyWithGroup) error
-	FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error
-	// FullSyncWithJitter performs a full sync with jitter delays between rule groups while maintaining atomicity.
-	FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error
+	// FullSync performs a full synchronization of alert instances.
+	// If jitterFunc is provided, applies jitter delays between batches to distribute database load.
+	// If jitterFunc is nil, executes batches without delays.
+	FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int, jitterFunc func(int) time.Duration) error
 }
 
 type OrgReader interface {

--- a/pkg/services/ngalert/state/persister_async.go
+++ b/pkg/services/ngalert/state/persister_async.go
@@ -17,20 +17,24 @@ type AlertInstancesProvider interface {
 }
 
 type AsyncStatePersister struct {
-	log       log.Logger
-	batchSize int
-	store     InstanceStore
-	ticker    *clock.Ticker
-	metrics   *metrics.State
+	log           log.Logger
+	batchSize     int
+	store         InstanceStore
+	ticker        *clock.Ticker
+	metrics       *metrics.State
+	jitterEnabled bool
+	interval      time.Duration
 }
 
 func NewAsyncStatePersister(log log.Logger, ticker *clock.Ticker, cfg ManagerCfg) StatePersister {
 	return &AsyncStatePersister{
-		log:       log,
-		store:     cfg.InstanceStore,
-		ticker:    ticker,
-		batchSize: cfg.StatePeriodicSaveBatchSize,
-		metrics:   cfg.Metrics,
+		log:           log,
+		store:         cfg.InstanceStore,
+		ticker:        ticker,
+		batchSize:     cfg.StatePeriodicSaveBatchSize,
+		metrics:       cfg.Metrics,
+		jitterEnabled: cfg.StatePeriodicSaveJitterEnabled,
+		interval:      cfg.StatePeriodicSaveInterval,
 	}
 }
 
@@ -57,7 +61,15 @@ func (a *AsyncStatePersister) fullSync(ctx context.Context, instancesProvider Al
 	startTime := time.Now()
 	a.log.Debug("Full state sync start")
 	instances := instancesProvider.GetAlertInstances()
-	if err := a.store.FullSync(ctx, instances, a.batchSize); err != nil {
+
+	var err error
+	if a.jitterEnabled {
+		err = a.fullSyncWithJitter(ctx, instances)
+	} else {
+		err = a.store.FullSync(ctx, instances, a.batchSize)
+	}
+
+	if err != nil {
 		a.log.Error("Full state sync failed", "duration", time.Since(startTime), "instances", len(instances))
 		return err
 	}
@@ -65,6 +77,38 @@ func (a *AsyncStatePersister) fullSync(ctx context.Context, instancesProvider Al
 	if a.metrics != nil {
 		a.metrics.StateFullSyncDuration.Observe(time.Since(startTime).Seconds())
 	}
+	return nil
+}
+
+func (a *AsyncStatePersister) calculateBatchJitterDelay(batchIndex, totalBatches int, window time.Duration) time.Duration {
+	if totalBatches <= 1 {
+		return 0
+	}
+
+	// Distribute batches evenly across the window
+	ratio := float64(batchIndex) / float64(totalBatches-1)
+	delay := time.Duration(float64(window) * ratio)
+
+	return delay
+}
+
+func (a *AsyncStatePersister) fullSyncWithJitter(ctx context.Context, instances []models.AlertInstance) error {
+	safetyRatio := 0.85
+	availableWindow := time.Duration(float64(a.interval) * safetyRatio)
+
+	totalBatches := (len(instances) + a.batchSize - 1) / a.batchSize
+
+	jitterFunc := func(batchIndex int) time.Duration {
+		return a.calculateBatchJitterDelay(batchIndex, totalBatches, availableWindow)
+	}
+
+	err := a.store.FullSyncWithJitter(ctx, instances, jitterFunc, a.batchSize)
+	if err != nil {
+		a.log.Error("Full state sync with jitter failed", "err", err)
+		return err
+	}
+
+	a.log.Debug("Full state sync with jitter completed", "instances", len(instances), "batches", totalBatches, "window", availableWindow)
 	return nil
 }
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"slices"
 	"sync"
+	"time"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	history_model "github.com/grafana/grafana/pkg/services/ngalert/state/historian/model"
@@ -82,6 +83,27 @@ func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.Ale
 	for _, instance := range instances {
 		f.recordedOps = append(f.recordedOps, instance)
 	}
+	return nil
+}
+
+func (f *FakeInstanceStore) FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	// Basic call recording (consistent with other fake methods)
+	f.recordedOps = []any{FakeInstanceStoreOp{
+		Name: "FullSyncWithJitter",
+		Args: []any{
+			len(instances),
+			batchSize,
+		},
+	}}
+
+	// Record instances (same as FullSync)
+	for _, instance := range instances {
+		f.recordedOps = append(f.recordedOps, instance)
+	}
+
 	return nil
 }
 

--- a/pkg/services/ngalert/state/testing.go
+++ b/pkg/services/ngalert/state/testing.go
@@ -76,34 +76,13 @@ func (f *FakeInstanceStore) DeleteAlertInstancesByRule(ctx context.Context, key 
 	return nil
 }
 
-func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error {
+func (f *FakeInstanceStore) FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int, jitterFunc func(int) time.Duration) error {
 	f.mtx.Lock()
 	defer f.mtx.Unlock()
 	f.recordedOps = []any{}
 	for _, instance := range instances {
 		f.recordedOps = append(f.recordedOps, instance)
 	}
-	return nil
-}
-
-func (f *FakeInstanceStore) FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error {
-	f.mtx.Lock()
-	defer f.mtx.Unlock()
-
-	// Basic call recording (consistent with other fake methods)
-	f.recordedOps = []any{FakeInstanceStoreOp{
-		Name: "FullSyncWithJitter",
-		Args: []any{
-			len(instances),
-			batchSize,
-		},
-	}}
-
-	// Record instances (same as FullSync)
-	for _, instance := range instances {
-		f.recordedOps = append(f.recordedOps, instance)
-	}
-
 	return nil
 }
 

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -14,6 +14,42 @@ import (
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 )
 
+// jitteredBatch represents a batch of alert instances with associated jitter delay
+type jitteredBatch struct {
+	index     int
+	instances []models.AlertInstance
+	delay     time.Duration
+}
+
+// createJitteredBatches splits instances into batches and calculates jitter delays
+func createJitteredBatches(instances []models.AlertInstance, batchSize int, jitterFunc func(int) time.Duration, logger log.Logger) []jitteredBatch {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	var batches []jitteredBatch
+	totalInstances := len(instances)
+
+	for start := 0; start < totalInstances; start += batchSize {
+		end := start + batchSize
+		if end > totalInstances {
+			end = totalInstances
+		}
+
+		batchIndex := start / batchSize
+		batch := instances[start:end]
+		delay := jitterFunc(batchIndex)
+
+		batches = append(batches, jitteredBatch{
+			index:     batchIndex,
+			instances: batch,
+			delay:     delay,
+		})
+	}
+
+	return batches
+}
+
 type InstanceDBStore struct {
 	SQLStore db.DB
 	Logger   log.Logger
@@ -237,6 +273,71 @@ func (st InstanceDBStore) FullSync(ctx context.Context, instances []models.Alert
 
 			if err := st.insertInstancesBatch(sess, batch); err != nil {
 				return fmt.Errorf("failed to insert batch [%d:%d]: %w", start, end, err)
+			}
+		}
+
+		if err := sess.Commit(); err != nil {
+			return fmt.Errorf("failed to commit alert_instance table: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// FullSyncWithJitter performs a full synchronization with jitter delays between batches.
+//
+// This method maintains atomicity by performing all operations within a single transaction,
+// while distributing the INSERT operations over time to reduce database load spikes.
+//
+// Unlike the rule-based approach, this method splits all instances into batches of the specified
+// size and applies jitter delays between each batch, making it consistent with the regular FullSync behavior.
+//
+// The instances parameter should be a flat list of all alert instances.
+// The jitterFunc should return the delay duration for a given batch index.
+func (st InstanceDBStore) FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error {
+	if len(instances) == 0 {
+		return nil
+	}
+
+	if batchSize <= 0 {
+		batchSize = 1
+	}
+
+	// Prepare all batches and sorting OUTSIDE the transaction
+	batches := createJitteredBatches(instances, batchSize, jitterFunc, st.Logger)
+
+	// Sort batches by delay time (ascending)
+	sort.Slice(batches, func(i, j int) bool {
+		return batches[i].delay < batches[j].delay
+	})
+
+	// Execute the optimized transaction with pre-calculated batches
+	return st.executeJitteredBatchesInTransaction(ctx, batches)
+}
+
+// executeJitteredBatchesInTransaction executes pre-calculated batches within a single transaction
+// with jitter delays. All preparation work should be done before calling this method.
+func (st InstanceDBStore) executeJitteredBatchesInTransaction(ctx context.Context, batches []jitteredBatch) error {
+	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *sqlstore.DBSession) error {
+		// Capture the actual transaction start time for accurate delay calculations
+		transactionStartTime := time.Now()
+
+		// First we delete all records from the table
+		if _, err := sess.Exec("DELETE FROM alert_instance"); err != nil {
+			return fmt.Errorf("failed to delete alert_instance table: %w", err)
+		}
+
+		// Execute batches in order with absolute time-based delays using transaction start time
+		for _, batch := range batches {
+			// Calculate target time and wait until then
+			targetTime := transactionStartTime.Add(batch.delay)
+			if sleepDuration := time.Until(targetTime); sleepDuration > 0 {
+				time.Sleep(sleepDuration)
+			}
+
+			// Insert this batch
+			if err := st.insertInstancesBatch(sess, batch.instances); err != nil {
+				return fmt.Errorf("failed to insert batch %d [%d instances]: %w", batch.index, len(batch.instances), err)
 			}
 		}
 

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/golang/snappy"
+	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
@@ -22,9 +23,7 @@ import (
 const baseIntervalSeconds = 10
 
 func TestIntegration_CompressedAlertRuleStateOperations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
+	testutil.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(
@@ -124,9 +123,8 @@ func createAlertInstance(orgID int64, ruleUID, labelsHash, reason string, state 
 }
 
 func TestIntegrationAlertInstanceOperations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
+	testutil.SkipIntegrationTestInShortMode(t)
+
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(t, baseIntervalSeconds)
 
@@ -301,9 +299,8 @@ func TestIntegrationAlertInstanceOperations(t *testing.T) {
 }
 
 func TestIntegrationFullSync(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
+	testutil.SkipIntegrationTestInShortMode(t)
+
 	batchSize := 1
 
 	ctx := context.Background()
@@ -511,9 +508,8 @@ func TestIntegrationFullSync(t *testing.T) {
 }
 
 func TestIntegrationFullSyncWithJitter(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test in short mode")
-	}
+	testutil.SkipIntegrationTestInShortMode(t)
+
 	batchSize := 2
 
 	ctx := context.Background()
@@ -641,9 +637,7 @@ func TestIntegrationFullSyncWithJitter(t *testing.T) {
 }
 
 func TestIntegration_ProtoInstanceDBStore_VerifyCompressedData(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
+	testutil.SkipIntegrationTestInShortMode(t)
 
 	ctx := context.Background()
 	ng, dbstore := tests.SetupTestEnv(

--- a/pkg/services/ngalert/store/instance_database_test.go
+++ b/pkg/services/ngalert/store/instance_database_test.go
@@ -319,7 +319,7 @@ func TestIntegrationFullSync(t *testing.T) {
 	}
 
 	t.Run("Should do a proper full sync", func(t *testing.T) {
-		err := ng.InstanceStore.FullSync(ctx, instances, batchSize)
+		err := ng.InstanceStore.FullSync(ctx, instances, batchSize, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -342,7 +342,7 @@ func TestIntegrationFullSync(t *testing.T) {
 	})
 
 	t.Run("Should remove non existing entries on sync", func(t *testing.T) {
-		err := ng.InstanceStore.FullSync(ctx, instances[1:], batchSize)
+		err := ng.InstanceStore.FullSync(ctx, instances[1:], batchSize, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -359,7 +359,7 @@ func TestIntegrationFullSync(t *testing.T) {
 
 	t.Run("Should add new entries on sync", func(t *testing.T) {
 		newRuleUID := "y"
-		err := ng.InstanceStore.FullSync(ctx, append(instances, generateTestAlertInstance(orgID, newRuleUID)), batchSize)
+		err := ng.InstanceStore.FullSync(ctx, append(instances, generateTestAlertInstance(orgID, newRuleUID)), batchSize, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -384,7 +384,7 @@ func TestIntegrationFullSync(t *testing.T) {
 	t.Run("Should save all instances when batch size is bigger than 1", func(t *testing.T) {
 		batchSize = 2
 		newRuleUID := "y"
-		err := ng.InstanceStore.FullSync(ctx, append(instances, generateTestAlertInstance(orgID, newRuleUID)), batchSize)
+		err := ng.InstanceStore.FullSync(ctx, append(instances, generateTestAlertInstance(orgID, newRuleUID)), batchSize, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -412,12 +412,12 @@ func TestIntegrationFullSync(t *testing.T) {
 			generateTestAlertInstance(orgID, "preexisting-1"),
 			generateTestAlertInstance(orgID, "preexisting-2"),
 		}
-		err := ng.InstanceStore.FullSync(ctx, initialInstances, 5)
+		err := ng.InstanceStore.FullSync(ctx, initialInstances, 5, nil)
 		require.NoError(t, err)
 
 		// Now call FullSync with no instances. According to the code, this should return nil
 		// and should not delete anything in the table.
-		err = ng.InstanceStore.FullSync(ctx, []models.AlertInstance{}, 5)
+		err = ng.InstanceStore.FullSync(ctx, []models.AlertInstance{}, 5, nil)
 		require.NoError(t, err)
 
 		// Check that the previously inserted instances are still present.
@@ -448,7 +448,7 @@ func TestIntegrationFullSync(t *testing.T) {
 		// Make the invalid instance actually invalid
 		invalidInstance.RuleUID = ""
 
-		err := ng.InstanceStore.FullSync(ctx, []models.AlertInstance{validInstance, invalidInstance}, 2)
+		err := ng.InstanceStore.FullSync(ctx, []models.AlertInstance{validInstance, invalidInstance}, 2, nil)
 		require.NoError(t, err)
 
 		// Only the valid instance should be saved.
@@ -467,7 +467,7 @@ func TestIntegrationFullSync(t *testing.T) {
 			generateTestAlertInstance(orgID, "batch-test2"),
 		}
 
-		err := ng.InstanceStore.FullSync(ctx, smallSet, 100)
+		err := ng.InstanceStore.FullSync(ctx, smallSet, 100, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -490,7 +490,7 @@ func TestIntegrationFullSync(t *testing.T) {
 
 	t.Run("Should handle a large set of instances with a moderate batchSize", func(t *testing.T) {
 		// Clear everything first.
-		err := ng.InstanceStore.FullSync(ctx, []models.AlertInstance{}, 1)
+		err := ng.InstanceStore.FullSync(ctx, []models.AlertInstance{}, 1, nil)
 		require.NoError(t, err)
 
 		largeCount := 300
@@ -499,7 +499,7 @@ func TestIntegrationFullSync(t *testing.T) {
 			largeSet[i] = generateTestAlertInstance(orgID, fmt.Sprintf("large-%d", i))
 		}
 
-		err = ng.InstanceStore.FullSync(ctx, largeSet, 50)
+		err = ng.InstanceStore.FullSync(ctx, largeSet, 50, nil)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -533,7 +533,7 @@ func TestIntegrationFullSyncWithJitter(t *testing.T) {
 	}
 
 	t.Run("Should do a proper full sync with jitter", func(t *testing.T) {
-		err := ng.InstanceStore.FullSyncWithJitter(ctx, instances, jitterFunc, batchSize)
+		err := ng.InstanceStore.FullSync(ctx, instances, batchSize, jitterFunc)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -556,7 +556,7 @@ func TestIntegrationFullSyncWithJitter(t *testing.T) {
 	})
 
 	t.Run("Should handle empty instances with jitter", func(t *testing.T) {
-		err := ng.InstanceStore.FullSyncWithJitter(ctx, []models.AlertInstance{}, jitterFunc, batchSize)
+		err := ng.InstanceStore.FullSync(ctx, []models.AlertInstance{}, batchSize, jitterFunc)
 		require.NoError(t, err)
 
 		res, err := ng.InstanceStore.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
@@ -578,7 +578,7 @@ func TestIntegrationFullSyncWithJitter(t *testing.T) {
 		}
 
 		start := time.Now()
-		err := ng.InstanceStore.FullSyncWithJitter(ctx, testInstances, immediateJitterFunc, 1)
+		err := ng.InstanceStore.FullSync(ctx, testInstances, 1, immediateJitterFunc)
 		elapsed := time.Since(start)
 		require.NoError(t, err)
 
@@ -607,7 +607,7 @@ func TestIntegrationFullSyncWithJitter(t *testing.T) {
 		}
 
 		start := time.Now()
-		err := ng.InstanceStore.FullSyncWithJitter(ctx, testInstances, realJitterFunc, 2)
+		err := ng.InstanceStore.FullSync(ctx, testInstances, 2, realJitterFunc)
 		elapsed := time.Since(start)
 		require.NoError(t, err)
 

--- a/pkg/services/ngalert/store/proto_instance_database.go
+++ b/pkg/services/ngalert/store/proto_instance_database.go
@@ -139,6 +139,12 @@ func (st ProtoInstanceDBStore) FullSync(ctx context.Context, instances []models.
 	return errors.New("fullsync is not implemented for proto instance database store")
 }
 
+func (st ProtoInstanceDBStore) FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error {
+	logger := st.Logger.FromContext(ctx)
+	logger.Error("FullSyncWithJitter called and not implemented")
+	return errors.New("fullsyncwithjitter is not implemented for proto instance database store")
+}
+
 func alertInstanceModelToProto(modelInstance models.AlertInstance) *pb.AlertInstance {
 	return &pb.AlertInstance{
 		Labels:            modelInstance.Labels,

--- a/pkg/services/ngalert/store/proto_instance_database.go
+++ b/pkg/services/ngalert/store/proto_instance_database.go
@@ -133,16 +133,10 @@ func (st ProtoInstanceDBStore) DeleteAlertInstancesByRule(ctx context.Context, k
 	})
 }
 
-func (st ProtoInstanceDBStore) FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int) error {
+func (st ProtoInstanceDBStore) FullSync(ctx context.Context, instances []models.AlertInstance, batchSize int, jitterFunc func(int) time.Duration) error {
 	logger := st.Logger.FromContext(ctx)
 	logger.Error("FullSync called and not implemented")
 	return errors.New("fullsync is not implemented for proto instance database store")
-}
-
-func (st ProtoInstanceDBStore) FullSyncWithJitter(ctx context.Context, instances []models.AlertInstance, jitterFunc func(int) time.Duration, batchSize int) error {
-	logger := st.Logger.FromContext(ctx)
-	logger.Error("FullSyncWithJitter called and not implemented")
-	return errors.New("fullsyncwithjitter is not implemented for proto instance database store")
 }
 
 func alertInstanceModelToProto(modelInstance models.AlertInstance) *pb.AlertInstance {

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -134,10 +134,11 @@ type UnifiedAlertingSettings struct {
 	PrometheusConversion          UnifiedAlertingPrometheusConversionSettings
 
 	// MaxStateSaveConcurrency controls the number of goroutines (per rule) that can save alert state in parallel.
-	MaxStateSaveConcurrency    int
-	StatePeriodicSaveInterval  time.Duration
-	StatePeriodicSaveBatchSize int
-	RulesPerRuleGroupLimit     int64
+	MaxStateSaveConcurrency        int
+	StatePeriodicSaveInterval      time.Duration
+	StatePeriodicSaveBatchSize     int
+	StatePeriodicSaveJitterEnabled bool
+	RulesPerRuleGroupLimit         int64
 
 	// Retention period for Alertmanager notification log entries.
 	NotificationLogRetention time.Duration
@@ -559,6 +560,8 @@ func (cfg *Cfg) ReadUnifiedAlertingSettings(iniFile *ini.File) error {
 	}
 
 	uaCfg.StatePeriodicSaveBatchSize = ua.Key("state_periodic_save_batch_size").MustInt(1)
+
+	uaCfg.StatePeriodicSaveJitterEnabled = ua.Key("state_periodic_save_jitter_enabled").MustBool(false)
 
 	uaCfg.NotificationLogRetention, err = gtime.ParseDuration(valueAsString(ua, "notification_log_retention", (5 * 24 * time.Hour).String()))
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**

This PR implements a jitter mechanism for periodic alert state storage to distribute database load over time instead of processing all alert instances simultaneously. When enabled via the `state_periodic_save_jitter_enabled` configuration option, the system spreads batch write operations across 85% of the save interval window, preventing database load spikes in high-cardinality alerting environments.

**Why do we need this feature?**

In production environments with high alert cardinality, the current periodic batch storage can cause database performance issues by processing all alert instances simultaneously at fixed intervals. Even when using periodic batch storage to improve performance, concentrating all database operations at a single point in time can overwhelm database resources, especially in resource-constrained environments.

Rather than performing all INSERT operations at once during the periodic save, distributing these operations across the time window until the next save cycle can maintain more stable service operation within limited database resources. This approach prevents resource saturation by spreading the database load over the available time interval, allowing the system to operate more gracefully within existing resource constraints.

For example, with 200,000 alert instances using a 5-minute interval and 4,000 batch size, instead of executing 50 batch operations simultaneously, the jitter mechanism distributes these operations across approximately 4.25 minutes (85% of 5 minutes), with each batch executed roughly every 5.2 seconds.

This PR provides system-level protection against such load spikes by distributing operations across time, reducing peak resource usage while maintaining the benefits of periodic batch storage. The jitter mechanism is particularly valuable in resource-constrained environments where maintaining consistent database performance is more critical than precise timing of state updates.

**Who is this feature for?**

- **Platform/Infrastructure teams** managing large-scale Grafana deployments with high alert cardinality
- **Organizations** prioritizing system stability over precise alert state timing
- **Production environments** with 1000+ alert rules and variable cardinality
- **Teams without dedicated database expertise** who need built-in system protections
- **Managed database environments** with limited tuning options

**Which issue(s) does this PR fix?**:

Fixes #110365 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
