### PR TITLE
[wip] investigation of seeding issues for permissions

### DIFF
--- a/investigation.md
+++ b/investigation.md
@@ -1,0 +1,28 @@
+How to reproduce
+
+Setup of initial state
+
+Setup postgres
+
+Edit `devenv/docker/blocks/postgres/.env`:
+
+```bash
+postgres_version=17-alpine
+```
+
+```bash
+make devenv sources="postgres"
+```
+
+Setup grafana w. 10.4.6
+git checkout v10.4.x <-- run `./dev.sh`
+
+
+
+```bash
+docker exec -i devenv-postgres-1 pg_restore -U grafana -d grafana --no-owner --no-privileges < db_grafana_68da3581157a57cbed2311c0.dump.txt
+```
+
+The dump may reference Azure-specific extensions that aren't available locally:
+ERROR:  extension "azure" is not available
+So it says that azure is not available; which is fine.


### PR DESCRIPTION
We have had some users with running into migration failures where we can see duplicate entries of a permission during seeding of basic roles.

### Why This Happens on Your Specific Upgrade

Your error log shows:
```
ERROR[10-01|13:51:00] failed to add newly seeded permissions logger=accesscontrol 
err="pq: duplicate key value violates unique constraint \"UQE_permission_action_scope_role_id\""
```

This happens because:
1. **Migrations ran successfully** - The unique index was added
2. **Database already has both OLD and NEW permissions** - From previous basic role provisioning
3. **Seeding tries to "update" from OLD → NEW** - Sees OLD exists, tries to insert NEW
4. **NEW already exists** - Duplicate key error
5. **Grafana fails to start** - Can't complete seeding

### Summary

During Grafana startup after upgrade from 10.4.6 → 11.6.x `duplicate key value violates unique constraint` error stops grafana to boot.

**Bug:** 
When upgrading permissions with changed scopes, the code checks if the old-scoped permission exists, but doesn't check if the new-scoped permission already exists before trying to insert it.

**The Root Cause:** 
The database has both **old** and **new** scoped permissions for the same action+role, causing the seeding logic to attempt inserting duplicates.
From seeding the basic roles with the **new** permissions.

**Solution:** 
We should add a second check to ensure the new permission doesn't already exist before trying to insert it.

```
Example for Admin role:
1. {Admin, "alert.notifications.receivers:read", "", ""}           (OLD)
2. {Admin, "alert.notifications.receivers:read", "receivers:*", ""} (NEW)
```

Between Grafana versions, we refine permission scopes. For:
- **In 10.4.6:** `alert.notifications.receivers:read` had empty scope `""`
- **In 11.6.x:** They changed it to scope `"receivers:*"` for better security

https://github.com/grafana/grafana/pull/91738/files#diff-f8c8c53ab4a12c9847cb08deb20866aa5e1a12c10a665464088ddadae630f600R10

During upgrade, the system should:
1. **Remove** the OLD scoped permission
2. **Add** the NEW scoped permission

This can happen if;
- Manual database manipulation
- Provisioning of basic roles

### Fix

```go
for old, new := range updated {
    if _, has := basicRolePerms[old]; has {
        // Only add the new permission if it doesn't already exist in the database
        // This prevents duplicate key violations when upgrading from older versions
        // where both old and new scoped permissions may exist simultaneously
        if _, exists := basicRolePerms[new]; !exists {
             result = append(result, new)
        }
    }
}
```

**Investigation**

## How to reproduce

The dump of the database was made and needs postgres version 17 to function.

Edit `devenv/docker/blocks/postgres/.env`:

```bash
postgres_version=17-alpine
```

```bash
make devenv sources="postgres"
```

git checkout v10.4.x -- `grafana`
git checkout v10.4.x -- `grafana-enterprise`
<-- run `./dev.sh`

```bash
docker exec -i devenv-postgres-1 pg_restore -U grafana -d grafana --no-owner --no-privileges < db_grafana_68da3581157a57cbed2311c0.dump.txt
```

