### PR TITLE
Annotations: Color palette & frame name override mapping

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
+++ b/packages/grafana-data/src/transformations/transformers/convertFrameType.ts
@@ -41,7 +41,6 @@ export interface OptionalAnnotationFields {
 
 export interface OptionalAnnotationOptions {
   frameName?: string;
-  // defaultColor?: string;
   colorScheme?: FieldColor;
 }
 

--- a/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
+++ b/public/app/features/transformers/FilterByValueTransformer/FilterByValueTransformerEditor.tsx
@@ -57,7 +57,7 @@ export const FilterByValueTransformerEditor = (props: TransformerUIProps<FilterB
 
   const onAddFilter = useCallback(() => {
     const frame = input[0];
-    const field = frame.fields.find((f) => f.type !== FieldType.time);
+    const field = frame?.fields?.find((f) => f.type !== FieldType.time);
 
     if (!field) {
       return;

--- a/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
@@ -21,7 +21,7 @@ import {
   OptionalAnnotationOptions,
 } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
-import { ColorPicker, DEFAULT_ANNOTATION_COLOR, InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';
+import { InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';
 
 import { FieldColorEditor } from '../../../core/components/OptionsUI/fieldColor';
@@ -84,6 +84,7 @@ export const ConvertFrameTypeTransformerEditor = ({
       onChange({
         ...options,
         annotationOptions: {
+          ...options.annotationOptions,
           [label]: value,
         },
       });
@@ -205,43 +206,18 @@ export const ConvertFrameTypeTransformerEditor = ({
 
           {/* Map dataframe with existing color strings */}
           <InlineFieldRow>
-            <InlineField labelWidth={20} label={t('transformers.annotation-transformer-editor.color', 'Color field')}>
-              <FieldNamePicker
-                context={{ data: input }}
-                value={options.annotationFieldMapping?.color ?? ''}
-                onChange={(value) => {
-                  onSelectAnnotationMapping('color', value);
-                }}
-                item={fieldNamePickerSettings}
-              />
-            </InlineField>
-          </InlineFieldRow>
-          <InlineFieldRow>
             <InlineField
               labelWidth={20}
               label={t('transformers.annotation-transformer-editor.color-scheme', 'Color scheme')}
             >
               <FieldColorEditor
-                item={{ id: 'colorScheme', name: 'colorScheme' }}
+                item={{ id: '', name: '' }}
                 context={{ data: input }}
                 value={options.annotationOptions?.colorScheme ?? { mode: FieldColorModeId.ContinuousBlYlRd }}
                 onChange={(value) => {
                   if (value) {
                     onSelectAnnotationOption('colorScheme', value);
                   }
-                }}
-              />
-            </InlineField>
-          </InlineFieldRow>
-          <InlineFieldRow>
-            <InlineField
-              labelWidth={20}
-              label={t('transformers.annotation-transformer-editor.default-color', 'Default color')}
-            >
-              <ColorPicker
-                color={options.annotationOptions?.defaultColor ?? DEFAULT_ANNOTATION_COLOR}
-                onChange={(value) => {
-                  onSelectAnnotationOption('defaultColor', value);
                 }}
               />
             </InlineField>

--- a/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFrameTypeTransformerEditor.tsx
@@ -3,6 +3,8 @@ import { useCallback } from 'react';
 
 import {
   DataTransformerID,
+  FieldColor,
+  FieldColorModeId,
   FieldNamePickerConfigSettings,
   GrafanaTheme2,
   SelectableValue,
@@ -13,15 +15,16 @@ import {
   TransformerUIProps,
 } from '@grafana/data';
 import {
+  AnnotationFieldMapping,
   ConvertFrameTypeTransformerOptions,
   FrameType,
-  AnnotationFieldMapping,
   OptionalAnnotationOptions,
 } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { ColorPicker, DEFAULT_ANNOTATION_COLOR, InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';
 import { FieldNamePicker } from '@grafana/ui/internal';
 
+import { FieldColorEditor } from '../../../core/components/OptionsUI/fieldColor';
 import { getTransformationContent } from '../docs/getTransformationContent';
 
 // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -77,7 +80,7 @@ export const ConvertFrameTypeTransformerEditor = ({
   );
 
   const onSelectAnnotationOption = useCallback(
-    (label: keyof OptionalAnnotationOptions, value?: string) => {
+    (label: keyof OptionalAnnotationOptions, value?: string | FieldColor) => {
       onChange({
         ...options,
         annotationOptions: {
@@ -186,6 +189,20 @@ export const ConvertFrameTypeTransformerEditor = ({
               />
             </InlineField>
           </InlineFieldRow>
+
+          <InlineFieldRow>
+            <InlineField labelWidth={20} label={t('transformers.annotation-transformer-editor.name', 'Frame name')}>
+              <FieldNamePicker
+                context={{ data: input }}
+                value={options.annotationOptions?.frameName ?? ''}
+                onChange={(value) => {
+                  onSelectAnnotationOption('frameName', value);
+                }}
+                item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+
           {/* Map dataframe with existing color strings */}
           <InlineFieldRow>
             <InlineField labelWidth={20} label={t('transformers.annotation-transformer-editor.color', 'Color field')}>
@@ -196,6 +213,23 @@ export const ConvertFrameTypeTransformerEditor = ({
                   onSelectAnnotationMapping('color', value);
                 }}
                 item={fieldNamePickerSettings}
+              />
+            </InlineField>
+          </InlineFieldRow>
+          <InlineFieldRow>
+            <InlineField
+              labelWidth={20}
+              label={t('transformers.annotation-transformer-editor.color-scheme', 'Color scheme')}
+            >
+              <FieldColorEditor
+                item={{ id: 'colorScheme', name: 'colorScheme' }}
+                context={{ data: input }}
+                value={options.annotationOptions?.colorScheme ?? { mode: FieldColorModeId.ContinuousBlYlRd }}
+                onChange={(value) => {
+                  if (value) {
+                    onSelectAnnotationOption('colorScheme', value);
+                  }
+                }}
               />
             </InlineField>
           </InlineFieldRow>


### PR DESCRIPTION

**What is this feature?**
* Adding default annotation color palette for each annotation frame.
* * Supporting fixed color overrides for transformation
* Cleaning up other color picking options
* Adding a new fieldName mapping field to the transform, meant to be paired with partition by values transformation so users can specify a single field to be used as the annotation name.

<img width="1466" height="413" alt="image" src="https://github.com/user-attachments/assets/30e59f5e-753b-4613-9165-dec2da0ce425" />
<img width="1723" height="788" alt="image" src="https://github.com/user-attachments/assets/49617c54-b9f5-4893-9459-e75b539259ea" />
<img width="1728" height="898" alt="image" src="https://github.com/user-attachments/assets/8f39a191-60c2-4368-838c-5ca40ff52cda" />



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
