### PR TITLE
Chore: Disable cgo by default for local builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,11 @@ GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 GO_RACE  := $(shell [ -n "$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )
 GO_RACE_FLAG := $(if $(GO_RACE),-race)
+GO_BUILD_CGO ?= 0
 GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 GO_BUILD_FLAGS += $(GO_RACE_FLAG)
+GO_BUILD_FLAGS += -cgo-enabled=$(GO_BUILD_CGO)
 GO_TEST_FLAGS += $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS))
 GIT_BASE = remotes/origin/main
 

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,10 @@ GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)
 GO_RACE  := $(shell [ -n "$(GO_RACE)" -o -e ".go-race-enabled-locally" ] && echo 1 )
 GO_RACE_FLAG := $(if $(GO_RACE),-race)
-GO_BUILD_CGO ?= 0
 GO_BUILD_FLAGS += $(if $(GO_BUILD_DEV),-dev)
 GO_BUILD_FLAGS += $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS))
 GO_BUILD_FLAGS += $(GO_RACE_FLAG)
-GO_BUILD_FLAGS += -cgo-enabled=$(GO_BUILD_CGO)
+GO_BUILD_FLAGS += $(if $(GO_BUILD_CGO),-cgo-enabled=$(GO_BUILD_CGO))
 GO_TEST_FLAGS += $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS))
 GIT_BASE = remotes/origin/main
 

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -18,6 +18,7 @@ import (
 const (
 	GoOSWindows = "windows"
 	GoOSLinux   = "linux"
+	GoOSDarwin  = "darwin"
 
 	BackendBinary = "grafana"
 	ServerBinary  = "grafana-server"
@@ -288,8 +289,9 @@ func setBuildEnv(opts BuildOpts) error {
 		}
 	}
 
-	if opts.goarch != "amd64" || opts.goos != GoOSLinux {
-		// needed for all other archs
+	if !(opts.goos == GoOSLinux && opts.goarch == "amd64") &&
+		!(opts.goos == GoOSDarwin) {
+		// needed for archs other than linux/amd64 and darwin/arm64 + darwin/amd64
 		opts.cgo = true
 	}
 

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -307,10 +307,12 @@ func setBuildEnv(opts BuildOpts) error {
 		}
 	}
 
+	cgoEnabled := "0"
 	if opts.cgo {
-		if err := os.Setenv("CGO_ENABLED", "1"); err != nil {
-			return err
-		}
+		cgoEnabled = "1"
+	}
+	if err := os.Setenv("CGO_ENABLED", cgoEnabled); err != nil {
+		return err
 	}
 
 	if opts.gocc == "" {

--- a/pkg/build/cmd.go
+++ b/pkg/build/cmd.go
@@ -289,8 +289,8 @@ func setBuildEnv(opts BuildOpts) error {
 		}
 	}
 
-	if !(opts.goos == GoOSLinux && opts.goarch == "amd64") &&
-		!(opts.goos == GoOSDarwin) {
+	if (opts.goos != GoOSLinux || opts.goarch != "amd64") &&
+		opts.goos != GoOSDarwin {
 		// needed for archs other than linux/amd64 and darwin/arm64 + darwin/amd64
 		opts.cgo = true
 	}

--- a/pkg/services/sqlstore/sqlstore.go
+++ b/pkg/services/sqlstore/sqlstore.go
@@ -16,6 +16,7 @@ import (
 	_ "github.com/lib/pq"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/grafana/grafana/pkg/util/sqlite"
 	"github.com/grafana/grafana/pkg/util/xorm"
 	"github.com/grafana/grafana/pkg/util/xorm/core"
 
@@ -248,6 +249,9 @@ func (ss *SQLStore) initEngine(engine *xorm.Engine) error {
 	}
 
 	ss.log.Info("Connecting to DB", "dbtype", ss.dbCfg.Type)
+	if ss.dbCfg.Type == migrator.SQLite {
+		ss.log.Info("Using SQLite driver", "driver", sqlite.DriverType())
+	}
 	if ss.dbCfg.Type == migrator.SQLite && strings.HasPrefix(ss.dbCfg.ConnectionString, "file:") &&
 		!strings.HasPrefix(ss.dbCfg.ConnectionString, "file::memory:") {
 		exists, err := fs.Exists(ss.dbCfg.Path)

--- a/pkg/util/sqlite/sqlite_cgo.go
+++ b/pkg/util/sqlite/sqlite_cgo.go
@@ -35,12 +35,13 @@ func IsUniqueConstraintViolation(err error) bool {
 }
 
 func ErrorMessage(err error) string {
-	if err == nil {
-		return ""
-	}
 	var sqliteErr sqlite3.Error
 	if errors.As(err, &sqliteErr) {
 		return sqliteErr.Error()
 	}
 	return err.Error()
+}
+
+func DriverType() string {
+	return "mattn/go-sqlite3 (CGO enabled)"
 }

--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -112,6 +112,10 @@ func init() {
 	sql.Register("sqlite3", &moderncDriver{Driver: &Driver{}})
 }
 
+func DriverType() string {
+	return "modernc.org/sqlite (CGO disabled)"
+}
+
 func IsBusyOrLocked(err error) bool {
 	var sqliteErr *sqlite.Error
 	if errors.As(err, &sqliteErr) {


### PR DESCRIPTION
This implements `CGO_ENABLED` properly, the catch is that the default value is undefined and may change from platform to platform, so when a flag is provided - we should explicitly set CGO_ENABLED to either 0 or 1 without assuming the default.

Quoting the Go docs:

> The cgo tool is enabled by default for native builds on systems where it is expected to work. It is disabled by default when cross-compiling as well as when the CC environment variable is unset and the default C compiler (typically gcc or clang) cannot be found on the system PATH.

This introduces a makefile variable GO_BUILD_CGO (values are 0 or 1). For macOS and linux/amd64 CGo is disabled for local builds by default. For Windows, unfortunately, it seems to be required due to `windows.h` dependency from Go runtime itself.