### PR TITLE
CI: Pass Github Token into `gh` for npm publish

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -271,27 +271,12 @@ jobs:
           docker manifest push "grafana/grafana-dev:${VERSION}"
           docker manifest push "grafana/grafana-dev:${VERSION}-ubuntu"
 
-  publish-npm-canaries:
-    if: github.ref_name == 'main'
-    name: Publish NPM canaries
-    uses: ./.github/workflows/release-npm.yml
-    permissions:
-      contents: read
-      id-token: write
-    needs:
-      - setup
-      - build
-    with:
-      grafana_commit: ${{ needs.setup.outputs.grafana-commit }}
-      version: ${{ needs.setup.outputs.version }}
-      build_id: ${{ github.run_id }}
-      version_type: "canary"
-
   dispatch-npm-canaries:
     if: github.ref_name == 'main'
     name: Dispatch publish NPM canaries
     permissions:
       actions: write
+      contents: read
     runs-on: ubuntu-x64-small
     needs:
       - setup
@@ -301,6 +286,7 @@ jobs:
           GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
           VERSION: ${{ needs.setup.outputs.version }}
           BUILD_ID: ${{ github.run_id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh workflow run release-npm.yml \
             --repo grafana/grafana \


### PR DESCRIPTION
 - Fixes missing token when using `gh` to workflow_dispatch `release-npm.yml`
 - Removes old, duplicated workflow