### PR TITLE
devenv: fix volumes section when sources don't contain one

### DIFF
--- a/devenv/create_docker_compose.sh
+++ b/devenv/create_docker_compose.sh
@@ -64,13 +64,6 @@ for dir in $@; do
     fi
 done
 
-volume_files=$($blocks_dir/**/$compose_volume_section_create_flag)
-
-if [[ ${#volume_files[@]} -ne 0 ]]; then
-    echo "Adding volume section to $compose_file"
-    cat $compose_volume_section_file >> $compose_file
-    echo "" >> $compose_file
-
     for dir in $@; do
         current_dir=$blocks_dir/$dir
         if [ ! -d "$current_dir" ]; then
@@ -80,11 +73,15 @@ if [[ ${#volume_files[@]} -ne 0 ]]; then
 
 
         if [ -f $current_dir/$compose_volume_section_create_flag ]; then
+            if [ -z ${inserted_volume_section_start+x} ]; then
+                echo "Adding volume section to $compose_file"
+                cat $compose_volume_section_file >> $compose_file
+                echo "" >> $compose_file
+                inserted_volume_section_start=true
+            fi
+
             echo "Adding volume for $current_dir to $compose_file"
             echo "  $dir-data-volume:" >> $compose_file
             echo "" >> $compose_file
         fi
     done
-
-    cat $compose_file
-fi


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

I introduced support for docker persistent volumes in devenv docker-compose but the checking for when to insert the section was following incorrect logic. It now correctly adds the section but only when included `sources` reference one.

**Why do we need this feature?**

Local dev

**Who is this feature for?**

Grafana developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
