### PR TITLE
Makefile: Change build-go to only build the binaries, and deprecate build-go-fast

### DIFF
--- a/.bra.toml
+++ b/.bra.toml
@@ -17,7 +17,7 @@ watch_exts = [".go", ".ini", ".toml", ".template.html"]
 ignore_files = [".*_gen.go"]
 build_delay = 1500
 cmds = [
-  ["make", "GO_BUILD_DEV=1", "build-go-fast"],
+  ["make", "GO_BUILD_DEV=1", "build-go"],
   ["make", "gen-jsonnet"],
   ["./bin/grafana", "server", "-profile", "-profile-addr=127.0.0.1", "-profile-port=6000", "-profile-block-rate=1", "-profile-mutex-rate=5", "-packaging=dev", "cfg:app_mode=development"]
 ]

--- a/Makefile
+++ b/Makefile
@@ -233,13 +233,13 @@ update-workspace: gen-go
 	bash scripts/go-workspace/update-workspace.sh
 
 .PHONY: build-go
-build-go: gen-go update-workspace ## Build all Go binaries.
+build-go: ## Build all Go binaries.
 	@echo "build go files with updated workspace"
 	$(GO) run build.go $(GO_BUILD_FLAGS) build
 
-build-go-fast: gen-go ## Build all Go binaries.
-	@echo "build go files"
-	$(GO) run build.go $(GO_BUILD_FLAGS) build
+.PHONY: build-go-fast
+build-go-fast: ## Build all Go binaries without updating workspace.
+	@echo "!!! [DEPRECATED] use build-go, they do the same thing now. This command will be removed soon"
 
 .PHONY: build-backend
 build-backend: ## Build Grafana backend.

--- a/scripts/grafana-server/start-server
+++ b/scripts/grafana-server/start-server
@@ -26,7 +26,7 @@ echo starting server
 # see https://github.com/air-verse/air/issues/525
 # if this gets resolved, we could remove the go build and rely on the binary being present as before
 if [[ ! -f ./bin/"$ARCH"grafana ]]; then
-  make GO_BUILD_DEV=1 build-go-fast
+  make GO_BUILD_DEV=1 build-go
 fi
 
 cp -r ./bin $RUNDIR


### PR DESCRIPTION
**What is this feature?**

Now that we commit the wire gen files, any drift would fail the build, so we can simplify the `build-go` target to only build the Go binaries, and that makes `build-go-fast` redudant.

**Why do we need this feature?**

Simpler build steps.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
