### PR TITLE
Sqlite: Increase busy_timeout to 7.5s for non-cgo driver

### DIFF
--- a/pkg/util/sqlite/sqlite_nocgo.go
+++ b/pkg/util/sqlite/sqlite_nocgo.go
@@ -67,7 +67,7 @@ func convertSQLite3URL(dsn string) (string, error) {
 	newDSN := dsn[:pos]
 
 	q := url.Values{}
-	q.Add("_pragma", "busy_timeout(5000)")
+	q.Add("_pragma", "busy_timeout(7500)") // Default of mattn/go-sqlite3 is 5s but we increase it to 7.5s to try and avoid busy errors.
 
 	for key, values := range params {
 		if alias, ok := dsnAlias[strings.ToLower(key)]; ok {


### PR DESCRIPTION
**What is this feature?**

Increases the busy_timeout param to 7.5s for the modernc.org/sqlite driver.

**Why do we need this feature?**

We are noticing sporadic "database is locked" errors in unit tests running the no-CGo driver.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
