### PR TITLE
[release-11.6.7] URLParams: Stringify true values as key=true always (fixes issues with variables with true value) 

### DIFF
--- a/.betterer.results
+++ b/.betterer.results
@@ -5240,9 +5240,6 @@ exports[`better eslint`] = {
     "public/app/features/panel/panellinks/linkSuppliers.ts:5381": [
       [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
     ],
-    "public/app/features/panel/panellinks/link_srv.ts:5381": [
-      [0, 0, 0, "Unexpected any. Specify a different type.", "0"]
-    ],
     "public/app/features/playlist/PlaylistCard.tsx:5381": [
       [0, 0, 0, "\'@grafana/ui/src/unstable\' import is restricted from being used by a pattern. Import from the public export instead.", "0"]
     ],

--- a/packages/grafana-data/src/utils/url.test.ts
+++ b/packages/grafana-data/src/utils/url.test.ts
@@ -11,7 +11,9 @@ describe('toUrlParams', () => {
       isNull: null,
       isUndefined: undefined,
     });
-    expect(url).toBe('server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=');
+    expect(url).toBe(
+      'server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true=true&number=20&isNull=&isUndefined='
+    );
   });
   it('should encode the same way as angularjs', () => {
     const url = urlUtil.toUrlParams({
@@ -25,7 +27,7 @@ describe('toUrlParams', () => {
       bool1: true,
       bool2: false,
     });
-    expect(url).toBe('bool1&bool2=false');
+    expect(url).toBe('bool1=true&bool2=false');
   });
   it("should encode the following special characters [!'()*]", () => {
     const url = urlUtil.toUrlParams({
@@ -45,7 +47,7 @@ describe('toUrlParams', () => {
       oneMore: false,
     });
     expect(params).toBe(
-      'server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true&number=20&isNull=&isUndefined=&oneMore=false'
+      'server=backend-01&hasSpace=has%20space&many=1&many=2&many=3&true=true&number=20&isNull=&isUndefined=&oneMore=false'
     );
   });
 
@@ -61,7 +63,7 @@ describe('toUrlParams', () => {
       bool1: true,
       bool2: false,
     });
-    expect(url).toBe('bool1&bool2=false');
+    expect(url).toBe('bool1=true&bool2=false');
   });
 });
 

--- a/packages/grafana-data/src/utils/url.ts
+++ b/packages/grafana-data/src/utils/url.ts
@@ -60,12 +60,7 @@ function toUrlParams(a: any, encodeAsAngularJS = true) {
 
   const add = (k: string, v: any) => {
     v = typeof v === 'function' ? v() : v === null ? '' : v === undefined ? '' : v;
-    if (typeof v !== 'boolean') {
-      s[s.length] = encodingFunction(k, true) + '=' + encodingFunction(v, true);
-    } else {
-      const valueQueryPart = v ? '' : '=' + encodingFunction('false', true);
-      s[s.length] = encodingFunction(k, true) + valueQueryPart;
-    }
+    s[s.length] = encodingFunction(k, true) + '=' + encodingFunction(v, true);
   };
 
   const buildParams = (prefix: string, obj: any) => {

--- a/packages/grafana-runtime/src/services/LocationService.test.tsx
+++ b/packages/grafana-runtime/src/services/LocationService.test.tsx
@@ -38,6 +38,13 @@ describe('LocationService', () => {
       expect(locationService.getLocation().search).toBe('?servers=A&servers=B&servers=C');
     });
 
+    it('should handle boolean string values', () => {
+      locationService.push('/?query1=false&query2=true&query3');
+      locationService.partial({ newProp: 'a' });
+
+      expect(locationService.getLocation().search).toBe('?query1=false&query2=true&query3=true&newProp=a');
+    });
+
     it('persist state', () => {
       locationService.push({
         pathname: '/d/123',

--- a/public/app/angular/AngularLocationWrapper.test.ts
+++ b/public/app/angular/AngularLocationWrapper.test.ts
@@ -88,14 +88,14 @@ describe('AngularLocationWrapper', () => {
       locationService.push('/path/b');
       wrapper.search('x=y&c');
       expect(wrapper.search()).toEqual({ x: 'y', c: true });
-      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?x=y&c');
+      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?x=y&c=true');
     });
 
     it('search() should accept object', function () {
       locationService.push('/path/b');
       wrapper.search({ one: '1', two: true });
       expect(wrapper.search()).toEqual({ one: '1', two: true });
-      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two');
+      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two=true');
     });
 
     it('should copy object', function () {
@@ -106,7 +106,7 @@ describe('AngularLocationWrapper', () => {
       obj.one = 'changed';
 
       expect(wrapper.search()).toEqual({ one: '1', two: true });
-      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two');
+      expect(wrapper.absUrl()).toBe('http://www.domain.com:9877/path/b?one=1&two=true');
     });
 
     it('should change single parameter', function () {

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.test.tsx
@@ -88,7 +88,7 @@ describe('ShareLinkTab', () => {
       await screen.findByRole('link', { name: selectors.pages.SharePanelModal.linkToRenderedImage })
     ).toHaveAttribute(
       'href',
-      'http://dashboards.grafana.com/grafana/render/d-solo/dash-1?from=2019-02-11T13:00:00.000Z&to=2019-02-11T19:00:00.000Z&panelId=panel-12&__feature.dashboardSceneSolo&width=1000&height=500&tz=Pacific%2FEaster'
+      'http://dashboards.grafana.com/grafana/render/d-solo/dash-1?from=2019-02-11T13:00:00.000Z&to=2019-02-11T19:00:00.000Z&panelId=panel-12&__feature.dashboardSceneSolo=true&width=1000&height=500&tz=Pacific%2FEaster'
     );
   });
 });

--- a/public/app/features/dashboard/services/TimeSrv.test.ts
+++ b/public/app/features/dashboard/services/TimeSrv.test.ts
@@ -297,7 +297,7 @@ describe('timeSrv', () => {
       timeSrv.setTime({ from: 'now-1h', to: 'now-10s' });
       timeSrv.setTime({ from: 'now-1h', to: 'now-10s' });
 
-      expect(locationUpdates[1].search).toEqual('?kiosk&from=now-1h&to=now-10s');
+      expect(locationUpdates[1].search).toEqual('?kiosk=true&from=now-1h&to=now-10s');
     });
 
     it('should not change the URL if the updateUrl param is false', () => {

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -252,18 +252,18 @@ export interface LinkService {
 
 export class LinkSrv implements LinkService {
   getLinkUrl(link: DashboardLink) {
-    let params: { [key: string]: any } = {};
+    let url = link.url ?? '';
 
     if (link.keepTime) {
-      params[`\$${DataLinkBuiltInVars.keepTime}`] = true;
+      url = urlUtil.appendQueryToUrl(url, `\$${DataLinkBuiltInVars.keepTime}`);
     }
 
     if (link.includeVars) {
-      params[`\$${DataLinkBuiltInVars.includeVars}`] = true;
+      url = urlUtil.appendQueryToUrl(url, `\$${DataLinkBuiltInVars.includeVars}`);
     }
 
-    let url = locationUtil.assureBaseUrl(urlUtil.appendQueryToUrl(link.url || '', urlUtil.toUrlParams(params)));
     url = getTemplateSrv().replace(url);
+    url = locationUtil.assureBaseUrl(url);
 
     return getConfig().disableSanitizeHtml ? url : textUtil.sanitizeUrl(url);
   }


### PR DESCRIPTION
Backport 1564e1bac9b1b7a0c07a9ee7d83988fe0e70998b from #106440

---

Restore some of the changes from https://github.com/grafana/grafana/pull/97346 (some made no sense), and fix the issues that the changes caused 

Fixes https://github.com/grafana/grafana/issues/97290
Fixes https://github.com/grafana/grafana/issues/106366
