### PR TITLE
Geomap: Fix duplicated data links

### DIFF
--- a/public/app/features/visualization/data-hover/DataHoverView.tsx
+++ b/public/app/features/visualization/data-hover/DataHoverView.tsx
@@ -31,12 +31,19 @@ export function getDisplayValuesAndLinks(data: DataFrame, rowIndex: number, colu
 
   const displayValues: DisplayValue[] = [];
   const links: Array<LinkModel<Field>> = [];
+  const linkLookup = new Set<string>();
 
   for (const field of visibleFields) {
     const value = field.values[rowIndex];
     const fieldDisplay = field.display ? field.display(value) : { text: `${value}`, numeric: +value };
 
-    links.push(...getDataLinks(field, rowIndex));
+    getDataLinks(field, rowIndex).forEach((link) => {
+      const key = `${link.title}/${link.href}`;
+      if (!linkLookup.has(key)) {
+        links.push(link);
+        linkLookup.add(key);
+      }
+    });
 
     displayValues.push({
       name: getFieldDisplayName(field, data),


### PR DESCRIPTION
This PR addresses an issue in Geomap, where data links were duplicated for each field. The regression was introduced in https://github.com/grafana/grafana/pull/109369

Fixes https://github.com/grafana/support-escalations/issues/18607
Fixes https://github.com/grafana/support-escalations/issues/18591


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
