### PR TITLE
Chore: Adds workflow that triggers plugin schema types update

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1279,6 +1279,7 @@ embed.go @grafana/grafana-as-code
 /.github/license_finder.yaml @bergquist
 /.github/actionlint.yaml @grafana/grafana-developer-enablement-squad
 /.github/workflows/pr-test-docker.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/update-schema-types.yml @grafana/plugins-platform-frontend
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -1,0 +1,22 @@
+name: Update Schema Types
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - docs/sources/developers/plugins/plugin.schema.json
+  workflow_dispatch:
+
+# These permissions are needed to assume roles from Github's OIDC.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  bundle-schema-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: grafana/plugin-actions/bundle-schema-types@main


### PR DESCRIPTION
> [!NOTE]  
> Waiting for https://github.com/grafana/plugin-actions/pull/120 to be merged before opening this for review

**What is this feature?**

This pull request introduces a new GitHub Actions workflow to automate the bundling of schema types whenever the plugin schema file is updated on the `main` branch or when manually triggered. This helps ensure that schema types are kept up to date with changes to the plugin schema.

Automation and CI improvements:

* Added a new workflow file `.github/workflows/update-schema-types.yml` that runs on pushes to `main` affecting `docs/sources/developers/plugins/plugin.schema.json` and on manual dispatch, and executes the `grafana/plugin-actions/bundle-schema-types@main` action to bundle schema types.

**Why do we need this feature?**

So we can keep schema types up to date

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
