### PR TITLE
Alerting: Add support for free form words for group and namespace filter

### DIFF
--- a/public/app/features/alerting/unified/rule-list/GroupedView.tsx
+++ b/public/app/features/alerting/unified/rule-list/GroupedView.tsx
@@ -49,13 +49,19 @@ interface DataSourceLoaderProps {
   rulesSourceIdentifier: DataSourceRulesSourceIdentifier;
   groupFilter?: string;
   namespaceFilter?: string;
+  freeFormWordsFilter?: string[];
 }
 
 export function GrafanaDataSourceLoader() {
   return <DataSourceSection name="Grafana" application="grafana" uid="grafana" isLoading={true} />;
 }
 
-function DataSourceLoader({ rulesSourceIdentifier, groupFilter, namespaceFilter }: DataSourceLoaderProps) {
+function DataSourceLoader({
+  rulesSourceIdentifier,
+  groupFilter,
+  namespaceFilter,
+  freeFormWordsFilter,
+}: DataSourceLoaderProps) {
   const { data: dataSourceInfo, isLoading, error } = useDiscoverDsFeaturesQuery({ uid: rulesSourceIdentifier.uid });
 
   const { uid, name } = rulesSourceIdentifier;
@@ -77,6 +83,7 @@ function DataSourceLoader({ rulesSourceIdentifier, groupFilter, namespaceFilter 
           application={dataSourceInfo.application}
           groupFilter={groupFilter}
           namespaceFilter={namespaceFilter}
+          freeFormWordsFilter={freeFormWordsFilter}
         />
       </DataSourceErrorBoundary>
     );

--- a/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedDataSourceLoader.tsx
@@ -23,6 +23,7 @@ interface LoaderProps extends Required<Pick<DataSourceSectionProps, 'application
   rulesSourceIdentifier: DataSourceRulesSourceIdentifier;
   groupFilter?: string;
   namespaceFilter?: string;
+  freeFormWordsFilter?: string[];
 }
 
 export function PaginatedDataSourceLoader({
@@ -30,6 +31,7 @@ export function PaginatedDataSourceLoader({
   application,
   groupFilter,
   namespaceFilter,
+  freeFormWordsFilter,
 }: LoaderProps) {
   const key = `${rulesSourceIdentifier.uid}-${groupFilter}-${namespaceFilter}`;
 
@@ -41,11 +43,18 @@ export function PaginatedDataSourceLoader({
       application={application}
       groupFilter={groupFilter}
       namespaceFilter={namespaceFilter}
+      freeFormWordsFilter={freeFormWordsFilter}
     />
   );
 }
 
-function PaginatedGroupsLoader({ rulesSourceIdentifier, application, groupFilter, namespaceFilter }: LoaderProps) {
+function PaginatedGroupsLoader({
+  rulesSourceIdentifier,
+  application,
+  groupFilter,
+  namespaceFilter,
+  freeFormWordsFilter,
+}: LoaderProps) {
   // If there are filters, we don't want to populate the cache to avoid performance issues
   // Filtering may trigger multiple HTTP requests, which would populate the cache with a lot of groups hurting performance
   const hasFilters = Boolean(groupFilter || namespaceFilter);
@@ -73,8 +82,9 @@ function PaginatedGroupsLoader({ rulesSourceIdentifier, application, groupFilter
       groupFilterFn(group, {
         namespace: namespaceFilter,
         groupName: groupFilter,
-      }),
-    [namespaceFilter, groupFilter]
+        freeFormWords: freeFormWordsFilter ?? [],
+      }).matches,
+    [namespaceFilter, groupFilter, freeFormWordsFilter]
   );
 
   const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
@@ -25,16 +25,24 @@ import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from './paginationLimi
 interface LoaderProps {
   groupFilter?: string;
   namespaceFilter?: string;
+  freeFormWordsFilter?: string[];
 }
 
-export function PaginatedGrafanaLoader({ groupFilter, namespaceFilter }: LoaderProps) {
+export function PaginatedGrafanaLoader({ groupFilter, namespaceFilter, freeFormWordsFilter }: LoaderProps) {
   const key = `${groupFilter}-${namespaceFilter}`;
 
   // Key is crucial. It resets the generator when filters change.
-  return <PaginatedGroupsLoader key={key} groupFilter={groupFilter} namespaceFilter={namespaceFilter} />;
+  return (
+    <PaginatedGroupsLoader
+      key={key}
+      groupFilter={groupFilter}
+      namespaceFilter={namespaceFilter}
+      freeFormWordsFilter={freeFormWordsFilter}
+    />
+  );
 }
 
-function PaginatedGroupsLoader({ groupFilter, namespaceFilter }: LoaderProps) {
+function PaginatedGroupsLoader({ groupFilter, namespaceFilter, freeFormWordsFilter }: LoaderProps) {
   // If there are filters, we don't want to populate the cache to avoid performance issues
   // Filtering may trigger multiple HTTP requests, which would populate the cache with a lot of groups hurting performance
   const hasFilters = Boolean(groupFilter || namespaceFilter);
@@ -62,8 +70,9 @@ function PaginatedGroupsLoader({ groupFilter, namespaceFilter }: LoaderProps) {
       groupFilterFn(group, {
         namespace: namespaceFilter,
         groupName: groupFilter,
-      }),
-    [namespaceFilter, groupFilter]
+        freeFormWords: freeFormWordsFilter ?? [],
+      }).matches,
+    [namespaceFilter, groupFilter, freeFormWordsFilter]
   );
 
   const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
@@ -73,9 +73,10 @@ export function useFilteredRulesIteratorProvider() {
       withAbort(abortController.signal),
       concatMap((groups) =>
         groups
-          .filter((group) => groupFilter(group, normalizedFilterState))
-          .flatMap((group) => group.rules.map((rule) => ({ group, rule })))
-          .filter(({ rule }) => ruleFilter(rule, normalizedFilterState))
+          .map((group) => ({ group, filterResult: groupFilter(group, normalizedFilterState) }))
+          .filter(({ filterResult }) => filterResult.matches)
+          .flatMap(({ group, filterResult }) => group.rules.map((rule) => ({ group, rule, filterResult })))
+          .filter(({ rule, filterResult }) => ruleFilter(rule, normalizedFilterState, filterResult.freeFormMatched))
           .map(({ group, rule }) => mapGrafanaRuleToRuleWithOrigin(group, rule))
       ),
       catchError(() => empty())


### PR DESCRIPTION
## What is this feature?

This PR adds support for free-form word filtering across alert rule groups and namespaces in the unified alerting rule list view.

## Why do we need this feature?

Currently, when users enter free-form search text, the filtering only matches against individual alert rule names. This means if a user searches for a group or namespace name, no results are returned even though relevant rules exist within those matching groups/namespaces. This creates a suboptimal search experience when users want to find rules by their organizational structure.

## What does this PR do?

Enhances the filtering logic to match free-form search text against:
- Alert rule names (existing behavior)
- **Group names** (new)
- **Namespace/folder names** (new)

When a match is found at the group or namespace level, all rules within that group are included in the results without requiring each individual rule name to match.

### Implementation details

- Modified `groupFilter()` to return a `GroupFilterResult` object that tracks whether the free-form text matched at the group level
- Updated `ruleFilter()` to accept a `freeFormAlreadyMatched` parameter that skips rule-level matching when the group/namespace already matched
- Propagated `freeFormWordsFilter` through the component hierarchy:
  - `GroupedView.tsx`
  - `PaginatedDataSourceLoader.tsx`
  - `PaginatedGrafanaLoader.tsx`
- Updated the filtered rules iterator to pass through the match context

This optimization prevents unnecessary filtering when we already know the entire group should be included, improving both performance and user experience.