### PR TITLE
EchoSrv: Guard backend initialisation with try/catch

### DIFF
--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -12,7 +12,9 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
   options = {};
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction, EchoEventType.ExperimentView];
 
-  constructor() {}
+  constructor() {
+    throw new Error('omg!!!!');
+  }
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {

--- a/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/BrowseConsoleBackend.ts
@@ -12,9 +12,7 @@ export class BrowserConsoleBackend implements EchoBackend<PageviewEchoEvent, unk
   options = {};
   supportedEvents = [EchoEventType.Pageview, EchoEventType.Interaction, EchoEventType.ExperimentView];
 
-  constructor() {
-    throw new Error('omg!!!!');
-  }
+  constructor() {}
 
   addEvent = (e: PageviewEchoEvent) => {
     if (isPageviewEvent(e)) {

--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -1,0 +1,182 @@
+import { config, registerEchoBackend, setEchoSrv } from '@grafana/runtime';
+import { reportMetricPerformanceMark } from 'app/core/utils/metrics';
+
+import { contextSrv } from '../context_srv';
+
+import { Echo } from './Echo';
+
+// Initialise EchoSrv backends, calls during frontend app startup
+export async function initEchoSrv() {
+  setEchoSrv(new Echo({ debug: process.env.NODE_ENV === 'development' }));
+
+  window.addEventListener('load', (e) => {
+    const loadMetricName = 'frontend_boot_load_time_seconds';
+    // Metrics below are marked in public/views/index.html
+    const jsLoadMetricName = 'frontend_boot_js_done_time_seconds';
+    const cssLoadMetricName = 'frontend_boot_css_time_seconds';
+
+    if (performance) {
+      performance.mark(loadMetricName);
+      reportMetricPerformanceMark('first-paint', 'frontend_boot_', '_time_seconds');
+      reportMetricPerformanceMark('first-contentful-paint', 'frontend_boot_', '_time_seconds');
+      reportMetricPerformanceMark(loadMetricName);
+      reportMetricPerformanceMark(jsLoadMetricName);
+      reportMetricPerformanceMark(cssLoadMetricName);
+    }
+  });
+
+  try {
+    await initPerformanceBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv Performance backend', error);
+  }
+
+  try {
+    await initFaroBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv Faro backend', error);
+  }
+
+  try {
+    await initGoogleAnalyticsBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv GoogleAnalytics backend', error);
+  }
+
+  try {
+    await initGoogleAnalaytics4Backend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv GoogleAnalaytics4 backend', error);
+  }
+
+  try {
+    await initRudderstackBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv Rudderstack backend', error);
+  }
+
+  try {
+    await initAzureAppInsightsBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv AzureAppInsights backend', error);
+  }
+
+  try {
+    await initConsoleBackend();
+  } catch (error) {
+    console.error('Error initializing EchoSrv Console backend', error);
+  }
+}
+
+async function initPerformanceBackend() {
+  if (contextSrv.user.orgRole === '') {
+    return;
+  }
+
+  const { PerformanceBackend } = await import('./backends/PerformanceBackend');
+  registerEchoBackend(new PerformanceBackend({}));
+}
+
+async function initFaroBackend() {
+  if (!config.grafanaJavascriptAgent.enabled) {
+    return;
+  }
+
+  // Ignore Rudderstack URLs
+  const rudderstackUrls = [
+    config.rudderstackConfigUrl,
+    config.rudderstackDataPlaneUrl,
+    config.rudderstackIntegrationsUrl,
+  ]
+    .filter(Boolean)
+    .map((url) => new RegExp(`${url}.*.`));
+
+  const { GrafanaJavascriptAgentBackend } = await import(
+    './backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend'
+  );
+
+  registerEchoBackend(
+    new GrafanaJavascriptAgentBackend({
+      ...config.grafanaJavascriptAgent,
+      app: {
+        version: config.buildInfo.version,
+        environment: config.buildInfo.env,
+      },
+      buildInfo: config.buildInfo,
+      user: {
+        id: String(contextSrv.user?.id),
+        email: contextSrv.user?.email,
+      },
+      ignoreUrls: rudderstackUrls,
+    })
+  );
+}
+
+async function initGoogleAnalyticsBackend() {
+  if (!config.googleAnalyticsId) {
+    return;
+  }
+
+  const { GAEchoBackend } = await import('./backends/analytics/GABackend');
+  registerEchoBackend(
+    new GAEchoBackend({
+      googleAnalyticsId: config.googleAnalyticsId,
+    })
+  );
+}
+
+async function initGoogleAnalaytics4Backend() {
+  if (!config.googleAnalytics4Id) {
+    return;
+  }
+
+  const { GA4EchoBackend } = await import('./backends/analytics/GA4Backend');
+  registerEchoBackend(
+    new GA4EchoBackend({
+      googleAnalyticsId: config.googleAnalytics4Id,
+      googleAnalytics4SendManualPageViews: config.googleAnalytics4SendManualPageViews,
+    })
+  );
+}
+
+async function initRudderstackBackend() {
+  if (!(config.rudderstackWriteKey && config.rudderstackDataPlaneUrl)) {
+    return;
+  }
+
+  const { RudderstackBackend } = await import('./backends/analytics/RudderstackBackend');
+  registerEchoBackend(
+    new RudderstackBackend({
+      writeKey: config.rudderstackWriteKey,
+      dataPlaneUrl: config.rudderstackDataPlaneUrl,
+      user: contextSrv.user,
+      sdkUrl: config.rudderstackSdkUrl,
+      configUrl: config.rudderstackConfigUrl,
+      integrationsUrl: config.rudderstackIntegrationsUrl,
+      buildInfo: config.buildInfo,
+    })
+  );
+}
+
+async function initAzureAppInsightsBackend() {
+  if (!config.applicationInsightsConnectionString) {
+    return;
+  }
+
+  const { ApplicationInsightsBackend } = await import('./backends/analytics/ApplicationInsightsBackend');
+  registerEchoBackend(
+    new ApplicationInsightsBackend({
+      connectionString: config.applicationInsightsConnectionString,
+      endpointUrl: config.applicationInsightsEndpointUrl,
+    })
+  );
+}
+
+async function initConsoleBackend() {
+  if (!config.analyticsConsoleReporting) {
+    return;
+  }
+
+  const { BrowserConsoleBackend } = await import('./backends/analytics/BrowseConsoleBackend');
+  registerEchoBackend(new BrowserConsoleBackend());
+}

--- a/public/app/core/utils/metrics.ts
+++ b/public/app/core/utils/metrics.ts
@@ -35,3 +35,15 @@ export function stopMeasure(eventName: string) {
     return;
   }
 }
+
+/**
+ * Report when a metric of a given name was marked during the document lifecycle. Works for markers with no duration,
+ * like PerformanceMark or PerformancePaintTiming (e.g. created with performance.mark, or first-contentful-paint)
+ */
+export function reportMetricPerformanceMark(metricName: string, prefix = '', suffix = ''): void {
+  const metric = performance.getEntriesByName(metricName).at(0);
+  if (metric) {
+    const metricName = metric.name.replace(/-/g, '_');
+    reportPerformance(`${prefix}${metricName}${suffix}`, Math.round(metric.startTime) / 1000);
+  }
+}


### PR DESCRIPTION
- Moves initEchoSrv out into a separate file
- Wrap each backend initialisation in a try/catch to prevent errors from crashing Grafana on startup


<img width="653" height="178" alt="Screenshot 2025-09-25 at 2 08 45 pm" src="https://github.com/user-attachments/assets/ae94857f-219e-4768-810a-3f1df4511618" />
