### PR TITLE
BarChart: Add OneClick AdHoc filtering support

### DIFF
--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -197,6 +197,17 @@ export const BarChartPanel = (props: PanelProps<Options>) => {
 
                 return [];
               }}
+              onAddAdHocFilter={onAddAdHocFilter}
+              getFilterInfo={(_seriesIdx, dataIdx) => {
+                const xField = vizSeries[0].fields[0];
+                if (xField && dataIdx != null) {
+                  return {
+                    key: xField.name,
+                    value: String(xField.values[dataIdx]),
+                  };
+                }
+                return null;
+              }}
               render={(u, dataIdxs, seriesIdx, isPinned, dismiss, timeRange2, viaSync, dataLinks, adHocFilters) => {
                 return (
                   <TimeSeriesTooltip


### PR DESCRIPTION
# I just want a dockerfile

So I can show this functionality, as part of Hackathon

Should replace: #108372

**EDIT:**
The dockerfile got built - it's full path can be seen here:
https://github.com/grafana/grafana/runs/51742825932

(I think you have to be a logged in Grafanista to see this)

---


**What is this feature?**

This PR adds OneClick AdHoc filtering support to the BarChart panel, allowing users to directly click on bars to apply filters without needing to go through the tooltip button interface.

**Why do we need this feature?**

This provides a more streamlined user experience for panel-to-panel filtering workflows. Users can now:
- Click directly on bars to apply filters when no data links are present (OneClick behavior)
- Still use the existing tooltip button approach when data links are available
- Get the best of both worlds - quick filtering and detailed tooltip interactions

**How does it work?**

The implementation preserves both filtering approaches:
1. **OneClick filtering**: When clicking on a bar with no data links, the filter is applied immediately
2. **Tooltip button filtering**: When data links are present or when the tooltip is pinned, users can use the filter buttons in the tooltip

**Technical details:**

- Extends  with  and  callbacks
- Maintains backward compatibility with existing  approach
- Cherry-picked and resolved conflicts from the original PR #108372 that was superseded by PR #107874

**Testing:**

This can be tested with any BarChart panel connected to a data source that supports AdHoc filtering (e.g., Prometheus, Loki) where the x-axis field is marked as filterable.

**Special notes for reviewer:**

This is a draft PR to get early feedback on the OneClick filtering UX. The functionality works alongside the existing tooltip button approach without breaking changes.