### PR TITLE
fix: actions config missing index

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -326,17 +326,11 @@ export const AnnotationsPlugin2 = ({
                 },
               },
             };
-
-            frame.fields.forEach((field: Field) => {
-              const actionsModel = getActions(
-                frame,
-                field,
-                scopedVars,
-                replaceVariables,
-                field.config.actions ?? [],
-                // @todo config?
-                {}
-              );
+            frame.fields.forEach((field: Field, index) => {
+              // @todo use getFieldActions
+              const actionsModel = getActions(frame, field, scopedVars, replaceVariables, field.config.actions ?? [], {
+                valueRowIndex: i,
+              });
 
               const actionsOut: Array<ActionModel<Field>> = [];
               const actionLookup = new Set<string>();


### PR DESCRIPTION
Fixes annotation action config which was breaking variables.

Now we can not only visualize alerts from the Grafana API as annotations, but we can also silence the alert (or other actions) directly from the annotation action button.

https://github.com/user-attachments/assets/f76d5836-7175-439f-9a36-5a764e1ba3c4

