### PR TITLE
Saved Queries: Fix buttons should not be displayed in Expressions query row

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.test.tsx
+++ b/public/app/features/query/components/QueryEditorRow.test.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { CoreApp, DataQueryRequest, dateTime, LoadingState, PanelData, toDataFrame } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 import { mockDataSource } from 'app/features/alerting/unified/mocks';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
 
 import { filterPanelDataToQuery, Props, QueryEditorRow } from './QueryEditorRow';
 
@@ -458,6 +459,29 @@ describe('QueryEditorRow', () => {
 
     it('should not render saved queries buttons when app is unified alerting', async () => {
       render(<QueryEditorRow {...props(testData)} app={CoreApp.UnifiedAlerting} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText('Save query')).not.toBeInTheDocument();
+        expect(screen.queryByText('Replace with saved query')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should not render saved queries buttons when query is an expression query', async () => {
+      const expressionQuery = {
+        refId: 'B',
+        datasource: {
+          uid: ExpressionDatasourceUID,
+          type: '__expr__',
+        },
+      };
+
+      const expressionProps = {
+        ...props(testData),
+        query: expressionQuery,
+        queries: [expressionQuery],
+      };
+
+      render(<QueryEditorRow {...expressionProps} />);
 
       await waitFor(() => {
         expect(screen.queryByText('Save query')).not.toBeInTheDocument();

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -34,6 +34,7 @@ import {
 } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 
 import { useQueryLibraryContext } from '../../explore/QueryLibrary/QueryLibraryContext';
+import { ExpressionDatasourceUID } from '../../expressions/types';
 
 import { QueryActionComponent, RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
@@ -386,10 +387,11 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     const hasEditorHelp = datasource?.components?.QueryEditorHelp;
     const isEditingQueryLibrary = queryLibraryRef !== undefined;
     const isUnifiedAlerting = app === CoreApp.UnifiedAlerting;
+    const isExpressionQuery = query.datasource?.uid === ExpressionDatasourceUID;
 
     return (
       <>
-        {!isEditingQueryLibrary && !isUnifiedAlerting && (
+        {!isEditingQueryLibrary && !isUnifiedAlerting && !isExpressionQuery && (
           <SavedQueryButtons
             query={query}
             app={app}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Hides saved query buttons when dealing with expressions in query editor rows.

https://github.com/user-attachments/assets/24c95cc1-aac9-493a-9c33-b5e7d0a3517f



**Why do we need this feature?**

We should not show saved query buttons when working with expressions.

Server-side expressions enable users to manipulate data returned from queries with math and other operations. They are not regular queries and we should not show saved query buttons in these cases

**Who is this feature for?**

everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-enterprise/issues/9769

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
