### PR TITLE
feat(investigations): add "Investigations" menu if loop enabled

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -76,6 +76,7 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 }
 
 // shouldIncludeInvestigations checks if the investigations feature should be included for the assistant app
+// see https://github.com/grafana/grafana-assistant-app/issues/2007 for more details
 func (s *ServiceImpl) shouldIncludeInvestigations(plugin pluginstore.Plugin, include *plugins.Includes, c *contextmodel.ReqContext) bool {
 	if plugin.ID != "grafana-assistant-app" || include.Name != "Investigations" {
 		return true

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -93,6 +93,32 @@ func (s *ServiceImpl) processAppPlugin(plugin pluginstore.Plugin, c *contextmode
 			continue
 		}
 
+		// show "investigations" menu only if enabled in the plugin settings
+		if plugin.ID == "grafana-assistant-app" && include.Name == "Investigations" {
+			ps, err := s.pluginSettings.GetPluginSettingByPluginID(c.Req.Context(), &pluginsettings.GetByPluginIDArgs{
+				PluginID: plugin.ID,
+				OrgID:    c.GetOrgID(),
+			})
+			if err != nil {
+				continue
+			}
+
+			loopData, exists := ps.JSONData["loop"]
+			if !exists {
+				continue
+			}
+
+			loopConfig, ok := loopData.(map[string]any)
+			if !ok {
+				continue
+			}
+
+			enabled, ok := loopConfig["enabled"].(bool)
+			if !ok || !enabled {
+				continue
+			}
+		}
+
 		if include.Type == "page" {
 			link := &navtree.NavLink{
 				Text:     include.Name,


### PR DESCRIPTION
**What is this feature?**

The "Investigations" menu should only be visible if the plugin settings have it enabled. Unfortunately that can not be configured in the plugin.json, thus this workaround which checks the plugin's settings and only adds the menu item if `loop.enabled` is `true`.

**NB:** this needs to be merged before we add the `includes` config in the plugin.