### PR TITLE
unified-storage: setup rollout-operator endpoint

### DIFF
--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -187,7 +187,7 @@ func (s *ModuleServer) Run() error {
 		if err != nil {
 			return nil, err
 		}
-		return sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, nil, s.log, s.registerer, docBuilders, s.storageMetrics, s.indexMetrics, s.searchServerRing, s.MemberlistKVConfig)
+		return sql.ProvideUnifiedStorageGrpcService(s.cfg, s.features, nil, s.log, s.registerer, docBuilders, s.storageMetrics, s.indexMetrics, s.searchServerRing, s.MemberlistKVConfig, s.httpServerRouter)
 	})
 
 	m.RegisterModule(modules.ZanzanaServer, func() (services.Service, error) {

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -202,7 +202,7 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) PrepareDownscale(w http.ResponseWriter, r *http.Request) {
-	s.log.Info("Preparing for downscale. Will not keep instance in ring on shutdown")
+	s.log.Info("Preparing for downscale. Will not keep instance in ring on shutdown.", "method", r.Method)
 	s.ringLifecycler.SetKeepInstanceInTheRingOnShutdown(false)
 }
 

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -164,7 +164,7 @@ func ProvideUnifiedStorageGrpcService(
 		subservices = append(subservices, s.ringLifecycler)
 
 		if httpServerRouter != nil {
-			httpServerRouter.Path("/prepare-downscale").Methods("GET").Handler(http.HandlerFunc(s.PrepareDownscale))
+			httpServerRouter.Path("/prepare-downscale").Methods("GET", "POST", "DELETE").Handler(http.HandlerFunc(s.PrepareDownscale))
 		}
 	}
 

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -202,8 +202,18 @@ func ProvideUnifiedStorageGrpcService(
 }
 
 func (s *service) PrepareDownscale(w http.ResponseWriter, r *http.Request) {
-	s.log.Info("Preparing for downscale. Will not keep instance in ring on shutdown.", "method", r.Method)
-	s.ringLifecycler.SetKeepInstanceInTheRingOnShutdown(false)
+	switch r.Method {
+	case http.MethodPost:
+		s.log.Info("Preparing for downscale. Will not keep instance in ring on shutdown.")
+		s.ringLifecycler.SetKeepInstanceInTheRingOnShutdown(false)
+	case http.MethodDelete:
+		s.log.Info("Downscale canceled. Will keep instance in ring on shutdown.")
+		s.ringLifecycler.SetKeepInstanceInTheRingOnShutdown(true)
+	case http.MethodGet:
+		// used for delayed downscale use case, which we don't support. Leaving here for completion sake
+		s.log.Info("Received GET request for prepare-downscale. Behavior not implemented.")
+	default:
+	}
 }
 
 var (

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -128,7 +128,7 @@ func TestClientServer(t *testing.T) {
 
 	features := featuremgmt.WithFeatures()
 
-	svc, err := sql.ProvideUnifiedStorageGrpcService(cfg, features, dbstore, nil, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{})
+	svc, err := sql.ProvideUnifiedStorageGrpcService(cfg, features, dbstore, nil, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil)
 	require.NoError(t, err)
 	var client resourcepb.ResourceStoreClient
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -129,7 +129,7 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 	var storage sql.UnifiedStorageGrpcService
 	if runstore {
 		storage, err = sql.ProvideUnifiedStorageGrpcService(env.Cfg, env.FeatureToggles, env.SQLStore,
-			env.Cfg.Logger, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{})
+			env.Cfg.Logger, prometheus.NewPedanticRegistry(), nil, nil, nil, nil, kv.Config{}, nil)
 		require.NoError(t, err)
 		ctx := context.Background()
 		err = storage.StartAsync(ctx)


### PR DESCRIPTION
for https://github.com/grafana/search-and-storage-team/issues/526

Setup `/prepare-downscale` http endpoint that the rollout-operator will use before scaling down the pod, so the pod knows it should leave the ring