### PR TITLE
Dashboard: Update logic to toggle legend visibility

### DIFF
--- a/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
+++ b/packages/grafana-data/src/panel/getPanelOptionsWithDefaults.ts
@@ -37,7 +37,7 @@ export function getPanelOptionsWithDefaults({
   currentFieldConfig,
   isAfterPluginChange,
 }: Props): OptionDefaults {
-  const optionsWithDefaults = mergeWith({}, plugin.defaults, currentOptions || {}, (objValue, srcValue) => {
+  const optionsWithDefaults = mergeWith({}, plugin.defaults ?? {}, currentOptions || {}, (objValue, srcValue) => {
     if (isArray(srcValue)) {
       return srcValue;
     }

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -124,6 +124,12 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     onTrigger: withFocusedPanel(scene, toggleVizPanelLegend),
   });
 
+  // Toggle all legends
+  keybindings.addBinding({
+    key: 'd l',
+    onTrigger: () => scene.getDashboardPanels().forEach((panel) => toggleVizPanelLegend(panel)),
+  });
+
   // Refresh
   keybindings.addBinding({
     key: 'd r',

--- a/public/app/features/dashboard/state/DashboardModel.test.ts
+++ b/public/app/features/dashboard/state/DashboardModel.test.ts
@@ -918,26 +918,23 @@ describe('DashboardModel', () => {
     beforeEach(() => {
       model = createDashboardModelFixture({
         panels: [
-          // @ts-expect-error
-          { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 2 }, legend: { show: true } },
-          // @ts-expect-error
-          { id: 3, type: 'graph', gridPos: { x: 0, y: 4, w: 12, h: 2 }, legend: { show: false } },
-          // @ts-expect-error
-          { id: 4, type: 'graph', gridPos: { x: 12, y: 4, w: 12, h: 2 }, legend: { show: false } },
+          { id: 1, type: 'graph', gridPos: { x: 0, y: 0, w: 24, h: 2 }, options: { legend: { showLegend: true } } },
+          { id: 3, type: 'graph', gridPos: { x: 0, y: 4, w: 12, h: 2 }, options: { legend: { showLegend: false } } },
+          { id: 4, type: 'graph', gridPos: { x: 12, y: 4, w: 12, h: 2 }, options: { legend: { showLegend: false } } },
         ],
       });
     });
 
     it('toggleLegendsForAll should toggle all legends on on first execution', () => {
       model.toggleLegendsForAll();
-      const legendsOn = model.panels.filter((panel) => panel.legend!.show === true);
+      const legendsOn = model.panels.filter((panel) => panel.options?.legend?.showLegend === true);
       expect(legendsOn.length).toBe(3);
     });
 
     it('toggleLegendsForAll should toggle all legends off on second execution', () => {
       model.toggleLegendsForAll();
       model.toggleLegendsForAll();
-      const legendsOn = model.panels.filter((panel) => panel.legend!.show === true);
+      const legendsOn = model.panels.filter((panel) => panel.options?.legend?.showLegend === true);
       expect(legendsOn.length).toBe(0);
     });
   });

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -1182,13 +1182,13 @@ export class DashboardModel implements TimeModel {
     const panelsWithLegends = this.panels.filter(isPanelWithLegend);
 
     // determine if more panels are displaying legends or not
-    const onCount = panelsWithLegends.filter((panel) => panel.legend.show).length;
+    const onCount = panelsWithLegends.filter((panel) => panel.options.legend.showLegend).length;
     const offCount = panelsWithLegends.length - onCount;
     const panelLegendsOn = onCount >= offCount;
 
     for (const panel of panelsWithLegends) {
-      panel.legend.show = !panelLegendsOn;
-      panel.render();
+      panel.options.legend.showLegend = !panelLegendsOn;
+      panel.updateOptions(panel.options);
     }
   }
 
@@ -1342,7 +1342,7 @@ export class DashboardModel implements TimeModel {
 }
 
 function isPanelWithLegend(panel: PanelModel): panel is PanelModel & Pick<Required<PanelModel>, 'legend'> {
-  return Boolean(panel.legend);
+  return Boolean(panel.options.legend);
 }
 
 function setScopedVars(panel: PanelModel, variable: TypedVariableModel, variableOption: any) {


### PR DESCRIPTION
This PR seeks to solve https://github.com/grafana/grafana/issues/67378 and complete the work of #60754. Did this work based on a customer request.

It seems that there were two issues.

- with scenes disabled, the method to toggle the legends was outdated and did not toggle the option correctly based on updates to the dashboard model.
- with scenes enabled, the shortcut simply wasn't implemented.
  - this is implemented now, although there is a JS error being thrown from an [incorrect bang operator in scenes where the `_plugin` attribute is not set](https://github.com/grafana/scenes/blob/0eca7162ea7a4702251652525315d2ca5740cfc7/packages/scenes/src/components/VizPanel/VizPanel.tsx#L408). This does not lead to any issues in actually using the application, so I think we'd be ok to move forward as-is and clean that up as a follow-up?
    ```
    Uncaught TypeError: Cannot read properties of undefined (reading 'defaults')
      at getPanelOptionsWithDefaults (app.a8b814846570ae520a86.js:466354:92)
      at VizPanel.onOptionsChange (app.a8b814846570ae520a86.js:34086:102)
      at toggleVizPanelLegend (app.a8b814846570ae520a86.js:614950:14)
      at app.a8b814846570ae520a86.js:616144:211
      at Array.forEach (<anonymous>)
      at Object.onTrigger (app.a8b814846570ae520a86.js:616144:119)
      at app.a8b814846570ae520a86.js:563378:14
      at Mousetrap._fireCallback (app.a8b814846570ae520a86.js:565334:11)
      at _callbackAndReset (app.a8b814846570ae520a86.js:565433:14)
      at Mousetrap._fireCallback (app.a8b814846570ae520a86.js:565334:11)
    ```