### PR TITLE
Docs: Add a note about email being required and the usage of sub claim

### DIFF
--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -147,7 +147,7 @@ Refer to the following table for information on what to configure based on how y
 
 #### Use the `sub` claim for login
 
-Many OIDC providers expose a stable subject identifier in the `sub` claim. You can use it to populate the Grafana login by setting `login_attribute_path` to `sub`. Because email is still required, also make sure Grafana can resolve the user's email (for example by including the `email` scope or mapping a custom field via `email_attribute_path`).
+Most of the OAuth2 providers expose a stable subject identifier in the `sub` claim. You can use it to populate the Grafana login by setting `login_attribute_path` to `sub`. Because email is still required, also make sure Grafana can resolve the user's email (for example by including the `email` scope or mapping a custom field via `email_attribute_path`).
 
 Example configuration:
 

--- a/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
+++ b/docs/sources/setup-grafana/configure-security/configure-authentication/generic-oauth/index.md
@@ -130,6 +130,10 @@ Grafana can resolve a user's login from the OAuth2 ID token, user information re
 Grafana looks at these sources in the order listed until it finds a login.
 If no login is found, then the user's login is set to user's email address.
 
+{{< admonition type="important" >}}
+Email is required for successful sign-up and login with Generic OAuth. Even if you map `login` from another claim (for example `sub`), Grafana still requires the user to have an email. Ensure your provider returns an email claim or configure `email_attribute_path` so Grafana can resolve it. Including the `email` scope is strongly recommended (for OIDC providers use `openid profile email`).
+{{< /admonition >}}
+
 Refer to the following table for information on what to configure based on how your Oauth2 provider returns a user's login:
 
 | Source of login                                                                 | Required configuration                           |
@@ -140,6 +144,21 @@ Refer to the following table for information on what to configure based on how y
 | Another field of the user information from the UserInfo endpoint.               | Set `login_attribute_path` configuration option. |
 | `login` or `username` field of the OAuth2 access token.                         | N/A                                              |
 | Another field of the OAuth2 access token.                                       | Set `login_attribute_path` configuration option. |
+
+#### Use the `sub` claim for login
+
+Many OIDC providers expose a stable subject identifier in the `sub` claim. You can use it to populate the Grafana login by setting `login_attribute_path` to `sub`. Because email is still required, also make sure Grafana can resolve the user's email (for example by including the `email` scope or mapping a custom field via `email_attribute_path`).
+
+Example configuration:
+
+```ini
+[auth.generic_oauth]
+enabled = true
+scopes = openid profile email
+login_attribute_path = sub
+# If your provider does not return `email` at the top level, map it explicitly
+# email_attribute_path = user.email
+```
 
 ### Configure display name
 


### PR DESCRIPTION
**What is this feature?**

Adds a small note making it clear that email is required by Grafana when using OAuth

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/18109

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
