### PR TITLE
Logs panel: Respect selected fields for downloading logs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3183,14 +3183,6 @@
       "count": 1
     }
   },
-  "public/app/features/logs/utils.ts": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    },
-    "no-restricted-syntax": {
-      "count": 6
-    }
-  },
   "public/app/features/manage-dashboards/DashboardImportPage.tsx": {
     "no-restricted-syntax": {
       "count": 2

--- a/public/app/features/inspector/utils/download.ts
+++ b/public/app/features/inspector/utils/download.ts
@@ -21,7 +21,7 @@ import { transformToZipkin } from '../../../plugins/datasource/zipkin/utils/tran
  * @param {(Pick<LogsModel, 'meta' | 'rows'>)} logsModel
  * @param {string} title
  */
-export function downloadLogsModelAsTxt(logsModel: Pick<LogsModel, 'meta' | 'rows'>, title = '') {
+export function downloadLogsModelAsTxt(logsModel: Pick<LogsModel, 'meta' | 'rows'>, title = '', fields: string[] = []) {
   let textToDownload = '';
 
   logsModel.meta?.forEach((metaItem) => {
@@ -31,7 +31,8 @@ export function downloadLogsModelAsTxt(logsModel: Pick<LogsModel, 'meta' | 'rows
   textToDownload = textToDownload + '\n\n';
 
   logsModel.rows.forEach((row) => {
-    const newRow = row.timeEpochMs + '\t' + dateTime(row.timeEpochMs).toISOString() + '\t' + row.entry + '\n';
+    const entry = !fields.length ? row.entry : fields.map((field) => row.labels[field] ?? '').join(' ');
+    const newRow = row.timeEpochMs + '\t' + dateTime(row.timeEpochMs).toISOString() + '\t' + entry + '\n';
     textToDownload = textToDownload + newRow;
   });
 

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -559,9 +559,9 @@ export const LogListContextProvider = ({
         logListState.filterLevels.length === 0
           ? logs
           : logs.filter((log) => logListState.filterLevels.includes(log.logLevel));
-      download(format, filteredLogs, logsMeta);
+      download(format, filteredLogs, logsMeta, displayedFields);
     },
-    [logListState.filterLevels, logs, logsMeta]
+    [displayedFields, logListState.filterLevels, logs, logsMeta]
   );
 
   const closeDetails = useCallback(() => {

--- a/public/app/features/logs/components/panel/LogListControls.test.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.test.tsx
@@ -448,7 +448,7 @@ describe('LogListControls', () => {
     await userEvent.click(screen.getByLabelText(DOWNLOAD_LOGS_LABEL_COPY));
     await userEvent.click(await screen.findByText(label));
     expect(downloadLogs).toHaveBeenCalledTimes(1);
-    expect(downloadLogs).toHaveBeenCalledWith(format, [], undefined);
+    expect(downloadLogs).toHaveBeenCalledWith(format, [], undefined, []);
   });
 
   test('Allows to download logs filtered logs', async () => {
@@ -465,7 +465,7 @@ describe('LogListControls', () => {
     );
     await userEvent.click(screen.getByLabelText(DOWNLOAD_LOGS_LABEL_COPY));
     await userEvent.click(await screen.findByText('txt'));
-    expect(downloadLogs).toHaveBeenCalledWith('text', filteredLogs, undefined);
+    expect(downloadLogs).toHaveBeenCalledWith('text', filteredLogs, undefined, []);
   });
 
   test('Controls new lines', async () => {

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -1,3 +1,5 @@
+import saveAs from 'file-saver';
+
 import {
   AbsoluteTimeRange,
   FieldType,
@@ -11,6 +13,7 @@ import {
 } from '@grafana/data';
 import { getMockFrames } from 'app/plugins/datasource/loki/mocks/frames';
 
+import { createLogRow } from './components/mocks/logRow';
 import { logSeriesToLogsModel } from './logsModel';
 import {
   calculateLogsLabelStats,
@@ -25,7 +28,11 @@ import {
   mergeLogsVolumeDataFrames,
   sortLogsResult,
   checkLogsSampled,
+  downloadLogs,
+  DownloadFormat,
 } from './utils';
+
+jest.mock('file-saver', () => jest.fn());
 
 describe('getLoglevel()', () => {
   it('returns no log level on empty line', () => {
@@ -586,5 +593,68 @@ describe('findMatchingRow', () => {
       const targetRow = { ...row, rowId: undefined };
       expect(findMatchingRow(targetRow)).toBeTruthy();
     }
+  });
+});
+
+describe('downloadLogs', () => {
+  const logs = [
+    createLogRow({ timeEpochMs: 100, entry: 'test entry', labels: { label: 'value', otherLabel: 'other value' } }),
+  ];
+  describe('Text format', () => {
+    beforeEach(() => {
+      jest.mocked(saveAs).mockClear();
+    });
+
+    it('Downloads logs in txt format', async () => {
+      downloadLogs(DownloadFormat.Text, logs);
+
+      const blob = jest.mocked(saveAs).mock.calls[0][0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toContain('test entry');
+    });
+
+    it('Downloads selected fields in txt format', async () => {
+      downloadLogs(DownloadFormat.Text, logs, [], ['label', 'otherLabel']);
+
+      const blob = jest.mocked(saveAs).mock.calls[0][0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(text).toContain('value other value');
+    });
+  });
+
+  describe('JSON format', () => {
+    beforeEach(() => {
+      jest.mocked(saveAs).mockClear();
+    });
+
+    it('Downloads logs in JSON format', async () => {
+      downloadLogs(DownloadFormat.Json, logs);
+
+      const blob = jest.mocked(saveAs).mock.calls[0][0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(JSON.parse(text)[0]).toEqual(
+        expect.objectContaining({
+          line: 'test entry',
+          fields: { label: 'value', otherLabel: 'other value' },
+        })
+      );
+    });
+
+    it('Downloads selected fields in JSON format', async () => {
+      downloadLogs(DownloadFormat.Json, logs, [], ['otherLabel']);
+
+      const blob = jest.mocked(saveAs).mock.calls[0][0];
+      const text = typeof blob === 'string' ? blob : await blob.text();
+
+      expect(JSON.parse(text)[0]).toEqual(
+        expect.objectContaining({
+          line: 'test entry',
+          fields: { otherLabel: 'other value' },
+        })
+      );
+    });
   });
 });

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -29,6 +29,7 @@ import {
   getTimeField,
   Field,
   LogsMetaItem,
+  store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getConfig } from 'app/core/config';
@@ -67,6 +68,7 @@ export function getLogLevel(line: string): LogLevel {
 }
 
 export function getLogLevelFromKey(key: string | number): LogLevel {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const level = LogLevel[key.toString().toLowerCase() as keyof typeof LogLevel];
   if (level) {
     return level;
@@ -429,15 +431,15 @@ function getDataSourceLabelType(labelType: string, datasourceType: string, plura
 
 const POPOVER_STORAGE_KEY = 'logs.popover.disabled';
 export function disablePopoverMenu() {
-  localStorage.setItem(POPOVER_STORAGE_KEY, 'true');
+  store.set(POPOVER_STORAGE_KEY, 'true');
 }
 
 export function enablePopoverMenu() {
-  localStorage.removeItem(POPOVER_STORAGE_KEY);
+  store.delete(POPOVER_STORAGE_KEY);
 }
 
 export function isPopoverMenuDisabled() {
-  return Boolean(localStorage.getItem(POPOVER_STORAGE_KEY));
+  return Boolean(store.get(POPOVER_STORAGE_KEY));
 }
 
 export enum DownloadFormat {

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -440,10 +440,15 @@ export enum DownloadFormat {
   CSV = 'csv',
 }
 
-export const downloadLogs = async (format: DownloadFormat, logRows: LogRowModel[], meta?: LogsMetaItem[]) => {
+export const downloadLogs = async (
+  format: DownloadFormat,
+  logRows: LogRowModel[],
+  meta?: LogsMetaItem[],
+  fields: string[] = []
+) => {
   switch (format) {
     case DownloadFormat.Text:
-      downloadLogsModelAsTxt({ meta, rows: logRows });
+      downloadLogsModelAsTxt({ meta, rows: logRows }, '', fields);
       break;
     case DownloadFormat.Json:
       const jsonLogs = logRowsToReadableJson(logRows);

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -467,18 +467,29 @@ export const downloadLogs = async (
       });
       dataFrameMap.forEach(async (dataFrame) => {
         const transforms: Array<DataTransformerConfig | CustomTransformOperator> = getLogsExtractFields(dataFrame);
-        transforms.push(
-          {
-            id: 'organize',
+        if (fields.length) {
+          transforms.push(addISODateTransformation, {
+            id: 'filterFieldsByName',
             options: {
-              excludeByName: {
-                ['labels']: true,
-                ['labelTypes']: true,
+              include: {
+                names: ['Date', ...fields],
               },
             },
-          },
-          addISODateTransformation
-        );
+          });
+        } else {
+          transforms.push(
+            {
+              id: 'organize',
+              options: {
+                excludeByName: {
+                  ['labels']: true,
+                  ['labelTypes']: true,
+                },
+              },
+            },
+            addISODateTransformation
+          );
+        }
         const transformedDataFrame = await lastValueFrom(transformDataFrame(transforms, [dataFrame]));
         downloadDataFrameAsCsv(transformedDataFrame[0], `Logs-${dataFrame.refId}`);
       });


### PR DESCRIPTION
Part of https://github.com/grafana/grafana/issues/77817
Closes https://github.com/grafana/grafana/issues/95661
Other relevant issues:
- https://github.com/grafana/grafana/issues/95661

When downloading logs, if there are selected fields, it should respect the selection.

### How to test

- Without selecting displayed fields, export logs. It should preserve the current behavior of main, exporting log lines and fields.
- Select displayed fields, export logs. The exported logs should respect the selected fields.