### PR TITLE
Provisioning: Refactor to combine validation and test endpoint logic

### DIFF
--- a/apps/provisioning/pkg/repository/tester.go
+++ b/apps/provisioning/pkg/repository/tester.go
@@ -1,0 +1,84 @@
+package repository
+
+import (
+	"context"
+	"net/http"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+// SimpleRepositoryTester will validate the repository configuration, and then proceed to test the connection to the repository
+type SimpleRepositoryTester struct {
+	validator RepositoryValidator
+}
+
+func NewSimpleRepositoryTester(validator RepositoryValidator) SimpleRepositoryTester {
+	return SimpleRepositoryTester{
+		validator: validator,
+	}
+}
+
+// TestRepository validates the repository and then runs a health check
+func (t *SimpleRepositoryTester) TestRepository(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
+	errors := t.validator.ValidateRepository(repo)
+	if len(errors) > 0 {
+		rsp := &provisioning.TestResults{
+			Code:    http.StatusUnprocessableEntity, // Invalid
+			Success: false,
+			Errors:  make([]provisioning.ErrorDetails, len(errors)),
+		}
+		for i, err := range errors {
+			rsp.Errors[i] = provisioning.ErrorDetails{
+				Type:   metav1.CauseType(err.Type),
+				Field:  err.Field,
+				Detail: err.Detail,
+			}
+		}
+		return rsp, nil
+	}
+
+	return repo.Test(ctx)
+}
+
+type VerifyAgainstExistingRepositories func(ctx context.Context, cfg *provisioning.Repository) *field.Error // defined this way to prevent an import cycle
+
+// RepositoryTesterWithExistingChecker will validate the repository configuration, run a health check, and then compare it against existing repositories
+type RepositoryTesterWithExistingChecker struct {
+	tester SimpleRepositoryTester
+	verify VerifyAgainstExistingRepositories
+}
+
+func NewRepositoryTesterWithExistingChecker(tester SimpleRepositoryTester, verify VerifyAgainstExistingRepositories) RepositoryTesterWithExistingChecker {
+	return RepositoryTesterWithExistingChecker{
+		tester: tester,
+		verify: verify,
+	}
+}
+
+// TestRepositoryAndCheckExisting validates the repository, runs a health check, and then compares it against existing repositories
+func (c *RepositoryTesterWithExistingChecker) TestRepositoryAndCheckExisting(ctx context.Context, repo Repository) (*provisioning.TestResults, error) {
+	rsp, err := c.tester.TestRepository(ctx, repo)
+	if err != nil {
+		return nil, err
+	}
+
+	if rsp.Success {
+		cfg := repo.Config()
+		if validationErr := c.verify(ctx, cfg); validationErr != nil {
+			rsp = &provisioning.TestResults{
+				Success: false,
+				Code:    http.StatusUnprocessableEntity,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseType(validationErr.Type),
+					Field:  validationErr.Field,
+					Detail: validationErr.Detail,
+				}},
+			}
+		}
+	}
+
+	return rsp, nil
+}

--- a/apps/provisioning/pkg/repository/tester_test.go
+++ b/apps/provisioning/pkg/repository/tester_test.go
@@ -1,0 +1,204 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestTestRepository(t *testing.T) {
+	tests := []struct {
+		name          string
+		repository    *MockRepository
+		expectedCode  int
+		expectedErrs  []provisioning.ErrorDetails
+		expectedError error
+	}{
+		{
+			name: "validation fails",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						// Missing required title
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				return m
+			}(),
+			expectedCode: http.StatusUnprocessableEntity,
+			expectedErrs: []provisioning.ErrorDetails{{
+				Type:   metav1.CauseTypeFieldValueRequired,
+				Field:  "spec.title",
+				Detail: "a repository title must be given",
+			}},
+		},
+		{
+			name: "test passes",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Title: "Test Repo",
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				m.On("Test", mock.Anything).Return(&provisioning.TestResults{
+					Code:    http.StatusOK,
+					Success: true,
+				}, nil)
+				return m
+			}(),
+			expectedCode: http.StatusOK,
+			expectedErrs: nil,
+		},
+		{
+			name: "test fails with error",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Title: "Test Repo",
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				m.On("Test", mock.Anything).Return(nil, fmt.Errorf("test error"))
+				return m
+			}(),
+			expectedError: fmt.Errorf("test error"),
+		},
+		{
+			name: "test fails with results",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Title: "Test Repo",
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				m.On("Test", mock.Anything).Return(&provisioning.TestResults{
+					Code:    http.StatusBadRequest,
+					Success: false,
+					Errors: []provisioning.ErrorDetails{{
+						Type:  metav1.CauseTypeFieldValueInvalid,
+						Field: "spec.property",
+					}},
+				}, nil)
+				return m
+			}(),
+			expectedCode: http.StatusBadRequest,
+			expectedErrs: []provisioning.ErrorDetails{{
+				Type:  metav1.CauseTypeFieldValueInvalid,
+				Field: "spec.property",
+			}},
+		},
+	}
+
+	tester := NewSimpleRepositoryTester(NewValidator(10*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			results, err := tester.TestRepository(context.Background(), tt.repository)
+
+			if tt.expectedError != nil {
+				require.Error(t, err)
+				require.Equal(t, tt.expectedError.Error(), err.Error())
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, results)
+			require.Equal(t, tt.expectedCode, results.Code)
+
+			if tt.expectedErrs != nil {
+				require.Equal(t, tt.expectedErrs, results.Errors)
+				require.False(t, results.Success)
+			} else {
+				require.True(t, results.Success)
+				require.Empty(t, results.Errors)
+			}
+		})
+	}
+}
+
+func TestTester_TestRepository(t *testing.T) {
+	repository := NewMockRepository(t)
+	repository.On("Config").Return(&provisioning.Repository{
+		Spec: provisioning.RepositorySpec{
+			Title: "Test Repo",
+		},
+	})
+	repository.On("Validate").Return(field.ErrorList{})
+	repository.On("Test", mock.Anything).Return(&provisioning.TestResults{
+		Code:    http.StatusOK,
+		Success: true,
+	}, nil)
+
+	tester := NewSimpleRepositoryTester(NewValidator(10*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true))
+	results, err := tester.TestRepository(context.Background(), repository)
+	require.NoError(t, err)
+	require.NotNil(t, results)
+	require.Equal(t, http.StatusOK, results.Code)
+	require.True(t, results.Success)
+}
+
+func TestFromFieldError(t *testing.T) {
+	tests := []struct {
+		name           string
+		fieldError     *field.Error
+		expectedCode   int
+		expectedField  string
+		expectedType   metav1.CauseType
+		expectedDetail string
+	}{
+		{
+			name: "required field error",
+			fieldError: &field.Error{
+				Type:   field.ErrorTypeRequired,
+				Field:  "spec.title",
+				Detail: "a repository title must be given",
+			},
+			expectedCode:   http.StatusBadRequest,
+			expectedField:  "spec.title",
+			expectedType:   metav1.CauseTypeFieldValueRequired,
+			expectedDetail: "a repository title must be given",
+		},
+		{
+			name: "not supported field error",
+			fieldError: &field.Error{
+				Type:   field.ErrorTypeNotSupported,
+				Field:  "spec.workflow",
+				Detail: "branch is only supported on git repositories",
+			},
+			expectedCode:   http.StatusBadRequest,
+			expectedField:  "spec.workflow",
+			expectedType:   metav1.CauseTypeFieldValueNotSupported,
+			expectedDetail: "branch is only supported on git repositories",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FromFieldError(tt.fieldError)
+
+			require.NotNil(t, result)
+			require.Equal(t, tt.expectedCode, result.Code)
+			require.False(t, result.Success)
+			require.Len(t, result.Errors, 1)
+
+			errorDetail := result.Errors[0]
+			require.Equal(t, tt.expectedField, errorDetail.Field)
+			require.Equal(t, tt.expectedType, errorDetail.Type)
+			require.Equal(t, tt.expectedDetail, errorDetail.Detail)
+		})
+	}
+}

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -1,12 +1,9 @@
 package repository
 
 import (
-	"context"
-	"fmt"
-	"net/http"
 	"testing"
+	"time"
 
-	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -75,6 +72,28 @@ func TestValidateRepository(t *testing.T) {
 			},
 		},
 		{
+			name: "sync interval too low",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Title: "Test Repo",
+						Sync: provisioning.SyncOptions{
+							Enabled:         true,
+							Target:          provisioning.SyncTargetTypeFolder,
+							IntervalSeconds: 5,
+						},
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				return m
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Contains(t, errors.ToAggregate().Error(), "spec.sync.intervalSeconds: Invalid value")
+			},
+		},
+		{
 			name: "reserved name",
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
@@ -133,6 +152,27 @@ func TestValidateRepository(t *testing.T) {
 			},
 		},
 		{
+			name: "github enabled when image rendering is not allowed",
+			repository: func() *MockRepository {
+				m := NewMockRepository(t)
+				m.On("Config").Return(&provisioning.Repository{
+					Spec: provisioning.RepositorySpec{
+						Title: "Test Repo",
+						Type:  provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				m.On("Validate").Return(field.ErrorList{})
+				return m
+			}(),
+			expectedErrs: 1,
+			validateError: func(t *testing.T, errors field.ErrorList) {
+				require.Contains(t, errors.ToAggregate().Error(), "spec.generateDashboardPreviews: Invalid value")
+			},
+		},
+		{
 			name: "mismatched git config",
 			repository: func() *MockRepository {
 				m := NewMockRepository(t)
@@ -163,16 +203,18 @@ func TestValidateRepository(t *testing.T) {
 						Sync: provisioning.SyncOptions{
 							Enabled:         true,
 							IntervalSeconds: 5,
+							Target:          provisioning.SyncTargetTypeInstance,
 						},
 					},
 				})
 				m.On("Validate").Return(field.ErrorList{})
 				return m
 			}(),
-			expectedErrs: 3,
+			expectedErrs: 4,
 			// 1. missing title
 			// 2. sync target missing
 			// 3. reserved name
+			// 4. sync target not supported
 		},
 		{
 			name: "branch workflow for non-github repository",
@@ -258,199 +300,14 @@ func TestValidateRepository(t *testing.T) {
 		},
 	}
 
+	validator := NewValidator(10*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder}, false)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			errors := ValidateRepository(tt.repository)
+			errors := validator.ValidateRepository(tt.repository)
 			require.Len(t, errors, tt.expectedErrs)
 			if tt.validateError != nil {
 				tt.validateError(t, errors)
 			}
-		})
-	}
-}
-
-func TestTestRepository(t *testing.T) {
-	tests := []struct {
-		name          string
-		repository    *MockRepository
-		expectedCode  int
-		expectedErrs  []provisioning.ErrorDetails
-		expectedError error
-	}{
-		{
-			name: "validation fails",
-			repository: func() *MockRepository {
-				m := NewMockRepository(t)
-				m.On("Config").Return(&provisioning.Repository{
-					Spec: provisioning.RepositorySpec{
-						// Missing required title
-					},
-				})
-				m.On("Validate").Return(field.ErrorList{})
-				return m
-			}(),
-			expectedCode: http.StatusUnprocessableEntity,
-			expectedErrs: []provisioning.ErrorDetails{{
-				Type:   metav1.CauseTypeFieldValueRequired,
-				Field:  "spec.title",
-				Detail: "a repository title must be given",
-			}},
-		},
-		{
-			name: "test passes",
-			repository: func() *MockRepository {
-				m := NewMockRepository(t)
-				m.On("Config").Return(&provisioning.Repository{
-					Spec: provisioning.RepositorySpec{
-						Title: "Test Repo",
-					},
-				})
-				m.On("Validate").Return(field.ErrorList{})
-				m.On("Test", mock.Anything).Return(&provisioning.TestResults{
-					Code:    http.StatusOK,
-					Success: true,
-				}, nil)
-				return m
-			}(),
-			expectedCode: http.StatusOK,
-			expectedErrs: nil,
-		},
-		{
-			name: "test fails with error",
-			repository: func() *MockRepository {
-				m := NewMockRepository(t)
-				m.On("Config").Return(&provisioning.Repository{
-					Spec: provisioning.RepositorySpec{
-						Title: "Test Repo",
-					},
-				})
-				m.On("Validate").Return(field.ErrorList{})
-				m.On("Test", mock.Anything).Return(nil, fmt.Errorf("test error"))
-				return m
-			}(),
-			expectedError: fmt.Errorf("test error"),
-		},
-		{
-			name: "test fails with results",
-			repository: func() *MockRepository {
-				m := NewMockRepository(t)
-				m.On("Config").Return(&provisioning.Repository{
-					Spec: provisioning.RepositorySpec{
-						Title: "Test Repo",
-					},
-				})
-				m.On("Validate").Return(field.ErrorList{})
-				m.On("Test", mock.Anything).Return(&provisioning.TestResults{
-					Code:    http.StatusBadRequest,
-					Success: false,
-					Errors: []provisioning.ErrorDetails{{
-						Type:  metav1.CauseTypeFieldValueInvalid,
-						Field: "spec.property",
-					}},
-				}, nil)
-				return m
-			}(),
-			expectedCode: http.StatusBadRequest,
-			expectedErrs: []provisioning.ErrorDetails{{
-				Type:  metav1.CauseTypeFieldValueInvalid,
-				Field: "spec.property",
-			}},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			results, err := TestRepository(context.Background(), tt.repository)
-
-			if tt.expectedError != nil {
-				require.Error(t, err)
-				require.Equal(t, tt.expectedError.Error(), err.Error())
-				return
-			}
-
-			require.NoError(t, err)
-			require.NotNil(t, results)
-			require.Equal(t, tt.expectedCode, results.Code)
-
-			if tt.expectedErrs != nil {
-				require.Equal(t, tt.expectedErrs, results.Errors)
-				require.False(t, results.Success)
-			} else {
-				require.True(t, results.Success)
-				require.Empty(t, results.Errors)
-			}
-		})
-	}
-}
-
-func TestTester_TestRepository(t *testing.T) {
-	repository := NewMockRepository(t)
-	repository.On("Config").Return(&provisioning.Repository{
-		Spec: provisioning.RepositorySpec{
-			Title: "Test Repo",
-		},
-	})
-	repository.On("Validate").Return(field.ErrorList{})
-	repository.On("Test", mock.Anything).Return(&provisioning.TestResults{
-		Code:    http.StatusOK,
-		Success: true,
-	}, nil)
-
-	results, err := TestRepository(context.Background(), repository)
-	require.NoError(t, err)
-	require.NotNil(t, results)
-	require.Equal(t, http.StatusOK, results.Code)
-	require.True(t, results.Success)
-}
-
-func TestFromFieldError(t *testing.T) {
-	tests := []struct {
-		name           string
-		fieldError     *field.Error
-		expectedCode   int
-		expectedField  string
-		expectedType   metav1.CauseType
-		expectedDetail string
-	}{
-		{
-			name: "required field error",
-			fieldError: &field.Error{
-				Type:   field.ErrorTypeRequired,
-				Field:  "spec.title",
-				Detail: "a repository title must be given",
-			},
-			expectedCode:   http.StatusBadRequest,
-			expectedField:  "spec.title",
-			expectedType:   metav1.CauseTypeFieldValueRequired,
-			expectedDetail: "a repository title must be given",
-		},
-		{
-			name: "not supported field error",
-			fieldError: &field.Error{
-				Type:   field.ErrorTypeNotSupported,
-				Field:  "spec.workflow",
-				Detail: "branch is only supported on git repositories",
-			},
-			expectedCode:   http.StatusBadRequest,
-			expectedField:  "spec.workflow",
-			expectedType:   metav1.CauseTypeFieldValueNotSupported,
-			expectedDetail: "branch is only supported on git repositories",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := FromFieldError(tt.fieldError)
-
-			require.NotNil(t, result)
-			require.Equal(t, tt.expectedCode, result.Code)
-			require.False(t, result.Success)
-			require.Len(t, result.Errors, 1)
-
-			errorDetail := result.Errors[0]
-			require.Equal(t, tt.expectedField, errorDetail.Field)
-			require.Equal(t, tt.expectedType, errorDetail.Type)
-			require.Equal(t, tt.expectedDetail, errorDetail.Detail)
 		})
 	}
 }

--- a/pkg/registry/apis/provisioning/controller/health.go
+++ b/pkg/registry/apis/provisioning/controller/health.go
@@ -23,14 +23,16 @@ type StatusPatcher interface {
 type HealthChecker struct {
 	statusPatcher StatusPatcher
 	healthMetrics healthMetrics
+	tester        repository.SimpleRepositoryTester
 }
 
 // NewHealthChecker creates a new health checker
-func NewHealthChecker(statusPatcher StatusPatcher, registry prometheus.Registerer) *HealthChecker {
+func NewHealthChecker(statusPatcher StatusPatcher, registry prometheus.Registerer, tester repository.SimpleRepositoryTester) *HealthChecker {
 	healthMetrics := registerHealthMetrics(registry)
 	return &HealthChecker{
 		statusPatcher: statusPatcher,
 		healthMetrics: healthMetrics,
+		tester:        tester,
 	}
 }
 
@@ -176,7 +178,7 @@ func (hc *HealthChecker) refreshHealth(ctx context.Context, repo repository.Repo
 		hc.healthMetrics.RecordHealthCheck(outcome, time.Since(start).Seconds())
 	}()
 
-	res, err := repository.TestRepository(ctx, repo)
+	res, err := hc.tester.TestRepository(ctx, repo)
 	if err != nil {
 		outcome = utils.ErrorOutcome
 		logger.Error("failed to test repository", "error", err)

--- a/pkg/registry/apis/provisioning/controller/health_test.go
+++ b/pkg/registry/apis/provisioning/controller/health_test.go
@@ -13,13 +13,15 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	repository "github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
 )
 
 func TestNewHealthChecker(t *testing.T) {
 	mockPatcher := mocks.NewStatusPatcher(t)
 
-	hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+	validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+	hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 	assert.NotNil(t, hc)
 	assert.Equal(t, mockPatcher, hc.statusPatcher)
@@ -136,7 +138,8 @@ func TestShouldCheckHealth(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
-			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+			validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 			result := hc.ShouldCheckHealth(tt.repo)
 			assert.Equal(t, tt.expected, result)
@@ -223,7 +226,8 @@ func TestHasRecentFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
-			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+			validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 			result := hc.HasRecentFailure(tt.healthStatus, tt.failureType)
 			assert.Equal(t, tt.expected, result)
@@ -265,7 +269,8 @@ func TestRecordFailure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
-			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+			validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 			repo := &provisioning.Repository{
 				Status: provisioning.RepositoryStatus{
@@ -310,7 +315,8 @@ func TestRecordFailure(t *testing.T) {
 
 func TestRecordFailureFunction(t *testing.T) {
 	mockPatcher := mocks.NewStatusPatcher(t)
-	hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+	validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+	hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 	testErr := errors.New("test error")
 	result := hc.recordFailure(provisioning.HealthFailureHook, testErr)
@@ -447,7 +453,8 @@ func TestRefreshHealth(t *testing.T) {
 				testError:  tt.testError,
 			}
 
-			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+			validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 			if tt.expectPatch {
 				if tt.patchError != nil {
@@ -557,7 +564,8 @@ func TestHasHealthStatusChanged(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockPatcher := mocks.NewStatusPatcher(t)
-			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry())
+			validator := repository.NewValidator(30*time.Second, []provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder, provisioning.SyncTargetTypeInstance}, true)
+			hc := NewHealthChecker(mockPatcher, prometheus.NewPedanticRegistry(), repository.NewSimpleRepositoryTester(validator))
 
 			result := hc.hasHealthStatusChanged(tt.old, tt.new)
 			assert.Equal(t, tt.expected, result)

--- a/pkg/registry/apis/provisioning/register_validate_test.go
+++ b/pkg/registry/apis/provisioning/register_validate_test.go
@@ -23,11 +23,12 @@ func TestAPIBuilderValidate(t *testing.T) {
 	mockRepo := repository.NewMockConfigRepository(t)
 	mockRepo.EXPECT().Validate().Return(nil)
 	factory.EXPECT().Build(mock.Anything, mock.Anything).Return(mockRepo, nil)
+	validator := repository.NewValidator(30*time.Second, []v0alpha1.SyncTargetType{v0alpha1.SyncTargetTypeFolder}, false)
 	b := &APIBuilder{
 		repoFactory:         factory,
 		allowedTargets:      []v0alpha1.SyncTargetType{v0alpha1.SyncTargetTypeFolder},
 		allowImageRendering: false,
-		minSyncInterval:     30 * time.Second,
+		validator:           validator,
 	}
 
 	t.Run("min sync interval is less than 10 seconds", func(t *testing.T) {


### PR DESCRIPTION
This PR refactors the repository test code.

It does a few things:
- Consolidates the config validation logic. This makes it sure that any config validation errors are displayed on the frontend (rather than only _some_ of it being executed in /test, and all being executed in the validation hook. eventually i think it would make sense for us move to using dry run for validation in the frontend.. but that can be later)
- To do that, the pr also allows us to set configuration for the validation checks.
- It also breaks apart the test file into more distinct responsibilities, the tester (which will check that the repo is able to be connected to) and the validator (which will do the config checks). The tester will still validate the config first, but validation is now its own thing.

Fixes https://github.com/grafana/git-ui-sync-project/issues/599