### PR TITLE
Add access to the Connections section if there are any plugin routes …

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -301,7 +301,7 @@ func TestAddAppLinks(t *testing.T) {
 
 		// Build nav-tree and check if the "Connections" page is there
 		treeRoot := navtree.NavTreeRoot{}
-		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
+		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx, &treeRoot))
 		connectionsNode := treeRoot.FindById("connections")
 		require.NotNil(t, connectionsNode)
 		require.Equal(t, "Connections", connectionsNode.Text)
@@ -336,7 +336,7 @@ func TestAddAppLinks(t *testing.T) {
 		service.navigationAppPathConfig = map[string]NavigationAppConfig{} // We don't configure it as a standalone plugin page
 
 		treeRoot := navtree.NavTreeRoot{}
-		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx))
+		treeRoot.AddSection(service.buildDataConnectionsNavLink(reqCtx, &treeRoot))
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
 

--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -552,28 +552,25 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext, tr
 	// Check if there are any plugin items already added to the Connections section
 	hasPluginItems := s.hasConnectionsPluginItems(treeRoot)
 
-	// Show Connections section if user has datasources access OR if there are plugin items
-	if hasDatasourcesAccess || hasPluginItems {
-		// Add new connection (only if user has datasources access)
-		if hasDatasourcesAccess {
-			children = append(children, &navtree.NavLink{
-				Id:       "connections-add-new-connection",
-				Text:     "Add new connection",
-				SubTitle: "Browse and create new connections",
-				Url:      baseUrl + "/add-new-connection",
-				Children: []*navtree.NavLink{},
-				Keywords: []string{"csv", "graphite", "json", "loki", "prometheus", "sql", "tempo"},
-			})
+	// Add datasources items if user has datasources access
+	if hasDatasourcesAccess {
+		children = append(children, &navtree.NavLink{
+			Id:       "connections-add-new-connection",
+			Text:     "Add new connection",
+			SubTitle: "Browse and create new connections",
+			Url:      baseUrl + "/add-new-connection",
+			Children: []*navtree.NavLink{},
+			Keywords: []string{"csv", "graphite", "json", "loki", "prometheus", "sql", "tempo"},
+		})
 
-			// Data sources
-			children = append(children, &navtree.NavLink{
-				Id:       "connections-datasources",
-				Text:     "Data sources",
-				SubTitle: "View and manage your connected data source connections",
-				Url:      baseUrl + "/datasources",
-				Children: []*navtree.NavLink{},
-			})
-		}
+		// Data sources
+		children = append(children, &navtree.NavLink{
+			Id:       "connections-datasources",
+			Text:     "Data sources",
+			SubTitle: "View and manage your connected data source connections",
+			Url:      baseUrl + "/datasources",
+			Children: []*navtree.NavLink{},
+		})
 	}
 
 	if len(children) > 0 || hasPluginItems {
@@ -597,7 +594,7 @@ func (s *ServiceImpl) buildDataConnectionsNavLink(c *contextmodel.ReqContext, tr
 func (s *ServiceImpl) hasConnectionsPluginItems(treeRoot *navtree.NavTreeRoot) bool {
 	// Look for any standalone plugin pages that are configured to be under the Connections section
 	// These would have IDs like "standalone-plugin-page-/connections/..."
-	for _, section := range treeRoot.Sections {
+	for _, section := range treeRoot.Children {
 		for _, child := range section.Children {
 			if child.Id != "" &&
 				(strings.HasPrefix(child.Id, "standalone-plugin-page-/connections/") ||

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -9,8 +9,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/navtree"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
@@ -156,5 +158,134 @@ func TestBuildStarredItemsNavLinks(t *testing.T) {
 		require.Equal(t, "A Dashboard", navLinks[0].Text)
 		require.Equal(t, "B Dashboard", navLinks[1].Text)
 		require.Equal(t, "C Dashboard", navLinks[2].Text)
+	})
+}
+
+func TestHasConnectionsPluginItems(t *testing.T) {
+	service := ServiceImpl{}
+
+	t.Run("Should return false when no connections items exist", func(t *testing.T) {
+		treeRoot := &navtree.NavTreeRoot{
+			Children: []*navtree.NavLink{
+				{
+					Id: "apps",
+					Children: []*navtree.NavLink{
+						{Id: "plugin-page-some-app", Url: "/a/some-app"},
+					},
+				},
+			},
+		}
+
+		result := service.hasConnectionsPluginItems(treeRoot)
+		require.False(t, result)
+	})
+
+	t.Run("Should return true when connections plugin items exist", func(t *testing.T) {
+		testCases := []struct {
+			name string
+			id   string
+			url  string
+		}{
+			{
+				name: "standalone plugin page by ID",
+				id:   "standalone-plugin-page-/connections/infrastructure",
+				url:  "/connections/infrastructure",
+			},
+			{
+				name: "plugin item by URL only",
+				id:   "some-plugin-item",
+				url:  "/connections/collector",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				treeRoot := &navtree.NavTreeRoot{
+					Children: []*navtree.NavLink{
+						{
+							Id: "some-section",
+							Children: []*navtree.NavLink{
+								{
+									Id:  tc.id,
+									Url: tc.url,
+								},
+							},
+						},
+					},
+				}
+
+				result := service.hasConnectionsPluginItems(treeRoot)
+				require.True(t, result)
+			})
+		}
+	})
+}
+
+func TestBuildDataConnectionsNavLink(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{
+		SignedInUser: &user.SignedInUser{
+			UserID: 1,
+			OrgID:  1,
+		},
+		Context: &web.Context{Req: httpReq},
+	}
+
+	t.Run("Should return nil when no access and no plugin items", func(t *testing.T) {
+		accessControl := actest.FakeAccessControl{}
+		service := ServiceImpl{
+			accessControl: &accessControl,
+		}
+
+		treeRoot := &navtree.NavTreeRoot{}
+
+		result := service.buildDataConnectionsNavLink(reqCtx, treeRoot)
+		require.Nil(t, result)
+	})
+
+	t.Run("Should return connections nav with datasource items when user has access", func(t *testing.T) {
+		accessControl := actest.FakeAccessControl{
+			ExpectedEvaluate: true,
+		}
+		service := ServiceImpl{
+			accessControl: &accessControl,
+		}
+
+		treeRoot := &navtree.NavTreeRoot{}
+
+		result := service.buildDataConnectionsNavLink(reqCtx, treeRoot)
+		require.NotNil(t, result)
+		require.Equal(t, "Connections", result.Text)
+		require.Equal(t, "connections", result.Id)
+		require.Len(t, result.Children, 2)
+	})
+
+	t.Run("Should return connections nav when plugin items exist", func(t *testing.T) {
+		accessControl := actest.FakeAccessControl{
+			ExpectedEvaluate: false, // No datasources access
+		}
+		service := ServiceImpl{
+			accessControl: &accessControl,
+		}
+
+		// TreeRoot with plugin items
+		treeRoot := &navtree.NavTreeRoot{
+			Children: []*navtree.NavLink{
+				{
+					Id: "some-section",
+					Children: []*navtree.NavLink{
+						{
+							Id:  "standalone-plugin-page-/connections/infrastructure",
+							Url: "/connections/infrastructure",
+						},
+					},
+				},
+			},
+		}
+
+		result := service.buildDataConnectionsNavLink(reqCtx, treeRoot)
+		require.NotNil(t, result)
+		require.Equal(t, "Connections", result.Text)
+		require.Empty(t, result.Children) // No datasource items, but section exists for plugins
 	})
 }

--- a/pkg/services/navtree/navtreeimpl/navtree_test.go
+++ b/pkg/services/navtree/navtreeimpl/navtree_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/star"
 	"github.com/grafana/grafana/pkg/services/star/startest"
 	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
 
@@ -234,6 +235,7 @@ func TestBuildDataConnectionsNavLink(t *testing.T) {
 	t.Run("Should return nil when no access and no plugin items", func(t *testing.T) {
 		accessControl := actest.FakeAccessControl{}
 		service := ServiceImpl{
+			cfg:           &setting.Cfg{AppSubURL: ""},
 			accessControl: &accessControl,
 		}
 
@@ -248,6 +250,7 @@ func TestBuildDataConnectionsNavLink(t *testing.T) {
 			ExpectedEvaluate: true,
 		}
 		service := ServiceImpl{
+			cfg:           &setting.Cfg{AppSubURL: ""},
 			accessControl: &accessControl,
 		}
 
@@ -265,6 +268,7 @@ func TestBuildDataConnectionsNavLink(t *testing.T) {
 			ExpectedEvaluate: false, // No datasources access
 		}
 		service := ServiceImpl{
+			cfg:           &setting.Cfg{AppSubURL: ""},
 			accessControl: &accessControl,
 		}
 


### PR DESCRIPTION
This PR adds access to the Connections section in case any of the plugins grant access to the Connections section
draft only for now, to decide between this PR and https://github.com/grafana/grafana/pull/111565 