### PR TITLE
[release-12.1.3] Table: Avoid thrown error due to internal React issue

### DIFF
--- a/public/app/plugins/panel/table/table-new/TablePanel.tsx
+++ b/public/app/plugins/panel/table/table-new/TablePanel.tsx
@@ -34,6 +34,10 @@ export function TablePanel(props: Props) {
 
   const theme = useTheme2();
   const panelContext = usePanelContext();
+  const _getActions = useCallback(
+    (frame: DataFrame, field: Field, rowIndex: number) => getCellActions(frame, field, rowIndex, replaceVariables),
+    [replaceVariables]
+  );
   const frames = hasDeprecatedParentRowIndex(data.series)
     ? migrateFromParentRowIndexToNestedFrames(data.series)
     : data.series;
@@ -56,11 +60,6 @@ export function TablePanel(props: Props) {
   }
 
   const enableSharedCrosshair = panelContext.sync && panelContext.sync() !== DashboardCursorSync.Off;
-
-  const _getActions = useCallback(
-    (frame: DataFrame, field: Field, rowIndex: number) => getCellActions(frame, field, rowIndex, replaceVariables),
-    [replaceVariables]
-  );
 
   const tableElement = (
     <TableNG


### PR DESCRIPTION
Fixes #111527

This was fixed in 12.2.0 in https://github.com/grafana/grafana/pull/109832, but we got a report on 12.1.x of the issue. This just patches that exact problem to avoid the table crash.