### PR TITLE
User API: add missing uid to user look up api

### DIFF
--- a/pkg/api/user.go
+++ b/pkg/api/user.go
@@ -117,6 +117,7 @@ func (hs *HTTPServer) GetUserByLoginOrEmail(c *contextmodel.ReqContext) response
 	}
 	result := user.UserProfileDTO{
 		ID:             usr.ID,
+		UID:            usr.UID,
 		Name:           usr.Name,
 		Email:          usr.Email,
 		Login:          usr.Login,


### PR DESCRIPTION
**What is this feature?**

This PR fixes an empty uid when looking up a user via `api/users/lookup?loginOrEmail=<USER>`. Some apis require the uid. Without including this UID, the user is forced to make an additional request to the search API and match on the id to find the UID.

Current response:

`{"id":17,"uid":"","email":"benchtester","name":"benchtester","login":"benchtester","theme":"","orgId":1,"isGrafanaAdmin":true,"isDisabled":false,"isExternal":false,"isExternallySynced":false,"isGrafanaAdminExternallySynced":false,"authLabels":null,"updatedAt":"2025-10-03T17:13:48Z","createdAt":"2025-10-03T17:10:30Z","avatarUrl":"","isProvisioned":false}`

New Response:

`{"id":17,"uid":"eezydd599999","email":"benchtester","name":"benchtester","login":"benchtester","theme":"","orgId":1,"isGrafanaAdmin":true,"isDisabled":false,"isExternal":false,"isExternallySynced":false,"isGrafanaAdminExternallySynced":false,"authLabels":null,"updatedAt":"2025-10-03T17:13:48Z","createdAt":"2025-10-03T17:10:30Z","avatarUrl":"","isProvisioned":false}`
