### PR TITLE
Secrets: Add config for enabling gRPC client-side load balancing

### DIFF
--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -311,6 +311,7 @@ func setupDecrypter(cfg *setting.Cfg, tracer tracing.Tracer, tokenExchangeClient
 		tracer,
 		address,
 		secretsTls,
+		secretsSec.Key("grpc_client_load_balancing").MustBool(false),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("create decrypt service: %w", err)

--- a/pkg/registry/apis/secret/decrypt/service.go
+++ b/pkg/registry/apis/secret/decrypt/service.go
@@ -34,7 +34,7 @@ func ProvideDecryptService(cfg *setting.Cfg, tracer trace.Tracer, decryptStorage
 
 		tlsConfig := readTLSFromConfig(cfg)
 
-		client, err := NewGRPCDecryptClientWithTLS(tokenExchangeClient, tracer, cfg.SecretsManagement.GrpcServerAddress, tlsConfig)
+		client, err := NewGRPCDecryptClientWithTLS(tokenExchangeClient, tracer, cfg.SecretsManagement.GrpcServerAddress, tlsConfig, cfg.SecretsManagement.GrpcClientLoadBalancing)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create grpc decrypt client: %w", err)
 		}

--- a/pkg/registry/apis/secret/inline/service.go
+++ b/pkg/registry/apis/secret/inline/service.go
@@ -24,16 +24,19 @@ func ProvideInlineSecureValueService(
 			cfg.SecretsManagement.GrpcServerAddress,
 			readTLSFromConfig(cfg),
 			tracer,
+			cfg.SecretsManagement.GrpcClientLoadBalancing,
 		)
 	}
 
 	return NewLocalInlineSecureValueService(tracer, secureValueService, accessClient), nil
 }
 
-func NewGRPCSecureValueService(tokenCfg *grpcutils.GrpcClientConfig,
+func NewGRPCSecureValueService(
+	tokenCfg *grpcutils.GrpcClientConfig,
 	address string,
 	tlsCfg TLSConfig,
 	tracer trace.Tracer,
+	clientLoadBalancingEnabled bool,
 ) (contracts.InlineSecureValueSupport, error) {
 	if address == "" {
 		return nil, fmt.Errorf("grpc_server_address is required when grpc client is enabled")
@@ -51,7 +54,7 @@ func NewGRPCSecureValueService(tokenCfg *grpcutils.GrpcClientConfig,
 		return nil, fmt.Errorf("failed to create token exchange client: %w", err)
 	}
 
-	client, err := NewGRPCInlineClient(tokenExchangeClient, tracer, address, tlsCfg)
+	client, err := NewGRPCInlineClient(tokenExchangeClient, tracer, address, tlsCfg, clientLoadBalancingEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create grpc inline secure value client: %w", err)
 	}

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -57,6 +57,7 @@ type StorageOptions struct {
 
 	// Secrets Manager Configuration for InlineSecureValueSupport
 	SecretsManagerGrpcClientEnable        bool
+	SecretsManagerGrpcClientLoadBalancing bool
 	SecretsManagerGrpcServerAddress       string
 	SecretsManagerGrpcServerUseTLS        bool
 	SecretsManagerGrpcServerTLSSkipVerify bool
@@ -115,6 +116,7 @@ func (o *StorageOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.SecretsManagerGrpcServerTLSSkipVerify, "grafana.secrets-manager.grpc-server-tls-skip-verify", false, "Skip TLS verification for gRPC server")
 	fs.StringVar(&o.SecretsManagerGrpcServerTLSServerName, "grafana.secrets-manager.grpc-server-tls-server-name", "", "Server name for TLS verification")
 	fs.StringVar(&o.SecretsManagerGrpcServerTLSCAFile, "grafana.secrets-manager.grpc-server-tls-ca-file", "", "CA file for TLS verification")
+	fs.BoolVar(&o.SecretsManagerGrpcClientLoadBalancing, "grafana.secrets-manager.grpc-client-load-balancing", false, "Enable client-side load balancing for gRPC client")
 }
 
 func (o *StorageOptions) Validate() []error {
@@ -218,6 +220,7 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 			o.SecretsManagerGrpcServerAddress,
 			tlsCfg,
 			tracer,
+			o.SecretsManagerGrpcClientLoadBalancing,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to create inline secure value service: %w", err)

--- a/pkg/setting/setting_secrets_manager.go
+++ b/pkg/setting/setting_secrets_manager.go
@@ -18,6 +18,7 @@ type SecretsManagerSettings struct {
 	ConfiguredKMSProviders map[string]map[string]string
 
 	GrpcClientEnable        bool   // Whether to enable the gRPC client. If disabled, it will use the in-process services implementations.
+	GrpcClientLoadBalancing bool   // Whether to enable gRPC client-side load balancing
 	GrpcServerUseTLS        bool   // Whether to use TLS when communicating with the gRPC server
 	GrpcServerTLSSkipVerify bool   // Whether to skip TLS verification when communicating with the gRPC server
 	GrpcServerTLSServerName string // Server name to use for TLS verification
@@ -43,6 +44,7 @@ func (cfg *Cfg) readSecretsManagerSettings() {
 	cfg.SecretsManagement.CurrentEncryptionProvider = secretsMgmt.Key("encryption_provider").MustString(MisconfiguredProvider)
 
 	cfg.SecretsManagement.GrpcClientEnable = secretsMgmt.Key("grpc_client_enable").MustBool(false)
+	cfg.SecretsManagement.GrpcClientLoadBalancing = secretsMgmt.Key("grpc_client_load_balancing").MustBool(false)
 	cfg.SecretsManagement.GrpcServerUseTLS = secretsMgmt.Key("grpc_server_use_tls").MustBool(false)
 	cfg.SecretsManagement.GrpcServerTLSSkipVerify = secretsMgmt.Key("grpc_server_tls_skip_verify").MustBool(false)
 	cfg.SecretsManagement.GrpcServerTLSServerName = valueAsString(secretsMgmt, "grpc_server_tls_server_name", "")


### PR DESCRIPTION
**What is this feature?**

Adds an option so the gRPC clients can do load balancing for decryption and inline.

**Why do we need this feature?**

Better balancing!

**Who is this feature for?**

For the machines

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/grafana-operator-experience-squad/issues/1577

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
