### PR TITLE
Unistore: ignore name when validating collection keys

### DIFF
--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -170,9 +170,9 @@ func (s *server) BulkProcess(stream resourcepb.BulkStore_BulkProcessServer) erro
 		})
 	}
 
-	// Verify all request keys are valid
+	// Verify all collection request keys are valid
 	for _, k := range settings.Collection {
-		if r := verifyRequestKey(k); r != nil {
+		if r := verifyRequestKeyCollection(k); r != nil {
 			return sendAndClose(&resourcepb.BulkResponse{
 				Error: &resourcepb.ErrorResult{
 					Message: fmt.Sprintf("invalid request key: %s", r.Message),

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -8,7 +8,24 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
+// verifyRequestKey verifies that the key is valid for a request (all fields set and valid, including name)
 func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
+	if err := verifyRequestKeyNamespaceGroupResource(key); err != nil {
+		return NewBadRequestError(err.Message)
+	}
+	if err := validation.IsValidGrafanaName(key.Name); err != nil {
+		return NewBadRequestError(err[0])
+	}
+	return nil
+}
+
+// verifyRequestKeyCollection verifies that the key is valid for a collection (namespace/group/resource set and valid)
+func verifyRequestKeyCollection(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
+	return verifyRequestKeyNamespaceGroupResource(key)
+}
+
+// verifyRequestKeyNamespaceGroupResource verifies that the key has namespace/group/resource set and valid
+func verifyRequestKeyNamespaceGroupResource(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 	if key == nil {
 		return NewBadRequestError("missing resource key")
 	}
@@ -25,9 +42,6 @@ func verifyRequestKey(key *resourcepb.ResourceKey) *resourcepb.ErrorResult {
 		return NewBadRequestError(err[0])
 	}
 	if err := validation.IsValidateResource(key.Resource); err != nil {
-		return NewBadRequestError(err[0])
-	}
-	if err := validation.IsValidGrafanaName(key.Name); err != nil {
 		return NewBadRequestError(err[0])
 	}
 	return nil


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Add a new function `verifyRequestKeyCollection` to validate request keys for Bulk operations.

Previous to this PR, we have been validating request keys for Bulk operations using the `verifyRequestKey` function, which validates also the `name` field, which is empty for Collections.

**Why do we need this feature?**

The request key `name` attribute is ignored for Bulk operations, therefore makes no sense to validate name when processing Bulk operations.


**Who is this feature for?**

@grafana/grafana-search-and-storage 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/search-and-storage-team/issues/534

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
