### PR TITLE
Remove dashboardDsAdHocFiltering feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -79,7 +79,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `unifiedNavbars`                       | Enables unified navbars                                                                                                                                       |                    |
 | `grafanaAssistantInProfilesDrilldown`  | Enables integration with Grafana Assistant in Profiles Drilldown                                                                                              | Yes                |
 | `tabularNumbers`                       | Use fixed-width numbers globally in the UI                                                                                                                    |                    |
-| `dashboardDsAdHocFiltering`            | Enables adhoc filtering support for the dashboard datasource                                                                                                  | Yes                |
 | `adhocFiltersInTooltips`               | Enable adhoc filter buttons in visualization tooltips                                                                                                         | Yes                |
 | `tempoSearchBackendMigration`          | Run search queries through the tempo backend                                                                                                                  |                    |
 

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1108,11 +1108,6 @@ export interface FeatureToggles {
   */
   unifiedStorageSearchDualReaderEnabled?: boolean;
   /**
-  * Enables adhoc filtering support for the dashboard datasource
-  * @default true
-  */
-  dashboardDsAdHocFiltering?: boolean;
-  /**
   * Supports __from and __to macros that always use the dashboard level time range
   */
   dashboardLevelTimeMacros?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1922,14 +1922,7 @@ var (
 			HideFromAdminPage: true,
 			HideFromDocs:      true,
 		},
-		{
-			Name:         "dashboardDsAdHocFiltering",
-			Description:  "Enables adhoc filtering support for the dashboard datasource",
-			Stage:        FeatureStageGeneralAvailability,
-			Owner:        grafanaDataProSquad,
-			FrontendOnly: true,
-			Expression:   "true",
-		},
+        
 		{
 			Name:         "dashboardLevelTimeMacros",
 			Description:  "Supports __from and __to macros that always use the dashboard level time range",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -247,7 +247,6 @@ otelLogsFormatting,experimental,@grafana/observability-logs,false,false,true
 alertingNotificationHistory,experimental,@grafana/alerting-squad,false,false,false
 pluginAssetProvider,experimental,@grafana/plugins-platform-backend,false,true,false
 unifiedStorageSearchDualReaderEnabled,experimental,@grafana/search-and-storage,false,false,false
-dashboardDsAdHocFiltering,GA,@grafana/datapro,false,false,true
 dashboardLevelTimeMacros,experimental,@grafana/dashboards-squad,false,false,true
 alertmanagerRemoteSecondaryWithRemoteState,experimental,@grafana/alerting-squad,false,false,false
 restrictedPluginApis,experimental,@grafana/plugins-platform-backend,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -999,10 +999,6 @@ const (
 	// Enable dual reader for unified storage search
 	FlagUnifiedStorageSearchDualReaderEnabled = "unifiedStorageSearchDualReaderEnabled"
 
-	// FlagDashboardDsAdHocFiltering
-	// Enables adhoc filtering support for the dashboard datasource
-	FlagDashboardDsAdHocFiltering = "dashboardDsAdHocFiltering"
-
 	// FlagDashboardLevelTimeMacros
 	// Supports __from and __to macros that always use the dashboard level time range
 	FlagDashboardLevelTimeMacros = "dashboardLevelTimeMacros"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1001,6 +1001,7 @@
         "name": "dashboardDsAdHocFiltering",
         "resourceVersion": "1756814786992",
         "creationTimestamp": "2025-07-23T08:12:25Z",
+        "deletionTimestamp": "2025-09-27T20:07:11Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2025-09-02 12:06:26.992384 +0000 UTC"
         }

--- a/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/AdHocVariableForm.tsx
@@ -4,7 +4,7 @@ import { DataSourceInstanceSettings, MetricFindValue, readCSV } from '@grafana/d
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { EditorField } from '@grafana/plugin-ui';
-import { config } from '@grafana/runtime';
+ 
 import { DataSourceRef } from '@grafana/schema';
 import { Alert, CodeEditor, Field, Switch, Box } from '@grafana/ui';
 import { DataSourcePicker } from 'app/features/datasources/components/picker/DataSourcePicker';
@@ -67,7 +67,7 @@ export function AdHocVariableForm({
             onChange={onDataSourceChange}
             width={30}
             variables={true}
-            dashboard={config.featureToggles.dashboardDsAdHocFiltering}
+            dashboard={true}
             noDefault
           />
         </EditorField>

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.test.tsx
@@ -30,9 +30,6 @@ jest.mock('app/core/config', () => ({
       },
     },
   },
-  featureToggles: {
-    dashboardDsAdHocFiltering: false, // Default to false, can be overridden in tests
-  },
 }));
 
 setupDataSources(mockDataSource({ isDefault: true }));
@@ -179,11 +176,7 @@ describe('DashboardQueryEditor', () => {
       jest.spyOn(getDashboardSrv(), 'getCurrent').mockImplementation(() => mockDashboard);
     });
 
-    it('shows the AdHoc Filters toggle when feature toggle is enabled', async () => {
-      await act(async () => {
-        config.featureToggles.dashboardDsAdHocFiltering = true;
-      });
-
+    it('always shows the AdHoc Filters toggle', async () => {
       const query: DashboardQuery = { refId: 'A', panelId: 1, adHocFiltersEnabled: false };
 
       await act(async () => {
@@ -200,31 +193,6 @@ describe('DashboardQueryEditor', () => {
 
       const adhocFiltersToggle = await screen.findByText('AdHoc Filters');
       expect(adhocFiltersToggle).toBeInTheDocument();
-    });
-
-    it('does not show the AdHoc Filters toggle when feature toggle is disabled', async () => {
-      await act(async () => {
-        config.featureToggles.dashboardDsAdHocFiltering = false;
-      });
-
-      const query: DashboardQuery = { refId: 'A', panelId: 1, adHocFiltersEnabled: false };
-
-      await act(async () => {
-        render(
-          <DashboardQueryEditor
-            datasource={{} as DashboardDatasource}
-            query={query}
-            data={mockPanelData}
-            onChange={mockOnChange}
-            onRunQuery={mockOnRunQueries}
-          />
-        );
-      });
-
-      // Wait for any async operations to complete
-      await waitFor(() => {
-        expect(screen.queryByText('AdHoc Filters')).not.toBeInTheDocument();
-      });
     });
   });
 });

--- a/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
+++ b/public/app/plugins/datasource/dashboard/DashboardQueryEditor.tsx
@@ -205,15 +205,13 @@ export function DashboardQueryEditor({ data, query, onChange, onRunQuery }: Prop
             </Field>
           )}
 
-          {config.featureToggles.dashboardDsAdHocFiltering && (
-            <Field
-              label="AdHoc Filters"
-              description="Apply --Dashboard-- data source AdHoc filters to this panel"
-              noMargin
-            >
-              <InlineSwitch value={Boolean(query.adHocFiltersEnabled)} onChange={onAdHocFiltersToggle} />
-            </Field>
-          )}
+          <Field
+            label="AdHoc Filters"
+            description="Apply --Dashboard-- data source AdHoc filters to this panel"
+            noMargin
+          >
+            <InlineSwitch value={Boolean(query.adHocFiltersEnabled)} onChange={onAdHocFiltersToggle} />
+          </Field>
         </Stack>
 
         {loadingResults ? (

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -12,7 +12,7 @@ import {
   AdHocVariableFilter,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
-import { setPluginImportUtils, config } from '@grafana/runtime';
+import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,
   SceneDataNode,
@@ -178,15 +178,6 @@ describe('DashboardDatasource', () => {
 
     // Test AdHoc filtering via the Public API first, to ensure Integration
     describe('Integration (Public API)', () => {
-      const originalToggleValue = config.featureToggles.dashboardDsAdHocFiltering;
-
-      beforeEach(() => {
-        config.featureToggles.dashboardDsAdHocFiltering = true;
-      });
-
-      afterEach(() => {
-        config.featureToggles.dashboardDsAdHocFiltering = originalToggleValue;
-      });
 
       it('should apply basic filtering end-to-end through public query method', async () => {
         const testFrame = createTestFrame([
@@ -224,45 +215,7 @@ describe('DashboardDatasource', () => {
         expect(result?.data[0].length).toBe(1);
       });
 
-      it('should respect feature toggle and not filter when disabled', async () => {
-        // Temporarily disable the feature toggle for this test
-        config.featureToggles.dashboardDsAdHocFiltering = false;
-
-        const testFrame = createTestFrame([
-          { name: 'name', type: FieldType.string, values: ['John', 'Jane', 'Bob'] },
-          { name: 'age', type: FieldType.number, values: [25, 30, 35] },
-        ]);
-
-        const scene = new SceneFlexLayout({
-          children: [
-            new SceneFlexItem({
-              body: new VizPanel({
-                key: getVizPanelKeyForPanelId(1),
-                $data: new SceneDataNode({
-                  data: {
-                    series: [testFrame],
-                    state: LoadingState.Done,
-                    timeRange: getDefaultTimeRange(),
-                  },
-                }),
-              }),
-            }),
-          ],
-        });
-
-        const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
-        const filters: AdHocVariableFilter[] = [{ key: 'name', operator: '=', value: 'John' }];
-
-        const observable = ds.query(createQueryRequest(filters, scene));
-
-        let result: DataQueryResponse | undefined;
-        observable.subscribe({ next: (data) => (result = data) });
-
-        // Should return unfiltered data since feature toggle is disabled
-        expect(result?.data[0].fields[0].values).toEqual(['John', 'Jane', 'Bob']);
-        expect(result?.data[0].fields[1].values).toEqual([25, 30, 35]);
-        expect(result?.data[0].length).toBe(3);
-      });
+      
 
       it('should respect per-panel adHocFiltersEnabled setting and not filter when disabled', async () => {
         const testFrame = createTestFrame([
@@ -723,26 +676,9 @@ describe('DashboardDatasource', () => {
     });
 
     describe('getDrilldownsApplicability', () => {
-      const originalToggleValue = config.featureToggles.dashboardDsAdHocFiltering;
       const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
 
-      beforeEach(() => {
-        config.featureToggles.dashboardDsAdHocFiltering = true;
-      });
-
-      afterEach(() => {
-        config.featureToggles.dashboardDsAdHocFiltering = originalToggleValue;
-      });
-
-      it('should return empty array when feature toggle is disabled', async () => {
-        config.featureToggles.dashboardDsAdHocFiltering = false;
-
-        const result = await ds.getDrilldownsApplicability({
-          filters: [{ key: 'name', operator: '=', value: 'test' }],
-        });
-
-        expect(result).toEqual([]);
-      });
+      
 
       it('should mark supported operators as applicable', async () => {
         const result = await ds.getDrilldownsApplicability({

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -20,7 +20,7 @@ import {
   DataSourceGetDrilldownsApplicabilityOptions,
   DrilldownsApplicability,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+ 
 import { isSceneObject, SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
   activateSceneObjectAndParentTree,
@@ -140,9 +140,9 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
             ...field,
             config: {
               ...field.config,
-              // Enable AdHoc filtering for string and numeric fields only when feature toggle and per-panel setting are enabled
+              // Enable AdHoc filtering for string and numeric fields only when per-panel setting is enabled
               filterable:
-                config.featureToggles.dashboardDsAdHocFiltering && query.adHocFiltersEnabled
+                query.adHocFiltersEnabled
                   ? field.type === FieldType.string || field.type === FieldType.number
                   : field.config.filterable,
             },
@@ -153,7 +153,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
         };
       });
 
-      if (!config.featureToggles.dashboardDsAdHocFiltering || !query.adHocFiltersEnabled || filters.length === 0) {
+      if (!query.adHocFiltersEnabled || filters.length === 0) {
         return [...series, ...annotations];
       }
 
@@ -247,11 +247,9 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
     const field = frame.fields[fieldIndex];
 
-    // Only support string and numeric fields when feature toggle is enabled
-    if (config.featureToggles.dashboardDsAdHocFiltering) {
-      if (field.type !== FieldType.string && field.type !== FieldType.number) {
-        return null;
-      }
+    // Only support string and numeric fields
+    if (field.type !== FieldType.string && field.type !== FieldType.number) {
+      return null;
     }
 
     // Map operator to matcher ID
@@ -357,10 +355,6 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
   async getDrilldownsApplicability(
     options?: DataSourceGetDrilldownsApplicabilityOptions<DashboardQuery>
   ): Promise<DrilldownsApplicability[]> {
-    if (!config.featureToggles.dashboardDsAdHocFiltering) {
-      return [];
-    }
-
     // Check if any query has adhoc filters enabled
     const hasAdHocFiltersEnabled = options?.queries?.some((query) => query.adHocFiltersEnabled);
 


### PR DESCRIPTION
**What is this feature?**

This PR removes the `dashboardDsAdHocFiltering` feature toggle from the codebase. The functionality it guarded, ad-hoc filtering support for the dashboard datasource, is now always enabled.

**Why do we need this feature?**

The `dashboardDsAdHocFiltering` feature toggle has been enabled by default on Grafana's `main` branch, indicating that the feature is stable and no longer requires a toggle. Removing it simplifies the codebase and reduces maintenance overhead.

**Who is this feature for?**

This change benefits all users who utilize ad-hoc filtering with the dashboard datasource, as the feature will now be unconditionally available. It also benefits developers by removing deprecated feature toggle logic.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective. (Ad-hoc filtering for dashboard datasource should always be available).
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A, this removes a GA toggle).
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (Docs updated by removing the toggle entry; not a "What's New" item as it's a cleanup).

---
<a href="https://cursor.com/background-agent?bcId=bc-cd3a431b-aa49-4714-94b5-fd52ecbe8cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cd3a431b-aa49-4714-94b5-fd52ecbe8cba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

