### PR TITLE
Palette: use `semi-dark-yellow` for more contrast

### DIFF
--- a/packages/grafana-data/src/field/fieldColor.test.ts
+++ b/packages/grafana-data/src/field/fieldColor.test.ts
@@ -47,7 +47,7 @@ describe('fieldColorModeRegistry', () => {
 
   it('Palette classic with series index 1', () => {
     const calcFn = getCalculator({ mode: FieldColorModeId.PaletteClassic, seriesIndex: 1, name: 'series2' });
-    expect(calcFn(70, 0, undefined)).toEqual('#FADE2A');
+    expect(calcFn(70, 0, undefined)).toEqual('#F2CC0C');
   });
 
   it('Palette uses name', () => {

--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -388,7 +388,7 @@ describe('FieldDisplay', () => {
 
       const result = getFieldDisplayValues(options);
       expect(result[0].display.color).toEqual('#73BF69');
-      expect(result[1].display.color).toEqual('#FADE2A');
+      expect(result[1].display.color).toEqual('#F2CC0C');
     });
 
     it('When showing all values lookup color via an override', () => {
@@ -435,7 +435,7 @@ describe('FieldDisplay', () => {
 
       const result = getFieldDisplayValues(options);
       expect(result[0].display.color).toEqual('#AAA');
-      expect(result[1].display.color).toEqual('#FADE2A');
+      expect(result[1].display.color).toEqual('#F2CC0C');
     });
 
     it('Multiple other string fields', () => {

--- a/packages/grafana-data/src/themes/createVisualizationColors.ts
+++ b/packages/grafana-data/src/themes/createVisualizationColors.ts
@@ -261,7 +261,7 @@ function getClassicPalette() {
 
   return [
     'green',
-    'yellow',
+    'semi-dark-yellow',
     'blue',
     'orange',
     'red',


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- change the second palette color from `yellow` to `semi-dark-yellow` for more contrast in light theme
- see [slack thread](https://raintank-corp.slack.com/archives/C03KVDHTWAH/p1759237506252429) for context

**Why do we need this feature?**

- so the second palette color is more visible

**Who is this feature for?**

- anyone using light theme

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
