### PR TITLE
Config: Add is_cloud to [environment] section

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -384,6 +384,7 @@ type Cfg struct {
 
 	StackID string
 	Slug    string
+	IsCloud bool // This simply identifies an instance running in Cloud, and is NOT for controlling enablement of Cloud features on-prem.
 
 	LocalFileSystemAvailable bool
 
@@ -1180,6 +1181,8 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	cfg.Env = valueAsString(iniFile.Section(""), "app_mode", "development")
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")
+	// This simply identifies an instance running in Cloud, and is NOT for controlling enablement of Cloud features on-prem.
+	cfg.IsCloud = iniFile.Section("environment").Key("is_cloud").MustBool(false)
 	cfg.LocalFileSystemAvailable = iniFile.Section("environment").Key("local_file_system_available").MustBool(true)
 	cfg.InstanceName = valueAsString(iniFile.Section(""), "instance_name", "unknown_instance_name")
 	plugins := valueAsString(iniFile.Section("paths"), "plugins", "")


### PR DESCRIPTION
**What is this feature?**

Adds a `is_cloud` setting in the `[environment]` section of the config

**Why do we need this feature?**

To know whether we are running in Cloud.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
