### PR TITLE
feat: customizable persistent volumes for devenv docker blocks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -310,6 +310,7 @@
 /devenv/docker/blocks/webdav/ @grafana/alerting-backend
 /devenv/docker/buildcontainer/ @bergquist
 /devenv/docker/compose_header.yml @grafana/grafana-backend-services-squad
+/devenv/docker/compose_volume_section.yml @grafana/grafana-backend-services-squad
 /devenv/docker/debtest/ @bergquist
 /devenv/docker/ha-test-unified-alerting/ @grafana/alerting-backend
 /devenv/docker/ha_test/ @grafana/grafana-backend-services-squad

--- a/devenv/create_docker_compose.sh
+++ b/devenv/create_docker_compose.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+shopt -s nullglob # Enable nullglob
+
 blocks_dir=docker/blocks
 docker_dir=docker
 template_dir=templates
@@ -8,6 +10,8 @@ grafana_config_file=conf.tmp
 grafana_config=config
 
 compose_header_file=docker/compose_header.yml
+compose_volume_section_file=docker/compose_volume_section.yml
+compose_volume_section_create_flag=docker_volume_create_true
 compose_file=docker-compose.yaml
 env_file=.env
 
@@ -60,3 +64,27 @@ for dir in $@; do
     fi
 done
 
+volume_files=$($blocks_dir/**/$compose_volume_section_create_flag)
+
+if [[ ${#volume_files[@]} -ne 0 ]]; then
+    echo "Adding volume section to $compose_file"
+    cat $compose_volume_section_file >> $compose_file
+    echo "" >> $compose_file
+
+    for dir in $@; do
+        current_dir=$blocks_dir/$dir
+        if [ ! -d "$current_dir" ]; then
+            echo "$current_dir is not a directory"
+            exit 1
+        fi
+
+
+        if [ -f $current_dir/$compose_volume_section_create_flag ]; then
+            echo "Adding volume for $current_dir to $compose_file"
+            echo "  $dir-data-volume:" >> $compose_file
+            echo "" >> $compose_file
+        fi
+    done
+
+    cat $compose_file
+fi

--- a/devenv/docker/compose_volume_section.yml
+++ b/devenv/docker/compose_volume_section.yml
@@ -1,0 +1,1 @@
+volumes:


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Docker blocks option in devenv doesn't allow adding a `volumes` part since they are themselves just partials that go under `services:`. This change offers an option, where if a given block has an empty file under its block:

```shell
touch src/devenv/blocks/<block_name>/docker_volume_create_true
```

Then, the resultant docker-compose will additionally have:
```yaml
volumes:
  <block-name>-data-volume
```

Such a volumes block will not be added if none of the devenv sources requested contain any `docker_volume_create_true` files.

**Why do we need this feature?**

Devs are using databases like mysql to oftentime store Grafana state and restarting the devenv causes them to lose their local instance state.

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
