### PR TITLE
Update hidden element copy

### DIFF
--- a/public/app/features/dashboard-scene/conditional-rendering/hooks/ConditionalRenderingOverlay.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/hooks/ConditionalRenderingOverlay.tsx
@@ -9,12 +9,7 @@ export const ConditionalRenderingOverlay = () => {
 
   return (
     <div className={styles.container}>
-      <Tooltip
-        content={t(
-          'dashboard.conditional-rendering.overlay.tooltip',
-          'Element is hidden due to conditional rendering.'
-        )}
-      >
+      <Tooltip content={t('dashboard.conditional-rendering.overlay.tooltip', 'Element is hidden by show/hide rules.')}>
         <Icon name="eye-slash" />
       </Tooltip>
     </div>

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -101,12 +101,7 @@ export function TabItemRenderer({ model }: SceneComponentProps<TabItem>) {
 function IsHiddenSuffix() {
   return (
     <Box paddingLeft={1} display={'inline'}>
-      <Tooltip
-        content={t(
-          'dashboard.conditional-rendering.overlay.tooltip',
-          'Element is hidden due to conditional rendering.'
-        )}
-      >
+      <Tooltip content={t('dashboard.conditional-rendering.overlay.tooltip', 'Element is hidden by show/hide rules.')}>
         <Icon name="eye-slash" />
       </Tooltip>
     </Box>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4553,7 +4553,7 @@
         "unsupported-object-type": "Conditional rendering not supported for this item type"
       },
       "overlay": {
-        "tooltip": "Element is hidden due to conditional rendering."
+        "tooltip": "Element is hidden by show/hide rules."
       },
       "root": {
         "title": "Show / hide rules"


### PR DESCRIPTION
Updates the tooltip text when hovering over an element hidden by conditional rendering.

Conditional rendering is only used internally, so this is changing the text to `show/hide rules` which is what we use elsewhere in the UI.