### PR TITLE
Add GetResourceStatsSingleResource to StorageBackend.

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -165,6 +165,10 @@ func (a *dashboardSqlAccess) GetResourceStats(ctx context.Context, namespace str
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (a *dashboardSqlAccess) GetResourceStatsSingleResource(ctx context.Context, res resource.NamespacedResource) (resource.ResourceStats, error) {
+	return resource.ResourceStats{}, fmt.Errorf("not implemented")
+}
+
 func (r *rowsWrapper) Close() error {
 	if r.rows == nil {
 		return nil

--- a/pkg/registry/apis/iam/noopstorage/storage_backend.go
+++ b/pkg/registry/apis/iam/noopstorage/storage_backend.go
@@ -27,6 +27,10 @@ func (c *StorageBackendImpl) GetResourceStats(ctx context.Context, namespace str
 	return []resource.ResourceStats{}, errNoopStorage
 }
 
+func (c *StorageBackendImpl) GetResourceStatsSingleResource(ctx context.Context, res resource.NamespacedResource) (resource.ResourceStats, error) {
+	return resource.ResourceStats{}, errNoopStorage
+}
+
 // ListHistory implements resource.StorageBackend.
 func (c *StorageBackendImpl) ListHistory(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {
 	return 0, errNoopStorage

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
@@ -61,6 +62,10 @@ func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider) *Resourc
 
 func (s *ResourcePermSqlBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]resource.ResourceStats, error) {
 	return []resource.ResourceStats{}, errNotImplemented
+}
+
+func (s *ResourcePermSqlBackend) GetResourceStatsSingleResource(ctx context.Context, res resource.NamespacedResource) (resource.ResourceStats, error) {
+	return resource.ResourceStats{}, errNotImplemented
 }
 
 func (s *ResourcePermSqlBackend) ListHistory(context.Context, *resourcepb.ListRequest, func(resource.ListIterator) error) (int64, error) {

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -122,6 +122,9 @@ func (s *cdkBackend) getPath(key *resourcepb.ResourceKey, rv int64) string {
 func (s *cdkBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error) {
 	return nil, fmt.Errorf("not implemented")
 }
+func (s *cdkBackend) GetResourceStatsSingleResource(ctx context.Context, resource NamespacedResource) (ResourceStats, error) {
+	return ResourceStats{}, fmt.Errorf("not implemented")
+}
 
 func (s *cdkBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64, err error) {
 	if event.Type == resourcepb.WatchEvent_ADDED {

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -574,22 +574,14 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 				return idx, nil
 			}
 
-			// Get correct value of size + RV for building the index. This is important for our Bleve
+			// Get number of documents for building the index. This is important for our Bleve
 			// backend to decide whether to build index in-memory or as file-based.
-			stats, err := s.storage.GetResourceStats(ctx, key.Namespace, 0)
+			stats, err := s.storage.GetResourceStatsSingleResource(ctx, key)
 			if err != nil {
 				return nil, fmt.Errorf("failed to get resource stats: %w", err)
 			}
 
-			size := int64(0)
-			for _, stat := range stats {
-				if stat.Namespace == key.Namespace && stat.Group == key.Group && stat.Resource == key.Resource {
-					size = stat.Count
-					break
-				}
-			}
-
-			idx, err = s.build(ctx, key, size, reason, false)
+			idx, err = s.build(ctx, key, stats.Count, reason, false)
 			if err != nil {
 				return nil, fmt.Errorf("error building search index, %w", err)
 			}

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -81,7 +81,7 @@ type mockStorageBackend struct {
 	resourceStats []ResourceStats
 }
 
-func (m *mockStorageBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error) {
+func (m *mockStorageBackend) GetResourceStats(ctx context.Context, resources []NamespacedResource, minCount int) ([]ResourceStats, error) {
 	var result []ResourceStats
 	for _, stat := range m.resourceStats {
 		// Apply the minCount filter like the real implementation does

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -115,8 +115,11 @@ type StorageBackend interface {
 	// For HA setups, this will be more events than the local WriteEvent above!
 	WatchWriteEvents(ctx context.Context) (<-chan *WrittenEvent, error)
 
-	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
+	// GetResourceStats returns resource stats within the storage backend.  When namespace is empty, it will apply to all
 	GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error)
+
+	// GetResourceStatsSingleResource returns resource stats for a single resource. Namespace should not be empty.
+	GetResourceStatsSingleResource(ctx context.Context, resource NamespacedResource) (ResourceStats, error)
 }
 
 type ModifiedResource struct {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -15,12 +15,13 @@ import (
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/grafana/grafana-app-sdk/logging"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/util/debouncer"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/debouncer"
 )
 
 const (
@@ -1067,6 +1068,10 @@ func (k *kvStorageBackend) WatchWriteEvents(ctx context.Context) (<-chan *Writte
 // GetResourceStats returns resource stats within the storage backend.
 func (k *kvStorageBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error) {
 	return k.dataStore.GetResourceStats(ctx, namespace, minCount)
+}
+
+func (k *kvStorageBackend) GetResourceStatsSingleResource(ctx context.Context, resource NamespacedResource) (ResourceStats, error) {
+	return k.dataStore.GetResourceStatsSingle(ctx, resource)
 }
 
 // readAndClose reads all data from a ReadCloser and ensures it's closed,

--- a/pkg/storage/unified/sql/data/resource_stats_single_resource.sql
+++ b/pkg/storage/unified/sql/data/resource_stats_single_resource.sql
@@ -1,0 +1,9 @@
+SELECT
+  COUNT(*),
+  COALESCE(MAX({{ .Ident "resource_version" }}), 0)
+FROM {{ .Ident "resource" }}
+WHERE 1 = 1
+  AND {{ .Ident "namespace" }} = {{ .Arg .Namespace }}
+  AND {{ .Ident "group" }} = {{ .Arg .Group }}
+  AND {{ .Ident "resource" }} = {{ .Arg .Resource }}
+;

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -35,6 +35,7 @@ var (
 	sqlResourceUpdate                   = mustTemplate("resource_update.sql")
 	sqlResourceRead                     = mustTemplate("resource_read.sql")
 	sqlResourceStats                    = mustTemplate("resource_stats.sql")
+	sqlResourceStatsSingleResource      = mustTemplate("resource_stats_single_resource.sql")
 	sqlResourceList                     = mustTemplate("resource_list.sql")
 	sqlResourceHistoryList              = mustTemplate("resource_history_list.sql")
 	sqlResourceHistoryListModifiedSince = mustTemplate("resource_history_list_since_modified.sql")
@@ -114,6 +115,17 @@ func (r sqlStatsRequest) Validate() error {
 	if r.Folder != "" && r.Namespace == "" {
 		return fmt.Errorf("folder constraint requires a namespace")
 	}
+	return nil
+}
+
+type sqlStatsSingleResourceRequest struct {
+	sqltemplate.SQLTemplate
+	Namespace string
+	Group     string
+	Resource  string
+}
+
+func (r sqlStatsSingleResourceRequest) Validate() error {
 	return nil
 }
 

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -398,6 +398,17 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlResourceStatsSingleResource: {
+				{
+					Name: "global",
+					Data: &sqlStatsSingleResourceRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Namespace:   "namespace",
+						Group:       "group",
+						Resource:    "resource",
+					},
+				},
+			},
 			sqlResourceBlobInsert: {
 				{
 					Name: "basic",


### PR DESCRIPTION
Unlike GetResourceStats, GetResourceStatsSingleResource only queries single resource. This is used when building individual search index.

Draft while building new functionality on top of this, to see if this is good-enough.