### PR TITLE
Annotations: add default color to transform

### DIFF
--- a/packages/grafana-data/src/internal/index.ts
+++ b/packages/grafana-data/src/internal/index.ts
@@ -28,6 +28,7 @@ export {
 } from '../transformations/transformers/convertFieldType';
 export {
   type ConvertFrameTypeTransformerOptions,
+  type OptionalAnnotationOptions,
   FrameType,
   type AnnotationFieldMapping,
 } from '../transformations/transformers/convertFrameType';

--- a/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
@@ -12,9 +12,14 @@ import {
   TransformerRegistryItem,
   TransformerUIProps,
 } from '@grafana/data';
-import { ConvertFrameTypeTransformerOptions, FrameType, AnnotationFieldMapping } from '@grafana/data/internal';
+import {
+  ConvertFrameTypeTransformerOptions,
+  FrameType,
+  AnnotationFieldMapping,
+  OptionalAnnotationOptions,
+} from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
-import { InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';
+import { ColorPicker, DEFAULT_ANNOTATION_COLOR, InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';
 
 import { getTransformationContent } from '../docs/getTransformationContent';
@@ -64,6 +69,18 @@ export const ConvertFrameTypeTransformerEditor = ({
         ...options,
         annotationFieldMapping: {
           ...options.annotationFieldMapping,
+          [label]: value,
+        },
+      });
+    },
+    [onChange, options]
+  );
+
+  const onSelectAnnotationOption = useCallback(
+    (label: keyof OptionalAnnotationOptions, value?: string) => {
+      onChange({
+        ...options,
+        annotationOptions: {
           [label]: value,
         },
       });
@@ -166,6 +183,32 @@ export const ConvertFrameTypeTransformerEditor = ({
                   onSelectAnnotationMapping('id', value);
                 }}
                 item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+          {/* Map dataframe with existing color strings */}
+          <InlineFieldRow>
+            <InlineField labelWidth={20} label={t('transformers.annotation-transformer-editor.color', 'Color field')}>
+              <FieldNamePicker
+                context={{ data: input }}
+                value={options.annotationFieldMapping?.color ?? ''}
+                onChange={(value) => {
+                  onSelectAnnotationMapping('color', value);
+                }}
+                item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+          <InlineFieldRow>
+            <InlineField
+              labelWidth={20}
+              label={t('transformers.annotation-transformer-editor.default-color', 'Default color')}
+            >
+              <ColorPicker
+                color={options.annotationOptions?.defaultColor ?? DEFAULT_ANNOTATION_COLOR}
+                onChange={(value) => {
+                  onSelectAnnotationOption('defaultColor', value);
+                }}
               />
             </InlineField>
           </InlineFieldRow>


### PR DESCRIPTION

**What is this feature?**

Adding default color to annotation transform options

<img width="1464" height="837" alt="image" src="https://github.com/user-attachments/assets/7abdd8b4-88e0-4766-a88a-4bbb98bb0ed3" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
