### PR TITLE
Table: Disable virtualization, hover overflow, and scrollbar width resizing on Safari 26

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -97,6 +97,7 @@ import {
   withDataLinksActionsTooltip,
   getSummaryCellTextAlign,
   parseStyleJson,
+  IS_SAFARI_26,
 } from './utils';
 
 const EXPANDED_COLUMN_KEY = 'expanded';
@@ -287,7 +288,7 @@ export function TableNG(props: TableNGProps) {
   const commonDataGridProps = useMemo(
     () =>
       ({
-        enableVirtualization: enableVirtualization !== false && rowHeight !== 'auto',
+        enableVirtualization: !IS_SAFARI_26 && enableVirtualization !== false && rowHeight !== 'auto',
         defaultColumnOptions: {
           minWidth: 50,
           resizable: true,
@@ -460,7 +461,8 @@ export function TableNG(props: TableNGProps) {
           ? clsx('table-cell-actions', getCellActionStyles(theme, textAlign))
           : undefined;
 
-        const shouldOverflow = rowHeight !== 'auto' && (shouldTextOverflow(field) || Boolean(maxRowHeight));
+        const shouldOverflow =
+          !IS_SAFARI_26 && rowHeight !== 'auto' && (shouldTextOverflow(field) || Boolean(maxRowHeight));
         const textWrap = rowHeight === 'auto' || shouldTextWrap(field);
         const withTooltip = withDataLinksActionsTooltip(field, cellType);
         const canBeColorized = canFieldBeColorized(cellType, applyToRowBgFn);

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -16,6 +16,7 @@ import {
   computeColWidths,
   buildHeaderHeightMeasurers,
   buildCellHeightMeasurers,
+  IS_SAFARI_26,
 } from './utils';
 
 // Helper function to get displayed value
@@ -468,7 +469,7 @@ export function useScrollbarWidth(ref: RefObject<DataGridHandle>, height: number
   useLayoutEffect(() => {
     const el = ref.current?.element;
 
-    if (!el) {
+    if (!el || IS_SAFARI_26) {
       return;
     }
 

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -232,22 +232,22 @@ export const getTooltipStyles = (theme: GrafanaTheme2, textAlign: TextAlign) => 
   }),
 });
 
-export const getActiveCellSelector = memoize((isNested?: boolean) => {
-  const SELECTORS = {
-    hover: {
-      nested: '.rdg-cell:hover &',
-      normal: '&:hover',
-    },
-    selected: {
-      nested: '[aria-selected=true] &',
-      normal: '&[aria-selected=true]',
-    },
-  };
+const ACTIVE_CELL_SELECTORS = {
+  hover: {
+    nested: '.rdg-cell:hover &',
+    normal: '&:hover',
+  },
+  selected: {
+    nested: '[aria-selected=true] &',
+    normal: '&[aria-selected=true]',
+  },
+} as const;
 
+export const getActiveCellSelector = memoize((isNested?: boolean) => {
   const selectors = [];
-  selectors.push(SELECTORS.selected[isNested ? 'nested' : 'normal']);
+  selectors.push(ACTIVE_CELL_SELECTORS.selected[isNested ? 'nested' : 'normal']);
   if (!IS_SAFARI_26) {
-    selectors.push(SELECTORS.hover[isNested ? 'nested' : 'normal']);
+    selectors.push(ACTIVE_CELL_SELECTORS.hover[isNested ? 'nested' : 'normal']);
   }
   return selectors.join(', ');
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -1,11 +1,12 @@
 import { css } from '@emotion/css';
 import { Property } from 'csstype';
+import memoize from 'micro-memoize';
 
 import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 
 import { COLUMN, TABLE } from './constants';
 import { TableCellStyles } from './types';
-import { getJustifyContent, TextAlign } from './utils';
+import { getJustifyContent, IS_SAFARI_26, TextAlign } from './utils';
 
 export const getGridStyles = (theme: GrafanaTheme2, enablePagination?: boolean, transparent?: boolean) => {
   const bgColor = transparent ? theme.colors.background.canvas : theme.colors.background.primary;
@@ -51,14 +52,14 @@ export const getGridStyles = (theme: GrafanaTheme2, enablePagination?: boolean, 
       '& > :not(.rdg-summary-row, .rdg-header-row) > .rdg-cell': {
         [getActiveCellSelector()]: { boxShadow: theme.shadows.z2 },
         // selected cells should appear below hovered cells.
-        '&:hover': { zIndex: theme.zIndex.tooltip - 7 },
+        ...(!IS_SAFARI_26 && { '&:hover': { zIndex: theme.zIndex.tooltip - 7 } }),
         '&[aria-selected=true]': { zIndex: theme.zIndex.tooltip - 6 },
       },
 
       '.rdg-cell.rdg-cell-frozen': {
-        backgroundColor: '--rdg-row-background-color',
+        backgroundColor: 'var(--rdg-row-background-color)',
         zIndex: theme.zIndex.tooltip - 4,
-        '&:hover': { zIndex: theme.zIndex.tooltip - 2 },
+        ...(!IS_SAFARI_26 && { '&:hover': { zIndex: theme.zIndex.tooltip - 2 } }),
         '&[aria-selected=true]': { zIndex: theme.zIndex.tooltip - 3 },
       },
 
@@ -70,7 +71,6 @@ export const getGridStyles = (theme: GrafanaTheme2, enablePagination?: boolean, 
           },
         },
       },
-
       '.rdg-summary-row >': {
         '.rdg-cell': {
           // 0.75 padding causes "jumping" on hover.
@@ -232,5 +232,22 @@ export const getTooltipStyles = (theme: GrafanaTheme2, textAlign: TextAlign) => 
   }),
 });
 
-export const getActiveCellSelector = (isNested?: boolean) =>
-  isNested ? '.rdg-cell:hover &, [aria-selected=true] &' : '&:hover, &[aria-selected=true]';
+export const getActiveCellSelector = memoize((isNested?: boolean) => {
+  const SELECTORS = {
+    hover: {
+      nested: '.rdg-cell:hover &',
+      normal: '&:hover',
+    },
+    selected: {
+      nested: '[aria-selected=true] &',
+      normal: '&[aria-selected=true]',
+    },
+  };
+
+  const selectors = [];
+  selectors.push(SELECTORS.selected[isNested ? 'nested' : 'normal']);
+  if (!IS_SAFARI_26) {
+    selectors.push(SELECTORS.hover[isNested ? 'nested' : 'normal']);
+  }
+  return selectors.join(', ');
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1029,3 +1029,13 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
     }
   }
 }
+
+// Safari 26 introduced rendering bugs which require us to disable several features of the table.
+export const IS_SAFARI_26 = (() => {
+  if (navigator == null) {
+    return false;
+  }
+  const userAgent = navigator.userAgent;
+  const safariVersionMatch = userAgent.match(/Version\/(\d+)\./);
+  return safariVersionMatch && parseInt(safariVersionMatch[1], 10) === 26;
+})();


### PR DESCRIPTION
Fixes #111590, for the most part.

The features of the table that seem most broken in Safari 26 were:

- hover interactions
- ResizeObservers and automatic width resizing based on the presence or absence of a scrollbar
- virtualization in general

So this PR sniffs for Safari 26 and disables all three, and the table is much more usable. There are still situations where Safari's max height rendering bugs lead to ugly artifacting, but the table is at least usable in the browser now. I'd still generally recommend that no one use that browser at the moment.

### Before

https://github.com/user-attachments/assets/e37affaf-1ac0-4e00-a28f-93c328d8af0c

### After

_Note the bugginess still present at end of video. I think that we're maybe going to need to accept a bit of glitchiness in this browser if the visualizations are usable for now, given the state of things, but I can continue investigating whether there are ways to avoid this._

https://github.com/user-attachments/assets/1bd6f7c0-d185-497a-8a8b-028a421c088b
