### PR TITLE
Elasticsearch: Add Elasticsearch 9 to supported versions

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -55,8 +55,9 @@ The following will help you get started working with Elasticsearch and Grafana:
 
 This data source supports these versions of Elasticsearch:
 
-- v7.17+
+- ≥ v7.17
 - v8.x
+- v9.x
 
 Our maintenance policy for Elasticsearch data source is aligned with the [Elastic Product End of Life Dates](https://www.elastic.co/support/eol) and we ensure proper functionality for supported versions. If you are using an Elasticsearch with version that is past its end-of-life (EOL), you can still execute queries, but you will receive a notification in the query builder indicating that the version of Elasticsearch you are using is no longer supported. It's important to note that in such cases, we do not guarantee the correctness of the functionality, and we will not be addressing any related issues.
 


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/111456.

This PR adds Elasticsearch 9 to the list of supported Elasticsearch versions. No changes were made to support this, the data source has been tested against ES9 and seems to be working. Also clarifies the supported version range for v7.x.