### PR TITLE
Remove unused arguments from ResourceIndex and SearchBackend interfaces.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -715,7 +715,7 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 
 			// Recheck if some other goroutine managed to build an index in the meantime.
 			// (That is, it finished running this function and stored the index into the cache)
-			idx := s.search.GetIndex(key)
+			idx = s.search.GetIndex(key)
 			if idx != nil {
 				return idx, nil
 			}

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -715,7 +715,7 @@ func (s *searchSupport) getOrCreateIndex(ctx context.Context, key NamespacedReso
 
 			// Recheck if some other goroutine managed to build an index in the meantime.
 			// (That is, it finished running this function and stored the index into the cache)
-			idx = s.search.GetIndex(key)
+			idx := s.search.GetIndex(key)
 			if idx != nil {
 				return idx, nil
 			}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -170,13 +170,8 @@ func NewBleveBackend(opts BleveOptions, tracer trace.Tracer, indexMetrics *resou
 }
 
 // GetIndex will return nil if the key does not exist
-func (b *bleveBackend) GetIndex(_ context.Context, key resource.NamespacedResource) (resource.ResourceIndex, error) {
-	idx := b.getCachedIndex(key, time.Now())
-	// Avoid returning typed nils.
-	if idx == nil {
-		return nil, nil
-	}
-	return idx, nil
+func (b *bleveBackend) GetIndex(key resource.NamespacedResource) resource.ResourceIndex {
+	return b.getCachedIndex(key, time.Now())
 }
 
 func (b *bleveBackend) GetOpenIndexes() []resource.NamespacedResource {
@@ -1358,7 +1353,7 @@ func (b *bleveIndex) stopUpdaterAndCloseIndex() error {
 	return b.index.Close()
 }
 
-func (b *bleveIndex) UpdateIndex(ctx context.Context, reason string) (int64, error) {
+func (b *bleveIndex) UpdateIndex(ctx context.Context) (int64, error) {
 	// We don't have to do anything if the index cannot be updated (typically in tests).
 	if b.updaterFn == nil {
 		return 0, nil

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -171,7 +171,12 @@ func NewBleveBackend(opts BleveOptions, tracer trace.Tracer, indexMetrics *resou
 
 // GetIndex will return nil if the key does not exist
 func (b *bleveBackend) GetIndex(key resource.NamespacedResource) resource.ResourceIndex {
-	return b.getCachedIndex(key, time.Now())
+	idx := b.getCachedIndex(key, time.Now())
+	// Avoid returning typed nils.
+	if idx == nil {
+		return nil
+	}
+	return idx
 }
 
 func (b *bleveBackend) GetOpenIndexes() []resource.NamespacedResource {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -903,8 +903,7 @@ func TestBuildIndexExpiration(t *testing.T) {
 			backend.runEvictExpiredOrUnownedIndexes(time.Now().Add(5 * time.Minute))
 
 			if tc.expectedEviction {
-				idx, err := backend.GetIndex(context.Background(), ns)
-				require.NoError(t, err)
+				idx := backend.GetIndex(ns)
 				require.Nil(t, idx)
 
 				_, err = builtIndex.DocCount(context.Background(), "")
@@ -913,8 +912,7 @@ func TestBuildIndexExpiration(t *testing.T) {
 				// Verify that there are no open indexes.
 				checkOpenIndexes(t, reg, 0, 0)
 			} else {
-				idx, err := backend.GetIndex(context.Background(), ns)
-				require.NoError(t, err)
+				idx := backend.GetIndex(ns)
 				require.NotNil(t, idx)
 
 				cnt, err := builtIndex.DocCount(context.Background(), "")
@@ -1246,7 +1244,7 @@ func TestIndexUpdate(t *testing.T) {
 	require.Equal(t, int64(0), resp.TotalHits)
 
 	// Update index.
-	_, err = idx.UpdateIndex(context.Background(), "test")
+	_, err = idx.UpdateIndex(context.Background())
 	require.NoError(t, err)
 
 	// Verify that index was updated -- number of docs didn't change, but we can search "gen_1" documents now.
@@ -1254,7 +1252,7 @@ func TestIndexUpdate(t *testing.T) {
 	require.Equal(t, int64(5), searchTitle(t, idx, "gen_1", 10, ns).TotalHits)
 
 	// Update index again.
-	_, err = idx.UpdateIndex(context.Background(), "test")
+	_, err = idx.UpdateIndex(context.Background())
 	require.NoError(t, err)
 	// Verify that index was updated again -- we can search "gen_2" now. "gen_1" documents are gone.
 	require.Equal(t, 10, docCount(t, idx))
@@ -1298,13 +1296,13 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	_, err = idx.UpdateIndex(ctx, "test")
+	_, err = idx.UpdateIndex(ctx)
 	require.NoError(t, err)
 
 	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false)
 	require.NoError(t, err)
 
-	_, err = idx.UpdateIndex(ctx, "test")
+	_, err = idx.UpdateIndex(ctx)
 	require.Contains(t, err.Error(), bleve.ErrorIndexClosed.Error())
 }
 
@@ -1340,10 +1338,8 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 				case <-time.After(time.Duration(i) * time.Millisecond): // introduce small jitter
 				}
 
-				idx, err := be.GetIndex(ctx, ns)
-				require.NoError(t, err) // GetIndex doesn't really return error.
-
-				_, err = idx.UpdateIndex(ctx, "test")
+				idx := be.GetIndex(ns)
+				_, err = idx.UpdateIndex(ctx)
 				if err != nil {
 					if errors.Is(err, bleve.ErrorIndexClosed) || errors.Is(err, context.Canceled) {
 						continue
@@ -1424,7 +1420,7 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 			prevRV := int64(0)
 			for ctx.Err() == nil {
 				// We use t.Context() here to avoid getting errors from context cancellation.
-				rv, err := idx.UpdateIndex(t.Context(), "test")
+				rv, err := idx.UpdateIndex(t.Context())
 				require.NoError(t, err)
 				require.Greater(t, rv, prevRV) // Each update should return new RV (that's how our update function works)
 				require.Equal(t, int64(10), searchTitle(t, idx, "Document", 10, ns).TotalHits)
@@ -1484,7 +1480,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 				attemptedUpdates.Inc()
 
 				// We use t.Context() here to avoid getting errors from context cancellation.
-				rv, err := idx.UpdateIndex(t.Context(), "test")
+				rv, err := idx.UpdateIndex(t.Context())
 				require.NoError(t, err)
 
 				// Our update function returns unix timestamp in millis. We expect it to not change at all, or change by minInterval.
@@ -1536,7 +1532,7 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("update fail", func(t *testing.T) {
-		_, err = idx.UpdateIndex(t.Context(), "test")
+		_, err = idx.UpdateIndex(t.Context())
 		require.ErrorIs(t, err, updateErr)
 	})
 
@@ -1544,7 +1540,7 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Millisecond)
 		defer cancel()
 
-		_, err = idx.UpdateIndex(ctx, "test")
+		_, err = idx.UpdateIndex(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
@@ -1553,7 +1549,7 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		_, err = idx.UpdateIndex(ctx, "test")
+		_, err = idx.UpdateIndex(ctx)
 		require.ErrorIs(t, err, context.Canceled)
 	})
 }

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -59,12 +59,11 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 	}
 
 	// Get the index should return nil if the index does not exist
-	index, err := backend.GetIndex(ctx, ns)
-	require.NoError(t, err)
+	index := backend.GetIndex(ns)
 	require.Nil(t, index)
 
 	// Build the index
-	index, err = backend.BuildIndex(ctx, ns, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+	index, err := backend.BuildIndex(ctx, ns, 0, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		// Write a test document
 		err := index.BulkIndex(&resource.BulkIndexRequest{
 			Items: []*resource.BulkIndexItem{
@@ -91,8 +90,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 	require.NotNil(t, index)
 
 	// Get the index should now return the index
-	index, err = backend.GetIndex(ctx, ns)
-	require.NoError(t, err)
+	index = backend.GetIndex(ns)
 	require.NotNil(t, index)
 }
 


### PR DESCRIPTION
Follow-up to https://github.com/grafana/grafana/pull/111978#discussion_r2401899074.