### PR TITLE
ShortURL: Fix wrong kind in RTK K8S API creation

### DIFF
--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -49,7 +49,7 @@ export const createShortLink = async function (path: string) {
         generatedAPI.endpoints.createShortUrl.initiate({
           shortUrl: {
             apiVersion: 'shorturl.grafana.app/v1alpha1',
-            kind: 'Playlist',
+            kind: 'ShortURL',
             metadata: {},
             spec: {
               path: getRelativeURLPath(path),


### PR DESCRIPTION
**What is this feature?**
Fix wrong kind in RTK K8S API creation added in [this PR](https://github.com/grafana/grafana/pull/112021)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
