### PR TITLE
FileStatusPage: Disable save button if repo is read only

### DIFF
--- a/public/app/features/provisioning/File/FileStatusPage.tsx
+++ b/public/app/features/provisioning/File/FileStatusPage.tsx
@@ -17,6 +17,7 @@ import { Page } from 'app/core/components/Page/Page';
 import { useQueryParams } from 'app/core/hooks/useQueryParams';
 
 import { PROVISIONING_URL } from '../constants';
+import { useGetResourceRepositoryView } from '../hooks/useGetResourceRepositoryView';
 
 export default function FileStatusPage() {
   const params = useParams();
@@ -26,6 +27,8 @@ export default function FileStatusPage() {
   const name = params['name'] ?? '';
   const path = params['*'] ?? '';
   const file = useGetRepositoryFilesWithPathQuery({ name, path, ref });
+  const { isReadOnlyRepo } = useGetResourceRepositoryView({ name });
+  console.log('isReadOnlyRepo', isReadOnlyRepo);
 
   return (
     <Page
@@ -41,7 +44,9 @@ export default function FileStatusPage() {
               {file.error.message}
             </Alert>
           )}
-          {file.isSuccess && file.data && <ResourceView wrap={file.data} repo={name} repoRef={ref} tab={tab} />}
+          {file.isSuccess && file.data && (
+            <ResourceView wrap={file.data} repo={name} repoRef={ref} tab={tab} isReadOnlyRepo={isReadOnlyRepo} />
+          )}
         </>
       </Page.Contents>
     </Page>
@@ -59,9 +64,10 @@ interface Props {
   repo: string;
   repoRef?: string;
   tab: TabSelection;
+  isReadOnlyRepo: boolean;
 }
 
-function ResourceView({ wrap, repo, repoRef, tab }: Props) {
+function ResourceView({ wrap, repo, repoRef, tab, isReadOnlyRepo }: Props) {
   const isDashboard = wrap.resource?.type?.kind === 'Dashboard';
   const existingName = wrap.resource?.existing?.metadata?.name;
   const location = useLocation();
@@ -159,8 +165,13 @@ function ResourceView({ wrap, repo, repoRef, tab }: Props) {
           </div>
           <Stack alignItems="flex-end" justifyContent="end">
             <Button
+              tooltip={
+                isReadOnlyRepo
+                  ? t('provisioning.resource-view.read-only-repo-tooltip', 'This is a read-only repository')
+                  : ''
+              }
               variant="primary"
-              disabled={replaceFileStatus.isLoading}
+              disabled={replaceFileStatus.isLoading || isReadOnlyRepo}
               onClick={() => {
                 replaceFile({
                   name: repo,
@@ -179,7 +190,7 @@ function ResourceView({ wrap, repo, repoRef, tab }: Props) {
             </Button>
             <DeleteButton
               size="md"
-              disabled={deleteFileStatus.isLoading}
+              disabled={deleteFileStatus.isLoading || isReadOnlyRepo}
               onConfirm={() => {
                 deleteFile({
                   name: repo,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11637,6 +11637,7 @@
         "removed-from-repo-test-ui": "removed from repo test UI",
         "updated-from-repo-test-ui": "updated from repo test UI"
       },
+      "read-only-repo-tooltip": "This is a read-only repository",
       "repository": "Repository",
       "tab-info": {
         "label": {


### PR DESCRIPTION
**What is this feature?**

- `FileStatusPage`: Disable Save button if repo is read only

**Why do we need this feature?**

- Prevent user confusion

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/583

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
