### PR TITLE
BrowseView: Git Provisioned Read Only Folder Disable Empty State Create Dashboard Button

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -206,7 +206,13 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
                   searchStateManager={stateManager}
                 />
               ) : (
-                <BrowseView permissions={permissions} width={width} height={height} folderUID={folderUID} />
+                <BrowseView
+                  permissions={permissions}
+                  width={width}
+                  height={height}
+                  folderUID={folderUID}
+                  isReadOnlyRepo={isReadOnlyRepo}
+                />
               )
             }
           </AutoSizer>

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -33,9 +33,10 @@ interface BrowseViewProps {
   width: number;
   folderUID: string | undefined;
   permissions: BrowseDashboardsPermissions;
+  isReadOnlyRepo?: boolean;
 }
 
-export function BrowseView({ folderUID, width, height, permissions }: BrowseViewProps) {
+export function BrowseView({ folderUID, width, height, permissions, isReadOnlyRepo }: BrowseViewProps) {
   const status = useBrowseLoadingStatus(folderUID);
   const dispatch = useDispatch();
   const flatTree = useFlatTreeState(folderUID);
@@ -163,6 +164,7 @@ export function BrowseView({ folderUID, width, height, permissions }: BrowseView
                 href={folderUID ? `dashboard/new?folderUid=${folderUID}` : 'dashboard/new'}
                 icon="plus"
                 size="lg"
+                disabled={isReadOnlyRepo}
               >
                 <Trans i18nKey="browse-dashboards.empty-state.button-title">Create dashboard</Trans>
               </LinkButton>
@@ -173,7 +175,7 @@ export function BrowseView({ folderUID, width, height, permissions }: BrowseView
                 : t('browse-dashboards.empty-state.title', "You haven't created any dashboards yet")
             }
           >
-            {folderUID && (
+            {folderUID && !isReadOnlyRepo && (
               <Trans i18nKey="browse-dashboards.empty-state.pro-tip">
                 Add/move dashboards to your folder at{' '}
                 <TextLink external={false} href="/dashboards">


### PR DESCRIPTION
**What is this feature?**

`BrowseView` : When it's git provisioned and read only repo, disable create new dashboard button in empty state. 

Before:  
<img width="1619" height="774" alt="image" src="https://github.com/user-attachments/assets/52876355-c57b-4fee-9abc-d055e3a6e60f" />


After:  
<img width="1114" height="677" alt="image" src="https://github.com/user-attachments/assets/b89e370c-fa76-42a6-a522-03ce7d111801" />


**Why do we need this feature?**

Prevent user click create button when its a repo only repo

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
