### PR TITLE
Folders: fix panic on move

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -91,6 +91,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, features featuremgmt.FeatureToggles, zanzanaClient zanzana.Client) *FolderAPIBuilder {
 	return &FolderAPIBuilder{
 		features:        features,
+		accessClient:    ac,
 		searcher:        searcher,
 		permissionStore: reconcilers.NewZanzanaPermissionStore(zanzanaClient),
 	}


### PR DESCRIPTION
This PR fixes a panic we were seeing when we would re-create a repo in a folder that had previously held a repo.

fixes https://github.com/grafana/git-ui-sync-project/issues/581