### PR TITLE
Annotations: Annotation visibility options

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -507,6 +507,9 @@ export enum VizOrientation {
  */
 export interface VizAnnotations {
   multiLane?: boolean;
+  regionOpacity?: number;
+  showLine?: boolean;
+  showRegions?: boolean;
 }
 
 /**

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -161,6 +161,9 @@ VizOrientation: "auto" | "vertical" | "horizontal" @cuetsy(kind="enum")
 // Breaks out each annotation frame into multiple lanes on the x-axis
 VizAnnotations: {
 	multiLane?: bool
+	showRegions?: bool
+	regionOpacity?: number
+	showLine?: bool
 } @cuetsy(kind="interface")
 
 // TODO docs

--- a/packages/grafana-ui/src/options/builder/annotations.tsx
+++ b/packages/grafana-ui/src/options/builder/annotations.tsx
@@ -54,10 +54,8 @@ export function addAnnotationOptions<
     category,
     name: t('grafana-ui.builder.annotations.region-opacity', 'Region opacity'),
     description: t('grafana-ui.builder.annotations.desc.region-opacity', 'Sets the annotation region opacity'),
-    showIf: (currentOptions) => {
-      return currentOptions.annotations?.showRegions;
-    },
-    defaultValue: 60,
+    showIf: (currentOptions) => currentOptions.annotations?.showRegions,
+    defaultValue: 10,
     settings: {
       min: 0,
       max: 100,

--- a/packages/grafana-ui/src/options/builder/annotations.tsx
+++ b/packages/grafana-ui/src/options/builder/annotations.tsx
@@ -1,13 +1,19 @@
 import { PanelOptionsEditorBuilder } from '@grafana/data';
 import { t } from '@grafana/i18n';
-
+import { Options as CandlestickOptions } from '@grafana/schema/src/raw/composable/candlestick/panelcfg/x/CandlestickPanelCfg_types.gen';
+import { Options as HeatmapOptions } from '@grafana/schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen';
+import { Options as StatetimelineOptions } from '@grafana/schema/src/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen';
+import { Options as StatusHistoryOptions } from '@grafana/schema/src/raw/composable/statushistory/panelcfg/x/StatusHistoryPanelCfg_types.gen';
+import { Options as TimeseriesOptions } from '@grafana/schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen';
 /**
  * Adds common text control options to a visualization options
  * @param builder
  * @param withTitle
  * @public
  */
-export function addAnnotationOptions<T>(builder: PanelOptionsEditorBuilder<T>, defaultValue = false) {
+export function addAnnotationOptions<
+  T extends HeatmapOptions | TimeseriesOptions | StatusHistoryOptions | StatetimelineOptions | CandlestickOptions,
+>(builder: PanelOptionsEditorBuilder<T>) {
   const category = [t('grafana-ui.builder.annotations', 'Annotations')];
 
   builder.addBooleanSwitch({
@@ -18,6 +24,43 @@ export function addAnnotationOptions<T>(builder: PanelOptionsEditorBuilder<T>, d
       'grafana-ui.builder.annotations.multi-lane-desc',
       'Breaks each annotation frame into a separate row in the visualization'
     ),
-    defaultValue,
+    defaultValue: false,
+  });
+
+  builder.addBooleanSwitch({
+    path: 'annotations.showLine',
+    category,
+    name: t('grafana-ui.builder.annotations.show-line-marker', 'Enable annotation indicator line'),
+    description: t(
+      'grafana-ui.builder.annotations.desc.show-line-marker',
+      'Toggles the vertical annotation indicator line in the visualization'
+    ),
+    defaultValue: true,
+  });
+
+  builder.addBooleanSwitch({
+    path: 'annotations.showRegions',
+    category,
+    name: t('grafana-ui.builder.annotations.show-regions', 'Enable region overlay'),
+    description: t(
+      'grafana-ui.builder.annotations.desc.show-regions',
+      'Toggles the region overlay in the visualization'
+    ),
+    defaultValue: true,
+  });
+
+  builder.addNumberInput({
+    path: 'annotations.regionOpacity',
+    category,
+    name: t('grafana-ui.builder.annotations.region-opacity', 'Region opacity'),
+    description: t('grafana-ui.builder.annotations.desc.region-opacity', 'Sets the annotation region opacity'),
+    showIf: (currentOptions) => {
+      return currentOptions.annotations?.showRegions;
+    },
+    defaultValue: 60,
+    settings: {
+      min: 0,
+      max: 100,
+    },
   });
 }

--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -7,7 +7,6 @@ import {
   ScaleDistribution,
   ScaleDistributionConfig,
   HeatmapCellLayout,
-  VizAnnotations,
 } from '@grafana/schema';
 import { commonOptionsBuilder, TooltipDisplayMode } from '@grafana/ui';
 import { addHideFrom, ScaleDistributionEditor } from '@grafana/ui/internal';

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -156,12 +156,15 @@ export const AnnotationsPlugin2 = ({
       ctx.save();
 
       ctx.beginPath();
-      ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height);
-      ctx.clip();
+      console.log('annos.length', annos.length, annos);
+      const additionalHeight = annotationsConfig?.multiLane ? annos.length * ANNOTATION_LANE_SIZE : 0;
+      ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height + additionalHeight);
+      // ctx.clip();
 
       // Multi-lane annotations do not support vertical lines or shaded regions
-      if (!annotationsConfig?.multiLane) {
-        annos.forEach((frame) => {
+      if (!annotationsConfig?.multiLane || annotationsConfig.showRegions || annotationsConfig.showLine) {
+        annos.forEach((frame, frameIdx) => {
+          const verticalOffset = annotationsConfig?.multiLane ? frameIdx * ANNOTATION_LANE_SIZE * 2 : 0;
           let vals = getVals(frame);
 
           if (frame.name === 'xymark') {
@@ -170,29 +173,31 @@ export const AnnotationsPlugin2 = ({
             let xKey = config.scales[0].props.scaleKey;
             let yKey = config.scales[1].props.scaleKey;
 
-            for (let i = 0; i < frame.length; i++) {
-              let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
+            if (annotationsConfig?.showLine !== false) {
+              for (let i = 0; i < frame.length; i++) {
+                let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
 
-              let x0 = u.valToPos(vals.xMin[i], xKey, true);
-              let x1 = u.valToPos(vals.xMax[i], xKey, true);
-              let y0 = u.valToPos(vals.yMax[i], yKey, true);
-              let y1 = u.valToPos(vals.yMin[i], yKey, true);
+                let x0 = u.valToPos(vals.xMin[i], xKey, true);
+                let x1 = u.valToPos(vals.xMax[i], xKey, true);
+                let y0 = u.valToPos(vals.yMax[i], yKey, true);
+                let y1 = u.valToPos(vals.yMin[i], yKey, true);
 
-              ctx.fillStyle = colorManipulator.alpha(color, vals.fillOpacity[i]);
-              ctx.fillRect(x0, y0, x1 - x0, y1 - y0);
+                ctx.fillStyle = colorManipulator.alpha(color, vals.fillOpacity[i]);
+                ctx.fillRect(x0, y0, x1 - x0, y1 - y0);
 
-              ctx.lineWidth = Math.round(vals.lineWidth[i] * uPlot.pxRatio);
+                ctx.lineWidth = Math.round(vals.lineWidth[i] * uPlot.pxRatio);
 
-              if (vals.lineStyle[i] === 'dash') {
-                // maybe extract this to vals.lineDash[i] in future?
-                ctx.setLineDash([5, 5]);
-              } else {
-                // solid
-                ctx.setLineDash([]);
+                if (vals.lineStyle[i] === 'dash') {
+                  // maybe extract this to vals.lineDash[i] in future?
+                  ctx.setLineDash([5, 5]);
+                } else {
+                  // solid
+                  ctx.setLineDash([]);
+                }
+
+                ctx.strokeStyle = color;
+                ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
               }
-
-              ctx.strokeStyle = color;
-              ctx.strokeRect(x0, y0, x1 - x0, y1 - y0);
             }
           } else {
             let y0 = u.bbox.top;
@@ -200,22 +205,30 @@ export const AnnotationsPlugin2 = ({
 
             ctx.lineWidth = 2;
             ctx.setLineDash([5, 5]);
+            if (annotationsConfig?.showRegions !== false || annotationsConfig.showLine !== false) {
+              for (let i = 0; i < vals.time.length; i++) {
+                let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
 
-            for (let i = 0; i < vals.time.length; i++) {
-              let color = getColorByName(vals.color?.[i] || DEFAULT_ANNOTATION_COLOR_HEX8);
+                let x0 = u.valToPos(vals.time[i], 'x', true);
+                if (annotationsConfig?.showLine !== false) {
+                  renderLine(ctx, y0, y1 + verticalOffset, x0, color);
+                }
 
-              let x0 = u.valToPos(vals.time[i], 'x', true);
-              renderLine(ctx, y0, y1, x0, color);
+                // If dataframe does not have end times, let's omit rendering the region for now to prevent runtime error in valToPos
+                // @todo do we want to fix isRegion to render a point (or use "to" as timeEnd) when we're missing timeEnd?
+                if (vals.isRegion?.[i] && vals.timeEnd?.[i]) {
+                  let x1 = u.valToPos(vals.timeEnd[i], 'x', true);
+                  if (annotationsConfig?.showLine !== false) {
+                    renderLine(ctx, y0, y1 + verticalOffset, x1, color);
+                  }
 
-              // If dataframe does not have end times, let's omit rendering the region for now to prevent runtime error in valToPos
-              // @todo do we want to fix isRegion to render a point (or use "to" as timeEnd) when we're missing timeEnd?
-              if (vals.isRegion?.[i] && vals.timeEnd?.[i]) {
-                let x1 = u.valToPos(vals.timeEnd[i], 'x', true);
-                renderLine(ctx, y0, y1, x1, color);
-
-                if (canvasRegionRendering) {
-                  ctx.fillStyle = colorManipulator.alpha(color, 0.1);
-                  ctx.fillRect(x0, y0, x1 - x0, u.bbox.height);
+                  if (canvasRegionRendering && annotationsConfig?.showRegions !== false) {
+                    const regionOpacity = annotationsConfig?.regionOpacity
+                      ? annotationsConfig?.regionOpacity / 100
+                      : 0.1;
+                    ctx.fillStyle = colorManipulator.alpha(color, regionOpacity);
+                    ctx.fillRect(x0, y0, x1 - x0, u.bbox.height + verticalOffset);
+                  }
                 }
               }
             }

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -157,14 +157,14 @@ export const AnnotationsPlugin2 = ({
 
       ctx.beginPath();
       console.log('annos.length', annos.length, annos);
-      const additionalHeight = annotationsConfig?.multiLane ? annos.length * ANNOTATION_LANE_SIZE : 0;
+      const additionalHeight = annotationsConfig?.multiLane ? annos.length * ANNOTATION_LANE_SIZE * uPlot.pxRatio : 0;
       ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height + additionalHeight);
-      // ctx.clip();
+      ctx.clip();
 
       // Multi-lane annotations do not support vertical lines or shaded regions
       if (!annotationsConfig?.multiLane || annotationsConfig.showRegions || annotationsConfig.showLine) {
         annos.forEach((frame, frameIdx) => {
-          const verticalOffset = annotationsConfig?.multiLane ? frameIdx * ANNOTATION_LANE_SIZE * 2 : 0;
+          const verticalOffset = annotationsConfig?.multiLane ? frameIdx * ANNOTATION_LANE_SIZE * uPlot.pxRatio : 0;
           let vals = getVals(frame);
 
           if (frame.name === 'xymark') {


### PR DESCRIPTION

**What is this feature?**
Add `regionOpacity`, `showLine`, `showRegions` controls to annotations options.
<img width="1728" height="442" alt="image" src="https://github.com/user-attachments/assets/a1f8e58e-3b35-4312-850b-d67dab63dc44" />
<img width="1728" height="492" alt="image" src="https://github.com/user-attachments/assets/ecb3562e-6a3e-4a46-ba9a-172ad2302cd2" />


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
