### PR TITLE
Docs: Remove session cookie option for http api auth docs

### DIFF
--- a/docs/sources/developers/http_api/authentication.md
+++ b/docs/sources/developers/http_api/authentication.md
@@ -1,6 +1,6 @@
 ---
 canonical: https://grafana.com/docs/grafana/latest/developers/http_api/authentication/
-description: 'You can authenticate HTTP API requests using basic authentication, a service account token, or a session cookie.'
+description: 'You can authenticate HTTP API requests using basic authentication or a service account token.'
 keywords:
   - grafana
   - http

--- a/docs/sources/shared/developers/authentication.md
+++ b/docs/sources/shared/developers/authentication.md
@@ -4,7 +4,7 @@ comments: |
   This file is used in the following files: developers/http_api/{_index.md,authentication.md}
 ---
 
-You can authenticate HTTP API requests using basic authentication, a service account token, or a session cookie (acquired via regular login or OAuth).
+You can authenticate HTTP API requests using basic authentication or a service account token.
 
 ### Basic auth
 


### PR DESCRIPTION
**What is this feature?**

Remove the "session cookie" auth option for the Grafana HTTP API from the docs, because that is not recommended to use.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
