### PR TITLE
CI: Specify canary input when dispatching npm publish

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -293,7 +293,8 @@ jobs:
             --ref main \
             --field grafana_commit="$GRAFANA_COMMIT" \
             --field version="$VERSION" \
-            --field build_id="$BUILD_ID"
+            --field build_id="$BUILD_ID"\
+            --field version_type="canary"
 
   # notify-pr creates (or updates) a comment in a pull request to link to this workflow where the release artifacts are
   # being built.


### PR DESCRIPTION
`release-npm.yml` has the following inputs:

```yml
  workflow_dispatch:
    inputs:
      grafana_commit:
        description: 'Grafana commit SHA to build against'
        required: true
      version:
        description: 'Version to publish as'
        required: true
      build_id:
        description: 'Run ID from the original release-build workflow'
        required: true
      version_type:
        description: 'Version type (canary, nightly, stable)'
        required: true
```


We're now properly passing through all inputs