### PR TITLE
LogLineDetailsFields: update word break

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsFields.tsx
@@ -419,7 +419,7 @@ const getFieldStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     lineHeight: theme.typography.body.lineHeight,
     whiteSpace: 'pre-wrap',
-    wordBreak: 'break-all',
+    wordBreak: 'break-word',
     maxHeight: '50vh',
     overflow: 'auto',
   }),


### PR DESCRIPTION
This PR addresses feedback on unbreakable log details values: https://github.com/grafana/grafana/issues/99075#issuecomment-3277079464

<img width="736" height="921" alt="imagen" src="https://github.com/user-attachments/assets/7b82acf9-413a-4bf8-a149-dbcd372179c6" />

<img width="1235" height="526" alt="imagen" src="https://github.com/user-attachments/assets/b69fb04a-0b9f-45d5-9b21-12de34e05873" />

### How to test

Either with a log stream with extremely long field values or by hardcoding test values in https://github.com/grafana/grafana/blob/main/public/app/features/logs/components/panel/LogLineDetailsFields.tsx#L488