### PR TITLE
Exemplars: add actions to exemplar tooltip

### DIFF
--- a/public/app/features/visualization/data-hover/ExemplarTooltip.tsx
+++ b/public/app/features/visualization/data-hover/ExemplarTooltip.tsx
@@ -1,4 +1,4 @@
-import { LinkModel } from '@grafana/data';
+import { ActionModel, Field, LinkModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   VizTooltipContent,
@@ -13,9 +13,10 @@ export interface Props {
   links?: LinkModel[];
   isPinned: boolean;
   maxHeight?: number;
+  actions: Array<ActionModel<Field>>;
 }
 
-export const ExemplarTooltip = ({ items, links, isPinned, maxHeight }: Props) => {
+export const ExemplarTooltip = ({ items, links, isPinned, maxHeight, actions }: Props) => {
   const timeItem = items.find((val) => val.label === 'Time');
 
   return (
@@ -33,7 +34,7 @@ export const ExemplarTooltip = ({ items, links, isPinned, maxHeight }: Props) =>
         maxHeight={maxHeight}
         scrollable={maxHeight != null}
       />
-      <VizTooltipFooter dataLinks={links ?? []} />
+      <VizTooltipFooter actions={actions} dataLinks={links ?? []} />
     </VizTooltipWrapper>
   );
 };

--- a/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/ExemplarsPlugin.tsx
@@ -3,6 +3,7 @@ import uPlot from 'uplot';
 
 import { DataFrame, Labels, TIME_SERIES_TIME_FIELD_NAME, TIME_SERIES_VALUE_FIELD_NAME, TimeZone } from '@grafana/data';
 import { FIXED_UNIT, EventsCanvas, UPlotConfigBuilder } from '@grafana/ui';
+import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtils';
 
 import { ExemplarMarker } from './ExemplarMarker';
 
@@ -77,6 +78,7 @@ export const ExemplarsPlugin = ({
 
       return (
         <ExemplarMarker
+          replaceVariables={replaceVariables}
           setClickedRowIndex={setLockedExemplarRowIndex}
           clickedRowIndex={lockedExemplarRowIndex}
           timeZone={timeZone}


### PR DESCRIPTION


**What is this feature?**

Adding actions to exemplar tooltip:
<img width="1728" height="896" alt="image" src="https://github.com/user-attachments/assets/fb8e6be8-4861-4839-bd1b-459fcc844e7b" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
