### PR TITLE
fix: avoid child paths in repositories

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/types.go
@@ -159,6 +159,66 @@ func (r *Repository) Branch() string {
 	return ""
 }
 
+// URL returns the URL for git-based repositories
+// or an empty string for local repositories
+func (r *Repository) URL() string {
+	if !r.Spec.Type.IsGit() {
+		return ""
+	}
+
+	switch r.Spec.Type {
+	case GitHubRepositoryType:
+		if r.Spec.GitHub != nil {
+			return r.Spec.GitHub.URL
+		}
+	case GitRepositoryType:
+		if r.Spec.Git != nil {
+			return r.Spec.Git.URL
+		}
+	case BitbucketRepositoryType:
+		if r.Spec.Bitbucket != nil {
+			return r.Spec.Bitbucket.URL
+		}
+	case GitLabRepositoryType:
+		if r.Spec.GitLab != nil {
+			return r.Spec.GitLab.URL
+		}
+	default:
+		return ""
+	}
+
+	return ""
+}
+
+func (r *Repository) Path() string {
+	switch r.Spec.Type {
+	case GitHubRepositoryType:
+		if r.Spec.GitHub != nil {
+			return r.Spec.GitHub.Path
+		}
+	case GitRepositoryType:
+		if r.Spec.Git != nil {
+			return r.Spec.Git.Path
+		}
+	case BitbucketRepositoryType:
+		if r.Spec.Bitbucket != nil {
+			return r.Spec.Bitbucket.Path
+		}
+	case GitLabRepositoryType:
+		if r.Spec.GitLab != nil {
+			return r.Spec.GitLab.Path
+		}
+	case LocalRepositoryType:
+		if r.Spec.Local != nil {
+			return r.Spec.Local.Path
+		}
+	default:
+		return ""
+	}
+
+	return ""
+}
+
 type RepositorySpec struct {
 	// The repository display name (shown in the UI)
 	Title string `json:"title"`

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -2,9 +2,11 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
+	"path/filepath"
 	"slices"
 	"strings"
 	"time"
@@ -73,6 +75,11 @@ var (
 	_ builder.APIGroupRouteProvider         = (*APIBuilder)(nil)
 	_ builder.APIGroupPostStartHookProvider = (*APIBuilder)(nil)
 	_ builder.OpenAPIPostProcessor          = (*APIBuilder)(nil)
+)
+
+var (
+	ErrRepositoryParentFolderConflict = errors.New("parent folder conflict")
+	ErrRepositoryDuplicatePath        = errors.New("duplicate repository path")
 )
 
 // JobHistoryConfig holds configuration for job history backends
@@ -626,18 +633,32 @@ func invalidRepositoryError(name string, list field.ErrorList) error {
 }
 
 func (b *APIBuilder) getRepositoriesInNamespace(ctx context.Context) ([]provisioning.Repository, error) {
-	obj, err := b.store.List(ctx, &internalversion.ListOptions{
-		Limit: 100,
-	})
-	if err != nil {
-		return nil, err
+	var allRepositories []provisioning.Repository
+	continueToken := ""
+
+	for {
+		obj, err := b.store.List(ctx, &internalversion.ListOptions{
+			Limit:    100,
+			Continue: continueToken,
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		repositoryList, ok := obj.(*provisioning.RepositoryList)
+		if !ok {
+			return nil, fmt.Errorf("expected repository list")
+		}
+
+		allRepositories = append(allRepositories, repositoryList.Items...)
+
+		continueToken = repositoryList.GetContinue()
+		if continueToken == "" {
+			break
+		}
 	}
 
-	all, ok := obj.(*provisioning.RepositoryList)
-	if !ok {
-		return nil, fmt.Errorf("expected repository list")
-	}
-	return all.Items, nil
+	return allRepositories, nil
 }
 
 // TODO: move this to a more appropriate place. Probably controller/validation.go
@@ -666,6 +687,30 @@ func (b *APIBuilder) verifyAgainstExistingRepositories(cfg *provisioning.Reposit
 			if v.Spec.Sync.Target == provisioning.SyncTargetTypeInstance && v.Name != cfg.Name {
 				return field.Forbidden(field.NewPath("spec", "sync", "target"),
 					"Cannot create folder repository when instance repository exists: "+v.Name)
+			}
+		}
+	}
+
+	// If repo is git, ensure no other repository is defined with a child path
+	if cfg.Spec.Type.IsGit() {
+		for _, v := range all {
+
+			if v.URL() == cfg.URL() {
+				if v.Path() == cfg.Path() {
+					return field.Forbidden(field.NewPath("spec", string(cfg.Spec.Type), "path"),
+						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))
+				}
+
+				relPath, err := filepath.Rel(v.Path(), cfg.Path())
+				if err != nil {
+					return field.Forbidden(field.NewPath("spec", string(cfg.Spec.Type), "path"), "failed to evaluate path: "+err.Error())
+				}
+				// https://pkg.go.dev/path/filepath#Rel
+				// Rel will return "../" if the relative paths are not related
+				if !strings.HasPrefix(relPath, "../") {
+					return field.Forbidden(field.NewPath("spec", string(cfg.Spec.Type), "path"),
+						fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))
+				}
 			}
 		}
 	}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -694,6 +694,10 @@ func (b *APIBuilder) verifyAgainstExistingRepositories(cfg *provisioning.Reposit
 	// If repo is git, ensure no other repository is defined with a child path
 	if cfg.Spec.Type.IsGit() {
 		for _, v := range all {
+			// skip itself
+			if cfg.Name == v.Name {
+				continue
+			}
 			if v.URL() == cfg.URL() {
 				if v.Path() == cfg.Path() {
 					return field.Forbidden(field.NewPath("spec", string(cfg.Spec.Type), "path"),

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -692,7 +692,6 @@ func (b *APIBuilder) verifyAgainstExistingRepositories(cfg *provisioning.Reposit
 	}
 
 	// If repo is git, ensure no other repository is defined with a child path
-	// TODO: implement for other providers as well
 	if cfg.Spec.Type.IsGit() {
 		for _, v := range all {
 			if v.URL() == cfg.URL() {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -692,9 +692,9 @@ func (b *APIBuilder) verifyAgainstExistingRepositories(cfg *provisioning.Reposit
 	}
 
 	// If repo is git, ensure no other repository is defined with a child path
+	// TODO: implement for other providers as well
 	if cfg.Spec.Type.IsGit() {
 		for _, v := range all {
-
 			if v.URL() == cfg.URL() {
 				if v.Path() == cfg.Path() {
 					return field.Forbidden(field.NewPath("spec", string(cfg.Spec.Type), "path"),

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -431,7 +431,8 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 					"Name":        test.name,
 					"URL":         test.input,
 					"SyncTarget":  "folder",
-					"SyncEnabled": false, // Disable sync since we're just testing URL cleanup
+					"SyncEnabled": false, // Disable sync since we're just testing URL cleanup,
+					"Path":        fmt.Sprintf("grafana-%s/", test.name),
 				})
 
 				_, err := helper.Repositories.Resource.Create(ctx, input, metav1.CreateOptions{})

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -226,23 +226,28 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			expectError error
 		}{
 			{
-				name:        "first repo with path 'demo' should succeed",
-				path:        "demo",
+				name:        "first repo with path 'demo/nested' should succeed",
+				path:        "demo/nested",
 				expectError: nil,
 			},
 			{
-				name:        "second repo with child path 'demo/nested' should fail",
-				path:        "demo/nested",
+				name:        "second repo with child path 'demo/nested/again' should fail",
+				path:        "demo/nested/again",
 				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
 			},
 			{
-				name:        "third repo with nested child path 'demo/nested/nested-second' should fail",
-				path:        "demo/nested/nested-second",
-				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
-			},
-			{
-				name:        "fourth repo with duplicate path 'demo' should fail",
+				name:        "third repo with parent path 'demo' should fail",
 				path:        "demo",
+				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
+			},
+			{
+				name:        "fourth repo with nested child path 'demo/nested/nested-second' should fail",
+				path:        "demo/nested/again/two",
+				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
+			},
+			{
+				name:        "fifth repo with duplicate path 'demo/nested' should fail",
+				path:        "demo/nested",
 				expectError: provisioningAPIServer.ErrRepositoryDuplicatePath,
 			},
 		}


### PR DESCRIPTION
Closes https://github.com/grafana/git-ui-sync-project/issues/585

Drive-by change also in the listing of repos to avoid the cap of 100 (now we cap though to 10 repos linked)