### PR TITLE
Docs: OaC/Git Sync updates for Obs Con

### DIFF
--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,6 +18,7 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
+
 Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 Git Sync and local file provisioning are [experimental features](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,7 +18,7 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,7 +18,7 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana OSS and Enterprise editions v12 and Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana OSS and Enterprise editions v12 and Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up to the public preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,11 +18,10 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Grafana Cloud Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
-TBC same form to register?
 {{< /admonition >}}
 
 Provisioning allows you to configure how to store your dashboard JSONs and other files in GitHub repositories using either Git Sync or a local path.

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,9 +18,9 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana OSS and Enterprise editions v12 and Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up to the public preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
-Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
+Git Sync and local file provisioning are [experimental features](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,12 +18,14 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Grafana Cloud Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
+
+TBC same form to register?
 {{< /admonition >}}
 
-Provisioning is an experimental feature that allows you to configure how to store your dashboard JSONs and other files in GitHub repositories using either Git Sync or a local path.
+Provisioning allows you to configure how to store your dashboard JSONs and other files in GitHub repositories using either Git Sync or a local path.
 
 Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. See [Git Sync workflow](#git-sync-workflow).
 

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -18,17 +18,17 @@ weight: 300
 # Provision resources and sync dashboards
 
 {{< admonition type="caution" >}}
-Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana v12 open source and Enterprise editions, and in Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Git Sync is available in [public preview](https://grafana.com/docs/release-life-cycle/) for Grafana OSS and Enterprise editions v12 and Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up for Git Sync public preview using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 {{< /admonition >}}
 
-Provisioning allows you to configure how to store your dashboard JSONs and other files in GitHub repositories using either Git Sync or a local path.
+Provisioning allows you to configure how to store your dashboard JSON and other files in GitHub repositories using either Git Sync or a local path.
 
-Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. See [Git Sync workflow](#git-sync-workflow).
+Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. Refer to [Git Sync workflow](#git-sync-workflow) for more information.
 
-Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](#local-file-workflow).
+Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. Refer to [Local file workflow](#local-file-workflow) for more information.
 
 ## Provisioned folders and connections
 

--- a/docs/sources/observability-as-code/provision-resources/_index.md
+++ b/docs/sources/observability-as-code/provision-resources/_index.md
@@ -29,7 +29,7 @@ Provisioning allows you to configure how to store your dashboard JSONs and other
 
 Of the two options, **Git Sync** is the favorited method for provisioning your dashboards. You can synchronize any new dashboards and changes to existing dashboards from the UI to your configured GitHub repository. If you push a change in the repository, those changes are mirrored in your Grafana instance. See [Git Sync workflow](#git-sync-workflow).
 
-Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](local-file-workflow).
+Alternatively, **local file provisioning** allows you to include in your Grafana instance resources (such as folders and dashboard JSON files) that are stored in a local file system. See [Local file workflow](#local-file-workflow).
 
 ## Provisioned folders and connections
 
@@ -42,8 +42,7 @@ You can set a single folder, or multiple folders to a different repository, with
 In the Git Sync workflow:
 
 - When you provision resources with Git Sync you can modify them from within the Grafana UI or within the GitHub repository. Changes made in either the repository or the Grafana UI are bidirectional.
-- Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database. By default, Grafana polls GitHub every 60 seconds.
-- The Grafana UI reads from the database and updates the UI to reflect these changes.
+- Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database. By default, Grafana polls GitHub every 60 seconds. The Grafana UI reads from the database and updates the UI to reflect these changes.
 
 For example, if you update a dashboard within the Grafana UI and click **Save** to preserve the changes, you'll be notified that the dashboard is provisioned in a GitHub repository. Next you'll be prompted to choose how to preserve the changes: either directly to a branch, or pushed to a new branch using a pull request in GitHub.
 
@@ -54,8 +53,7 @@ For more information, see [Introduction to Git Sync](https://grafana.com/docs/gr
 In the local file workflow:
 
 - All provisioned resources are changed in the local files.
-- Any changes made in the provisioned files are reflected in the Grafana database.
-- The Grafana UI reads the database and updates the UI to reflect these changes.
+- Any changes made in the provisioned files are reflected in the Grafana database. The Grafana UI reads the database and updates the UI to reflect these changes.
 - You can't use the Grafana UI to edit or delete provisioned resources.
 
 Learn more in [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).

--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -17,7 +17,7 @@ weight: 200
 
 {{< admonition type="caution" >}}
 
-Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
+Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but it's **not available in Grafana Cloud**. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -17,11 +17,7 @@ weight: 200
 
 {{< admonition type="caution" >}}
 
-Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
-
-Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
-
-TBC same form to register?
+Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/file-path-setup.md
@@ -16,9 +16,12 @@ weight: 200
 # Set up file provisioning
 
 {{< admonition type="caution" >}}
-Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
 
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+Local file provisioning is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions, but is not available in Grafana Cloud. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
+
+Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
+
+TBC same form to register?
 
 {{< /admonition >}}
 
@@ -48,9 +51,13 @@ Refer to [Provision Grafana](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/
 ### Limitations
 
 - A provisioned dashboard can't be deleted from within Grafana UI. The dashboard has to be deleted at the local file system and those changes synced to Grafana.
-- Changes from the local file system are one way: you can't save changes from the UI to GitHub.
+- Changes from the local file system are one way: you can't save changes from the Grafana UI to GitHub.
 
 ## Before you begin
+
+{{< admonition type="note" >}}
+Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature.
+{{< /admonition >}}
 
 To set up file provisioning, you need:
 
@@ -122,15 +129,15 @@ The set up process verifies the path and provides an error message if a problem 
 
 ### Choose what to synchronize
 
-In this section, you determine the actions taken with the storage you selected.
+Choose to either sync your entire organization resources with external storage, or to sync certain resources to a new Grafana folder (with up to 10 connections).
 
-1. Select how resources should be handled in Grafana.
+- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
 
-- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. You can only have one provisioned connection with this selection.
-- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 folders. - Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
-<!--  - Select **Migrate instance to repository** to migrate the Grafana instance to the repository. This option is not available during the first time you set up remote provisioning. -->
+- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
 
-1. Select **Synchronize** to continue.
+Next, enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
+
+Click **Synchronize** to continue.
 
 ### Synchronize with external storage
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -49,13 +49,13 @@ Git Sync is an experimental feature and is under continuous development. Reporti
 
 When Git Sync is enabled, the database load might increase, especially for instances with a lot of folders and nested folders. Evaluate the performance impact, if any, in a non-production environment.
 
+## Before you begin
+
 {{< admonition type="caution" >}}
 
 See also [Known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync#known-limitations/) before using Git Sync.
 
 {{< /admonition >}}
-
-## Before you begin
 
 To set up Git Sync, you need:
 
@@ -65,7 +65,7 @@ To set up Git Sync, you need:
   - If you want to use a local file path, refer to [the local file path guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
 - A GitHub access token. The Grafana UI will prompt you during setup.
 - Optional: A public Grafana instance.
-- Optional: Image Renderer plugin to save image previews with your PRs.
+- Optional: the [Image Renderer plugin](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs.
 
 ## Enable required feature toggles
 
@@ -132,15 +132,13 @@ If you're using Git Sync in Grafana Cloud you can only sync specific folders for
 
 In this step you can decide which elements to synchronize. Keep in mind the available options depend on the status of your GitHub repository. The first time you connect Grafana with a GitHub repository, you need to synchronize with external storage. If you are syncing with a new or empty repository, you won't have an option to migrate dashboards.
 
-Choose to either sync your entire organization resources with external storage, or to sync certain resources to a new Grafana folder (with up to 10 connections).
+1. Choose to either sync your entire organization resources with external storage, or to sync certain resources to a new Grafana folder (with up to 10 connections).
 
-- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
+  - Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
 
-- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
-
-Next, enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
-
-Click **Synchronize** to continue.
+  - Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
+1. Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
+1. Click **Synchronize** to continue.
 
 <!-- ### Synchronize with external storage
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -17,7 +17,11 @@ weight: 100
 
 {{< admonition type="caution" >}}
 
-TBC
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+
+You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -17,9 +17,9 @@ weight: 100
 
 {{< admonition type="caution" >}}
 
-Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.
 
-Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
 You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -32,9 +32,9 @@ To set up Git Sync and synchronize with a GitHub repository follow these steps:
 
 Optionally, you can [extend Git Sync](#configure-webhooks-and-image-rendering) by enabling pull request notifications and image previews of dashboard changes.
 
-| Capability                                            | Benefit                                                                         | Requires                                      |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------- |
-| Adds a table summarizing changes to your pull request | Provides a convenient way to save changes back to GitHub.                       | Webhooks configured                           |
+| Capability                                            | Benefit                                                                         | Requires                               |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------- | -------------------------------------- |
+| Adds a table summarizing changes to your pull request | Provides a convenient way to save changes back to GitHub.                       | Webhooks configured                    |
 | Add a dashboard preview image to a PR                 | View a snapshot of dashboard changes to a pull request without opening Grafana. | Image renderer and webhooks configured |
 
 {{< admonition type="note" >}}
@@ -134,9 +134,10 @@ In this step you can decide which elements to synchronize. Keep in mind the avai
 
 1. Choose to either sync your entire organization resources with external storage, or to sync certain resources to a new Grafana folder (with up to 10 connections).
 
-  - Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
+- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
 
-  - Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
+- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
+
 1. Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
 1. Click **Synchronize** to continue.
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -65,7 +65,7 @@ To set up Git Sync, you need:
   - If you want to use a local file path, refer to [the local file path guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
 - A GitHub access token. The Grafana UI will prompt you during setup.
 - Optional: A public Grafana instance.
-- Optional: the [Image Renderer plugin](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs.
+- Optional: the [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs.
 
 ## Enable required feature toggles
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -53,7 +53,7 @@ When Git Sync is enabled, the database load might increase, especially for insta
 
 {{< admonition type="caution" >}}
 
-See also [Known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync#known-limitations/) before using Git Sync.
+Refer to [Known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync#known-limitations/) before using Git Sync.
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -16,38 +16,44 @@ weight: 100
 # Set up Git Sync
 
 {{< admonition type="caution" >}}
-Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
 
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+TBC
 
 {{< /admonition >}}
 
-Git Sync lets you manage Grafana dashboards as code by storing dashboards JSON files and folders in a remote GitHub repository.
-Alternatively, you can configure a local file system instead of using GitHub.
-Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) for information.
+Git Sync lets you manage Grafana dashboards as code by storing dashboard JSON files and folders in a remote GitHub repository.
 
-This page explains how to use Git Sync with a GitHub repository.
+To set up Git Sync and synchronize with a GitHub repository follow these steps:
 
-To set up Git Sync, you need to:
+1. [Enable feature toggles in Grafana](#enable-required-feature-toggles) (first time set up).
+1. [Create a GitHub access token](#create-a-github-access-token).
+1. [Configure a connection to your GitHub repository](#set-up-the-connection-to-github).
+1. [Choose what content to sync with Grafana](#choose-what-to-synchronize).
 
-1. Enable feature toggles in Grafana (first time set up).
-1. Configure a connection to your GitHub repository.
-1. Choose what content to sync with Grafana.
-1. Optional: Extend Git Sync by enabling pull request notifications and image previews of dashboard changes.
+Optionally, you can [extend Git Sync](#configure-webhooks-and-image-rendering) by enabling pull request notifications and image previews of dashboard changes.
 
 | Capability                                            | Benefit                                                                         | Requires                                      |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------- |
 | Adds a table summarizing changes to your pull request | Provides a convenient way to save changes back to GitHub.                       | Webhooks configured                           |
 | Add a dashboard preview image to a PR                 | View a snapshot of dashboard changes to a pull request without opening Grafana. | Image renderer plugin and webhooks configured |
 
+{{< admonition type="note" >}}
+
+Alternatively, you can configure a local file system instead of using GitHub. Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) for more information.
+
+{{< /admonition >}}
+
 ## Performance impacts of enabling Git Sync
 
-Git Sync is an experimental feature and is under continuous development.
+Git Sync is an experimental feature and is under continuous development. Reporting any issues you encounter can help us improve Git Sync.
 
-We recommend evaluating the performance impact, if any, in a non-production environment.
+When Git Sync is enabled, the database load might increase, especially for instances with a lot of folders and nested folders. Evaluate the performance impact, if any, in a non-production environment.
 
-When Git Sync is enabled, the database load might increase, especially for instances with a lot of folders and nested folders.
-Reporting any issues you encounter can help us improve Git Sync.
+{{< admonition type="caution" >}}
+
+See also [Known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync#known-limitations/) before using Git Sync.
+
+{{< /admonition >}}
 
 ## Before you begin
 
@@ -57,7 +63,7 @@ To set up Git Sync, you need:
 - Enable the required feature toggles in your Grafana instance. Refer to [Enable required feature toggles](#enable-required-feature-toggles) for instructions.
 - A GitHub repository to store your dashboards in.
   - If you want to use a local file path, refer to [the local file path guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
-- A GitHub access token. The Grafana UI will also explain this to you as you set it up.
+- A GitHub access token. The Grafana UI will prompt you during setup.
 - Optional: A public Grafana instance.
 - Optional: Image Renderer plugin to save image previews with your PRs.
 
@@ -118,27 +124,25 @@ To connect your GitHub repository, follow these steps:
 
 ### Choose what to synchronize
 
-You can choose to either use one repository for an entire organization or to a new Grafana folder (up to 10 connections).
-If you choose to sync all resources with external storage, then all of your dashboards are synced to that one repository.
-You won't have the option of setting up additional repositories to connect to.
+{{< admonition type="caution" >}}
 
-You can choose to synchronize all resources with GitHub or you can sync resources to a new Grafana folder.
-The options you have depend on the status of your GitHub repository.
-For example, if you are syncing with a new or empty repository, you won't have an option to migrate dashboards.
+If you're using Git Sync in Grafana Cloud you can only sync specific folders for the moment. Git Sync will be available for your full instance soon.
 
-1. Select how resources should be handled in Grafana.
+{{< /admonition >}}
 
-- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. You can only have one provisioned connection with this selection.
-- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections. - Enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
-<!--  - Select **Migrate instance to repository** to migrate the Grafana instance to the repository. This option is not available during the first time you set up remote provisioning. -->
+In this step you can decide which elements to synchronize. Keep in mind the available options depend on the status of your GitHub repository. The first time you connect Grafana with a GitHub repository, you need to synchronize with external storage. If you are syncing with a new or empty repository, you won't have an option to migrate dashboards.
 
-1. Select **Synchronize** to continue.
+Choose to either sync your entire organization resources with external storage, or to sync certain resources to a new Grafana folder (with up to 10 connections).
 
-<!-- This is only relevant if we include the "Migrate instance to repository" option above. -->
+- Choose **Sync all resources with external storage** if you want to sync and manage your entire Grafana instance through external storage. With this option, all of your dashboards are synced to that one repository. You can only have one provisioned connection with this selection, and you won't have the option of setting up additional repositories to connect to.
+
+- Choose **Sync external storage to new Grafana folder** to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 connections.
+
+Next, enter a **Display name** for the repository connection. Resources stored in this connection appear under the chosen display name in the Grafana UI.
+
+Click **Synchronize** to continue.
+
 <!-- ### Synchronize with external storage
-
-The first time you connect Grafana with a GitHub repository, you need to synchronize with external storage.
-Future updates will be automatically saved to the repository and provisioned back to the instance.
 
 {{< admonition type="note">}}
 During the synchronization process, your dashboards will be temporarily unavailable.
@@ -164,8 +168,7 @@ Finally, you can set up how often your configured storage is polled for updates.
 
 To verify that your dashboards are available at the location that you specified, click **Dashboards**. The name of the dashboard is listed in the **Name** column.
 
-Now that your dashboards have been synced from a repository, you can customize the name, change the branch, and create a pull request (PR) for it.
-Refer to [Use Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/) for more information.
+Now that your dashboards have been synced from a repository, you can customize the name, change the branch, and create a pull request (PR) for it. Refer to [Manage provisioned repositories with Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/use-git-sync/) for more information.
 
 ## Configure webhooks and image rendering
 

--- a/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/observability-as-code/provision-resources/git-sync-setup.md
@@ -35,7 +35,7 @@ Optionally, you can [extend Git Sync](#configure-webhooks-and-image-rendering) b
 | Capability                                            | Benefit                                                                         | Requires                                      |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------- |
 | Adds a table summarizing changes to your pull request | Provides a convenient way to save changes back to GitHub.                       | Webhooks configured                           |
-| Add a dashboard preview image to a PR                 | View a snapshot of dashboard changes to a pull request without opening Grafana. | Image renderer plugin and webhooks configured |
+| Add a dashboard preview image to a PR                 | View a snapshot of dashboard changes to a pull request without opening Grafana. | Image renderer and webhooks configured |
 
 {{< admonition type="note" >}}
 
@@ -65,7 +65,7 @@ To set up Git Sync, you need:
   - If you want to use a local file path, refer to [the local file path guide](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/).
 - A GitHub access token. The Grafana UI will prompt you during setup.
 - Optional: A public Grafana instance.
-- Optional: the [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs.
+- Optional: The [Image Renderer service](https://github.com/grafana/grafana-image-renderer) to save image previews with your PRs.
 
 ## Enable required feature toggles
 
@@ -159,7 +159,7 @@ Finally, you can set up how often your configured storage is polled for updates.
 1. For **Update instance interval (seconds)**, enter how often you want the instance to pull updates from GitHub. The default value is 60 seconds.
 1. Optional: Select **Read only** to ensure resources can't be modified in Grafana.
 <!-- No workflow option listed in the UI. 1. For **Workflows**, select the GitHub workflows that you want to allow to run in the repository. Both **Branch** and **Write** are selected by default. -->
-1. Optional: If you have the Grafana Image Renderer plugin configured, you can **Enable dashboards previews in pull requests**. If image rendering is not available, then you can't select this option. For more information, refer to [Grafana Image Renderer](https://grafana.com/grafana/plugins/grafana-image-renderer/).
+1. Optional: If you have the Grafana Image Renderer plugin configured, you can **Enable dashboards previews in pull requests**. If image rendering is not available, then you can't select this option. For more information, refer to the [Image Renderer service](https://github.com/grafana/grafana-image-renderer).
 1. Select **Finish** to proceed.
 
 ## Verify your dashboards in Grafana
@@ -215,8 +215,7 @@ The necessary paths required to be exposed are (RegExp):
 By setting up image rendering, you can add visual previews of dashboard updates directly in pull requests.
 Image rendering also requires webhooks.
 
-You can enable this capability by installing the Grafana Image Renderer plugin in your Grafana instance.
-For more information and installation instructions, refer to [Grafana Image Renderer](https://grafana.com/grafana/plugins/grafana-image-renderer/).
+You can enable this capability by installing the Grafana Image Renderer in your Grafana instance. For more information and installation instructions, refer to the [Image Renderer service](https://github.com/grafana/grafana-image-renderer).
 
 ## Modify configurations after set up is complete
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -17,7 +17,11 @@ weight: 100
 
 {{< admonition type="caution" >}}
 
-TBC
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+
+You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -16,9 +16,8 @@ weight: 100
 # Introduction to Git Sync
 
 {{< admonition type="caution" >}}
-Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
 
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+TBC
 
 {{< /admonition >}}
 
@@ -28,55 +27,67 @@ Using Git Sync, you can:
 - Manage dashboard configuration outside of Grafana instances
 - Replicate dashboards across multiple instances
 
-Whenever a dashboard is modified, Grafana can commit changes to Git upon saving. Users can configure settings to either enforce PR approvals before merging or allow direct commits.
-
-Users can push changes directly to GitHub and see them in Grafana. Similarly, automated workflows can do changes that will be automatically represented in Grafana by updating Git.
-
-Because the dashboards are defined in JSON files, you can enable as-code workflows where the JSON is output from Go, TypeScript, or another coding language in the format of a dashboard schema.
-
-To learn more about creating dashboards in a coding language to provision them for Git Sync, refer to the [Foundation SDK](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/foundation-sdk) documentation.
-
 ## How it works
 
-Git Sync is bidirectional and also works with changes done directly in GitHub as well as within the Grafana UI.
+Because dashboards are defined in JSON files, you can enable as-code workflows where the JSON file is an output from Go, TypeScript, or another coding language in the format of a dashboard schema. To learn more about creating dashboards in a coding language to provision them for Git Sync, refer to the [Foundation SDK](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/foundation-sdk) documentation.
+
+Git Sync is bidirectional and works both with changes done directly in GitHub as well as in the Grafana UI.
+
+### Making changes in Grafana
+
+Whenever you modify a dashboard directly from the UI, Grafana can commit changes to Git upon saving. You can configure settings to either enforce PR approvals before merging in your repository, or allow direct commits.
+
 Grafana periodically polls GitHub at a regular internal to synchronize any changes.
-With the webhooks feature enabled, repository notifications appear almost immediately.
-Without webhooks, Grafana polls for changes at the specified interval.
+
+- With the webhooks feature enabled, repository notifications appear almost immediately.
+- Without webhooks, Grafana polls for changes at the specified interval.
+
 The default polling interval is 60 seconds.
 
-Any changes made in the provisioned files stored in the GitHub repository are reflected in the Grafana database.
-The Grafana UI reads the database and updates the UI to reflect these changes.
+### Making changes in your GitHub repositories
+
+With Git Sync, you can make changes in your provisioned files in GitHub and see them in Grafana. Automated workflows ensure those changes are automatically represented in the Grafana database by updating Git. The Grafana UI reads the database and updates the UI to reflect these changes.
+
+## Known limitations
+
+Git Sync is under development and the following limitations apply:
+
+- You can only authenticate using your GitHub token.
+- Support for native Git and other providers, such as GitLab or Bitbucket, is scheduled.
+- If you're using Git Sync in Grafana Cloud you can only sync specific folders for the moment. Git Sync will be available for your full instance soon.
+- Restoring resources from the UI is currently not possible. As an alternative, you can restore dashboards directly in your GitHub repository by raising a PR, and they will be updated in Grafana.
 
 ## Common use cases
 
-Git Sync in Grafana lets you manage dashboards as code.
-Because your dashboard JSON files are stored in GitHub, you and your team can version control, collaborate, and automate deployments efficiently.
+Git Sync in Grafana lets you manage your dashboards as code as JSON files stored in GitHub. You and your team can version control, collaborate, and automate deployments efficiently.
 
 ### Version control and auditing
 
-Organizations can maintain a structured, version-controlled history of Grafana dashboards.
-The version control lets you revert to previous versions when necessary, compare modifications across commits, and ensure transparency in dashboard management.
+Organizations can maintain a structured, version-controlled history of Grafana dashboards. The version control lets you revert to previous versions when necessary, compare modifications across commits, and ensure transparency in dashboard management.
+
 Additionally, having a detailed history of changes enhances compliance efforts, as teams can generate audit logs that document who made changes, when they were made, and why.
 
 ### Automated deployment and CI/CD integration
 
-Teams can streamline their workflow by integrating dashboard updates into their CI/CD pipelines.
-By pushing changes to GitHub, automated processes can trigger validation checks, test dashboard configurations, and deploy updates programmatically using the `grafanactl` CLI and Foundation SDK.
+Teams can streamline their workflow by integrating dashboard updates into their CI/CD pipelines. By pushing changes to GitHub, automated processes can trigger validation checks, test dashboard configurations, and deploy updates programmatically using the `grafanactl` CLI and Foundation SDK.
+
 This reduces the risk of human errors, ensures consistency across environments, and enables a faster, more reliable release cycle for dashboards used in production monitoring and analytics.
 
 ### Collaborative dashboard development
 
 With Git Sync, multiple users can work on dashboards simultaneously without overwriting each other’s modifications.
-By leveraging pull requests and branch-based workflows, teams can submit changes for review before merging them into the main branch. This process not only improves quality control but also ensures that dashboards adhere to best practices and organizational standards. Additionally, GitHub’s built-in discussion and review tools facilitate effective collaboration, making it easier to address feedback before changes go live.
+By leveraging pull requests and branch-based workflows, teams can submit changes for review before merging them into the main branch. This process not only improves quality control but also ensures that dashboards adhere to best practices and organizational standards.
+
+Additionally, GitHub’s built-in discussion and review tools facilitate effective collaboration, making it easier to address feedback before changes go live.
 
 ### Multi-environment synchronization
 
-Enterprises managing multiple Grafana instances, such as development, staging, and production environments, can seamlessly sync dashboards across these instances.
-This ensures consistency in visualization and monitoring configurations, reducing discrepancies that might arise from manually managing dashboards in different environments.
+Enterprises managing multiple Grafana instances, such as development, staging, and production environments, can seamlessly sync dashboards across these instances. This ensures consistency in visualization and monitoring configurations, reducing discrepancies that might arise from manually managing dashboards in different environments.
+
 By using Git Sync, teams can automate deployments across environments, eliminating repetitive setup tasks and maintaining a standardized monitoring infrastructure across the organization.
 
 ### Disaster recovery and backup
 
 By continuously syncing dashboards to GitHub, organizations can create an always-updated backup, ensuring dashboards are never lost due to accidental deletion or system failures.
-If an issue arises--such as a corrupted dashboard, unintended modification, or a system crash--teams can quickly restore the latest functional version from the Git repository.
-This not only minimizes downtime but also adds a layer of resilience to Grafana monitoring setups, ensuring critical dashboards remain available when needed.
+
+If an issue arises, such as a corrupted dashboard, unintended modification, or a system crash, teams can quickly restore the latest functional version from the Git repository. This not only minimizes downtime but also adds a layer of resilience to Grafana monitoring setups, ensuring critical dashboards remain available when needed.

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -37,12 +37,10 @@ Git Sync is bidirectional and works both with changes done directly in GitHub as
 
 Whenever you modify a dashboard directly from the UI, Grafana can commit changes to Git upon saving. You can configure settings to either enforce PR approvals before merging in your repository, or allow direct commits.
 
-Grafana periodically polls GitHub at a regular internal to synchronize any changes.
+Grafana periodically polls GitHub at a regular internal to synchronize any changes. The default polling interval is 60 seconds.
 
-- With the webhooks feature enabled, repository notifications appear almost immediately.
+- If you enable the [webhooks feature](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering), repository notifications appear almost immediately.
 - Without webhooks, Grafana polls for changes at the specified interval.
-
-The default polling interval is 60 seconds.
 
 ### Making changes in your GitHub repositories
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -17,9 +17,9 @@ weight: 100
 
 {{< admonition type="caution" >}}
 
-Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.
 
-Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
 You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 

--- a/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/intro-git-sync.md
@@ -33,7 +33,7 @@ Because dashboards are defined in JSON files, you can enable as-code workflows w
 
 Git Sync is bidirectional and works both with changes done directly in GitHub as well as in the Grafana UI.
 
-### Making changes in Grafana
+### Make changes in Grafana
 
 Whenever you modify a dashboard directly from the UI, Grafana can commit changes to Git upon saving. You can configure settings to either enforce PR approvals before merging in your repository, or allow direct commits.
 
@@ -42,7 +42,7 @@ Grafana periodically polls GitHub at a regular internal to synchronize any chang
 - If you enable the [webhooks feature](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/git-sync-setup/#configure-webhooks-and-image-rendering), repository notifications appear almost immediately.
 - Without webhooks, Grafana polls for changes at the specified interval.
 
-### Making changes in your GitHub repositories
+### Make changes in your GitHub repositories
 
 With Git Sync, you can make changes in your provisioned files in GitHub and see them in Grafana. Automated workflows ensure those changes are automatically represented in the Grafana database by updating Git. The Grafana UI reads the database and updates the UI to reflect these changes.
 

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -114,9 +114,9 @@ Saving changes requires opening a pull request in your GitHub repository.
 
 ### Remove dashboards
 
-You can remove a provisioned dashboard by deleting the dashboard from the repository.
+You can remove a provisioned dashboard by deleting the dashboard from the repository. The Grafana UI updates when the changes from the GitHub repository sync.
 
-Grafana updates when the changes from the GitHub repository sync.
+To restore a deleted dashboard, raise a PR directly in your GitHub repository. Restoring resources from the UI is currently not possible. 
 
 ### Tips
 

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -17,7 +17,9 @@ weight: 300
 
 {{< admonition type="caution" >}}
 
-TBC
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud. Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+
+Git Sync and local file provisioning are [experimental features](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided.
 
 {{< /admonition >}}
 

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -116,7 +116,7 @@ Saving changes requires opening a pull request in your GitHub repository.
 
 You can remove a provisioned dashboard by deleting the dashboard from the repository. The Grafana UI updates when the changes from the GitHub repository sync.
 
-To restore a deleted dashboard, raise a PR directly in your GitHub repository. Restoring resources from the UI is currently not possible. 
+To restore a deleted dashboard, raise a PR directly in your GitHub repository. Restoring resources from the UI is currently not possible.
 
 ### Tips
 

--- a/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
+++ b/docs/sources/observability-as-code/provision-resources/provisioned-dashboards.md
@@ -16,9 +16,8 @@ weight: 300
 # Work with provisioned dashboards
 
 {{< admonition type="caution" >}}
-Git Sync and File path provisioning an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana. These features aren't available publicly in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
 
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+TBC
 
 {{< /admonition >}}
 
@@ -30,16 +29,17 @@ For more information, refer to the [Dashboards](https://grafana.com/docs/grafana
 
 Dashboards and folders synchronized using Git Sync or a local file path are referred to as "provisioned" resources.
 
-Of the two experimental options, Git Sync is the recommended method for provisioning your dashboards.
+### Git Sync provisioning
+
+Of the two experimental options, **Git Sync** is the recommended method for provisioning your dashboards.
 You can synchronize any new dashboards and changes to existing dashboards to your configured GitHub repository.
 If you push a change in the repository, those changes are mirrored in your Grafana instance.
-For more information on configuring Git Sync, refer to [Set up Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/).
+
+For more information on configuring Git Sync, refer to [Introduction to Git Sync](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync/).
 
 ### Local path provisioning
 
-Using the local path provisioning makes files from a specified path available within Grafana.
-These provisioned resources can only be modified in the local files and not within Grafana.
-Any changes made in the configured local path are updated in Grafana.
+Local path provisioning makes files from a specified path available within Grafana, and any changes made in the configured local path are updated in Grafana. Note that these provisioned resources can only be modified in the local files and not within Grafana.
 
 Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup) to learn more about the version of local file provisioning in Grafana 12.
 
@@ -128,9 +128,6 @@ Grafana updates when the changes from the GitHub repository sync.
 ## Manage dashboards provisioned with file provisioning
 
 To update any resources in the local path, you need to edit the files directly and then save them locally.
-These changes are synchronized to Grafana.
-However, you can't create, edit, or delete these resources using the Grafana UI.
-
-For more information, refer to [How it works](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/).
+These changes are synchronized to Grafana. However, you can't create, edit, or delete these resources using the Grafana UI.
 
 Refer to [Set up file provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/file-path-setup/) for configuration instructions.

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -19,7 +19,13 @@ weight: 400
 # Manage provisioned repositories with Git Sync
 
 {{< admonition type="caution" >}}
-TBC
+
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+
+You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
+
 {{< /admonition >}}
 
 After you have set up Git Sync, you can synchronize any changes you make in your existing provisioned folders in the UI with your configured GitHub repository. Similarly, if you push a change into your repository, those changes are mirrored in your Grafana instance.

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -19,20 +19,16 @@ weight: 400
 # Manage provisioned repositories with Git Sync
 
 {{< admonition type="caution" >}}
-Git Sync is an [experimental feature](https://grafana.com/docs/release-life-cycle/) introduced in Grafana v12 for open source and Enterprise editions. Engineering and on-call support is not available. Documentation is either limited or not provided outside of code comments. No SLA is provided. Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature. This feature is not publicly available in Grafana Cloud yet. Only the cloud-hosted version of GitHub (GitHub.com) is supported at this time. GitHub Enterprise is not yet compatible.
-
-Sign up for Grafana Cloud Git Sync early access using [this form](https://forms.gle/WKkR3EVMcbqsNnkD9).
-
+TBC
 {{< /admonition >}}
 
-After you have set up Git Sync, you can synchronize any changes in your existing dashboards with your configured GitHub repository. Similarly, if you push a change in the repository, those changes are mirrored in your Grafana instance.
+After you have set up Git Sync, you can synchronize any changes you make in your existing provisioned folders in the UI with your configured GitHub repository. Similarly, if you push a change into your repository, those changes are mirrored in your Grafana instance.
 
 ## View current status of synchronization
 
-Each repository synchronized with Git Sync has a dashboard that provides a summary of resources, health, pull status, webhook, sync jobs, resources, and files.
-Use the detailed information accessed in **View** to help troubleshoot and understand the health of your repository's connection with Grafana.
+When you synchronize a repository, Git Sync also creates a dashboard that provides a summary of resources, health, pull status, webhook, sync jobs, resources, and files.
 
-To view the current status, follow these steps.
+Use the **View** section in **Provisioning** to see detailed information about the current status of your sync, understand the health of your repository's connection with Grafana, and [troubleshoot](#troubleshoot-synchronization) possible issues:
 
 1. Log in to your Grafana server with an account that has the Grafana Admin or Editor flag set.
 1. Select **Administration** in the left-side menu and then **Provisioning**.
@@ -44,7 +40,7 @@ To view the current status, follow these steps.
 
 Synchronizing resources from provisioned repositories into your Grafana instance pulls the resources into the selected folder. Existing dashboards with the same `uid` are overwritten.
 
-To sync changes from your dashboards with your Git repository:
+To sync changes from your Grafana dashboards with your Git repository:
 
 1. From the left menu, select **Administration** > **Provisioning**.
 1. Select **Pull** under the repository you want to sync.
@@ -63,6 +59,12 @@ To delete a repository, follow these steps.
 Refer to [Work with provisioned dashboards](../provisioned-dashboards) for information on removing provisioned files.
 
 ## Troubleshoot synchronization
+
+{{< admonition type="caution" >}}
+
+Before you proceed to troubleshoot, understand the [known limitations](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/observability-as-code/provision-resources/intro-git-sync#known-limitations/).
+
+{{< /admonition >}}
 
 Monitor the **View** status page for synchronization issues and status updates. Common events include:
 

--- a/docs/sources/observability-as-code/provision-resources/use-git-sync.md
+++ b/docs/sources/observability-as-code/provision-resources/use-git-sync.md
@@ -20,9 +20,9 @@ weight: 400
 
 {{< admonition type="caution" >}}
 
-Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.  
+Git Sync is available in [private preview](https://grafana.com/docs/release-life-cycle/) for Grafana Cloud, and is an [experimental feature](https://grafana.com/docs/release-life-cycle/) in Grafana v12 for open source and Enterprise editions.
 
-Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided. 
+Support and documentation is available but might be limited to enablement, configuration, and some troubleshooting. No SLAs are provided.
 
 You can sign up to the private preview using the [Git Sync early access form](https://forms.gle/WKkR3EVMcbqsNnkD9).
 


### PR DESCRIPTION
**Takes over https://github.com/grafana/grafana/pull/111743**

Changes to go live on Monday 6:

* New notes/admonitions on public preview
* Explain limitations to restoring dashboards
* Only GH is supported - other providers eg GL coming soon
* Cloud - only selected folders (not all instance) can be synced
* Note on "more features coming" (no links to Aha)

PLUS mount docs / Sync with Jack