### PR TITLE
Extsvcacc: Split permission scope

### DIFF
--- a/pkg/services/accesscontrol/acimpl/service_test.go
+++ b/pkg/services/accesscontrol/acimpl/service_test.go
@@ -927,8 +927,14 @@ func TestIntegrationService_SaveExternalServiceRole(t *testing.T) {
 				// Check that the permissions and assignment are stored correctly
 				perms, errGetPerms := ac.getUserPermissions(ctx, &user.SignedInUser{OrgID: r.cmd.AssignmentOrgID, UserID: 2}, accesscontrol.Options{})
 				require.NoError(t, errGetPerms)
+
+				// Only compare action and scope
+				expPerms := make([]accesscontrol.Permission, len(r.cmd.Permissions))
+				for i, p := range r.cmd.Permissions {
+					expPerms[i] = accesscontrol.Permission{Action: p.Action, Scope: p.Scope}
+				}
 				// shared with me is added by default for all users in pkg/services/accesscontrol/acimpl/service.go
-				assert.Equal(t, append([]accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:sharedwithme"}}, r.cmd.Permissions...), perms)
+				assert.Equal(t, append([]accesscontrol.Permission{{Action: "folders:read", Scope: "folders:uid:sharedwithme"}}, expPerms...), perms)
 			}
 		})
 	}

--- a/pkg/services/accesscontrol/database/externalservices_test.go
+++ b/pkg/services/accesscontrol/database/externalservices_test.go
@@ -249,3 +249,95 @@ func TestIntegrationAccessControlStore_DeleteExternalServiceRole(t *testing.T) {
 		})
 	}
 }
+
+func Test_permissionDiff(t *testing.T) {
+	tests := []struct {
+		name        string
+		previous    []accesscontrol.Permission
+		new         []accesscontrol.Permission
+		wantAdded   []accesscontrol.Permission
+		wantRemoved []accesscontrol.Permission
+	}{
+		{
+			name: "no changes",
+			previous: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{ID: 2, Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			new: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			wantAdded:   []accesscontrol.Permission{},
+			wantRemoved: []accesscontrol.Permission{},
+		},
+		{
+			name: "add new permissions",
+			previous: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+			},
+			new: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			wantAdded: []accesscontrol.Permission{
+				{Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			wantRemoved: []accesscontrol.Permission{},
+		},
+		{
+			name: "remove existing permissions",
+			previous: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{ID: 2, Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			new: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+			},
+			wantAdded: []accesscontrol.Permission{},
+			wantRemoved: []accesscontrol.Permission{
+				{ID: 2, Action: "users:write", Scope: "users:id:2"},
+			},
+		},
+		{
+			name: "add and remove permissions",
+			previous: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{ID: 2, Action: "users:write", Scope: "users:id:2", Kind: "users", Attribute: "id", Identifier: "2"},
+			},
+			new: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+				{Action: "users:delete", Scope: "users:id:3", Kind: "users", Attribute: "id", Identifier: "3"},
+			},
+			wantAdded: []accesscontrol.Permission{
+				{Action: "users:delete", Scope: "users:id:3", Kind: "users", Attribute: "id", Identifier: "3"},
+			},
+			wantRemoved: []accesscontrol.Permission{
+				{ID: 2, Action: "users:write", Scope: "users:id:2"},
+			},
+		},
+		{
+			name: "recreate unsplit permissions",
+			previous: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1"},
+			},
+			new: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+			},
+			wantAdded: []accesscontrol.Permission{
+				{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"},
+			},
+			wantRemoved: []accesscontrol.Permission{
+				{ID: 1, Action: "users:read", Scope: "users:id:1"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdded, gotRemoved := permissionDiff(tt.previous, tt.new)
+			require.ElementsMatch(t, tt.wantAdded, gotAdded, "added permissions do not match")
+			require.ElementsMatch(t, tt.wantRemoved, gotRemoved, "removed permissions do not match")
+		})
+	}
+}

--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -310,6 +310,7 @@ func (cmd *SaveExternalServiceRoleCommand) Validate() error {
 			continue
 		}
 		dedupMap[cmd.Permissions[i]] = true
+		cmd.Permissions[i].Kind, cmd.Permissions[i].Attribute, cmd.Permissions[i].Identifier = SplitScope(cmd.Permissions[i].Scope)
 		dedup = append(dedup, cmd.Permissions[i])
 	}
 	cmd.Permissions = dedup

--- a/pkg/services/accesscontrol/models_test.go
+++ b/pkg/services/accesscontrol/models_test.go
@@ -79,7 +79,7 @@ func TestSaveExternalServiceRoleCommand_Validate(t *testing.T) {
 			},
 			wantErr:         false,
 			wantID:          "app-1",
-			wantPermissions: []Permission{{Action: "users:read", Scope: "users:id:1"}},
+			wantPermissions: []Permission{{Action: "users:read", Scope: "users:id:1", Kind: "users", Attribute: "id", Identifier: "1"}},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
We investigated an issue with @jcalisto on a service account temporarily not allowed to create a folder.

Turns out, this is due to the new AuthZ service, checking the scope split and not the scope itself.
In the case of managed service accounts, we create the role without expanding its permissions.
However a migration then runs and fixes it.