### PR TITLE
Provisioning: Fix pull stuck in pending

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/worker.go
@@ -140,17 +140,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		setupSpan.End()
 		logger.Error("failed to create repository resources client", "error", err)
 		setupError := fmt.Errorf("create repository resources client: %w", err)
-		syncStatus.State = provisioning.JobStateError
-		syncStatus.Finished = time.Now().UnixMilli()
-		syncStatus.Message = []string{setupError.Error()}
-		if updateErr := r.patchStatus(ctx, cfg, map[string]interface{}{
-			"op":    "replace",
-			"path":  "/status/sync",
-			"value": syncStatus,
-		}); updateErr != nil {
-			logger.Error("failed to update sync status after setup error", "error", updateErr)
-		}
-
+		progress.Complete(ctx, setupError)
 		return tracing.Error(span, setupError)
 	}
 	clients, err := r.clients.Clients(setupCtx, cfg.Namespace)
@@ -158,17 +148,7 @@ func (r *SyncWorker) Process(ctx context.Context, repo repository.Repository, jo
 		setupSpan.End()
 		logger.Error("failed to get clients for the repository", "error", err)
 		setupError := fmt.Errorf("get clients for %s: %w", cfg.Name, err)
-		syncStatus.State = provisioning.JobStateError
-		syncStatus.Finished = time.Now().UnixMilli()
-		syncStatus.Message = []string{setupError.Error()}
-		if updateErr := r.patchStatus(ctx, cfg, map[string]interface{}{
-			"op":    "replace",
-			"path":  "/status/sync",
-			"value": syncStatus,
-		}); updateErr != nil {
-			logger.Error("failed to update sync status after setup error", "error", updateErr)
-		}
-
+		progress.Complete(ctx, setupError)
 		return tracing.Error(span, setupError)
 	}
 	setupSpan.End()


### PR DESCRIPTION
This PR fixes an issue where jobs would get stuck in pending if any of the resource clients are unavailable. Instead, we should fail the pull job and retry on the next sync loop.

Fixes https://github.com/grafana/git-ui-sync-project/issues/572