### PR TITLE
[release-12.1.3] NPM: Backport NPM publishing from main

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,11 @@
+name: Setup Node.js
+description: Sets up a node.js environment with presets for the Grafana repository.
+
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version-file: '.nvmrc'
+        cache: 'yarn'
+        cache-dependency-path: 'yarn.lock'

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -39,12 +39,14 @@ permissions: {}
 
 jobs:
   # If called with version_type 'canary' or 'stable', build + publish to NPM
-  # If called with version_type 'nightly', just tag the given version with nightly tag. It was already published by the canary build.
+  # If called with version_type 'nightly', do nothing (we're not yet tagging them with the nightly tag)
 
   publish:
     name: Publish NPM packages
     runs-on: github-hosted-ubuntu-x64-small
     if: inputs.version_type == 'canary' || inputs.version_type == 'stable'
+    # Required for this workflow to have permission to publish NPM packages
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write
@@ -89,11 +91,8 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.grafana_commit }}
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'yarn'
-          cache-dependency-path: 'yarn.lock'
+      - name: Setup Node
+        uses: ./.github/actions/setup-node
 
       # Trusted Publishing is only available in npm v11.5.1 and later
       - name: Update npm
@@ -121,6 +120,9 @@ jobs:
       - name: Debug packed files
         run: tree -a ./npm-artifacts
 
+      - name: Validate packages
+        run: ./scripts/validate-npm-packages.sh
+
       - name: Debug OIDC Claims
         uses: github/actions-oidc-debugger@2e9ba5d3f4bebaad1f91a2cede055115738b7ae8
         with:
@@ -130,17 +132,3 @@ jobs:
         env:
           NPM_TAG: ${{ steps.npm-tag.outputs.NPM_TAG }}
         run: ./scripts/publish-npm-packages.sh --dist-tag "$NPM_TAG" --registry 'https://registry.npmjs.org/'
-
-  # TODO: finish this step
-  tag-nightly:
-    name: Tag nightly release
-    runs-on: github-hosted-ubuntu-x64-small
-    if: inputs.version_type == 'nightly'
-
-    steps:
-      - name: Checkout workflow ref
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-
-      # TODO: tag the given release with nightly

--- a/scripts/validate-npm-packages.sh
+++ b/scripts/validate-npm-packages.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # This script is used to validate the npm packages that are published to npmjs.org are in the correct format.
 # It won't catch things like malformed JS or Types but it will assert that the package has

--- a/scripts/validate-npm-packages.sh
+++ b/scripts/validate-npm-packages.sh
@@ -9,8 +9,13 @@ ARTIFACTS_DIR="./npm-artifacts"
 for file in "$ARTIFACTS_DIR"/*.tgz; do
   echo "🔍 Checking NPM package: $file"
 
-  # Ignore named-exports for now as builds aren't compatible yet.
-  yarn attw "$file" --ignore-rules "named-exports" "false-cjs"
+  if [[ "$file" == *"@grafana-i18n"* ]]; then
+    IGNORE_RULES="named-exports false-cjs untyped-resolution"
+  else
+    IGNORE_RULES="named-exports false-cjs"
+  fi
+  # shellcheck disable=SC2086
+  yarn attw "$file" --ignore-rules $IGNORE_RULES --profile node16
   yarn publint "$file"
 done
 

--- a/scripts/validate-npm-packages.sh
+++ b/scripts/validate-npm-packages.sh
@@ -10,9 +10,8 @@ for file in "$ARTIFACTS_DIR"/*.tgz; do
   echo "🔍 Checking NPM package: $file"
 
   # Ignore named-exports for now as builds aren't compatible yet.
-  yarn attw "$file" --ignore-rules "named-exports"
+  yarn attw "$file" --ignore-rules "named-exports" "false-cjs"
   yarn publint "$file"
-
 done
 
 echo "🚀 All NPM package checks passed! 🚀"


### PR DESCRIPTION
Backport the NPM publishing workflow and scripts from main to correct publishing from the 11.5.x release branch.