### PR TITLE
Resource permissions: Make sure that list response includes the next page token

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -95,7 +95,7 @@ func (s *ResourcePermSqlBackend) ListIterator(ctx context.Context, req *resource
 	}
 
 	pagination := &common.Pagination{
-		Limit:    limit,
+		Limit:    limit + 1, // fetch one more to determine if there is a next page
 		Continue: token.offset,
 	}
 

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -580,6 +580,9 @@ func TestIntegration_ResourcePermSqlBackend_ListIterator(t *testing.T) {
 				continueToken = it.ContinueToken()
 				require.NoError(t, json.Unmarshal(it.Value(), &perm))
 				results = append(results, perm.Name)
+				if len(results) >= int(req.Limit) {
+					return nil
+				}
 			}
 			return nil
 		})
@@ -591,6 +594,9 @@ func TestIntegration_ResourcePermSqlBackend_ListIterator(t *testing.T) {
 				continueToken = it.ContinueToken()
 				require.NoError(t, json.Unmarshal(it.Value(), &perm))
 				results = append(results, perm.Name)
+				if len(results) >= int(req.Limit) {
+					return nil
+				}
 			}
 			return nil
 		})
@@ -603,6 +609,9 @@ func TestIntegration_ResourcePermSqlBackend_ListIterator(t *testing.T) {
 				continueToken = it.ContinueToken()
 				require.NoError(t, json.Unmarshal(it.Value(), &perm))
 				results = append(results, perm.Name)
+				if len(results) >= int(req.Limit) {
+					return nil
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
Thanks @alexanderzobnin for finding the issue! Resource permission list response was missing `continue` token from the metadata for the cases where there are more results. This PR fixes it, relying on the logic in unified resource server ([code](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/resource/server.go#L1003-L1009)). 

Here's the thinking behind the fix:
* if the desired number of results is reached and there are more results (`iter.Next()` is `true` when checked [here](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/resource/server.go#L1005)), then the next page token is set;
* however, we always only fetched the desired number of results, so our list iterator implementation returned `false` when checking `iter.Next()` [here](https://github.com/grafana/grafana/blob/main/pkg/registry/apis/iam/resourcepermission/list_iterator.go#L89) as `r.idx >= len(r.resourcePermissions)` condition was met;
* the fix is to fetch one more result, so we would know that there are more results and `Next()` would return true.

I think this fix has no negative side-effects, but let me know if you have any concerns. I also don't think there's any neat way of testing this, short of calling the [unified resource `List` function](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/resource/server.go#L918).

To test manually:
* start up Grafana locally with `kubernetesAuthzResourcePermissionApis` feature flag enabled and https protocol;
* make sure you have some resource permissions set (you can create them through the UI by adding some permissions on dashboards and folders);
* call `curl --insecure -u admin:admin -H "Content-Type: application/yaml" -X GET https://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/resourcepermissions` to list all the resource permissions;
* call `curl --insecure -u admin:admin -H "Content-Type: application/yaml" -X GET https://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/resourcepermissions\?limit=2` to list only two resource permissions and observer that `continue` token is set in the `metadata` of the response object.