### PR TITLE
docs(rbac): add Private data source connect fixed roles new our docs

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -182,13 +182,12 @@ The following table lists the default RBAC OnCall role assignments to the basic 
 | Editor        | `plugins:grafana-oncall-app:editor` | Default [Editor](ref:rbac-basic-roles) assignments.                                                                                                      |
 | Viewer        | `plugins:grafana-oncall-app:reader` | Default [Viewer](ref:rbac-basic-roles) assignments.                                                                                                      |
 
-
 ### Private data source connect roles
 
 The following table lists how private data source connect fixed roles are assigned to the basic roles:
 
-| Basic role      | Associated fixed roles                                                                 | Description                                                                 |
-| --------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Grafana Admin   | `plugins:grafana-pdc-app.private-networks:write`, `plugins:grafana-pdc-app.private-networks:read` | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
+| Basic role    | Associated fixed roles                                                                            | Description                                                                                                                                              |
+| ------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Grafana Admin | `plugins:grafana-pdc-app.private-networks:write`, `plugins:grafana-pdc-app.private-networks:read` | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
 
 > **Note:** These private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -182,9 +182,16 @@ The following table lists the default RBAC OnCall role assignments to the basic 
 | Editor        | `plugins:grafana-oncall-app:editor` | Default [Editor](ref:rbac-basic-roles) assignments.                                                                                                      |
 | Viewer        | `plugins:grafana-oncall-app:reader` | Default [Viewer](ref:rbac-basic-roles) assignments.                                                                                                      |
 
+<<<<<<< HEAD
 ### Private Data Source Connect roles
 
 The following table lists how Private Data Source Connect fixed roles are assigned to the basic roles:
+=======
+
+### Private data source connect roles
+
+The following table lists how Private data source connect fixed roles are assigned to the basic roles:
+>>>>>>> 0355930f8d2 (docs(rbac): update to 'Private data source connect roles' wording throughout)
 
 | Basic role      | Associated fixed roles                                      | Description                                                                 |
 | --------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
@@ -193,4 +200,8 @@ The following table lists how Private Data Source Connect fixed roles are assign
 | Editor          | `plugins:grafana-pdc-app.private-networks:write`            | Default [Editor](ref:rbac-basic-roles) assignments.                                                              |
 | Viewer          | `plugins:grafana-pdc-app.private-networks:read`             | Default [Viewer](ref:rbac-basic-roles) assignments.                                                              |
 
+<<<<<<< HEAD
 > **Note:** These Private Data Source Connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
+=======
+> **Note:** These Private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
+>>>>>>> 0355930f8d2 (docs(rbac): update to 'Private data source connect roles' wording throughout)

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -182,9 +182,9 @@ The following table lists the default RBAC OnCall role assignments to the basic 
 | Editor        | `plugins:grafana-oncall-app:editor` | Default [Editor](ref:rbac-basic-roles) assignments.                                                                                                      |
 | Viewer        | `plugins:grafana-oncall-app:reader` | Default [Viewer](ref:rbac-basic-roles) assignments.                                                                                                      |
 
-### Private Datasource Connect roles
+### Private Data Source Connect roles
 
-The following table lists how Private Datasource Connect fixed roles are assigned to the basic roles:
+The following table lists how Private Data Source Connect fixed roles are assigned to the basic roles:
 
 | Basic role      | Associated fixed roles                                      | Description                                                                 |
 | --------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
@@ -193,4 +193,4 @@ The following table lists how Private Datasource Connect fixed roles are assigne
 | Editor          | `plugins:grafana-pdc-app.private-networks:write`            | Default [Editor](ref:rbac-basic-roles) assignments.                                                              |
 | Viewer          | `plugins:grafana-pdc-app.private-networks:read`             | Default [Viewer](ref:rbac-basic-roles) assignments.                                                              |
 
-> **Note:** These Private Datasource Connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
+> **Note:** These Private Data Source Connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -190,4 +190,6 @@ The following table lists how private data source connect fixed roles are assign
 | ------------- | ------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Grafana Admin | `plugins:grafana-pdc-app.private-networks:write`, `plugins:grafana-pdc-app.private-networks:read` | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
 
-> **Note:** These private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
+{{< admonition type="note" >}}
+These private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
+{{< /admonition >}}

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -182,26 +182,13 @@ The following table lists the default RBAC OnCall role assignments to the basic 
 | Editor        | `plugins:grafana-oncall-app:editor` | Default [Editor](ref:rbac-basic-roles) assignments.                                                                                                      |
 | Viewer        | `plugins:grafana-oncall-app:reader` | Default [Viewer](ref:rbac-basic-roles) assignments.                                                                                                      |
 
-<<<<<<< HEAD
-### Private Data Source Connect roles
-
-The following table lists how Private Data Source Connect fixed roles are assigned to the basic roles:
-=======
 
 ### Private data source connect roles
 
-The following table lists how Private data source connect fixed roles are assigned to the basic roles:
->>>>>>> 0355930f8d2 (docs(rbac): update to 'Private data source connect roles' wording throughout)
+The following table lists how private data source connect fixed roles are assigned to the basic roles:
 
-| Basic role      | Associated fixed roles                                      | Description                                                                 |
-| --------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
-| Grafana Admin   | `plugins:grafana-pdc-app.private-networks:write`            | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
-| Admin           | `plugins:grafana-pdc-app.private-networks:write`            | Default [Grafana organization administrator](ref:rbac-basic-roles) assignments.                                    |
-| Editor          | `plugins:grafana-pdc-app.private-networks:write`            | Default [Editor](ref:rbac-basic-roles) assignments.                                                              |
-| Viewer          | `plugins:grafana-pdc-app.private-networks:read`             | Default [Viewer](ref:rbac-basic-roles) assignments.                                                              |
+| Basic role      | Associated fixed roles                                                                 | Description                                                                 |
+| --------------- | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Grafana Admin   | `plugins:grafana-pdc-app.private-networks:write`, `plugins:grafana-pdc-app.private-networks:read` | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
 
-<<<<<<< HEAD
-> **Note:** These Private Data Source Connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
-=======
-> **Note:** These Private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.
->>>>>>> 0355930f8d2 (docs(rbac): update to 'Private data source connect roles' wording throughout)
+> **Note:** These private data source connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.

--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/index.md
@@ -181,3 +181,16 @@ The following table lists the default RBAC OnCall role assignments to the basic 
 | Admin         | `plugins:grafana-oncall-app:admin`  | Default [Grafana organization administrator](ref:rbac-basic-roles) assignments.                                                                          |
 | Editor        | `plugins:grafana-oncall-app:editor` | Default [Editor](ref:rbac-basic-roles) assignments.                                                                                                      |
 | Viewer        | `plugins:grafana-oncall-app:reader` | Default [Viewer](ref:rbac-basic-roles) assignments.                                                                                                      |
+
+### Private Datasource Connect roles
+
+The following table lists how Private Datasource Connect fixed roles are assigned to the basic roles:
+
+| Basic role      | Associated fixed roles                                      | Description                                                                 |
+| --------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Grafana Admin   | `plugins:grafana-pdc-app.private-networks:write`            | Default [Grafana server administrator](/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#grafana-server-administrators) assignments. |
+| Admin           | `plugins:grafana-pdc-app.private-networks:write`            | Default [Grafana organization administrator](ref:rbac-basic-roles) assignments.                                    |
+| Editor          | `plugins:grafana-pdc-app.private-networks:write`            | Default [Editor](ref:rbac-basic-roles) assignments.                                                              |
+| Viewer          | `plugins:grafana-pdc-app.private-networks:read`             | Default [Viewer](ref:rbac-basic-roles) assignments.                                                              |
+
+> **Note:** These Private Datasource Connect fixed roles must be granted alongside the `fixed:datasources:writer` role for the permissions to take effect.


### PR DESCRIPTION
docs(rbac): add Private data source connect fixed roles mapping to rbac-fixed-basic-role-definitions page