### PR TITLE
[release-12.2.1] Chore: Fix @grafana/alerting package repo (#111532)

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -14,7 +14,7 @@
   "sideEffects": false,
   "repository": {
     "type": "git",
-    "url": "git+http://github.com/grafana/grafana.git",
+    "url": "http://github.com/grafana/grafana.git",
     "directory": "packages/grafana-alerting"
   },
   "main": "src/index.ts",


### PR DESCRIPTION
Backports fix to alerting package.json repo property
