### PR TITLE
[wip] Provisioning: Reduce the chance of the race condition in job driver

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -63,6 +63,17 @@ func checkManagerPropertiesOnUpdateSpec(auth authtypes.AuthInfo, obj utils.Grafa
 			}}
 		}
 	}
+
+	// Cannot change the manager if already set
+	if okNew && okOld && managerNew != managerOld {
+		return &apierrors.StatusError{ErrStatus: metav1.Status{
+			Status:  metav1.StatusFailure,
+			Code:    http.StatusForbidden,
+			Reason:  metav1.StatusReasonForbidden,
+			Message: "Can not change resource manager",
+		}}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
wip..

currently the concurrent job controllers list a set of jobs that do not have a given label attached to them ([here](https://github.com/grafana/grafana/blob/52eaa77bdde2dad3393d31afc53ffb3bbf4cfaa2/pkg/registry/apis/provisioning/jobs/persistentstore.go#L108)). But if all 3 concurrent job controllers list them at the same time, they will all get the same jobs and begin working them.

Although they update them to "claim" them [here](https://github.com/grafana/grafana/blob/52eaa77bdde2dad3393d31afc53ffb3bbf4cfaa2/pkg/registry/apis/provisioning/jobs/persistentstore.go#L137), there is nothing stopping a job from updating another claimed job.

The idea with this PR is:
- Change from using a "claimed" label to using managed by annotations
- Prevent in unified storage the ability to change the manager from one manager to another

A few thoughts:
- We may want to add another manager type, maybe "controller"? Otherwise it is a bit hacky just using the repo type
- This doesn't completely solve the problem, but should make it less often. iirc, an update on an object does not block an update on the same object in unistore. so if the requests happen at the _exact_ same time to update and can get through this function before the other updates, this will still occur. however, this would be better than before just relying on the singular list.
- Long term, we probably want something like https://kubernetes.io/docs/concepts/architecture/leases/ supported in unistore. 