### PR TITLE
Graphite: Improve functions endpoint

### DIFF
--- a/pkg/tsdb/graphite/resource_handler.go
+++ b/pkg/tsdb/graphite/resource_handler.go
@@ -294,7 +294,13 @@ func (s *Service) handleFunctions(ctx context.Context, dsInfo *datasourceInfo, _
 
 	_, rawBody, statusCode, err := doGraphiteRequest[map[string]any](ctx, dsInfo, s.logger, req, true)
 	if err != nil {
-		return nil, statusCode, fmt.Errorf("version request failed: %v", err)
+		return nil, statusCode, fmt.Errorf("functions request failed: %v", err)
+	}
+
+	// It's possible that a HTML response may be returned
+	// This isn't valid so we'll return an error and use the default functions
+	if strings.HasPrefix(string(*rawBody), "<") {
+		return []byte{}, http.StatusNotAcceptable, fmt.Errorf("invalid functions response received from Graphite")
 	}
 
 	if rawBody == nil {

--- a/pkg/tsdb/graphite/resource_handler_test.go
+++ b/pkg/tsdb/graphite/resource_handler_test.go
@@ -735,21 +735,41 @@ func TestHandleFunctions(t *testing.T) {
 			responseBody:  `{"error": "internal error"}`,
 			statusCode:    500,
 			expectError:   true,
-			errorContains: "version request failed",
+			errorContains: "functions request failed",
 		},
 		{
 			name:          "functions request not found",
 			responseBody:  `{"error": "not found"}`,
 			statusCode:    404,
 			expectError:   true,
-			errorContains: "version request failed",
+			errorContains: "functions request failed",
 		},
 		{
 			name:          "network error",
 			responseBody:  "",
 			statusCode:    0,
 			expectError:   true,
-			errorContains: "version request failed",
+			errorContains: "functions request failed",
+		},
+		{
+			name: "html response",
+			responseBody: `<html>
+			<head>
+				<title>Graphite Browser</title>
+			</head>
+					
+
+			<frameset rows="60,*" frameborder="1" border="1">
+			<frame src="/browser/header/" name="Header" id='header' scrolling="no" noresize="true" />
+			
+				<frame src="/composer/?" name="content" id="composerFrame"/>
+			
+			</frameset>
+			</html>
+			`,
+			statusCode:    200,
+			expectError:   true,
+			errorContains: "invalid functions response received from Graphite",
 		},
 	}
 

--- a/public/app/plugins/datasource/graphite/datasource.ts
+++ b/public/app/plugins/datasource/graphite/datasource.ts
@@ -1029,9 +1029,15 @@ export class GraphiteDatasource
     };
 
     if (config.featureToggles.graphiteBackendMode) {
-      const functions = await this.getResource<string>('functions');
-      this.funcDefs = gfunc.parseFuncDefs(functions);
-      return this.funcDefs;
+      try {
+        const functions = await this.getResource<string>('functions');
+        this.funcDefs = gfunc.parseFuncDefs(functions);
+        return this.funcDefs;
+      } catch (error) {
+        console.error('Fetching graphite functions error', error);
+        this.funcDefs = gfunc.getFuncDefs(this.graphiteVersion);
+        return this.funcDefs;
+      }
     }
 
     return lastValueFrom(


### PR DESCRIPTION
This PR improves the logic related to the functions endpoint. It's possible that Graphite can return a HTML response which doesn't contain the functions definitions. In this case, we should use the default function definitions.

This PR ensures we check the body of the response on the backend and if it looks like a HTML response an error is returned to the frontend. This error is caught and the default function definitions are returned.

This only affects the endpoint when the backend toggle is enabled.