### PR TITLE
Dashboards: Add validation for manager property on parent folder

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -10,6 +10,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
@@ -329,7 +330,12 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 
 	// Validate folder existence if specified
 	if !a.IsDryRun() && accessor.GetFolder() != "" {
-		if err := b.validateFolderExists(ctx, accessor.GetFolder(), id.GetOrgID()); err != nil {
+		folder, err := b.validateFolderExists(ctx, accessor.GetFolder(), id.GetOrgID())
+		if err != nil {
+			return err
+		}
+
+		if err := b.validateFolderManagedBySameManager(folder, accessor); err != nil {
 			return err
 		}
 	}
@@ -398,8 +404,13 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 			return err
 		}
 
-		if err := b.validateFolderExists(ctx, newAccessor.GetFolder(), nsInfo.OrgID); err != nil {
+		folder, err := b.validateFolderExists(ctx, newAccessor.GetFolder(), nsInfo.OrgID)
+		if err != nil {
 			return apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), newAccessor.GetFolder())
+		}
+
+		if err := b.validateFolderManagedBySameManager(folder, newAccessor); err != nil {
+			return err
 		}
 	}
 
@@ -412,21 +423,42 @@ func (b *DashboardsAPIBuilder) validateUpdate(ctx context.Context, a admission.A
 }
 
 // validateFolderExists checks if a folder exists
-func (b *DashboardsAPIBuilder) validateFolderExists(ctx context.Context, folderUID string, orgID int64) error {
+func (b *DashboardsAPIBuilder) validateFolderExists(ctx context.Context, folderUID string, orgID int64) (*unstructured.Unstructured, error) {
 	ns, err := request.NamespaceInfoFrom(ctx, false)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	folderClient := b.folderClientProvider.GetOrCreateHandler(ns.Value)
-	_, err = folderClient.Get(ctx, folderUID, orgID, metav1.GetOptions{})
+	folder, err := folderClient.Get(ctx, folderUID, orgID, metav1.GetOptions{})
 	// Check if the error is a context deadline exceeded error
 	if err != nil {
 		// historically, we returned a more verbose error with folder name when its not found, below just keeps that behavior
 		if apierrors.IsNotFound(err) {
-			return apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), folderUID)
+			return nil, apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), folderUID)
 		}
 
-		return err
+		return nil, err
+	}
+
+	return folder, nil
+}
+
+// validation should fail if:
+// 1. The parent folder is managed but this dashboard is not
+// 2. The parent folder is managed by a different repository than this dashboard
+func (b *DashboardsAPIBuilder) validateFolderManagedBySameManager(folder *unstructured.Unstructured, dashboardAccessor utils.GrafanaMetaAccessor) error {
+	folderAccessor, err := utils.MetaAccessor(folder)
+	if err != nil {
+		return fmt.Errorf("error getting meta accessor: %w", err)
+	}
+
+	if folderManager, ok := folderAccessor.GetManagerProperties(); ok && folderManager.Kind == utils.ManagerKindRepo {
+		manager, ok := dashboardAccessor.GetManagerProperties()
+		if !ok {
+			return fmt.Errorf("folder is managed by a repository, but the dashboard is not managed")
+		} else if manager.Kind != utils.ManagerKindRepo || manager.Identity != folderManager.Identity {
+			return fmt.Errorf("folder is managed by a repository, but the dashboard is not managed by the same manager")
+		}
 	}
 
 	return nil

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -336,7 +336,7 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 		}
 
 		if err := b.validateFolderManagedBySameManager(folder, accessor); err != nil {
-			return err
+			return apierrors.NewBadRequest(err.Error())
 		}
 	}
 

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -456,7 +456,8 @@ func (b *DashboardsAPIBuilder) validateFolderManagedBySameManager(folder *unstru
 		manager, ok := dashboardAccessor.GetManagerProperties()
 		if !ok {
 			return fmt.Errorf("folder is managed by a repository, but the dashboard is not managed")
-		} else if manager.Kind != utils.ManagerKindRepo || manager.Identity != folderManager.Identity {
+		}
+		if manager.Kind != utils.ManagerKindRepo || manager.Identity != folderManager.Identity {
 			return fmt.Errorf("folder is managed by a repository, but the dashboard is not managed by the same manager")
 		}
 	}


### PR DESCRIPTION
This PR adds validation to dashboard creates and updates based on if the parent folder is managed by a repo.

Specifically, it will now fail if:
1. A dashboard is attempted to be created/updated inside a folder that is managed by a repo
2. A dashboard is attempted to be created/updated inside a folder that is managed by a different repo