### PR TITLE
Dashboards: Increase limit of annotation tags

### DIFF
--- a/public/app/features/annotations/api.ts
+++ b/public/app/features/annotations/api.ts
@@ -39,7 +39,7 @@ class LegacyAnnotationServer implements AnnotationServer {
   }
 
   async tags() {
-    const response = await getBackendSrv().get<AnnotationTagsResponse>('/api/annotations/tags');
+    const response = await getBackendSrv().get<AnnotationTagsResponse>('/api/annotations/tags?limit=1000');
     return response.result.tags.map(({ tag, count }) => ({
       term: tag,
       count,


### PR DESCRIPTION
**What is this feature?**

Increases the limit of annotation tags, the default is 100.