### PR TITLE
AuthZ: Fix cacheHit computation

### DIFF
--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -760,12 +760,10 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 	cacheHit := false
 	if t.HasFolderSupport() {
 		var err error
-		ok = false
 		if !req.Options.SkipCache {
-			tree, ok = s.getCachedFolderTree(ctx, req.Namespace)
-			cacheHit = ok
+			tree, cacheHit = s.getCachedFolderTree(ctx, req.Namespace)
 		}
-		if !ok {
+		if !cacheHit {
 			tree, err = s.buildFolderTree(ctx, req.Namespace)
 			if err != nil {
 				ctxLogger.Error("could not build folder and dashboard tree", "error", err)

--- a/pkg/services/authz/rbac/service.go
+++ b/pkg/services/authz/rbac/service.go
@@ -763,7 +763,7 @@ func (s *Service) listPermission(ctx context.Context, scopeMap map[string]bool, 
 		ok = false
 		if !req.Options.SkipCache {
 			tree, ok = s.getCachedFolderTree(ctx, req.Namespace)
-			cacheHit = true
+			cacheHit = ok
 		}
 		if !ok {
 			tree, err = s.buildFolderTree(ctx, req.Namespace)


### PR DESCRIPTION
We always assumed cache was hit, even if the getCachedFolderTree function returned false.