### PR TITLE
CI: Use workflow_dispatch from release-build for canaries

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -287,6 +287,28 @@ jobs:
       build_id: ${{ github.run_id }}
       version_type: "canary"
 
+  dispatch-npm-canaries:
+    if: github.ref_name == 'main'
+    name: Dispatch publish NPM canaries
+    permissions:
+      actions: write
+    runs-on: ubuntu-x64-small
+    needs:
+      - setup
+    steps:
+      - name: Dispatch action
+        env:
+          GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
+          VERSION: ${{ needs.setup.outputs.version }}
+          BUILD_ID: ${{ github.run_id }}
+        run: |
+          gh workflow run npm-publish.yml \
+            --repo grafana/grafana \
+            --ref main \
+            --field grafana_commit="$GRAFANA_COMMIT" \
+            --field version="$VERSION" \
+            --field build_id="$BUILD_ID"
+
   # notify-pr creates (or updates) a comment in a pull request to link to this workflow where the release artifacts are
   # being built.
   notify-pr:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -302,7 +302,7 @@ jobs:
           VERSION: ${{ needs.setup.outputs.version }}
           BUILD_ID: ${{ github.run_id }}
         run: |
-          gh workflow run npm-publish.yml \
+          gh workflow run release-npm.yml \
             --repo grafana/grafana \
             --ref main \
             --field grafana_commit="$GRAFANA_COMMIT" \

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,4 +1,5 @@
-name: Publish NPM packages
+name: Release NPM packages
+run-name: Publish NPM ${{ inputs.version_type }} ${{ inputs.version }}
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
It appears NPM does not support publishing via a workflow_call triggered workflow, so the canary npm publishing is currently failing https://github.com/grafana/grafana/actions/runs/17851914896/job/50763280072

This switches it to workflow_dispatch which should work
