### PR TITLE
docs: fix broken "help wanted issues" link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ Interact and be heard:
 
 We welcome your technical contributions! Here are some examples:
 
-- Contribute to the Grafana codebase- check out these [help-wanted issues](<(https://github.com/grafana/grafana/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)>)
+- Contribute to the Grafana codebase- check out these [help wanted issues](https://github.com/grafana/grafana/labels/help%20wanted)
+
 - Develop community [plugins](https://grafana.com/developers/plugin-tools)
 - Report [bugs](https://github.com/grafana/grafana/issues/new?template=0-bug-report.yaml)
 - [Triage issues](https://github.com/grafana/grafana/blob/4414b92e93440cc9ed0f281989ee71dc16216a15/contribute/triage-issues.md)


### PR DESCRIPTION
This PR fixes a broken link in CONTRIBUTING.md. The "help wanted issues" link
previously redirected to an incorrect page. Updated it to point to:
https://github.com/grafana/grafana/labels/help%20wanted

closes #111435 