### PR TITLE
PostgreSQL: Refactor feature toggle handling for standalone mode

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -15,7 +15,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/instancemgmt"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/grafana/grafana-plugin-sdk-go/data/sqlutil"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 
@@ -129,7 +128,7 @@ func newPostgresPGX(ctx context.Context, userFacingDefaultError string, rowLimit
 	return p, handler, nil
 }
 
-func NewInstanceSettings(logger log.Logger, features featuremgmt.FeatureToggles, dataPath string) datasource.InstanceFactoryFunc {
+func NewInstanceSettings(logger log.Logger, usePGX bool, dataPath string) datasource.InstanceFactoryFunc {
 	return func(ctx context.Context, settings backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 		cfg := backend.GrafanaConfigFromContext(ctx)
 		sqlCfg, err := cfg.SQL()
@@ -167,14 +166,12 @@ func NewInstanceSettings(logger log.Logger, features featuremgmt.FeatureToggles,
 			DecryptedSecureJSONData: settings.DecryptedSecureJSONData,
 		}
 
-		isPGX := features.IsEnabled(ctx, featuremgmt.FlagPostgresDSUsePGX)
-
 		userFacingDefaultError, err := cfg.UserFacingDefaultError()
 		if err != nil {
 			return nil, err
 		}
 
-		if isPGX {
+		if usePGX {
 			pgxlogger := logger.FromContext(ctx).With("driver", "pgx")
 			pgxTlsManager := newPgxTlsManager(pgxlogger)
 			pgxTlsSettings, err := pgxTlsManager.getTLSSettings(dsInfo)
@@ -184,7 +181,7 @@ func NewInstanceSettings(logger log.Logger, features featuremgmt.FeatureToggles,
 
 			// Ensure cleanupCertFiles is called after the connection is opened
 			defer pgxTlsManager.cleanupCertFiles(pgxTlsSettings)
-			cnnstr, err := generateConnectionString(dsInfo, pgxTlsSettings, isPGX, pgxlogger)
+			cnnstr, err := generateConnectionString(dsInfo, pgxTlsSettings, usePGX, pgxlogger)
 			if err != nil {
 				return "", err
 			}
@@ -202,7 +199,7 @@ func NewInstanceSettings(logger log.Logger, features featuremgmt.FeatureToggles,
 			if err != nil {
 				return "", err
 			}
-			cnnstr, err := generateConnectionString(dsInfo, tlsSettings, isPGX, pqlogger)
+			cnnstr, err := generateConnectionString(dsInfo, tlsSettings, usePGX, pqlogger)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres_service.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres_service.go
@@ -20,8 +20,9 @@ type Service struct {
 
 func ProvideService(cfg *setting.Cfg, features featuremgmt.FeatureToggles) *Service {
 	logger := backend.NewLoggerWith("logger", "tsdb.postgres")
+	usePGX := features.IsEnabled(context.Background(), featuremgmt.FlagPostgresDSUsePGX)
 	s := &Service{
-		im:       datasource.NewInstanceManager(NewInstanceSettings(logger, features, cfg.DataPath)),
+		im:       datasource.NewInstanceManager(NewInstanceSettings(logger, usePGX, cfg.DataPath)),
 		features: features,
 	}
 	return s

--- a/pkg/tsdb/grafana-postgresql-datasource/standalone/main.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/standalone/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/datasource"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	postgres "github.com/grafana/grafana/pkg/tsdb/grafana-postgresql-datasource"
 )
@@ -14,11 +13,9 @@ import (
 func main() {
 	// No need to pass logger name, it will be set by the plugin SDK
 	logger := backend.NewLoggerWith()
-	// TODO: get rid of setting.NewCfg() and featuremgmt.FeatureToggles once PostgresDSUsePGX is removed
+	// TODO: get rid of setting.NewCfg() once PostgresDSUsePGX is removed
 	cfg := setting.NewCfg()
-	// We want to enable the feature toggle for api server
-	features := featuremgmt.WithFeatures(featuremgmt.FlagPostgresDSUsePGX)
-	if err := datasource.Manage("grafana-postgresql-datasource", postgres.NewInstanceSettings(logger, features, cfg.DataPath), datasource.ManageOpts{}); err != nil {
+	if err := datasource.Manage("grafana-postgresql-datasource", postgres.NewInstanceSettings(logger, true, cfg.DataPath), datasource.ManageOpts{}); err != nil {
 		log.DefaultLogger.Error(err.Error())
 		os.Exit(1)
 	}


### PR DESCRIPTION
This PR fixes an issue that running the standalone version of postgresql datasource would use libpq instead of pgx driver. We want to run with the pgx driver always.

To test it please follow the step by step guide in https://github.com/grafana/grafana/pull/111620

When as_external is true the driver in the logs should be pgx. When as_external is false we should be able to control the driver value with the feature toggle.