### PR TITLE
Logs: Fix spacing between the logs volume and logs panel

### DIFF
--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -77,7 +77,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       label: 'exploreMain',
       // Is needed for some transition animations to work.
       position: 'relative',
-      marginTop: '21px',
+      marginTop: theme.spacing(3),
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -799,28 +799,30 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           onClickHideField={hideField}
         />
       )}
-      <PanelChrome
-        title={t('explore.unthemed-logs.title-logs-volume', 'Logs volume')}
-        collapsible
-        collapsed={!logsVolumeEnabled}
-        onToggleCollapse={onToggleLogsVolumeCollapse}
-      >
-        {logsVolumeEnabled && (
-          <LogsVolumePanelList
-            toggleLegendRef={toggleLegendRef}
-            absoluteRange={absoluteRange}
-            width={width}
-            logsVolumeData={logsVolumeData}
-            onUpdateTimeRange={onChangeTime}
-            timeZone={timeZone}
-            splitOpen={splitOpen}
-            onLoadLogsVolume={loadLogsVolumeData}
-            onDisplayedSeriesChanged={onDisplayedSeriesChanged}
-            eventBus={logsVolumeEventBus}
-            onClose={() => onToggleLogsVolumeCollapse(true)}
-          />
-        )}
-      </PanelChrome>
+      <div className={styles.logsVolumePanel}>
+        <PanelChrome
+          title={t('explore.unthemed-logs.title-logs-volume', 'Logs volume')}
+          collapsible
+          collapsed={!logsVolumeEnabled}
+          onToggleCollapse={onToggleLogsVolumeCollapse}
+        >
+          {logsVolumeEnabled && (
+            <LogsVolumePanelList
+              toggleLegendRef={toggleLegendRef}
+              absoluteRange={absoluteRange}
+              width={width}
+              logsVolumeData={logsVolumeData}
+              onUpdateTimeRange={onChangeTime}
+              timeZone={timeZone}
+              splitOpen={splitOpen}
+              onLoadLogsVolume={loadLogsVolumeData}
+              onDisplayedSeriesChanged={onDisplayedSeriesChanged}
+              eventBus={logsVolumeEventBus}
+              onClose={() => onToggleLogsVolumeCollapse(true)}
+            />
+          )}
+        </PanelChrome>
+      </div>
       <PanelChrome
         titleItems={[
           config.featureToggles.logsExploreTableVisualisation ? (
@@ -1277,6 +1279,9 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
     stickyNavigation: css({
       overflow: 'visible',
       ...(config.featureToggles.logsInfiniteScrolling && { marginBottom: '0px' }),
+    }),
+    logsVolumePanel: css({
+      marginBottom: theme.spacing(1.5),
     }),
   };
 };


### PR DESCRIPTION
just a small nit. this changes the spacing between the `logs volume` and the `logs` panel when rendered in explore.

**before vs after:**
- in the before (left), you can see there is no spacing between the two panels
- in the after (right), you can see there is an appropriate margin between the two.

<div>
<img width="49%" height="946" alt="Screenshot 2025-10-02 at 23 41 51" src="https://github.com/user-attachments/assets/f3a7bca6-7a57-49e8-8ecb-87ad58163b3d" />

<img width="49%" height="947" alt="Screenshot 2025-10-02 at 23 44 20" src="https://github.com/user-attachments/assets/fcc6fa21-a1fe-4614-8c66-a8ac7760b728" />
</div>