### PR TITLE
SynchronizeStep: fix when user can click next when repo is not ready

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -248,7 +248,7 @@ describe('ProvisioningWizard', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: /3\. Synchronize with external storage/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Begin synchronization/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Check repository status/i })).toBeInTheDocument();
       });
     });
 

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -248,7 +248,7 @@ describe('ProvisioningWizard', () => {
 
       await waitFor(() => {
         expect(screen.getByRole('heading', { name: /3\. Synchronize with external storage/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /Check repository status/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /Begin synchronization/i })).toBeInTheDocument();
       });
     });
 

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -47,9 +47,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
 
   // healthStatusNotReady: If the repository is not yet ready (e.g., initial setup), synchronization cannot be started.
   // User can potentially fail at this step if they click too fast and repo is not ready.
-  const healthStatusNotReady =
-    repositoryStatusQuery?.data?.status?.health.healthy === false &&
-    repositoryStatusQuery?.data?.status?.observedGeneration === 0;
+  const healthStatusNotReady = true;
 
   const hasError = repositoryStatusQuery.isError;
   const isLoading = repositoryStatusQuery.isLoading || repositoryStatusQuery.isFetching;
@@ -158,11 +156,21 @@ export const SynchronizeStep = memo(function SynchronizeStep({
       )}
 
       {healthStatusNotReady ? (
-        <Field noMargin>
-          <Button onClick={() => repositoryStatusQuery.refetch()} disabled={isLoading}>
-            <Trans i18nKey="provisioning.wizard.check-status-button">Check ready to synchronize status</Trans>
-          </Button>
-        </Field>
+        <>
+          <Stack>
+            <Spinner />{' '}
+            <Trans i18nKey="provisioning.wizard.check-status-message">
+              Repository connecting, synchronize will be ready soon...
+            </Trans>
+          </Stack>
+          <Stack>
+            <Stack>
+              <Button onClick={() => repositoryStatusQuery.refetch()} disabled={isLoading}>
+                <Trans i18nKey="provisioning.wizard.check-status-button">Check repository status</Trans>
+              </Button>
+            </Stack>
+          </Stack>
+        </>
       ) : (
         <Field noMargin>
           {hasError || (checked !== undefined && isRepositoryHealthy === false) ? (

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -56,8 +56,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
   // healthStatusNotReady: If the repository is not yet ready (e.g., initial setup), synchronization cannot be started.
   // User can potentially fail at this step if they click too fast and repo is not ready.
   const healthStatusNotReady =
-    isRepositoryHealthy === false &&
-    repositoryStatusQuery?.data?.status?.observedGeneration === 0;
+    isRepositoryHealthy === false && repositoryStatusQuery?.data?.status?.observedGeneration === 0;
 
   // Stop polling when repository becomes healthy
   useEffect(() => {

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -56,7 +56,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
   // healthStatusNotReady: If the repository is not yet ready (e.g., initial setup), synchronization cannot be started.
   // User can potentially fail at this step if they click too fast and repo is not ready.
   const healthStatusNotReady =
-    repositoryStatusQuery?.data?.status?.health.healthy === false &&
+    isRepositoryHealthy === false &&
     repositoryStatusQuery?.data?.status?.observedGeneration === 0;
 
   // Stop polling when repository becomes healthy

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -158,9 +158,11 @@ export const SynchronizeStep = memo(function SynchronizeStep({
       )}
 
       {healthStatusNotReady ? (
-        <Button onClick={() => repositoryStatusQuery.refetch()} disabled={isLoading}>
-          <Trans i18nKey="provisioning.wizard.check-status-button">Check ready to synchronize status</Trans>
-        </Button>
+        <Field noMargin>
+          <Button onClick={() => repositoryStatusQuery.refetch()} disabled={isLoading}>
+            <Trans i18nKey="provisioning.wizard.check-status-button">Check ready to synchronize status</Trans>
+          </Button>
+        </Field>
       ) : (
         <Field noMargin>
           {hasError || (checked !== undefined && isRepositoryHealthy === false) ? (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11693,7 +11693,7 @@
       "button-next": "Finish",
       "button-start": "Begin synchronization",
       "check-status-button": "Check repository status",
-      "check-status-message": "Repository connecting, synchronize will be ready soon...",
+      "check-status-message": "Repository connecting, synchronize will be ready soon.",
       "discard-modal": {
         "body": "This will delete the repository configuration and you will lose all progress. Are you sure you want to discard your changes?",
         "confirm": "Yes, discard",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11692,7 +11692,8 @@
       "button-cancelling": "Cancelling...",
       "button-next": "Finish",
       "button-start": "Begin synchronization",
-      "check-status-button": "Check ready to synchronize status",
+      "check-status-button": "Check repository status",
+      "check-status-message": "Repository connecting, synchronize will be ready soon...",
       "discard-modal": {
         "body": "This will delete the repository configuration and you will lose all progress. Are you sure you want to discard your changes?",
         "confirm": "Yes, discard",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11692,6 +11692,7 @@
       "button-cancelling": "Cancelling...",
       "button-next": "Finish",
       "button-start": "Begin synchronization",
+      "check-status-button": "Check ready to synchronize status",
       "discard-modal": {
         "body": "This will delete the repository configuration and you will lose all progress. Are you sure you want to discard your changes?",
         "confirm": "Yes, discard",


### PR DESCRIPTION
**What is this feature?**

`SynchronizeStep`: Prevent user start sync if repo is not ready yet. 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/593

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
