### PR TITLE
AUTHZ: add option to bypass team membership cache

### DIFF
--- a/pkg/services/team/team.go
+++ b/pkg/services/team/team.go
@@ -19,7 +19,7 @@ type Service interface {
 	GetTeamIDsByUser(ctx context.Context, query *GetTeamIDsByUserQuery) ([]int64, error)
 	IsTeamMember(ctx context.Context, orgId int64, teamId int64, userId int64) (bool, error)
 	RemoveUsersMemberships(tx context.Context, userID int64) error
-	GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool) ([]*TeamMemberDTO, error)
+	GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool, bypassCache bool) ([]*TeamMemberDTO, error)
 	GetTeamMembers(ctx context.Context, query *GetTeamMembersQuery) ([]*TeamMemberDTO, error)
 	RegisterDelete(query string)
 }

--- a/pkg/services/team/teamtest/team.go
+++ b/pkg/services/team/teamtest/team.go
@@ -58,7 +58,7 @@ func (s *FakeService) RemoveUsersMemberships(ctx context.Context, userID int64) 
 	return s.ExpectedError
 }
 
-func (s *FakeService) GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool) ([]*team.TeamMemberDTO, error) {
+func (s *FakeService) GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool, bypassCache bool) ([]*team.TeamMemberDTO, error) {
 	return s.ExpectedMembers, s.ExpectedError
 }
 


### PR DESCRIPTION
**What is this feature?**

Allows bypassing of the team membership cache.  Useful for testing.

