### PR TITLE
DS-Apiservers: fix error handling in ds apiservers

### DIFF
--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -99,7 +99,8 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 		})
 
 		// all errors get converted into k8 errors when sent in responder.Error and lose important context like downstream info
-		if e, ok := err.(errutil.Error); ok && e.Source == errutil.SourceDownstream {
+		var e errutil.Error
+		if errors.As(err, &e) && e.Source == errutil.SourceDownstream {
 			responder.Object(int(backend.StatusBadRequest),
 				&query.QueryDataResponse{QueryDataResponse: backend.QueryDataResponse{Responses: map[string]backend.DataResponse{
 					"A": {

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/data/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	query "github.com/grafana/grafana/pkg/apis/query/v0alpha1"
 	query_headers "github.com/grafana/grafana/pkg/registry/apis/query"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -96,6 +97,21 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 			PluginContext: pluginCtx,
 			Headers:       query_headers.ExtractKnownHeaders(req.Header),
 		})
+
+		// all errors get converted into k8 errors when sent in responder.Error and lose important context like downstream info
+		if e, ok := err.(errutil.Error); ok && e.Source == errutil.SourceDownstream {
+			responder.Object(int(backend.StatusBadRequest),
+				&query.QueryDataResponse{QueryDataResponse: backend.QueryDataResponse{Responses: map[string]backend.DataResponse{
+					"A": {
+						Error:       errors.New(e.LogMessage),
+						ErrorSource: backend.ErrorSourceDownstream,
+						Status:      backend.StatusBadRequest,
+					},
+				}}},
+			)
+			return
+		}
+
 		if err != nil {
 			responder.Error(err)
 			return


### PR DESCRIPTION
**What is this feature?**

Improves error handling in grafana cloud, not user facing.

**Why do we need this feature?**

many of our datasources return errors like so: 
```
func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
    // ... various things
    if err != nil {
        return nil, backend.DownstreamError(fmt.Errorf("some error"))
    }
}
```

this seems to work well enough in grpc/st modes, but when we run these datasources as separate apiservers, they eventually hit this part of the code path which will send: 
```
responder.Error(error)
```

But if we use the debugger to see what happens when we responder.Error, we'll see that we end up coercing the error into a k8s style error: https://github.com/kubernetes/apiserver/blob/v0.34.1/pkg/endpoints/handlers/responsewriters/writers.go#L381

and in the process lose all of our important context like the original status code, the fact that it was a downstream error, etc. So for now if it's a downstream error, I think we should instead return a queryDataResponse object so it gets sent un-changed. It's not ideal because we've lost important things like the refId etc, but it is better than not getting anything. 

**Who is this feature for?**
internal grafana devs

**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/grafana-enterprise/issues/9803

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
