### PR TITLE
Provisioning: Allow viewers to view /status subresource and wait on the frontend before sync

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -40,7 +40,6 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/loki"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -350,7 +349,7 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 						return authorizer.DecisionDeny, "editor role is required", nil
 					}
 				case "status":
-					if id.GetOrgRole().Includes(identity.RoleViewer) && a.GetVerb() == utils.VerbGet {
+					if id.GetOrgRole().Includes(identity.RoleViewer) && a.GetVerb() == apiutils.VerbGet {
 						return authorizer.DecisionAllow, "", nil
 					}
 					return authorizer.DecisionDeny, "users cannot update the status of a repository", nil

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -330,7 +330,7 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					}
 					return authorizer.DecisionDeny, "admin role is required", nil
 
-				case "refs":
+				case "refs", "status":
 					// This is strictly a read operation. It is handy on the frontend for viewers.
 					if id.GetOrgRole().Includes(identity.RoleViewer) {
 						return authorizer.DecisionAllow, "", nil
@@ -340,7 +340,7 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					// Access to files is controlled by the AccessClient
 					return authorizer.DecisionAllow, "", nil
 
-				case "resources", "sync", "history", "status":
+				case "resources", "sync", "history":
 					// These are strictly read operations.
 					// Sync can also be somewhat destructive, but it's expected to be fine to import changes.
 					if id.GetOrgRole().Includes(identity.RoleEditor) {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -40,6 +40,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/loki"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	apiutils "github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
@@ -330,7 +331,7 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					}
 					return authorizer.DecisionDeny, "admin role is required", nil
 
-				case "refs", "status":
+				case "refs":
 					// This is strictly a read operation. It is handy on the frontend for viewers.
 					if id.GetOrgRole().Includes(identity.RoleViewer) {
 						return authorizer.DecisionAllow, "", nil
@@ -348,7 +349,11 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					} else {
 						return authorizer.DecisionDeny, "editor role is required", nil
 					}
-
+				case "status":
+					if id.GetOrgRole().Includes(identity.RoleViewer) && a.GetVerb() == utils.VerbGet {
+						return authorizer.DecisionAllow, "", nil
+					}
+					return authorizer.DecisionDeny, "users cannot update the status of a repository", nil
 				default:
 					if id.GetIsGrafanaAdmin() {
 						return authorizer.DecisionAllow, "", nil

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -340,7 +340,7 @@ func (b *APIBuilder) GetAuthorizer() authorizer.Authorizer {
 					// Access to files is controlled by the AccessClient
 					return authorizer.DecisionAllow, "", nil
 
-				case "resources", "sync", "history":
+				case "resources", "sync", "history", "status":
 					// These are strictly read operations.
 					// Sync can also be somewhat destructive, but it's expected to be fine to import changes.
 					if id.GetOrgRole().Includes(identity.RoleEditor) {

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -7,6 +7,7 @@ import {
   useCreateRepositoryJobsMutation,
   useGetFrontendSettingsQuery,
   useGetRepositoryFilesQuery,
+  useGetRepositoryStatusQuery,
   useGetResourceStatsQuery,
 } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -29,6 +30,7 @@ jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
   ...jest.requireActual('app/api/clients/provisioning/v0alpha1'),
   useGetFrontendSettingsQuery: jest.fn(),
   useGetRepositoryFilesQuery: jest.fn(),
+  useGetRepositoryStatusQuery: jest.fn(),
   useGetResourceStatsQuery: jest.fn(),
   useCreateRepositoryJobsMutation: jest.fn(),
 }));
@@ -42,6 +44,9 @@ const mockUseGetFrontendSettingsQuery = useGetFrontendSettingsQuery as jest.Mock
 >;
 const mockUseGetRepositoryFilesQuery = useGetRepositoryFilesQuery as jest.MockedFunction<
   typeof useGetRepositoryFilesQuery
+>;
+const mockUseGetRepositoryStatusQuery = useGetRepositoryStatusQuery as jest.MockedFunction<
+  typeof useGetRepositoryStatusQuery
 >;
 const mockUseGetResourceStatsQuery = useGetResourceStatsQuery as jest.MockedFunction<typeof useGetResourceStatsQuery>;
 const mockUseCreateRepositoryJobsMutation = useCreateRepositoryJobsMutation as jest.MockedFunction<
@@ -127,6 +132,23 @@ describe('ProvisioningWizard', () => {
     mockUseGetRepositoryFilesQuery.mockReturnValue({
       data: [],
       isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    mockUseGetRepositoryStatusQuery.mockReturnValue({
+      data: {
+        status: {
+          health: {
+            healthy: true,
+            checked: true,
+            message: '',
+          },
+        },
+      },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
       error: null,
       refetch: jest.fn(),
     });

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -40,7 +40,7 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
     message: repositoryHealthMessages,
     checked,
   } = repositoryStatusQuery?.data?.status?.health || {};
-  const isButtonDisabled = checked !== undefined && isRepositoryHealthy === false;
+  const isButtonDisabled = repositoryStatusQuery.isFetching || (checked !== undefined && isRepositoryHealthy === false);
 
   const startSynchronization = async () => {
     const [history] = getValues(['migrate.history']);

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -40,7 +40,9 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
     message: repositoryHealthMessages,
     checked,
   } = repositoryStatusQuery?.data?.status?.health || {};
-  const isButtonDisabled = checked !== undefined && isRepositoryHealthy === false;
+  
+  const hasError = repositoryStatusQuery.isError;  
+  const isButtonDisabled = hasError || (checked !== undefined && isRepositoryHealthy === false);
 
   const startSynchronization = async () => {
     const [history] = getValues(['migrate.history']);
@@ -65,7 +67,21 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
           to the repository and provisioned back into the instance.
         </Trans>
       </Text>
-      {repositoryHealthMessages && !isRepositoryHealthy && (
+      {hasError && (
+        <ProvisioningAlert
+          error={{
+            title: t(
+              'provisioning.synchronize-step.repository-error',
+              'Repository error'
+            ),
+            message: t(
+              'provisioning.synchronize-step.repository-error-message',
+              'Unable to check repository status. Please verify the repository configuration and try again.'
+            ),
+          }}
+        />
+      )}
+      {repositoryHealthMessages && !isRepositoryHealthy && !hasError && (
         <ProvisioningAlert
           error={{
             title: t(
@@ -134,7 +150,7 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
       )}
 
       <Field noMargin>
-        {isRepositoryHealthy === false ? (
+        {hasError || isRepositoryHealthy === false ? (
           <Button variant="destructive" onClick={() => onCancel?.(repoName)} disabled={isCancelling}>
             {isCancelling ? (
               <Trans i18nKey="provisioning.wizard.button-cancelling">Cancelling...</Trans>

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -40,8 +40,8 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
     message: repositoryHealthMessages,
     checked,
   } = repositoryStatusQuery?.data?.status?.health || {};
-  
-  const hasError = repositoryStatusQuery.isError;  
+
+  const hasError = repositoryStatusQuery.isError;
   const isButtonDisabled = hasError || (checked !== undefined && isRepositoryHealthy === false);
 
   const startSynchronization = async () => {
@@ -70,10 +70,7 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
       {hasError && (
         <ProvisioningAlert
           error={{
-            title: t(
-              'provisioning.synchronize-step.repository-error',
-              'Repository error'
-            ),
+            title: t('provisioning.synchronize-step.repository-error', 'Repository error'),
             message: t(
               'provisioning.synchronize-step.repository-error-message',
               'Unable to check repository status. Please verify the repository configuration and try again.'

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -40,7 +40,7 @@ export function SynchronizeStep({ isLegacyStorage, onCancel, isCancelling }: Syn
     message: repositoryHealthMessages,
     checked,
   } = repositoryStatusQuery?.data?.status?.health || {};
-  const isButtonDisabled = repositoryStatusQuery.isFetching || (checked !== undefined && isRepositoryHealthy === false);
+  const isButtonDisabled = checked !== undefined && isRepositoryHealthy === false;
 
   const startSynchronization = async () => {
     const [history] = getValues(['migrate.history']);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11674,6 +11674,8 @@
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"
     },
     "synchronize-step": {
+      "repository-error": "Repository error",
+      "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",
       "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below.",
       "synchronization-description": "Include commits for each historical value",
       "synchronization-options": "Synchronization options"


### PR DESCRIPTION
Editors & admins need to be able to view the status in the creation flow. In the UI, there is a check that prevents synchronizing if the repo is unhealthy.

We also need to prevent in the UI synchronizing repos while the status is being fetched. 

Fixes https://github.com/grafana/git-ui-sync-project/issues/587