### PR TITLE
Unified Storage - Fix bug when cleaning up legacy on create

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -1227,7 +1227,7 @@ func (s *Service) nestedFolderDelete(ctx context.Context, cmd *folder.DeleteFold
 		return descendantUIDs, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
-	_, err := s.Get(ctx, &folder.GetFolderQuery{
+	_, err := s.store.Get(ctx, folder.GetFolderQuery{
 		UID:          &cmd.UID,
 		OrgID:        cmd.OrgID,
 		SignedInUser: cmd.SignedInUser,


### PR DESCRIPTION
fixes https://github.com/grafana/search-and-storage-team/issues/520

When deleting a legacy folder, in `nestedFolderDelete()` we were deleting from unified storage instead of legacy.