### PR TITLE
CloudMigrations: Increase timeout of eventual checks and add debug message in flaky test

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration_test.go
@@ -425,14 +425,29 @@ func Test_OnlyQueriesStatusFromGMSWhenRequired(t *testing.T) {
 			Status:    status,
 		})
 		assert.NoError(t, err)
-		_, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
+		snapshot, err := s.GetSnapshot(context.Background(), cloudmigration.GetSnapshotsQuery{
 			SnapshotUID: uid,
 			SessionUID:  sess.UID,
 		})
 		assert.NoError(t, err)
-		require.Eventually(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 }, time.Second, 10*time.Millisecond)
+		assert.Equal(t, status, snapshot.Status)
+
+		require.Eventually(
+			t,
+			func() bool { return gmsClientMock.GetSnapshotStatusCallCount() == i+1 },
+			2*time.Second,
+			100*time.Millisecond,
+			"GMS client mock GetSnapshotStatus count: %d", gmsClientMock.GetSnapshotStatusCallCount(),
+		)
 	}
-	assert.Never(t, func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 }, time.Second, 10*time.Millisecond)
+
+	assert.Never(
+		t,
+		func() bool { return gmsClientMock.GetSnapshotStatusCallCount() > 2 },
+		2*time.Second,
+		100*time.Millisecond,
+		"GMS client mock GetSnapshotStatus called more than expected: %d times", gmsClientMock.GetSnapshotStatusCallCount(),
+	)
 }
 
 // Implementation inspired by ChatGPT, OpenAI's language model.

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -45,7 +45,7 @@ func TestGetAlertMuteTimings(t *testing.T) {
 	t.Run("it returns the mute timings", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 		s.features = featuremgmt.WithFeatures(featuremgmt.FlagOnPremToCloudMigrations)
 
 		user := &user.SignedInUser{OrgID: 1}
@@ -69,7 +69,7 @@ func TestGetNotificationTemplates(t *testing.T) {
 	t.Run("it returns the notification templates", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1}
 
@@ -92,7 +92,7 @@ func TestGetContactPoints(t *testing.T) {
 	t.Run("it returns the contact points", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{
 			OrgID: 1,
@@ -115,7 +115,7 @@ func TestGetContactPoints(t *testing.T) {
 	t.Run("it returns an error when user lacks permission to read contact point secrets", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{
 			OrgID: 1,
@@ -144,7 +144,7 @@ func TestGetNotificationPolicies(t *testing.T) {
 	t.Run("it returns the contact points", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1}
 
@@ -172,7 +172,7 @@ func TestGetAlertRules(t *testing.T) {
 	t.Run("it returns the alert rules", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: alertRulesPermissions}}
 
@@ -191,7 +191,7 @@ func TestGetAlertRules(t *testing.T) {
 			c.CloudMigration.AlertRulesState = setting.GMSAlertRulesPaused
 		}
 
-		s := setUpServiceTest(t, false, alertRulesState).(*Service)
+		s := setUpServiceTest(t, alertRulesState).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: alertRulesPermissions}}
 
@@ -218,7 +218,7 @@ func TestGetAlertRuleGroups(t *testing.T) {
 	t.Run("it returns the alert rule groups", func(t *testing.T) {
 		t.Parallel()
 
-		s := setUpServiceTest(t, false).(*Service)
+		s := setUpServiceTest(t).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: alertRulesPermissions}}
 
@@ -257,7 +257,7 @@ func TestGetAlertRuleGroups(t *testing.T) {
 			c.CloudMigration.AlertRulesState = setting.GMSAlertRulesPaused
 		}
 
-		s := setUpServiceTest(t, false, alertRulesState).(*Service)
+		s := setUpServiceTest(t, alertRulesState).(*Service)
 
 		user := &user.SignedInUser{OrgID: 1, Permissions: map[int64]map[string][]string{1: alertRulesPermissions}}
 


### PR DESCRIPTION
**What is this feature?**

- Removes an unused param in `setUpServiceTest` for simpler setup
- Increases the timeout for eventual checks in a flaky test (`Test_OnlyQueriesStatusFromGMSWhenRequired`) 2x
- Adds debug messages to this flaky test to understand better why it is flaking

**Why do we need this feature?**

Fix flaky tests!

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
