### PR TITLE
chore(tracing): Initialize tracing early, before wire

### DIFF
--- a/pkg/cmd/grafana-server/commands/cli.go
+++ b/pkg/cmd/grafana-server/commands/cli.go
@@ -11,9 +11,7 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	_ "github.com/grafana/pyroscope-go/godeltaprof/http/pprof"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/grafana/grafana/pkg/api"
@@ -21,8 +19,10 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/process"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/server"
 	"github.com/grafana/grafana/pkg/services/apiserver/standalone"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 )
 
@@ -108,6 +108,11 @@ func RunServer(opts standalone.BuildInfo, cli *cli.Context) error {
 
 	// Initialize the OpenFeature feature flag system
 	if err := featuremgmt.InitOpenFeatureWithCfg(cfg); err != nil {
+		return err
+	}
+
+	// Initialize tracing early to ensure it's always available for other services
+	if err := tracing.InitTracing(cfg); err != nil {
 		return err
 	}
 

--- a/pkg/infra/tracing/tracing.go
+++ b/pkg/infra/tracing/tracing.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-kit/log/level"
+	"github.com/grafana/dskit/services"
 	jaegerpropagator "go.opentelemetry.io/contrib/propagators/jaeger"
 	"go.opentelemetry.io/contrib/samplers/jaegerremote"
 	"go.opentelemetry.io/otel"
@@ -27,11 +29,9 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/credentials"
 
-	"github.com/go-kit/log/level"
-
-	"github.com/grafana/dskit/services"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 const (
@@ -103,6 +103,23 @@ func ProvideService(tracingCfg *TracingConfig) (*TracingService, error) {
 		return nil, err
 	}
 	return ots, nil
+}
+
+// InitTracing initializes the tracing service with the provided configuration.
+// Used to initialize tracing early to ensure it's always available for other
+// services, outside of the wire context.
+func InitTracing(cfg *setting.Cfg) error {
+	tracingCfg, err := ParseTracingConfig(cfg)
+	if err != nil {
+		return fmt.Errorf("parse tracing config: %w", err)
+	}
+
+	_, err = ProvideService(tracingCfg)
+	if err != nil {
+		return fmt.Errorf("initialize tracing: %w", err)
+	}
+
+	return nil
 }
 
 func NewNoopTracerService() *TracingService {


### PR DESCRIPTION
**What is this feature?**

I want to make sure the OTel provider is initialized early enough for services that aren't wired up with wire.

**Why do we need this feature?**

More complete trace propagation, helps us split out services that don't need wire involved...