### PR TITLE
Fix: Sorting with sparse arrays containing empty values

### DIFF
--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -365,6 +365,7 @@ describe('sorted DataFrame', () => {
       { name: 'fourth', type: FieldType.time, values: [1, 2, 3], nanos: [10, 20, 30] },
     ],
   });
+
   it('Should sort numbers', () => {
     const sorted = sortDataFrame(frame, 0, true);
     expect(sorted.length).toEqual(3);
@@ -385,6 +386,17 @@ describe('sorted DataFrame', () => {
     expect(sorted.fields[1].nanos).toBeUndefined();
     expect(sorted.fields[3].values).toEqual([3, 2, 1]);
     expect(sorted.fields[3].nanos).toEqual([30, 20, 10]);
+  });
+
+  it('Should handle arrays with empty values correctly', () => {
+    // Create a sparse array with empty slots (undefined values)
+    const values = ['502', '502', , '500', '500', '200', '404']; // Note the empty slot at index 2
+    const frame = toDataFrame({
+      fields: [{ name: 'status', type: FieldType.string, values }],
+    });
+    const sorted = sortDataFrame(frame, 0, false);
+
+    expect(sorted.fields[0].values).toEqual(['200', '404', '500', '500', '502', '502', undefined]);
   });
 });
 

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -429,18 +429,20 @@ export function sortDataFrame(data: DataFrame, sortIndex?: number, reverse = fal
 
   return {
     ...data,
-    fields: data.fields.map((f) => {
-      const newF = {
-        ...f,
-        values: f.values.map((v, i) => f.values[index[i]]),
+    fields: data.fields.map((field) => {
+      const newValues = Array.from({ length: field.values.length }, (_, i) => field.values[index[i]]);
+
+      const newField = {
+        ...field,
+        values: newValues,
       };
 
       // only add .nanos if it exists
-      const { nanos } = f;
+      const { nanos } = field;
       if (nanos !== undefined) {
-        newF.nanos = nanos.map((n, i) => nanos[index[i]]);
+        newField.nanos = Array.from({ length: nanos.length }, (_, i) => nanos[index[i]]);
       }
-      return newF;
+      return newField;
     }),
   };
 }


### PR DESCRIPTION
### Problem
The `sortDataFrame` function in `processDataFrame.ts` was not properly handling sparse arrays with empty values (e.g., `['502', '502', empty, '500', '500', '200', '404']`). The original implementation used `field.values.map((_, i) => field.values[index[i]])` which skips over empty array slots, causing incorrect sorting behavior and inaccurate value counting.

### Solution
- Replaced `map()` with `Array.from()` to explicitly handle all array indices, including empty slots
- This ensures that empty values are preserved and correctly positioned during sorting operations
- The fix maintains the original array length and properly maps all indices according to the sort order
