### PR TITLE
Annotations: DataLink support

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -5,9 +5,20 @@ import { createPortal } from 'react-dom';
 import tinycolor from 'tinycolor2';
 import uPlot from 'uplot';
 
-import { arrayToDataFrame, colorManipulator, DataFrame, DataTopic } from '@grafana/data';
+import {
+  arrayToDataFrame,
+  colorManipulator,
+  DataFrame,
+  DataTopic,
+  Field,
+  formattedValueToString,
+  LinkModel,
+} from '@grafana/data';
 import { TimeZone, VizAnnotations } from '@grafana/schema';
 import { DEFAULT_ANNOTATION_COLOR, getPortalContainer, UPlotConfigBuilder, useStyles2, useTheme2 } from '@grafana/ui';
+import { VizTooltipItem } from '@grafana/ui/internal';
+
+import { getDataLinks } from '../../status-history/utils';
 
 import { AnnotationMarker2 } from './annotations2/AnnotationMarker2';
 import { ANNOTATION_LANE_SIZE, getAnnotationFrames } from './utils';
@@ -268,8 +279,25 @@ export const AnnotationsPlugin2 = ({
             }
           };
 
+          let items: VizTooltipItem[] = [];
+          let links: LinkModel[] = [];
+
+          frame.fields.forEach((field: Field) => {
+            const value = field.values[i];
+
+            links.push(...getDataLinks(field, i));
+
+            const fieldDisplay = field.display?.(value) ?? { text: `${value}`, numeric: +value };
+
+            items.push({
+              label: field.state?.displayName ?? field.name,
+              value: formattedValueToString(fieldDisplay),
+            });
+          });
+
           markers.push(
             <AnnotationMarker2
+              links={links}
               pinAnnotation={setAnnotation}
               isPinned={annoIdx === `${frameIdx}:${i}`}
               // @todo let users control if anno tooltips show on hover?

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -279,20 +279,10 @@ export const AnnotationsPlugin2 = ({
             }
           };
 
-          let items: VizTooltipItem[] = [];
           let links: LinkModel[] = [];
 
           frame.fields.forEach((field: Field) => {
-            const value = field.values[i];
-
             links.push(...getDataLinks(field, i));
-
-            const fieldDisplay = field.display?.(value) ?? { text: `${value}`, numeric: +value };
-
-            items.push({
-              label: field.state?.displayName ?? field.name,
-              value: formattedValueToString(fieldDisplay),
-            });
           });
 
           markers.push(

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationMarker2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationMarker2.tsx
@@ -5,7 +5,7 @@ import { useState } from 'react';
 import * as React from 'react';
 import { createPortal } from 'react-dom';
 
-import { GrafanaTheme2 } from '@grafana/data';
+import { GrafanaTheme2, LinkModel } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { TimeZone } from '@grafana/schema';
 import { ClickOutsideWrapper, floatingUtils, useStyles2 } from '@grafana/ui';
@@ -24,6 +24,7 @@ interface AnnoBoxProps {
   pinAnnotation: (pin: boolean) => void;
   isPinned: boolean;
   showOnHover: boolean;
+  links?: LinkModel[];
 }
 
 export const AnnotationMarker2 = ({
@@ -37,6 +38,7 @@ export const AnnotationMarker2 = ({
   pinAnnotation,
   isPinned,
   showOnHover,
+  links,
 }: AnnoBoxProps) => {
   const styles = useStyles2(getStyles);
   const placement = 'bottom';
@@ -59,6 +61,7 @@ export const AnnotationMarker2 = ({
   const contents =
     (isPinned && !editing) || (showOnHover && isHovering && !editing) ? (
       <AnnotationTooltip2
+        links={links}
         onClose={onClose}
         isPinned={isPinned}
         annoIdx={annoIdx}

--- a/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/annotations2/AnnotationTooltip2.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
 
-import { GrafanaTheme2, dateTimeFormat, systemDateFormats, textUtil } from '@grafana/data';
+import { GrafanaTheme2, dateTimeFormat, systemDateFormats, textUtil, LinkModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Stack, IconButton, Tag, usePanelContext, useStyles2 } from '@grafana/ui';
+import { VizTooltipFooter } from '@grafana/ui/internal';
 import alertDef from 'app/features/alerting/state/alertDef';
 
 interface Props {
@@ -13,11 +14,12 @@ interface Props {
   onEdit: () => void;
   isPinned: boolean;
   onClose: () => void;
+  links?: LinkModel[];
 }
 
 const retFalse = () => false;
 
-export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit, isPinned, onClose }: Props) => {
+export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit, isPinned, onClose, links }: Props) => {
   const annoId = annoVals.id?.[annoIdx];
 
   const styles = useStyles2(getStyles);
@@ -130,6 +132,8 @@ export const AnnotationTooltip2 = ({ annoVals, annoIdx, timeZone, onEdit, isPinn
           </Stack>
         </div>
       </div>
+
+      <VizTooltipFooter dataLinks={links ?? []} />
     </div>
   );
 };


### PR DESCRIPTION
**What is this feature?**
Adding DataLink support in annotation tooltips

<img width="1452" height="838" alt="image" src="https://github.com/user-attachments/assets/ae286c49-5e76-4d42-9646-9bc92aed32b4" />
**Why do we need this feature?**

Allows annotation frames to get datalinks added with field config overrides.

**Who is this feature for?**

Annotation users, developers

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
