### PR TITLE
Remote Alertmanager: Add timeout to the remoteClient

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -139,6 +139,7 @@ func NewAlertmanager(ctx context.Context, cfg AlertmanagerConfig, store stateSto
 		Logger:   logger,
 		Password: cfg.BasicAuthPassword,
 		TenantID: cfg.TenantID,
+		Timeout:  cfg.Timeout,
 		URL:      u,
 	}
 	mc, err := remoteClient.New(mcCfg, metrics, tracer)

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	alertingNotify "github.com/grafana/alerting/notify"
 
@@ -65,7 +66,8 @@ type Config struct {
 	TenantID string
 	Password string
 
-	Logger log.Logger
+	Logger  log.Logger
+	Timeout time.Duration
 }
 
 // successResponse represents a successful response from the Mimir API.
@@ -98,6 +100,7 @@ func New(cfg *Config, metrics *metrics.RemoteAlertmanager, tracer tracing.Tracer
 
 	c := &http.Client{
 		Transport: rt,
+		Timeout:   cfg.Timeout,
 	}
 	tc := alertingInstrument.NewTimedClient(c, metrics.RequestLatency)
 	trc := alertingInstrument.NewTracedClient(tc, tracer, "remote.alertmanager.client")


### PR DESCRIPTION
We're not passing the timeout to the `remoteClient`.