### PR TITLE
Advisor: Remove header overrides for PATCH methods

### DIFF
--- a/public/app/api/clients/advisor/v0alpha1/index.ts
+++ b/public/app/api/clients/advisor/v0alpha1/index.ts
@@ -1,34 +1,6 @@
 import { generatedAPI } from './endpoints.gen';
 
-export const advisorAPIv0alpha1 = generatedAPI.enhanceEndpoints({
-  endpoints: {
-    // Need to mutate the generated query to set the Content-Type header correctly
-    updateCheck: (endpointDefinition) => {
-      const originalQuery = endpointDefinition.query;
-      if (originalQuery) {
-        endpointDefinition.query = (requestOptions) => ({
-          ...originalQuery(requestOptions),
-          headers: {
-            'Content-Type': 'application/json-patch+json',
-          },
-          body: JSON.stringify(requestOptions.patch),
-        });
-      }
-    },
-    updateCheckType: (endpointDefinition) => {
-      const originalQuery = endpointDefinition.query;
-      if (originalQuery) {
-        endpointDefinition.query = (requestOptions) => ({
-          ...originalQuery(requestOptions),
-          headers: {
-            'Content-Type': 'application/json-patch+json',
-          },
-          body: JSON.stringify(requestOptions.patch),
-        });
-      }
-    },
-  },
-});
+export const advisorAPIv0alpha1 = generatedAPI.enhanceEndpoints({});
 export const {
   useGetCheckQuery,
   useListCheckQuery,


### PR DESCRIPTION
**What is this feature?**
https://github.com/grafana/grafana/pull/111879 removed the need to override the specify headers for app platform PATCH requests (I think?)

**Why do we need this feature?**
Simpler code! 🧹 

**Who is this feature for?**
UI devs