### PR TITLE
Alerting: Fix threshold params

### DIFF
--- a/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
+++ b/public/app/features/expressions/components/__snapshots__/hysteresis.test.ts.snap
@@ -72,7 +72,6 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
     {
       "evaluator": {
         "params": [
-          10,
           0,
         ],
         "type": "lt",
@@ -90,7 +89,6 @@ exports[`thresholdReducer should update Threshold Type, and unloadEvaluator para
       "type": "query",
       "unloadEvaluator": {
         "params": [
-          10,
           0,
         ],
         "type": "gt",

--- a/public/app/features/expressions/components/hysteresis.test.ts
+++ b/public/app/features/expressions/components/hysteresis.test.ts
@@ -159,7 +159,7 @@ describe('thresholdReducer', () => {
     expect(newState.conditions[0].evaluator.type).toEqual(EvalFunction.IsBelow);
     expect(newState.conditions[0].unloadEvaluator?.type).toEqual(EvalFunction.IsAbove);
     expect(onError).toHaveBeenCalledWith(undefined);
-    expect(newState.conditions[0].unloadEvaluator?.params[0]).toEqual(10);
+    expect(newState.conditions[0].unloadEvaluator?.params[0]).toEqual(0);
   });
   it('Should update unlooadEvaluator when checking hysteresis', () => {
     const initialState: ThresholdExpressionQuery = {

--- a/public/app/features/expressions/components/thresholdReducer.ts
+++ b/public/app/features/expressions/components/thresholdReducer.ts
@@ -33,6 +33,9 @@ export const thresholdReducer = createReducer<ThresholdExpressionQuery>(
       //set new type in evaluator
       state.conditions[0].evaluator.type = typeInPayload;
 
+      //reset params
+      state.conditions[0].evaluator.params = [0];
+
       // check if hysteresis is checked
       const hsyteresisIsChecked = Boolean(state.conditions[0].unloadEvaluator);
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes params in model not being reset once we switch between range and isAbove or isBelow threshold types in the alert rule form.

**Why do we need this feature?**

It's a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

Related to this [escalation](https://github.com/grafana/support-escalations/issues/18631)

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
