### PR TITLE
[release-12.1.3] [InfluxDB]: Remove version notices

### DIFF
--- a/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/config/ConfigEditor.tsx
@@ -60,11 +60,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
     this.htmlPrefix = uniqueId('influxdb-config');
   }
 
-  versionNotice = {
-    Flux: 'Support for Flux in Grafana is currently in beta',
-    SQL: 'Support for SQL in Grafana is currently in alpha',
-  };
-
   onVersionChanged = (selected: SelectableValue<InfluxVersion>) => {
     const { options, onOptionsChange } = this.props;
 
@@ -125,17 +120,6 @@ export class ConfigEditor extends PureComponent<Props, State> {
             />
           </Field>
         </FieldSet>
-
-        {options.jsonData.version !== InfluxVersion.InfluxQL && (
-          <Alert severity="info" title={this.versionNotice[options.jsonData.version!]}>
-            <p>
-              Please report any issues to: <br />
-              <a href="https://github.com/grafana/grafana/issues/new/choose">
-                https://github.com/grafana/grafana/issues
-              </a>
-            </p>
-          </Alert>
-        )}
 
         {isDirectAccess && (
           <Alert title="Error" severity="error">


### PR DESCRIPTION
Backport 0bccb1c4ba559f1371cc7f96b32fb0fab7b893ed from #111778

---

The InfluxDB data source has had version notices for SQL (alpha) and Flux (beta) for the past 2 years. Both of these languages are stable so these notices can be removed.

Closes #111771 
