### PR TITLE
docs(iam): Remove RBAC actions for access policies

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
@@ -24,11 +24,6 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#grafana-adaptive-metrics-action-definitions
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/custom-role-actions-scopes/#grafana-adaptive-metrics-action-definitions
-  cloud-access-policies-action-definitions:
-    - pattern: /docs/grafana/
-      destination: docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#cloud-access-policies-action-definitions
-    - pattern: /docs/grafana-cloud/
-      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#cloud-access-policies-action-definitions
   rbac-role-definitions:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
@@ -67,7 +62,6 @@ The following list contains app plugins that have fine-grained RBAC support.
 
 | App plugin                                                                                                                                                                            | App plugin ID                  | App plugin permission documentation                                                                                                                                        |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [Access policies](https://grafana.com/docs/grafana-cloud/account-management/authentication-and-permissions/access-policies/)                                                          | `grafana-auth-app`             | [RBAC actions for Access Policies](ref:cloud-access-policies-action-definitions)                                                                                           |
 | [Adaptive metrics](https://grafana.com/docs/grafana-cloud/cost-management-and-billing/reduce-costs/metrics-costs/control-metrics-usage-via-adaptive-metrics/adaptive-metrics-plugin/) | `grafana-adaptive-metrics-app` | [RBAC actions for Adaptive Metrics](ref:adaptive-metrics-permissions)                                                                                                      |
 | [Incident](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/incident/)                                                                                                     | `grafana-incident-app`         | n/a                                                                                                                                                                        |
 | [OnCall](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/oncall/)                                                                                                         | `grafana-oncall-app`           | [Configure RBAC for OnCall](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/oncall/manage/user-and-team-management/#manage-users-and-teams-for-grafana-oncall) |

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-for-app-plugins/index.md
@@ -5,6 +5,7 @@ description: Learn about how to configure access to app plugins using RBAC
 labels:
   products:
     - cloud
+    - enterprise
 menuTitle: RBAC for app plugins
 title: RBAC for app plugins
 weight: 90


### PR DESCRIPTION
**What is this feature?**

Given the fact that the `grafana-auth-app:write` permission is effectively the same as assigning the Admin role to a Grafana user, the "RBAC" differentiation is not quite there yet. This PR removes the direct link from the "RBAC for app plugins" page.

**Why do we need this feature?**

Since the RBAC feature for the Access Policies plugin doesn't quite offer much in terms of granularity, we would like to de-emphasize it – starting from this link.