### PR TITLE
CommandPalette: Make the search match take section priority into account

### DIFF
--- a/public/app/features/commandPalette/actions/recentScopesActions.ts
+++ b/public/app/features/commandPalette/actions/recentScopesActions.ts
@@ -17,17 +17,11 @@ export function getRecentScopesActions(): CommandPaletteAction[] {
 
   return recentScopes.map((recentScope) => {
     const names = recentScope.map((scope) => scope.spec.title).join(', ');
-    const keywords = recentScope
-      .map((scope) => `${scope.spec.title} ${scope.metadata.name}`)
-      .concat(names)
-      .join(' ');
+    const keywords = recentScope.map((scope) => `${scope.spec.title} ${scope.metadata.name}`).join(' ');
     return {
       id: names,
       name: names,
-      section: {
-        name: t('command-palette.section.recent-scopes', 'Recent scopes'),
-        priority: RECENT_SCOPES_PRIORITY,
-      },
+      section: t('command-palette.section.recent-scopes', 'Recent scopes'),
       subtitle: recentScope[0]?.parentNode?.spec.title,
       keywords: keywords,
       priority: RECENT_SCOPES_PRIORITY,

--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -194,9 +194,14 @@ function useInternalMatches(filtered: ActionImpl[], search: string): Match[] {
       // Sections with higher priority should be ranked higher even if they don't match the search term to the same extent
       const priority = throttledFiltered[index].priority;
 
+      // Weigh priority to have less impact for fewer results than more
+      const weightedPriority = priority * (matchingIndices.length / 10);
+
+      const score = matchingIndices.length + weightedPriority - order;
+
       return {
         action: throttledFiltered[index],
-        score: matchingIndices.length + priority - order,
+        score,
       };
     });
 

--- a/public/app/features/commandPalette/useMatches.ts
+++ b/public/app/features/commandPalette/useMatches.ts
@@ -191,15 +191,12 @@ function useInternalMatches(filtered: ActionImpl[], search: string): Match[] {
 
     // Convert indices back to Match objects with proper scoring
     const results: Match[] = matchingIndices.map((index, order) => {
-      const name = throttledFiltered[index].name;
-      const fullNameMatch = name.toLowerCase() === throttledSearch.toLowerCase();
-      let score = matchingIndices.length - order; // Higher score for better ranked matches
-      if (fullNameMatch) {
-        score += 100; // Bumping for exact matches
-      }
+      // Sections with higher priority should be ranked higher even if they don't match the search term to the same extent
+      const priority = throttledFiltered[index].priority;
+
       return {
         action: throttledFiltered[index],
-        score,
+        score: matchingIndices.length + priority - order,
       };
     });
 

--- a/public/app/features/commandPalette/values.ts
+++ b/public/app/features/commandPalette/values.ts
@@ -1,4 +1,3 @@
-// Bumped to way higher value, to give it more weight when searching
 export const RECENT_SCOPES_PRIORITY = 9;
 export const SCOPES_PRIORITY = 8;
 export const RECENT_DASHBOARDS_PRIORITY = 6;

--- a/public/app/features/commandPalette/values.ts
+++ b/public/app/features/commandPalette/values.ts
@@ -1,5 +1,5 @@
 // Bumped to way higher value, to give it more weight when searching
-export const RECENT_SCOPES_PRIORITY = 50;
+export const RECENT_SCOPES_PRIORITY = 9;
 export const SCOPES_PRIORITY = 8;
 export const RECENT_DASHBOARDS_PRIORITY = 6;
 export const ACTIONS_PRIORITY = 5;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds section priority to the score calculation. KBar probably already use it internally, but not to the extent we would like.

Priority weighs more, the more search results there are.

Searches were performed with `scopeSearchAllLevels = true` feature flag.

Here are some examples, with the scores at the end


Search for `loki`

<img width="350" height="360" alt="image" src="https://github.com/user-attachments/assets/9941b886-1595-4572-8ef9-71c013f1d705" />


Search for `profile`
<img width="233" height="110" alt="image" src="https://github.com/user-attachments/assets/0332e60b-2b47-470f-a59f-abe6c3f446c8" />


Search for `dev`
<img width="719" height="665" alt="image" src="https://github.com/user-attachments/assets/7066abe3-4142-44df-a100-81f0d1e04ee2" />


**Why do we need this feature?**

Then the search priority better matches the manual priority list we have.

**Who is this feature for?**

This will mainly affect scope users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

This is a followup for the more hacky PR https://github.com/grafana/grafana/pull/111805

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
