### PR TITLE
Log error from token exchange middleware

### DIFF
--- a/pkg/clientauth/middleware/token-exchange.go
+++ b/pkg/clientauth/middleware/token-exchange.go
@@ -84,6 +84,7 @@ func (m tokenExchangeMiddlewareImpl) RoundTrip(req *http.Request) (res *http.Res
 	})
 
 	if err != nil {
+		log.Error("token signing failed", "error", err)
 		return nil, fmt.Errorf("failed to exchange token: %w", err)
 	}
 	req.Header.Set("X-Access-Token", "Bearer "+token.Token)


### PR DESCRIPTION
When testing the open feature, I misconfigured my local development environment, which caused the token exchange middleware to fail during a feature evaluation request. I’ve added a log line to make it easier to spot such issues.