### PR TITLE
Plugins: Dependencies do not inherit parent URL for preinstall

### DIFF
--- a/pkg/plugins/manager/installer.go
+++ b/pkg/plugins/manager/installer.go
@@ -71,7 +71,7 @@ func (m *PluginInstaller) Add(ctx context.Context, pluginID, version string, opt
 	for _, dep := range archive.Dependencies {
 		m.log.Info(fmt.Sprintf("Fetching %s dependency %s...", pluginID, dep.ID))
 
-		err = m.Add(ctx, dep.ID, "", opts)
+		err = m.Add(ctx, dep.ID, "", plugins.NewAddOpts(opts.GrafanaVersion(), opts.OS(), opts.Arch(), ""))
 		if err != nil {
 			var dupeErr plugins.DuplicateError
 			if errors.As(err, &dupeErr) {


### PR DESCRIPTION
**What is this feature?**

Fixes a bug where if you try to preinstall via URL a plugin which contains dependencies, it will result in a invalid install.

IE 

grafana-foobar-app plugin.json:
```json
"dependencies": {
  "grafanaDependency": ">=12.0.0",
  "plugins": [
    {
      "id": "yesoreyeram-infinity-datasource",
    }
  ]
}
```

Grafana config.ini:
```ini
[plugins]
preinstall=grafana-foobar-app@1.0.0@https://storage.googleapis.com/grafana-plugins/grafana-foobar-app.zip
```

**Who is this feature for?**

Grafana operators 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/111738

