### PR TITLE
Transformations: Hide "Match all/any" conditions for less than two filters

### DIFF
--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.test.tsx
@@ -67,3 +67,62 @@ describe('FilterByValueTransformerEditor', () => {
     });
   });
 });
+it('hides conditions field when there is 0 or 1 filter', () => {
+  const onChangeMock = jest.fn();
+  const input: DataFrame[] = [
+    {
+      fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
+      length: 0,
+    },
+  ];
+
+  // Test with 0 filters
+  const { queryByText, rerender } = render(
+    <FilterByValueTransformerEditor
+      input={input}
+      options={{ type: FilterByValueType.include, match: FilterByValueMatch.all, filters: [] }}
+      onChange={onChangeMock}
+    />
+  );
+  expect(queryByText('Conditions')).not.toBeInTheDocument();
+
+  // Test with 1 filter
+  rerender(
+    <FilterByValueTransformerEditor
+      input={input}
+      options={{
+        type: FilterByValueType.include,
+        match: FilterByValueMatch.all,
+        filters: [{ fieldName: 'test', config: { id: ValueMatcherID.isNull, options: {} } }],
+      }}
+      onChange={onChangeMock}
+    />
+  );
+  expect(queryByText('Conditions')).not.toBeInTheDocument();
+});
+
+it('shows conditions field when there are more than 1 filter', () => {
+  const onChangeMock = jest.fn();
+  const input: DataFrame[] = [
+    {
+      fields: [{ name: 'field1', type: FieldType.string, config: {}, values: [] }],
+      length: 0,
+    },
+  ];
+
+  const { getByText } = render(
+    <FilterByValueTransformerEditor
+      input={input}
+      options={{
+        type: FilterByValueType.include,
+        match: FilterByValueMatch.all,
+        filters: [
+          { fieldName: 'test1', config: { id: ValueMatcherID.isNull, options: {} } },
+          { fieldName: 'test2', config: { id: ValueMatcherID.isNull, options: {} } },
+        ],
+      }}
+      onChange={onChangeMock}
+    />
+  );
+  expect(getByText('Conditions')).toBeInTheDocument();
+});

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -124,14 +124,16 @@ export const FilterByValueTransformerEditor = (props: TransformerUIProps<FilterB
           <RadioButtonGroup options={filterTypes} value={options.type} onChange={onChangeType} fullWidth />
         </div>
       </InlineField>
-      <InlineField
-        label={t('transformers.filter-by-value-transformer-editor.label-conditions', 'Conditions')}
-        labelWidth={16}
-      >
-        <div className="width-15">
-          <RadioButtonGroup options={filterMatch} value={options.match} onChange={onChangeMatch} fullWidth />
-        </div>
-      </InlineField>
+      {options.filters.length > 1 && (
+        <InlineField
+          label={t('transformers.filter-by-value-transformer-editor.label-conditions', 'Conditions')}
+          labelWidth={16}
+        >
+          <div className="width-15">
+            <RadioButtonGroup options={filterMatch} value={options.match} onChange={onChangeMatch} fullWidth />
+          </div>
+        </InlineField>
+      )}
       <Box paddingLeft={2}>
         {options.filters.map((filter, idx) => (
           <FilterByValueFilterEditor


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR improves the user experience in the Filter by Value transformer editor by conditionally hiding the "Conditions" field (Match all/Match any) when there are 0 or 1 filters. The conditions field now only appears when there are 2 or more filters, since matching conditions are only relevant when multiple filters exist.

**Why do we need this feature?**

Currently, the "Conditions" field is always visible in the Filter by Value transformer editor, even when there's only one filter or no filters at all. This creates confusion for users because:

With 0 filters: The conditions field serves no purpose
With 1 filter: There's nothing to match "all" or "any" against - the single filter is always applied
Hiding this field when irrelevant reduces UI clutter and prevents user confusion about when these options apply.

**Which issue(s) does this PR fix?:**
#97239 