### PR TITLE
Alerting: Fix sending limit_alerts to the alertRuleApi

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.test.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.test.ts
@@ -1,0 +1,73 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { of } from 'rxjs';
+import { createFetchResponse } from 'test/helpers/createFetchResponse';
+
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+
+import { PrometheusAPIFilters, alertRuleApi } from './alertRuleApi';
+
+const fetchMock = jest.fn();
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({
+    fetch: fetchMock,
+  }),
+}));
+
+const createTestStore = () =>
+  configureStore({
+    reducer: {
+      [alertRuleApi.reducerPath]: alertRuleApi.reducer,
+    },
+    middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(alertRuleApi.middleware),
+  });
+
+async function executePrometheusRuleNamespacesQuery(
+  args: Partial<Parameters<typeof alertRuleApi.endpoints.prometheusRuleNamespaces.initiate>[0]> = {}
+) {
+  const store = createTestStore();
+  await store.dispatch(
+    alertRuleApi.endpoints.prometheusRuleNamespaces.initiate({
+      ruleSourceName: GRAFANA_RULES_SOURCE_NAME,
+      ...args,
+    })
+  );
+
+  const [request] = fetchMock.mock.calls[fetchMock.mock.calls.length - 1] ?? [];
+  return request;
+}
+
+describe('alertRuleApi', () => {
+  describe('prometheusRuleNamespaces query parameters', () => {
+    beforeEach(() => {
+      fetchMock.mockReset();
+      fetchMock.mockImplementation(() => of(createFetchResponse({ data: { groups: [] } })));
+    });
+
+    afterEach(() => {
+      fetchMock.mockReset();
+    });
+
+    it('includes limit_alerts when value is zero', async () => {
+      const request = await executePrometheusRuleNamespacesQuery({ limitAlerts: 0 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(request.params?.[PrometheusAPIFilters.LimitAlerts]).toBe('0');
+    });
+
+    it('omits limit_alerts when value is undefined', async () => {
+      const request = await executePrometheusRuleNamespacesQuery();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(request.params?.[PrometheusAPIFilters.LimitAlerts]).toBeUndefined();
+    });
+
+    it('includes limit_limit value', async () => {
+      const request = await executePrometheusRuleNamespacesQuery({ limitAlerts: 25 });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(request.params?.[PrometheusAPIFilters.LimitAlerts]).toBe('25');
+    });
+  });
+});

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -212,7 +212,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         }
 
         if (limitAlerts !== undefined) {
-          queryParams[PrometheusAPIFilters.LimitAlerts] = String(PrometheusAPIFilters.LimitAlerts);
+          queryParams[PrometheusAPIFilters.LimitAlerts] = String(limitAlerts);
         }
 
         if (maxGroups) {


### PR DESCRIPTION
**What is this feature?**

Fixes `limit_alerts` parameter in the alert rule API client.

**Why do we need this feature?**

There is a bug because of which the frontend sends `&limit_alerts=limit_alerts` as the parameter.