### PR TITLE
Provisioning: Prevent dashboard imports on provisioned folders

### DIFF
--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { ManagerKind } from 'app/features/apiserver/types';
+import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { FolderDTO } from 'app/types/folders';
 
 import { mockFolderDTO } from '../fixtures/folder.fixture';
@@ -13,7 +14,6 @@ jest.mock('app/features/provisioning/hooks/useIsProvisionedInstance', () => ({
   useIsProvisionedInstance: jest.fn(),
 }));
 
-import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 const mockUseIsProvisionedInstance = useIsProvisionedInstance as jest.MockedFunction<typeof useIsProvisionedInstance>;
 
 const mockParentFolder = mockFolderDTO();

--- a/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.test.tsx
@@ -2,6 +2,7 @@ import { render as rtlRender, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TestProvider } from 'test/helpers/TestProvider';
 
+import { ManagerKind } from 'app/features/apiserver/types';
 import { FolderDTO } from 'app/types/folders';
 
 import { mockFolderDTO } from '../fixtures/folder.fixture';
@@ -74,5 +75,23 @@ describe('NewActionsButton', () => {
     expect(screen.queryByText('New dashboard')).not.toBeInTheDocument();
     expect(screen.queryByText('Import')).not.toBeInTheDocument();
     expect(screen.getByText('New folder')).toBeInTheDocument();
+  });
+
+  it('should hide Import button when folder is provisioned', async () => {
+    const provisionedFolder = mockFolderDTO(1, { managedBy: ManagerKind.Repo });
+    await renderAndOpen(provisionedFolder);
+
+    expect(screen.getByRole('link', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(screen.getByText('New folder')).toBeInTheDocument();
+    expect(screen.queryByText('Import')).not.toBeInTheDocument();
+  });
+
+  it('should show Import button when folder is not provisioned', async () => {
+    const regularFolder = mockFolderDTO(1, { managedBy: undefined });
+    await renderAndOpen(regularFolder);
+
+    expect(screen.getByRole('link', { name: 'New dashboard' })).toBeInTheDocument();
+    expect(screen.getByText('New folder')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Import' })).toBeInTheDocument();
   });
 });

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -86,7 +86,7 @@ export default function CreateNewButton({
         />
       )}
       {canCreateFolder && <MenuItem onClick={() => setShowNewFolderDrawer(true)} label={getNewFolderPhrase()} />}
-      {canCreateDashboard && (
+      {canCreateDashboard && parentFolder?.managedBy !== ManagerKind.Repo && (
         <MenuItem
           label={getImportPhrase()}
           onClick={() =>

--- a/public/app/features/browse-dashboards/components/CreateNewButton.tsx
+++ b/public/app/features/browse-dashboards/components/CreateNewButton.tsx
@@ -86,7 +86,7 @@ export default function CreateNewButton({
         />
       )}
       {canCreateFolder && <MenuItem onClick={() => setShowNewFolderDrawer(true)} label={getNewFolderPhrase()} />}
-      {canCreateDashboard && parentFolder?.managedBy !== ManagerKind.Repo && (
+      {canCreateDashboard && !isProvisionedInstance && parentFolder?.managedBy !== ManagerKind.Repo && (
         <MenuItem
           label={getImportPhrase()}
           onClick={() =>


### PR DESCRIPTION
This PR prevents dashboard imports within provisioned folder

https://github.com/user-attachments/assets/ba5c073c-801b-4938-a034-038d5b776ea4

Fixes https://github.com/grafana/git-ui-sync-project/issues/568
