### PR TITLE
Remote Alertmanager: Use the correct OrgID when creating the store

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -222,7 +222,6 @@ func (ng *AlertNG) init() error {
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, skipInvalid bool) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, skipInvalid)
 		}
-		store := notifier.NewFileStore(cfg.OrgID, ng.KVStore)
 
 		// This function will be used by the MOA to create new Alertmanagers.
 		var override func(notifier.OrgAlertmanagerFactory) notifier.OrgAlertmanagerFactory
@@ -230,12 +229,12 @@ func (ng *AlertNG) init() error {
 		if remotePrimary {
 			ng.Log.Debug("Starting Grafana with remote primary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemotePrimary).Set(1)
-			override = remote.NewRemotePrimaryFactory(cfg, store, crypto, autogenFn, m, ng.tracer)
+			override = remote.NewRemotePrimaryFactory(cfg, ng.KVStore, crypto, autogenFn, m, ng.tracer)
 		} else {
 			ng.Log.Debug("Starting Grafana with remote secondary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemoteSecondary).Set(1)
 			override = remote.NewRemoteSecondaryFactory(cfg,
-				store,
+				ng.KVStore,
 				ng.store,
 				ng.Cfg.UnifiedAlerting.RemoteAlertmanager.SyncInterval,
 				crypto,

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
@@ -60,7 +60,7 @@ func TestMultiorgAlertmanager_RemoteSecondaryMode(t *testing.T) {
 	}
 	secretsService := secretsManager.SetupTestService(t, fakes.NewFakeSecretsStore())
 	override := remote.NewRemoteSecondaryFactory(remoteAMCfg,
-		notifier.NewFileStore(remoteAMCfg.OrgID, kvStore),
+		kvStore,
 		configStore,
 		10*time.Second,
 		notifier.NewCrypto(secretsService, configStore, log.NewNopLogger()),

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -7,6 +7,7 @@ import (
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -25,7 +26,7 @@ type RemotePrimaryForkedAlertmanager struct {
 // NewRemotePrimaryFactory returns a function to override the default AM factory in the multi-org Alertmanager.
 func NewRemotePrimaryFactory(
 	cfg AlertmanagerConfig,
-	store stateStore,
+	store kvstore.KVStore,
 	crypto Crypto,
 	autogenFn AutogenFn,
 	m *metrics.RemoteAlertmanager,
@@ -43,7 +44,7 @@ func NewRemotePrimaryFactory(
 			cfg.OrgID = orgID
 			cfg.PromoteConfig = true
 			l := log.New("ngalert.forked-alertmanager.remote-primary")
-			remoteAM, err := NewAlertmanager(ctx, cfg, store, crypto, autogenFn, m, t)
+			remoteAM, err := NewAlertmanager(ctx, cfg, notifier.NewFileStore(cfg.OrgID, store), crypto, autogenFn, m, t)
 			if err != nil {
 				l.Error("Failed to create remote Alertmanager, falling back to using only the internal one", "err", err)
 				return internalAM, nil

--- a/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_secondary_forked_alertmanager.go
@@ -8,6 +8,7 @@ import (
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
+	"github.com/grafana/grafana/pkg/infra/kvstore"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
@@ -65,7 +66,7 @@ func (c *RemoteSecondaryConfig) Validate() error {
 // NewRemoteSecondaryFactory returns a function to override the default AM factory in the multi-org Alertmanager.
 func NewRemoteSecondaryFactory(
 	cfg AlertmanagerConfig,
-	stateStore stateStore,
+	store kvstore.KVStore,
 	cfgStore configStore,
 	syncInterval time.Duration,
 	crypto Crypto,
@@ -79,7 +80,7 @@ func NewRemoteSecondaryFactory(
 			// Create the remote Alertmanager first so we don't need to unregister internal AM metrics if this fails.
 			cfg.OrgID = orgID
 			l := log.New("ngalert.forked-alertmanager.remote-secondary")
-			remoteAM, err := NewAlertmanager(ctx, cfg, stateStore, crypto, autogenFn, m, t)
+			remoteAM, err := NewAlertmanager(ctx, cfg, notifier.NewFileStore(cfg.OrgID, store), crypto, autogenFn, m, t)
 			if err != nil && withRemoteState {
 				// We can't start the internal Alertmanager without the remote state.
 				return nil, fmt.Errorf("failed to create remote Alertmanager, can't start the internal Alertmanager without the remote state: %w", err)


### PR DESCRIPTION
We're using the zero-value, the org ID is always zero. This results in Grafana sending an empty state (silences + nflog) to the remote Alertmanager. 