### PR TITLE
Docs: Set role global property to false in TF role provisioning example

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-terraform-provisioning/index.md
@@ -174,7 +174,7 @@ resource "grafana_role" "my_new_role" {
   description = "My test role"
   version = 1
   uid = "newroleuid"
-  global = true
+  global = false
 
   permissions {
     action = "org.users:add"


### PR DESCRIPTION
**What is this feature?**

Updating the docs to have a better Terraform role creation example.

**Why do we need this feature?**

We want to discourage the creation of global roles, as they often cause confusions (they can't be created and managed using service accounts) and most use cases are satisfied with organization scoped roles.
