### PR TITLE
Fix folder parents getter max depth validation

### DIFF
--- a/pkg/registry/apis/folders/parents.go
+++ b/pkg/registry/apis/folders/parents.go
@@ -72,7 +72,9 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 				break
 			}
 
-			if len(info.Items) >= maxDepth {
+			// if we exceed max depth, return an error
+			// info.Items does not include the general folder, so we do not add +1 here
+			if len(info.Items) > maxDepth {
 				err = folderLegacy.ErrMaximumDepthReached
 				break
 			}

--- a/pkg/registry/apis/folders/parents.go
+++ b/pkg/registry/apis/folders/parents.go
@@ -72,13 +72,6 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 				break
 			}
 
-			// if we exceed max depth, return an error
-			// info.Items does not include the general folder, so we do not add +1 here
-			if len(info.Items) > maxDepth {
-				err = folderLegacy.ErrMaximumDepthReached
-				break
-			}
-
 			found[parentFolder.Name] = true
 			folder = parentFolder
 		}

--- a/pkg/registry/apis/folders/parents_test.go
+++ b/pkg/registry/apis/folders/parents_test.go
@@ -111,21 +111,6 @@ func TestParents(t *testing.T) {
 			},
 			expectedErr: "cyclic folder references found",
 		},
-		{
-			name: "too deep",
-			request: input{
-				name:   "test",
-				folder: "p1",
-			},
-			maxDepth:    3,
-			expectedErr: "[folder.maximum-depth-reached]",
-			expected: &folders.FolderInfoList{Items: []folders.FolderInfo{
-				{Name: "test", Parent: "p1"},
-				{Name: "p1", Parent: "p2"},
-				{Name: "p2", Parent: "p3"},
-				{Name: "p3", Parent: "p4"}, // should not try calling p4
-			}},
-		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/apis/folders/parents_test.go
+++ b/pkg/registry/apis/folders/parents_test.go
@@ -148,6 +148,13 @@ func TestParents(t *testing.T) {
 							},
 						}, nil).Maybe() // we don't care how often they are called
 				}
+				p := len(tt.expected.Items)
+				m.On("Get", context.TODO(), tt.expected.Items[p-1].Parent, &metav1.GetOptions{}).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: tt.expected.Items[p-1].Parent,
+						},
+					}, nil).Maybe() // we don't care how often they are called
 			} else {
 				for k, v := range tt.getter {
 					v.Name = k // set the name

--- a/pkg/registry/apis/folders/parents_test.go
+++ b/pkg/registry/apis/folders/parents_test.go
@@ -133,13 +133,6 @@ func TestParents(t *testing.T) {
 							},
 						}, nil).Maybe() // we don't care how often they are called
 				}
-				p := len(tt.expected.Items)
-				m.On("Get", context.TODO(), tt.expected.Items[p-1].Parent, &metav1.GetOptions{}).Return(
-					&folders.Folder{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: tt.expected.Items[p-1].Parent,
-						},
-					}, nil).Maybe() // we don't care how often they are called
 			} else {
 				for k, v := range tt.getter {
 					v.Name = k // set the name

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -2,6 +2,7 @@ package folders
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -82,6 +83,59 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 			},
 			err: folder.ErrFolderCannotBeParentOfItself,
 		},
+		{
+			name: "should not allow creating a folder that will become too deep",
+			input: input{
+				annotations: map[string]string{utils.AnnoKeyFolder: "p1"},
+				obj: &folders.Folder{
+					Spec: folders.FolderSpec{
+						Title: "title",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "p0",
+						Annotations: map[string]string{"grafana.app/folder": "p1"},
+					},
+				},
+				name: "p0",
+			},
+			setupFn: func(m *grafanarest.MockStorage) {
+				m.On("Get", mock.Anything, "p1", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "p1",
+							Annotations: map[string]string{"grafana.app/folder": "p2"},
+						},
+					}, nil)
+				m.On("Get", mock.Anything, "p2", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "p2",
+							Annotations: map[string]string{"grafana.app/folder": "p3"},
+						},
+					}, nil)
+				m.On("Get", mock.Anything, "p3", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "p3",
+							Annotations: map[string]string{"grafana.app/folder": "p4"},
+						},
+					}, nil)
+				m.On("Get", mock.Anything, "p4", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:        "p4",
+							Annotations: map[string]string{"grafana.app/folder": "p5"},
+						},
+					}, nil)
+				m.On("Get", mock.Anything, "p5", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "p5",
+						},
+					}, nil)
+			},
+			err: fmt.Errorf("folder max depth exceeded, max depth is 4"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,7 +173,7 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 			if tt.err == nil {
 				require.NoError(t, err)
 			} else {
-				require.ErrorIs(t, err, tt.err)
+				require.Contains(t, err.Error(), tt.err.Error())
 				return
 			}
 		})

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -58,41 +58,6 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 			},
 		},
 		{
-			name: "should not allow creating a folder in a tree that is too deep",
-			input: input{
-				obj: &folders.Folder{
-					Spec: folders.FolderSpec{
-						Title: "foo",
-					},
-				},
-				annotations: map[string]string{"grafana.app/folder": "p1"}, // already max depth
-				name:        "valid-name",
-			},
-			setupFn: func(m *grafanarest.MockStorage) {
-				m.On("Get", mock.Anything, "p1", mock.Anything).Return(
-					&folders.Folder{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        "p1",
-							Annotations: map[string]string{"grafana.app/folder": "p2"},
-						},
-					}, nil).Maybe()
-				m.On("Get", mock.Anything, "p2", mock.Anything).Return(
-					&folders.Folder{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:        "p2",
-							Annotations: map[string]string{"grafana.app/folder": "p3"},
-						},
-					}, nil).Maybe()
-				m.On("Get", mock.Anything, "p3", mock.Anything).Return(
-					&folders.Folder{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "p3",
-						},
-					}, nil).Maybe()
-			},
-			err: folder.ErrMaximumDepthReached,
-		},
-		{
 			name: "should return error when title is empty",
 			input: input{
 				obj: &folders.Folder{

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -83,6 +83,12 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 							Annotations: map[string]string{"grafana.app/folder": "p3"},
 						},
 					}, nil).Maybe()
+				m.On("Get", mock.Anything, "p3", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "p3",
+						},
+					}, nil).Maybe()
 			},
 			err: folder.ErrMaximumDepthReached,
 		},
@@ -334,6 +340,12 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:        "p3",
 							Annotations: map[string]string{"grafana.app/folder": "p4"},
+						},
+					}, nil)
+				m.On("Get", mock.Anything, "p4", mock.Anything).Return(
+					&folders.Folder{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "p4",
 						},
 					}, nil)
 			},


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the max depth folder validation from Folder API server parents getter. 

**Why do we need this feature?**

When using the folder api server, the folder max depth limit was off by 1

**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/support-escalations/issues/18613

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
