### PR TITLE
Dashboard Panel: Expose Image Renderer URL to Copy

### DIFF
--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -30,6 +30,7 @@ describe('SharePanelInternally', () => {
     expect(screen.getByPlaceholderText('1')).toBeDisabled(); // Scale factor input
     expect(screen.getByRole('button', { name: /generate image/i })).toBeDisabled();
     expect(screen.getByRole('button', { name: /download image/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /copy image link/i })).toBeDisabled();
   });
 
   it('should enable all image generation inputs when renderer is available', async () => {
@@ -55,6 +56,19 @@ describe('SharePanelInternally', () => {
 
     expect(screen.getByRole('button', { name: /generate image/i })).toBeEnabled();
     expect(screen.getByRole('button', { name: /download image/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /copy image link/i })).toBeEnabled();
+  });
+
+  it('should copy image link when copy image link button is clicked', async () => {
+    document.execCommand = jest.fn();
+
+    config.rendererAvailable = true;
+    buildAndRenderScenario();
+
+    const copyImageLinkButton = screen.getByRole('button', { name: /copy image link/i });
+    await userEvent.click(copyImageLinkButton);
+
+    expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
 });
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
@@ -8,7 +8,7 @@ import { lastValueFrom } from 'rxjs';
 import { GrafanaTheme2, UrlQueryMap } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, getBackendSrv } from '@grafana/runtime';
-import { Button, Field, FieldSet, Icon, Input, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, ClipboardButton, Field, FieldSet, Icon, Input, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { DashboardInteractions } from '../../utils/interactions';
 import { ImagePreview } from '../components/ImagePreview';
@@ -196,6 +196,15 @@ export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }
               >
                 <Trans i18nKey="link.share-panel.download-image">Download image</Trans>
               </Button>
+              <ClipboardButton
+                icon="link"
+                variant="secondary"
+                disabled={disabled || loading || !isValid}
+                aria-describedby={!image && !loading ? 'copy-image-link-disabled-help' : undefined}
+                getText={() => imageUrl}
+              >
+                <Trans i18nKey="link.share-panel.copy-image-link">Copy image link</Trans>
+              </ClipboardButton>
             </Stack>
             {disabled && (
               <Text variant="bodySmall" color="secondary" id="generate-button-disabled-help">

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
@@ -202,7 +202,7 @@ export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }
                 disabled={disabled || !isValid}
                 aria-describedby={disabled || !isValid ? 'copy-image-link-disabled-help' : undefined}
                 getText={() => imageUrl}
-                onClipboardCopy={() => DashboardInteractions.copyImageUrlClicked()}
+                onClipboardCopy={() => DashboardInteractions.copyImageUrlClicked({ shareResource: 'panel' })}
               >
                 <Trans i18nKey="link.share-panel.copy-image-link">Copy image link</Trans>
               </ClipboardButton>

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
@@ -199,9 +199,10 @@ export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }
               <ClipboardButton
                 icon="link"
                 variant="secondary"
-                disabled={disabled || loading || !isValid}
-                aria-describedby={!image && !loading ? 'copy-image-link-disabled-help' : undefined}
+                disabled={disabled || !isValid}
+                aria-describedby={disabled || !isValid ? 'copy-image-link-disabled-help' : undefined}
                 getText={() => imageUrl}
+                onClipboardCopy={() => DashboardInteractions.copyImageUrlClicked()}
               >
                 <Trans i18nKey="link.share-panel.copy-image-link">Copy image link</Trans>
               </ClipboardButton>

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -187,6 +187,9 @@ export const DashboardInteractions = {
   downloadDashboardImageClicked: (properties?: Record<string, unknown>) => {
     reportDashboardInteraction('dashboard_image_downloaded', properties);
   },
+  copyImageUrlClicked: (properties?: Record<string, unknown>) => {
+    reportDashboardInteraction('dashboard_image_url_copied', properties);
+  },
 };
 
 const reportDashboardInteraction: typeof reportInteraction = (name, properties) => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9348,7 +9348,8 @@
     "share-panel": {
       "config-description": "Create a personalized, direct link to share your panel within your organization, with the following customization settings:",
       "download-image": "Download image",
-      "render-image": "Generate image"
+      "render-image": "Generate image",
+      "copy-image-link": "Copy image link"
     }
   },
   "live": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9347,9 +9347,9 @@
     },
     "share-panel": {
       "config-description": "Create a personalized, direct link to share your panel within your organization, with the following customization settings:",
+      "copy-image-link": "Copy image link",
       "download-image": "Download image",
-      "render-image": "Generate image",
-      "copy-image-link": "Copy image link"
+      "render-image": "Generate image"
     }
   },
   "live": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
This re-exposes the Image Renderer URL as it had been before.

**Why do we need this feature?**
Multiple users conveyed an interest in the feature returning.

**Who is this feature for?**
For users that have an established interest in copying the panel renderer url.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/110716

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<img width="703" height="791" alt="Screenshot 2025-09-23 at 4 00 33 PM" src="https://github.com/user-attachments/assets/7ef1be2e-aef2-4238-94a3-8116932b30e6" />



<img width="668" height="655" alt="Screenshot 2025-09-23 at 4 00 27 PM" src="https://github.com/user-attachments/assets/e50060e0-86fe-44ea-92de-606f4e2f872f" />
