### PR TITLE
Timeseries: Numeric duration values could render as NaN (#73795)

### DIFF
--- a/packages/grafana-data/src/field/displayProcessor.test.ts
+++ b/packages/grafana-data/src/field/displayProcessor.test.ts
@@ -423,6 +423,11 @@ describe('Format value', () => {
       const processor = getDisplayProcessorFromConfig({ decimals: 5 }, FieldType.number);
       expect(processor(35, 2).text).toEqual('35.00000');
     });
+
+    it('does not attempt to coerce non-numeric strings back to numbers', () => {
+      const processor = getDisplayProcessorFromConfig({ unit: 'dthms' }, FieldType.number);
+      expect(processor(35, 2).text).toEqual('00:00:35'); // we're checking that this isn't NaN.
+    });
   });
 });
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -49,7 +49,7 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
   const { palette } = options.theme.visualization;
 
   let unit = config.unit;
-  let hasDateUnit = unit && (timeFormats[unit] || unit.startsWith('time:'));
+  let hasDateUnit = Boolean(unit && (timeFormats[unit] || unit.startsWith('time:')));
   let showMs = false;
 
   if (field.type === FieldType.time && !hasDateUnit) {
@@ -152,7 +152,11 @@ export function getDisplayProcessor(options?: DisplayProcessorOptions): DisplayP
           // this is needed because we may have determined the minimum determined `adjacentDecimals` for y tick increments based on
           // e.g. 'seconds' field unit (0.15s, 0.20s, 0.25s), but then formatFunc decided to return milli or nanos (150, 200, 250)
           // so we end up with excess precision: 150.00, 200.00, 250.00
-          v.text = +v.text + '';
+          // #73795 - some units, like duration formats, return text which cannot be coerced back into a number safely at this point.
+          const asNum = +v.text;
+          if (!Number.isNaN(asNum)) {
+            v.text = asNum + '';
+          }
         } else {
           v = formatFunc(numeric, config.decimals, null, options.timeZone, showMs);
         }


### PR DESCRIPTION
Fixes #73795

Updated the display processor logic to check for a NaN before writing over the text value in the situation where a number formatter has resulted in a non-numeric string at this point, which I believe will mainly apply to duration and other similar units.

### Before

https://github.com/user-attachments/assets/036b6409-5778-40b0-b609-f8e903eda514

### After

https://github.com/user-attachments/assets/07b09b78-fb14-4a46-983a-246eb64b8c24