### PR TITLE
unified-storage: dont index -- Grafana -- datasource dashboard fields

### DIFF
--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -334,6 +334,9 @@ func filterOutSpecialDatasources(dash *DashboardSummaryInfo) {
 			case "-- Dashboard --":
 				// The `Dashboard` datasource refers to the results of the query used in another panel
 				continue
+			case "grafana":
+				// this is the uid for the -- Grafana -- datasource
+				continue
 			default:
 				dsRefs = append(dsRefs, ds)
 			}

--- a/pkg/services/store/kind/dashboard/testdata/check-string-datasource-id-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/check-string-datasource-id-info.json
@@ -2,24 +2,12 @@
   "id": 250,
   "title": "fast streaming",
   "tags": null,
-  "datasource": [
-    {
-      "uid": "grafana",
-      "type": "datasource"
-    }
-  ],
   "panels": [
     {
       "id": 3,
       "title": "Panel Title",
       "type": "timeseries",
-      "pluginVersion": "7.5.0-pre",
-      "datasource": [
-        {
-          "uid": "grafana",
-          "type": "datasource"
-        }
-      ]
+      "pluginVersion": "7.5.0-pre"
     }
   ],
   "schemaVersion": 27,

--- a/pkg/services/store/kind/dashboard/testdata/special-datasource-types-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/special-datasource-types-info.json
@@ -4,10 +4,6 @@
   "tags": null,
   "datasource": [
     {
-      "uid": "grafana",
-      "type": "datasource"
-    },
-    {
       "uid": "dgd92lq7k",
       "type": "frser-sqlite-datasource"
     },
@@ -22,10 +18,6 @@
       "title": "mixed ds with grafana ds",
       "type": "timeseries",
       "datasource": [
-        {
-          "uid": "grafana",
-          "type": "datasource"
-        },
         {
           "uid": "dgd92lq7k",
           "type": "frser-sqlite-datasource"
@@ -45,13 +37,7 @@
     {
       "id": 6,
       "title": "grafana ds",
-      "type": "timeseries",
-      "datasource": [
-        {
-          "uid": "grafana",
-          "type": "datasource"
-        }
-      ]
+      "type": "timeseries"
     },
     {
       "id": 2,

--- a/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
+++ b/pkg/storage/unified/search/testdata/doc/dashboard-aaa-out.json
@@ -26,7 +26,6 @@
   "createdBy": "user:be2g71ke8yoe8b",
   "fields": {
     "ds_types": [
-      "datasource",
       "my-custom-plugin"
     ],
     "errors_last_1_days": 1,
@@ -46,12 +45,6 @@
       "group": "my-custom-plugin",
       "kind": "DataSource",
       "name": "DSUID"
-    },
-    {
-      "relation": "depends-on",
-      "group": "datasource",
-      "kind": "DataSource",
-      "name": "grafana"
     },
     {
       "relation": "depends-on",


### PR DESCRIPTION
part of what motivated https://github.com/grafana/search-and-storage-team/issues/525

this is a builtin datasource, so I don't think it makes sense for us to index on it