### PR TITLE
Graphite: Backend querying improvements

### DIFF
--- a/pkg/tests/api/graphite/graphite_test.go
+++ b/pkg/tests/api/graphite/graphite_test.go
@@ -85,7 +85,7 @@ func TestIntegrationGraphite(t *testing.T) {
 		// nolint:gosec
 		resp, err := http.Post(u, "application/json", buf1)
 		require.NoError(t, err)
-		require.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		t.Cleanup(func() {
 			err := resp.Body.Close()
 			require.NoError(t, err)

--- a/pkg/tsdb/graphite/graphite.go
+++ b/pkg/tsdb/graphite/graphite.go
@@ -100,7 +100,7 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 func (s *Service) createRequest(ctx context.Context, dsInfo *datasourceInfo, params URLParams) (*http.Request, error) {
 	u, err := url.Parse(dsInfo.URL)
 	if err != nil {
-		return nil, err
+		return nil, backend.DownstreamError(err)
 	}
 
 	if params.SubPath != "" {
@@ -125,7 +125,7 @@ func (s *Service) createRequest(ctx context.Context, dsInfo *datasourceInfo, par
 	req, err := http.NewRequestWithContext(ctx, method, u.String(), params.Body)
 	if err != nil {
 		s.logger.Info("Failed to create request", "error", err)
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, backend.PluginError(fmt.Errorf("failed to create request: %w", err))
 	}
 
 	for k, v := range params.Headers {

--- a/pkg/tsdb/graphite/healthcheck_test.go
+++ b/pkg/tsdb/graphite/healthcheck_test.go
@@ -42,7 +42,7 @@ func (rt *healthCheckFailRoundTripper) RoundTrip(req *http.Request) (*http.Respo
 		Status:        "400",
 		StatusCode:    400,
 		Header:        nil,
-		Body:          nil,
+		Body:          io.NopCloser(strings.NewReader("this is a failed healthcheck")),
 		ContentLength: 0,
 		Request:       req,
 	}, nil
@@ -107,7 +107,7 @@ func Test_CheckHealth(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, backend.HealthStatusError, res.Status)
 		assert.Equal(t, "Graphite health check failed. See details below", res.Message)
-		assert.Equal(t, []byte("{\"verboseMessage\": \"request failed, status: 400\" }"), res.JSONDetails)
+		assert.Equal(t, []byte("{\"verboseMessage\": \"request failed with error: this is a failed healthcheck\" }"), res.JSONDetails)
 	})
 }
 

--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -276,12 +276,8 @@ func parseGraphiteError(status int, body string) (errorMsg string) {
 		if strings.HasPrefix(body, "<body") {
 			htmlErrorMsg := ""
 			tokenizer := html.NewTokenizer(strings.NewReader(body))
-			for {
-				// Break here as that typically means we've reached EOF
-				if tokenizer.Next() == html.ErrorToken {
-					break
-				}
-
+			// Break here as that typically means we've reached EOF
+			for tokenizer.Next() != html.ErrorToken {
 				token := tokenizer.Token()
 				if token.Type == html.TextToken {
 					trimmed := strings.TrimSpace(token.Data)

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -117,13 +117,14 @@ func TestProcessQuery(t *testing.T) {
 
 	t.Run("QueryData happy path with service provider and plugin context", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_, _ = w.Write([]byte(`[
+			_, err := w.Write([]byte(`[
 				{
 					"target": "target A",
 					"tags": { "fooTag": "fooValue", "barTag": "barValue", "int": 100, "float": 3.14 },
 					"datapoints": [[50, 1], [null, 2], [100, 3]]
 				}	
 			]`))
+			require.NoError(t, err)
 		}))
 		t.Cleanup(server.Close)
 
@@ -578,7 +579,8 @@ Error: Target not found
 				}
 
 				w.WriteHeader(tt.serverStatus)
-				w.Write([]byte(response))
+				_, err = w.Write([]byte(response))
+				require.NoError(t, err)
 			}))
 			defer server.Close()
 

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -661,7 +661,7 @@ func TestParseGraphiteError(t *testing.T) {
 			name:     "HTML error",
 			status:   500,
 			body:     `<body><h1>Internal Server Error</h1><p>Target not found</p></body>`,
-			expected: "Internal Server ErrorTarget not found",
+			expected: "Internal Server Error\nTarget not found",
 		},
 		{
 			name:   "complex HTML error",
@@ -672,27 +672,27 @@ func TestParseGraphiteError(t *testing.T) {
 <div>Error: Invalid metric path &#39;stats.invalid.metric&#39;</div>
 Final error message here
 </body>`,
-			expected: "Final error message here",
+			expected: "Internal Server Error\nThe server encountered an unexpected condition that prevented it from fulfilling the request.\nError: Invalid metric path 'stats.invalid.metric'\nFinal error message here",
 		},
 		{
 			name:     "HTML error with unicode",
 			status:   500,
 			body:     `<body><p>Error: Invalid path &#x27;test&#x27; and &#x22;value&#x22;</p></body>`,
-			expected: "Error: Invalid path test and value",
+			expected: "Error: Invalid path 'test' and \"value\"",
 		},
 		{
 			name:   "HTML with whitespace and newlines",
 			status: 500,
 			body: `<body>
 
-<h1>Error</h1>
+		<h1>Error</h1>
 
-<p>Something went wrong</p>
+		<p>Something went wrong</p>
 
-Critical failure occurred
+		Critical failure occurred
 
-</body>`,
-			expected: "Critical failure occurred",
+		</body>`,
+			expected: "Error\nSomething went wrong\nCritical failure occurred",
 		},
 	}
 

--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -3,6 +3,7 @@ package graphite
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana-plugin-sdk-go/experimental"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -99,7 +101,7 @@ func TestProcessQuery(t *testing.T) {
 			Queries: queries,
 		})
 		assert.NoError(t, err)
-		expectedResponse := backend.ErrDataResponseWithSource(400, backend.ErrorSourceDownstream, "no query target found for the alert rule")
+		expectedResponse := backend.ErrDataResponseWithSource(400, backend.ErrorSourceDownstream, "no query target found")
 		assert.Equal(t, expectedResponse, rsp.Responses["A"])
 	})
 
@@ -256,6 +258,446 @@ func TestFixIntervalFormat(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tr := fixIntervalFormat(tc.target)
 			assert.Equal(t, tc.expected, tr)
+		})
+	}
+}
+
+func TestRunQueryE2E(t *testing.T) {
+	tests := []struct {
+		name            string
+		serverResponse  string
+		serverStatus    int
+		queries         []backend.DataQuery
+		expectError     bool
+		errorContains   string
+		multipleTargets map[string]string
+	}{
+		{
+			name:         "successful single query with data",
+			serverStatus: 200,
+			serverResponse: `[
+				{
+					"target": "stats.counters.web.hits",
+					"datapoints": [[100, 1609459200], [150, 1609459260], [120, 1609459320]]
+				}
+			]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459320, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:         "successful single query with null values",
+			serverStatus: 200,
+			serverResponse: `[
+				{
+					"target": "stats.counters.web.hits",
+					"datapoints": [[100, 1609459200], [null, 1609459260], [120, 1609459320]]
+				}
+			]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459320, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:         "successful single query with tags",
+			serverStatus: 200,
+			serverResponse: `[
+				{
+					"target": "stats.counters.web.hits",
+					"tags": {
+						"host": "server1",
+						"environment": "production",
+						"port": 8080,
+						"rate": 99.5
+					},
+					"datapoints": [[100, 1609459200], [150, 1609459260]]
+				}
+			]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:         "successful multiple queries",
+			serverStatus: 200,
+			multipleTargets: map[string]string{
+				"stats.counters.web.hits": `[
+					{
+						"target": "stats.counters.web.hits",
+						"datapoints": [[100, 1609459200], [150, 1609459260]]
+					}
+				]`,
+				"stats.counters.api.calls": `[
+					{
+						"target": "stats.counters.api.calls",
+						"datapoints": [[50, 1609459200], [75, 1609459260]]
+					}
+				]`,
+			},
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+				{
+					RefID: "B",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.api.calls"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:           "query with empty target",
+			serverStatus:   200,
+			serverResponse: `[]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": ""
+					}`),
+				},
+			},
+			expectError:   true,
+			errorContains: "no query target found",
+		},
+		{
+			name:         "mixed queries - some empty, some valid",
+			serverStatus: 200,
+			serverResponse: `[
+				{
+					"target": "stats.counters.web.hits",
+					"datapoints": [[100, 1609459200], [150, 1609459260]]
+				}
+			]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": ""
+					}`),
+				},
+				{
+					RefID: "B",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name:           "server error response",
+			serverStatus:   500,
+			serverResponse: `{"error": "Internal server error"}`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError:   true,
+			errorContains: "request failed with error",
+		},
+		{
+			name:         "server error response with HTML content",
+			serverStatus: 500,
+			serverResponse: `<body>
+<h1>Internal Server Error</h1>
+<p>The server encountered an unexpected condition that prevented it from fulfilling the request.</p>
+<div>Error: Invalid metric path &#39;stats.invalid.metric&#39;</div>
+Error: Target not found
+</body>`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.invalid.metric"
+					}`),
+				},
+			},
+			expectError:   true,
+			errorContains: "Error: Target not found", // Should parse HTML and extract the last meaningful line
+		},
+		{
+			name:           "malformed JSON response",
+			serverStatus:   200,
+			serverResponse: `[{invalid json}]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "stats.counters.web.hits"
+					}`),
+				},
+			},
+			expectError: true,
+		},
+		{
+			name:           "invalid query JSON",
+			serverStatus:   200,
+			serverResponse: `[]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON:          []byte(`{invalid json}`),
+				},
+			},
+			expectError:   true,
+			errorContains: "failed to decode the Graphite query",
+		},
+		{
+			name:         "interval format transformation",
+			serverStatus: 200,
+			serverResponse: `[
+				{
+					"target": "hitcount(stats.counters.web.hits, '1min')",
+					"datapoints": [[100, 1609459200], [150, 1609459260]]
+				}
+			]`,
+			queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					TimeRange: backend.TimeRange{
+						From: time.Unix(1609459200, 0),
+						To:   time.Unix(1609459260, 0),
+					},
+					MaxDataPoints: 1000,
+					JSON: []byte(`{
+						"target": "hitcount(stats.counters.web.hits, '1m')"
+					}`),
+				},
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testName := strings.ReplaceAll(tt.name, " ", "_")
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				err := r.ParseForm()
+				require.NoError(t, err)
+
+				// Choose response based on target for multiple queries
+				response := tt.serverResponse
+				if tt.multipleTargets != nil {
+					target := r.FormValue("target")
+					if targetResponse, ok := tt.multipleTargets[target]; ok {
+						response = targetResponse
+					}
+				}
+
+				if !strings.Contains(tt.name, "empty target") {
+					assert.NotEmpty(t, r.FormValue("target"))
+				}
+
+				w.WriteHeader(tt.serverStatus)
+				w.Write([]byte(response))
+			}))
+			defer server.Close()
+
+			dsInfo := &datasourceInfo{
+				Id:         1,
+				URL:        server.URL,
+				HTTPClient: &http.Client{},
+			}
+
+			service := &Service{
+				logger: backend.Logger,
+			}
+
+			req := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{
+					DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+						ID:  1,
+						URL: server.URL,
+					},
+					OrgID: 1,
+				},
+				Queries: tt.queries,
+			}
+
+			result, err := service.RunQuery(context.Background(), req, dsInfo)
+
+			if tt.expectError {
+				if err != nil {
+					if tt.errorContains != "" {
+						assert.Contains(t, err.Error(), tt.errorContains)
+					}
+				} else {
+					require.NotNil(t, result)
+					found := false
+					for _, resp := range result.Responses {
+						if resp.Error != nil {
+							found = true
+							if tt.errorContains != "" {
+								assert.Contains(t, resp.Error.Error(), tt.errorContains)
+							}
+							break
+						}
+					}
+					assert.True(t, found, "Expected error but none found")
+				}
+			} else {
+				assert.NoError(t, err)
+				require.NotNil(t, result)
+
+				for refID, resp := range result.Responses {
+					experimental.CheckGoldenJSONResponse(t, "testdata", fmt.Sprintf("%s-RefID-%s.golden", testName, refID), &resp, false)
+				}
+			}
+		})
+	}
+}
+
+func TestParseGraphiteError(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   int
+		body     string
+		expected string
+	}{
+		{
+			name:     "simple text error",
+			status:   400,
+			body:     "Bad request: invalid target",
+			expected: "Bad request: invalid target",
+		},
+		{
+			name:     "JSON error",
+			status:   400,
+			body:     `{"error": "Invalid target format"}`,
+			expected: `{"error": "Invalid target format"}`,
+		},
+		{
+			name:     "HTML error",
+			status:   500,
+			body:     `<body><h1>Internal Server Error</h1><p>Target not found</p></body>`,
+			expected: "Internal Server ErrorTarget not found",
+		},
+		{
+			name:   "complex HTML error",
+			status: 500,
+			body: `<body>
+<h1>Internal Server Error</h1>
+<p>The server encountered an unexpected condition that prevented it from fulfilling the request.</p>
+<div>Error: Invalid metric path &#39;stats.invalid.metric&#39;</div>
+Final error message here
+</body>`,
+			expected: "Final error message here",
+		},
+		{
+			name:     "HTML error with unicode",
+			status:   500,
+			body:     `<body><p>Error: Invalid path &#x27;test&#x27; and &#x22;value&#x22;</p></body>`,
+			expected: "Error: Invalid path test and value",
+		},
+		{
+			name:   "HTML with whitespace and newlines",
+			status: 500,
+			body: `<body>
+
+<h1>Error</h1>
+
+<p>Something went wrong</p>
+
+Critical failure occurred
+
+</body>`,
+			expected: "Critical failure occurred",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseGraphiteError(tt.status, tt.body)
+			assert.Equal(t, tt.expected, result)
 		})
 	}
 }

--- a/pkg/tsdb/graphite/testdata/interval_format_transformation-RefID-A.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/interval_format_transformation-RefID-A.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: A
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "A",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "hitcount(stats.counters.web.hits, '1min')"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid-RefID-B.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/mixed_queries_-_some_empty,_some_valid-RefID-B.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: B
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "B",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-A.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-A.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: A
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "A",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-B.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_multiple_queries-RefID-B.golden.jsonc
@@ -1,0 +1,72 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: B
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 50               |
+//  | 2021-01-01 00:01:00 +0000 UTC | 75               |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "B",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.api.calls"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            50,
+            75
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_data-RefID-A.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_data-RefID-A.golden.jsonc
@@ -1,0 +1,75 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: A
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150              |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "A",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            150,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values-RefID-A.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_null_values-RefID-A.golden.jsonc
@@ -1,0 +1,75 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: A
+//  Dimensions: 2 Fields by 3 Rows
+//  +-------------------------------+------------------+
+//  | Name: time                    | Name: value      |
+//  | Labels:                       | Labels:          |
+//  | Type: []time.Time             | Type: []*float64 |
+//  +-------------------------------+------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100              |
+//  | 2021-01-01 00:01:00 +0000 UTC | null             |
+//  | 2021-01-01 00:02:00 +0000 UTC | 120              |
+//  +-------------------------------+------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "A",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {},
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000,
+            1609459320000
+          ],
+          [
+            100,
+            null,
+            120
+          ]
+        ]
+      }
+    }
+  ]
+}

--- a/pkg/tsdb/graphite/testdata/successful_single_query_with_tags-RefID-A.golden.jsonc
+++ b/pkg/tsdb/graphite/testdata/successful_single_query_with_tags-RefID-A.golden.jsonc
@@ -1,0 +1,77 @@
+//  🌟 This was machine generated.  Do not edit. 🌟
+//  
+//  Frame[0] {
+//      "type": "timeseries-multi",
+//      "typeVersion": [
+//          0,
+//          0
+//      ]
+//  }
+//  Name: A
+//  Dimensions: 2 Fields by 2 Rows
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | Name: time                    | Name: value                                                        |
+//  | Labels:                       | Labels: environment=production, host=server1, port=8080, rate=99.5 |
+//  | Type: []time.Time             | Type: []*float64                                                   |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  | 2021-01-01 00:00:00 +0000 UTC | 100                                                                |
+//  | 2021-01-01 00:01:00 +0000 UTC | 150                                                                |
+//  +-------------------------------+--------------------------------------------------------------------+
+//  
+//  
+//  🌟 This was machine generated.  Do not edit. 🌟
+{
+  "status": 200,
+  "frames": [
+    {
+      "schema": {
+        "name": "A",
+        "meta": {
+          "type": "timeseries-multi",
+          "typeVersion": [
+            0,
+            0
+          ]
+        },
+        "fields": [
+          {
+            "name": "time",
+            "type": "time",
+            "typeInfo": {
+              "frame": "time.Time"
+            }
+          },
+          {
+            "name": "value",
+            "type": "number",
+            "typeInfo": {
+              "frame": "float64",
+              "nullable": true
+            },
+            "labels": {
+              "environment": "production",
+              "host": "server1",
+              "port": "8080",
+              "rate": "99.5"
+            },
+            "config": {
+              "displayNameFromDS": "stats.counters.web.hits"
+            }
+          }
+        ]
+      },
+      "data": {
+        "values": [
+          [
+            1609459200000,
+            1609459260000
+          ],
+          [
+            100,
+            150
+          ]
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces some improvements to the backend Graphite querying experience.

Errors are now returned in data frames, supporting more informative errors when querying. Additionally, `errorsource` values have been added across the board (please double check these!).

Finally, I've duplicated the frontend error handling logic to the backend and I've added E2E unit tests for the query logic.

<img width="1468" height="340" alt="image" src="https://github.com/user-attachments/assets/54839b92-80ce-4576-ba81-4805dfa6e58a" />
