### PR TITLE
Docs: Marking the image renderer plugin as deprecated

### DIFF
--- a/docs/sources/setup-grafana/image-rendering/_index.md
+++ b/docs/sources/setup-grafana/image-rendering/_index.md
@@ -32,6 +32,12 @@ Alert notifications can include images, but rendering many images at the same ti
 
 ## Install Grafana Image Renderer plugin
 
+{{< admonition type="caution" >}}
+Starting with Grafana v12.2, the Grafana Image Renderer plugin is deprecated and is no longer maintained.
+
+Instead, use the Grafana Image Renderer remote rendering service.
+{{< /admonition >}}
+
 {{< admonition type="note" >}}
 All PhantomJS support has been removed. Instead, use the Grafana Image Renderer plugin or remote rendering service.
 {{< /admonition >}}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Marks the image renderer plugin as deprecated and direct people to use the remote rendering service instead

**Why do we need this feature?**

The plugin has been deprecated

**Who is this feature for?**

Any users of the image renderer plugin
