### PR TITLE
Advisor: Retry before patching objects

### DIFF
--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -274,17 +274,11 @@ func waitForItem(ctx context.Context, log logging.Logger, client resource.Client
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	})
-	retries := 0
 	if err != nil && k8serrors.IsNotFound(err) {
-		for retries < 5 {
-			log.Info("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
-			time.Sleep(retryAnnotationPollingInterval)
-			retries++
-			_, err = client.Get(ctx, resource.Identifier{
-				Namespace: obj.GetNamespace(),
-				Name:      obj.GetName(),
-			})
-		}
+		// Wait for the item to be persisted
+		// TODO: Retry to get the item will still return the same error but not sure why
+		log.Info("Waiting for item to be persisted", "check", obj.GetName())
+		time.Sleep(2 * time.Second)
 	}
 	return err
 }

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -275,16 +275,14 @@ func waitForItem(ctx context.Context, log logging.Logger, client resource.Client
 		Name:      obj.GetName(),
 	})
 	retries := 0
-	if err != nil && k8serrors.IsNotFound(err) {
-		for err != nil && k8serrors.IsNotFound(err) && retries < 5 {
-			log.Debug("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
-			time.Sleep(retryAnnotationPollingInterval)
-			retries++
-			_, err = client.Get(ctx, resource.Identifier{
-				Namespace: obj.GetNamespace(),
-				Name:      obj.GetName(),
-			})
-		}
+	for err != nil && k8serrors.IsNotFound(err) && retries < 5 {
+		log.Debug("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
+		time.Sleep(retryAnnotationPollingInterval)
+		retries++
+		_, err = client.Get(ctx, resource.Identifier{
+			Namespace: obj.GetNamespace(),
+			Name:      obj.GetName(),
+		})
 	}
 	return err
 }

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -276,7 +276,7 @@ func waitForItem(ctx context.Context, log logging.Logger, client resource.Client
 	})
 	retries := 0
 	if err != nil && k8serrors.IsNotFound(err) {
-		for retries < 5 {
+		for err != nil && k8serrors.IsNotFound(err) && retries < 5 {
 			log.Debug("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
 			time.Sleep(retryAnnotationPollingInterval)
 			retries++

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -14,6 +14,7 @@ import (
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
 	"github.com/grafana/grafana/pkg/services/contexthandler"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 var retryAnnotationPollingInterval = 1 * time.Second
@@ -81,7 +82,11 @@ func processCheck(ctx context.Context, log logging.Logger, client resource.Clien
 		}
 		return fmt.Errorf("error running steps: %w", err)
 	}
-
+	// Wait for the item to be persisted before patching the object
+	err = waitForItem(ctx, log, client, obj)
+	if err != nil {
+		return err
+	}
 	report := &advisorv0alpha1.CheckReport{
 		Failures: failures,
 		Count:    int64(len(items)),
@@ -262,6 +267,26 @@ func retryAnnotationChanged(oldObj, newObj resource.Object) bool {
 	newAnnotations := newObj.GetAnnotations()
 	return newAnnotations[checks.RetryAnnotation] != "" &&
 		oldAnnotations[checks.RetryAnnotation] != newAnnotations[checks.RetryAnnotation]
+}
+
+func waitForItem(ctx context.Context, log logging.Logger, client resource.Client, obj resource.Object) error {
+	_, err := client.Get(ctx, resource.Identifier{
+		Namespace: obj.GetNamespace(),
+		Name:      obj.GetName(),
+	})
+	retries := 0
+	if err != nil && k8serrors.IsNotFound(err) {
+		for retries < 5 {
+			log.Info("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
+			time.Sleep(retryAnnotationPollingInterval)
+			retries++
+			_, err = client.Get(ctx, resource.Identifier{
+				Namespace: obj.GetNamespace(),
+				Name:      obj.GetName(),
+			})
+		}
+	}
+	return err
 }
 
 // waitForRetryAnnotation waits for the retry annotation to match the item to retry

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -277,7 +277,7 @@ func waitForItem(ctx context.Context, log logging.Logger, client resource.Client
 	retries := 0
 	if err != nil && k8serrors.IsNotFound(err) {
 		for retries < 5 {
-			log.Info("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
+			log.Debug("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
 			time.Sleep(retryAnnotationPollingInterval)
 			retries++
 			_, err = client.Get(ctx, resource.Identifier{

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -274,11 +274,17 @@ func waitForItem(ctx context.Context, log logging.Logger, client resource.Client
 		Namespace: obj.GetNamespace(),
 		Name:      obj.GetName(),
 	})
+	retries := 0
 	if err != nil && k8serrors.IsNotFound(err) {
-		// Wait for the item to be persisted
-		// TODO: Retry to get the item will still return the same error but not sure why
-		log.Info("Waiting for item to be persisted", "check", obj.GetName())
-		time.Sleep(2 * time.Second)
+		for retries < 5 {
+			log.Info("Waiting for item to be persisted", "check", obj.GetName(), "retries", retries)
+			time.Sleep(retryAnnotationPollingInterval)
+			retries++
+			_, err = client.Get(ctx, resource.Identifier{
+				Namespace: obj.GetNamespace(),
+				Name:      obj.GetName(),
+			})
+		}
 	}
 	return err
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

After https://github.com/grafana/grafana/pull/111009, quick checks (e.g. config checks) have started to fail with errors like:

```
ERROR[09-26|14:23:02] Error processing check                   caller=logger.go:234 time=2025-09-26T14:23:02.174519+02:00 app=advisor.app check=instance error="checks.advisor.grafana.app \"check-5fnst\" not found"
```

<img width="368" height="579" alt="image" src="https://github.com/user-attachments/assets/fe118cff-5405-4010-aad7-dc676308e8bc" />


I assume the reason is the same than https://github.com/grafana/grafana/pull/109918 and we are trying to PATCH an object before it has been firstly saved so I have added the same fix, adding a retry which should wait until the resource is available.

Tested that it works as expected in a ephemeral instance.