### PR TITLE
Table: WIP on Safari 26 debugging

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -881,11 +881,6 @@
       "count": 2
     }
   },
-  "packages/grafana-ui/src/components/Table/TableNG/utils.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/Table/TableRT/Filter.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -108,7 +108,8 @@ export function TableNG(props: TableNGProps) {
     disableSanitizeHtml,
     enablePagination = false,
     enableSharedCrosshair = false,
-    enableVirtualization,
+    // TODO: Uncomment 1/3
+    // enableVirtualization,
     frozenColumns = 0,
     getActions = () => [],
     height,
@@ -287,7 +288,10 @@ export function TableNG(props: TableNGProps) {
   const commonDataGridProps = useMemo(
     () =>
       ({
-        enableVirtualization: enableVirtualization !== false && rowHeight !== 'auto',
+        // NOTE: Disable virtualization for tables with footers to prevent boundary calculation issues in Safari
+        enableVirtualization: false,
+        // TODO: Uncomment 2/3, above isn't a real fix, just trying to narrow down root cause.
+        // enableVirtualization: enableVirtualization !== false && rowHeight !== 'auto',
         defaultColumnOptions: {
           minWidth: 50,
           resizable: true,
@@ -312,7 +316,8 @@ export function TableNG(props: TableNGProps) {
         headerRowHeight: noHeader ? 0 : TABLE.HEADER_ROW_HEIGHT,
       }) satisfies Partial<DataGridProps<TableRow, TableSummaryRow>>,
     [
-      enableVirtualization,
+      // TODO: Uncomment 3/3
+      // enableVirtualization,
       hasFooter,
       resizeHandler,
       sortColumns,

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -563,26 +563,25 @@ export const useReducerEntries = (
       return [];
     }
 
-    // Create a new state object that matches the original behavior exactly
-    const newState: FooterFieldState = {
+    // Create a local state object without mutating the field
+    const localState: FooterFieldState = {
       lastProcessedRowCount: 0,
       ...(field.state || {}), // Preserve any existing state properties
     };
 
-    // Assign back to field
-    field.state = newState;
+    // DO NOT assign back to field to avoid persistent mutations
 
     const currentRowCount = rows.length;
-    const lastRowCount = newState.lastProcessedRowCount;
+    const lastRowCount = localState.lastProcessedRowCount;
 
     // Check if we need to invalidate the cache
     if (lastRowCount !== currentRowCount) {
       // Cache should be invalidated as row count has changed
-      if (newState.calcs) {
-        delete newState.calcs;
+      if (localState.calcs) {
+        delete localState.calcs;
       }
       // Update the row count tracker
-      newState.lastProcessedRowCount = currentRowCount;
+      localState.lastProcessedRowCount = currentRowCount;
     }
 
     // Calculate all specified reducers

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -50,15 +50,16 @@ export const getGridStyles = (theme: GrafanaTheme2, enablePagination?: boolean, 
       // add a box shadow on hover and selection for all body cells
       '& > :not(.rdg-summary-row, .rdg-header-row) > .rdg-cell': {
         [getActiveCellSelector()]: { boxShadow: theme.shadows.z2 },
-        // selected cells should appear below hovered cells.
-        '&:hover': { zIndex: theme.zIndex.tooltip - 7 },
+        // TODO: Uncomment CSS 1/2, below is a workaround for Safari layout issues
+        // '&:hover': { zIndex: theme.zIndex.tooltip - 7 },
         '&[aria-selected=true]': { zIndex: theme.zIndex.tooltip - 6 },
       },
 
       '.rdg-cell.rdg-cell-frozen': {
-        backgroundColor: '--rdg-row-background-color',
+        backgroundColor: 'var(--rdg-row-background-color)',
         zIndex: theme.zIndex.tooltip - 4,
-        '&:hover': { zIndex: theme.zIndex.tooltip - 2 },
+        // TODO: Uncomment CSS 2/2, below is a workaround for Safari layout issues
+        // '&:hover': { zIndex: theme.zIndex.tooltip - 2 },
         '&[aria-selected=true]': { zIndex: theme.zIndex.tooltip - 3 },
       },
 

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -237,5 +237,16 @@ export const getTooltipStyles = (theme: GrafanaTheme2, textAlign: TextAlign) => 
   }),
 });
 
-export const getActiveCellSelector = (isNested?: boolean) =>
-  isNested ? '.rdg-cell:hover &, [aria-selected=true] &' : '&:hover, &[aria-selected=true]';
+export const getActiveCellSelector = (isNested?: boolean) => {
+  // Safari-specific: Disable hover styles to prevent layout overflow bugs
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+  const isSafari = typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+
+  if (isSafari) {
+    // For Safari, only use selection (no hover) to prevent layout issues
+    return isNested ? '[aria-selected=true] &' : '&[aria-selected=true]';
+  }
+
+  // For other browsers, use normal hover + selection
+  return isNested ? '.rdg-cell:hover &, [aria-selected=true] &' : '&:hover, &[aria-selected=true]';
+};

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -138,24 +138,28 @@ export const getHeaderCellStyles = (theme: GrafanaTheme2, justifyContent: Proper
     '&:last-child': { borderInlineEnd: 'none' },
   });
 
-export const getDefaultCellStyles: TableCellStyles = (theme, { textAlign, shouldOverflow, maxHeight }) =>
-  css({
+export const getDefaultCellStyles: TableCellStyles = (theme, { textAlign, shouldOverflow, maxHeight }) => {
+  const isSafari = typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  const safeShouldOverflow = shouldOverflow && !isSafari;
+
+  return css({
     display: 'flex',
     alignItems: 'center',
     textAlign,
     justifyContent: Boolean(maxHeight) ? 'flex-start' : getJustifyContent(textAlign),
     ...(maxHeight && { overflowY: 'hidden' }),
-    ...(shouldOverflow && { minHeight: '100%' }),
+    ...(safeShouldOverflow && { minHeight: '100%' }),
 
     [getActiveCellSelector()]: {
       '.table-cell-actions': { display: 'flex' },
-      ...(shouldOverflow && {
+      ...(safeShouldOverflow && {
         zIndex: theme.zIndex.tooltip - 2,
         height: 'fit-content',
         minWidth: 'fit-content',
       }),
     },
   });
+};
 
 export const getMaxHeightCellStyles: TableCellStyles = (_theme, { textAlign, maxHeight }) =>
   css({

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -692,6 +692,7 @@ export const frameToRecords = (frame: DataFrame): TableRow[] => {
 
   // Creates a function that converts a DataFrame into an array of TableRows
   // Uses new Function() for performance as it's faster than creating rows using loops
+  /* eslint-disable-next-line @typescript-eslint/consistent-type-assertions */
   const convert = new Function('frame', fnBody) as FrameToRowsConverter;
   return convert(frame);
 };

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -852,8 +852,17 @@ export const calculateFooterHeight = (fields: Field[]): number => {
     maxReducerCount = Math.max(maxReducerCount, field.config.custom?.footer?.reducers?.length ?? 0);
   }
 
+  if (maxReducerCount === 0) {
+    return 0;
+  }
+
   // Base height (+ padding) + height per reducer
-  return maxReducerCount > 0 ? maxReducerCount * TABLE.LINE_HEIGHT + TABLE.CELL_PADDING * 2 : 0;
+  const baseHeight = maxReducerCount * TABLE.LINE_HEIGHT + TABLE.CELL_PADDING * 2;
+
+  // Safari-specific: Reduce footer height slightly to prevent virtualization double-accounting
+  // eslint-disable-next-line @typescript-eslint/prefer-regexp-exec
+  const isSafari = typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  return isSafari ? Math.max(baseHeight - TABLE.CELL_PADDING, TABLE.LINE_HEIGHT) : baseHeight;
 };
 
 /**


### PR DESCRIPTION
# ⚠️ **DO NOT MERGE!** ⚠️ 

This is a debugging exploration to try to figure out ways to workaround layout degradation of Table in the recently release Safari version 26.0 ... the work in this PR is both incomplete, and incorrect ... less glitchy than what's on `main` though so it's a start.

![Flailing at life.](https://github.com/user-attachments/assets/cc8464b3-2b80-4fd5-b1e2-c08bac529501)

A bunch of this is me flailing around until I found things that _(kind of)_ worked, I tried to keep the commits quite small to enable whomever picks up this work next to `git cherry-pick` commits as needed.

**Tangent:** 📓  _There also seems to be a runaway render loop caused by several `ResizeObserver` callbacks that are not wrapped in a `requestAnimationFrame()`._

```
❌  ResizeObserver loop completed with undelivered notifications.
```

_I went pretty far down that rabbit hole, but it didn't seem to be root cause. So I dropped those changes for now to avoid distractions. Might be worth circling back on later, those runaway loops probably aren't helping us with perf IMO._


### Before


https://github.com/user-attachments/assets/2943fc76-c9db-4e0a-b92e-561d8cec9284


### After

https://github.com/user-attachments/assets/b6d9f58d-a9b0-4da0-9034-edf2eb7be9cc



**Which issue(s) does this PR fix?**:

Does not fix https://github.com/grafana/grafana/issues/111590


**Special notes for your reviewer:**

> [!NOTE]
> _To test this you probably need to upgrade to Mac OSX Tahoe and get Safari 26.0_