### PR TITLE
Alerting: Display error message in central state history view

### DIFF
--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventDetails.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventDetails.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from 'test/test-utils';
+
+import { TimeRange, dateTime } from '@grafana/data';
+import { GrafanaAlertState } from 'app/types/unified-alerting-dto';
+
+import { EventDetails } from './EventDetails';
+
+// Mock hooks and modules used by EventDetails internals to avoid network/stateful behavior
+jest.mock('../../../hooks/useCombinedRule', () => ({
+  useCombinedRule: () => ({ error: null, loading: false, result: { annotations: {} } }),
+}));
+
+jest.mock('../../../api/stateHistoryApi', () => ({
+  stateHistoryApi: {
+    useGetRuleHistoryQuery: () => ({ currentData: undefined, isLoading: false, isError: false, error: undefined }),
+  },
+}));
+
+jest.mock('../state-history/LokiStateHistory', () => ({
+  useFrameSubset: () => ({ frameSubset: [], frameTimeRange: undefined }),
+}));
+
+describe('EventDetails', () => {
+  it('renders error message row when current state is Error', () => {
+    const record = {
+      timestamp: Date.now(),
+      line: {
+        previous: GrafanaAlertState.Normal,
+        current: GrafanaAlertState.Error,
+        error: 'test error message',
+        labels: { instance: 'i-123' },
+        ruleUID: 'grafana/uid-1',
+      },
+    };
+
+    const timeRange: TimeRange = {
+      from: dateTime(0),
+      to: dateTime(1),
+      raw: { from: dateTime(0), to: dateTime(1) },
+    };
+
+    render(<EventDetails record={record} addFilter={jest.fn()} timeRange={timeRange} />);
+
+    const errorRow = screen.getByTestId('state-history-error');
+    expect(errorRow).toBeInTheDocument();
+    expect(errorRow).toHaveTextContent('Error message:');
+    expect(errorRow).toHaveTextContent('test error message');
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/central-state-history/EventDetails.tsx
+++ b/public/app/features/alerting/unified/components/rules/central-state-history/EventDetails.tsx
@@ -6,6 +6,7 @@ import { DataFrame, DataFrameJSON, GrafanaTheme2, TimeRange } from '@grafana/dat
 import { Trans, t } from '@grafana/i18n';
 import { Icon, Stack, Text, useStyles2, useTheme2 } from '@grafana/ui';
 import { CombinedRule } from 'app/types/unified-alerting';
+import { GrafanaAlertState, mapStateWithReasonToBaseState } from 'app/types/unified-alerting-dto';
 
 import { trackUseCentralHistoryExpandRow } from '../../../Analytics';
 import { stateHistoryApi } from '../../../api/stateHistoryApi';
@@ -15,6 +16,7 @@ import { parsePromQLStyleMatcherLooseSafe } from '../../../utils/matchers';
 import { parse } from '../../../utils/rule-id';
 import { MetaText } from '../../MetaText';
 import { AnnotationValue } from '../../rule-viewer/tabs/Details';
+import { ErrorMessageRow } from '../state-history/ErrorMessageRow';
 import { LogTimelineViewer } from '../state-history/LogTimelineViewer';
 import { useFrameSubset } from '../state-history/LokiStateHistory';
 import { LogRecord } from '../state-history/common';
@@ -72,6 +74,9 @@ export function EventDetails({ record, addFilter, timeRange }: EventDetailsProps
         <StateTransition record={record} addFilter={addFilter} />
         <ValueInTransition record={record} />
       </Stack>
+      {mapStateWithReasonToBaseState(record.line.current) === GrafanaAlertState.Error && record.line.error && (
+        <ErrorMessageRow message={record.line.error} />
+      )}
       <Annotations rule={rule} />
       <StateVisualization ruleUID={ruleUID} timeRange={timeRange} labels={labelsInInstance ?? {}} />
     </Stack>


### PR DESCRIPTION
This PR displays the error message in the Alert Central State History View underneath the 'Error' state, see Slack thread: https://raintank-corp.slack.com/archives/C04LG9N6R4J/p1739785205421479

Before:
<img width="1512" height="808" alt="Screenshot 2025-09-22 at 15 31 54" src="https://github.com/user-attachments/assets/7be0570f-9e42-46dc-996b-af93425fe545" />

After:
<img width="1509" height="810" alt="Screenshot 2025-09-22 at 15 39 33" src="https://github.com/user-attachments/assets/fa15df9a-1f01-4763-a088-afd11009c5c5" />

![Kapture 2025-09-22 at 15 55 21](https://github.com/user-attachments/assets/73dec7b8-1ec4-44b8-a20d-ce364aefe7e2)

