### PR TITLE
AccessControl: Increase limit of LBAC for Datasources rules

### DIFF
--- a/pkg/services/sqlstore/migrations/datasource_mig.go
+++ b/pkg/services/sqlstore/migrations/datasource_mig.go
@@ -146,4 +146,8 @@ func addDataSourceMigration(mg *Migrator) {
 	mg.AddMigration("Update secure_json_data column to MediumText", NewRawSQLMigration("").
 		Mysql("ALTER TABLE data_source MODIFY COLUMN secure_json_data MEDIUMTEXT;"),
 	)
+
+	mg.AddMigration("Update json_data column to MediumText", NewRawSQLMigration("").
+		Mysql("ALTER TABLE data_source MODIFY COLUMN json_data MEDIUMTEXT;"),
+	)
 }


### PR DESCRIPTION
This pull request adds a new database migration to update the `json_data` column type in the `data_source` table to `MEDIUMTEXT`, aligning it with the existing migration for the `secure_json_data` column.

**Database migrations:**

* Added a migration to change the `json_data` column in the `data_source` table to use the `MEDIUMTEXT` type, which allows for larger JSON payloads.

**Why**

LBAC for datasources rules currently cap at around 400 to 600 due to 16kb limit

**Issues**

Users who are part of too many teams and whose header payload exceeds 64kb won't be able to query