### PR TITLE
Dashboard: Backend always set `metricEditorMode: 0` regardless `metricQueryType` and `expression`

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v34.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v34.go
@@ -6,62 +6,9 @@ import (
 )
 
 // V34 migrates CloudWatch queries that use multiple statistics into separate queries.
-//
-// This migration addresses CloudWatch queries where a single query uses multiple statistics
-// (e.g., statistics: ['Max', 'Min']). The migration splits these into separate queries,
-// each with a single statistic (e.g., one query with statistic: 'Max', another with statistic: 'Min').
-//
-// The migration works by:
-// 1. Identifying CloudWatch queries in panel targets that have a 'statistics' array
-// 2. Creating separate queries for each statistic in the array
-// 3. Replacing the original 'statistics' array with a single 'statistic' field
-// 4. Generating new refIds for additional queries (B, C, D, etc.)
-// 5. Applying the same logic to CloudWatch annotation queries
-// 6. Adding statistic suffixes to annotation names when multiple annotations are created
-//
-// Panel Query Example - Multiple Statistics:
-//
-// Before migration:
-//
-//	target: {
-//	  refId: "A",
-//	  dimensions: {"InstanceId": "i-123"},
-//	  namespace: "AWS/EC2",
-//	  region: "us-east-1",
-//	  metricName: "CPUUtilization",
-//	  statistics: ["Average", "Maximum", "Minimum"]
-//	}
-//
-// After migration:
-//
-//	targets: [
-//	  { refId: "A", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Average" },
-//	  { refId: "B", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Maximum" },
-//	  { refId: "C", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Minimum" }
-//	]
-//
-// Annotation Query Example - Multiple Statistics:
-// Before migration:
-//
-//	annotation: {
-//	  name: "CloudWatch Alerts",
-//	  dimensions: {"InstanceId": "i-123"},
-//	  namespace: "AWS/EC2",
-//	  region: "us-east-1",
-//	  prefixMatching: false,
-//	  statistics: ["Maximum", "Minimum"]
-//	}
-//
-// After migration:
-//
-//	annotations: [
-//	  { name: "CloudWatch Alerts - Maximum", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", prefixMatching: false, statistic: "Maximum" },
-//	  { name: "CloudWatch Alerts - Minimum", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", prefixMatching: false, statistic: "Minimum" }
-//	]
 func V34(_ context.Context, dashboard map[string]interface{}) error {
 	dashboard["schemaVersion"] = int(34)
 
-	// Migrate panel queries if panels exist and are an array
 	if panelsValue, exists := dashboard["panels"]; exists && IsArray(panelsValue) {
 		panels := panelsValue.([]interface{})
 		for _, panel := range panels {
@@ -72,7 +19,6 @@ func V34(_ context.Context, dashboard map[string]interface{}) error {
 
 			migrateCloudWatchQueriesInPanel(p)
 
-			// Handle nested panels in collapsed rows
 			if !IsArray(p["panels"]) {
 				continue
 			}
@@ -88,7 +34,6 @@ func V34(_ context.Context, dashboard map[string]interface{}) error {
 		}
 	}
 
-	// Always migrate annotation queries regardless of whether panels exist
 	migrateCloudWatchAnnotationQueries(dashboard)
 
 	return nil
@@ -116,60 +61,45 @@ func migrateCloudWatchQueriesInPanel(panel map[string]interface{}) {
 			continue
 		}
 
-		// Add CloudWatch fields if missing (matches frontend migrateCloudWatchQuery logic)
-		// Frontend: if (!query.hasOwnProperty('metricQueryType'))
 		if _, hasMetricQueryType := t["metricQueryType"]; !hasMetricQueryType {
-			t["metricQueryType"] = 0 // MetricQueryType.Search
+			t["metricQueryType"] = 0
 		}
 
-		// Frontend: if (!query.hasOwnProperty('metricEditorMode'))
 		if _, hasMetricEditorMode := t["metricEditorMode"]; !hasMetricEditorMode {
 			metricQueryType := GetIntValue(t, "metricQueryType", 0)
-			if metricQueryType == 1 { // MetricQueryType.Insights
-				t["metricEditorMode"] = 1 // MetricEditorMode.Code
+			if metricQueryType == 1 {
+				t["metricEditorMode"] = 1
 			} else {
-				// Frontend: query.expression ? MetricEditorMode.Code : MetricEditorMode.Builder
 				expression := GetStringValue(t, "expression")
 				if expression != "" {
-					t["metricEditorMode"] = 1 // MetricEditorMode.Code
+					t["metricEditorMode"] = 1
 				} else {
-					t["metricEditorMode"] = 0 // MetricEditorMode.Builder
+					t["metricEditorMode"] = 0
 				}
 			}
 		}
 
-		// Get valid statistics (including null and empty strings)
 		validStats, isEmpty := getValidStatistics(t["statistics"])
 
-		// Handle empty array case (delete statistics field like frontend)
 		if isEmpty {
-			// Delete statistics field to match frontend behavior
 			delete(t, "statistics")
 			newTargets = append(newTargets, t)
 			continue
 		}
 
-		// Remove statistics field for processing
 		delete(t, "statistics")
 
-		// Handle based on number of valid statistics
 		switch len(validStats) {
 		case 0:
-			// No valid statistics - keep query as-is
 			newTargets = append(newTargets, t)
 		case 1:
-			// Single statistic - set statistic field (matches frontend behavior)
-			// Frontend doesn't set statistic property for null values
 			if validStats[0] != nil {
 				t["statistic"] = validStats[0]
 			}
 			newTargets = append(newTargets, t)
 		default:
-			// Multiple statistics - create separate queries
 			for i, stat := range validStats {
 				newQuery := copyMap(t)
-				// Set statistic field (matches frontend behavior)
-				// Frontend doesn't set statistic property for null values
 				if stat != nil {
 					newQuery["statistic"] = stat
 				}
@@ -211,46 +141,33 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 			continue
 		}
 
-		// Get original name for suffix generation
 		originalName := GetStringValue(a, "name")
-
-		// Get valid statistics (including null and empty strings)
 		validStats, isEmpty := getValidStatistics(a["statistics"])
 
-		// Handle empty array case (delete statistics field like frontend)
 		if isEmpty {
-			// Delete statistics field to match frontend behavior
 			delete(a, "statistics")
 			annotationsList[i] = a
 			continue
 		}
 
-		// Handle based on number of valid statistics
 		switch len(validStats) {
 		case 0:
-			// No valid statistics - remove statistics field
 			delete(a, "statistics")
 			annotationsList[i] = a
 		case 1:
-			// Single statistic - set statistic field (matches frontend behavior)
 			delete(a, "statistics")
-			// Frontend doesn't set statistic property for null values
 			if validStats[0] != nil {
 				a["statistic"] = validStats[0]
 			}
 			annotationsList[i] = a
 		default:
-			// Multiple statistics - create separate annotations
 			delete(a, "statistics")
 			for j, stat := range validStats {
 				newAnnotation := copyMap(a)
-				// Set statistic field (matches frontend behavior)
-				// Frontend doesn't set statistic property for null values
 				if stat != nil {
 					newAnnotation["statistic"] = stat
 				}
 
-				// Add suffix to name
 				if originalName != "" {
 					suffix := getSuffixForStat(stat)
 					newAnnotation["name"] = originalName + " - " + suffix
@@ -270,24 +187,19 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 	}
 }
 
-// getValidStatistics extracts valid statistics from the statistics field
 func getValidStatistics(statisticsField interface{}) ([]interface{}, bool) {
 	statistics, ok := statisticsField.([]interface{})
 	if !ok {
 		return nil, false
 	}
 
-	// Special case: empty arrays should be preserved
 	if len(statistics) == 0 {
-		return nil, true // Return nil with true flag to indicate "empty array"
+		return nil, true
 	}
 
-	// Frontend processes ALL values in statistics array, regardless of type
-	// It doesn't filter out invalid types - it processes them as-is
 	return statistics, false
 }
 
-// getSuffixForStat returns the appropriate suffix for annotation names
 func getSuffixForStat(stat interface{}) string {
 	if stat == nil {
 		return "null"
@@ -298,23 +210,21 @@ func getSuffixForStat(stat interface{}) string {
 		}
 		return statString
 	}
-	// For non-string types, convert to string representation like JavaScript does
 	switch v := stat.(type) {
 	case map[string]interface{}:
-		return "[object Object]" // JavaScript behavior for objects
+		return "[object Object]"
 	case []interface{}:
-		return "" // JavaScript behavior for arrays (empty string)
+		return ""
 	case bool:
 		if v {
 			return "true"
 		}
 		return "false"
 	default:
-		return fmt.Sprintf("%v", stat) // Numbers and other types
+		return fmt.Sprintf("%v", stat)
 	}
 }
 
-// copyMap creates a shallow copy of a map
 func copyMap(original map[string]interface{}) map[string]interface{} {
 	copy := make(map[string]interface{})
 	for k, v := range original {
@@ -323,15 +233,7 @@ func copyMap(original map[string]interface{}) map[string]interface{} {
 	return copy
 }
 
-// isString checks if value is a string
-func isString(value interface{}) bool {
-	_, ok := value.(string)
-	return ok
-}
-
-// isCloudWatchQuery checks if a query target is a CloudWatch query.
 func isCloudWatchQuery(target map[string]interface{}) bool {
-	// Check for required CloudWatch query fields
 	_, hasDimensions := target["dimensions"]
 	_, hasNamespace := target["namespace"]
 	_, hasRegion := target["region"]
@@ -340,9 +242,7 @@ func isCloudWatchQuery(target map[string]interface{}) bool {
 	return hasDimensions && hasNamespace && hasRegion && hasMetricName
 }
 
-// isLegacyCloudWatchAnnotationQuery checks if an annotation is a legacy CloudWatch annotation query.
 func isLegacyCloudWatchAnnotationQuery(annotation map[string]interface{}) bool {
-	// Check for required CloudWatch annotation fields
 	_, hasDimensions := annotation["dimensions"]
 	_, hasNamespace := annotation["namespace"]
 	_, hasRegion := annotation["region"]
@@ -352,9 +252,7 @@ func isLegacyCloudWatchAnnotationQuery(annotation map[string]interface{}) bool {
 	return hasDimensions && hasNamespace && hasRegion && hasPrefixMatching && hasStatistics
 }
 
-// generateNextRefId generates a new refId for additional queries created during migration.
 func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
-	// Collect all existing refIds
 	used := make(map[string]bool)
 	for _, target := range allTargets {
 		if t, ok := target.(map[string]interface{}); ok {
@@ -364,7 +262,6 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
-	// Generate next available refId starting from A
 	for c := 'A'; c <= 'Z'; c++ {
 		candidate := string(c)
 		if !used[candidate] {
@@ -372,7 +269,6 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
-	// If all single letters are taken, use double letters
 	for c1 := 'A'; c1 <= 'Z'; c1++ {
 		for c2 := 'A'; c2 <= 'Z'; c2++ {
 			candidate := string(c1) + string(c2)
@@ -382,6 +278,5 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
-	// Fallback (should never happen in practice)
 	return "X" + string(rune('0'+additionalIndex))
 }

--- a/apps/dashboard/pkg/migration/schemaversion/v34.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v34.go
@@ -6,9 +6,62 @@ import (
 )
 
 // V34 migrates CloudWatch queries that use multiple statistics into separate queries.
+//
+// This migration addresses CloudWatch queries where a single query uses multiple statistics
+// (e.g., statistics: ['Max', 'Min']). The migration splits these into separate queries,
+// each with a single statistic (e.g., one query with statistic: 'Max', another with statistic: 'Min').
+//
+// The migration works by:
+// 1. Identifying CloudWatch queries in panel targets that have a 'statistics' array
+// 2. Creating separate queries for each statistic in the array
+// 3. Replacing the original 'statistics' array with a single 'statistic' field
+// 4. Generating new refIds for additional queries (B, C, D, etc.)
+// 5. Applying the same logic to CloudWatch annotation queries
+// 6. Adding statistic suffixes to annotation names when multiple annotations are created
+//
+// Panel Query Example - Multiple Statistics:
+//
+// Before migration:
+//
+//	target: {
+//	  refId: "A",
+//	  dimensions: {"InstanceId": "i-123"},
+//	  namespace: "AWS/EC2",
+//	  region: "us-east-1",
+//	  metricName: "CPUUtilization",
+//	  statistics: ["Average", "Maximum", "Minimum"]
+//	}
+//
+// After migration:
+//
+//	targets: [
+//	  { refId: "A", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Average" },
+//	  { refId: "B", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Maximum" },
+//	  { refId: "C", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", metricName: "CPUUtilization", statistic: "Minimum" }
+//	]
+//
+// Annotation Query Example - Multiple Statistics:
+// Before migration:
+//
+//	annotation: {
+//	  name: "CloudWatch Alerts",
+//	  dimensions: {"InstanceId": "i-123"},
+//	  namespace: "AWS/EC2",
+//	  region: "us-east-1",
+//	  prefixMatching: false,
+//	  statistics: ["Maximum", "Minimum"]
+//	}
+//
+// After migration:
+//
+//	annotations: [
+//	  { name: "CloudWatch Alerts - Maximum", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", prefixMatching: false, statistic: "Maximum" },
+//	  { name: "CloudWatch Alerts - Minimum", dimensions: {"InstanceId": "i-123"}, namespace: "AWS/EC2", region: "us-east-1", prefixMatching: false, statistic: "Minimum" }
+//	]
 func V34(_ context.Context, dashboard map[string]interface{}) error {
 	dashboard["schemaVersion"] = int(34)
 
+	// Migrate panel queries if panels exist and are an array
 	if panelsValue, exists := dashboard["panels"]; exists && IsArray(panelsValue) {
 		panels := panelsValue.([]interface{})
 		for _, panel := range panels {
@@ -19,6 +72,7 @@ func V34(_ context.Context, dashboard map[string]interface{}) error {
 
 			migrateCloudWatchQueriesInPanel(p)
 
+			// Handle nested panels in collapsed rows
 			if !IsArray(p["panels"]) {
 				continue
 			}
@@ -34,6 +88,7 @@ func V34(_ context.Context, dashboard map[string]interface{}) error {
 		}
 	}
 
+	// Always migrate annotation queries regardless of whether panels exist
 	migrateCloudWatchAnnotationQueries(dashboard)
 
 	return nil
@@ -61,45 +116,57 @@ func migrateCloudWatchQueriesInPanel(panel map[string]interface{}) {
 			continue
 		}
 
+		// Add CloudWatch fields if missing (matches frontend migrateCloudWatchQuery logic)
 		if _, hasMetricQueryType := t["metricQueryType"]; !hasMetricQueryType {
-			t["metricQueryType"] = 0
+			t["metricQueryType"] = 0 // MetricQueryType.Search
 		}
 
 		if _, hasMetricEditorMode := t["metricEditorMode"]; !hasMetricEditorMode {
 			metricQueryType := GetIntValue(t, "metricQueryType", 0)
-			if metricQueryType == 1 {
-				t["metricEditorMode"] = 1
+			if metricQueryType == 1 { // MetricQueryType.Insights
+				t["metricEditorMode"] = 1 // MetricEditorMode.Code
 			} else {
 				expression := GetStringValue(t, "expression")
 				if expression != "" {
-					t["metricEditorMode"] = 1
+					t["metricEditorMode"] = 1 // MetricEditorMode.Code
 				} else {
-					t["metricEditorMode"] = 0
+					t["metricEditorMode"] = 0 // MetricEditorMode.Builder
 				}
 			}
 		}
 
+		// Get valid statistics (including null and empty strings)
 		validStats, isEmpty := getValidStatistics(t["statistics"])
 
+		// Handle empty array case (delete statistics field like frontend)
 		if isEmpty {
+			// Delete statistics field to match frontend behavior
 			delete(t, "statistics")
 			newTargets = append(newTargets, t)
 			continue
 		}
 
+		// Remove statistics field for processing
 		delete(t, "statistics")
 
+		// Handle based on number of valid statistics
 		switch len(validStats) {
 		case 0:
+			// No valid statistics - keep query as-is
 			newTargets = append(newTargets, t)
 		case 1:
+			// Single statistic - set statistic field
+			// Frontend doesn't set statistic property for null values
 			if validStats[0] != nil {
 				t["statistic"] = validStats[0]
 			}
 			newTargets = append(newTargets, t)
 		default:
+			// Multiple statistics - create separate queries
 			for i, stat := range validStats {
 				newQuery := copyMap(t)
+				// Set statistic field
+				// Frontend doesn't set statistic property for null values
 				if stat != nil {
 					newQuery["statistic"] = stat
 				}
@@ -141,33 +208,46 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 			continue
 		}
 
+		// Get original name for suffix generation
 		originalName := GetStringValue(a, "name")
+
+		// Get valid statistics (including null and empty strings)
 		validStats, isEmpty := getValidStatistics(a["statistics"])
 
+		// Handle empty array case (delete statistics field like frontend)
 		if isEmpty {
+			// Delete statistics field to match frontend behavior
 			delete(a, "statistics")
 			annotationsList[i] = a
 			continue
 		}
 
+		// Handle based on number of valid statistics
 		switch len(validStats) {
 		case 0:
+			// No valid statistics - remove statistics field
 			delete(a, "statistics")
 			annotationsList[i] = a
 		case 1:
+			// Single statistic - set statistic field (matches frontend behavior)
 			delete(a, "statistics")
+			// Frontend doesn't set statistic property for null values
 			if validStats[0] != nil {
 				a["statistic"] = validStats[0]
 			}
 			annotationsList[i] = a
 		default:
+			// Multiple statistics - create separate annotations
 			delete(a, "statistics")
 			for j, stat := range validStats {
 				newAnnotation := copyMap(a)
+				// Set statistic field (matches frontend behavior)
+				// Frontend doesn't set statistic property for null values
 				if stat != nil {
 					newAnnotation["statistic"] = stat
 				}
 
+				// Add suffix to name
 				if originalName != "" {
 					suffix := getSuffixForStat(stat)
 					newAnnotation["name"] = originalName + " - " + suffix
@@ -187,19 +267,24 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 	}
 }
 
+// getValidStatistics extracts valid statistics from the statistics field
 func getValidStatistics(statisticsField interface{}) ([]interface{}, bool) {
 	statistics, ok := statisticsField.([]interface{})
 	if !ok {
 		return nil, false
 	}
 
+	// Special case: empty arrays should be preserved
 	if len(statistics) == 0 {
-		return nil, true
+		return nil, true // Return nil with true flag to indicate "empty array"
 	}
 
+	// Frontend processes ALL values in statistics array, regardless of type
+	// It doesn't filter out invalid types - it processes them as-is
 	return statistics, false
 }
 
+// getSuffixForStat returns the appropriate suffix for annotation names
 func getSuffixForStat(stat interface{}) string {
 	if stat == nil {
 		return "null"
@@ -210,21 +295,23 @@ func getSuffixForStat(stat interface{}) string {
 		}
 		return statString
 	}
+	// For non-string types, convert to string representation like JavaScript does
 	switch v := stat.(type) {
 	case map[string]interface{}:
-		return "[object Object]"
+		return "[object Object]" // JavaScript behavior for objects
 	case []interface{}:
-		return ""
+		return "" // JavaScript behavior for arrays (empty string)
 	case bool:
 		if v {
 			return "true"
 		}
 		return "false"
 	default:
-		return fmt.Sprintf("%v", stat)
+		return fmt.Sprintf("%v", stat) // Numbers and other types
 	}
 }
 
+// copyMap creates a shallow copy of a map
 func copyMap(original map[string]interface{}) map[string]interface{} {
 	copy := make(map[string]interface{})
 	for k, v := range original {
@@ -233,7 +320,9 @@ func copyMap(original map[string]interface{}) map[string]interface{} {
 	return copy
 }
 
+// isCloudWatchQuery checks if a query target is a CloudWatch query.
 func isCloudWatchQuery(target map[string]interface{}) bool {
+	// Check for required CloudWatch query fields
 	_, hasDimensions := target["dimensions"]
 	_, hasNamespace := target["namespace"]
 	_, hasRegion := target["region"]
@@ -242,7 +331,9 @@ func isCloudWatchQuery(target map[string]interface{}) bool {
 	return hasDimensions && hasNamespace && hasRegion && hasMetricName
 }
 
+// isLegacyCloudWatchAnnotationQuery checks if an annotation is a legacy CloudWatch annotation query.
 func isLegacyCloudWatchAnnotationQuery(annotation map[string]interface{}) bool {
+	// Check for required CloudWatch annotation fields
 	_, hasDimensions := annotation["dimensions"]
 	_, hasNamespace := annotation["namespace"]
 	_, hasRegion := annotation["region"]
@@ -252,7 +343,9 @@ func isLegacyCloudWatchAnnotationQuery(annotation map[string]interface{}) bool {
 	return hasDimensions && hasNamespace && hasRegion && hasPrefixMatching && hasStatistics
 }
 
+// generateNextRefId generates a new refId for additional queries created during migration.
 func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
+	// Collect all existing refIds
 	used := make(map[string]bool)
 	for _, target := range allTargets {
 		if t, ok := target.(map[string]interface{}); ok {
@@ -262,6 +355,7 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
+	// Generate next available refId starting from A
 	for c := 'A'; c <= 'Z'; c++ {
 		candidate := string(c)
 		if !used[candidate] {
@@ -269,6 +363,7 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
+	// If all single letters are taken, use double letters
 	for c1 := 'A'; c1 <= 'Z'; c1++ {
 		for c2 := 'A'; c2 <= 'Z'; c2++ {
 			candidate := string(c1) + string(c2)
@@ -278,5 +373,6 @@ func generateNextRefId(allTargets []interface{}, additionalIndex int) string {
 		}
 	}
 
+	// Fallback (should never happen in practice)
 	return "X" + string(rune('0'+additionalIndex))
 }

--- a/apps/dashboard/pkg/migration/schemaversion/v34.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v34.go
@@ -1,6 +1,9 @@
 package schemaversion
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 // V34 migrates CloudWatch queries that use multiple statistics into separate queries.
 //
@@ -113,9 +116,27 @@ func migrateCloudWatchQueriesInPanel(panel map[string]interface{}) {
 			continue
 		}
 
-		// Add CloudWatch fields if missing (set to 0 if not present)
-		t["metricEditorMode"] = GetIntValue(t, "metricEditorMode", 0)
-		t["metricQueryType"] = GetIntValue(t, "metricQueryType", 0)
+		// Add CloudWatch fields if missing (matches frontend migrateCloudWatchQuery logic)
+		// Frontend: if (!query.hasOwnProperty('metricQueryType'))
+		if _, hasMetricQueryType := t["metricQueryType"]; !hasMetricQueryType {
+			t["metricQueryType"] = 0 // MetricQueryType.Search
+		}
+
+		// Frontend: if (!query.hasOwnProperty('metricEditorMode'))
+		if _, hasMetricEditorMode := t["metricEditorMode"]; !hasMetricEditorMode {
+			metricQueryType := GetIntValue(t, "metricQueryType", 0)
+			if metricQueryType == 1 { // MetricQueryType.Insights
+				t["metricEditorMode"] = 1 // MetricEditorMode.Code
+			} else {
+				// Frontend: query.expression ? MetricEditorMode.Code : MetricEditorMode.Builder
+				expression := GetStringValue(t, "expression")
+				if expression != "" {
+					t["metricEditorMode"] = 1 // MetricEditorMode.Code
+				} else {
+					t["metricEditorMode"] = 0 // MetricEditorMode.Builder
+				}
+			}
+		}
 
 		// Get valid statistics (including null and empty strings)
 		validStats, isEmpty := getValidStatistics(t["statistics"])
@@ -137,19 +158,20 @@ func migrateCloudWatchQueriesInPanel(panel map[string]interface{}) {
 			// No valid statistics - keep query as-is
 			newTargets = append(newTargets, t)
 		case 1:
-			// Single statistic - set statistic field if not null
-			if statString := GetStringValue(map[string]interface{}{"stat": validStats[0]}, "stat"); statString != "" {
-				t["statistic"] = statString
+			// Single statistic - set statistic field (matches frontend behavior)
+			// Frontend doesn't set statistic property for null values
+			if validStats[0] != nil {
+				t["statistic"] = validStats[0]
 			}
 			newTargets = append(newTargets, t)
 		default:
 			// Multiple statistics - create separate queries
 			for i, stat := range validStats {
 				newQuery := copyMap(t)
+				// Set statistic field (matches frontend behavior)
+				// Frontend doesn't set statistic property for null values
 				if stat != nil {
-					if statString, ok := stat.(string); ok {
-						newQuery["statistic"] = statString
-					}
+					newQuery["statistic"] = stat
 				}
 
 				if i == 0 {
@@ -210,10 +232,11 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 			delete(a, "statistics")
 			annotationsList[i] = a
 		case 1:
-			// Single statistic - set statistic field if not null
+			// Single statistic - set statistic field (matches frontend behavior)
 			delete(a, "statistics")
-			if statString := GetStringValue(map[string]interface{}{"stat": validStats[0]}, "stat"); statString != "" {
-				a["statistic"] = statString
+			// Frontend doesn't set statistic property for null values
+			if validStats[0] != nil {
+				a["statistic"] = validStats[0]
 			}
 			annotationsList[i] = a
 		default:
@@ -221,11 +244,10 @@ func migrateCloudWatchAnnotationQueries(dashboard map[string]interface{}) {
 			delete(a, "statistics")
 			for j, stat := range validStats {
 				newAnnotation := copyMap(a)
-
+				// Set statistic field (matches frontend behavior)
+				// Frontend doesn't set statistic property for null values
 				if stat != nil {
-					if statString, ok := stat.(string); ok {
-						newAnnotation["statistic"] = statString
-					}
+					newAnnotation["statistic"] = stat
 				}
 
 				// Add suffix to name
@@ -260,14 +282,9 @@ func getValidStatistics(statisticsField interface{}) ([]interface{}, bool) {
 		return nil, true // Return nil with true flag to indicate "empty array"
 	}
 
-	var valid []interface{}
-	for _, stat := range statistics {
-		// Include null and strings (including empty strings)
-		if stat == nil || isString(stat) {
-			valid = append(valid, stat)
-		}
-	}
-	return valid, false
+	// Frontend processes ALL values in statistics array, regardless of type
+	// It doesn't filter out invalid types - it processes them as-is
+	return statistics, false
 }
 
 // getSuffixForStat returns the appropriate suffix for annotation names
@@ -281,7 +298,20 @@ func getSuffixForStat(stat interface{}) string {
 		}
 		return statString
 	}
-	return ""
+	// For non-string types, convert to string representation like JavaScript does
+	switch v := stat.(type) {
+	case map[string]interface{}:
+		return "[object Object]" // JavaScript behavior for objects
+	case []interface{}:
+		return "" // JavaScript behavior for arrays (empty string)
+	case bool:
+		if v {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", stat) // Numbers and other types
+	}
 }
 
 // copyMap creates a shallow copy of a map

--- a/apps/dashboard/pkg/migration/schemaversion/v34_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v34_test.go
@@ -185,7 +185,7 @@ func TestV34(t *testing.T) {
 			},
 		},
 		{
-			name: "handles invalid statistics in CloudWatch annotation queries",
+			name: "handles annotation with empty statistics array",
 			input: map[string]interface{}{
 				"annotations": map[string]interface{}{
 					"list": []interface{}{
@@ -195,7 +195,102 @@ func TestV34(t *testing.T) {
 							"namespace":      "AWS/EC2",
 							"region":         "us-east-1",
 							"prefixMatching": false,
-							"statistics":     []interface{}{123, "Sum", nil},
+							"statistics":     []interface{}{},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles annotation with single statistic",
+			input: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistics":     []interface{}{"Average"},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistic":      "Average",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles annotation with null statistic",
+			input: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistics":     []interface{}{nil},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							// No statistic property for null
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles annotation with all suffix types (for getSuffixForStat coverage)",
+			input: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistics":     []interface{}{123, true, false, map[string]interface{}{}, []interface{}{}, "", "Average"},
 						},
 					},
 				},
@@ -213,19 +308,52 @@ func TestV34(t *testing.T) {
 							"statistic":      123,
 						},
 						map[string]interface{}{
-							"name":           "CloudWatch Annotation - Sum",
+							"name":           "CloudWatch Annotation - true",
 							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
 							"namespace":      "AWS/EC2",
 							"region":         "us-east-1",
 							"prefixMatching": false,
-							"statistic":      "Sum",
+							"statistic":      true,
 						},
 						map[string]interface{}{
-							"name":           "CloudWatch Annotation - null",
+							"name":           "CloudWatch Annotation - false",
 							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
 							"namespace":      "AWS/EC2",
 							"region":         "us-east-1",
 							"prefixMatching": false,
+							"statistic":      false,
+						},
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation - [object Object]",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistic":      map[string]interface{}{},
+						},
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation - ",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistic":      []interface{}{},
+						},
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation - ",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistic":      "",
+						},
+						map[string]interface{}{
+							"name":           "CloudWatch Annotation - Average",
+							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
+							"namespace":      "AWS/EC2",
+							"region":         "us-east-1",
+							"prefixMatching": false,
+							"statistic":      "Average",
 						},
 					},
 				},
@@ -611,6 +739,88 @@ func TestV34(t *testing.T) {
 			},
 		},
 		{
+			name: "preserves existing metricQueryType (hasOwnProperty test)",
+			input: map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{
+								"refId":           "A",
+								"dimensions":      map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":       "AWS/EC2",
+								"region":          "us-east-1",
+								"metricName":      "CPUUtilization",
+								"metricQueryType": 1, // Already exists - should be preserved
+								"statistics":      []interface{}{"Average"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{
+								"refId":            "A",
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"metricQueryType":  1, // Preserved
+								"metricEditorMode": 1, // Set to Code due to Insights
+								"statistic":        "Average",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "preserves existing metricEditorMode (hasOwnProperty test)",
+			input: map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{
+								"refId":            "A",
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"metricEditorMode": 1, // Already exists - should be preserved
+								"statistics":       []interface{}{"Average"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{
+								"refId":            "A",
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"metricEditorMode": 1, // Preserved
+								"metricQueryType":  0, // Set to default
+								"statistic":        "Average",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name: "preserves existing metricEditorMode and metricQueryType values",
 			input: map[string]interface{}{
 				"panels": []interface{}{
@@ -664,6 +874,174 @@ func TestV34(t *testing.T) {
 								"metricQueryType":  1,
 							},
 						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles refId generation with existing refIds",
+			input: map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{"refId": "A", "expr": "prometheus"},
+							map[string]interface{}{"refId": "C", "expr": "prometheus"}, // Skip B to test gap filling
+							map[string]interface{}{
+								"refId":      "D",
+								"dimensions": map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":  "AWS/EC2",
+								"region":     "us-east-1",
+								"metricName": "CPUUtilization",
+								"statistics": []interface{}{"Average", "Maximum"},
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": []interface{}{
+							map[string]interface{}{"refId": "A", "expr": "prometheus"},
+							map[string]interface{}{"refId": "C", "expr": "prometheus"},
+							map[string]interface{}{
+								"refId":            "D",
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"statistic":        "Average",
+								"metricEditorMode": 0,
+								"metricQueryType":  0,
+							},
+							map[string]interface{}{
+								"refId":            "B", // Should use the available B
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"statistic":        "Maximum",
+								"metricEditorMode": 0,
+								"metricQueryType":  0,
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles non-CloudWatch annotation (skips migration)",
+			input: map[string]interface{}{
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":       "Regular Annotation",
+							"datasource": "prometheus",
+						},
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"annotations": map[string]interface{}{
+					"list": []interface{}{
+						map[string]interface{}{
+							"name":       "Regular Annotation",
+							"datasource": "prometheus",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "handles missing annotations list",
+			input: map[string]interface{}{
+				"annotations": map[string]interface{}{},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"annotations":   map[string]interface{}{},
+			},
+		},
+		{
+			name: "handles missing annotations entirely",
+			input: map[string]interface{}{
+				"panels": []interface{}{},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"panels":        []interface{}{},
+			},
+		},
+		{
+			name: "tests generateNextRefId double letter generation",
+			input: map[string]interface{}{
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": func() []interface{} {
+							targets := []interface{}{}
+							// Create A-Z refIds
+							for c := 'A'; c <= 'Z'; c++ {
+								targets = append(targets, map[string]interface{}{
+									"refId": string(c),
+									"expr":  "prometheus",
+								})
+							}
+							// Add CloudWatch query that will need double letter refId
+							targets = append(targets, map[string]interface{}{
+								"refId":      "AA",
+								"dimensions": map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":  "AWS/EC2",
+								"region":     "us-east-1",
+								"metricName": "CPUUtilization",
+								"statistics": []interface{}{"Average", "Maximum"},
+							})
+							return targets
+						}(),
+					},
+				},
+			},
+			expected: map[string]interface{}{
+				"schemaVersion": int(34),
+				"panels": []interface{}{
+					map[string]interface{}{
+						"id": 1,
+						"targets": func() []interface{} {
+							targets := []interface{}{}
+							// Create A-Z refIds
+							for c := 'A'; c <= 'Z'; c++ {
+								targets = append(targets, map[string]interface{}{
+									"refId": string(c),
+									"expr":  "prometheus",
+								})
+							}
+							// Add the migrated CloudWatch queries
+							targets = append(targets, map[string]interface{}{
+								"refId":            "AA",
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"statistic":        "Average",
+								"metricEditorMode": 0,
+								"metricQueryType":  0,
+							})
+							targets = append(targets, map[string]interface{}{
+								"refId":            "AB", // Next available double letter
+								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
+								"namespace":        "AWS/EC2",
+								"region":           "us-east-1",
+								"metricName":       "CPUUtilization",
+								"statistic":        "Maximum",
+								"metricEditorMode": 0,
+								"metricQueryType":  0,
+							})
+							return targets
+						}(),
 					},
 				},
 			},

--- a/apps/dashboard/pkg/migration/schemaversion/v34_test.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v34_test.go
@@ -205,44 +205,13 @@ func TestV34(t *testing.T) {
 				"annotations": map[string]interface{}{
 					"list": []interface{}{
 						map[string]interface{}{
-							"name":           "CloudWatch Annotation - Sum",
+							"name":           "CloudWatch Annotation - 123",
 							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
 							"namespace":      "AWS/EC2",
 							"region":         "us-east-1",
 							"prefixMatching": false,
-							"statistic":      "Sum",
+							"statistic":      123,
 						},
-						map[string]interface{}{
-							"name":           "CloudWatch Annotation - null",
-							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
-							"namespace":      "AWS/EC2",
-							"region":         "us-east-1",
-							"prefixMatching": false,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "handles multiple valid statistics mixed with invalid ones in annotation",
-			input: map[string]interface{}{
-				"annotations": map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
-							"name":           "CloudWatch Annotation",
-							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
-							"namespace":      "AWS/EC2",
-							"region":         "us-east-1",
-							"prefixMatching": false,
-							"statistics":     []interface{}{123, "Sum", nil, "Average"},
-						},
-					},
-				},
-			},
-			expected: map[string]interface{}{
-				"schemaVersion": int(34),
-				"annotations": map[string]interface{}{
-					"list": []interface{}{
 						map[string]interface{}{
 							"name":           "CloudWatch Annotation - Sum",
 							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
@@ -253,45 +222,6 @@ func TestV34(t *testing.T) {
 						},
 						map[string]interface{}{
 							"name":           "CloudWatch Annotation - null",
-							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
-							"namespace":      "AWS/EC2",
-							"region":         "us-east-1",
-							"prefixMatching": false,
-						},
-						map[string]interface{}{
-							"name":           "CloudWatch Annotation - Average",
-							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
-							"namespace":      "AWS/EC2",
-							"region":         "us-east-1",
-							"prefixMatching": false,
-							"statistic":      "Average",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "handles CloudWatch annotation with all invalid statistics",
-			input: map[string]interface{}{
-				"annotations": map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
-							"name":           "CloudWatch Annotation",
-							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
-							"namespace":      "AWS/EC2",
-							"region":         "us-east-1",
-							"prefixMatching": false,
-							"statistics":     []interface{}{123, nil, map[string]interface{}{"invalid": "value"}},
-						},
-					},
-				},
-			},
-			expected: map[string]interface{}{
-				"schemaVersion": int(34),
-				"annotations": map[string]interface{}{
-					"list": []interface{}{
-						map[string]interface{}{
-							"name":           "CloudWatch Annotation",
 							"dimensions":     map[string]interface{}{"InstanceId": "i-123"},
 							"namespace":      "AWS/EC2",
 							"region":         "us-east-1",
@@ -443,94 +373,6 @@ func TestV34(t *testing.T) {
 								"region":     "us-east-1",
 								"metricName": "CPUUtilization",
 								"statistics": []interface{}{},
-							},
-						},
-					},
-				},
-			},
-			expected: map[string]interface{}{
-				"schemaVersion": int(34),
-				"panels": []interface{}{
-					map[string]interface{}{
-						"id": 1,
-						"targets": []interface{}{
-							map[string]interface{}{
-								"refId":            "A",
-								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
-								"namespace":        "AWS/EC2",
-								"region":           "us-east-1",
-								"metricName":       "CPUUtilization",
-								"metricEditorMode": 0,
-								"metricQueryType":  0,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "handles invalid statistics values gracefully",
-			input: map[string]interface{}{
-				"panels": []interface{}{
-					map[string]interface{}{
-						"id": 1,
-						"targets": []interface{}{
-							map[string]interface{}{
-								"refId":      "A",
-								"dimensions": map[string]interface{}{"InstanceId": "i-123"},
-								"namespace":  "AWS/EC2",
-								"region":     "us-east-1",
-								"metricName": "CPUUtilization",
-								"statistics": []interface{}{123, nil, "Average", map[string]interface{}{"invalid": "value"}},
-							},
-						},
-					},
-				},
-			},
-			expected: map[string]interface{}{
-				"schemaVersion": int(34),
-				"panels": []interface{}{
-					map[string]interface{}{
-						"id": 1,
-						"targets": []interface{}{
-							map[string]interface{}{
-								"refId":            "A",
-								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
-								"namespace":        "AWS/EC2",
-								"region":           "us-east-1",
-								"metricName":       "CPUUtilization",
-								"metricEditorMode": 0,
-								"metricQueryType":  0,
-							},
-							map[string]interface{}{
-								"refId":            "B",
-								"dimensions":       map[string]interface{}{"InstanceId": "i-123"},
-								"namespace":        "AWS/EC2",
-								"region":           "us-east-1",
-								"metricName":       "CPUUtilization",
-								"statistic":        "Average",
-								"metricEditorMode": 0,
-								"metricQueryType":  0,
-							},
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "handles CloudWatch query with all invalid statistics",
-			input: map[string]interface{}{
-				"panels": []interface{}{
-					map[string]interface{}{
-						"id": 1,
-						"targets": []interface{}{
-							map[string]interface{}{
-								"refId":      "A",
-								"dimensions": map[string]interface{}{"InstanceId": "i-123"},
-								"namespace":  "AWS/EC2",
-								"region":     "us-east-1",
-								"metricName": "CPUUtilization",
-								"statistics": []interface{}{123, nil, map[string]interface{}{"invalid": "value"}},
 							},
 						},
 					},

--- a/apps/dashboard/pkg/migration/testdata/input/v34.multiple_stats_cloudwatch.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v34.multiple_stats_cloudwatch.json
@@ -72,6 +72,40 @@
         "statistics": ["InvalidStat", "Sum", null, "Average"]
       },
       {
+        "name": "CloudWatch Annotation with Null in Statistics",
+        "enable": true,
+        "iconColor": "orange",
+        "datasource": {
+          "uid": "default-ds-uid",
+          "type": "prometheus",
+          "apiVersion": "v1"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "namespace": "AWS/EC2",
+        "region": "us-east-1",
+        "prefixMatching": false,
+        "statistics": [null, "Average", ""]
+      },
+      {
+        "name": "CloudWatch Annotation Only Invalid Statistics",
+        "enable": true,
+        "iconColor": "pink",
+        "datasource": {
+          "uid": "default-ds-uid",
+          "type": "prometheus",
+          "apiVersion": "v1"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "namespace": "AWS/EC2",
+        "region": "us-east-1",
+        "prefixMatching": false,
+        "statistics": [123, true, {}]
+      },
+      {
         "name": "Non-CloudWatch Annotation",
         "enable": true,
         "iconColor": "purple",
@@ -347,6 +381,143 @@
     },
     {
       "id": 10,
+      "type": "timeseries",
+      "title": "CloudWatch Query Missing Editor Fields",
+      "datasource": {
+        "uid": "default-ds-uid",
+        "type": "prometheus",
+        "apiVersion": "v1"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "default-ds-uid",
+            "type": "prometheus",
+            "apiVersion": "v1"
+          },
+          "dimensions": {
+            "InstanceId": "i-missing-fields"
+          },
+          "namespace": "AWS/EC2",
+          "region": "us-east-1",
+          "metricName": "CPUUtilization",
+          "statistics": ["Average"]
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "CloudWatch Query with Expression (Code Mode)",
+      "datasource": {
+        "uid": "default-ds-uid",
+        "type": "prometheus",
+        "apiVersion": "v1"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "default-ds-uid",
+            "type": "prometheus",
+            "apiVersion": "v1"
+          },
+          "dimensions": {
+            "InstanceId": "i-with-expression"
+          },
+          "namespace": "AWS/EC2",
+          "region": "us-east-1",
+          "metricName": "CPUUtilization",
+          "expression": "SEARCH('{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"', 'Average', 300)",
+          "statistics": ["Average", "Maximum"]
+        }
+      ]
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "CloudWatch Insights Query Missing Editor Mode",
+      "datasource": {
+        "uid": "default-ds-uid",
+        "type": "prometheus",
+        "apiVersion": "v1"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "default-ds-uid",
+            "type": "prometheus",
+            "apiVersion": "v1"
+          },
+          "dimensions": {
+            "InstanceId": "i-insights"
+          },
+          "namespace": "AWS/EC2",
+          "region": "us-east-1",
+          "metricName": "CPUUtilization",
+          "metricQueryType": 1,
+          "statistics": ["Average"]
+        }
+      ]
+    },
+    {
+      "id": 13,
+      "type": "timeseries",
+      "title": "CloudWatch Query with Null Statistics",
+      "datasource": {
+        "uid": "default-ds-uid",
+        "type": "prometheus",
+        "apiVersion": "v1"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "default-ds-uid",
+            "type": "prometheus",
+            "apiVersion": "v1"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "namespace": "AWS/EC2",
+          "region": "us-east-1",
+          "metricName": "CPUUtilization",
+          "statistics": [null, "Average", "", "Maximum"]
+        }
+      ]
+    },
+    {
+      "id": 14,
+      "type": "timeseries",
+      "title": "CloudWatch Query with Only Invalid Statistics",
+      "datasource": {
+        "uid": "default-ds-uid",
+        "type": "prometheus",
+        "apiVersion": "v1"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "uid": "default-ds-uid",
+            "type": "prometheus",
+            "apiVersion": "v1"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "namespace": "AWS/EC2",
+          "region": "us-east-1",
+          "metricName": "CPUUtilization",
+          "statistics": [123, true, {}, []]
+        }
+      ]
+    },
+    {
+      "id": 15,
       "type": "timeseries",
       "title": "Non-CloudWatch Panel",
       "datasource": {

--- a/apps/dashboard/pkg/migration/testdata/output/latest_version/v34.multiple_stats_cloudwatch.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/output/latest_version/v34.multiple_stats_cloudwatch.v42.json
@@ -82,6 +82,39 @@
       },
       {
         "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - null",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - 123",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": 123
+      },
+      {
+        "datasource": {
           "uid": "prometheus"
         },
         "enable": true,
@@ -171,6 +204,74 @@
         "prefixMatching": false,
         "region": "us-east-1",
         "statistic": "Average"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - Average",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": "Average"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - ",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": ""
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - true",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": true
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - [object Object]",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": {}
       }
     ]
   },
@@ -631,9 +732,274 @@
     },
     {
       "datasource": {
-        "uid": "prometheus"
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
       },
       "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-missing-fields"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        }
+      ],
+      "title": "CloudWatch Query Missing Editor Fields",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-with-expression"
+          },
+          "expression": "SEARCH('{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"', 'Average', 300)",
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-with-expression"
+          },
+          "expression": "SEARCH('{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"', 'Average', 300)",
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": "Maximum"
+        }
+      ],
+      "title": "CloudWatch Query with Expression (Code Mode)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-insights"
+          },
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 1,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        }
+      ],
+      "title": "CloudWatch Insights Query Missing Editor Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "C",
+          "region": "us-east-1",
+          "statistic": ""
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "D",
+          "region": "us-east-1",
+          "statistic": "Maximum"
+        }
+      ],
+      "title": "CloudWatch Query with Null Statistics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 14,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": 123
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": true
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "C",
+          "region": "us-east-1",
+          "statistic": {}
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "D",
+          "region": "us-east-1",
+          "statistic": []
+        }
+      ],
+      "title": "CloudWatch Query with Only Invalid Statistics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "id": 15,
       "targets": [
         {
           "datasource": {

--- a/apps/dashboard/pkg/migration/testdata/output/single_version/v34.multiple_stats_cloudwatch.v34.json
+++ b/apps/dashboard/pkg/migration/testdata/output/single_version/v34.multiple_stats_cloudwatch.v34.json
@@ -82,6 +82,39 @@
       },
       {
         "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - null",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - 123",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": 123
+      },
+      {
+        "datasource": {
           "uid": "prometheus"
         },
         "enable": true,
@@ -171,6 +204,74 @@
         "prefixMatching": false,
         "region": "us-east-1",
         "statistic": "Average"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - Average",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": "Average"
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-null-annotation"
+        },
+        "enable": true,
+        "iconColor": "orange",
+        "name": "CloudWatch Annotation with Null in Statistics - ",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": ""
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - true",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": true
+      },
+      {
+        "datasource": {
+          "apiVersion": "v1",
+          "type": "prometheus",
+          "uid": "default-ds-uid"
+        },
+        "dimensions": {
+          "InstanceId": "i-invalid-annotation"
+        },
+        "enable": true,
+        "iconColor": "pink",
+        "name": "CloudWatch Annotation Only Invalid Statistics - [object Object]",
+        "namespace": "AWS/EC2",
+        "prefixMatching": false,
+        "region": "us-east-1",
+        "statistic": {}
       }
     ]
   },
@@ -631,9 +732,274 @@
     },
     {
       "datasource": {
-        "uid": "prometheus"
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
       },
       "id": 10,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-missing-fields"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        }
+      ],
+      "title": "CloudWatch Query Missing Editor Fields",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 11,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-with-expression"
+          },
+          "expression": "SEARCH('{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"', 'Average', 300)",
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-with-expression"
+          },
+          "expression": "SEARCH('{AWS/EC2,InstanceId} MetricName=\"CPUUtilization\"', 'Average', 300)",
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": "Maximum"
+        }
+      ],
+      "title": "CloudWatch Query with Expression (Code Mode)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 12,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-insights"
+          },
+          "metricEditorMode": 1,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 1,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": "Average"
+        }
+      ],
+      "title": "CloudWatch Insights Query Missing Editor Mode",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 13,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": "Average"
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "C",
+          "region": "us-east-1",
+          "statistic": ""
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-null-stats"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "D",
+          "region": "us-east-1",
+          "statistic": "Maximum"
+        }
+      ],
+      "title": "CloudWatch Query with Null Statistics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "apiVersion": "v1",
+        "type": "prometheus",
+        "uid": "default-ds-uid"
+      },
+      "id": 14,
+      "targets": [
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "A",
+          "region": "us-east-1",
+          "statistic": 123
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "B",
+          "region": "us-east-1",
+          "statistic": true
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "C",
+          "region": "us-east-1",
+          "statistic": {}
+        },
+        {
+          "datasource": {
+            "apiVersion": "v1",
+            "type": "prometheus",
+            "uid": "default-ds-uid"
+          },
+          "dimensions": {
+            "InstanceId": "i-invalid-only"
+          },
+          "metricEditorMode": 0,
+          "metricName": "CPUUtilization",
+          "metricQueryType": 0,
+          "namespace": "AWS/EC2",
+          "refId": "D",
+          "region": "us-east-1",
+          "statistic": []
+        }
+      ],
+      "title": "CloudWatch Query with Only Invalid Statistics",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "uid": "prometheus"
+      },
+      "id": 15,
       "targets": [
         {
           "datasource": {


### PR DESCRIPTION
*Problem*

The v34 CloudWatch migration had several inconsistencies between backend and frontend implementations, causing test failures and potential data migration issues:

- **MetricEditorMode Logic**: Backend always set `metricEditorMode: 0` regardless of context, while frontend uses conditional logic based on `metricQueryType` and `expression` properties
- **MetricQueryType Handling**: Backend always overwrote values with `0`, while frontend only sets when property doesn't exist (`hasOwnProperty` check)
- **Statistics Processing**: Backend and frontend handled invalid statistics types differently
- **Null Statistic Values**: Backend was setting `statistic: null` while frontend omits the property entirely
- **Object String Representation**: Backend showed `"map[]"` while frontend shows `"[object Object]"` for annotation name suffixes

*Solution*

Implemented comprehensive fixes to achieve 100% backend-frontend consistency:

### **Core Logic Fixes**
- **MetricEditorMode Logic**: Implemented proper conditional logic matching frontend `migrateCloudWatchQuery`:
  - If `metricQueryType === 1` (Insights) → `metricEditorMode: 1` (Code)
  - If `expression` exists → `metricEditorMode: 1` (Code)
  - Otherwise → `metricEditorMode: 0` (Builder)
  - Only set when property doesn't exist (matches `hasOwnProperty` behavior)

- **MetricQueryType Handling**: Only set default value when property doesn't exist, preserving existing values

- **Statistics Processing**: Process ALL values in statistics array regardless of type, matching frontend behavior

- **Null Handling**: Skip setting statistic property for null values to match frontend omission behavior

- **JavaScript-Compatible String Conversion**: Implemented proper object-to-string conversion:
  - Objects: `"[object Object]"` (matches JavaScript `String(obj)`)
  - Arrays: `""` (empty string)
  - Booleans: `"true"` / `"false"`
  - Numbers: Standard string representation

### **Enhanced Test Coverage**
Updated `v34.multiple_stats_cloudwatch.json` with comprehensive test cases covering:

- **Basic Scenarios**: Single/multiple statistics, empty arrays
- **Editor Mode Logic**: Missing fields, expressions, Insights queries, existing values
- **Invalid Types**: Numbers, booleans, objects, arrays in statistics
- **Null Values**: Null statistics handling
- **Nested Panels**: CloudWatch queries in collapsed rows
- **Annotation Queries**: All scenarios for CloudWatch annotations
- **Mixed Queries**: CloudWatch and non-CloudWatch queries in same panel

### **Technical Implementation**
- **Frontend Behavior Replication**: Backend now exactly matches frontend `migrateMultipleStatsMetricsQuery` and `migrateMultipleStatsAnnotationQuery` logic
- **Property Existence Checks**: Implemented `hasOwnProperty` equivalent checks
- **Type-Safe Processing**: Proper handling of all JavaScript types in Go
- **Edge Case Coverage**: Comprehensive handling of null, empty, and invalid values

*How to test*

1. **Backend tests**:
   ```bash
   go test ./apps/dashboard/pkg/migration/ -run TestMigrate.*v34 -v
   go test ./apps/dashboard/pkg/migration/ -run TestMigrateSingleVersion.*v34 -v
   ```

2. **Frontend consistency tests**:
   ```bash
   yarn test DashboardMigratorToBackend --no-watch --testNamePattern="v34.*multiple_stats_cloudwatch"
   yarn test DashboardMigratorSingleVersion --no-watch --testNamePattern="v34.*multiple_stats_cloudwatch"
   ```

3. **Verification**:
   - Verify all v34 migration tests pass
   - Confirm backend output exactly matches frontend `getSaveModel()` output
   - Test all CloudWatch query and annotation scenarios

## Impact

- ✅ **100% Backend-Frontend Consistency**: v34 migration now produces identical results
- ✅ **Comprehensive Test Coverage**: All CloudWatch migration scenarios covered
- ✅ **JavaScript Compatibility**: Proper type conversion matching frontend behavior
- ✅ **Edge Case Handling**: Robust handling of null, invalid, and mixed statistics
- ✅ **Enhanced Reliability**: Prevents CloudWatch migration discrepancies in production