### PR TITLE
FolderActionsButton: Move folder action set up for provisioned folders

### DIFF
--- a/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
+++ b/public/app/features/browse-dashboards/components/FolderActionsButton.tsx
@@ -7,7 +7,9 @@ import { Button, Drawer, Dropdown, Icon, Menu, MenuItem } from '@grafana/ui';
 import { Permissions } from 'app/core/components/AccessControl';
 import { appEvents } from 'app/core/core';
 import { RepoType } from 'app/features/provisioning/Wizard/types';
+import { BulkMoveProvisionedResource } from 'app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource';
 import { DeleteProvisionedFolderForm } from 'app/features/provisioning/components/Folders/DeleteProvisionedFolderForm';
+import { useIsProvisionedInstance } from 'app/features/provisioning/hooks/useIsProvisionedInstance';
 import { getReadOnlyTooltipText } from 'app/features/provisioning/utils/repository';
 import { ShowModalReactEvent } from 'app/types/events';
 import { FolderDTO } from 'app/types/folders';
@@ -29,14 +31,18 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const [isOpen, setIsOpen] = useState(false);
   const [showPermissionsDrawer, setShowPermissionsDrawer] = useState(false);
   const [showDeleteProvisionedFolderDrawer, setShowDeleteProvisionedFolderDrawer] = useState(false);
+  const [showMoveProvisionedFolderDrawer, setShowMoveProvisionedFolderDrawer] = useState(false);
   const [moveFolder] = useMoveFolderMutationFacade();
+  const isProvisionedInstance = useIsProvisionedInstance();
 
   const deleteFolder = useDeleteFolderMutationFacade();
 
   const { canEditFolders, canDeleteFolders, canViewPermissions, canSetPermissions } = getFolderPermissions(folder);
   const isProvisionedFolder = folder.managedBy === ManagerKind.Repo;
+  // When its single provisioned folder, cannot move the root repository folder
+  const isProvisionedRootFolder = isProvisionedFolder && !isProvisionedInstance && folder.parentUid === undefined;
   // Can only move folders when the folder is not provisioned
-  const canMoveFolder = canEditFolders && !isProvisionedFolder;
+  const canMoveFolder = canEditFolders && !isProvisionedRootFolder;
 
   const onMove = async (destinationUID: string) => {
     await moveFolder({ folderUID: folder.uid, destinationUID: destinationUID });
@@ -115,6 +121,10 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
     setShowDeleteProvisionedFolderDrawer(true);
   };
 
+  const handleShowMoveProvisionedFolderDrawer = () => {
+    setShowMoveProvisionedFolderDrawer(true);
+  };
+
   const managePermissionsLabel = t('browse-dashboards.folder-actions-button.manage-permissions', 'Manage permissions');
   const moveLabel = t('browse-dashboards.folder-actions-button.move', 'Move');
   const deleteLabel = t('browse-dashboards.folder-actions-button.delete', 'Delete');
@@ -122,7 +132,12 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
   const menu = (
     <Menu>
       {canViewPermissions && <MenuItem onClick={() => setShowPermissionsDrawer(true)} label={managePermissionsLabel} />}
-      {canMoveFolder && !isReadOnlyRepo && <MenuItem onClick={showMoveModal} label={moveLabel} />}
+      {canMoveFolder && !isReadOnlyRepo && (
+        <MenuItem
+          onClick={isProvisionedFolder ? handleShowMoveProvisionedFolderDrawer : showMoveModal}
+          label={moveLabel}
+        />
+      )}
       {canDeleteFolders && !isReadOnlyRepo && (
         <MenuItem
           destructive
@@ -172,6 +187,19 @@ export function FolderActionsButton({ folder, repoType, isReadOnlyRepo }: Props)
           <DeleteProvisionedFolderForm
             parentFolder={folder}
             onDismiss={() => setShowDeleteProvisionedFolderDrawer(false)}
+          />
+        </Drawer>
+      )}
+      {showMoveProvisionedFolderDrawer && (
+        <Drawer
+          title={t('browse-dashboards.action.move-provisioned-folder', 'Move provisioned folder')}
+          subtitle={folder.title}
+          onClose={() => setShowMoveProvisionedFolderDrawer(false)}
+        >
+          <BulkMoveProvisionedResource
+            folderUid={folder.uid}
+            selectedItems={{ dashboard: {}, folder: { [folder.uid]: true } }}
+            onDismiss={() => setShowMoveProvisionedFolderDrawer(false)}
           />
         </Drawer>
       )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3496,6 +3496,7 @@
       "move-modal-field-label": "Folder name",
       "move-modal-text": "This action will move the following content:",
       "move-modal-title": "Move",
+      "move-provisioned-folder": "Move provisioned folder",
       "moving": "Moving...",
       "new-folder-name-required-phrase": "Folder name is required.",
       "selected-mix-resources-modal-text": "You have selected both provisioned and non-provisioned resources. These cannot be processed together. Please select only provisioned resources or only non-provisioned resources and try again.",


### PR DESCRIPTION
**What is this feature?**

`FolderActionsButton` : Allow move action on folder. 
<img width="560" height="274" alt="image" src="https://github.com/user-attachments/assets/fa010cc0-ab23-4750-be29-50f32bdbc043" />


**Why do we need this feature?**

Add missing feature

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/590

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
