### PR TITLE
Dashboards: Add network call checks for reloadable dashboards in E2Es

### DIFF
--- a/e2e-playwright/dashboard-cujs/dashboard-navigation.spec.ts
+++ b/e2e-playwright/dashboard-cujs/dashboard-navigation.spec.ts
@@ -11,7 +11,7 @@ import {
   getScopesDashboardsSearchInput,
   getScopesSelectorInput,
 } from './cuj-selectors';
-import { getConfigDashboards } from './utils';
+import { checkDashboardReloadBehavior, getConfigDashboards, trackDashboardReloadRequests } from './utils';
 
 test.use({
   featureToggles: {
@@ -117,9 +117,13 @@ test.describe(
             await groupByVariable.press('Enter');
             await groupByVariable.press('Escape');
 
-            await expect(scopesDashboards.first()).toBeVisible();
+            const { getRequests, waitForExpectedRequests } = await trackDashboardReloadRequests(page);
             await scopesDashboards.first().click();
-            await page.waitForURL('**/d/**');
+            await waitForExpectedRequests();
+            await page.waitForLoadState('networkidle');
+
+            const requests = getRequests();
+            expect(checkDashboardReloadBehavior(requests)).toBe(true);
 
             //all values are set after dashboard switch
             await expect(markdownContent).toContainText(`GroupByVar: dev\n\nAdHocVar: ${processedPills}`);

--- a/e2e-playwright/dashboard-cujs/dashboard-navigation.spec.ts
+++ b/e2e-playwright/dashboard-cujs/dashboard-navigation.spec.ts
@@ -117,6 +117,8 @@ test.describe(
             await groupByVariable.press('Enter');
             await groupByVariable.press('Escape');
 
+            await expect(scopesDashboards.first()).toBeVisible();
+
             const { getRequests, waitForExpectedRequests } = await trackDashboardReloadRequests(page);
             await scopesDashboards.first().click();
             await waitForExpectedRequests();

--- a/e2e-playwright/dashboard-cujs/utils.ts
+++ b/e2e-playwright/dashboard-cujs/utils.ts
@@ -78,7 +78,7 @@ export async function trackDashboardReloadRequests(page: Page): Promise<{
 }> {
   const dashboardRequests: DashboardRequest[] = [];
   let resolveWhenComplete: () => void;
-  let expectedRequestCount = 1; // Start with expecting 1 request
+  let expectedRequestCount = 1; //initial request that gives us the meta param
 
   const completionPromise = new Promise<void>((resolve) => {
     resolveWhenComplete = resolve;

--- a/e2e-playwright/dashboard-cujs/utils.ts
+++ b/e2e-playwright/dashboard-cujs/utils.ts
@@ -5,6 +5,8 @@ import * as path from 'path';
 const USE_LIVE_DATA = Boolean(process.env.API_CONFIG_PATH);
 const API_CONFIG_PATH = process.env.API_CONFIG_PATH ?? '../dashboards/cujs/config.json';
 
+const RELOADABLE_DASHBOARD_REQUEST_NO = 2;
+
 async function loadApiConfig() {
   const configPath = path.resolve(__dirname, API_CONFIG_PATH);
 
@@ -62,4 +64,74 @@ export async function prepareAPIMocks(page: Page) {
   }
 
   return apiConfig;
+}
+
+interface DashboardRequest {
+  url: string;
+  timestamp: number;
+  response: { metadata: { annotations: string[] } };
+}
+
+export async function trackDashboardReloadRequests(page: Page): Promise<{
+  getRequests: () => DashboardRequest[];
+  waitForExpectedRequests: () => Promise<void>;
+}> {
+  const dashboardRequests: DashboardRequest[] = [];
+  let resolveWhenComplete: () => void;
+  let expectedRequestCount = 1; // Start with expecting 1 request
+
+  const completionPromise = new Promise<void>((resolve) => {
+    resolveWhenComplete = resolve;
+  });
+
+  const handler = async (route) => {
+    const response = await route.fetch();
+    const responseJson = await response.json();
+    const isFirstRequest = dashboardRequests.length === 0;
+
+    dashboardRequests.push({
+      url: route.request().url(),
+      timestamp: Date.now(),
+      response: responseJson,
+    });
+
+    // After first request, check if we should expect more
+    if (isFirstRequest) {
+      const hasReloadAnnotation = responseJson?.metadata?.annotations?.['grafana.app/reloadOnParamsChange'] === 'true';
+
+      if (hasReloadAnnotation) {
+        expectedRequestCount = RELOADABLE_DASHBOARD_REQUEST_NO;
+      }
+    }
+
+    // Resolve if we've reached the expected count
+    if (dashboardRequests.length >= expectedRequestCount) {
+      resolveWhenComplete();
+    }
+
+    await route.fulfill({ response });
+  };
+
+  await page.route('**/dashboards/**/dto?**', handler);
+
+  return {
+    getRequests: () => dashboardRequests,
+    waitForExpectedRequests: () => completionPromise,
+  };
+}
+
+export function checkDashboardReloadBehavior(requests: DashboardRequest[]): boolean {
+  if (requests.length === 0) {
+    return false;
+  }
+
+  const firstRequest = requests[0];
+  const hasReloadAnnotation =
+    firstRequest?.response?.metadata?.annotations?.['grafana.app/reloadOnParamsChange'] === 'true';
+
+  if (hasReloadAnnotation) {
+    return requests.length === RELOADABLE_DASHBOARD_REQUEST_NO;
+  } else {
+    return requests.length === 1;
+  }
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds an extra verification on the E2Es for reloadable dashboards. For both type of dashboards, either reloadable or not, we now verify if the network calls number is correct.

**Why do we need this feature?**

Adds extra verification for the reloadable dashboards case.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
