### PR TITLE
fix: version migration

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v16.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16.go
@@ -128,21 +128,36 @@ func upgradeToGridLayout(dashboard map[string]interface{}) {
 				continue
 			}
 
-			// Set default span (line 1063 in TS)
-			span := GetFloatValue(panel, "span", defaultPanelSpan)
+			// Check if panel already has gridPos but no valid span
+			// If span is missing or zero, and gridPos exists, preserve gridPos dimensions
+			var panelWidth, panelHeight int
+			span := GetFloatValue(panel, "span", 0)
+			existingGridPos, hasGridPos := panel["gridPos"].(map[string]interface{})
 
-			// Handle minSpan conversion (lines 1064-1066 in TS)
-			if minSpan, hasMinSpan := panel["minSpan"]; hasMinSpan {
-				if minSpanFloat, ok := ConvertToFloat(minSpan); ok && minSpanFloat > 0 {
-					panel["minSpan"] = int(math.Min(float64(gridColumnCount), (float64(gridColumnCount)/12.0)*minSpanFloat))
+			if hasGridPos && span == 0 {
+				// Panel already has gridPos but no valid span - preserve its dimensions
+				panelWidth = GetIntValue(existingGridPos, "w", int(defaultPanelSpan*widthFactor))
+				panelHeight = GetIntValue(existingGridPos, "h", rowGridHeight)
+			} else {
+				// Normal migration path: calculate from span
+				// Set default span if still 0 (line 1063 in TS)
+				if span == 0 {
+					span = defaultPanelSpan
 				}
-			}
 
-			panelWidth := int(math.Floor(span * widthFactor))
-			panelHeight := rowGridHeight
-			if panelHeightValue, hasHeight := panel["height"]; hasHeight {
-				if h, ok := ConvertToFloat(panelHeightValue); ok {
-					panelHeight = getGridHeight(h)
+				// Handle minSpan conversion (lines 1064-1066 in TS)
+				if minSpan, hasMinSpan := panel["minSpan"]; hasMinSpan {
+					if minSpanFloat, ok := ConvertToFloat(minSpan); ok && minSpanFloat > 0 {
+						panel["minSpan"] = int(math.Min(float64(gridColumnCount), (float64(gridColumnCount)/12.0)*minSpanFloat))
+					}
+				}
+
+				panelWidth = int(math.Floor(span * widthFactor))
+				panelHeight = rowGridHeight
+				if panelHeightValue, hasHeight := panel["height"]; hasHeight {
+					if h, ok := ConvertToFloat(panelHeightValue); ok {
+						panelHeight = getGridHeight(h)
+					}
 				}
 			}
 


### PR DESCRIPTION
Currently if there was a span that was set to `0` it was removing the panels from migration `panels: []`.

Issue was in [the TS file](https://github.com/grafana/grafana/blob/a72e02f88a2a9d50f43fe4350926abe970fddd21/public/app/features/dashboard/state/DashboardMigrator.ts#L1082) the condition:
`panel.span = panel.span || DEFAULT_PANEL_SPAN;` was defaulting to the `DEFAULT_PANEL_SPAN` as `0` is faulty.

<details>
  <summary>Demo dashboard</summary>
  
 ```json
 {
  "__requires": [
    {
      "id": "grafana",
      "name": "Grafana",
      "type": "grafana",
      "version": "8.0.0"
    }
  ],
  "annotations": {
    "list": []
  },
  "editable": false,
  "gnetId": null,
  "graphTooltip": 0,
  "hideControls": false,
  "links": [
    {
      "icon": "external link",
      "targetBlank": true,
      "title": "Source (deployment_tools)",
      "type": "link",
      "url": ""
    }
  ],
  "panels": [
    {
      "gridPos": {
        "h": 3,
        "w": 24,
        "x": 0,
        "y": 0
      },
      "options": {
        "content": "This dashboard walks through the various components required for git sync, in the hopes to help debugging any issues.\n",
        "mode": "markdown"
      },
      "title": "Git Sync",
      "type": "text"
    }
  ],
  "refresh": "10s",
  "rows": [
    {
      "collapse": false,
      "collapsed": false,
      "height": "250px",
      "panels": [
        {
          "gridPos": {
            "h": 11,
            "w": 24,
            "x": 0,
            "y": 5
          },
          "id": 6,
          "options": {
            "content": "The job controller is responsible for watching for new jobs, claiming them, and running the logic to complete them. It then deletes the job resource and creates a historicjob resource.\n\nThere are a few different job types it can run _in cloud_:\n1. Pull: This is the most common. It syncs Grafana to what is in the repo.\n2. Move: This moves resources from one folder to another.\n3. Push: Pushes resources already within Grafana into a repository.\n4. Delete: Deletes resources. Does not include when the entire repository object is deleted, that is handled by the repo controller.\n\nDependencies:\n- Dashboard API Server: To create, update, delete dashboards.\n- Folders API Server: To create, update, delete folders.\n- Provisioning API Server: To watch, update, delete jobs, and create historic jobs.\n- Unified Storage Search: To get stats on repositories.\n- Secrets Service: To decrypt repository secrets, to be able to retrieve the contents of a repository.\n- IAM API Server: (In the future) To create ResourcePermissions on root level resources.\n",
            "mode": "markdown"
          },
          "span": 0,
          "title": "Job Controller Overview",
          "type": "text"
        },
        {
          "gridPos": {
            "h": 3,
            "w": 24,
            "x": 0,
            "y": 16
          },
          "id": 7,
          "options": {
            "content": "General errors will likely be seen in the logs. This section looks at the logs of the controller, as well as overall success rate.",
            "mode": "markdown"
          },
          "span": 0,
          "title": "General Errors",
          "type": "text"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "fieldConfig": {
            "defaults": {
              "thresholds": {
                "mode": "absolute",
                "steps": [
                  {
                    "color": "red",
                    "value": 0
                  },
                  {
                    "color": "yellow",
                    "value": 0.95
                  },
                  {
                    "color": "green",
                    "value": 1
                  }
                ]
              },
              "unit": "percentunit"
            }
          },
          "gridPos": {
            "h": 9,
            "w": 3,
            "x": 0,
            "y": 19
          },
          "id": 8,
          "span": 0,
          "targets": [
            {
              "expr": "sum by (action) (grafana_provisioning_jobs_processed_total{outcome=\"success\", cluster=\"$cluster\", namespace=\"grafana-apps\"})\n/\nsum by (action) (grafana_provisioning_jobs_processed_total{cluster=\"$cluster\", namespace=\"grafana-apps\"})\n",
              "legendFormat": "{{action}}"
            }
          ],
          "title": "Job Success Rate",
          "type": "stat"
        },
        {
          "datasource": {
            "type": "loki",
            "uid": "${loki}"
          },
          "gridPos": {
            "h": 9,
            "w": 10,
            "x": 3,
            "y": 19
          },
          "id": 9,
          "options": {
            "enableLogDetails": true,
            "showTime": false,
            "sortOrder": "Descending",
            "wrapLogMessage": true
          },
          "span": 0,
          "targets": [
            {
              "expr": "{namespace=\"grafana-apps\", cluster=\"$cluster\", job=\"grafana-apps/provisioning-jobs-operator\"} | logfmt | level=\"error\""
            }
          ],
          "title": "Errors",
          "type": "logs"
        },
        {
          "datasource": {
            "type": "loki",
            "uid": "${loki}"
          },
          "gridPos": {
            "h": 9,
            "w": 11,
            "x": 13,
            "y": 19
          },
          "id": 10,
          "options": {
            "enableLogDetails": true,
            "showTime": false,
            "sortOrder": "Descending",
            "wrapLogMessage": true
          },
          "span": 0,
          "targets": [
            {
              "expr": "{namespace=\"grafana-apps\", cluster=\"$cluster\", job=\"grafana-apps/provisioning-jobs-operator\"} | logfmt"
            }
          ],
          "title": "All",
          "type": "logs"
        },
        {
          "gridPos": {
            "h": 3,
            "w": 24,
            "x": 0,
            "y": 28
          },
          "id": 11,
          "options": {
            "content": "The next section looks at various things that can contribute to latency of jobs, such as the action duration to process the job (based on various factors like the amount of changes needed and the job type), as well as the queue length and time waiting in the queue. It also has traces of the sync job to debug further.\n",
            "mode": "markdown"
          },
          "span": 0,
          "title": "Latency Debugging",
          "type": "text"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "description": "If needed, we can adjust this in the operator.ini with [operator][concurrent_drivers]",
          "gridPos": {
            "h": 6,
            "w": 5,
            "x": 0,
            "y": 31
          },
          "id": 12,
          "span": 0,
          "targets": [
            {
              "expr": "max(grafana_provisioning_jobs_concurrent_driver_num_drivers{cluster=\"$cluster\", namespace=\"grafana-apps\"})",
              "instant": true
            }
          ],
          "title": "Concurrent Job Drivers",
          "type": "stat"
        },
        {
          "datasource": {
            "type": "tempo",
            "uid": "${tempo}"
          },
          "gridPos": {
            "h": 6,
            "w": 19,
            "x": 5,
            "y": 31
          },
          "id": 13,
          "span": 0,
          "targets": [
            {
              "filters": [
                {
                  "id": "span-name",
                  "operator": "=",
                  "scope": "span",
                  "tag": "name",
                  "value": ["provisioning.sync.process"]
                },
                {
                  "id": "k8s-cluster-name",
                  "operator": "=",
                  "scope": "resource",
                  "tag": "k8s.cluster.name",
                  "value": ["$cluster"]
                }
              ],
              "query": "{name=\"provisioning.sync.process\"}",
              "queryType": "traceqlSearch"
            }
          ],
          "title": "Recent Sync Traces",
          "type": "table"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "description": "Histogram showing p99, p95, p50, and p10 percentiles for job processing duration based on number of resources changed",
          "fieldConfig": {
            "defaults": {
              "thresholds": {
                "mode": "absolute",
                "steps": [
                  {
                    "color": "green",
                    "value": 0
                  },
                  {
                    "color": "yellow",
                    "value": 2
                  },
                  {
                    "color": "red",
                    "value": 5
                  }
                ]
              },
              "unit": "s"
            }
          },
          "gridPos": {
            "h": 10,
            "w": 8,
            "x": 0,
            "y": 55
          },
          "id": 14,
          "span": 0,
          "targets": [
            {
              "expr": "histogram_quantile(0.99, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (le, resources_changed_bucket, action)) and on(resources_changed_bucket, action) sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (resources_changed_bucket, action) > 0",
              "legendFormat": "{{action}} q0.99 - size {{resources_changed_bucket}}",
              "refId": "B"
            },
            {
              "expr": "histogram_quantile(0.9, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (le, resources_changed_bucket, action)) and on(resources_changed_bucket, action) sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (resources_changed_bucket, action) > 0",
              "legendFormat": "{{action}} q0.95 - size {{resources_changed_bucket}}",
              "refId": "C"
            },
            {
              "expr": "histogram_quantile(0.5, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (le, resources_changed_bucket, action)) and on(resources_changed_bucket, action) sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (resources_changed_bucket, action) > 0",
              "legendFormat": "{{action}} q0.5 - size {{resources_changed_bucket}}",
              "refId": "D"
            },
            {
              "expr": "histogram_quantile(0.1, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (le, resources_changed_bucket, action)) and on(resources_changed_bucket, action) sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (resources_changed_bucket, action) > 0",
              "legendFormat": "{{action}} q0.1 - size {{resources_changed_bucket}}",
              "refId": "E"
            }
          ],
          "timeFrom": "7d",
          "title": "7d avg of job durations",
          "transformations": [
            {
              "id": "reduce",
              "options": {
                "mode": "seriesToRows",
                "reducers": ["mean"]
              }
            },
            {
              "id": "seriesToRows"
            },
            {
              "id": "organize",
              "options": {
                "renameByName": {
                  "Field": "Type",
                  "Mean": "Avg Duration",
                  "Metric": "Legend",
                  "Value": "Duration"
                }
              }
            }
          ],
          "type": "table"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "description": "Histogram showing p99, p95, p50, and p10 percentiles for job processing duration based on number of resources changed",
          "gridPos": {
            "h": 10,
            "w": 16,
            "x": 8,
            "y": 55
          },
          "id": 15,
          "span": 0,
          "targets": [
            {
              "expr": "histogram_quantile(0.99, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[5m])) by (le, resources_changed_bucket, action))",
              "legendFormat": "{{action}} q0.99 - size {{resources_changed_bucket}}",
              "refId": "B"
            },
            {
              "expr": "histogram_quantile(0.95, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[5m])) by (le, resources_changed_bucket, action))",
              "legendFormat": "{{action}} q0.95 - size {{resources_changed_bucket}}",
              "refId": "C"
            },
            {
              "expr": "histogram_quantile(0.5, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[5m])) by (le, resources_changed_bucket, action))",
              "legendFormat": "{{action}} q0.5 - size {{resources_changed_bucket}}",
              "refId": "D"
            },
            {
              "expr": "histogram_quantile(0.1, sum(rate(grafana_provisioning_jobs_duration_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[5m])) by (le, resources_changed_bucket, action))",
              "legendFormat": "{{action}} q0.1 - size {{resources_changed_bucket}}",
              "refId": "E"
            }
          ],
          "title": "Job Duration",
          "type": "timeseries"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "description": "Total number of jobs waiting to be processed",
          "gridPos": {
            "h": 5,
            "w": 4,
            "x": 0,
            "y": 65
          },
          "id": 16,
          "span": 0,
          "targets": [
            {
              "expr": "clamp_min(sum(grafana_provisioning_jobs_queue_size{cluster=\"$cluster\", namespace=\"grafana-apps\"}), 0)",
              "legendFormat": "Queue size"
            }
          ],
          "title": "Queue Size",
          "type": "stat"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "fieldConfig": {
            "defaults": {
              "unit": "s"
            }
          },
          "gridPos": {
            "h": 5,
            "w": 4,
            "x": 4,
            "y": 65
          },
          "id": 17,
          "span": 0,
          "targets": [
            {
              "expr": "avg(histogram_quantile(0.5, sum(rate(grafana_provisioning_jobs_queue_wait_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[7d])) by (le)))",
              "legendFormat": "Queue size"
            }
          ],
          "timeFrom": "7d",
          "title": "7d avg Queue Wait Time",
          "type": "stat"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "description": "How long a job is in the queue before being picked up",
          "gridPos": {
            "h": 5,
            "w": 16,
            "x": 8,
            "y": 65
          },
          "id": 18,
          "span": 0,
          "targets": [
            {
              "expr": "histogram_quantile(0.99, sum(rate(grafana_provisioning_jobs_queue_wait_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[$__rate_interval])) by (le))",
              "legendFormat": "q0.99",
              "refId": "B"
            },
            {
              "expr": "histogram_quantile(0.95, sum(rate(grafana_provisioning_jobs_queue_wait_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[$__rate_interval])) by (le))",
              "legendFormat": "q0.95",
              "refId": "C"
            },
            {
              "expr": "histogram_quantile(0.5, sum(rate(grafana_provisioning_jobs_queue_wait_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[$__rate_interval])) by (le))",
              "legendFormat": "q0.5",
              "refId": "D"
            },
            {
              "expr": "histogram_quantile(0.1, sum(rate(grafana_provisioning_jobs_queue_wait_seconds_bucket{cluster=\"$cluster\", namespace=\"grafana-apps\"}[$__rate_interval])) by (le))",
              "legendFormat": "q0.1",
              "refId": "E"
            }
          ],
          "title": "Queue Wait Time",
          "type": "timeseries"
        },
        {
          "gridPos": {
            "h": 3,
            "w": 24,
            "x": 0,
            "y": 52
          },
          "id": 19,
          "options": {
            "content": "Checks that memory and cpu are scaled properly",
            "mode": "markdown"
          },
          "span": 0,
          "title": "K8s Resources",
          "type": "text"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "gridPos": {
            "h": 9,
            "w": 7,
            "x": 0,
            "y": 55
          },
          "id": 20,
          "span": 0,
          "targets": [
            {
              "expr": "count by (cluster, channel)(label_replace(label_replace(kube_pod_container_info{namespace=\"grafana-apps\", container=\"grafana-operator\", pod=~\"provisioning-jobs.*\", cluster=~\"$cluster\"}, \"version\", \"$1\", \"image\", \".+:(.+)\"), \"channel\", \"$1\", \"container\", \".+-(.+)\"))",
              "legendFormat": "{{cluster}}"
            }
          ],
          "title": "Running Pod(s)",
          "type": "timeseries"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "gridPos": {
            "h": 9,
            "w": 8,
            "x": 7,
            "y": 55
          },
          "id": 21,
          "span": 0,
          "targets": [
            {
              "expr": "max(kube_pod_container_resource_requests{namespace=\"grafana-apps\", resource=\"memory\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs.*\"})",
              "legendFormat": "Memory Request"
            },
            {
              "expr": "max(kube_pod_container_resource_limits{namespace=\"grafana-apps\", resource=\"memory\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs.*\"})",
              "legendFormat": "Memory Limit"
            },
            {
              "expr": "max(container_memory_usage_bytes{namespace=\"grafana-apps\",cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs.*\"}) by (pod)",
              "legendFormat": "Container usage {{pod}}"
            }
          ],
          "title": "Memory Utilization",
          "type": "timeseries"
        },
        {
          "datasource": {
            "type": "prometheus",
            "uid": "${prom}"
          },
          "gridPos": {
            "h": 9,
            "w": 9,
            "x": 15,
            "y": 55
          },
          "id": 22,
          "span": 0,
          "targets": [
            {
              "expr": "sum(irate(container_cpu_usage_seconds_total{namespace=\"grafana-apps\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs-.*\"}[$__rate_interval])) by (pod, container, cpu)",
              "legendFormat": "Usage {{pod}}"
            },
            {
              "expr": "sum(irate(container_cpu_cfs_throttled_seconds_total{namespace=\"grafana-apps\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs-.*\"}[$__rate_interval])) by (pod, container)",
              "legendFormat": "Throttling {{pod}}"
            },
            {
              "expr": "max(kube_pod_container_resource_limits{namespace=\"grafana-apps\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs-.*\", resource=\"cpu\"})",
              "legendFormat": "CPU limit"
            },
            {
              "expr": "max(kube_pod_container_resource_requests{namespace=\"grafana-apps\", cluster=~\"$cluster\", container=\"grafana-operator\", pod=~\"provisioning-jobs-.*\", resource=\"cpu\"})",
              "legendFormat": "CPU request"
            }
          ],
          "title": "CPU Utilization",
          "type": "timeseries"
        }
      ],
      "repeat": null,
      "repeatIteration": null,
      "repeatRowId": null,
      "showTitle": true,
      "title": "Jobs Controller",
      "titleSize": "h6"
    }
  ],
  "schemaVersion": 14,
  "style": "dark",
  "tags": ["as-code"],
  "templating": {
    "list": [
      {
        "current": {
          "value": "grafanacloud-prom"
        },
        "hide": 0,
        "label": "Data source",
        "name": "datasource",
        "options": [],
        "query": "prometheus",
        "refresh": 1,
        "regex": "",
        "type": "datasource"
      },
      {
        "current": {
          "value": "grafanacloud-prom"
        },
        "name": "prom",
        "query": "prometheus",
        "refresh": 1,
        "regex": "",
        "type": "datasource"
      },
      {
        "current": {
          "value": "grafanacloud-logs"
        },
        "name": "loki",
        "query": "loki",
        "refresh": 1,
        "regex": "",
        "type": "datasource"
      },
      {
        "current": {
          "text": "grafanacloud-ops-traces",
          "value": "grafanacloud-traces"
        },
        "name": "tempo",
        "query": "tempo",
        "refresh": 1,
        "regex": "grafanacloud-ops-traces|.*(tempo-dev-01).*",
        "type": "datasource"
      },
      {
        "current": {
          "text": "dev-us-central-0",
          "value": "dev-us-central-0"
        },
        "datasource": {
          "type": "prometheus",
          "uid": "${prom}"
        },
        "name": "cluster",
        "query": "label_values(grafana_provisioning_jobs_concurrent_driver_num_drivers,cluster)",
        "refresh": 1,
        "type": "query"
      }
    ]
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {
    "refresh_intervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
    "time_options": ["5m", "15m", "1h", "6h", "12h", "24h", "2d", "7d", "30d"]
  },
  "timezone": "utc",
  "title": "Demo json",
  "uid": "747008c5b31b8cd523733e93f1144a80",
  "version": 0
}

  ```
</details>