### PR TITLE
Geomap: Ensure default marker path consistency

### DIFF
--- a/public/app/plugins/panel/geomap/migrations.test.ts
+++ b/public/app/plugins/panel/geomap/migrations.test.ts
@@ -76,7 +76,7 @@ describe('Worldmap Migrations', () => {
                     "min": 2,
                   },
                   "symbol": {
-                    "fixed": "build/img/icons/marker/circle.svg",
+                    "fixed": "img/icons/marker/circle.svg",
                     "mode": "fixed",
                   },
                   "symbolAlign": {

--- a/public/app/plugins/panel/geomap/style/markers.test.ts
+++ b/public/app/plugins/panel/geomap/style/markers.test.ts
@@ -8,7 +8,10 @@ import {
   opacityExpression,
   rotationExpression,
   offsetExpression,
+  getMarkerMaker,
+  circleMarker,
 } from './markers';
+import { defaultStyleConfig } from './types';
 
 // Mock dependencies
 jest.mock('app/features/dimensions/resource', () => ({
@@ -99,5 +102,32 @@ describe('getWebGLStyle', () => {
 
     // Clean up the spy
     consoleErrorSpy.mockRestore();
+  });
+});
+
+describe('Icon Path Consistency', () => {
+  const circleIconPath = 'img/icons/marker/circle.svg';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use consistent paths between default and selected circle icons', () => {
+    // Default config should use the standard marker path format
+    expect(defaultStyleConfig.symbol.fixed).toBe(circleIconPath);
+  });
+
+  it('should handle default and explicitly selected circle icons the same way for WebGL style', async () => {
+    const defaultStyle = await getWebGLStyle(); // No symbol
+    const explicitCircleStyle = await getWebGLStyle(circleIconPath);
+
+    expect(explicitCircleStyle).toEqual(defaultStyle);
+  });
+
+  it('should create valid marker maker for default icon', async () => {
+    const defaultMaker = await getMarkerMaker(); // No symbol
+
+    // Default should use the built-in circle marker
+    expect(defaultMaker).toBe(circleMarker);
   });
 });

--- a/public/app/plugins/panel/geomap/style/markers.test.ts
+++ b/public/app/plugins/panel/geomap/style/markers.test.ts
@@ -113,7 +113,6 @@ describe('Icon Path Consistency', () => {
   });
 
   it('should use consistent paths between default and selected circle icons', () => {
-    // Default config should use the standard marker path format
     expect(defaultStyleConfig.symbol.fixed).toBe(circleIconPath);
   });
 
@@ -127,7 +126,6 @@ describe('Icon Path Consistency', () => {
   it('should create valid marker maker for default icon', async () => {
     const defaultMaker = await getMarkerMaker(); // No symbol
 
-    // Default should use the built-in circle marker
     expect(defaultMaker).toBe(circleMarker);
   });
 });

--- a/public/app/plugins/panel/geomap/style/types.ts
+++ b/public/app/plugins/panel/geomap/style/types.ts
@@ -74,7 +74,7 @@ export const defaultStyleConfig = Object.freeze({
   opacity: 0.4,
   symbol: {
     mode: ResourceDimensionMode.Fixed,
-    fixed: 'build/img/icons/marker/circle.svg',
+    fixed: 'img/icons/marker/circle.svg',
   },
   symbolAlign: {
     horizontal: HorizontalAlign.Center,


### PR DESCRIPTION
When creating a new Geomap marker layer with default marker type, url was being routed incorrectly. This is only experienced when creating a new panel as saving and reloading resolves the issue.

Before (note the `GET .../public/build/build/img/icons/marker/circle.svg 404 (Not Found)` console error)
<img width="1585" height="811" alt="image" src="https://github.com/user-attachments/assets/e30ce6b6-9de1-4672-ba4c-7061a5922d42" />

After:
<img width="1582" height="826" alt="image" src="https://github.com/user-attachments/assets/816ff1d5-c000-4212-b0f1-b13315d07a3a" />

Related to https://github.com/grafana/grafana/pull/110146 and https://github.com/grafana/grafana/pull/110316
