### PR TITLE
Provisioning: set sync state if empty

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -110,6 +110,10 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 	lastRef := repo.Config().Status.Sync.LastRef
 	syncStatus.LastRef = lastRef
 
+	if syncStatus.State == "" {
+		syncStatus.State = provisioning.JobStateWorking
+	}
+
 	// Update sync status at start using JSON patch
 	patchOperations := []map[string]interface{}{
 		{


### PR DESCRIPTION
**What is this feature?**

When the Sync job worker starts its pull work, it sets the `Repository` resource's Sync status - taking the data from the given `Job`'s status

In certain cases the `Job` status' `state` field it's empty, which then causes the same field to be empty in the `Repository`. This is weird as such field is shown in the UI.

https://github.com/user-attachments/assets/3eb94c4e-a8a6-495f-99a9-ed9a2b46440e

**Why do we need this feature?**

To correctly show the Pull status in the UI

**Who is this feature for?**

Users of GitSync feature.

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/git-ui-sync-project/issues/538

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
