### PR TITLE
Provisioning: Wait for status check in frontend

### DIFF
--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -46,6 +46,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
   } = repositoryStatusQuery?.data?.status?.health || {};
 
   const hasError = repositoryStatusQuery.isError;
+  const isLoading = repositoryStatusQuery.isLoading || repositoryStatusQuery.isFetching;
   const isButtonDisabled = hasError || (checked !== undefined && isRepositoryHealthy === false);
 
   const startSynchronization = async () => {
@@ -56,7 +57,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
     }
   };
 
-  if (repositoryStatusQuery.isFetching) {
+  if (isLoading) {
     return <Spinner />;
   }
   if (job) {
@@ -151,7 +152,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
       )}
 
       <Field noMargin>
-        {hasError || isRepositoryHealthy === false ? (
+        {hasError || (checked !== undefined && isRepositoryHealthy === false) ? (
           <Button variant="destructive" onClick={() => onCancel?.(repoName)} disabled={isCancelling}>
             {isCancelling ? (
               <Trans i18nKey="provisioning.wizard.button-cancelling">Cancelling...</Trans>


### PR DESCRIPTION
**What is this feature?**

This PR fixes a frontend issue where we weren't waiting for the status endpoint to return fully and be processed, which would result in the "cancel" button showing up rather than loading

To reproduce, click through the flow very quickly in cloud. Ephemeral instance is below that has the fix.

<img width="2286" height="1024" alt="image" src="https://github.com/user-attachments/assets/c091a661-e35c-4158-ad04-c3f2462a1c48" />
