### PR TITLE
docs(alerting): `alertingSaveStateCompressed` is enabled by default

### DIFF
--- a/docs/sources/alerting/set-up/performance-limitations/index.md
+++ b/docs/sources/alerting/set-up/performance-limitations/index.md
@@ -58,20 +58,20 @@ For more information, refer to [this GitHub issue](https://github.com/grafana/gr
 
 ## High load on database caused by a high number of alert instances
 
-If you have a high number of alert instances, it can happen that the load on the database gets very high, as each state
-transition of an alert instance is saved in the database after every evaluation.
+If you have a high number of alert rules or alert instances, the load on the database can get very high.
 
-### Compressed alert state
+By default, Grafana performs one SQL update per alert rule after each evaluation, which updates all alert instances belonging to the rule.
 
-When the `alertingSaveStateCompressed` feature toggle is enabled, Grafana saves the alert rule state in a compressed form. Instead of performing an individual SQL update for each alert instance, Grafana performs a single SQL update per alert rule, updating all alert instances belonging to that rule.
-
-This can significantly reduce database overhead for alert rules with many alert instances.
+You can change this behavior by disabling the `alertingSaveStateCompressed` feature flag. In this case, Grafana performs a separate SQL update for each state change of an alert instance. This configuration is rarely recommended, as it can add significant database overhead for alert rules with many instances.
 
 ### Save state periodically
 
-High load can be also prevented by writing to the database periodically, instead of after every evaluation.
+You can also reduce database load by writing states periodically instead of after every evaluation.
 
-To save state periodically, enable the `alertingSaveStatePeriodic` feature toggle.
+To save state periodically:
+
+1. Enable the `alertingSaveStatePeriodic` feature toggle.
+1. Disable the `alertingSaveStateCompressed` feature toggle.
 
 By default, it saves the states every 5 minutes to the database and on each shutdown. The periodic interval
 can also be configured using the `state_periodic_save_interval` configuration flag. During this process, Grafana deletes all existing alert instances from the database and then writes the entire current set of instances back in batches in a single transaction.

--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -101,7 +101,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `pdfTables`                     | Enables generating table data as PDF in reporting                                                      |
 | `canvasPanelPanZoom`            | Allow pan and zoom in canvas panel                                                                     |
 | `regressionTransformation`      | Enables regression analysis transformation                                                             |
-| `alertingSaveStateCompressed`   | Enables the compressed protobuf-based alert state storage                                              |
+| `alertingSaveStateCompressed`   | Enables the compressed protobuf-based alert state storage. Default is enabled.                         |
 | `sqlExpressions`                | Enables SQL Expressions, which can execute SQL queries against data source results.                    |
 | `queryLibrary`                  | Enables Saved queries (query library) feature                                                          |
 | `enableSCIM`                    | Enables SCIM support for user and group management                                                     |


### PR DESCRIPTION
Docs for [Alerting: Enable alertingSaveStateCompressed by default](https://github.com/grafana/grafana/pull/109390).

⭐ [Preview](https://deploy-preview-grafana-111897-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/set-up/performance-limitations/#high-load-on-database-caused-by-a-high-number-of-alert-instances)

