### PR TITLE
Themes: Fix internal border radius of MenuItem to match new outer border radius

### DIFF
--- a/packages/grafana-data/src/themes/createComponents.ts
+++ b/packages/grafana-data/src/themes/createComponents.ts
@@ -1,5 +1,12 @@
 import { ThemeColors } from './createColors';
 import { ThemeShadows } from './createShadows';
+import type { Radii } from './createShape';
+import type { ThemeSpacingTokens } from './createSpacing';
+
+interface MenuComponentTokens {
+  borderRadius: keyof Radii;
+  padding: ThemeSpacingTokens;
+}
 
 /** @beta */
 export interface ThemeComponents {
@@ -53,6 +60,7 @@ export interface ThemeComponents {
     rowHoverBackground: string;
     rowSelected: string;
   };
+  menu: MenuComponentTokens;
 }
 
 export function createComponents(colors: ThemeColors, shadows: ThemeShadows): ThemeComponents {
@@ -69,6 +77,11 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
     borderHover: colors.border.strong,
     text: colors.text.primary,
     background: colors.mode === 'dark' ? colors.background.canvas : colors.background.primary,
+  };
+
+  const menu: MenuComponentTokens = {
+    borderRadius: 'default',
+    padding: 0.5,
   };
 
   return {
@@ -114,5 +127,6 @@ export function createComponents(colors: ThemeColors, shadows: ThemeShadows): Th
       rowHoverBackground: colors.action.hover,
       rowSelected: colors.action.selected,
     },
+    menu,
   };
 }

--- a/packages/grafana-ui/src/components/Menu/Menu.tsx
+++ b/packages/grafana-ui/src/components/Menu/Menu.tsx
@@ -25,6 +25,7 @@ export interface MenuProps extends React.HTMLAttributes<HTMLDivElement> {
 const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
   ({ header, children, ariaLabel, onOpen, onClose, onKeyDown, ...otherProps }, forwardedRef) => {
     const styles = useStyles2(getStyles);
+    const componentTokens = useComponentTokens();
 
     const localRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(forwardedRef, () => localRef.current!);
@@ -36,12 +37,11 @@ const MenuComp = React.forwardRef<HTMLDivElement, MenuProps>(
         {...otherProps}
         aria-label={ariaLabel}
         backgroundColor="elevated"
-        borderRadius="default"
+        borderRadius={componentTokens.borderRadius}
         boxShadow="z3"
         display="inline-block"
         onKeyDown={handleKeys}
-        paddingX={0.5}
-        paddingY={0.5}
+        padding={componentTokens.padding}
         ref={localRef}
         role="menu"
         tabIndex={-1}
@@ -69,6 +69,18 @@ export const Menu = Object.assign(MenuComp, {
   Divider: MenuDivider,
   Group: MenuGroup,
 });
+
+const useComponentTokens = () =>
+  useStyles2((theme: GrafanaTheme2) => {
+    const {
+      components: { menu },
+    } = theme;
+
+    return {
+      padding: menu.padding,
+      borderRadius: menu.borderRadius,
+    };
+  });
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -6,12 +6,14 @@ import { GrafanaTheme2, LinkTarget } from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { getFocusStyles } from '../../themes/mixins';
+import { getFocusStyles, getInternalRadius } from '../../themes/mixins';
 import { IconName } from '../../types/icon';
 import { Icon } from '../Icon/Icon';
 import { Stack } from '../Layout/Stack/Stack';
 
 import { SubMenu } from './SubMenu';
+
+export const MENU_ITEM_PADDING = 4;
 
 /** @internal */
 export type MenuItemElement = HTMLAnchorElement & HTMLButtonElement & HTMLDivElement;
@@ -225,7 +227,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'center',
       padding: theme.spacing(0.5, 1.5),
       minHeight: theme.spacing(4),
-      borderRadius: theme.shape.radius.default,
+      borderRadius: getInternalRadius(theme, MENU_ITEM_PADDING, { parentBorderWidth: 0 }),
       margin: 0,
       border: 'none',
       width: '100%',

--- a/packages/grafana-ui/src/components/Menu/MenuItem.tsx
+++ b/packages/grafana-ui/src/components/Menu/MenuItem.tsx
@@ -13,8 +13,6 @@ import { Stack } from '../Layout/Stack/Stack';
 
 import { SubMenu } from './SubMenu';
 
-export const MENU_ITEM_PADDING = 4;
-
 /** @internal */
 export type MenuItemElement = HTMLAnchorElement & HTMLButtonElement & HTMLDivElement;
 
@@ -215,6 +213,8 @@ export const MenuItem = React.memo(
 MenuItem.displayName = 'MenuItem';
 
 const getStyles = (theme: GrafanaTheme2) => {
+  const menuPadding = theme.components.menu.padding * theme.spacing.gridSize;
+
   return {
     item: css({
       background: 'none',
@@ -227,7 +227,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       justifyContent: 'center',
       padding: theme.spacing(0.5, 1.5),
       minHeight: theme.spacing(4),
-      borderRadius: getInternalRadius(theme, MENU_ITEM_PADDING, { parentBorderWidth: 0 }),
+      borderRadius: getInternalRadius(theme, menuPadding, { parentBorderWidth: 0 }),
       margin: 0,
       border: 'none',
       width: '100%',


### PR DESCRIPTION
**What is this feature?**

This PR updates the internal border radius used by the `MenuItem` component in the hover state to harmonise with the new larger outer border radius of 6px used on the `Menu` component. This is a follow-on to [this PR](https://github.com/grafana/grafana/pull/111478) which increases the default border radius on many components to `6px`, which may require some more finessing in examples like this.

<img src="https://github.com/user-attachments/assets/c2f583bf-59e8-4d59-8a35-cc483682f625" width="180" height="180" alt="image" />

_Before_

<img width="781" height="227" alt="image" src="https://github.com/user-attachments/assets/625fc9a6-c79f-4c18-979e-8c1babbe1149" />

_After_

<img width="782" height="223" alt="image" src="https://github.com/user-attachments/assets/7020d801-ea34-441c-8bbb-b72eba88290d" />

In addition to fixing this visual discrepancy I’ve also tried a first stab (with @ashharrison90’s input) at an approach to codify the tokens used by `Menu` and `MenuItem` without hardcoding any values locally.

### ~~Added `theme.numericValue()` function to `ThemeSpacing`~~

~~This allows us to interrogate the theme to derive a single _numeric_ value in pixels corresponding to the `theme.spacing()` function, instead of returning a string in the format `Npx`; this is necessary for now since the `getInternalRadius()` mixin requires a numeric argument for the `offset` argument.~~

Update: yanked this from the PR for now to keep things focused on the purpose of the PR.

### Added `menu` tokens to `createComponents`

This interface allows for us to specify the outer border radius and internal padding of the `Menu` component so that `MenuItem` can also consume the same values and use them to derive the _internal_ border radius.

**Why do we need this feature?**

For any components with nested border radii, for these to look ‘correct’ they need to use a border radius equal to the outer radius _minus_ the external border radius of the parent. For now this relationship is determined by the `getInternalRadius` mixin, combined with the internal padding and border-width properties of the parent.

**Who is this feature for?**

This PR doesn't fix any specific usability bug, but does address a visual defect as we look to improve overall polish.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
