### PR TITLE
feat(ci): Allow overriding runs-on for publish-artifact workflow

### DIFF
--- a/.github/workflows/publish-artifact.yml
+++ b/.github/workflows/publish-artifact.yml
@@ -33,9 +33,13 @@ on:
         type: string
         required: false
         default: github-prerelease-writer@grafanalabs-workload-identity.iam.gserviceaccount.com
+      runs-on:
+        type: string
+        required: false
+        default: github-hosted-ubuntu-x64-small
 jobs:
   publish:
-    runs-on: github-hosted-ubuntu-x64-small
+    runs-on: ${{ inputs.runs-on }}
     name: Publish
     permissions:
       id-token: write


### PR DESCRIPTION
**Why do we need this feature?**

We're hitting limits with some runners. This helps us experiment with other runners.

**Who is this feature for?**

maintainers

