### PR TITLE
datasources: querier: do not check for related toggles

### DIFF
--- a/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
+++ b/packages/grafana-runtime/src/utils/DataSourceWithBackend.ts
@@ -211,23 +211,12 @@ class DataSourceWithBackend<
 
     // Use the new query service for explore
     if (config.featureToggles.queryServiceFromExplore && request.app === CoreApp.Explore) {
-      // make sure query-service is enabled on the backend
-      const isQueryServiceEnabled = config.featureToggles.queryService;
-      const isExperimentalAPIsEnabled = config.featureToggles.grafanaAPIServerWithExperimentalAPIs;
-      if (!isQueryServiceEnabled && !isExperimentalAPIsEnabled) {
-        console.warn('feature toggle queryServiceFromExplore also requires the queryService to be running');
-      } else {
-        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
-      }
+      url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
     }
 
     // Use the new query service
     if (config.featureToggles.queryServiceFromUI) {
-      if (!(config.featureToggles.queryService || config.featureToggles.grafanaAPIServerWithExperimentalAPIs)) {
-        console.warn('feature toggle queryServiceFromUI also requires the queryService to be running');
-      } else {
-        url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
-      }
+      url = `/apis/query.grafana.app/v0alpha1/namespaces/${config.namespace}/query?ds_type=${this.type}`;
     }
 
     if (hasExpr) {


### PR DESCRIPTION
currently, when the `queryServiceFromUI` feature toggle is enabled (meaning: send requests to `/apis/query.grafana.app/.../` ), we also check if other feature toggles are enabled, to make sure there is something listening on `/apis/query.grafana.app`.

but, this complicates certain setups, where we want to send requests to `/apis/query.grafana.app`, even if the single-tenant-query-service is not enabled.

for this reason, we are removing this check. we will have to be careful when enabling this feature toggle.