### PR TITLE
Table: Cell actions now hide properly on hover out after clicking

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/styles.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/styles.ts
@@ -148,12 +148,15 @@ export const getDefaultCellStyles: TableCellStyles = (theme, { textAlign, should
     ...(shouldOverflow && { minHeight: '100%' }),
 
     [getActiveCellSelector()]: {
-      '.table-cell-actions': { display: 'flex' },
       ...(shouldOverflow && {
         zIndex: theme.zIndex.tooltip - 2,
         height: 'fit-content',
         minWidth: 'fit-content',
       }),
+    },
+
+    [getHoverOnlyCellSelector()]: {
+      '.table-cell-actions': { display: 'flex' },
     },
   });
 
@@ -251,4 +254,11 @@ export const getActiveCellSelector = memoize((isNested?: boolean) => {
     selectors.push(ACTIVE_CELL_SELECTORS.hover[isNested ? 'nested' : 'normal']);
   }
   return selectors.join(', ');
+});
+
+export const getHoverOnlyCellSelector = memoize((isNested?: boolean) => {
+  if (IS_SAFARI_26) {
+    return '';
+  }
+  return ACTIVE_CELL_SELECTORS.hover[isNested ? 'nested' : 'normal'];
 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Table cell filter actions (filter-plus/filter-minus buttons) would remain visible after clicking them, even when the mouse moved away from the cell.

Before:

https://github.com/user-attachments/assets/91a0e666-ad53-404b-80dd-6f3b32492df1

After:

https://github.com/user-attachments/assets/c884e762-f1be-48ec-b0d0-2dbb9e74d7df

