### PR TITLE
Permission Creator: Remove user type check

### DIFF
--- a/pkg/storage/unified/apistore/permissions.go
+++ b/pkg/storage/unified/apistore/permissions.go
@@ -39,11 +39,6 @@ func afterCreatePermissionCreator(ctx context.Context,
 		return nil, errors.New("missing auth info")
 	}
 
-	idtype := auth.GetIdentityType()
-	if idtype != authtypes.TypeUser && idtype != authtypes.TypeServiceAccount && idtype != authtypes.TypeAccessPolicy {
-		return nil, fmt.Errorf("only users, service accounts, and access policies may grant permissions using an annotation")
-	}
-
 	return func(ctx context.Context) error {
 		return setter(ctx, key, auth, val)
 	}, nil

--- a/pkg/storage/unified/apistore/permissions_test.go
+++ b/pkg/storage/unified/apistore/permissions_test.go
@@ -9,7 +9,6 @@ import (
 	authtypes "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -45,86 +44,5 @@ func TestAfterCreatePermissionCreator(t *testing.T) {
 		require.Error(t, err)
 		require.Nil(t, creator)
 		require.Contains(t, err.Error(), "missing auth info")
-	})
-
-	t.Run("should succeed for user identity", func(t *testing.T) {
-		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
-			Type:    authtypes.TypeUser,
-			OrgID:   1,
-			OrgRole: "Admin",
-			UserID:  1,
-		})
-		obj := &v0alpha1.Dashboard{}
-		key := &resourcepb.ResourceKey{
-			Group:     "test",
-			Resource:  "test",
-			Namespace: "test",
-			Name:      "test",
-		}
-
-		creator, err := afterCreatePermissionCreator(ctx, key, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
-		require.NoError(t, err)
-		require.NotNil(t, creator)
-
-		err = creator(ctx)
-		require.NoError(t, err)
-	})
-
-	t.Run("should succeed for service account identity", func(t *testing.T) {
-		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
-			Type:    authtypes.TypeServiceAccount,
-			OrgID:   1,
-			OrgRole: "Admin",
-			UserID:  1,
-		})
-		obj := &v0alpha1.Dashboard{}
-		key := &resourcepb.ResourceKey{
-			Group:     "test",
-			Resource:  "test",
-			Namespace: "test",
-			Name:      "test",
-		}
-
-		creator, err := afterCreatePermissionCreator(ctx, key, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
-		require.NoError(t, err)
-		require.NotNil(t, creator)
-
-		err = creator(ctx)
-		require.NoError(t, err)
-	})
-
-	t.Run("should succeed for access policy identity", func(t *testing.T) {
-		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
-			Type:    authtypes.TypeAccessPolicy,
-			OrgID:   1,
-			OrgRole: "Admin",
-			UserID:  1,
-		})
-		obj := &v0alpha1.Dashboard{}
-		key := &resourcepb.ResourceKey{
-			Group:     "test",
-			Resource:  "test",
-			Namespace: "test",
-			Name:      "test",
-		}
-
-		creator, err := afterCreatePermissionCreator(ctx, key, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
-		require.NoError(t, err)
-		require.NotNil(t, creator)
-
-		err = creator(ctx)
-		require.NoError(t, err)
-	})
-
-	t.Run("should error for non-user/non-service-account identity", func(t *testing.T) {
-		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{
-			Type: authtypes.TypeAnonymous,
-		})
-		obj := &v0alpha1.Dashboard{}
-
-		creator, err := afterCreatePermissionCreator(ctx, nil, utils.AnnoGrantPermissionsDefault, obj, mockSetter)
-		require.Error(t, err)
-		require.Nil(t, creator)
-		require.Contains(t, err.Error(), "only users, service accounts, and access policies may grant permissions")
 	})
 }


### PR DESCRIPTION
Originally the intent was that the permission creator would only be used by users. We recently added the access policy check to allow git sync to do this, so it isn't really serving its purpose anymore. With this check, too, anonymous users are not able to create dashboards in a folder that they have been granted edit access to (when a viewer in a folder has edit). 

This pr removes the check since it isnt serving its intended purpose anymore.