### PR TITLE
[11.6.x] Fix interpolation in panel repeats

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DashboardGridItem.tsx
@@ -157,6 +157,8 @@ export class DashboardGridItem
               name: variable.state.name,
               value: variableValues[index],
               text: String(variableTexts[index]),
+              isMulti: variable.state.isMulti,
+              includeAll: variable.state.includeAll,
             }),
           ],
         }),

--- a/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-responsive-grid/ResponsiveGridItem.tsx
@@ -104,6 +104,8 @@ export class ResponsiveGridItem extends SceneObjectBase<ResponsiveGridItemState>
               name: variable.state.name,
               value: variableValues[index],
               text: String(variableTexts[index]),
+              isMulti: variable.state.isMulti,
+              includeAll: variable.state.includeAll,
             }),
           ],
         }),


### PR DESCRIPTION
**What is this feature?**

When creating the `LocalVariable` for panel repeats, we omit the `isMulti` and `includeAll` properties which causes issues with variables interpolation. However, we do include these in row repeats.

This PR aims at fixing this.

In 12.2.x we are already doing this along the repeats rework.

**Why do we need this feature?**

Fix bugs.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

@aangelisc confirmed this is fixing the issues with the Azure datasource.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
