### PR TITLE
Rebuild search indexes asynchronously

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -580,8 +580,8 @@ type Cfg struct {
 	IndexMinCount                              int
 	IndexRebuildInterval                       time.Duration
 	IndexCacheTTL                              time.Duration
-	MaxFileIndexAge                            time.Duration // Max age of file-based indexes. Index older than this will not be reused between restarts.
-	MinFileIndexBuildVersion                   string        // Minimum version of Grafana that built the file-based index. If index was built with older Grafana, it will not be reused between restarts.
+	MaxFileIndexAge                            time.Duration // Max age of file-based indexes. Index older than this will be rebuilt asynchronously.
+	MinFileIndexBuildVersion                   string        // Minimum version of Grafana that built the file-based index. If index was built with older Grafana, it will be rebuilt asynchronously.
 	EnableSharding                             bool
 	QOSEnabled                                 bool
 	QOSNumberWorker                            int

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -575,6 +575,7 @@ type Cfg struct {
 	MaxPageSizeBytes                           int
 	IndexPath                                  string
 	IndexWorkers                               int
+	IndexRebuildWorkers                        int
 	IndexMaxBatchSize                          int
 	IndexFileThreshold                         int
 	IndexMinCount                              int

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -54,6 +54,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
 	cfg.IndexWorkers = section.Key("index_workers").MustInt(10)
+	cfg.IndexRebuildWorkers = section.Key("index_rebuild_workers").MustInt(5)
 	cfg.IndexMaxBatchSize = section.Key("index_max_batch_size").MustInt(100)
 	cfg.EnableSharding = section.Key("enable_sharding").MustBool(false)
 	cfg.QOSEnabled = section.Key("qos_enabled").MustBool(false)

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -20,6 +20,7 @@ type BleveIndexMetrics struct {
 	UpdateLatency        prometheus.Histogram
 	UpdatedDocuments     prometheus.Summary
 	SearchUpdateWaitTime *prometheus.HistogramVec
+	RebuildQueueLength   prometheus.Gauge
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -84,6 +85,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}, []string{"reason"}),
+		RebuildQueueLength: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
+			Name: "index_server_rebuild_queue_length",
+			Help: "Number of indexes waiting for rebuild",
+		}),
 	}
 
 	// Initialize labels.

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -584,6 +584,10 @@ func (s *searchSupport) findIndexesToRebuild(ctx context.Context, now time.Time)
 				minBuildTime:       minBuildTime,
 				minBuildVersion:    s.minBuildVersion,
 			})
+
+			if s.indexMetrics != nil {
+				s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
+			}
 		}
 	}
 }
@@ -598,6 +602,10 @@ func (s *searchSupport) runIndexRebuilder(ctx context.Context) {
 		if err != nil {
 			s.log.Info("index rebuilder stopped", "error", err)
 			return
+		}
+
+		if s.indexMetrics != nil {
+			s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
 		}
 
 		s.rebuildIndex(ctx, req)

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -592,7 +592,7 @@ func (s *searchSupport) findIndexesToRebuild(ctx context.Context, now time.Time)
 	}
 }
 
-// runIndexRebuilder is a goroutine waiting for rebuild requests, and rebuils indexes specified in the request.
+// runIndexRebuilder is a goroutine waiting for rebuild requests, and rebuilds indexes specified in those requests.
 // Rebuild requests can be generated periodically (if configured), or after new documents have been imported into the storage with old RVs.
 func (s *searchSupport) runIndexRebuilder(ctx context.Context) {
 	defer s.bgTaskWg.Done()
@@ -616,7 +616,7 @@ func (s *searchSupport) rebuildIndex(ctx context.Context, req rebuildRequest) {
 	ctx, span := s.tracer.Start(ctx, tracingPrexfixSearch+"RebuildIndex")
 	defer span.End()
 
-	l := s.log.With("namespace", req.NamespacedResource.Namespace, "group", req.NamespacedResource.Group, "resource", req.NamespacedResource.Resource)
+	l := s.log.With("namespace", req.Namespace, "group", req.Group, "resource", req.Resource)
 
 	idx, err := s.search.GetIndex(ctx, req.NamespacedResource)
 	if err != nil {
@@ -671,7 +671,6 @@ func (s *searchSupport) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		span.RecordError(err)
 		l.Error("failed to rebuild index", "error", err)
 	}
-	return
 }
 
 func shouldRebuildIndex(minBuildVersion *semver.Version, buildInfo IndexBuildInfo, minBuildTime time.Time, rebuildLogger *slog.Logger) bool {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -219,10 +219,9 @@ func TestSearchGetOrCreateIndex(t *testing.T) {
 	}
 
 	opts := SearchOptions{
-		Backend:       search,
-		Resources:     supplier,
-		WorkerThreads: 1,
-		InitMinCount:  1, // set min count to default for this test
+		Backend:      search,
+		Resources:    supplier,
+		InitMinCount: 1, // set min count to default for this test
 	}
 
 	support, err := newSearchSupport(opts, storage, nil, nil, noop.NewTracerProvider().Tracer("test"), nil, nil)
@@ -275,10 +274,9 @@ func TestSearchGetOrCreateIndexWithIndexUpdate(t *testing.T) {
 	}
 
 	opts := SearchOptions{
-		Backend:       search,
-		Resources:     supplier,
-		WorkerThreads: 1,
-		InitMinCount:  1, // set min count to default for this test
+		Backend:      search,
+		Resources:    supplier,
+		InitMinCount: 1, // set min count to default for this test
 	}
 
 	// Enable searchAfterWrite
@@ -326,10 +324,9 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	}
 
 	opts := SearchOptions{
-		Backend:       search,
-		Resources:     supplier,
-		WorkerThreads: 1,
-		InitMinCount:  1, // set min count to default for this test
+		Backend:      search,
+		Resources:    supplier,
+		InitMinCount: 1, // set min count to default for this test
 	}
 
 	support, err := newSearchSupport(opts, storage, nil, nil, noop.NewTracerProvider().Tracer("test"), nil, nil)

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -188,6 +188,10 @@ func (m *mockSearchBackend) TotalDocs() int64 {
 	return 0
 }
 
+func (m *mockSearchBackend) GetOpenIndexes() []NamespacedResource {
+	return nil
+}
+
 func TestSearchGetOrCreateIndex(t *testing.T) {
 	// Setup mock implementations
 	storage := &mockStorageBackend{

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -9,9 +9,10 @@ import (
 	"testing"
 	"time"
 
+	"log/slog"
+
 	"github.com/Masterminds/semver"
 	"github.com/grafana/authlib/types"
-	"github.com/sagikazarmark/slog-shim"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -144,12 +144,6 @@ type buildIndexCall struct {
 	fields SearchableDocumentFields
 }
 
-type buildEmptyIndexCall struct {
-	key    NamespacedResource
-	size   int64 // should be 0 for empty indexes
-	fields SearchableDocumentFields
-}
-
 func (m *mockSearchBackend) GetIndex(ctx context.Context, key NamespacedResource) (ResourceIndex, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
@@ -21,7 +22,6 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/dskit/backoff"
-	"github.com/grafana/dskit/ring"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apimachinery/validation"
@@ -184,10 +184,14 @@ type SearchOptions struct {
 	// Skip building index on startup for small indexes
 	InitMinCount int
 
-	// Interval for periodic index rebuilds (0 disables periodic rebuilds)
-	RebuildInterval time.Duration
+	// How often to rebuild dashboard index. 0 disables periodic rebuilds.
+	DashboardIndexMaxAge time.Duration
 
-	Ring *ring.Ring
+	// Maximum age of file-based index that can be reused. Ignored if zero.
+	MaxIndexAge time.Duration
+
+	// Minimum build version for reusing file-based indexes. Ignored if nil.
+	MinBuildVersion *semver.Version
 }
 
 type ResourceServerOptions struct {
@@ -420,6 +424,10 @@ func (s *server) Stop(ctx context.Context) error {
 			stopFailed = true
 			s.initErr = fmt.Errorf("service stopeed with error: %w", err)
 		}
+	}
+
+	if s.search != nil {
+		s.search.stop()
 	}
 
 	// Stops the streaming

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -179,7 +179,7 @@ type SearchOptions struct {
 	Resources DocumentBuilderSupplier
 
 	// How many threads should build indexes
-	WorkerThreads int
+	InitWorkerThreads int
 
 	// Skip building index on startup for small indexes
 	InitMinCount int
@@ -192,6 +192,9 @@ type SearchOptions struct {
 
 	// Minimum build version for reusing file-based indexes. Ignored if nil.
 	MinBuildVersion *semver.Version
+
+	// Number of workers to use for index rebuilds.
+	IndexRebuildWorkers int
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -52,7 +52,7 @@ const (
 // Keys used to store internal data in index.
 const (
 	internalRVKey        = "rv"         // Encoded as big-endian int64
-	internalBuildInfoKey = "build_info" // Encoded as JSON of IndexBuildInfo struct
+	internalBuildInfoKey = "build_info" // Encoded as JSON of buildInfo struct
 )
 
 var _ resource.SearchBackend = &bleveBackend{}
@@ -74,9 +74,6 @@ type BleveOptions struct {
 	IndexCacheTTL time.Duration
 
 	BuildVersion string
-
-	MaxFileIndexAge time.Duration   // Maximum age of file-based index that can be reused. Ignored if zero.
-	MinBuildVersion *semver.Version // Minimum build version for reusing file-based indexes. Ignored if nil.
 
 	Logger *slog.Logger
 
@@ -177,6 +174,17 @@ func (b *bleveBackend) GetIndex(_ context.Context, key resource.NamespacedResour
 		return nil, nil
 	}
 	return idx, nil
+}
+
+func (b *bleveBackend) GetOpenIndexes() []resource.NamespacedResource {
+	b.cacheMx.RLock()
+	defer b.cacheMx.RUnlock()
+
+	result := make([]resource.NamespacedResource, 0, len(b.cache))
+	for key := range b.cache {
+		result = append(result, key)
+	}
+	return result
 }
 
 func (b *bleveBackend) getCachedIndex(key resource.NamespacedResource, now time.Time) *bleveIndex {
@@ -318,7 +326,7 @@ func newBleveIndex(path string, mapper mapping.IndexMapping, buildTime time.Time
 		return nil, err
 	}
 
-	bi := IndexBuildInfo{
+	bi := buildInfo{
 		BuildTime:    buildTime.Unix(),
 		BuildVersion: buildVersion,
 	}
@@ -336,27 +344,9 @@ func newBleveIndex(path string, mapper mapping.IndexMapping, buildTime time.Time
 	return ix, nil
 }
 
-type IndexBuildInfo struct {
+type buildInfo struct {
 	BuildTime    int64  `json:"build_time"`    // Unix seconds timestamp of time when the index was built
 	BuildVersion string `json:"build_version"` // Grafana version used when building the index
-}
-
-func (bi IndexBuildInfo) GetBuildTime() time.Time {
-	if bi.BuildTime == 0 {
-		return time.Time{}
-	}
-	return time.Unix(bi.BuildTime, 0)
-}
-
-func (bi IndexBuildInfo) GetBuildVersion() *semver.Version {
-	if bi.BuildVersion == "" {
-		return nil
-	}
-	v, err := semver.NewVersion(bi.BuildVersion)
-	if err != nil {
-		return nil
-	}
-	return v
 }
 
 // BuildIndex builds an index from scratch or retrieves it from the filesystem.
@@ -435,11 +425,7 @@ func (b *bleveBackend) BuildIndex(
 		// This happens on startup, or when memory-based index has expired. (We don't expire file-based indexes)
 		// If we do have an unexpired cached index already, we always build a new index from scratch.
 		if cachedIndex == nil && !rebuild {
-			minBuildTime := time.Time{}
-			if b.opts.MaxFileIndexAge > 0 {
-				minBuildTime = time.Now().Add(-b.opts.MaxFileIndexAge)
-			}
-			index, fileIndexName, indexRV = b.findPreviousFileBasedIndex(resourceDir, minBuildTime, b.opts.MinBuildVersion)
+			index, fileIndexName, indexRV = b.findPreviousFileBasedIndex(resourceDir)
 		}
 
 		if index != nil {
@@ -658,7 +644,7 @@ func formatIndexName(now time.Time) string {
 	return now.Format("20060102-150405")
 }
 
-func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string, minBuildTime time.Time, minBuildVersion *semver.Version) (bleve.Index, string, int64) {
+func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string) (bleve.Index, string, int64) {
 	entries, err := os.ReadDir(resourceDir)
 	if err != nil {
 		return nil, "", 0
@@ -682,31 +668,6 @@ func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string, minBuildTi
 			b.log.Error("error getting rv from index", "indexDir", indexDir, "err", err)
 			_ = idx.Close()
 			continue
-		}
-
-		buildInfo, err := getBuildInfo(idx)
-		if err != nil {
-			b.log.Error("error getting build info from index", "indexDir", indexDir, "err", err)
-			_ = idx.Close()
-			continue
-		}
-
-		if !minBuildTime.IsZero() {
-			bt := buildInfo.GetBuildTime()
-			if bt.IsZero() || bt.Before(minBuildTime) {
-				b.log.Debug("index build time is before minBuildTime, not reusing the index", "indexDir", indexDir, "indexBuildTime", bt, "minBuildTime", minBuildTime)
-				_ = idx.Close()
-				continue
-			}
-		}
-
-		if minBuildVersion != nil {
-			bv := buildInfo.GetBuildVersion()
-			if bv == nil || bv.Compare(minBuildVersion) < 0 {
-				b.log.Debug("index build version is before minBuildVersion, not reusing the index", "indexDir", indexDir, "indexBuildVersion", bv, "minBuildVersion", minBuildVersion)
-				_ = idx.Close()
-				continue
-			}
 		}
 
 		return idx, indexName, indexRV
@@ -878,19 +839,44 @@ func getRV(index bleve.Index) (int64, error) {
 	return int64(binary.BigEndian.Uint64(raw)), nil
 }
 
-func getBuildInfo(index bleve.Index) (IndexBuildInfo, error) {
+func getBuildInfo(index bleve.Index) (buildInfo, error) {
 	raw, err := index.GetInternal([]byte(internalBuildInfoKey))
 	if err != nil {
-		return IndexBuildInfo{}, err
+		return buildInfo{}, err
 	}
 
 	if len(raw) == 0 {
-		return IndexBuildInfo{}, nil
+		return buildInfo{}, nil
 	}
 
-	res := IndexBuildInfo{}
+	res := buildInfo{}
 	err = json.Unmarshal(raw, &res)
 	return res, err
+}
+
+func (b *bleveIndex) BuildInfo() (resource.IndexBuildInfo, error) {
+	bi, err := getBuildInfo(b.index)
+	if err != nil {
+		return resource.IndexBuildInfo{}, err
+	}
+
+	bt := time.Time{}
+	if bi.BuildTime > 0 {
+		bt = time.Unix(bi.BuildTime, 0)
+	}
+
+	var bv *semver.Version
+	if bi.BuildVersion != "" {
+		v, err := semver.NewVersion(bi.BuildVersion)
+		if err == nil {
+			bv = v
+		}
+	}
+
+	return resource.IndexBuildInfo{
+		BuildTime:    bt,
+		BuildVersion: bv,
+	}, nil
 }
 
 func (b *bleveIndex) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -607,18 +607,6 @@ func isPathWithinRoot(path, absoluteRoot string) bool {
 	return true
 }
 
-// cacheKeys returns list of keys for indexes in the cache (including possibly expired ones).
-func (b *bleveBackend) cacheKeys() []resource.NamespacedResource {
-	b.cacheMx.RLock()
-	defer b.cacheMx.RUnlock()
-
-	keys := make([]resource.NamespacedResource, 0, len(b.cache))
-	for k := range b.cache {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // TotalDocs returns the total number of documents across all indices
 func (b *bleveBackend) TotalDocs() int64 {
 	var totalDocs int64
@@ -626,7 +614,7 @@ func (b *bleveBackend) TotalDocs() int64 {
 	// We do this to avoid keeping a lock for the entire TotalDocs function, since DocCount may be slow (due to disk access).
 
 	now := time.Now()
-	for _, key := range b.cacheKeys() {
+	for _, key := range b.GetOpenIndexes() {
 		idx := b.getCachedIndex(key, now)
 		if idx == nil {
 			continue

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/blevesearch/bleve/v2"
 	authlib "github.com/grafana/authlib/types"
 	"github.com/prometheus/client_golang/prometheus"
@@ -827,24 +826,6 @@ func withRootDir(root string) setupOption {
 	}
 }
 
-func withBuildVersion(version string) setupOption {
-	return func(options *BleveOptions) {
-		options.BuildVersion = version
-	}
-}
-
-func withMinBuildVersion(version *semver.Version) setupOption {
-	return func(options *BleveOptions) {
-		options.MinBuildVersion = version
-	}
-}
-
-func withMaxFileIndexAge(maxAge time.Duration) setupOption {
-	return func(options *BleveOptions) {
-		options.MaxFileIndexAge = maxAge
-	}
-}
-
 func withOwnsIndexFn(fn func(key resource.NamespacedResource) (bool, error)) setupOption {
 	return func(options *BleveOptions) {
 		options.OwnsIndex = fn
@@ -978,81 +959,39 @@ func TestBuildIndex(t *testing.T) {
 		Resource:  "resource",
 	}
 
-	const alwaysRebuildDueToAge = 1 * time.Nanosecond
-	const neverRebuildDueToAge = 1 * time.Hour
-
 	for _, rebuild := range []bool{false, true} {
-		for _, version := range []string{"", "12.5.123"} {
-			for _, minBuildVersion := range []*semver.Version{nil, semver.MustParse("12.0.0"), semver.MustParse("13.0.0")} {
-				for _, maxIndexAge := range []time.Duration{0, alwaysRebuildDueToAge, neverRebuildDueToAge} {
-					shouldRebuild := rebuild
-					if minBuildVersion != nil {
-						shouldRebuild = shouldRebuild || version == "" || minBuildVersion.GreaterThan(semver.MustParse(version))
-					}
-					if maxIndexAge > 0 {
-						shouldRebuild = shouldRebuild || maxIndexAge == alwaysRebuildDueToAge
-					}
+		testName := fmt.Sprintf("rebuild=%t", rebuild)
 
-					testName := ""
-					if shouldRebuild {
-						testName += "should REBUILD index"
-					} else {
-						testName += "should REUSE index"
-					}
+		t.Run(testName, func(t *testing.T) {
+			tmpDir := t.TempDir()
 
-					if rebuild {
-						testName += " when rebuild is true"
-					} else {
-						testName += " when rebuild is false"
-					}
+			const (
+				firstIndexDocsCount  = 10
+				secondIndexDocsCount = 1000
+			)
 
-					if version != "" {
-						testName += " build version is " + version
-					} else {
-						testName += " build version is empty"
-					}
-
-					if minBuildVersion != nil {
-						testName += " min build version is " + minBuildVersion.String()
-					} else {
-						testName += " min build version is nil"
-					}
-
-					testName += " max index age is " + maxIndexAge.String()
-
-					t.Run(testName, func(t *testing.T) {
-						tmpDir := t.TempDir()
-
-						const (
-							firstIndexDocsCount  = 10
-							secondIndexDocsCount = 1000
-						)
-
-						{
-							backend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir), withBuildVersion(version))
-							_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, nil, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, rebuild)
-							require.NoError(t, err)
-							backend.Stop()
-						}
-
-						// Make sure we pass at least 1 nanosecond (alwaysRebuildDueToAge) to ensure that the index needs to be rebuild.
-						time.Sleep(1 * time.Millisecond)
-
-						newBackend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir), withBuildVersion(version), withMinBuildVersion(minBuildVersion), withMaxFileIndexAge(maxIndexAge))
-						idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, nil, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, rebuild)
-						require.NoError(t, err)
-
-						cnt, err := idx.DocCount(context.Background(), "")
-						require.NoError(t, err)
-						if shouldRebuild {
-							require.Equal(t, int64(secondIndexDocsCount), cnt, "Index has been not rebuilt")
-						} else {
-							require.Equal(t, int64(firstIndexDocsCount), cnt, "Index has not been reused")
-						}
-					})
-				}
+			{
+				backend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
+				_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, nil, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, rebuild)
+				require.NoError(t, err)
+				backend.Stop()
 			}
-		}
+
+			// Make sure we pass at least 1 nanosecond (alwaysRebuildDueToAge) to ensure that the index needs to be rebuild.
+			time.Sleep(1 * time.Millisecond)
+
+			newBackend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
+			idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, nil, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, rebuild)
+			require.NoError(t, err)
+
+			cnt, err := idx.DocCount(context.Background(), "")
+			require.NoError(t, err)
+			if rebuild {
+				require.Equal(t, int64(secondIndexDocsCount), cnt, "Index has been not rebuilt")
+			} else {
+				require.Equal(t, int64(firstIndexDocsCount), cnt, "Index has not been reused")
+			}
+		})
 	}
 }
 

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -57,7 +57,8 @@ func NewSearchOptions(
 		return resource.SearchOptions{
 			Backend:              bleve,
 			Resources:            docs,
-			WorkerThreads:        cfg.IndexWorkers,
+			InitWorkerThreads:    cfg.IndexWorkers,
+			IndexRebuildWorkers:  cfg.IndexRebuildWorkers,
 			InitMinCount:         cfg.IndexMinCount,
 			DashboardIndexMaxAge: cfg.IndexRebuildInterval,
 			MaxIndexAge:          cfg.MaxFileIndexAge,

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -41,15 +41,13 @@ func NewSearchOptions(
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{
-			Root:            root,
-			FileThreshold:   int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
-			BatchSize:       cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
-			IndexCacheTTL:   cfg.IndexCacheTTL,             // How long to keep the index cache in memory
-			BuildVersion:    cfg.BuildVersion,
-			MaxFileIndexAge: cfg.MaxFileIndexAge,
-			MinBuildVersion: minVersion,
-			UseFullNgram:    features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageUseFullNgram),
-			OwnsIndex:       ownsIndexFn,
+			Root:          root,
+			FileThreshold: int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
+			BatchSize:     cfg.IndexMaxBatchSize,         // This is the batch size for how many objects to add to the index at once
+			IndexCacheTTL: cfg.IndexCacheTTL,             // How long to keep the index cache in memory
+			BuildVersion:  cfg.BuildVersion,
+			UseFullNgram:  features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageUseFullNgram),
+			OwnsIndex:     ownsIndexFn,
 		}, tracer, indexMetrics)
 
 		if err != nil {
@@ -57,11 +55,13 @@ func NewSearchOptions(
 		}
 
 		return resource.SearchOptions{
-			Backend:         bleve,
-			Resources:       docs,
-			WorkerThreads:   cfg.IndexWorkers,
-			InitMinCount:    cfg.IndexMinCount,
-			RebuildInterval: cfg.IndexRebuildInterval,
+			Backend:              bleve,
+			Resources:            docs,
+			WorkerThreads:        cfg.IndexWorkers,
+			InitMinCount:         cfg.IndexMinCount,
+			DashboardIndexMaxAge: cfg.IndexRebuildInterval,
+			MaxIndexAge:          cfg.MaxFileIndexAge,
+			MinBuildVersion:      minVersion,
 		}, nil
 	}
 	return resource.SearchOptions{}, nil

--- a/pkg/util/debouncer/queue.go
+++ b/pkg/util/debouncer/queue.go
@@ -1,0 +1,111 @@
+package debouncer
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+type CombineFn[T any] func(a, b T) (c T, ok bool)
+
+// Queue is a queue of elements. Elements added to the queue can be combined together by the provided combiner function.
+// Once the queue is closed, no more elements can be added, but Next() will still return remaining elements.
+type Queue[T any] struct {
+	combineFn CombineFn[T]
+
+	mu       sync.Mutex
+	elements []T
+	closed   bool
+	waitChan chan struct{} // if not nil, will be closed when new element is added
+}
+
+func NewQueue[T any](combineFn CombineFn[T]) *Queue[T] {
+	return &Queue[T]{
+		combineFn: combineFn,
+	}
+}
+
+func (q *Queue[T]) Len() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return len(q.elements)
+}
+
+func (q *Queue[T]) Add(n T) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	if q.closed {
+		panic("queue already closed")
+	}
+
+	for i, e := range q.elements {
+		if c, ok := q.combineFn(e, n); ok {
+			// No need to signal, since we are not adding new element.
+			q.elements[i] = c
+			return
+		}
+	}
+
+	q.elements = append(q.elements, n)
+	q.notifyWaiters()
+}
+
+// Must be called with lock held.
+func (q *Queue[T]) notifyWaiters() {
+	if q.waitChan != nil {
+		// Wakes up all waiting goroutines (but also possibly zero, if they stopped waiting already).
+		close(q.waitChan)
+		q.waitChan = nil
+	}
+}
+
+var ErrClosed = errors.New("queue closed")
+
+// Next returns the next element in the queue. If no element is available, Next will block until
+// an element is added to the queue, or provided context is done.
+// If the queue is closed, ErrClosed is returned.
+func (q *Queue[T]) Next(ctx context.Context) (T, error) {
+	var zero T
+
+	q.mu.Lock()
+	unlockInDefer := true
+	defer func() {
+		if unlockInDefer {
+			q.mu.Unlock()
+		}
+	}()
+
+	for len(q.elements) == 0 {
+		if q.closed {
+			return zero, ErrClosed
+		}
+
+		// Wait for an element. Make sure there's a wait channel that we can use.
+		wch := q.waitChan
+		if wch == nil {
+			wch = make(chan struct{})
+			q.waitChan = wch
+		}
+		// Unlock before waiting
+		q.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			unlockInDefer = false
+			return zero, ctx.Err()
+		case <-wch:
+			q.mu.Lock()
+		}
+	}
+
+	first := q.elements[0]
+	q.elements = q.elements[1:]
+	return first, nil
+}
+
+func (q *Queue[T]) Close() {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.closed = true
+	q.notifyWaiters()
+}

--- a/pkg/util/debouncer/queue.go
+++ b/pkg/util/debouncer/queue.go
@@ -3,6 +3,7 @@ package debouncer
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 )
 
@@ -29,6 +30,13 @@ func (q *Queue[T]) Len() int {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	return len(q.elements)
+}
+
+// Elements returns copy of the queue.
+func (q *Queue[T]) Elements() []T {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	return slices.Clone(q.elements)
 }
 
 func (q *Queue[T]) Add(n T) {

--- a/pkg/util/debouncer/queue_test.go
+++ b/pkg/util/debouncer/queue_test.go
@@ -1,0 +1,155 @@
+package debouncer
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/atomic"
+	"go.uber.org/goleak"
+)
+
+// This verifies that all goroutines spawned from tests are finished at the end of tests.
+// Applies to all tests in the package.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func TestQueueBasic(t *testing.T) {
+	q := NewQueue(func(a, b int) (c int, ok bool) {
+		return a + b, true
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
+	defer cancel()
+	// Empty queue will time out.
+	require.Equal(t, context.DeadlineExceeded, nextErr(t, q, ctx))
+
+	q.Add(10)
+	require.Equal(t, 10, next(t, q))
+	require.Equal(t, 0, q.Len())
+
+	q.Add(20)
+	require.Equal(t, 20, next(t, q))
+	require.Equal(t, 0, q.Len())
+
+	q.Add(10)
+	require.Equal(t, 1, q.Len())
+	q.Add(20)
+	require.Equal(t, 1, q.Len())
+	require.Equal(t, 30, next(t, q))
+	require.Equal(t, 0, q.Len())
+
+	q.Add(100)
+	require.Equal(t, 1, q.Len())
+	q.Close()
+	require.Equal(t, 1, q.Len())
+	require.Equal(t, 100, next(t, q))
+	require.Equal(t, ErrClosed, nextErr(t, q, context.Background()))
+	require.Equal(t, 0, q.Len())
+
+	// We can call Next repeatedly, but will always get error.
+	require.Equal(t, ErrClosed, nextErr(t, q, context.Background()))
+}
+
+func TestQueueConcurrency(t *testing.T) {
+	q := NewQueue(func(a, b int64) (c int64, ok bool) {
+		// Combine the same numbers together.
+		if a == b {
+			return a + b, true
+		}
+		return 0, false
+	})
+
+	const numbers = 10000
+	const writeConcurrency = 50
+	const readConcurrency = 25
+
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	totalWrittenSum := atomic.NewInt64(0)
+	totalReadSum := atomic.NewInt64(0)
+	addCalls := atomic.NewInt64(0)
+	nextCalls := atomic.NewInt64(0)
+
+	// We will add some numbers to the queue.
+	writesWG := sync.WaitGroup{}
+	for i := 0; i < writeConcurrency; i++ {
+		writesWG.Add(1)
+		go func() {
+			defer writesWG.Done()
+			for j := 0; j < numbers; j++ {
+				v := r.Int63n(100) // Generate small number, so that we have a chance for combining some numbers.
+				q.Add(v)
+				addCalls.Inc()
+				totalWrittenSum.Add(v)
+			}
+		}()
+	}
+
+	readsWG := sync.WaitGroup{}
+	for i := 0; i < readConcurrency; i++ {
+		readsWG.Add(1)
+		go func() {
+			defer readsWG.Done()
+
+			for {
+				v, err := q.Next(context.Background())
+				if errors.Is(err, ErrClosed) {
+					return
+				}
+				require.NoError(t, err)
+
+				nextCalls.Inc()
+				totalReadSum.Add(v)
+			}
+		}()
+	}
+
+	writesWG.Wait()
+	// Close queue after sending all numbers. This signals readers that they can stop.
+	q.Close()
+
+	// Wait until all readers finish too.
+	readsWG.Wait()
+
+	// Verify that all numbers were sent, combined and received.
+	require.Equal(t, int64(writeConcurrency*numbers), addCalls.Load())
+	require.Equal(t, totalWrittenSum.Load(), totalReadSum.Load())
+	require.LessOrEqual(t, nextCalls.Load(), addCalls.Load())
+	t.Log("add calls:", addCalls.Load(), "next calls:", nextCalls.Load(), "total written sum:", totalWrittenSum.Load(), "total read sum:", totalReadSum.Load())
+}
+
+func TestQueueCloseUnblocksReaders(t *testing.T) {
+	q := NewQueue(func(a, b int) (c int, ok bool) {
+		return a + b, true
+	})
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		time.Sleep(50 * time.Millisecond)
+		q.Close()
+	}()
+
+	_, err := q.Next(context.Background())
+	require.ErrorIs(t, err, ErrClosed)
+
+	wg.Wait()
+}
+
+func next[T any](t *testing.T, q *Queue[T]) T {
+	v, err := q.Next(context.Background())
+	require.NoError(t, err)
+	return v
+}
+func nextErr[T any](t *testing.T, q *Queue[T], ctx context.Context) error {
+	_, err := q.Next(ctx)
+	require.Error(t, err)
+	return err
+}


### PR DESCRIPTION
Index rebuilds based on max index age or min build version were previously done synchronously, when opening existing file-based index. That can add a lot of latency to search operations after configuring the options for the first time. In this PR we're changing that -- search support now checks open indexes periodically and decides whether they need to be rebuilt. If so, rebuild is done asynchronously on one or more worker goroutines.

Previously existing dashboard rebuild feature was reimplemented using this mechanism as well.

This also opens possibility to implement index rebuild after importing documents to the index (will be done in next PR).

This PR introduces new metric for monitoring length of the rebuild queue, and new option to control number of goroutines for doing the background rebuilds (defaults to 5).