### PR TITLE
fix(folders): allow to move folder to root

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -94,6 +94,11 @@ func validateOnUpdate(ctx context.Context,
 	// Validate the move operation
 	newParent := folderObj.GetFolder()
 
+	// If we move to root, we don't need to validate the depth.
+	if newParent == folder.RootFolderUID {
+		return nil
+	}
+
 	// folder cannot be moved to a k6 folder
 	if newParent == accesscontrol.K6FolderUID {
 		return fmt.Errorf("k6 project may not be moved")


### PR DESCRIPTION
This PR fixes an issue with the validator in unified storage. If we want to move a folder to the root, which is identified as an empty string, we would always get a not found error. Instead of running the validation when moving to root, we can just skip it as we are always decreasing in depth.

Added an integration test to make sure we don't regress.