### PR TITLE
Add support for the future rename of the docs plugin app to Grafana Pathfinder

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -14,7 +14,10 @@ const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   'grafana-investigations-app',
   'grafana-assistant-app',
   'grafana-dash-app',
+  // The docs plugin ID is going to transition from grafana-grafanadocsplugin-app to grafana-pathfinder-app.
+  // Support both until that migration is complete.
   'grafana-grafanadocsplugin-app',
+  'grafana-pathfinder-app',
 ];
 
 export type ExtensionSidebarContextType = {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -14,6 +14,9 @@ interface ToolbarItemButtonProps {
 
 function getPluginIcon(pluginId?: string): string {
   switch (pluginId) {
+    // The docs plugin ID is going to transition from grafana-grafanadocsplugin-app to grafana-pathfinder-app.
+    // Support both until that migration is complete.
+    case 'grafana-grafanadocsplugin-app':
     case 'grafana-pathfinder-app':
       return 'book';
     case 'grafana-investigations-app':

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -14,7 +14,7 @@ interface ToolbarItemButtonProps {
 
 function getPluginIcon(pluginId?: string): string {
   switch (pluginId) {
-    case 'grafana-grafanadocsplugin-app':
+    case 'grafana-pathfinder-app':
       return 'book';
     case 'grafana-investigations-app':
       return 'eye';


### PR DESCRIPTION
Tested in local development by installing both the existing plugin and the renamed plugin using https://github.com/grafana/docs-plugin/commit/1251e0a8877ed85ea1c9371543ad4baee1637405 

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
