### PR TITLE
POC: Alternative way to open Pathfinder from help icon

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -595,6 +595,7 @@ export {
   type PluginExtensionAddedFunctionConfig,
   type PluginExtensionResourceAttributesContext,
   type CentralAlertHistorySceneV1Props,
+  type PluginExtensionTopbarHelpV1Context,
 } from './types/pluginExtensions';
 export {
   type ScopeDashboardBindingSpec,

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -167,7 +167,6 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   context?: Readonly<Context>;
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
-
   /**
    * @internal
    * Opens the extension sidebar with the registered component.

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -5,6 +5,7 @@ import { DataQuery, DataSourceJsonData } from '@grafana/schema';
 import { ScopedVars } from './ScopedVars';
 import { DataSourcePluginMeta, DataSourceSettings } from './datasource';
 import { IconName } from './icon';
+import { NavModelItem } from './navModel';
 import { PanelData } from './panel';
 import { AbsoluteTimeRange, RawTimeRange, TimeZone } from './time';
 
@@ -322,4 +323,8 @@ type Dashboard = {
   uid: string;
   title: string;
   tags: string[];
+};
+
+export type PluginExtensionTopbarHelpV1Context = {
+  helpNode: NavModelItem;
 };

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -167,7 +167,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   context?: Readonly<Context>;
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
-  openInSidebar: (exposedComponentId: string, props?: Record<string, unknown>) => void;
+
   /**
    * @internal
    * Opens the extension sidebar with the registered component.

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -167,6 +167,7 @@ export type PluginExtensionEventHelpers<Context extends object = object> = {
   context?: Readonly<Context>;
   // Opens a modal dialog and renders the provided React component inside it
   openModal: (options: PluginExtensionOpenModalOptions) => void;
+  openInSidebar: (exposedComponentId: string, props?: Record<string, unknown>) => void;
   /**
    * @internal
    * Opens the extension sidebar with the registered component.
@@ -206,6 +207,7 @@ export enum PluginExtensionPoints {
   LogsViewResourceAttributes = 'grafana/logsview/resource-attributes',
   AppChrome = 'grafana/app/chrome/v1',
   ExtensionSidebar = 'grafana/extension-sidebar/v0-alpha',
+  TopBarHelpButtonV1 = 'grafana/topbar/help-button/v1',
 }
 
 // Don't use directly in a plugin!

--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -207,7 +207,7 @@ export enum PluginExtensionPoints {
   LogsViewResourceAttributes = 'grafana/logsview/resource-attributes',
   AppChrome = 'grafana/app/chrome/v1',
   ExtensionSidebar = 'grafana/extension-sidebar/v0-alpha',
-  TopBarHelpButtonV1 = 'grafana/topbar/help-button/v1',
+  TopbarHelpV1 = 'grafana/app/topbar/help/v1',
 }
 
 // Don't use directly in a plugin!

--- a/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
@@ -1,7 +1,13 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { GrafanaTheme2, NavModelItem, PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
+import {
+  GrafanaTheme2,
+  NavModelItem,
+  PluginExtensionLink,
+  PluginExtensionPoints,
+  PluginExtensionTopbarHelpV1Context,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { usePluginLinks } from '@grafana/runtime';
 import { Dropdown, ToolbarButton, useStyles2 } from '@grafana/ui';
@@ -21,7 +27,7 @@ const allowedPluginId = 'grafana-grafanadocsplugin-app';
 
 export function HelpDropdownButton({ helpNode }: Props) {
   const styles = useStyles2(getStyles);
-  const context = useMemo(() => ({ helpNode }), [helpNode]);
+  const context = useMemo<PluginExtensionTopbarHelpV1Context>(() => ({ helpNode }), [helpNode]);
   const { dockedComponentId, isOpen: isSidebarOpen } = useExtensionSidebarContext();
 
   const { links, isLoading } = usePluginLinks({

--- a/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
-import { GrafanaTheme2, NavModelItem, PluginExtensionPoints } from '@grafana/data';
+import { GrafanaTheme2, NavModelItem, PluginExtensionLink, PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { usePluginLinks } from '@grafana/runtime';
 import { Dropdown, ToolbarButton, useStyles2 } from '@grafana/ui';
@@ -17,6 +17,8 @@ interface Props {
   helpNode: NavModelItem;
 }
 
+const allowedPluginId = 'grafana-grafanadocsplugin-app';
+
 export function HelpDropdownButton({ helpNode }: Props) {
   const styles = useStyles2(getStyles);
   const context = useMemo(() => ({ helpNode }), [helpNode]);
@@ -27,22 +29,22 @@ export function HelpDropdownButton({ helpNode }: Props) {
     context,
   });
 
-  const pathfinderLink = useMemo(() => {
-    return links.find((link) => link.pluginId === 'grafana-grafanadocsplugin-app');
+  const link = useMemo(() => {
+    return links.find((link) => link.pluginId === allowedPluginId);
   }, [links]);
 
   if (isLoading) {
     return null;
   }
 
-  if (pathfinderLink) {
+  if (link) {
     return (
       <ToolbarButton
         iconOnly
         icon="question-circle"
         aria-label={t('navigation.help.aria-label', 'Help')}
-        onClick={pathfinderLink.onClick}
-        className={isOpenInSidebar(dockedComponentId, isSidebarOpen) ? styles.helpButtonActive : undefined}
+        onClick={link.onClick}
+        className={isOpenInSidebar(dockedComponentId, isSidebarOpen, link) ? styles.helpButtonActive : undefined}
       />
     );
   }
@@ -65,18 +67,20 @@ function getStyles(theme: GrafanaTheme2) {
   };
 }
 
-function isOpenInSidebar(dockedComponentId: string | undefined, isSidebarOpen: boolean): boolean {
+function isOpenInSidebar(
+  dockedComponentId: string | undefined,
+  isSidebarOpen: boolean,
+  link: PluginExtensionLink
+): boolean {
   if (!isSidebarOpen) {
     return false;
   }
   if (!dockedComponentId) {
     return false;
   }
-  const componentMeta = getComponentMetaFromComponentId(dockedComponentId);
-  if (!componentMeta) {
+  const meta = getComponentMetaFromComponentId(dockedComponentId);
+  if (!meta) {
     return false;
   }
-  return (
-    componentMeta.pluginId === 'grafana-grafanadocsplugin-app' && componentMeta.componentTitle === 'Grafana Pathfinder'
-  );
+  return meta.pluginId === link.pluginId && meta.componentTitle === link.title;
 }

--- a/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
@@ -25,7 +25,7 @@ export function HelpDropdownButton({ helpNode }: Props) {
   const { dockedComponentId, isOpen: isSidebarOpen } = useExtensionSidebarContext();
 
   const { links, isLoading } = usePluginLinks({
-    extensionPointId: PluginExtensionPoints.TopBarHelpButtonV1,
+    extensionPointId: PluginExtensionPoints.TopbarHelpV1,
     context,
   });
 

--- a/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
@@ -1,0 +1,82 @@
+import { css } from '@emotion/css';
+import { useMemo } from 'react';
+
+import { GrafanaTheme2, NavModelItem, PluginExtensionPoints } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { usePluginLinks } from '@grafana/runtime';
+import { Dropdown, ToolbarButton, useStyles2 } from '@grafana/ui';
+
+import {
+  getComponentMetaFromComponentId,
+  useExtensionSidebarContext,
+} from '../ExtensionSidebar/ExtensionSidebarProvider';
+
+import { TopNavBarMenu } from './TopNavBarMenu';
+
+interface Props {
+  helpNode: NavModelItem;
+}
+
+export function HelpDropdownButton({ helpNode }: Props) {
+  const styles = useStyles2(getStyles);
+  const context = useMemo(() => ({ helpNode }), [helpNode]);
+  const { dockedComponentId, isOpen: isSidebarOpen } = useExtensionSidebarContext();
+
+  const { links, isLoading } = usePluginLinks({
+    extensionPointId: PluginExtensionPoints.TopBarHelpButtonV1,
+    context,
+  });
+
+  const pathfinderLink = useMemo(() => {
+    return links.find((link) => link.pluginId === 'grafana-grafanadocsplugin-app');
+  }, [links]);
+
+  if (isLoading) {
+    return null;
+  }
+
+  if (pathfinderLink) {
+    return (
+      <ToolbarButton
+        iconOnly
+        icon="question-circle"
+        aria-label={t('navigation.help.aria-label', 'Help')}
+        onClick={pathfinderLink.onClick}
+        className={isOpenInSidebar(dockedComponentId, isSidebarOpen) ? styles.helpButtonActive : undefined}
+      />
+    );
+  }
+
+  return (
+    <Dropdown overlay={() => <TopNavBarMenu node={helpNode} />} placement="bottom-end">
+      <ToolbarButton iconOnly icon="question-circle" aria-label={t('navigation.help.aria-label', 'Help')} />
+    </Dropdown>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    helpButtonActive: css({
+      borderRadius: theme.shape.radius.circle,
+      backgroundColor: theme.colors.primary.transparent,
+      border: `1px solid ${theme.colors.primary.borderTransparent}`,
+      color: theme.colors.text.primary,
+    }),
+  };
+}
+
+function isOpenInSidebar(dockedComponentId: string | undefined, isSidebarOpen: boolean): boolean {
+  if (!isSidebarOpen) {
+    return false;
+  }
+  if (!dockedComponentId) {
+    return false;
+  }
+  const componentMeta = getComponentMetaFromComponentId(dockedComponentId);
+  if (!componentMeta) {
+    return false;
+  }
+  return (
+    componentMeta.pluginId === 'grafana-grafanadocsplugin-app' && componentMeta.componentTitle === 'Grafana Pathfinder'
+  );
+}

--- a/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpDropdownButton.tsx
@@ -27,7 +27,10 @@ const allowedPluginId = 'grafana-grafanadocsplugin-app';
 
 export function HelpDropdownButton({ helpNode }: Props) {
   const styles = useStyles2(getStyles);
-  const context = useMemo<PluginExtensionTopbarHelpV1Context>(() => ({ helpNode }), [helpNode]);
+  const context = useMemo<PluginExtensionTopbarHelpV1Context>(
+    () => ({ helpNode: withoutParents(helpNode) }),
+    [helpNode]
+  );
   const { dockedComponentId, isOpen: isSidebarOpen } = useExtensionSidebarContext();
 
   const { links, isLoading } = usePluginLinks({
@@ -70,6 +73,14 @@ function getStyles(theme: GrafanaTheme2) {
       border: `1px solid ${theme.colors.primary.borderTransparent}`,
       color: theme.colors.text.primary,
     }),
+  };
+}
+
+function withoutParents(node: NavModelItem): NavModelItem {
+  const { parentItem, ...rest } = node;
+  return {
+    ...rest,
+    children: node.children?.map(withoutParents),
   };
 }
 

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -6,7 +6,7 @@ import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { ScopesContextValue } from '@grafana/runtime';
-import { Dropdown, Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
 import { useGrafana } from 'app/core/context/GrafanaContext';
@@ -24,11 +24,11 @@ import { enrichHelpItem } from '../MegaMenu/utils';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 import { QuickAdd } from '../QuickAdd/QuickAdd';
 
+import { HelpDropdownButton } from './HelpDropdownButton';
 import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
-import { TopNavBarMenu } from './TopNavBarMenu';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
 
@@ -98,11 +98,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopSearchBarCommandPaletteTrigger />
           {unifiedHistoryEnabled && !isSmallScreen && <HistoryContainer />}
           {!isSmallScreen && <QuickAdd />}
-          {enrichedHelpNode && (
-            <Dropdown overlay={() => <TopNavBarMenu node={enrichedHelpNode} />} placement="bottom-end">
-              <ToolbarButton iconOnly icon="question-circle" aria-label={t('navigation.help.aria-label', 'Help')} />
-            </Dropdown>
-          )}
+          {enrichedHelpNode && <HelpDropdownButton helpNode={enrichedHelpNode} />}
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}
           {!showToolbarLevel && actions}

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -20,7 +20,7 @@ import { reportInteraction, config, AppPluginConfig } from '@grafana/runtime';
 import { Modal } from '@grafana/ui';
 import appEvents from 'app/core/app_events';
 import { getPluginSettings } from 'app/features/plugins/pluginSettings';
-import { CloseExtensionSidebarEvent, OpenExtensionSidebarEvent, ShowModalReactEvent } from 'app/types/events';
+import { CloseExtensionSidebarEvent, ShowModalReactEvent, ToggleExtensionSideBarEvent } from 'app/types/events';
 
 import { RestrictedGrafanaApisProvider } from '../components/restrictedGrafanaApis/RestrictedGrafanaApisProvider';
 
@@ -540,7 +540,7 @@ export function getLinkExtensionOnClick(
         openModal: createOpenModalFunction(config),
         openSidebar: (componentTitle, context) => {
           appEvents.publish(
-            new OpenExtensionSidebarEvent({
+            new ToggleExtensionSideBarEvent({
               props: context,
               pluginId,
               componentTitle,

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -181,6 +181,10 @@ export class CloseExtensionSidebarEvent extends BusEventBase {
   static type = 'close-extension-sidebar';
 }
 
+export class ToggleExtensionSideBarEvent extends BusEventWithPayload<OpenExtensionSidebarPayload> {
+  static type = 'toggle-extension-sidebar';
+}
+
 /**
  * @deprecated use ShowModalReactEvent instead that has this capability built in
  */


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is a small POC on an alternative way of implementing the "open pathfinder on help icon click" functionality. The code should be considered as a first step and should be improved in future versions. Currently we are filtering so only Pathfinder can replace the help functionality. In a future we could (not saying that we want to) let other plugins extend this button and let the user configure which app to trigger when asking for help.

There are a couple of things that I aim to solve with this suggestion compared with the initial PR.

1. No backend code needed to detect if Pathfinder app is available. The extensions framework will handle that out of the box and won't return a link if the app is disabled, not installed or if it isn't adding any links.
2. Minimised the need of knowledge about the plugin extending this extension point. The only thing required in this version is the allow list including the plugin id (could be replaced with configuration long term).
3. I'm still using the "sidebar functionality" but instead of relying on a convention I will let the plugin trigger the request to open the content from the registered plugin link.
4. Pathfinder will be able to render the proper help menu links since we are passing the `helpNode` via the context.

On the plugin side we need to do a couple of changes:

- We need to extend the new extension point added in this PR with a plugin link.
- From that onClick plugin link we need to call the `openSidebar(..)` functionality and pass the context as props.
- Expose the component that we want to render in the sideBar with the same title as the link.
- Consume the `helpNode` in the plugins exposed component to render the "real" help menu buttons.

Long term I think we should improve the APIs around the Sidebar so they are a bit more flexible and that we can in an easier way detect the isOpen state within Grafana.

**Why do we need this feature?**
We would like to open Pathfinder instead of the help menu to provide a better help experience to our Grafana users.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
