### PR TITLE
Alerting: Use empty feature manager for creating test state

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -1317,7 +1317,7 @@ func stateForRule(rule *models.AlertRule, ts time.Time, evalState eval.State) *s
 	for k, v := range rule.Labels {
 		s.Labels[k] = v
 	}
-	for k, v := range state.GetRuleExtraLabels(&logtest.Fake{}, rule, "", true, nil) {
+	for k, v := range state.GetRuleExtraLabels(&logtest.Fake{}, rule, "", true, featuremgmt.WithFeatures()) {
 		if _, ok := s.Labels[k]; !ok {
 			s.Labels[k] = v
 		}


### PR DESCRIPTION
**What is this feature?**
This PR fixes flaky test introduced in https://github.com/grafana/grafana/pull/111900. The test state was initialized with nil feature manager but scheduler uses empty one. This leads to different CacheID and tests that rely upon preset state - start failing when rule contains notification settings. 
