### PR TITLE
Docs: Edits to OaC/Git Sync

### DIFF
--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -27,20 +27,20 @@ Provisioning is an experimental feature that allows you to configure how to stor
 
 Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. See [Git Sync workflow](#git-sync-workflow).
 
-Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](local-file-workflow). 
+Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](local-file-workflow).
 
 ## Provisioned folders and connections
 
-The dashboards saved in your GitHub repository or local folder appear in Grafana in the 'provisioned' folder. The dashboards and folders saved to the local path are referred to as 'provisioned' resources and are labeled as such in the Grafana UI. You can update any provisioned dashboard that is either stored within a GitHub repository (Git Sync workflow) or in a local file (local file workflow). 
+The dashboards saved in your GitHub repository or local folder appear in Grafana in the 'provisioned' folder. The dashboards and folders saved to the local path are referred to as 'provisioned' resources and are labeled as such in the Grafana UI. You can update any provisioned dashboard that is either stored within a GitHub repository (Git Sync workflow) or in a local file (local file workflow).
 
 You can set a single folder, or multiple folders to a different repository, with up to 10 connections. Alternatively, your entire Grafana instance can be the provisioned folder.
 
 ## Git Sync workflow
 
-In the Git Sync workflow: 
+In the Git Sync workflow:
 
 - When you provision resources with Git Sync you can modify them from within the Grafana UI or within the GitHub repository. Changes made in either the repository or the Grafana UI are bidirectional.
-- Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database. By default, Grafana polls GitHub every 60 seconds. 
+- Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database. By default, Grafana polls GitHub every 60 seconds.
 - The Grafana UI reads from the database and updates the UI to reflect these changes.
 
 For example, if you update a dashboard within the Grafana UI and click **Save** to preserve the changes, you'll be notified that the dashboard is provisioned in a GitHub repository. Next you'll be prompted to choose how to preserve the changes: either directly to a branch, or pushed to a new branch using a pull request in GitHub.
@@ -49,9 +49,9 @@ For more information, see [Introduction to Git Sync](https://grafana.com/docs/gr
 
 ## Local file workflow
 
-In the local file workflow: 
+In the local file workflow:
 
-- All provisioned resources are changed in the local files. 
+- All provisioned resources are changed in the local files.
 - Any changes made in the provisioned files are reflected in the Grafana database.
 - The Grafana UI reads the database and updates the UI to reflect these changes.
 - You can't use the Grafana UI to edit or delete provisioned resources.

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -23,52 +23,40 @@ Provisioning is an [experimental feature](https://grafana.com/docs/release-life-
 Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 {{< /admonition >}}
 
-Using Provisioning, you can configure how to store your dashboard JSON files in either GitHub repositories using Git Sync or a local path.
+Provisioning is an experimental feature that allows you to configure how to store your dashboard JSONs and other files in GitHub repositories using either Git Sync or a local path.
 
-Of the two experimental options, Git Sync is the recommended method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards to your configured GitHub repository.
-If you push a change in the repository, those changes are mirrored in your Grafana instance.
-For more information on configuring Git Sync, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup).
+Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. See [Git Sync workflow](#git-sync-workflow).
 
-Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) to learn more about the version of local file provisioning in Grafana 12.
+Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](local-file-workflow). 
 
 ## Provisioned folders and connections
 
-Dashboards and folders saved to the local path are referred to as "provisioned" resources and are labeled as such in the Grafana UI.
-
-Dashboards saved in your GitHub repository or local folder configured appear in a provisioned folder in Grafana.
+The dashboards saved in your GitHub repository or local folder appear in Grafana in the 'provisioned' folder. The dashboards and folders saved to the local path are referred to as 'provisioned' resources and are labeled as such in the Grafana UI. You can update any provisioned dashboard that is either stored within a GitHub repository (Git Sync workflow) or in a local file (local file workflow). 
 
 You can set a single folder, or multiple folders to a different repository, with up to 10 connections. Alternatively, your entire Grafana instance can be the provisioned folder.
 
-## How it works
+## Git Sync workflow
 
-A user decides to update a provisioned dashboard that is either stored within a GitHub repository (Git Sync workflow) or in a local file (local file workflow).
+In the Git Sync workflow: 
 
-### Git Sync workflow
+- When you provision resources with Git Sync you can modify them from within the Grafana UI or within the GitHub repository. Changes made in either the repository or the Grafana UI are bidirectional.
+- Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database. By default, Grafana polls GitHub every 60 seconds. 
+- The Grafana UI reads from the database and updates the UI to reflect these changes.
 
-Resources provisioned with Git Sync can be modified from within the Grafana UI or within the GitHub repository.
-Changes made in either the repository or the Grafana UI are bidirectional.
+For example, if you update a dashboard within the Grafana UI and click **Save** to preserve the changes, you'll be notified that the dashboard is provisioned in a GitHub repository. Next you'll be prompted to choose how to preserve the changes: either directly to a branch, or pushed to a new branch using a pull request in GitHub.
 
-For example, when a user updates dashboards within the Grafana UI, they choose **Save** to preserve the changes.
-Grafana notifies them that the dashboard is provisioned in a GitHub repository.
-They choose how to preserve their changes: either saved directly to a branch or pushed to a new branch using a pull request in GitHub.
-If they chose a new branch, then they open the pull request and follow their normal workflow.
+For more information, see [Introduction to Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync) and [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup).
 
-Grafana polls GitHub at a regular interval.
-The connection is established using a personal access token for authorization.
-With the webhooks feature enabled, repository notifications appear almost immediately.
-Without webhooks, Grafana polls for changes at the specified interval.
-The default polling interval is 60 seconds.
+## Local file workflow
 
-Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database.
-The Grafana UI reads the database and updates the UI to reflect these changes.
+In the local file workflow: 
 
-### Local file workflow
+- All provisioned resources are changed in the local files. 
+- Any changes made in the provisioned files are reflected in the Grafana database.
+- The Grafana UI reads the database and updates the UI to reflect these changes.
+- You can't use the Grafana UI to edit or delete provisioned resources.
 
-In the local file workflow, all provisioned resources are changed in the local files.
-The user can't use the Grafana UI to edit or delete provisioned resources.
-
-Any changes made in the provisioned files are reflected in the Grafana database.
-The Grafana UI reads the database and updates the UI to reflect these changes.
+Learn more in [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
 
 ## Explore provisioning
 

--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -22,7 +22,7 @@ Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.
 
 {{< /admonition >}}
 
-File provisioning in Grafana lets you include resources, including folders and dashboard JSON files, that are stored in a local file system.
+Use local file provisioning to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system.
 
 This page explains how to set up local file provisioning.
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -13,7 +13,7 @@ title: Git Sync
 weight: 100
 ---
 
-# Git Sync
+# Introduction to Git Sync
 
 {{< admonition type="caution" >}}
 Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -12,7 +12,7 @@ labels:
     - enterprise
     - oss
 title: Manage provisioned repositories with Git Sync
-menuTitle: Manage repositories
+menuTitle: Manage repositories with Git Sync
 weight: 400
 ---
 
@@ -25,8 +25,7 @@ Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.
 
 {{< /admonition >}}
 
-After you have set up Git Sync, you can synchronize dashboards and changes to existing dashboards to your configured GitHub repository.
-If you push a change in the repository, those changes are mirrored in your Grafana instance.
+After you have set up Git Sync, you can synchronize any changes in your existing dashboards with your configured GitHub repository. Similarly, if you push a change in the repository, those changes are mirrored in your Grafana instance.
 
 ## View current status of synchronization
 


### PR DESCRIPTION
Edits to Git Sync docs prior to ObsCon updates.

Next steps in https://github.com/grafana/grafana/pull/111743.
