### PR TITLE
CI: Use self-hosted runners

### DIFF
--- a/.github/workflows/run-dashboard-search-e2e.yml
+++ b/.github/workflows/run-dashboard-search-e2e.yml
@@ -15,7 +15,7 @@ permissions: {}
 
 jobs:
   setup:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     if: github.event.pull_request.draft == false
     outputs:
       ini_files: ${{ steps.get_files.outputs.ini_files }}
@@ -83,7 +83,7 @@ jobs:
 
   run_tests:
       needs: setup
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-x64
       continue-on-error: true
       if: github.event.pull_request.draft == false
       strategy:


### PR DESCRIPTION
We're running out of storage on the GitHub-hosted runners, so switch to self-hosted AWS runners. They have more storage (at least 100 GiB), so we should do a lot better.