### PR TITLE
Chore: Fix e2e-selectors eslint rule to check for `startsWith`

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -4484,6 +4484,11 @@
       "count": 1
     }
   },
+  "public/app/plugins/panel/geomap/components/DebugOverlay.tsx": {
+    "@grafana/no-aria-label-selectors": {
+      "count": 1
+    }
+  },
   "public/app/plugins/panel/geomap/components/MarkersLegend.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2

--- a/packages/grafana-eslint-rules/rules/no-aria-label-e2e-selectors.cjs
+++ b/packages/grafana-eslint-rules/rules/no-aria-label-e2e-selectors.cjs
@@ -50,7 +50,7 @@ const rule = createRule({
             (v) =>
               v.type === 'ImportBinding' &&
               v.parent.type === 'ImportDeclaration' &&
-              v.parent.source.value === GRAFANA_E2E_PACKAGE_NAME
+              v.parent.source.value.startsWith(GRAFANA_E2E_PACKAGE_NAME)
           );
 
           if (importDef) {

--- a/packages/grafana-eslint-rules/tests/no-aria-label-e2e-selectors.test.js
+++ b/packages/grafana-eslint-rules/tests/no-aria-label-e2e-selectors.test.js
@@ -19,12 +19,15 @@ const ruleTester = new RuleTester();
 ruleTester.run('eslint no-aria-label-e2e-selector', noAriaLabelE2ESelector, {
   valid: [
     {
+      name: 'direct aria-label usage',
       code: `<div aria-label="foo" />`,
     },
     {
+      name: 'basic jsx expression container aria-label usage',
       code: `<div aria-label={"foo"} />`,
     },
     {
+      name: 'imported from something else',
       code: `
 import { someOtherImport } from './some-other-location';
 
@@ -34,8 +37,22 @@ import { someOtherImport } from './some-other-location';
   ],
   invalid: [
     {
+      name: 'imported from e2e-selectors package',
       code: `
 import { selectors } from '@grafana/e2e-selectors';
+
+<div aria-label={selectors.pages.AddDashboard.addNewPanel} />
+      `,
+      errors: [
+        {
+          message: 'Use data-testid for E2E selectors instead of aria-label',
+        },
+      ],
+    },
+    {
+      name: 'imported from elsewhere in e2e-selectors package',
+      code: `
+import { selectors } from '@grafana/e2e-selectors/src';
 
 <div aria-label={selectors.pages.AddDashboard.addNewPanel} />
       `,


### PR DESCRIPTION
**What is this feature?**
Update e2e selector rule to check if the imports starts with the package name, so it catches imports from elsewhere (`/src`)
There was only one occurrence of this, I added it to suppressions
