### PR TITLE
Storage: Fast path when list with metadata.name=XYZ

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -944,32 +944,8 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	}
 
 	// Fast path for getting single value in a list
-	if req.Source == resourcepb.ListRequest_STORE && req.Options.Key.Namespace != "" {
-		for _, v := range req.Options.Fields {
-			if v.Key == "metadata.name" && v.Operator == `=` {
-				if len(v.Values) == 1 {
-					read := &resourcepb.ReadRequest{
-						Key:             req.Options.Key,
-						ResourceVersion: req.ResourceVersion,
-					}
-					read.Key.Name = v.Values[0]
-					found, err := s.Read(ctx, read)
-					if err != nil {
-						return &resourcepb.ListResponse{Error: AsErrorResult(err)}, nil
-					}
-
-					// Return a value when it exists
-					rsp := &resourcepb.ListResponse{}
-					if len(found.Value) > 0 {
-						rsp.Items = []*resourcepb.ResourceWrapper{{
-							Value:           found.Value,
-							ResourceVersion: found.ResourceVersion,
-						}}
-					}
-					return rsp, nil
-				}
-			}
-		}
+	if rsp := s.tryFastPathList(ctx, req); rsp != nil {
+		return rsp, nil
 	}
 
 	if req.Limit < 1 {
@@ -1063,6 +1039,40 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	}
 	rsp.ResourceVersion = rv
 	return rsp, err
+}
+
+// Some list queries can be calculated with simple reads
+func (s *server) tryFastPathList(ctx context.Context, req *resourcepb.ListRequest) *resourcepb.ListResponse {
+	if req.Source != resourcepb.ListRequest_STORE || req.Options.Key.Namespace == "" {
+		return nil
+	}
+
+	for _, v := range req.Options.Fields {
+		if v.Key == "metadata.name" && v.Operator == `=` {
+			if len(v.Values) == 1 {
+				read := &resourcepb.ReadRequest{
+					Key:             req.Options.Key,
+					ResourceVersion: req.ResourceVersion,
+				}
+				read.Key.Name = v.Values[0]
+				found, err := s.Read(ctx, read)
+				if err != nil {
+					return &resourcepb.ListResponse{Error: AsErrorResult(err)}
+				}
+
+				// Return a value when it exists
+				rsp := &resourcepb.ListResponse{}
+				if len(found.Value) > 0 {
+					rsp.Items = []*resourcepb.ResourceWrapper{{
+						Value:           found.Value,
+						ResourceVersion: found.ResourceVersion,
+					}}
+				}
+				return rsp
+			}
+		}
+	}
+	return nil
 }
 
 // isTrashItemAuthorized checks if the user has access to the trash item.

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -944,7 +944,7 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	}
 
 	// Fast path for getting single value in a list
-	if req.Source == resourcepb.ListRequest_STORE {
+	if req.Source == resourcepb.ListRequest_STORE && req.Options.Key.Namespace != "" {
 		for _, v := range req.Options.Fields {
 			if v.Key == "metadata.name" && v.Operator == `=` {
 				if len(v.Values) == 1 {


### PR DESCRIPTION
When showing an item in the UI, there are cases where we need to check if something exists but avoid 404 (don't ask... [RTK](https://redux-toolkit.js.org/rtk-query/overview) reasons!)

A solution that seems to work is to use a list with `metadata.name` selector:
https://github.com/grafana/grafana/blob/main/public/app/features/stars/StarToolbarButton.tsx#L26

this gives the UI a 200 -- and will either have an item or not if we matched something...

HOWEVER, behind the scenes we are querying everything and then checking if each item matches the requested query 😬 