### PR TITLE
Transformations: Remove `content.ts` from bundle

### DIFF
--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationEditorHelpDisplay.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationEditorHelpDisplay.tsx
@@ -1,8 +1,7 @@
 import { TransformerRegistryItem } from '@grafana/data';
 import { Drawer } from '@grafana/ui';
 import { OperationRowHelp } from 'app/core/components/QueryOperationRow/OperationRowHelp';
-
-import { getLinkToDocs } from '../../../transformers/docs/content';
+import { FALLBACK_DOCS_LINK } from 'app/features/transformers/docs/constants';
 
 interface TransformationEditorHelpDisplayProps {
   isOpen: boolean;
@@ -20,7 +19,8 @@ export const TransformationEditorHelpDisplay = ({
     help,
   } = transformer;
 
-  const helpContent = help ? help : getLinkToDocs();
+  const helpContent = help ? help : FALLBACK_DOCS_LINK;
+
   const helpElement = (
     <Drawer title={name} subtitle="Transformation help" onClose={() => onCloseClick(false)}>
       <OperationRowHelp markdown={helpContent} styleOverrides={{ borderTop: '2px solid' }} />

--- a/public/app/features/transformers/docs/constants.ts
+++ b/public/app/features/transformers/docs/constants.ts
@@ -1,0 +1,1 @@
+export const FALLBACK_DOCS_LINK = `Go to the <a href="https://grafana.com/docs/grafana/latest/panels/transformations/?utm_source=grafana" target="_blank" rel="noreferrer">transformation documentation</a> for more general documentation.`;

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -1610,14 +1610,6 @@ ${buildImageContent(
   },
 };
 
-export function getLinkToDocs(): string {
-  return `
-  Go to the <a href="https://grafana.com/docs/grafana/latest/panels/transformations/?utm_source=grafana" target="_blank" rel="noreferrer">
-  transformation documentation
-  </a> for more general documentation.
-  `;
-}
-
 function buildImageContent(source: string, imageRenderType: ImageRenderType, imageAltText: string) {
   return imageRenderType === 'shortcodeFigure'
     ? // This will build a Hugo Shortcode "figure" image template, which shares the same default class and max-width.

--- a/public/app/features/transformers/docs/getTransformationContent.ts
+++ b/public/app/features/transformers/docs/getTransformationContent.ts
@@ -2,7 +2,6 @@ import { FALLBACK_DOCS_LINK } from './constants';
 import { transformationDocsContent, ImageRenderType } from './content';
 
 export function getTransformationContent(id: string): { name: string; helperDocs: string } {
-  console.log('getTransformationContent', id);
   if (id in transformationDocsContent) {
     const { name, getHelperDocs, links } = transformationDocsContent[id];
 

--- a/public/app/features/transformers/docs/getTransformationContent.ts
+++ b/public/app/features/transformers/docs/getTransformationContent.ts
@@ -1,6 +1,8 @@
-import { transformationDocsContent, getLinkToDocs, ImageRenderType } from './content';
+import { FALLBACK_DOCS_LINK } from './constants';
+import { transformationDocsContent, ImageRenderType } from './content';
 
 export function getTransformationContent(id: string): { name: string; helperDocs: string } {
+  console.log('getTransformationContent', id);
   if (id in transformationDocsContent) {
     const { name, getHelperDocs, links } = transformationDocsContent[id];
 
@@ -23,7 +25,7 @@ export function getTransformationContent(id: string): { name: string; helperDocs
         name,
         helperDocs: `
         ${cleansedMarkdown}
-        ${getLinkToDocs()}
+        ${FALLBACK_DOCS_LINK}
   ${renderedLinks}
         `,
       };
@@ -34,7 +36,7 @@ export function getTransformationContent(id: string): { name: string; helperDocs
       name,
       helperDocs: `
       ${cleansedMarkdown}
-      ${getLinkToDocs()}
+      ${FALLBACK_DOCS_LINK}
       `,
     };
   }
@@ -42,7 +44,7 @@ export function getTransformationContent(id: string): { name: string; helperDocs
   // If the transformation has no documentation, return an external link to the online documentation.
   return {
     name: 'No documentation found',
-    helperDocs: getLinkToDocs(),
+    helperDocs: FALLBACK_DOCS_LINK,
   };
 }
 


### PR DESCRIPTION
### What does this PR do? 📓 

@leeoniya noticed 70.67KB of docs content being pulled into the transformations bundle. Sizeable and not necessary, so this code change leads to that ~71KB going bye bye. It also just cleans up some stuff and removes the function that caused it.

After running `yarn build:stats`

Before:

<img width="911" height="318" alt="image" src="https://github.com/user-attachments/assets/8ca82f09-29b3-4c05-a49a-b18a8c28bb6f" />

After:

<img width="911" height="269" alt="image" src="https://github.com/user-attachments/assets/53fbe0b5-ef29-429c-b7e6-65fb31dd093f" />