### PR TITLE
Table: Avoid overflow issues in Safari 26

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -791,7 +791,7 @@ export function TableNG(props: TableNGProps) {
   const displayedEnd = pageRangeEnd;
   const numRows = sortedRows.length;
 
-  return (
+  let rendered = (
     <>
       <DataGrid<TableRow, TableSummaryRow>
         {...commonDataGridProps}
@@ -879,6 +879,12 @@ export function TableNG(props: TableNGProps) {
       )}
     </>
   );
+
+  if (IS_SAFARI_26) {
+    rendered = <div className={styles.safariWrapper}>{rendered}</div>;
+  }
+
+  return rendered;
 }
 
 /**

--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -123,6 +123,7 @@ export const getGridStyles = (theme: GrafanaTheme2, enablePagination?: boolean, 
       padding: theme.spacing(0, 1, 0, 2),
     }),
     menuItem: css({ maxWidth: '200px' }),
+    safariWrapper: css({ contain: 'strict', height: '100%' }),
   };
 };
 


### PR DESCRIPTION
We had one Safari 26 issue which https://github.com/grafana/grafana/pull/111834 did not help resolve, which is flashing overflowed content on interaction with the table. `overflow: scroll` wrapper doesn't help, but using `contain: strict` does actually prevent it, so we'll wrap the complete contents of TableNG with a container that applies that style. What is truly bizarre about this is the fact that the z-index issue where the footer is rendered behind the table content is also solved by this.

### Before

https://github.com/user-attachments/assets/809a68c7-7ae6-4d05-aa73-1c73c54a1e01

### After

https://github.com/user-attachments/assets/5f4d0a61-2446-4d04-9943-91b2a91c8822
