### PR TITLE
E2E: Fix trace-view-scrolling test flakiness

### DIFF
--- a/e2e-playwright/fixtures/long-trace-response.json
+++ b/e2e-playwright/fixtures/long-trace-response.json
@@ -598,7 +598,7 @@
                 "auth-validator",
                 "config-loader",
                 "config-writer",
-                "metrics-collector",
+                "metrics-collector-last-span",
                 "log-writer",
                 "log-reader",
                 "event-publisher",


### PR DESCRIPTION
I noticed some flakiness on this test in another PR, which I can reproduce by running the test locally 10 times

```
yarn e2e:playwright --grep "Can lazy load big traces" --repeat-each 10
```

The trace view uses a virtualised list to render only the spans in the viewport. Previously, this test would count how many spans are in the page, scroll the last one into view, and then count them again and assert that there's now more on the page.

However this methodology is flawed - depending on timing, it's possible for there to still be the same number of spans in the page, even if they're different. It wasn't actually testing the expected behaviour.

I tweaked the test to instead assert that a specific span is not visible, and then scroll until it is visible. This more directly matches the expected behaviour for both the user and the component.

I ran this 10 times in parallel and it passed all of them!

<img width="644" height="216" alt="Screenshot 2025-10-01 at 5 46 54 pm" src="https://github.com/user-attachments/assets/6583a12a-e9f7-4dc0-84ee-3cc35a829dd7" />

