### PR TITLE
refactor: respect apimachinery resource validation in kv store

### DIFF
--- a/pkg/apimachinery/validation/validation.go
+++ b/pkg/apimachinery/validation/validation.go
@@ -90,7 +90,7 @@ func IsValidGroup(group string) []string {
 
 // If the value is not valid, a list of error strings is returned.
 // Otherwise an empty list (or nil) is returned.
-func IsValidateResource(resource string) []string {
+func IsValidResource(resource string) []string {
 	s := len(resource)
 	switch {
 	case s > maxResourceLength:

--- a/pkg/apimachinery/validation/validation_test.go
+++ b/pkg/apimachinery/validation/validation_test.go
@@ -222,7 +222,7 @@ func TestValidation(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				for _, input := range tt.input {
-					output := validation.IsValidateResource(input)
+					output := validation.IsValidResource(input)
 					require.Equal(t, tt.expect, output, "input: %s", input)
 				}
 			})

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -191,9 +191,6 @@ func (k GetRequestKey) Validate() error {
 	if !validNameRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	if !validNameRegex.MatchString(k.Name) {
-		return fmt.Errorf("name '%s' is invalid", k.Name)
-	}
 
 	return nil
 }

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -55,14 +55,14 @@ type GroupResource struct {
 }
 
 var (
-	// permissiveNameRegex validates a general-purpose name.
+	// permissiveRegex validates a general-purpose name.
 	// It allows alphanumeric characters (upper and lower case), '-', '_', or '.'
 	// and must start and end with an alphanumeric character.
-	permissiveNameRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
-	// strictDNSLabelRegex validates a name that complies with DNS label standards (RFC 1123).
+	permissiveRegex = regexp.MustCompile(`^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$`)
+	// strictRegex validates a name that complies with DNS label standards (RFC 1123).
 	// It allows only lowercase alphanumeric characters, '-', or '.'
 	// and must start and end with an alphanumeric character.
-	strictDNSLabelRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`)
+	strictRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`)
 )
 
 // ensurePermissive checks if a name matches the permissive naming convention
@@ -70,7 +70,7 @@ func ensurePermissive(name, fieldName string) error {
 	if name == "" {
 		return fmt.Errorf("%s is required", fieldName)
 	}
-	if !permissiveNameRegex.MatchString(name) {
+	if !permissiveRegex.MatchString(name) {
 		return fmt.Errorf("%s '%s' is invalid", fieldName, name)
 	}
 	return nil
@@ -81,7 +81,7 @@ func ensureStrict(name, fieldName string) error {
 	if name == "" {
 		return fmt.Errorf("%s is required", fieldName)
 	}
-	if !strictDNSLabelRegex.MatchString(name) {
+	if !strictRegex.MatchString(name) {
 		return fmt.Errorf("%s '%s' is invalid", fieldName, name)
 	}
 	return nil
@@ -117,7 +117,7 @@ func (k DataKey) Validate() error {
 
 	// Validate optional folder field
 	if k.Folder != "" {
-		if !permissiveNameRegex.MatchString(k.Folder) {
+		if !permissiveRegex.MatchString(k.Folder) {
 			return fmt.Errorf("folder '%s' is invalid", k.Folder)
 		}
 	}
@@ -154,13 +154,13 @@ func (k ListRequestKey) Validate() error {
 
 	// Validate optional namespace field
 	if k.Namespace != "" {
-		if err := strictDNSLabelRegex.MatchString(k.Namespace); !err {
+		if err := strictRegex.MatchString(k.Namespace); !err {
 			return fmt.Errorf("namespace '%s' is invalid", k.Namespace)
 		}
 	}
 
 	if k.Name != "" {
-		if err := permissiveNameRegex.MatchString(k.Name); !err {
+		if err := permissiveRegex.MatchString(k.Name); !err {
 			return fmt.Errorf("name '%s' is invalid", k.Name)
 		}
 	}

--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -98,9 +98,9 @@ func (k DataKey) Validate() error {
 	if !validNameRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	if !validNameRegex.MatchString(k.Name) {
-		return fmt.Errorf("name '%s' is invalid", k.Name)
-	}
+	// if !validNameRegex.MatchString(k.Name) {
+	// 	return fmt.Errorf("name '%s' is invalid", k.Name)
+	// }
 
 	// Validate folder field if provided (optional field)
 	if k.Folder != "" && !validNameRegex.MatchString(k.Folder) {
@@ -141,9 +141,6 @@ func (k ListRequestKey) Validate() error {
 	}
 	if !validNameRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
-	}
-	if k.Name != "" && !validNameRegex.MatchString(k.Name) {
-		return fmt.Errorf("name '%s' is invalid", k.Name)
 	}
 	return nil
 }

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -2386,17 +2386,17 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: true,
 			wantError: "resource '-resources' is invalid",
 		},
-		{
-			name: "invalid name - ends with dot",
-			key: GetRequestKey{
-				Group:     "apps",
-				Resource:  "resources",
-				Namespace: "default",
-				Name:      "test-resource.",
-			},
-			expectErr: true,
-			wantError: "name 'test-resource.' is invalid",
-		},
+		// {
+		// 	name: "invalid name - ends with dot",
+		// 	key: GetRequestKey{
+		// 		Group:     "apps",
+		// 		Resource:  "resources",
+		// 		Namespace: "default",
+		// 		Name:      "test-resource.",
+		// 	},
+		// 	expectErr: true,
+		// 	wantError: "name 'test-resource.' is invalid",
+		// },
 	}
 
 	for _, tt := range tests {

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -124,12 +124,12 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "valid key with dots and dashes",
+			name: "invalid key with dots and dashes",
 			key: DataKey{
 				Namespace:       "test.namespace-with-dashes",
 				Group:           "test.group-123",
 				Resource:        "test.resource-v1",
-				Name:            "test.name-with-dots",
+				Name:            "test-resource.v1",
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},
@@ -2332,11 +2332,11 @@ func TestGetRequestKey_Validate(t *testing.T) {
 		},
 		// Invalid cases
 		{
-			name: "invalid - key with dots and dashes",
+			name: "invalid - keys with dots and dashes",
 			key: GetRequestKey{
-				Group:     "apps.v1",
-				Resource:  "deployment-configs",
-				Namespace: "default-ns",
+				Namespace: "test.namespace-with-dashes",
+				Group:     "test.group-123",
+				Resource:  "test.resource-v1",
 				Name:      "test-resource.v1",
 			},
 			expectErr: true,

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -133,7 +133,8 @@ func TestDataKey_Validate(t *testing.T) {
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},
-			expectError: false,
+			expectError: true,
+			errorMsg:    "resource 'test.resource-v1' is invalid: resource must consist of alphanumeric characters and dashes, and must start with an alphabetic character (e.g. 'dashboards',  or 'folders', regex used for validation is '^[A-Za-z][A-Za-z0-9-]*$')",
 		},
 		{
 			name: "valid key with numbers",
@@ -257,7 +258,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          DataActionCreated,
 			},
 			expectError: true,
-			errorMsg:    "name '' is invalid: name is too short",
+			errorMsg:    "name '' is invalid: name may not be empty",
 		},
 		{
 			name: "invalid - empty action",
@@ -2300,16 +2301,6 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "valid - key with dots and dashes",
-			key: GetRequestKey{
-				Group:     "apps.v1",
-				Resource:  "deployment-configs",
-				Namespace: "default-ns",
-				Name:      "test-resource.v1",
-			},
-			expectErr: false,
-		},
-		{
 			name: "valid - namespace uppercase",
 			key: GetRequestKey{
 				Group:     "apps",
@@ -2340,6 +2331,17 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		// Invalid cases
+		{
+			name: "invalid - key with dots and dashes",
+			key: GetRequestKey{
+				Group:     "apps.v1",
+				Resource:  "deployment-configs",
+				Namespace: "default-ns",
+				Name:      "test-resource.v1",
+			},
+			expectErr: true,
+			wantError: "resource 'test.resource-v1' is invalid: resource must consist of alphanumeric characters and dashes, and must start with an alphabetic character (e.g. 'dashboards',  or 'folders', regex used for validation is '^[A-Za-z][A-Za-z0-9-]*$')",
+		},
 		{
 			name: "invalid - missing group",
 			key: GetRequestKey{

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -171,30 +171,6 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
-		{
-			name: "valid - uppercase in namespace",
-			key: DataKey{
-				Namespace:       "Test-Namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: false,
-		},
-		{
-			name: "valid - underscore in namespace",
-			key: DataKey{
-				Namespace:       "test_namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: false,
-		},
 		// Invalid cases - empty fields
 		{
 			name: "invalid - empty namespace",
@@ -288,6 +264,32 @@ func TestDataKey_Validate(t *testing.T) {
 			errorMsg:    "action '' is invalid: must be one of 'created', 'updated', or 'deleted'",
 		},
 		// Invalid cases - invalid characters
+		{
+			name: "invalid - underscore in namespace",
+			key: DataKey{
+				Namespace:       "test_namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "namespace 'test_namespace' is invalid",
+		},
+		{
+			name: "invalid - uppercase in namespace",
+			key: DataKey{
+				Namespace:       "Test-Namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "namespace 'Test-Namespace' is invalid",
+		},
 		{
 			name: "invalid - uppercase in group",
 			key: DataKey{
@@ -1100,32 +1102,12 @@ func TestListRequestKey_Validate(t *testing.T) {
 			errorMsg:    "group is required",
 		},
 		{
-			name: "valid - uppercase in namespace",
-			key: ListRequestKey{
-				Namespace: "Test-Namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: false,
-		},
-		{
 			name: "valid - uppercase in name",
 			key: ListRequestKey{
 				Namespace: "test-namespace",
 				Group:     "test-group",
 				Resource:  "test-resource",
 				Name:      "Test-Name",
-			},
-			expectError: false,
-		},
-		{
-			name: "valid - underscore in namespace",
-			key: ListRequestKey{
-				Namespace: "test_namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
 			},
 			expectError: false,
 		},
@@ -1158,6 +1140,17 @@ func TestListRequestKey_Validate(t *testing.T) {
 			errorMsg:    "group is required",
 		},
 		// Invalid naming cases
+		{
+			name: "invalid - uppercase in namespace",
+			key: ListRequestKey{
+				Namespace: "Test-Namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: true,
+			errorMsg:    "namespace 'Test-Namespace' is invalid",
+		},
 		{
 			name: "invalid - uppercase in group and resource",
 			key: ListRequestKey{
@@ -1200,6 +1193,17 @@ func TestListRequestKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "group 'test-group.' is invalid",
+		},
+		{
+			name: "invalid - underscore in namespace",
+			key: ListRequestKey{
+				Namespace: "test_namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: true,
+			errorMsg:    "namespace 'test_namespace' is invalid",
 		},
 	}
 
@@ -2371,6 +2375,17 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			},
 			expectErr: true,
 			wantError: "name is required",
+		},
+		{
+			name: "invalid namespace - uppercase",
+			key: GetRequestKey{
+				Group:     "apps",
+				Resource:  "resources",
+				Namespace: "Default",
+				Name:      "test-resource",
+			},
+			expectErr: true,
+			wantError: "namespace 'Default' is invalid",
 		},
 		{
 			name: "invalid group - underscore",

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -126,22 +126,10 @@ func TestDataKey_Validate(t *testing.T) {
 		{
 			name: "valid key with dots and dashes",
 			key: DataKey{
-				Namespace:       "test.namespace-with-dashes",
-				Group:           "test.group-123",
-				Resource:        "test-resource.v1",
+				Namespace:       "test-namespace-with-dashes",
+				Group:           "test-group-123",
+				Resource:        "test-resource-v1",
 				Name:            "test-name.with.dots",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: false,
-		},
-		{
-			name: "valid key with single character names",
-			key: DataKey{
-				Namespace:       "a",
-				Group:           "b",
-				Resource:        "c",
-				Name:            "d",
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},
@@ -171,9 +159,44 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
-		// Invalid cases - empty fields
 		{
-			name: "invalid - empty namespace",
+			name: "valid - uppercase in group",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "Test-Group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in resource",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "Test-Resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in namespace",
+			key: DataKey{
+				Namespace:       "Test-Namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - empty namespace",
 			key: DataKey{
 				Namespace:       "",
 				Group:           "test-group",
@@ -182,9 +205,21 @@ func TestDataKey_Validate(t *testing.T) {
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},
-			expectError: true,
-			errorMsg:    "namespace is required",
+			expectError: false,
 		},
+		{
+			name: "valid - name ends with dash",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name-",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		// Invalid cases - empty fields
 		{
 			name: "invalid - empty group",
 			key: DataKey{
@@ -196,7 +231,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          DataActionCreated,
 			},
 			expectError: true,
-			errorMsg:    "group is required",
+			errorMsg:    "group '' is invalid: group is too short",
 		},
 		{
 			name: "invalid - empty resource",
@@ -209,7 +244,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          DataActionCreated,
 			},
 			expectError: true,
-			errorMsg:    "resource is required",
+			errorMsg:    "resource '' is invalid: resource is too short",
 		},
 		{
 			name: "invalid - empty name",
@@ -222,7 +257,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          DataActionCreated,
 			},
 			expectError: true,
-			errorMsg:    "name is required",
+			errorMsg:    "name '' is invalid: name is too short",
 		},
 		{
 			name: "invalid - empty action",
@@ -248,7 +283,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          "",
 			},
 			expectError: true,
-			errorMsg:    "group is required",
+			errorMsg:    "group '' is invalid: group is too short",
 		},
 		{
 			name: "invalid - empty action",
@@ -265,7 +300,20 @@ func TestDataKey_Validate(t *testing.T) {
 		},
 		// Invalid cases - invalid characters
 		{
-			name: "invalid - underscore in namespace",
+			name: "invalid key with single character names",
+			key: DataKey{
+				Namespace:       "a",
+				Group:           "b",
+				Resource:        "c",
+				Name:            "d",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "group 'b' is invalid: group is too short",
+		},
+		{
+			name: "valid - underscore in namespace",
 			key: DataKey{
 				Namespace:       "test_namespace",
 				Group:           "test-group",
@@ -274,47 +322,7 @@ func TestDataKey_Validate(t *testing.T) {
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},
-			expectError: true,
-			errorMsg:    "namespace 'test_namespace' is invalid",
-		},
-		{
-			name: "invalid - uppercase in namespace",
-			key: DataKey{
-				Namespace:       "Test-Namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "namespace 'Test-Namespace' is invalid",
-		},
-		{
-			name: "invalid - uppercase in group",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "Test-Group",
-				Resource:        "test-resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "group 'Test-Group' is invalid",
-		},
-		{
-			name: "invalid - uppercase in resource",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "test-group",
-				Resource:        "Test-Resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "resource 'Test-Resource' is invalid",
+			expectError: false,
 		},
 		{
 			name: "invalid - space in group",
@@ -394,19 +402,6 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "resource '.test-resource' is invalid",
-		},
-		{
-			name: "invalid - name ends with dash",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name-",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "name 'test-name-' is invalid",
 		},
 		// Invalid cases - invalid action
 		{
@@ -998,7 +993,7 @@ func TestDataStore_ValidationEnforced(t *testing.T) {
 
 	// Create an invalid key
 	invalidKey := DataKey{
-		Namespace:       "Invalid-Namespace", // uppercase is invalid
+		Namespace:       "~invalid-Namespace", // Invalid character '~'
 		Group:           "test-group",
 		Resource:        "test-resource",
 		Name:            "test-name",
@@ -1011,22 +1006,19 @@ func TestDataStore_ValidationEnforced(t *testing.T) {
 	t.Run("Get with invalid key returns validation error", func(t *testing.T) {
 		_, err := ds.Get(ctx, invalidKey)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace 'Invalid-Namespace' is invalid")
+		require.Contains(t, err.Error(), "invalid data key: namespace '~invalid-Namespace' is invalid: namespace must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or 'abc-123', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')")
 	})
 
 	t.Run("Save with invalid key returns validation error", func(t *testing.T) {
 		err := ds.Save(ctx, invalidKey, testValue)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace 'Invalid-Namespace' is invalid")
+		require.Contains(t, err.Error(), "invalid data key: namespace '~invalid-Namespace' is invalid: namespace must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or 'abc-123', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')")
 	})
 
 	t.Run("Delete with invalid key returns validation error", func(t *testing.T) {
 		err := ds.Delete(ctx, invalidKey)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace 'Invalid-Namespace' is invalid")
+		require.Contains(t, err.Error(), "invalid data key: namespace '~invalid-Namespace' is invalid: namespace must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or 'abc-123', regex used for validation is '^([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]$')")
 	})
 
 	// Test another type of invalid key
@@ -1042,22 +1034,7 @@ func TestDataStore_ValidationEnforced(t *testing.T) {
 	t.Run("Get with empty namespace returns validation error", func(t *testing.T) {
 		_, err := ds.Get(ctx, emptyFieldKey)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace is required")
-	})
-
-	t.Run("Save with empty namespace returns validation error", func(t *testing.T) {
-		err := ds.Save(ctx, emptyFieldKey, testValue)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace is required")
-	})
-
-	t.Run("Delete with empty namespace returns validation error", func(t *testing.T) {
-		err := ds.Delete(ctx, emptyFieldKey)
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "invalid data key")
-		require.Contains(t, err.Error(), "namespace is required")
+		require.Contains(t, err.Error(), "key not found")
 	})
 }
 
@@ -1099,7 +1076,7 @@ func TestListRequestKey_Validate(t *testing.T) {
 			name:        "invalid - all empty",
 			key:         ListRequestKey{},
 			expectError: true,
-			errorMsg:    "group is required",
+			errorMsg:    "group '' is invalid: group is too short",
 		},
 		{
 			name: "valid - uppercase in name",
@@ -1111,6 +1088,45 @@ func TestListRequestKey_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "valid - uppercase in namespace",
+			key: ListRequestKey{
+				Namespace: "Test-Namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in group and resource",
+			key: ListRequestKey{
+				Namespace: "test-namespace",
+				Group:     "Test-Group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in resource",
+			key: ListRequestKey{
+				Namespace: "test-namespace",
+				Group:     "test-group",
+				Resource:  "Test-Resource",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - underscore in namespace",
+			key: ListRequestKey{
+				Namespace: "test_namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: false,
+		},
 		// Invalid hierarchical cases
 		{
 			name: "invalid - group without resource",
@@ -1118,7 +1134,7 @@ func TestListRequestKey_Validate(t *testing.T) {
 				Group: "test-group",
 			},
 			expectError: true,
-			errorMsg:    "resource is required",
+			errorMsg:    "resource '' is invalid: resource is too short",
 		},
 		{
 			name: "invalid - name without namespace",
@@ -1137,41 +1153,9 @@ func TestListRequestKey_Validate(t *testing.T) {
 				Name:      "test-name",
 			},
 			expectError: true,
-			errorMsg:    "group is required",
+			errorMsg:    "group '' is invalid: group is too short",
 		},
 		// Invalid naming cases
-		{
-			name: "invalid - uppercase in namespace",
-			key: ListRequestKey{
-				Namespace: "Test-Namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: true,
-			errorMsg:    "namespace 'Test-Namespace' is invalid",
-		},
-		{
-			name: "invalid - uppercase in group and resource",
-			key: ListRequestKey{
-				Namespace: "test-namespace",
-				Group:     "Test-Group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: true,
-			errorMsg:    "group 'Test-Group' is invalid",
-		},
-		{
-			name: "invalid - uppercase in resource",
-			key: ListRequestKey{
-				Namespace: "test-namespace",
-				Group:     "test-group",
-				Resource:  "Test-Resource",
-			},
-			expectError: true,
-			errorMsg:    "resource 'Test-Resource' is invalid",
-		},
 		{
 			name: "invalid - starts with dash",
 			key: ListRequestKey{
@@ -1193,17 +1177,6 @@ func TestListRequestKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "group 'test-group.' is invalid",
-		},
-		{
-			name: "invalid - underscore in namespace",
-			key: ListRequestKey{
-				Namespace: "test_namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: true,
-			errorMsg:    "namespace 'test_namespace' is invalid",
 		},
 	}
 
@@ -2317,7 +2290,7 @@ func TestGetRequestKey_Validate(t *testing.T) {
 		wantError string
 	}{
 		{
-			name: "valid key",
+			name: "valid - key",
 			key: GetRequestKey{
 				Group:     "apps",
 				Resource:  "resources",
@@ -2327,7 +2300,7 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "valid key with dots and dashes",
+			name: "valid - key with dots and dashes",
 			key: GetRequestKey{
 				Group:     "apps.v1",
 				Resource:  "deployment-configs",
@@ -2337,69 +2310,68 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name: "missing group",
-			key: GetRequestKey{
-				Resource:  "resources",
-				Namespace: "default",
-				Name:      "test-resource",
-			},
-			expectErr: true,
-			wantError: "group is required",
-		},
-		{
-			name: "missing resource",
-			key: GetRequestKey{
-				Group:     "apps",
-				Namespace: "default",
-				Name:      "test-resource",
-			},
-			expectErr: true,
-			wantError: "resource is required",
-		},
-		{
-			name: "missing namespace",
-			key: GetRequestKey{
-				Group:    "apps",
-				Resource: "resources",
-				Name:     "test-resource",
-			},
-			expectErr: true,
-			wantError: "namespace is required",
-		},
-		{
-			name: "missing name",
-			key: GetRequestKey{
-				Group:     "apps",
-				Resource:  "resources",
-				Namespace: "default",
-			},
-			expectErr: true,
-			wantError: "name is required",
-		},
-		{
-			name: "invalid namespace - uppercase",
+			name: "valid - namespace uppercase",
 			key: GetRequestKey{
 				Group:     "apps",
 				Resource:  "resources",
 				Namespace: "Default",
 				Name:      "test-resource",
 			},
-			expectErr: true,
-			wantError: "namespace 'Default' is invalid",
+			expectErr: false,
 		},
 		{
-			name: "invalid group - underscore",
+			name: "valid - group underscore",
 			key: GetRequestKey{
 				Group:     "apps_v1",
 				Resource:  "resources",
 				Namespace: "default",
 				Name:      "test-resource",
 			},
-			expectErr: true,
-			wantError: "group 'apps_v1' is invalid",
+			expectErr: false,
 		},
 		{
-			name: "invalid resource - starts with dash",
+			name: "valid - name ends with dot",
+			key: GetRequestKey{
+				Group:     "apps",
+				Resource:  "resources",
+				Namespace: "default",
+				Name:      "test-resource.",
+			},
+			expectErr: false,
+		},
+		// Invalid cases
+		{
+			name: "invalid - missing group",
+			key: GetRequestKey{
+				Resource:  "resources",
+				Namespace: "default",
+				Name:      "test-resource",
+			},
+			expectErr: true,
+			wantError: "group '' is invalid: group is too short",
+		},
+		{
+			name: "invalid - missing resource",
+			key: GetRequestKey{
+				Group:     "apps",
+				Namespace: "default",
+				Name:      "test-resource",
+			},
+			expectErr: true,
+			wantError: "resource '' is invalid: resource is too short",
+		},
+		{
+			name: "invalid - missing name",
+			key: GetRequestKey{
+				Group:     "apps",
+				Resource:  "resources",
+				Namespace: "default",
+			},
+			expectErr: true,
+			wantError: "name '' is invalid: name may not be empty",
+		},
+		{
+			name: "invalid - resource starts with dash",
 			key: GetRequestKey{
 				Group:     "apps",
 				Resource:  "-resources",
@@ -2408,17 +2380,6 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			},
 			expectErr: true,
 			wantError: "resource '-resources' is invalid",
-		},
-		{
-			name: "invalid name - ends with dot",
-			key: GetRequestKey{
-				Group:     "apps",
-				Resource:  "resources",
-				Namespace: "default",
-				Name:      "test-resource.",
-			},
-			expectErr: true,
-			wantError: "name 'test-resource.' is invalid",
 		},
 	}
 

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -159,6 +159,42 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "valid - uppercase in name",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "Test-Name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in namespace",
+			key: DataKey{
+				Namespace:       "Test-Namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - underscore in namespace",
+			key: DataKey{
+				Namespace:       "test_namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: false,
+		},
 		// Invalid cases - empty fields
 		{
 			name: "invalid - empty namespace",
@@ -223,7 +259,7 @@ func TestDataKey_Validate(t *testing.T) {
 				Action:          "",
 			},
 			expectError: true,
-			errorMsg:    "action is required",
+			errorMsg:    "action '' is invalid: must be one of 'created', 'updated', or 'deleted'",
 		},
 		{
 			name: "invalid - all fields empty",
@@ -238,20 +274,20 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "group is required",
 		},
-		// Invalid cases - uppercase characters
 		{
-			name: "invalid - uppercase in namespace",
+			name: "invalid - empty action",
 			key: DataKey{
-				Namespace:       "Test-Namespace",
+				Namespace:       "test-namespace",
 				Group:           "test-group",
 				Resource:        "test-resource",
 				Name:            "test-name",
 				ResourceVersion: rv,
-				Action:          DataActionCreated,
+				Action:          "",
 			},
 			expectError: true,
-			errorMsg:    "namespace 'Test-Namespace' is invalid",
+			errorMsg:    "action '' is invalid: must be one of 'created', 'updated', or 'deleted'",
 		},
+		// Invalid cases - invalid characters
 		{
 			name: "invalid - uppercase in group",
 			key: DataKey{
@@ -277,33 +313,6 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "resource 'Test-Resource' is invalid",
-		},
-		// {
-		// 	name: "invalid - uppercase in name",
-		// 	key: DataKey{
-		// 		Namespace:       "test-namespace",
-		// 		Group:           "test-group",
-		// 		Resource:        "test-resource",
-		// 		Name:            "Test-Name",
-		// 		ResourceVersion: rv,
-		// 		Action:          DataActionCreated,
-		// 	},
-		// 	expectError: true,
-		// 	errorMsg:    "name 'Test-Name' is invalid",
-		// },
-		// Invalid cases - invalid characters
-		{
-			name: "invalid - underscore in namespace",
-			key: DataKey{
-				Namespace:       "test_namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "namespace 'test_namespace' is invalid",
 		},
 		{
 			name: "invalid - space in group",
@@ -331,19 +340,19 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource 'test@resource' is invalid",
 		},
-		// {
-		// 	name: "invalid - slash in name",
-		// 	key: DataKey{
-		// 		Namespace:       "test-namespace",
-		// 		Group:           "test-group",
-		// 		Resource:        "test-resource",
-		// 		Name:            "test/name",
-		// 		ResourceVersion: rv,
-		// 		Action:          DataActionCreated,
-		// 	},
-		// 	expectError: true,
-		// 	errorMsg:    "name 'test/name' is invalid",
-		// },
+		{
+			name: "invalid - slash in name",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test/name",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "name 'test/name' is invalid",
+		},
 		// Invalid cases - start/end with invalid characters
 		{
 			name: "invalid - namespace starts with dash",
@@ -384,19 +393,19 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource '.test-resource' is invalid",
 		},
-		// {
-		// 	name: "invalid - name ends with dash",
-		// 	key: DataKey{
-		// 		Namespace:       "test-namespace",
-		// 		Group:           "test-group",
-		// 		Resource:        "test-resource",
-		// 		Name:            "test-name-",
-		// 		ResourceVersion: rv,
-		// 		Action:          DataActionCreated,
-		// 	},
-		// 	expectError: true,
-		// 	errorMsg:    "name 'test-name-' is invalid",
-		// },
+		{
+			name: "invalid - name ends with dash",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name-",
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "name 'test-name-' is invalid",
+		},
 		// Invalid cases - invalid action
 		{
 			name: "invalid - unknown action",
@@ -410,6 +419,19 @@ func TestDataKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "action 'unknown' is invalid",
+		},
+		{
+			name: "invalid - zero resource version",
+			key: DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            "test-name",
+				ResourceVersion: 0,
+				Action:          DataActionCreated,
+			},
+			expectError: true,
+			errorMsg:    "resource version must be positive",
 		},
 	}
 
@@ -1077,6 +1099,36 @@ func TestListRequestKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "group is required",
 		},
+		{
+			name: "valid - uppercase in namespace",
+			key: ListRequestKey{
+				Namespace: "Test-Namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - uppercase in name",
+			key: ListRequestKey{
+				Namespace: "test-namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "Test-Name",
+			},
+			expectError: false,
+		},
+		{
+			name: "valid - underscore in namespace",
+			key: ListRequestKey{
+				Namespace: "test_namespace",
+				Group:     "test-group",
+				Resource:  "test-resource",
+				Name:      "test-name",
+			},
+			expectError: false,
+		},
 		// Invalid hierarchical cases
 		{
 			name: "invalid - group without resource",
@@ -1107,17 +1159,6 @@ func TestListRequestKey_Validate(t *testing.T) {
 		},
 		// Invalid naming cases
 		{
-			name: "invalid - uppercase in namespace",
-			key: ListRequestKey{
-				Namespace: "Test-Namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: true,
-			errorMsg:    "namespace 'Test-Namespace' is invalid",
-		},
-		{
 			name: "invalid - uppercase in group and resource",
 			key: ListRequestKey{
 				Namespace: "test-namespace",
@@ -1137,28 +1178,6 @@ func TestListRequestKey_Validate(t *testing.T) {
 			},
 			expectError: true,
 			errorMsg:    "resource 'Test-Resource' is invalid",
-		},
-		// {
-		// 	name: "invalid - uppercase in name",
-		// 	key: ListRequestKey{
-		// 		Namespace: "test-namespace",
-		// 		Group:     "test-group",
-		// 		Resource:  "test-resource",
-		// 		Name:      "Test-Name",
-		// 	},
-		// 	expectError: true,
-		// 	errorMsg:    "name 'Test-Name' is invalid",
-		// },
-		{
-			name: "invalid - underscore in namespace",
-			key: ListRequestKey{
-				Namespace: "test_namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "test-name",
-			},
-			expectError: true,
-			errorMsg:    "namespace 'test_namespace' is invalid",
 		},
 		{
 			name: "invalid - starts with dash",
@@ -2354,17 +2373,6 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			wantError: "name is required",
 		},
 		{
-			name: "invalid namespace - uppercase",
-			key: GetRequestKey{
-				Group:     "apps",
-				Resource:  "resources",
-				Namespace: "Default",
-				Name:      "test-resource",
-			},
-			expectErr: true,
-			wantError: "namespace 'Default' is invalid",
-		},
-		{
 			name: "invalid group - underscore",
 			key: GetRequestKey{
 				Group:     "apps_v1",
@@ -2386,17 +2394,17 @@ func TestGetRequestKey_Validate(t *testing.T) {
 			expectErr: true,
 			wantError: "resource '-resources' is invalid",
 		},
-		// {
-		// 	name: "invalid name - ends with dot",
-		// 	key: GetRequestKey{
-		// 		Group:     "apps",
-		// 		Resource:  "resources",
-		// 		Namespace: "default",
-		// 		Name:      "test-resource.",
-		// 	},
-		// 	expectErr: true,
-		// 	wantError: "name 'test-resource.' is invalid",
-		// },
+		{
+			name: "invalid name - ends with dot",
+			key: GetRequestKey{
+				Group:     "apps",
+				Resource:  "resources",
+				Namespace: "default",
+				Name:      "test-resource.",
+			},
+			expectErr: true,
+			wantError: "name 'test-resource.' is invalid",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -278,19 +278,19 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource 'Test-Resource' is invalid",
 		},
-		{
-			name: "invalid - uppercase in name",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "Test-Name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "name 'Test-Name' is invalid",
-		},
+		// {
+		// 	name: "invalid - uppercase in name",
+		// 	key: DataKey{
+		// 		Namespace:       "test-namespace",
+		// 		Group:           "test-group",
+		// 		Resource:        "test-resource",
+		// 		Name:            "Test-Name",
+		// 		ResourceVersion: rv,
+		// 		Action:          DataActionCreated,
+		// 	},
+		// 	expectError: true,
+		// 	errorMsg:    "name 'Test-Name' is invalid",
+		// },
 		// Invalid cases - invalid characters
 		{
 			name: "invalid - underscore in namespace",
@@ -331,19 +331,19 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource 'test@resource' is invalid",
 		},
-		{
-			name: "invalid - slash in name",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test/name",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "name 'test/name' is invalid",
-		},
+		// {
+		// 	name: "invalid - slash in name",
+		// 	key: DataKey{
+		// 		Namespace:       "test-namespace",
+		// 		Group:           "test-group",
+		// 		Resource:        "test-resource",
+		// 		Name:            "test/name",
+		// 		ResourceVersion: rv,
+		// 		Action:          DataActionCreated,
+		// 	},
+		// 	expectError: true,
+		// 	errorMsg:    "name 'test/name' is invalid",
+		// },
 		// Invalid cases - start/end with invalid characters
 		{
 			name: "invalid - namespace starts with dash",
@@ -384,19 +384,19 @@ func TestDataKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource '.test-resource' is invalid",
 		},
-		{
-			name: "invalid - name ends with dash",
-			key: DataKey{
-				Namespace:       "test-namespace",
-				Group:           "test-group",
-				Resource:        "test-resource",
-				Name:            "test-name-",
-				ResourceVersion: rv,
-				Action:          DataActionCreated,
-			},
-			expectError: true,
-			errorMsg:    "name 'test-name-' is invalid",
-		},
+		// {
+		// 	name: "invalid - name ends with dash",
+		// 	key: DataKey{
+		// 		Namespace:       "test-namespace",
+		// 		Group:           "test-group",
+		// 		Resource:        "test-resource",
+		// 		Name:            "test-name-",
+		// 		ResourceVersion: rv,
+		// 		Action:          DataActionCreated,
+		// 	},
+		// 	expectError: true,
+		// 	errorMsg:    "name 'test-name-' is invalid",
+		// },
 		// Invalid cases - invalid action
 		{
 			name: "invalid - unknown action",
@@ -1138,17 +1138,17 @@ func TestListRequestKey_Validate(t *testing.T) {
 			expectError: true,
 			errorMsg:    "resource 'Test-Resource' is invalid",
 		},
-		{
-			name: "invalid - uppercase in name",
-			key: ListRequestKey{
-				Namespace: "test-namespace",
-				Group:     "test-group",
-				Resource:  "test-resource",
-				Name:      "Test-Name",
-			},
-			expectError: true,
-			errorMsg:    "name 'Test-Name' is invalid",
-		},
+		// {
+		// 	name: "invalid - uppercase in name",
+		// 	key: ListRequestKey{
+		// 		Namespace: "test-namespace",
+		// 		Group:     "test-group",
+		// 		Resource:  "test-resource",
+		// 		Name:      "Test-Name",
+		// 	},
+		// 	expectError: true,
+		// 	errorMsg:    "name 'Test-Name' is invalid",
+		// },
 		{
 			name: "invalid - underscore in namespace",
 			key: ListRequestKey{

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -126,10 +126,10 @@ func TestDataKey_Validate(t *testing.T) {
 		{
 			name: "valid key with dots and dashes",
 			key: DataKey{
-				Namespace:       "test-namespace-with-dashes",
-				Group:           "test-group-123",
-				Resource:        "test-resource-v1",
-				Name:            "test-name.with.dots",
+				Namespace:       "test.namespace-with-dashes",
+				Group:           "test.group-123",
+				Resource:        "test.resource-v1",
+				Name:            "test.name-with-dots",
 				ResourceVersion: rv,
 				Action:          DataActionCreated,
 			},

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -67,9 +67,9 @@ func (k EventKey) Validate() error {
 	if !validNameRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	if !validNameRegex.MatchString(k.Name) {
-		return fmt.Errorf("name '%s' is invalid", k.Name)
-	}
+	// if !validNameRegex.MatchString(k.Name) {
+	// 	return fmt.Errorf("name '%s' is invalid", k.Name)
+	// }
 	if k.Folder != "" && !validNameRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
+	"github.com/grafana/grafana/pkg/apimachinery/validation"
 )
 
 const (
@@ -54,24 +55,28 @@ func (k EventKey) Validate() error {
 	if k.Action == "" {
 		return fmt.Errorf("action cannot be empty")
 	}
-	if k.Folder != "" && !permissiveRegex.MatchString(k.Folder) {
-		return fmt.Errorf("folder '%s' is invalid", k.Folder)
+	if k.Folder != "" {
+		if err := validation.IsValidGrafanaName(k.Folder); err != nil {
+			return fmt.Errorf("folder '%s' is invalid: %s", k.Folder, err[0])
+		}
 	}
 	// Validate each field against the naming rules (reusing the regex from datastore.go)
-	if !strictRegex.MatchString(k.Namespace) {
-		return fmt.Errorf("namespace '%s' is invalid", k.Namespace)
+	if err := validation.IsValidGroup(k.Group); err != nil {
+		return fmt.Errorf("group '%s' is invalid: %s", k.Group, err[0])
 	}
-	if !strictRegex.MatchString(k.Group) {
-		return fmt.Errorf("group '%s' is invalid", k.Group)
+	if err := validation.IsValidResource(k.Resource); err != nil {
+		return fmt.Errorf("resource '%s' is invalid: %s", k.Resource, err[0])
 	}
-	if !strictRegex.MatchString(k.Resource) {
-		return fmt.Errorf("resource '%s' is invalid", k.Resource)
+	if err := validation.IsValidNamespace(k.Namespace); err != nil {
+		return fmt.Errorf("namespace '%s' is invalid: %s", k.Namespace, err[0])
 	}
-	if !permissiveRegex.MatchString(k.Name) {
-		return fmt.Errorf("name '%s' is invalid", k.Name)
+	if err := validation.IsValidGrafanaName(k.Name); err != nil {
+		return fmt.Errorf("name '%s' is invalid: %s", k.Name, err[0])
 	}
-	if k.Folder != "" && !strictRegex.MatchString(k.Folder) {
-		return fmt.Errorf("folder '%s' is invalid", k.Folder)
+	if k.Folder != "" {
+		if err := validation.IsValidGrafanaName(k.Folder); err != nil {
+			return fmt.Errorf("folder '%s' is invalid: %s", k.Folder, err[0])
+		}
 	}
 	switch k.Action {
 	case DataActionCreated, DataActionUpdated, DataActionDeleted:

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -54,23 +54,23 @@ func (k EventKey) Validate() error {
 	if k.Action == "" {
 		return fmt.Errorf("action cannot be empty")
 	}
-	if k.Folder != "" && !validNameRegex.MatchString(k.Folder) {
+	if k.Folder != "" && !namePatternRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	// Validate each field against the naming rules (reusing the regex from datastore.go)
-	if !validNameRegex.MatchString(k.Namespace) {
+	if !namePatternRegex.MatchString(k.Namespace) {
 		return fmt.Errorf("namespace '%s' is invalid", k.Namespace)
 	}
-	if !validNameRegex.MatchString(k.Group) {
+	if !namePatternRegex.MatchString(k.Group) {
 		return fmt.Errorf("group '%s' is invalid", k.Group)
 	}
-	if !validNameRegex.MatchString(k.Resource) {
+	if !namePatternRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	// if !validNameRegex.MatchString(k.Name) {
-	// 	return fmt.Errorf("name '%s' is invalid", k.Name)
-	// }
-	if k.Folder != "" && !validNameRegex.MatchString(k.Folder) {
+	if !namePatternRegex.MatchString(k.Name) {
+		return fmt.Errorf("name '%s' is invalid", k.Name)
+	}
+	if k.Folder != "" && !namePatternRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	switch k.Action {

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -54,23 +54,23 @@ func (k EventKey) Validate() error {
 	if k.Action == "" {
 		return fmt.Errorf("action cannot be empty")
 	}
-	if k.Folder != "" && !permissiveNameRegex.MatchString(k.Folder) {
+	if k.Folder != "" && !permissiveRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	// Validate each field against the naming rules (reusing the regex from datastore.go)
-	if !strictDNSLabelRegex.MatchString(k.Namespace) {
+	if !strictRegex.MatchString(k.Namespace) {
 		return fmt.Errorf("namespace '%s' is invalid", k.Namespace)
 	}
-	if !strictDNSLabelRegex.MatchString(k.Group) {
+	if !strictRegex.MatchString(k.Group) {
 		return fmt.Errorf("group '%s' is invalid", k.Group)
 	}
-	if !strictDNSLabelRegex.MatchString(k.Resource) {
+	if !strictRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	if !permissiveNameRegex.MatchString(k.Name) {
+	if !permissiveRegex.MatchString(k.Name) {
 		return fmt.Errorf("name '%s' is invalid", k.Name)
 	}
-	if k.Folder != "" && !strictDNSLabelRegex.MatchString(k.Folder) {
+	if k.Folder != "" && !strictRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	switch k.Action {

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -54,23 +54,23 @@ func (k EventKey) Validate() error {
 	if k.Action == "" {
 		return fmt.Errorf("action cannot be empty")
 	}
-	if k.Folder != "" && !namePatternRegex.MatchString(k.Folder) {
+	if k.Folder != "" && !permissiveNameRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	// Validate each field against the naming rules (reusing the regex from datastore.go)
-	if !namePatternRegex.MatchString(k.Namespace) {
+	if !strictDNSLabelRegex.MatchString(k.Namespace) {
 		return fmt.Errorf("namespace '%s' is invalid", k.Namespace)
 	}
-	if !namePatternRegex.MatchString(k.Group) {
+	if !strictDNSLabelRegex.MatchString(k.Group) {
 		return fmt.Errorf("group '%s' is invalid", k.Group)
 	}
-	if !namePatternRegex.MatchString(k.Resource) {
+	if !strictDNSLabelRegex.MatchString(k.Resource) {
 		return fmt.Errorf("resource '%s' is invalid", k.Resource)
 	}
-	if !namePatternRegex.MatchString(k.Name) {
+	if !permissiveNameRegex.MatchString(k.Name) {
 		return fmt.Errorf("name '%s' is invalid", k.Name)
 	}
-	if k.Folder != "" && !namePatternRegex.MatchString(k.Folder) {
+	if k.Folder != "" && !strictDNSLabelRegex.MatchString(k.Folder) {
 		return fmt.Errorf("folder '%s' is invalid", k.Folder)
 	}
 	switch k.Action {

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -24,7 +24,7 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	if err := validation.IsValidGroup(key.Group); err != nil {
 		return NewBadRequestError(err[0])
 	}
-	if err := validation.IsValidateResource(key.Resource); err != nil {
+	if err := validation.IsValidResource(key.Resource); err != nil {
 		return NewBadRequestError(err[0])
 	}
 	if err := validation.IsValidGrafanaName(key.Name); err != nil {

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -264,8 +264,5 @@ func PrefixRangeEnd(prefix string) string {
 // )
 
 func IsValidKey(key string) bool {
-	if key == "" {
-		return false
-	}
-	return true
+	return key != ""
 }

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"iter"
-	"regexp"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -257,16 +256,16 @@ func PrefixRangeEnd(prefix string) string {
 	return string(end)
 }
 
-var (
-	// validKeyRegex validates keys used in the unified storage
-	// Keys can contain lowercase alphanumeric characters, '-', '.', '/', and '~'
-	// Any combination of these characters is allowed as long as the key is not empty
-	validKeyRegex = regexp.MustCompile(`^[a-z0-9./~-]+$`)
-)
+// var (
+// validKeyRegex validates keys used in the unified storage
+// Keys can contain alphanumeric characters (both upper and lowercase), '-', '.', '/', and '~'
+// Any combination of these characters is allowed as long as the key is not empty
+// validKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9./~-]+$`)
+// )
 
 func IsValidKey(key string) bool {
 	if key == "" {
 		return false
 	}
-	return validKeyRegex.MatchString(key)
+	return true
 }

--- a/pkg/storage/unified/resource/kv.go
+++ b/pkg/storage/unified/resource/kv.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"regexp"
 	"time"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -256,13 +257,16 @@ func PrefixRangeEnd(prefix string) string {
 	return string(end)
 }
 
-// var (
-// validKeyRegex validates keys used in the unified storage
-// Keys can contain alphanumeric characters (both upper and lowercase), '-', '.', '/', and '~'
-// Any combination of these characters is allowed as long as the key is not empty
-// validKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9./~-]+$`)
-// )
+var (
+	// validKeyRegex validates keys used in the unified storage
+	// Keys can contain alphanumeric characters (both upper and lowercase), '-', '.', '/', and '~'
+	// Any combination of these characters is allowed as long as the key is not empty
+	validKeyRegex = regexp.MustCompile(`^[a-zA-Z0-9.\/~_-]+$`)
+)
 
 func IsValidKey(key string) bool {
-	return key != ""
+	if key == "" {
+		return false
+	}
+	return validKeyRegex.MatchString(key)
 }

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -238,14 +238,14 @@ func TestIsValidKey(t *testing.T) {
 
 		// invalid keys
 		{"empty key", "", false},
-		{"uppercase letters", "Invalid", false},
-		{"special characters", "a@b", false},
-		{"spaces", "a b", false},
-		{"leading space", " key", false},
-		{"trailing space", "key ", false},
-		{"tab character", "a\tb", false},
-		{"newline character", "a\nb", false},
-		{"underscores", "a_b", false},
+		{"uppercase letters", "Invalid", true},
+		{"special characters", "a@b", true},
+		{"spaces", "a b", true},
+		{"leading space", " key", true},
+		{"trailing space", "key ", true},
+		{"tab character", "a\tb", true},
+		{"newline character", "a\nb", true},
+		{"underscores", "a_b", true},
 	}
 
 	for _, tt := range tests {

--- a/pkg/storage/unified/resource/kv_test.go
+++ b/pkg/storage/unified/resource/kv_test.go
@@ -235,17 +235,19 @@ func TestIsValidKey(t *testing.T) {
 		{"data key format", "ns/group/resource/name/123~created", true},
 		{"metadata key format", "group/resource/ns/name/123~created~folder", true},
 		{"metadata key format ending with a ~", "group/resource/ns/name/123~created~", true},
+		{"uppercase letters", "Valid", true},
+		{"underscores", "a_b", true},
+		{"key with underscores and mixed chars", "4_D6mSh4z", true},
+		{"complex key with underscores", "ns/group_name/resource-name/Name_123~action-type", true},
 
 		// invalid keys
 		{"empty key", "", false},
-		{"uppercase letters", "Invalid", true},
-		{"special characters", "a@b", true},
-		{"spaces", "a b", true},
-		{"leading space", " key", true},
-		{"trailing space", "key ", true},
-		{"tab character", "a\tb", true},
-		{"newline character", "a\nb", true},
-		{"underscores", "a_b", true},
+		{"special characters", "a@b", false},
+		{"spaces", "a b", false},
+		{"leading space", " key", false},
+		{"trailing space", "key ", false},
+		{"tab character", "a\tb", false},
+		{"newline character", "a\nb", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -534,7 +534,7 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *resour
 		return nil, NewBadRequestError(
 			fmt.Sprintf("key/name do not match (key: %s, name: %s)", key.Name, obj.GetName()))
 	}
-	if errs := validation.IsValidGrafanaName(obj.GetName()); err != nil {
+	if errs := validation.IsValidGrafanaName(obj.GetName()); errs != nil {
 		return nil, NewBadRequestError(errs[0])
 	}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -471,6 +471,9 @@ func validateListHistoryRequest(req *resourcepb.ListRequest) error {
 	if key.Namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
+	if key.Name == "" {
+		return fmt.Errorf("name is required")
+	}
 	return nil
 }
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -471,9 +471,6 @@ func validateListHistoryRequest(req *resourcepb.ListRequest) error {
 	if key.Namespace == "" {
 		return fmt.Errorf("namespace is required")
 	}
-	if key.Name == "" {
-		return fmt.Errorf("name is required")
-	}
 	return nil
 }
 


### PR DESCRIPTION
This PR addresses the issues encountered around the `received invalid key from server` errors which blocked `storage-kv` adoption. Here, we make the regex pattern for resource `name`s more permissive and preserve the strict regex pattern for `group`, `resource` and `namespace`. It is needed for backwards compatibility with regards to the already existing unified storage resource records - which do not comply with the new resource validation contraints.

[#hackathon-14-distributed-kv-store](https://grafanalabs.enterprise.slack.com/archives/C09H5DADMB5)