### PR TITLE
Provisioning: Allow setting concurrent jobs settings and add metric

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
+++ b/pkg/registry/apis/provisioning/jobs/concurrent_driver.go
@@ -21,7 +21,6 @@ type ConcurrentJobDriver struct {
 	repoGetter           RepoGetter
 	historicJobs         HistoryWriter
 	workers              []Worker
-	registry             prometheus.Registerer
 	notifications        chan struct{}
 }
 
@@ -58,6 +57,8 @@ func NewConcurrentJobDriver(
 		cleanupInterval = 5 * time.Minute // Maximum cleanup interval
 	}
 
+	recordConcurrentDriverMetric(registry, numDrivers)
+
 	return &ConcurrentJobDriver{
 		numDrivers:           numDrivers,
 		jobTimeout:           jobTimeout,
@@ -69,7 +70,6 @@ func NewConcurrentJobDriver(
 		historicJobs:         historicJobs,
 		workers:              workers,
 		notifications:        notifications,
-		registry:             registry,
 	}, nil
 }
 

--- a/pkg/registry/apis/provisioning/jobs/metrics.go
+++ b/pkg/registry/apis/provisioning/jobs/metrics.go
@@ -110,3 +110,15 @@ func getResourceCountBucket(count int) string {
 		return "1000+"
 	}
 }
+
+func recordConcurrentDriverMetric(registry prometheus.Registerer, numDrivers int) {
+	concurrentDriver := prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "grafana_provisioning_jobs_concurrent_driver_num_drivers",
+			Help: "Number of concurrent job drivers",
+		},
+		[]string{},
+	)
+	registry.MustRegister(concurrentDriver)
+	concurrentDriver.WithLabelValues().Set(float64(numDrivers))
+}


### PR DESCRIPTION
This PR makes the settings on the concurrent job driver configurable (with the same defaults) when the operator is run on its own and adds a metric on the number of concurrent drivers.

<img width="786" height="57" alt="Screenshot 2025-09-22 at 1 43 16 PM" src="https://github.com/user-attachments/assets/235d169e-61f2-4fd1-8d9e-70c82b0d6b95" />

Relates to https://github.com/grafana/git-ui-sync-project/issues/577