### PR TITLE
Explore: Add missing height to logs in Explore

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1003,7 +1003,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           {(!config.featureToggles.newLogsPanel || visualisationType === 'table') &&
             config.featureToggles.logsPanelControls &&
             hasData && (
-              <div className={styles.logRowsWrapper} data-testid="logRows">
+              <div className={styles.controlledLogRowsWrapper} data-testid="logRows">
                 <ControlledLogRows
                   ref={logsContainerRef}
                   logsTableFrames={props.logsFrames}
@@ -1257,9 +1257,12 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
       overflowY: 'visible',
       width: '100%',
     }),
-    logRowsWrapper: css({
+    controlledLogRowsWrapper: css({
       width: '100%',
       maxHeight: '80vh',
+    }),
+    logRowsWrapper: css({
+      width: '100%',
     }),
     visualisationType: css({
       display: 'flex',

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -1259,6 +1259,7 @@ const getStyles = (theme: GrafanaTheme2, wrapLogMessage: boolean, tableHeight: n
     }),
     logRowsWrapper: css({
       width: '100%',
+      maxHeight: '80vh',
     }),
     visualisationType: css({
       display: 'flex',


### PR DESCRIPTION
This PR fixes a missing max-height on the container of controlled log rows.

### How to test

- Disable newLogsPanel
- Make sure logsPanelControls is enabled
- Query logs: scroll to top/bottom buttons and infinite scrolling should work.

This shouldn't affect the logs panel with either `logsPanelControls` disabled or with `newLogsPanel` enabled.