### PR TITLE
SCIM: Update documentation mentioning that unused attributes will be ignored

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-scim-provisioning/configure-scim-with-azuread/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-scim-provisioning/configure-scim-with-azuread/_index.md
@@ -139,6 +139,10 @@ Configure the following required attributes:
 | `objectId`                                                    | `externalId`                   |
 | `Switch([IsSoftDeleted], , "False", "True", "True", "False")` | `active`                       |
 
+{{< admonition type="note" >}}
+During provisioning, if the identity provider sends user attributes that has no use in Grafana, those attributes will be gracefully ignored.
+{{< /admonition >}}
+
 ### Enable provisioning
 
 Click **Start provisioning** from the top action bar in the **Overview** page from your Azure AD enterprise application.

--- a/docs/sources/setup-grafana/configure-security/configure-scim-provisioning/manage-users-teams/_index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-scim-provisioning/manage-users-teams/_index.md
@@ -77,6 +77,10 @@ SCIM uses a specific process to establish and maintain user identity between the
 
 This process ensures secure and consistent user identification across both systems, preventing security issues that could arise from email changes or other user attribute modifications.
 
+{{< admonition type="note" >}}
+During provisioning, if the identity provider sends user attributes that has no use in Grafana, those attributes will be gracefully ignored.
+{{< /admonition >}}
+
 ### Existing Grafana users
 
 For users who already exist in the Grafana instance:


### PR DESCRIPTION
**What is this feature?**

Updates documentation now that unused SCIM attributes will be ignored instead of rejecting the request.

**Why do we need this feature?**

Customer feedback has shed light on the importance of relying on default configurations. Ignoring the unused attributes makes more sense than rejecting the request altogether.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1672

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
