### PR TITLE
Provisioning: Show field errors for sync interval

### DIFF
--- a/public/app/features/provisioning/Wizard/FinishStep.tsx
+++ b/public/app/features/provisioning/Wizard/FinishStep.tsx
@@ -12,7 +12,12 @@ import { getGitProviderFields } from './fields';
 import { WizardFormData } from './types';
 
 export const FinishStep = memo(function FinishStep() {
-  const { register, watch, setValue } = useFormContext<WizardFormData>();
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<WizardFormData>();
   const settings = useGetFrontendSettingsQuery();
 
   const [type, readOnly] = watch(['repository.type', 'repository.readOnly']);
@@ -42,6 +47,8 @@ export const FinishStep = memo(function FinishStep() {
             'How often to sync changes from the repository'
           )}
           required
+          error={errors?.repository?.sync?.intervalSeconds?.message}
+          invalid={!!errors?.repository?.sync?.intervalSeconds?.message}
         >
           <Input
             {...register('repository.sync.intervalSeconds', {

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -3,7 +3,7 @@ import { ErrorDetails } from 'app/api/clients/provisioning/v0alpha1';
 import { WizardFormData } from '../Wizard/types';
 
 export type RepositoryField = keyof WizardFormData['repository'];
-export type RepositoryFormPath = `repository.${RepositoryField}`;
+export type RepositoryFormPath = `repository.${RepositoryField}` | `repository.sync.intervalSeconds`;
 export type FormErrorTuple = [RepositoryFormPath | null, { message: string } | null];
 
 /**
@@ -25,7 +25,13 @@ export const getFormErrors = (errors: ErrorDetails[]): FormErrorTuple => {
     'bitbucket.url',
     'git.branch',
     'git.url',
+    'sync.intervalSeconds',
   ];
+
+  const nestedFieldMap: Record<string, RepositoryFormPath> = {
+    'sync.intervalSeconds': 'repository.sync.intervalSeconds',
+  };
+
   const fieldMap: Record<string, RepositoryFormPath> = {
     path: 'repository.path',
     branch: 'repository.branch',
@@ -37,6 +43,12 @@ export const getFormErrors = (errors: ErrorDetails[]): FormErrorTuple => {
     if (error.field) {
       const cleanField = error.field.replace('spec.', '');
       if (fieldsToValidate.includes(cleanField)) {
+        // Check for direct nested field mapping first
+        if (cleanField in nestedFieldMap) {
+          return [nestedFieldMap[cleanField], { message: error.detail || `Invalid ${cleanField}` }];
+        }
+
+        // Fall back to simple field mapping for non-nested fields
         const fieldParts = cleanField.split('.');
         const lastPart = fieldParts[fieldParts.length - 1];
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Show field errors for the sync interval field. 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/598

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
