### PR TITLE
Tag / content discrepancy

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-database-encryption/integrate-with-hashicorp-vault/index.md
@@ -6,7 +6,6 @@ description: Learn how to integrate Grafana with Hashicorp Vault so that you can
 labels:
   products:
     - enterprise
-    - oss
 title: Integrate Grafana with Hashicorp Vault
 weight: 500
 ---


### PR DESCRIPTION
Content is quite clear: Vault integration is an Enterprise feature. The OSS tag is incorrect on the said page