### PR TITLE
Table: Support string-based time fields in sorting

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -448,28 +448,28 @@ describe('TableNG utils', () => {
 
   describe('getComparator', () => {
     it('should compare numbers correctly', () => {
-      const comparator = getComparator(FieldType.number);
+      const comparator = getComparator(FieldType.number, 0);
       expect(comparator(1, 2)).toBeLessThan(0);
       expect(comparator(2, 1)).toBeGreaterThan(0);
       expect(comparator(1, 1)).toBe(0);
     });
 
     it('should handle undefined values', () => {
-      const comparator = getComparator(FieldType.number);
+      const comparator = getComparator(FieldType.number, 0);
       expect(comparator(undefined, 1)).toBeLessThan(0);
       expect(comparator(1, undefined)).toBeGreaterThan(0);
       expect(comparator(undefined, undefined)).toBe(0);
     });
 
     it('should compare strings case-insensitively', () => {
-      const comparator = getComparator(FieldType.string);
+      const comparator = getComparator(FieldType.string, 0);
       expect(comparator('a', 'B')).toBeLessThan(0);
       expect(comparator('B', 'a')).toBeGreaterThan(0);
       expect(comparator('a', 'a')).toBe(0);
     });
 
-    it('should handle time values', () => {
-      const comparator = getComparator(FieldType.time);
+    it('should handle numeric time values', () => {
+      const comparator = getComparator(FieldType.time, 1672531200000);
       const t1 = 1672531200000; // 2023-01-01
       const t2 = 1672617600000; // 2023-01-02
 
@@ -478,16 +478,24 @@ describe('TableNG utils', () => {
       expect(comparator(t1, t1)).toBe(0);
     });
 
+    it('should handle string time values', () => {
+      const comparator = getComparator(FieldType.time, '2020-01-01T00:00:00Z');
+      const t1 = '2020-01-01T00:00:00Z';
+      const t2 = '2020-01-02T00:00:00Z';
+
+      expect(comparator(t1, t2)).toBeLessThan(0);
+      expect(comparator(t2, t1)).toBeGreaterThan(0);
+      expect(comparator(t1, t1)).toBe(0);
+    });
+
     it('should handle boolean values', () => {
-      const comparator = getComparator(FieldType.boolean);
+      const comparator = getComparator(FieldType.boolean, false);
       expect(comparator(false, true)).toBeLessThan(0);
       expect(comparator(true, false)).toBeGreaterThan(0);
       expect(comparator(true, true)).toBe(0);
     });
 
     it('should compare frame values', () => {
-      const comparator = getComparator(FieldType.frame);
-
       // simulate using `first`.
       const frame1: DataFrameWithValue = {
         value: 1,
@@ -501,6 +509,8 @@ describe('TableNG utils', () => {
         value: 4,
         ...createDataFrame({ fields: [{ name: 'a', values: [4, 5, 6, 7] }] }),
       };
+
+      const comparator = getComparator(FieldType.frame, frame1);
 
       expect(comparator(frame1, frame2)).toBeLessThan(0);
       expect(comparator(frame2, frame1)).toBeGreaterThan(0);

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -635,7 +635,7 @@ export function applySort(
 
     for (let i = 0; i < sortColumns.length; i++) {
       const { columnKey, direction } = sortColumns[i];
-      const compare = getComparator(columnTypes[columnKey]);
+      const compare = getComparator(columnTypes[columnKey], a[columnKey]);
       const sortDir = direction === 'ASC' ? 1 : -1;
 
       result = sortDir * compare(a[columnKey], b[columnKey]);
@@ -721,12 +721,13 @@ const frameCompare: Comparator = (a, b) => {
 /**
  * @internal
  */
-export function getComparator(sortColumnType: FieldType): Comparator {
+export function getComparator(sortColumnType: FieldType, exampleValue: unknown): Comparator {
   switch (sortColumnType) {
     // Handle sorting for frame type fields (sparklines)
     case FieldType.frame:
       return frameCompare;
     case FieldType.time:
+      return typeof exampleValue === 'string' ? strCompare : numCompare;
     case FieldType.number:
     case FieldType.boolean:
       return numCompare;


### PR DESCRIPTION
Fixes #111919

While all of the test cases we saw in testing the new table had Time fields with numeric values, this OSS issue came in with a time field containing ISO strings. This PR updates the sort algorithm to account for this.