### PR TITLE
Folder API: Lock delete action to legacy API

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -166,23 +166,14 @@ describe('useDeleteMultipleFoldersMutationFacade', () => {
 
   it('deletes multiple folders and publishes success alert', async () => {
     config.featureToggles.foldersAppPlatformAPI = true;
+    // Same test as for legacy as right now we always use legacy API for deletes.
     const folderUIDs = ['uid1', 'uid2'];
     const deleteFolders = useDeleteMultipleFoldersMutationFacade();
     await deleteFolders({ folderUIDs });
 
     // Should call deleteFolder for each UID
-    expect(mockDeleteFolder).toHaveBeenCalledTimes(folderUIDs.length);
-    expect(mockDeleteFolder).toHaveBeenCalledWith({ name: 'uid1' });
-    expect(mockDeleteFolder).toHaveBeenCalledWith({ name: 'uid2' });
-
-    // Should publish success alert
-    expect(publishMockFn).toHaveBeenCalledWith({
-      type: AppEvents.alertSuccess.name,
-      payload: ['Folder deleted'],
-    });
-
-    // Should dispatch refreshParents
-    expect(dispatchMockFn).toHaveBeenCalled();
+    expect(mockDeleteFolderLegacy).toHaveBeenCalledTimes(1);
+    expect(mockDeleteFolderLegacy).toHaveBeenCalledWith({ folderUIDs });
   });
 
   it('uses legacy call when flag is false', async () => {

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -172,37 +172,41 @@ export function useGetFolderQueryFacade(uid?: string) {
 }
 
 export function useDeleteFolderMutationFacade() {
-  const [deleteFolder] = useDeleteFolderMutation();
+  const [deleteFolderMutation] = useDeleteFolderMutation();
   const [deleteFolderLegacy] = useDeleteFolderMutationLegacy();
   const refresh = useRefreshFolders();
   const notify = useAppNotification();
 
-  return async (folder: FolderDTO) => {
-    if (config.featureToggles.foldersAppPlatformAPI) {
-      const result = await deleteFolder({ name: folder.uid });
-      if (!result.error) {
-        // we could do this in the enhanceEndpoint method, but we would also need to change the args as we need parentUID
-        // here and so it seemed easier to do it here.
-        refresh({ childrenOf: folder.parentUid });
-        // Before this was done in backend srv automatically because the old API sent a message wiht 200 request. see
-        // public/app/core/services/backend_srv.ts#L341-L361. New API does not do that so we do it here.
-        notify.success(t('folders.api.folder-deleted-success', 'Folder deleted'));
-      }
-      return result;
-    } else {
-      return deleteFolderLegacy(folder);
+  // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
+  const isBackendSupport = false;
+  if (!(config.featureToggles.foldersAppPlatformAPI && isBackendSupport)) {
+    return deleteFolderLegacy;
+  }
+
+  return async function deleteFolder(folder: FolderDTO) {
+    const result = await deleteFolderMutation({ name: folder.uid });
+    if (!result.error) {
+      // we could do this in the enhanceEndpoint method, but we would also need to change the args as we need parentUID
+      // here and so it seemed easier to do it here.
+      refresh({ childrenOf: folder.parentUid });
+      // Before this was done in backend srv automatically because the old API sent a message wiht 200 request. see
+      // public/app/core/services/backend_srv.ts#L341-L361. New API does not do that so we do it here.
+      notify.success(t('folders.api.folder-deleted-success', 'Folder deleted'));
     }
+    return result;
   };
 }
 
 export function useDeleteMultipleFoldersMutationFacade() {
-  const [deleteFolders] = useDeleteFoldersMutationLegacy();
+  const [deleteFoldersLegacy] = useDeleteFoldersMutationLegacy();
   const [deleteFolder] = useDeleteFolderMutation();
   const dispatch = useDispatch();
   const refresh = useRefreshFolders();
 
-  if (!config.featureToggles.foldersAppPlatformAPI) {
-    return deleteFolders;
+  // TODO right now the app platform backend does not support cascading delete of children so we cannot use it.
+  const isBackendSupport = false;
+  if (!(config.featureToggles.foldersAppPlatformAPI && isBackendSupport)) {
+    return deleteFoldersLegacy;
   }
 
   return async function deleteFolders({ folderUIDs }: DeleteFoldersArgs) {


### PR DESCRIPTION
As we don't have support for cascading deletes in the new API yet we lock the delete action to legacy API only even with `foldersAppPlatformAPI=true`