### PR TITLE
Alerting: Return 409 Conflict instead of 500 when deleting in-use contact point

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -199,6 +199,12 @@ func (srv *ProvisioningSrv) RoutePutContactPoint(c *contextmodel.ReqContext, cp 
 
 func (srv *ProvisioningSrv) RouteDeleteContactPoint(c *contextmodel.ReqContext, UID string) response.Response {
 	err := srv.contactPointService.DeleteContactPoint(c.Req.Context(), c.GetOrgID(), UID)
+	if errors.Is(err, provisioning.ErrContactPointUsedInRule) {
+		return response.ErrOrFallback(http.StatusConflict, "contact point is in use by a route", err)
+	}
+	if errors.Is(err, provisioning.ErrContactPointReferenced) {
+		return response.ErrOrFallback(http.StatusConflict, "contact point is referenced by a notification policy", err)
+	}
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "failed to delete contact point", err)
 	}


### PR DESCRIPTION
Fixes #111799 

## Description

Fixes the issue where deleting a contact point that is still in use returns HTTP 500 (Internal Server Error). Now returns **HTTP 409 Conflict** with a descriptive error message.

## Which issue(s) this PR fixes


## changes

- Added error handling in `RouteDeleteContactPoint` to check for `ErrContactPointUsedInRule` and `ErrContactPointReferenced`
- Both errors now return HTTP 409 Conflict instead of HTTP 500 Internal Server Error
- Maintains proper error structure with messageId and descriptive messages

## used 409 conflict instead of 400 bad request

The issue suggested returning 400 instead of 500. While both are client errors, **409 Conflict is more semantically accurate**:

- **400 Bad Request:** Indicates the request is malformed or syntactically incorrect
- **409 Conflict:** The request is valid, but conflicts with the current server state (the contact point is referenced by other resources)

This follows industry standards (GitHub, Kubernetes, Docker all use 409 for dependency conflicts).

## Testing

**Before fix:**
```bash
HTTP/1.1 500 Internal Server Error
```

**After fix:**
```bash
$ curl -X DELETE http://localhost:3000/api/v1/provisioning/contact-points/{uid} -v
HTTP/1.1 409 Conflict
{
  "statusCode": 409,
  "messageId": "alerting.notifications.contact-points.referenced",
  "message": "Contact point is currently referenced by a notification policy."
}
```

- All existing tests pass
-  contact point in use → returns 409
- unused contact point → returns 202 (successful deletion)
