### PR TITLE
Chore: Use `PermissionLevel` instead of `PermissionLevelString` enum

### DIFF
--- a/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/api/folders/handlers.ts
@@ -37,7 +37,7 @@ const listFoldersHandler = () =>
     const limit = parseInt(url.searchParams.get('limit') ?? '1000', 10);
     const page = parseInt(url.searchParams.get('page') ?? '1', 10);
 
-    const tree = permission === 'Edit' ? mockTreeThatViewersCanEdit : mockTree;
+    const tree = permission?.toLowerCase() === 'edit' ? mockTreeThatViewersCanEdit : mockTree;
 
     // reconstruct a folder API response from the flat tree fixture
     const folders = tree

--- a/public/app/core/components/FolderFilter/FolderFilter.tsx
+++ b/public/app/core/components/FolderFilter/FolderFilter.tsx
@@ -9,7 +9,6 @@ import { config } from 'app/core/config';
 import { getBackendSrv } from 'app/core/services/backend_srv';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardSearchItemType } from 'app/features/search/types';
-import { PermissionLevelString } from 'app/types/acl';
 import { FolderInfo } from 'app/types/folders';
 
 export interface FolderFilterProps {
@@ -69,7 +68,7 @@ async function getFoldersAsOptions(
       query: searchString,
       kind: ['folder'],
       limit: 100,
-      permission: PermissionLevelString.View,
+      permission: 'view',
     });
 
     const options = queryResponse.view.map((item) => ({
@@ -89,7 +88,7 @@ async function getFoldersAsOptions(
   const params = {
     query: searchString,
     type: DashboardSearchItemType.DashFolder,
-    permission: PermissionLevelString.View,
+    permission: 'view',
   };
 
   const searchHits = await getBackendSrv().search(params);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -14,7 +14,7 @@ import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { QueryResponse } from 'app/features/search/service/types';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
-import { PermissionLevelString } from 'app/types/acl';
+import { PermissionLevel } from 'app/types/acl';
 
 import { FolderRepo } from './FolderRepo';
 import { getDOMId, NestedFolderList } from './NestedFolderList';
@@ -57,7 +57,7 @@ export interface NestedFolderPickerProps {
 
 const debouncedSearch = debounce(getSearchResults, 300);
 
-async function getSearchResults(searchQuery: string, permission?: PermissionLevelString) {
+async function getSearchResults(searchQuery: string, permission?: PermissionLevel) {
   const queryResponse = await getGrafanaSearcher().search({
     query: searchQuery,
     kind: ['folder'],
@@ -99,11 +99,11 @@ export function NestedFolderPicker({
   const lastSearchTimestamp = useRef<number>(0);
 
   // Map the permission string union to enum value for compatibility
-  const permissionLevel = useMemo(() => {
+  const permissionLevel = useMemo<PermissionLevel>(() => {
     if (permission === 'view') {
-      return PermissionLevelString.View;
+      return 'view';
     } else if (permission === 'edit') {
-      return PermissionLevelString.Edit;
+      return 'edit';
     }
 
     throw new Error('Invalid permission');

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -98,17 +98,6 @@ export function NestedFolderPicker({
   const [error] = useState<Error | undefined>(undefined); // TODO: error not populated anymore
   const lastSearchTimestamp = useRef<number>(0);
 
-  // Map the permission string union to enum value for compatibility
-  const permissionLevel = useMemo<PermissionLevel>(() => {
-    if (permission === 'view') {
-      return 'view';
-    } else if (permission === 'edit') {
-      return 'edit';
-    }
-
-    throw new Error('Invalid permission');
-  }, [permission]);
-
   const isBrowsing = Boolean(overlayOpen && !(search && searchResults));
   const {
     items: browseFlatTree,
@@ -117,7 +106,7 @@ export function NestedFolderPicker({
   } = useFoldersQuery({
     isBrowsing,
     openFolders: foldersOpenState,
-    permission: permissionLevel,
+    permission,
     rootFolderUID,
     rootFolderItem,
   });
@@ -131,7 +120,7 @@ export function NestedFolderPicker({
     const timestamp = Date.now();
     setIsFetchingSearchResults(true);
 
-    debouncedSearch(search, permissionLevel).then((queryResponse) => {
+    debouncedSearch(search, permission).then((queryResponse) => {
       // Only keep the results if it's was issued after the most recently resolved search.
       // This prevents results showing out of order if first request is slower than later ones.
       // We don't need to worry about clearing the isFetching state either - if there's a later
@@ -143,7 +132,7 @@ export function NestedFolderPicker({
         lastSearchTimestamp.current = timestamp;
       }
     });
-  }, [search, permissionLevel]);
+  }, [search, permission]);
 
   // the order of middleware is important!
   const middleware = [

--- a/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQuery.ts
@@ -1,6 +1,6 @@
 import { config } from '@grafana/runtime';
 import { DashboardsTreeItem } from 'app/features/browse-dashboards/types';
-import { PermissionLevelString } from 'app/types/acl';
+import { PermissionLevel } from 'app/types/acl';
 
 import { useFoldersQueryAppPlatform } from './useFoldersQueryAppPlatform';
 import { useFoldersQueryLegacy } from './useFoldersQueryLegacy';
@@ -8,7 +8,7 @@ import { useFoldersQueryLegacy } from './useFoldersQueryLegacy';
 export interface UseFoldersQueryProps {
   isBrowsing: boolean;
   openFolders: Record<string, boolean>;
-  permission?: PermissionLevelString;
+  permission?: PermissionLevel;
   rootFolderUID?: string;
   rootFolderItem?: DashboardsTreeItem;
 }

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -15,7 +15,7 @@ import { isDashboardV2Resource, isV1DashboardCommand, isV2DashboardCommand } fro
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { dispatch } from 'app/store/store';
-import { PermissionLevelString } from 'app/types/acl';
+import { PermissionLevel } from 'app/types/acl';
 import { SaveDashboardResponseDTO, ImportDashboardResponseDTO } from 'app/types/dashboard';
 import { FolderListItemDTO, FolderDTO, DescendantCount, DescendantCountDTO } from 'app/types/folders';
 
@@ -71,7 +71,7 @@ export interface ListFolderQueryArgs {
   page: number;
   parentUid: string | undefined;
   limit: number;
-  permission?: PermissionLevelString;
+  permission?: PermissionLevel;
 }
 
 export const browseDashboardsAPI = createApi({

--- a/public/app/features/search/service/sql.ts
+++ b/public/app/features/search/service/sql.ts
@@ -2,7 +2,7 @@ import { DataFrame, DataFrameView, FieldType, getDisplayProcessor, SelectableVal
 import { config } from '@grafana/runtime';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
 import { backendSrv } from 'app/core/services/backend_srv';
-import { PermissionLevelString } from 'app/types/acl';
+import { PermissionLevel } from 'app/types/acl';
 
 import { DEFAULT_MAX_VALUES, GENERAL_FOLDER_UID, TYPE_KIND_MAP } from '../constants';
 import { DashboardSearchHit, DashboardSearchItemType } from '../types';
@@ -21,7 +21,7 @@ interface APIQuery {
   folderUIDs?: string[];
   sort?: string;
   starred?: boolean;
-  permission?: PermissionLevelString;
+  permission?: PermissionLevel;
   deleted?: boolean;
 }
 

--- a/public/app/features/search/service/types.ts
+++ b/public/app/features/search/service/types.ts
@@ -1,6 +1,6 @@
 import { DataFrameView, SelectableValue } from '@grafana/data';
 import { TermCount } from 'app/core/components/TagFilter/TagFilter';
-import { PermissionLevelString } from 'app/types/acl';
+import { PermissionLevel } from 'app/types/acl';
 
 import { ManagerKind } from '../../apiserver/types';
 
@@ -39,7 +39,7 @@ export interface SearchQuery {
   limit?: number;
   from?: number;
   starred?: boolean;
-  permission?: PermissionLevelString;
+  permission?: PermissionLevel;
   deleted?: boolean;
   offset?: number;
 }

--- a/public/app/types/acl.ts
+++ b/public/app/types/acl.ts
@@ -5,13 +5,6 @@ export enum TeamPermissionLevel {
 
 export type PermissionLevel = 'view' | 'edit' | 'admin';
 
-/** @deprecated Use PermissionLevel instead */
-export enum PermissionLevelString {
-  View = 'View',
-  Edit = 'Edit',
-  Admin = 'Admin',
-}
-
 export enum SearchQueryType {
   Folder = 'dash-folder',
   Dashboard = 'dash-db',


### PR DESCRIPTION
**What is this feature?**
Removes the deprecated `PermissionLevelString` in favour of `PermissionLevel`

**Why do we need this feature?**
🧹 

**Who is this feature for?**
UI devs