### PR TITLE
FlameGraph: Ensure total is only counted once for recursive function calls

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -53,28 +53,7 @@ const FlameGraphTopTableContainer = memo(
     onTableSort,
     colorScheme,
   }: Props) => {
-    const table = useMemo(() => {
-      // Group the data by label, we show only one row per label and sum the values
-      // TODO: should be by filename + funcName + linenumber?
-      let filteredTable: { [key: string]: TableData } = Object.create(null);
-      for (let i = 0; i < data.data.length; i++) {
-        const value = data.getValue(i);
-        const valueRight = data.getValueRight(i);
-        const self = data.getSelf(i);
-        const label = data.getLabel(i);
-
-        // If user is doing text search we filter out labels in the same way we highlight them in flame graph.
-        if (!matchedLabels || matchedLabels.has(label)) {
-          filteredTable[label] = filteredTable[label] || {};
-          filteredTable[label].self = filteredTable[label].self ? filteredTable[label].self + self : self;
-          filteredTable[label].total = filteredTable[label].total ? filteredTable[label].total + value : value;
-          filteredTable[label].totalRight = filteredTable[label].totalRight
-            ? filteredTable[label].totalRight + valueRight
-            : valueRight;
-        }
-      }
-      return filteredTable;
-    }, [data, matchedLabels]);
+    const table = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
 
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
@@ -123,6 +102,49 @@ const FlameGraphTopTableContainer = memo(
 );
 
 FlameGraphTopTableContainer.displayName = 'FlameGraphTopTableContainer';
+
+function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>) {
+  // Group the data by label, we show only one row per label and sum the values
+  // TODO: should be by filename + funcName + linenumber?
+  let filteredTable: { [key: string]: TableData } = Object.create(null);
+
+  // Track call stack to detect recursive calls
+  const callStack: string[] = [];
+
+  for (let i = 0; i < data.data.length; i++) {
+    const value = data.getValue(i);
+    const valueRight = data.getValueRight(i);
+    const self = data.getSelf(i);
+    const label = data.getLabel(i);
+    const level = data.getLevel(i);
+
+    // Maintain call stack based on level changes
+    while (callStack.length > level) {
+      callStack.pop();
+    }
+
+    // Check if this is a recursive call (same label already in call stack)
+    const isRecursive = callStack.some((entry) => entry === label);
+
+    // If user is doing text search we filter out labels in the same way we highlight them in flame graph.
+    if (!matchedLabels || matchedLabels.has(label)) {
+      filteredTable[label] = filteredTable[label] || {};
+      filteredTable[label].self = filteredTable[label].self ? filteredTable[label].self + self : self;
+
+      // Only add to total if this is not a recursive call
+      if (!isRecursive) {
+        filteredTable[label].total = filteredTable[label].total ? filteredTable[label].total + value : value;
+        filteredTable[label].totalRight = filteredTable[label].totalRight
+          ? filteredTable[label].totalRight + valueRight
+          : valueRight;
+      }
+    }
+
+    // Add current call to the stack
+    callStack.push(label);
+  }
+  return filteredTable;
+}
 
 function buildTableDataFrame(
   data: FlameGraphDataContainer,
@@ -364,5 +386,7 @@ const getStylesActionCell = () => {
     }),
   };
 };
+
+export { buildFilteredTable };
 
 export default FlameGraphTopTableContainer;


### PR DESCRIPTION
This fixes the top table, which is built incorrectly for symbols, that do do recursive calls.

Example flamegraph reproducing the problem: https://flamegraph.com/share/2bb59df3-9930-11f0-94ec-760777e76ccd
