### PR TITLE
Plugins: Identify plugin ID when provisioning fails for any reason

### DIFF
--- a/pkg/services/provisioning/plugins/plugin_provisioner_test.go
+++ b/pkg/services/provisioning/plugins/plugin_provisioner_test.go
@@ -100,8 +100,28 @@ func TestPluginProvisioner(t *testing.T) {
 		}
 
 		err := ap.applyChanges(context.Background(), "")
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "plugin is auto enabled and cannot be disabled")
+		require.ErrorIs(t, err, ErrPluginProvisioningAutoEnabled)
+	})
+
+	t.Run("Should return error trying to configure a non-existing plugin", func(t *testing.T) {
+		cfg := []*pluginsAsConfig{
+			{
+				Apps: []*appFromConfig{
+					{PluginID: "test-plugin", OrgID: 2, Enabled: false},
+				},
+			},
+		}
+		reader := &testConfigReader{result: cfg}
+		store := &mockStore{}
+		ap := PluginProvisioner{
+			log:            log.New("test"),
+			cfgProvider:    reader,
+			pluginSettings: store,
+			pluginStore:    pluginstore.NewFakePluginStore(),
+		}
+
+		err := ap.applyChanges(context.Background(), "")
+		require.ErrorIs(t, err, ErrPluginProvisioningNotFound)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Identifies the plugin ID when provisioning fails.

**Why do we need this feature?**

Easier to debug at glance what plugin is failing to be provisioned.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
