### PR TITLE
FolderPicker: Don't show parent folder when not searching

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -173,6 +173,11 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
     ) : null;
   }
 
+  // We don't have a direct value of whether things are coming from user searching but this seems to be a good
+  // approximation as when searching all items will be at top level, while things that are actually in the top level
+  // when just looking at a folders tree should not have parent.
+  const isSearchItem = level === 0 && item.parentUID !== undefined;
+
   return (
     // don't need a key handler here, it's handled at the input level in NestedFolderPicker
     // eslint-disable-next-line jsx-a11y/click-events-have-key-events
@@ -217,7 +222,7 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
           <Text truncate>{item.title}</Text>
           <FolderRepo folder={item} />
         </label>
-        <FolderParent item={items[index]} />
+        {isSearchItem && <FolderParent item={items[index]} />}
       </div>
     </div>
   );


### PR DESCRIPTION
[Previous PR](https://github.com/grafana/grafana/issues/110949) introduced a parent folder subtext next to an item, but also shows it when just showing the folder tree. This fixes it so it shows only when searching.

Not what we want:
<img width="196" height="175" alt="Screenshot 2025-09-29 at 17 30 46" src="https://github.com/user-attachments/assets/cf74c548-3404-4e45-b567-32842a47b31b" />
