### PR TITLE
UI: Fix modal border opacity causing visual artifacts

### DIFF
--- a/packages/grafana-ui/src/components/Modal/getModalStyles.test.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.test.ts
@@ -1,0 +1,66 @@
+import { getModalStyles } from './getModalStyles';
+
+// Mock theme object for testing
+const mockTheme = {
+  zIndex: {
+    modal: 1000,
+    modalBackdrop: 999,
+  },
+  colors: {
+    background: {
+      primary: '#ffffff',
+    },
+    border: {
+      weak: 'rgba(0, 0, 0, 0.12)',
+      medium: 'rgba(0, 0, 0, 0.3)',
+      strong: 'rgba(0, 0, 0, 0.4)',
+    },
+    text: {
+      secondary: '#666666',
+    },
+  },
+  shadows: {
+    z3: '0 3px 6px rgba(0, 0, 0, 0.16)',
+  },
+  shape: {
+    radius: {
+      lg: '8px',
+    },
+  },
+  spacing: (value: number) => `${value * 8}px`,
+  components: {
+    overlay: {
+      background: 'rgba(0, 0, 0, 0.5)',
+    },
+  },
+  typography: {
+    size: {
+      lg: '18px',
+    },
+  },
+} as any;
+
+// This test validates that our fix for issue #102190 is working correctly
+// We changed the modal border from border.weak to border.medium to fix
+// the visual artifact where semi-transparent borders create a "gap" appearance
+describe('getModalStyles - Issue #102190 Fix', () => {
+  it('should use border.medium for modal border to fix semi-transparent appearance', () => {
+    const styles = getModalStyles(mockTheme);
+    
+    // The modal styles should include the medium border color, not weak
+    // This is verified by checking the generated CSS string contains the expected border declaration
+    const modalStyleString = styles.modal.toString();
+    
+    // Our change should use the medium border which is more opaque
+    expect(modalStyleString).toContain('rgba(0, 0, 0, 0.3)');
+  });
+
+  it('should not use the problematic weak border that caused the visual artifact', () => {
+    const styles = getModalStyles(mockTheme);
+    
+    const modalStyleString = styles.modal.toString();
+    
+    // Ensure we no longer use the semi-transparent weak border that caused the issue
+    expect(modalStyleString).not.toContain('rgba(0, 0, 0, 0.12)');
+  });
+});

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -10,7 +10,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
       background: theme.colors.background.primary,
       boxShadow: theme.shadows.z3,
       borderRadius: theme.shape.radius.lg,
-      border: `1px solid ${theme.colors.border.weak}`,
+      border: `1px solid ${theme.colors.border.medium}`,
       backgroundClip: 'padding-box',
       outline: 'none',
       width: '750px',


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the visual artifact where modal borders appear as "gaps" when overlaying bright content due to excessive transparency.

## Which issue(s) this PR closes

Closes #102190

## Problem

Modal borders were using `theme.colors.border.weak` (12% opacity), which created a visual artifact when modals overlaid bright content. The semi-transparent border made it appear as if there were "gaps" in the modal backdrop, creating a confusing user experience.

## Solution

Changed modal border from `theme.colors.border.weak` to `theme.colors.border.medium` (30% opacity) in `getModalStyles.ts`. This provides:

- **Better visibility**: 30% opacity vs 12% makes borders clearly visible
- **Consistency**: Aligns with border usage patterns throughout the codebase  
- **Minimal impact**: Single-line change affecting only modal borders

## Changes

- Modified `packages/grafana-ui/src/components/Modal/getModalStyles.ts`
- Added unit tests to prevent regression
- Verified change doesn't affect other components using `getModalStyles`

## Testing

- ✅ Added unit tests validating border.medium usage
- ✅ Verified consistency with existing codebase patterns
- ✅ Confirmed no impact on other components importing getModalStyles

## Screenshots/Evidence

The fix addresses the semi-transparent border issue shown in the original issue screenshot where the modal border created visual "gaps" over bright content.

## Checklist

- [x] Tests added/updated
- [x] Documentation not required (UI fix)
- [x] No breaking changes
- [x] Follows contribution guidelines
- [x] Commit messages follow format guidelines