### PR TITLE
Provisioning: always set job status when a sync job is created

### DIFF
--- a/pkg/registry/apis/provisioning/jobs.go
+++ b/pkg/registry/apis/provisioning/jobs.go
@@ -20,16 +20,23 @@ type JobQueueGetter interface {
 }
 
 type jobsConnector struct {
-	repoGetter RepoGetter
-	jobs       JobQueueGetter
-	historic   jobs.HistoryReader
+	repoGetter            RepoGetter
+	statusPatcherProvider StatusPatcherProvider
+	jobs                  JobQueueGetter
+	historic              jobs.HistoryReader
 }
 
-func NewJobsConnector(repoGetter RepoGetter, jobs JobQueueGetter, historic jobs.HistoryReader) *jobsConnector {
+func NewJobsConnector(
+	repoGetter RepoGetter,
+	statusPatcherProvider StatusPatcherProvider,
+	jobs JobQueueGetter,
+	historic jobs.HistoryReader,
+) *jobsConnector {
 	return &jobsConnector{
-		repoGetter: repoGetter,
-		jobs:       jobs,
-		historic:   historic,
+		repoGetter:            repoGetter,
+		statusPatcherProvider: statusPatcherProvider,
+		jobs:                  jobs,
+		historic:              historic,
 	}
 }
 
@@ -124,6 +131,20 @@ func (c *jobsConnector) Connect(
 			return
 		}
 		spec.Repository = name
+
+		err = c.statusPatcherProvider.GetStatusPatcher().Patch(ctx, cfg, map[string]interface{}{
+			"op":   "replace",
+			"path": "/status/sync",
+			"value": &provisioning.SyncStatus{
+				State:   provisioning.JobStatePending,
+				LastRef: cfg.Status.Sync.LastRef,
+				Started: time.Now().UnixMilli(),
+			},
+		})
+		if err != nil {
+			responder.Error(err)
+			return
+		}
 
 		job, err := c.jobs.GetJobQueue().Insert(ctx, cfg.Namespace, spec)
 		if err != nil {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -494,7 +494,7 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	storage[provisioning.RepositoryResourceInfo.StoragePath("history")] = &historySubresource{
 		repoGetter: b,
 	}
-	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = NewJobsConnector(b, b, jobHistory)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("jobs")] = NewJobsConnector(b, b, b, jobHistory)
 
 	// Add any extra storage
 	for _, extra := range b.extras {


### PR DESCRIPTION
**What is this feature?**

In Provisioning, when a Sync job is manually created by a user via a manual Pull, the `status` subresource is not updated to reflect the fact a job is running. 

This PR addresses that. 

**Who is this feature for?**

Users of GitSync. 

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/538

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
