### PR TITLE
SQL Expressions: Fix string constant in frame type

### DIFF
--- a/pkg/expr/convert_to_full_long.go
+++ b/pkg/expr/convert_to_full_long.go
@@ -15,7 +15,7 @@ const (
 
 	// These are not types in the SDK or dataplane contract yet.
 	numericFullLongType    = "numeric_full_long"
-	timeseriesFullLongType = "time_series_full_long"
+	timeseriesFullLongType = "timeseries_full_long"
 )
 
 func ConvertToFullLong(frames data.Frames) (data.Frames, error) {

--- a/pkg/expr/convert_to_full_long.go
+++ b/pkg/expr/convert_to_full_long.go
@@ -14,8 +14,8 @@ const (
 	SQLDisplayFieldName = "__display_name__"
 
 	// These are not types in the SDK or dataplane contract yet.
-	numericFullLongType    = "numeric_full_long"
-	timeseriesFullLongType = "timeseries_full_long"
+	numericFullLongType    = "numeric-full-long"
+	timeseriesFullLongType = "timeseries-full-long"
 )
 
 func ConvertToFullLong(frames data.Frames) (data.Frames, error) {


### PR DESCRIPTION
s/time_series/timeseries
this makes it more consistent with the other timeseries kind strings, see https://github.com/grafana/grafana-plugin-sdk-go/blob/896568c764b7dc295d652f527fc21ab937078543/data/frame_type.go#L27

**What is this feature?**

When SQL expressions converts labeled input, it outputs the numeric or time series in the `full_long` format. This changes `times_series_full_long` to `timeseries_full_long` for consistency with the other frame type constants.

**Special notes for your reviewer:**

- I can't find anything currently referencing this string/type so don't think changelog is needed.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
