### PR TITLE
Dashboards: Use folder client provider if folder client is nil

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -676,16 +676,19 @@ func (b *DashboardsAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 
 func (b *DashboardsAPIBuilder) verifyFolderAccessPermissions(ctx context.Context, user identity.Requester, folderIds ...string) error {
 	folderClient := b.folderClient
+	orgID := user.GetOrgID()
+
 	if b.folderClient == nil && b.folderClientProvider != nil {
 		ns, err := request.NamespaceInfoFrom(ctx, false)
 		if err != nil {
 			return err
 		}
 		folderClient = b.folderClientProvider.GetOrCreateHandler(ns.Value)
+		orgID = ns.OrgID
 	}
 
 	for _, folderId := range folderIds {
-		resp, err := folderClient.Get(ctx, folderId, user.GetOrgID(), metav1.GetOptions{}, "access")
+		resp, err := folderClient.Get(ctx, folderId, orgID, metav1.GetOptions{}, "access")
 		if err != nil {
 			return dashboards.ErrFolderAccessDenied
 		}

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -675,8 +675,17 @@ func (b *DashboardsAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 }
 
 func (b *DashboardsAPIBuilder) verifyFolderAccessPermissions(ctx context.Context, user identity.Requester, folderIds ...string) error {
+	folderClient := b.folderClient
+	if b.folderClient == nil && b.folderClientProvider != nil {
+		ns, err := request.NamespaceInfoFrom(ctx, false)
+		if err != nil {
+			return err
+		}
+		folderClient = b.folderClientProvider.GetOrCreateHandler(ns.Value)
+	}
+
 	for _, folderId := range folderIds {
-		resp, err := b.folderClient.Get(ctx, folderId, user.GetOrgID(), metav1.GetOptions{}, "access")
+		resp, err := folderClient.Get(ctx, folderId, user.GetOrgID(), metav1.GetOptions{}, "access")
 		if err != nil {
 			return dashboards.ErrFolderAccessDenied
 		}


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/111490, the folder client may not always be there, but instead the folder client provider. If that is the case, use that.

Relates to https://github.com/grafana/git-ui-sync-project/issues/578