### PR TITLE
Trash: Keep provisioned objects out of the trash

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1093,6 +1093,11 @@ func (s *server) isTrashItemAuthorized(ctx context.Context, iter ListIterator, t
 		return false
 	}
 
+	// provisioned objects should not be retrievable in the trash
+	if obj.GetAnnotation(utils.AnnoKeyManagerKind) != "" {
+		return false
+	}
+
 	// Trash is only accessible to admins or the user who deleted the object
 	return obj.GetUpdatedBy() == user.GetUID() || trashChecker(iter.Name(), iter.Folder())
 }

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -885,6 +885,9 @@ func (k *kvStorageBackend) processTrashEntries(ctx context.Context, req *resourc
 	// Sort the entries
 	sortByResourceVersion(filteredKeys, sortAscending)
 
+	// Remove provisioned objects from trash
+	filteredKeys = k.removeProvisionedObjects(ctx, filteredKeys)
+
 	// Pagination: filter out items up to and including lastSeenRV
 	pagedKeys := applyPagination(filteredKeys, lastSeenRV, sortAscending)
 
@@ -903,6 +906,43 @@ func (k *kvStorageBackend) processTrashEntries(ctx context.Context, req *resourc
 	}
 
 	return listRV, nil
+}
+
+// provisioned objects should not be retrievable in the trash
+func (k *kvStorageBackend) removeProvisionedObjects(ctx context.Context, keys []DataKey) []DataKey {
+	writeIndex := 0
+	for readIndex := 0; readIndex < len(keys); readIndex++ {
+		key := keys[readIndex]
+		data, err := k.dataStore.Get(ctx, key)
+		if err != nil && data == nil {
+			continue
+		}
+
+		value, err := readAndClose(data)
+		if err != nil {
+			continue
+		}
+
+		partial := &metav1.PartialObjectMetadata{}
+		err = json.Unmarshal(value, partial)
+		if err != nil {
+			continue
+		}
+
+		obj, err := utils.MetaAccessor(partial)
+		if err != nil {
+			continue
+		}
+
+		if obj.GetAnnotation(utils.AnnoKeyManagerKind) != "" {
+			continue
+		}
+
+		keys[writeIndex] = keys[readIndex]
+		writeIndex++
+	}
+
+	return keys[:writeIndex]
 }
 
 // kvHistoryIterator implements ListIterator for KV storage history

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -965,7 +965,7 @@ func (i *kvHistoryIterator) Next() bool {
 	i.err = nil
 
 	// if the resource is provisioned and we are skipping provisioned resources, continue onto the next one
-	if meta.GetAnnotation(utils.AnnoKeyManagerKind) != "" && i.skipProvisioned {
+	if i.skipProvisioned && meta.GetAnnotation(utils.AnnoKeyManagerKind) != "" {
 		return i.Next()
 	}
 

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -1041,6 +1041,36 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 	rv2, err := backend.WriteEvent(ctx, writeEvent)
 	require.NoError(t, err)
 
+	// Do the same for a provisioned object
+	provisionedObj, err := createTestObjectWithName("provisioned-obj", appsNamespace, "test-data")
+	require.NoError(t, err)
+	metaAccessorProvisioned, err := utils.MetaAccessor(provisionedObj)
+	require.NoError(t, err)
+	metaAccessorProvisioned.SetAnnotation(utils.AnnoKeyManagerKind, "repo")
+
+	writeEventProvisioned := WriteEvent{
+		Type: resourcepb.WatchEvent_ADDED,
+		Key: &resourcepb.ResourceKey{
+			Namespace: "default",
+			Group:     "apps",
+			Resource:  "resources",
+			Name:      "provisioned-obj",
+		},
+		Value:      objectToJSONBytes(t, provisionedObj),
+		Object:     metaAccessorProvisioned,
+		PreviousRV: 0,
+	}
+
+	rv3, err := backend.WriteEvent(ctx, writeEventProvisioned)
+	require.NoError(t, err)
+
+	writeEventProvisioned.Type = resourcepb.WatchEvent_DELETED
+	writeEventProvisioned.PreviousRV = rv3
+	writeEventProvisioned.Object = metaAccessorProvisioned
+	writeEventProvisioned.ObjectOld = metaAccessorProvisioned
+	_, err = backend.WriteEvent(ctx, writeEventProvisioned)
+	require.NoError(t, err)
+
 	// List the trash (deleted items)
 	listReq := &resourcepb.ListRequest{
 		Options: &resourcepb.ListOptions{
@@ -1081,7 +1111,7 @@ func TestKvStorageBackend_ListTrash_Success(t *testing.T) {
 
 	require.NoError(t, err)
 	require.Greater(t, rv, int64(0))
-	require.Len(t, trashItems, 1) // Should have the deleted item
+	require.Len(t, trashItems, 1) // Should have the non-provisioned deleted item
 
 	// Verify the trash item
 	require.Equal(t, "test-resource", trashItems[0].name)


### PR DESCRIPTION
Before:
<img width="958" height="379" alt="Screenshot 2025-09-28 at 11 08 48 AM" src="https://github.com/user-attachments/assets/6d44113c-46c6-4b80-863a-6e9e7f2b8fc0" />

After (deleted a dashboard not provisioned):
<img width="951" height="393" alt="Screenshot 2025-09-28 at 11 10 00 AM" src="https://github.com/user-attachments/assets/b6d4ff5e-dd5d-433a-bb67-2a1e7eccdfbd" />


Fixes https://github.com/grafana/git-ui-sync-project/issues/563