### PR TITLE
Annotations: preprocess tags in convertSeriesToAnnotation 

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
@@ -154,6 +154,7 @@ function mapSourceFieldNameToAnnoFieldName(
 }
 
 function convertSeriesToAnnotation(frame: DataFrame, options: ConvertFrameTypeTransformerOptions): DataFrame {
+  console.log('frame', frame);
   // TODO: ensure time field
   // TODO: ensure value field
   const mappedFrame = {

--- a/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
@@ -160,9 +160,14 @@ function convertSeriesToAnnotation(frame: DataFrame, options: ConvertFrameTypeTr
     ...frame,
     fields: [
       ...frame.fields.map((sourceField) => {
+        const name = mapSourceFieldNameToAnnoFieldName(options, sourceField.name) ?? sourceField.name;
+        // Tags will throw errors if not array of values
+        if (name === 'tags') {
+          sourceField = { ...sourceField, values: [...sourceField.values.map((v) => (Array.isArray(v) ? v : [v]))] };
+        }
         return {
           ...sourceField,
-          name: mapSourceFieldNameToAnnoFieldName(options, sourceField.name) ?? sourceField.name,
+          name,
         };
       }),
     ],

--- a/packages/grafana-ui/src/options/builder/annotations.tsx
+++ b/packages/grafana-ui/src/options/builder/annotations.tsx
@@ -14,14 +14,14 @@ import { Options as TimeseriesOptions } from '@grafana/schema/src/raw/composable
 export function addAnnotationOptions<
   T extends HeatmapOptions | TimeseriesOptions | StatusHistoryOptions | StatetimelineOptions | CandlestickOptions,
 >(builder: PanelOptionsEditorBuilder<T>) {
-  const category = [t('grafana-ui.builder.annotations', 'Annotations')];
+  const category = [t('grafana-ui.builder.annotations.category', 'Annotations')];
 
   builder.addBooleanSwitch({
     path: 'annotations.multiLane',
     category,
-    name: t('grafana-ui.builder.annotations.multi-lane-name', 'Enable multi-lane annotations'),
+    name: t('grafana-ui.builder.annotations.lane.name', 'Enable multi lane annotations'),
     description: t(
-      'grafana-ui.builder.annotations.multi-lane-desc',
+      'grafana-ui.builder.annotations.lane.desc',
       'Breaks each annotation frame into a separate row in the visualization'
     ),
     defaultValue: false,

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -17,7 +17,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
   .setPanelOptions((builder) => {
     commonOptionsBuilder.addTooltipOptions(builder, false, true, optsWithHideZeros);
     commonOptionsBuilder.addLegendOptions(builder);
-    commonOptionsBuilder.addAnnotationOptions(builder)
+    commonOptionsBuilder.addAnnotationOptions(builder);
 
     if (config.featureToggles.timeComparison && config.featureToggles.dashboardScene) {
       commonOptionsBuilder.addTimeCompareOption(builder);

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -156,7 +156,6 @@ export const AnnotationsPlugin2 = ({
       ctx.save();
 
       ctx.beginPath();
-      console.log('annos.length', annos.length, annos);
       const additionalHeight = annotationsConfig?.multiLane ? annos.length * ANNOTATION_LANE_SIZE * uPlot.pxRatio : 0;
       ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height + additionalHeight);
       ctx.clip();

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8328,6 +8328,21 @@
       "log-base": "Log base"
     },
     "builder": {
+      "annotations": {
+        "category": "Annotations",
+        "desc": {
+          "region-opacity": "Sets the annotation region opacity",
+          "show-line-marker": "Toggles the vertical annotation indicator line in the visualization",
+          "show-regions": "Toggles the region overlay in the visualization"
+        },
+        "lane": {
+          "desc": "Breaks each annotation frame into a separate row in the visualization",
+          "name": "Enable multi lane annotations"
+        },
+        "region-opacity": "Region opacity",
+        "show-line-marker": "Enable annotation indicator line",
+        "show-regions": "Enable region overlay"
+      },
       "axis": {
         "category-axis": "Axis",
         "color-label": "Color",
@@ -13087,6 +13102,16 @@
     }
   },
   "transformers": {
+    "annotation-transformer-editor": {
+      "color": "Color field",
+      "default-color": "Default color",
+      "id": "Annotation ID",
+      "start-time": "Start time",
+      "tags": "Tags",
+      "text": "Text",
+      "timeEnd": "End time",
+      "title": "Title"
+    },
     "axis-editor": {
       "log-mode-options": {
         "description": {


### PR DESCRIPTION
**What is this feature?**

Fixing tags field which do not contain array values
<img width="1384" height="431" alt="image" src="https://github.com/user-attachments/assets/a1cf558d-e4b4-44c0-baea-f7b6923989e1" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
