### PR TITLE
Influx: Improve variable regex handling

### DIFF
--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -374,15 +374,15 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     if (!queryMatches) {
       return value;
     }
+    // Use the variable specific regex against the query
+    if (!query.match(regex)) {
+      return value;
+    }
     for (const match of queryMatches) {
       // It is expected that the RegExp should be valid. As our regex matcher matches any text between two '/'
       // we also validate that the expression compiles before assuming it is a regular expression.
       try {
-        new RegExp(`/${match}/`);
-        // Use the variable specific regex against the query
-        if (!query.match(regex)) {
-          continue;
-        }
+        new RegExp(match);
 
         // If the value is a string array first escape them then join them with pipe
         // then put inside parenthesis.

--- a/public/app/plugins/datasource/influxdb/datasource.ts
+++ b/public/app/plugins/datasource/influxdb/datasource.ts
@@ -360,10 +360,7 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
     // we want to see how it's been used. If it is used in a regex expression
     // we escape it. Otherwise, we return it directly.
     // The regex below searches for regexes within the query string
-    const regexMatcher = new RegExp(
-      /(\s*(=|!)~\s*)\/((?![*+?])(?:[^\r\n\[/\\]|\\.|\[(?:[^\r\n\]\\]|\\.)*\])+)\/((?:g(?:im?|mi?)?|i(?:gm?|mg?)?|m(?:gi?|ig?)?)?)/,
-      'gm'
-    );
+    const regexMatcher = new RegExp(/(?<=\/).+?(?=\/)/, 'gm');
     // If matches are found this regex is evaluated to check if the variable is contained in the regex /^...$/ (^ and $ is optional)
     // i.e. /^$myVar$/ or /$myVar/ or /^($myVar)$/
     const regex = new RegExp(`\\/(?:\\^)?(.*)(\\$${variable.name})(.*)(?:\\$)?\\/`, 'gm');
@@ -378,13 +375,21 @@ export default class InfluxDatasource extends DataSourceWithBackend<InfluxQuery,
       return value;
     }
     for (const match of queryMatches) {
-      if (!match.match(regex)) {
-        continue;
-      }
+      // It is expected that the RegExp should be valid. As our regex matcher matches any text between two '/'
+      // we also validate that the expression compiles before assuming it is a regular expression.
+      try {
+        new RegExp(`/${match}/`);
+        // Use the variable specific regex against the query
+        if (!query.match(regex)) {
+          continue;
+        }
 
-      // If the value is a string array first escape them then join them with pipe
-      // then put inside parenthesis.
-      return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
+        // If the value is a string array first escape them then join them with pipe
+        // then put inside parenthesis.
+        return typeof value === 'string' ? escapeRegex(value) : `(${value.map((v) => escapeRegex(v)).join('|')})`;
+      } catch (e) {
+        console.warn(`Supplied match is not valid regex: ${match}`);
+      }
     }
 
     return value;


### PR DESCRIPTION
Influx queries can contain regular expressions. This substantially complicates how variables are interpolated, as they may be contained within regular expressions and may therefore contain characters that require escaping.

This PR aims to simplify how we handle identifying regular expressions contained within a query. Previously, we were using a complicated regex, which was intended to be a one-size-fits-all. This was then updated to try and capture regular expressions in a manner more syntactically correct for InfluxQL. However, both of these approaches missed edge-cases.

I've simplified the regex to now find all strings that are between a `/` character. We then validate if that string can be compiled as a valid regular expression. If it can, we continue on to escape the variable appropriately, otherwise we emit a warning to the console and continue.

I've also added a test for this case. You can see this implementation works as expected as this test fails with the previous logic.

Queries are now correctly handled, including those that contain division operators.

Fixes a bug introduced in #105194.

Fixes #110110
Fixes #110005