### PR TITLE
`apimachinery`: Add missing description of  `ScopeSpec struct` for types.go

### DIFF
--- a/pkg/apimachinery/apis/common/v0alpha1/types.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/types.go
@@ -52,8 +52,7 @@ type Scope struct {
 }
 
 type ScopeSpec struct {
-	Title       string `json:"title"`
-	Description string `json:"description,omitempty"`
+	Title string `json:"title"`
 	// Provides a default path for the scope. This refers to a list of nodes in the selector. This is used to display the title next to the selected scope and expand the selector to the proper path.
 	// This will override whichever is selected from in the selector.
 	// The path is a list of node ids, starting at the direct parent of the selected node towards the root.

--- a/pkg/apimachinery/apis/common/v0alpha1/types.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/types.go
@@ -52,7 +52,8 @@ type Scope struct {
 }
 
 type ScopeSpec struct {
-	Title string `json:"title"`
+	Title       string `json:"title"`
+	Description string `json:"description,omitempty"`
 	// Provides a default path for the scope. This refers to a list of nodes in the selector. This is used to display the title next to the selected scope and expand the selector to the proper path.
 	// This will override whichever is selected from in the selector.
 	// The path is a list of node ids, starting at the direct parent of the selected node towards the root.

--- a/pkg/apimachinery/apis/common/v0alpha1/zz_generated.openapi.go
+++ b/pkg/apimachinery/apis/common/v0alpha1/zz_generated.openapi.go
@@ -248,6 +248,12 @@ func schema_apimachinery_apis_common_v0alpha1_ScopeSpec(ref common.ReferenceCall
 							Format:  "",
 						},
 					},
+					"description": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"defaultPath": {
 						VendorExtensible: spec.VendorExtensible{
 							Extensions: spec.Extensions{


### PR DESCRIPTION
The test data contains a spec.description field for scopes, but the actual `ScopeSpec struct` in
  `grafana/grafana/pkg/apimachinery/apis/common/v0alpha1/types.go:54-64` does NOT have a
  description field defined.

Fix options:
  1. Add description field to ScopeSpec struct: Description string 'json:"description,omitempty"'
  2. Remove description field from test data files

Opted for option 1