### PR TITLE
FolderPicker: Don't show expand button for empty folders and move search icon

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderList.tsx
@@ -32,6 +32,7 @@ interface NestedFolderListProps {
   onFolderSelect: (item: DashboardViewItem) => void;
   isItemLoaded: (itemIndex: number) => boolean;
   requestLoadMore: (folderUid: string | undefined) => void;
+  emptyFolders: Set<string>;
 }
 
 export function NestedFolderList({
@@ -44,6 +45,7 @@ export function NestedFolderList({
   onFolderSelect,
   isItemLoaded,
   requestLoadMore,
+  emptyFolders,
 }: NestedFolderListProps) {
   const infiniteLoaderRef = useRef<InfiniteLoader>(null);
   const styles = useStyles2(getStyles);
@@ -57,8 +59,18 @@ export function NestedFolderList({
       onFolderExpand,
       onFolderSelect,
       idPrefix,
+      emptyFolders,
     }),
-    [items, focusedItemIndex, foldersAreOpenable, selectedFolder, onFolderExpand, onFolderSelect, idPrefix]
+    [
+      items,
+      focusedItemIndex,
+      foldersAreOpenable,
+      selectedFolder,
+      onFolderExpand,
+      onFolderSelect,
+      idPrefix,
+      emptyFolders,
+    ]
   );
 
   const handleIsItemLoaded = useCallback(
@@ -119,8 +131,16 @@ interface RowProps {
 const SKELETON_WIDTHS = [100, 200, 130, 160, 150];
 
 function Row({ index, style: virtualStyles, data }: RowProps) {
-  const { items, focusedItemIndex, foldersAreOpenable, selectedFolder, onFolderExpand, onFolderSelect, idPrefix } =
-    data;
+  const {
+    items,
+    focusedItemIndex,
+    foldersAreOpenable,
+    selectedFolder,
+    onFolderExpand,
+    onFolderSelect,
+    idPrefix,
+    emptyFolders,
+  } = data;
   const { item, isOpen, level, parentUID } = items[index];
   const rowRef = useRef<HTMLDivElement>(null);
   const labelId = useId();
@@ -203,7 +223,7 @@ function Row({ index, style: virtualStyles, data }: RowProps) {
       <div className={styles.rowBody}>
         <Indent level={level} spacing={2} />
 
-        {foldersAreOpenable ? (
+        {foldersAreOpenable && !emptyFolders.has(item.uid) ? (
           <IconButton
             size={CHEVRON_SIZE}
             // by using onMouseDown here instead of onClick we can stop focus moving
@@ -257,7 +277,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
 
     folderButtonSpacer: css({
-      paddingLeft: theme.spacing(0.5),
+      paddingLeft: theme.spacing(2.5),
     }),
 
     row: css({

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -111,7 +111,7 @@ export function NestedFolderPicker({
 
   const isBrowsing = Boolean(overlayOpen && !(search && searchResults));
   const {
-    foldersMap,
+    emptyFolders,
     items: browseFlatTree,
     isLoading: isBrowseLoading,
     requestNextPage: fetchFolderPage,
@@ -123,7 +123,7 @@ export function NestedFolderPicker({
     rootFolderItem,
   });
 
-  const emptyFolders = useEmptyFolders(foldersOpenState, foldersMap);
+  // const emptyFolders = useEmptyFolders(foldersOpenState, foldersMap);
 
   useEffect(() => {
     if (!search) {
@@ -421,31 +421,3 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
   };
 };
-
-/**
- * Returns a set of folder UIDs that are empty. Meaning that even after querying on they still have no children.
- */
-function useEmptyFolders(
-  foldersOpenState: Record<string, boolean>,
-  foldersMap: Record<string, { children: string[] }>
-): Set<string> {
-  return useMemo(() => {
-    const newEmptyFolders = new Set<string>();
-
-    // Check each open folder to see if it's empty. We are checking expanded folders only, which means we check only
-    // folders where we actually asked the backend to load the children.
-    Object.entries(foldersOpenState).forEach(([uid, isOpen]) => {
-      if (isOpen) {
-        const collection = uid ? foldersMap[uid] : foldersMap['general'];
-        if (!collection) {
-          return;
-        }
-
-        if (collection.children.length === 0) {
-          newEmptyFolders.add(uid);
-        }
-      }
-    });
-    return newEmptyFolders;
-  }, [foldersMap, foldersOpenState]);
-}

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -123,8 +123,6 @@ export function NestedFolderPicker({
     rootFolderItem,
   });
 
-  // const emptyFolders = useEmptyFolders(foldersOpenState, foldersMap);
-
   useEffect(() => {
     if (!search) {
       setSearchResults(null);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -331,7 +331,7 @@ export function NestedFolderPicker({
       <Input
         ref={refs.setReference}
         autoFocus
-        prefix={label ? <Icon name="folder" /> : null}
+        prefix={label ? <Icon name="folder" /> : <Icon name="search" />}
         placeholder={label ?? t('browse-dashboards.folder-picker.search-placeholder', 'Search folders')}
         value={search}
         invalid={invalid}
@@ -344,7 +344,6 @@ export function NestedFolderPicker({
         aria-owns={overlayId}
         aria-activedescendant={getDOMId(overlayId, flatTree[focusedItemIndex]?.item.uid)}
         role="combobox"
-        suffix={<Icon name="search" />}
         {...getReferenceProps()}
         onKeyDown={handleKeyDown}
       />

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -137,9 +137,10 @@ export function useFoldersQueryLegacy({
 
   // Convert the individual responses into a flat list of folders, with level indicating
   // the depth in the hierarchy.
-  const treeList = useMemo(() => {
+  const [foldersMap, treeList] = useMemo(() => {
+    const foldersMap: Record<string, { children: string[] }> = { general: { children: [] } };
     if (!isBrowsing) {
-      return [];
+      return [foldersMap, []];
     }
 
     function createFlatList(
@@ -163,6 +164,12 @@ export function useFoldersQueryLegacy({
               parentUID: item.parentUid,
             },
           };
+          foldersMap[item.uid] = { children: [] };
+          if (item.parentUid) {
+            foldersMap[item.parentUid].children.push(item.uid);
+          } else {
+            foldersMap['general'].children.push(item.uid);
+          }
 
           const childPages = folderIsOpen && state.pagesByParent[item.uid];
           if (childPages) {
@@ -187,10 +194,11 @@ export function useFoldersQueryLegacy({
     const rootFlatTree = createFlatList(rootFolderUID ?? undefined, startingPages ?? [], 1);
     rootFlatTree.unshift(rootFolderItem || getRootFolderItem());
 
-    return rootFlatTree;
+    return [foldersMap, rootFlatTree];
   }, [state, isBrowsing, openFolders, rootFolderUID, rootFolderItem]);
 
   return {
+    foldersMap,
     items: treeList,
     isLoading: state.isLoading,
     requestNextPage,

--- a/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
+++ b/public/app/core/components/NestedFolderPicker/useFoldersQueryLegacy.ts
@@ -61,8 +61,6 @@ export function useFoldersQueryLegacy({
   // Set of UIDs for which children were requested but were empty.
   const [emptyFolders, setEmptyFolders] = useState<Set<string>>(new Set());
 
-  // const foldersMap: Record<string, { children: string[] }> = { general: { children: [] } };
-
   // Keep a list of selectors for dynamic state selection
   const [selectors, setSelectors] = useState<
     Array<ReturnType<typeof browseDashboardsAPI.endpoints.listFolders.select>>


### PR DESCRIPTION
Small UX improvements:

- Move the search icon to the prefix so it's a bit clearer that it's a search box
<img width="243" height="119" alt="Screenshot 2025-10-01 at 12 13 56" src="https://github.com/user-attachments/assets/abced5b5-335a-4886-8a48-a2dec8f1b927" />

- We don't know in advance that a folder is empty, but once we expand it, check if it has content, we can remove the expand chevron so it's clearer it's empty, and the user does not expand it by accident again

https://github.com/user-attachments/assets/4c2e7f52-e2bb-4f3c-a7ac-05a2096e1287

