### PR TITLE
LastImportTime for resource.

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"iter"
 	"strconv"
 	"strings"
 	"sync"

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"iter"
 	"strconv"
 	"strings"
 	"sync"

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -242,6 +242,12 @@ func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource
 	}
 }
 
+func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
+	return func(yield func(resource.ResourceLastImportTime, error) bool) {
+		yield(resource.ResourceLastImportTime{}, errors.New("not implemented"))
+	}
+}
+
 // List implements StorageBackend.
 func (a *dashboardSqlAccess) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
 	if req.ResourceVersion != 0 {

--- a/pkg/registry/apis/iam/noopstorage/storage_backend.go
+++ b/pkg/registry/apis/iam/noopstorage/storage_backend.go
@@ -61,3 +61,9 @@ func (c *StorageBackendImpl) WatchWriteEvents(ctx context.Context) (<-chan *reso
 func (c *StorageBackendImpl) WriteEvent(context.Context, resource.WriteEvent) (int64, error) {
 	return 0, errNoopStorage
 }
+
+func (c *StorageBackendImpl) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
+	return func(yield func(resource.ResourceLastImportTime, error) bool) {
+		yield(resource.ResourceLastImportTime{}, errNoopStorage)
+	}
+}

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
+
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
@@ -294,4 +295,10 @@ func (s *ResourcePermSqlBackend) WriteEvent(ctx context.Context, event resource.
 	}
 
 	return rv, err
+}
+
+func (s *ResourcePermSqlBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
+	return func(yield func(resource.ResourceLastImportTime, error) bool) {
+		yield(resource.ResourceLastImportTime{}, errNotImplemented)
+	}
 }

--- a/pkg/storage/unified/resource/bulk.go
+++ b/pkg/storage/unified/resource/bulk.go
@@ -33,12 +33,13 @@ func grpcMetaValueIsTrue(vals []string) bool {
 }
 
 type BulkRequestIterator interface {
+	// Next advances the iterator to the next element if one exists.
 	Next() bool
 
-	// The next event we should process
+	// Request returns the current element. Only valid after Next() returns true.
 	Request() *resourcepb.BulkRequest
 
-	// Rollback requested
+	// RollbackRequested returns true if there was an error advancing the iterator. Checked after Next() returns true.
 	RollbackRequested() bool
 }
 

--- a/pkg/storage/unified/resource/cdk_backend.go
+++ b/pkg/storage/unified/resource/cdk_backend.go
@@ -75,6 +75,12 @@ type cdkBackend struct {
 	stream      chan<- *WrittenEvent
 }
 
+func (s *cdkBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error] {
+	return func(yield func(ResourceLastImportTime, error) bool) {
+		yield(ResourceLastImportTime{}, errors.New("not implemented"))
+	}
+}
+
 func (s *cdkBackend) ListModifiedSince(ctx context.Context, key NamespacedResource, sinceRv int64) (int64, iter.Seq2[*ModifiedResource, error]) {
 	return 0, func(yield func(*ModifiedResource, error) bool) {
 		yield(nil, errors.New("not implemented"))

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -129,6 +129,12 @@ func (m *mockStorageBackend) ListModifiedSince(ctx context.Context, key Namespac
 	}
 }
 
+func (m *mockStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error] {
+	return func(yield func(ResourceLastImportTime, error) bool) {
+		yield(ResourceLastImportTime{}, errors.New("not implemented"))
+	}
+}
+
 // mockSearchBackend implements SearchBackend for testing with tracking capabilities
 type mockSearchBackend struct {
 	openIndexes []NamespacedResource

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -86,6 +86,11 @@ type BackendReadResponse struct {
 	Error *resourcepb.ErrorResult
 }
 
+type ResourceLastImportTime struct {
+	NamespacedResource
+	LastImportTime time.Time
+}
+
 // The StorageBackend is an internal abstraction that supports interacting with
 // the underlying raw storage medium.  This interface is never exposed directly,
 // it is provided by concrete instances that actually write values.
@@ -118,6 +123,9 @@ type StorageBackend interface {
 
 	// Get resource stats within the storage backend.  When namespace is empty, it will apply to all
 	GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error)
+
+	// GetResourceLastImportTimes returns import times for all namespaced resources in the backend.
+	GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error]
 }
 
 type ModifiedResource struct {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -15,12 +15,13 @@ import (
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/grafana/grafana-app-sdk/logging"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
-	"github.com/grafana/grafana/pkg/util/debouncer"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/util/debouncer"
 )
 
 const (
@@ -1074,6 +1075,12 @@ func (k *kvStorageBackend) WatchWriteEvents(ctx context.Context) (<-chan *Writte
 // GetResourceStats returns resource stats within the storage backend.
 func (k *kvStorageBackend) GetResourceStats(ctx context.Context, namespace string, minCount int) ([]ResourceStats, error) {
 	return k.dataStore.GetResourceStats(ctx, namespace, minCount)
+}
+
+func (k *kvStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error] {
+	return func(yield func(ResourceLastImportTime, error) bool) {
+		yield(ResourceLastImportTime{}, fmt.Errorf("Not implemented"))
+	}
 }
 
 // readAndClose reads all data from a ReadCloser and ensures it's closed,

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1079,7 +1079,7 @@ func (k *kvStorageBackend) GetResourceStats(ctx context.Context, namespace strin
 
 func (k *kvStorageBackend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[ResourceLastImportTime, error] {
 	return func(yield func(ResourceLastImportTime, error) bool) {
-		yield(ResourceLastImportTime{}, fmt.Errorf("Not implemented"))
+		yield(ResourceLastImportTime{}, fmt.Errorf("not implemented"))
 	}
 }
 

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1489,8 +1489,8 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 					if rvDiff == 0 {
 						// OK
 					} else {
-						// Allow returned RV to be within 10% of minInterval.
-						require.InDelta(t, minInterval.Milliseconds(), rvDiff, float64(minInterval.Milliseconds())*0.10)
+						// Allow returned RV to be within 20% of minInterval (to account for slow CI machines).
+						require.InDelta(t, minInterval.Milliseconds(), rvDiff, float64(minInterval.Milliseconds())*0.20)
 					}
 				}
 

--- a/pkg/storage/unified/sql/bulk.go
+++ b/pkg/storage/unified/sql/bulk.go
@@ -282,7 +282,7 @@ func (b *backend) updateLastImportTime(ctx context.Context, tx db.Tx, key *resou
 		Namespace:      key.Namespace,
 		Group:          key.Group,
 		Resource:       key.Resource,
-		LastImportTime: now,
+		LastImportTime: now.UTC(),
 	}); err != nil {
 		return fmt.Errorf("insert resource last import time: %w", err)
 	}

--- a/pkg/storage/unified/sql/bulk.go
+++ b/pkg/storage/unified/sql/bulk.go
@@ -170,7 +170,7 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 		// Calculate the RV based on incoming request timestamps
 		rv := newBulkRV()
 
-		summaries := make(map[string]*resourcepb.BulkResponse_Summary, len(setting.Collection)*4)
+		summaries := make(map[string]*resourcepb.BulkResponse_Summary, len(setting.Collection))
 
 		// First clear everything in the transaction
 		if setting.RebuildCollection {
@@ -181,6 +181,14 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 				}
 				summaries[resource.NSGR(key)] = summary
 				rsp.Summary = append(rsp.Summary, summary)
+			}
+		} else {
+			for _, key := range setting.Collection {
+				summaries[resource.NSGR(key)] = &resourcepb.BulkResponse_Summary{
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+				}
 			}
 		}
 
@@ -253,6 +261,12 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 			if err != nil {
 				b.log.Warn("error increasing RV", "error", err)
 			}
+
+			// Update the last import time. This is important to trigger reindexing
+			// of the resource for a given namespace.
+			if err := b.updateLastImportTime(ctx, tx, key, time.Now()); err != nil {
+				return rollbackWithError(err)
+			}
 		}
 		return nil
 	})
@@ -260,6 +274,19 @@ func (b *backend) processBulk(ctx context.Context, setting resource.BulkSettings
 		rsp.Error = resource.AsErrorResult(err)
 	}
 	return rsp
+}
+
+func (b *backend) updateLastImportTime(ctx context.Context, tx db.Tx, key *resourcepb.ResourceKey, now time.Time) error {
+	if _, err := dbutil.Exec(ctx, tx, sqlResourceLastImportTimeInsert, sqlResourceLastImportTimeInsertRequest{
+		SQLTemplate:    sqltemplate.New(b.dialect),
+		Namespace:      key.Namespace,
+		Group:          key.Group,
+		Resource:       key.Resource,
+		LastImportTime: now,
+	}); err != nil {
+		return fmt.Errorf("insert resource last import time: %w", err)
+	}
+	return nil
 }
 
 type bulkWroker struct {

--- a/pkg/storage/unified/sql/data/resource_last_import_time_insert.sql
+++ b/pkg/storage/unified/sql/data/resource_last_import_time_insert.sql
@@ -36,7 +36,7 @@
        {{ .Arg .Namespace }},
        {{ .Arg .LastImportTime }}
     ) ON CONFLICT ({{ .Ident "group" }}, {{ .Ident "resource" }}, {{ .Ident "namespace" }})
-      SET {{ .Ident "last_import_time" }} = {{ .Arg .LastImportTime }}
+      DO UPDATE SET {{ .Ident "last_import_time" }} = {{ .Arg .LastImportTime }}
 
 {{ end }}
 ;

--- a/pkg/storage/unified/sql/data/resource_last_import_time_insert.sql
+++ b/pkg/storage/unified/sql/data/resource_last_import_time_insert.sql
@@ -1,0 +1,42 @@
+{{ if eq $.DialectName "mysql" }}
+  INSERT INTO {{ .Ident "resource_last_import_time" }} (
+      {{ .Ident "group" }},
+      {{ .Ident "resource" }},
+      {{ .Ident "namespace" }},
+      {{ .Ident "last_import_time" }}
+    ) VALUES (
+      {{ .Arg .Group }},
+      {{ .Arg .Resource }},
+      {{ .Arg .Namespace }},
+      {{ .Arg .LastImportTime }}
+    ) ON DUPLICATE KEY UPDATE {{ .Ident "last_import_time" }} = {{ .Arg .LastImportTime }}
+
+{{ else if eq $.DialectName "sqlite" }}
+   INSERT OR REPLACE INTO {{ .Ident "resource_last_import_time" }} (
+       {{ .Ident "group" }},
+       {{ .Ident "resource" }},
+       {{ .Ident "namespace" }},
+       {{ .Ident "last_import_time" }}
+   ) VALUES (
+       {{ .Arg .Group }},
+       {{ .Arg .Resource }},
+       {{ .Arg .Namespace }},
+       {{ .Arg .LastImportTime }}
+   )
+
+{{ else if eq $.DialectName "postgres" }}
+    INSERT INTO {{ .Ident "resource_last_import_time" }} (
+       {{ .Ident "group" }},
+       {{ .Ident "resource" }},
+       {{ .Ident "namespace" }},
+       {{ .Ident "last_import_time" }}
+     ) VALUES (
+       {{ .Arg .Group }},
+       {{ .Arg .Resource }},
+       {{ .Arg .Namespace }},
+       {{ .Arg .LastImportTime }}
+    ) ON CONFLICT ({{ .Ident "group" }}, {{ .Ident "resource" }}, {{ .Ident "namespace" }})
+      SET {{ .Ident "last_import_time" }} = {{ .Arg .LastImportTime }}
+
+{{ end }}
+;

--- a/pkg/storage/unified/sql/data/resource_last_import_time_query.sql
+++ b/pkg/storage/unified/sql/data/resource_last_import_time_query.sql
@@ -1,0 +1,8 @@
+SELECT
+  {{ .Ident "namespace" }},
+  {{ .Ident "group" }},
+  {{ .Ident "resource" }},
+  {{ .Ident "last_import_time" }}
+FROM
+  {{ .Ident "resource_last_import_time" }}
+;

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -116,6 +116,17 @@ func initResourceTables(mg *migrator.Migrator) string {
 		},
 	})
 
+	tables = append(tables, migrator.Table{
+		Name: "resource_last_import_time",
+		Columns: []*migrator.Column{
+			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "resource", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
+			{Name: "namespace", Type: migrator.DB_NVarchar, Length: 63, Nullable: false},
+			{Name: "last_import_time", Type: migrator.DB_DateTime, Nullable: false},
+		},
+		PrimaryKeys: []string{"group", "resource", "namespace"},
+	})
+
 	// Initialize all tables
 	for t := range tables {
 		mg.AddMigration("drop table "+tables[t].Name, migrator.NewDropTableMigration(tables[t].Name))

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -58,6 +58,9 @@ var (
 
 	sqlResourceBlobInsert = mustTemplate("resource_blob_insert.sql")
 	sqlResourceBlobQuery  = mustTemplate("resource_blob_query.sql")
+
+	sqlResourceLastImportTimeInsert = mustTemplate("resource_last_import_time_insert.sql")
+	sqlResourceLastImportTimeQuery  = mustTemplate("resource_last_import_time_query.sql")
 )
 
 // TxOptions.
@@ -452,5 +455,37 @@ func (r sqlResourceListModifiedSinceRequest) Validate() error {
 	if r.LatestRv < r.SinceRv {
 		return fmt.Errorf("latest resource version must be greater or equal to since resource version")
 	}
+	return nil
+}
+
+type sqlResourceLastImportTimeInsertRequest struct {
+	sqltemplate.SQLTemplate
+	Namespace      string
+	Group          string
+	Resource       string
+	LastImportTime time.Time
+}
+
+func (r sqlResourceLastImportTimeInsertRequest) Validate() error {
+	if r.Namespace == "" {
+		return fmt.Errorf("missing namespace")
+	}
+	if r.Group == "" {
+		return fmt.Errorf("missing group")
+	}
+	if r.Resource == "" {
+		return fmt.Errorf("missing resource")
+	}
+	if r.LastImportTime.IsZero() {
+		return fmt.Errorf("last import time cannot be zero")
+	}
+	return nil
+}
+
+type sqlResourceLastImportTimeQueryRequest struct {
+	sqltemplate.SQLTemplate
+}
+
+func (r *sqlResourceLastImportTimeQueryRequest) Validate() error {
 	return nil
 }

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -495,5 +495,25 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlResourceLastImportTimeInsert: {
+				{
+					Name: "insert",
+					Data: &sqlResourceLastImportTimeInsertRequest{
+						SQLTemplate:    mocks.NewTestingSQLTemplate(),
+						Namespace:      "ns",
+						Group:          "group",
+						Resource:       "res",
+						LastImportTime: time.Date(2025, 10, 07, 22, 30, 05, 0, time.UTC),
+					},
+				},
+			},
+			sqlResourceLastImportTimeQuery: {
+				{
+					Name: "insert",
+					Data: &sqlResourceLastImportTimeQueryRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+					},
+				},
+			},
 		}})
 }

--- a/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_insert-insert.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_insert-insert.sql
@@ -1,0 +1,12 @@
+  INSERT INTO `resource_last_import_time` (
+      `group`,
+      `resource`,
+      `namespace`,
+      `last_import_time`
+    ) VALUES (
+      'group',
+      'res',
+      'ns',
+      '2025-10-07 22:30:05 +0000 UTC'
+    ) ON DUPLICATE KEY UPDATE `last_import_time` = '2025-10-07 22:30:05 +0000 UTC'
+;

--- a/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_query-insert.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_query-insert.sql
@@ -1,0 +1,8 @@
+SELECT
+  `namespace`,
+  `group`,
+  `resource`,
+  `last_import_time`
+FROM
+  `resource_last_import_time`
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_insert-insert.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_insert-insert.sql
@@ -1,0 +1,13 @@
+    INSERT INTO "resource_last_import_time" (
+       "group",
+       "resource",
+       "namespace",
+       "last_import_time"
+     ) VALUES (
+       'group',
+       'res',
+       'ns',
+       '2025-10-07 22:30:05 +0000 UTC'
+    ) ON CONFLICT ("group", "resource", "namespace")
+      SET "last_import_time" = '2025-10-07 22:30:05 +0000 UTC'
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_insert-insert.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_insert-insert.sql
@@ -9,5 +9,5 @@
        'ns',
        '2025-10-07 22:30:05 +0000 UTC'
     ) ON CONFLICT ("group", "resource", "namespace")
-      SET "last_import_time" = '2025-10-07 22:30:05 +0000 UTC'
+      DO UPDATE SET "last_import_time" = '2025-10-07 22:30:05 +0000 UTC'
 ;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_query-insert.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_query-insert.sql
@@ -1,0 +1,8 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  "last_import_time"
+FROM
+  "resource_last_import_time"
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_insert-insert.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_insert-insert.sql
@@ -1,0 +1,12 @@
+   INSERT OR REPLACE INTO "resource_last_import_time" (
+       "group",
+       "resource",
+       "namespace",
+       "last_import_time"
+   ) VALUES (
+       'group',
+       'res',
+       'ns',
+       '2025-10-07 22:30:05 +0000 UTC'
+   )
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_query-insert.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_query-insert.sql
@@ -1,0 +1,8 @@
+SELECT
+  "namespace",
+  "group",
+  "resource",
+  "last_import_time"
+FROM
+  "resource_last_import_time"
+;

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -30,6 +30,8 @@ func TestBadgerKVStorageBackend(t *testing.T) {
 			// TODO: fix these tests and remove this skip
 			TestBlobSupport:       true,
 			TestListModifiedSince: true,
+			// Badger does not support bulk import yet.
+			TestGetResourceLastImportTime: true,
 		},
 	})
 }


### PR DESCRIPTION
This PR introduces new table `resource_last_import_time` in SQL unified storage backend, which keeps track of timestamp when last import into given namespace/group/resource was done. This will be used by indexing servers to reindex given namespace/group/resource if the index was built before this time.