### PR TITLE
Prometheus Dashboards: Use $__rate_interval instead of hardcoded value

### DIFF
--- a/packages/grafana-prometheus/src/dashboards/prometheus_2_stats.json
+++ b/packages/grafana-prometheus/src/dashboards/prometheus_2_stats.json
@@ -180,15 +180,12 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[5m]))",
+          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "samples",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -273,12 +270,9 @@
         {
           "expr": "topk(5, max(scrape_duration_seconds) by (job))",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "{{job}}",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -366,20 +360,15 @@
           "expr": "sum(process_resident_memory_bytes{job=\"prometheus\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "p8s process resident memory",
-          "refId": "D",
-          "step": 20
+          "refId": "D"
         },
         {
           "expr": "process_virtual_memory_bytes{job=\"prometheus\"}",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
           "legendFormat": "virtual memory",
-          "refId": "C",
-          "step": 20
+          "refId": "C"
         }
       ],
       "timeFrom": null,
@@ -454,10 +443,8 @@
         {
           "expr": "prometheus_tsdb_wal_corruptions_total{job=\"prometheus\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "",
-          "refId": "A",
-          "step": 60
+          "refId": "A"
         }
       ],
       "title": "WAL Corruptions",
@@ -540,21 +527,15 @@
         {
           "expr": "sum(prometheus_tsdb_head_active_appenders{job=\"prometheus\"})",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "active_appenders",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
           "expr": "sum(process_open_fds{job=\"prometheus\"})",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "open_fds",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -670,10 +651,8 @@
         {
           "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "blocks",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -759,11 +738,8 @@
         {
           "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\"}",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "chunks",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -862,18 +838,14 @@
         {
           "expr": "prometheus_tsdb_head_gc_duration_seconds{job=\"prometheus\",quantile=\"0.99\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "duration-p99",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "collections",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -971,38 +943,29 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "duration-{{p99}}",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "compactions",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "failed",
-          "refId": "C",
-          "step": 20
+          "refId": "C"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "triggered",
-          "refId": "D",
-          "step": 20
+          "refId": "D"
         }
       ],
       "timeFrom": null,
@@ -1085,21 +1048,17 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "reloads",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
           "legendFormat": "failures",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -1184,10 +1143,8 @@
         {
           "expr": "prometheus_engine_query_duration_seconds{job=\"prometheus\", quantile=\"0.99\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "{{slice}}_p99",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -1272,11 +1229,8 @@
         {
           "expr": "max(prometheus_rule_group_duration_seconds{job=\"prometheus\"}) by (quantile)",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "{{quantile}}",
-          "refId": "A",
-          "step": 10
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -1359,20 +1313,16 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "missed",
-          "refId": "B",
-          "step": 10
+          "refId": "B"
         },
         {
-          "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "iterations",
-          "refId": "A",
-          "step": 10
+          "refId": "A"
         }
       ],
       "timeFrom": null,

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -179,15 +179,13 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[5m]))",
+          "expr": "sum(irate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\"}[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "samples",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
+
         }
       ],
       "timeFrom": null,
@@ -272,12 +270,9 @@
         {
           "expr": "topk(5, max(scrape_duration_seconds) by (job))",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "{{job}}",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -365,20 +360,15 @@
           "expr": "sum(process_resident_memory_bytes{job=\"prometheus\"})",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "p8s process resident memory",
-          "refId": "D",
-          "step": 20
+          "refId": "D"
         },
         {
           "expr": "process_virtual_memory_bytes{job=\"prometheus\"}",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
           "legendFormat": "virtual memory",
-          "refId": "C",
-          "step": 20
+          "refId": "C"
         }
       ],
       "timeFrom": null,
@@ -453,7 +443,6 @@
         {
           "expr": "prometheus_tsdb_wal_corruptions_total{job=\"prometheus\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "",
           "refId": "A",
           "step": 60
@@ -539,21 +528,15 @@
         {
           "expr": "sum(prometheus_tsdb_head_active_appenders{job=\"prometheus\"})",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "active_appenders",
           "metric": "",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
           "expr": "sum(process_open_fds{job=\"prometheus\"})",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "open_fds",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -669,10 +652,8 @@
         {
           "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "blocks",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -758,11 +739,8 @@
         {
           "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\"}",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "chunks",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -861,18 +839,14 @@
         {
           "expr": "prometheus_tsdb_head_gc_duration_seconds{job=\"prometheus\",quantile=\"0.99\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "duration-p99",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "collections",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -970,38 +944,29 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[5m])) by (le))",
+          "expr": "histogram_quantile(0.99, sum(rate(prometheus_tsdb_compaction_duration_bucket{job=\"prometheus\"}[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "duration-{{p99}}",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "compactions",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "failed",
-          "refId": "C",
-          "step": 20
+          "refId": "C"
         },
         {
-          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[5m])",
+          "expr": "irate(prometheus_tsdb_compactions_triggered_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "triggered",
-          "refId": "D",
-          "step": 20
+          "refId": "D"
         }
       ],
       "timeFrom": null,
@@ -1084,21 +1049,17 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "reloads",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         },
         {
-          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
           "hide": false,
-          "intervalFactor": 2,
           "legendFormat": "failures",
-          "refId": "B",
-          "step": 20
+          "refId": "B"
         }
       ],
       "timeFrom": null,
@@ -1183,10 +1144,8 @@
         {
           "expr": "prometheus_engine_query_duration_seconds{job=\"prometheus\", quantile=\"0.99\"}",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "{{slice}}_p99",
-          "refId": "A",
-          "step": 20
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -1271,8 +1230,6 @@
         {
           "expr": "max(prometheus_rule_group_duration_seconds{job=\"prometheus\"}) by (quantile)",
           "format": "time_series",
-          "interval": "",
-          "intervalFactor": 2,
           "legendFormat": "{{quantile}}",
           "refId": "A",
           "step": 10
@@ -1358,17 +1315,15 @@
       "pluginVersion": "8.1.0-pre",
       "targets": [
         {
-          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "missed",
           "refId": "B",
           "step": 10
         },
         {
-          "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[5m])",
+          "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
-          "intervalFactor": 2,
           "legendFormat": "iterations",
           "refId": "A",
           "step": 10

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -185,7 +185,6 @@
           "legendFormat": "samples",
           "metric": "",
           "refId": "A"
-
         }
       ],
       "timeFrom": null,

--- a/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
+++ b/public/app/plugins/datasource/prometheus/dashboards/prometheus_2_stats.json
@@ -443,8 +443,7 @@
           "expr": "prometheus_tsdb_wal_corruptions_total{job=\"prometheus\"}",
           "format": "time_series",
           "legendFormat": "",
-          "refId": "A",
-          "step": 60
+          "refId": "A"
         }
       ],
       "title": "WAL Corruptions",
@@ -1230,8 +1229,7 @@
           "expr": "max(prometheus_rule_group_duration_seconds{job=\"prometheus\"}) by (quantile)",
           "format": "time_series",
           "legendFormat": "{{quantile}}",
-          "refId": "A",
-          "step": 10
+          "refId": "A"
         }
       ],
       "timeFrom": null,
@@ -1317,15 +1315,13 @@
           "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "missed",
-          "refId": "B",
-          "step": 10
+          "refId": "B"
         },
         {
           "expr": "rate(prometheus_rule_group_iterations_total{job=\"prometheus\"}[$__rate_interval])",
           "format": "time_series",
           "legendFormat": "iterations",
-          "refId": "A",
-          "step": 10
+          "refId": "A"
         }
       ],
       "timeFrom": null,


### PR DESCRIPTION
# Prometheus Dashboard Enhancement: Use `$__rate_interval` for Dynamic Querying

##  Overview

This update improves the built-in Prometheus stats dashboard (`prometheus_2_stats.json`) by replacing hardcoded intervals with Grafana's dynamic `$__rate_interval` variable. It also removes redundant query parameters to align with Grafana's best practices.

## Changes Made

- Replaced all `[5m]` intervals in PromQL expressions with `[$__rate_interval]`
- Removed:
  - `"intervalFactor": 2`
  - `"step": 20`
  - `"interval": ""`

## Related Issue

Closes [#110370](https://github.com/grafana/grafana/issues/110370)

## Notes for Reviewers

- Dashboard renders correctly with `$__rate_interval`
- Removed fields are no longer necessary due to Grafana's dynamic query engine
- Aligns with Grafana documentation and query best practices

