### PR TITLE
Docs: Fix broken workshop link CLI workflows (fixes #112116)

### DIFF
--- a/docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md
+++ b/docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md
@@ -95,7 +95,7 @@ This workflow helps you back up all Grafana resources from one instance and late
 
 With this workflow, you can define and manage dashboards as code, saving them to a version control system like Git. This is useful for teams that want to maintain a history of changes, collaborate on dashboard design, and ensure consistency across environments.
 
-1. Use a dashboard generation script (for example, with the [Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)). You can find an example implementation in the Grafana as code [hands-on lab repository](https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang).
+1. Use a dashboard generation script (for example, with the [Foundation SDK](https://github.com/grafana/grafana-foundation-sdk)). You can find an example implementation in the Grafana as code [hands-on lab repository](https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang-starter).
 
 1. Serve and preview the output of the dashboard generator locally:
 


### PR DESCRIPTION
<!--
Thanks for the PR! Quick tips:

1) First-time contributor? Read https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md
2) For docs-only changes, keep the PR small and link the reported issue.
3) If this is WIP, open as a Draft PR.
4) If merge conflicts appear, please rebase on the latest main.
-->

## Summary

Fix a broken external link in the Grafana CLI workflows doc.

* File: `docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md`
* Change: update the "hands-on lab repository" URL from `part-one-golang` (404) to the correct `part-one-golang-starter`.

```diff
- https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang
+ https://github.com/grafana/dashboards-as-code-workshop/tree/main/part-one-golang-starter
```

## Context / Why

The existing link returns 404. The updated link points to the correct workshop folder so readers can follow along without errors.

## Who is affected?

Readers following the Observability-as-Code / Grafana CLI workflows documentation and workshop.

## How to verify

1. Build or preview docs, or open the rendered page for:
   `docs/sources/observability-as-code/grafana-cli/grafanacli-workflows.md`
2. Click the updated link and confirm it loads successfully and matches the intended workshop content.

## Linked issue

Fixes #112116

## Notes for reviewers

* Scope is a single URL correction; no content restructure.
* No changelog or "What’s New" entry required for this routine docs fix.

## Checklist

* [x] From a reader’s perspective, the link now resolves correctly.
* [x] This is a docs-only change; no tests required.
* [x] No feature flags involved.
* [x] Docs build should pass CI.
* [x] No "add to what’s new" label needed.
