### PR TITLE
Chore: Enable comprehensive CI testing for RRC branches

### DIFF
--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -10,9 +10,10 @@ on:
     branches:
       - main
       - release-*.*.*
-      - steady
-      - fast
-      - slow
+    tags:
+      - rrc_steady_*
+      - rrc_fast_*
+      - rrc_slow_*
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -9,6 +9,10 @@ on:
   push:
     branches:
       - main
+      - release-*.*.*
+      - steady
+      - fast
+      - slow
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -10,10 +10,9 @@ on:
     branches:
       - main
       - release-*.*.*
-    tags:
-      - rrc_steady_*
-      - rrc_fast_*
-      - rrc_slow_*
+      - steady
+      - fast
+      - slow
     paths-ignore:
       - '*.md'
       - 'docs/**'

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
       - release-*.*.*
+      - steady
+      - fast
+      - slow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -6,9 +6,10 @@ on:
     branches:
       - main
       - release-*.*.*
-      - steady
-      - fast
-      - slow
+    tags:
+      - rrc_steady_*
+      - rrc_fast_*
+      - rrc_slow_*
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -6,10 +6,9 @@ on:
     branches:
       - main
       - release-*.*.*
-    tags:
-      - rrc_steady_*
-      - rrc_fast_*
-      - rrc_slow_*
+      - steady
+      - fast
+      - slow
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
       - release-*.*.*
+      - steady
+      - fast
+      - slow
 
 # TODO: re-enable this before merging
 # concurrency:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -6,9 +6,10 @@ on:
     branches:
       - main
       - release-*.*.*
-      - steady
-      - fast
-      - slow
+    tags:
+      - rrc_steady_*
+      - rrc_fast_*
+      - rrc_slow_*
 
 # TODO: re-enable this before merging
 # concurrency:

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -6,10 +6,9 @@ on:
     branches:
       - main
       - release-*.*.*
-    tags:
-      - rrc_steady_*
-      - rrc_fast_*
-      - rrc_slow_*
+      - steady
+      - fast
+      - slow
 
 # TODO: re-enable this before merging
 # concurrency:

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - release-*.*.*
+      - steady
+      - fast
+      - slow
 
 permissions: {}
 

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
       - release-*.*.*
-      - steady
-      - fast
-      - slow
+    tags:
+      - rrc_steady_*
+      - rrc_fast_*
+      - rrc_slow_*
 
 permissions: {}
 

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -5,10 +5,9 @@ on:
     branches:
       - main
       - release-*.*.*
-    tags:
-      - rrc_steady_*
-      - rrc_fast_*
-      - rrc_slow_*
+      - steady
+      - fast
+      - slow
 
 permissions: {}
 

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -5,10 +5,9 @@ on:
     branches:
       - main
       - release-*.*.*
-    tags:
-      - rrc_steady_*
-      - rrc_fast_*
-      - rrc_slow_*
+      - steady
+      - fast
+      - slow
   pull_request:
     types:
       - opened

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
       - release-*.*.*
+      - steady
+      - fast
+      - slow
   pull_request:
     types:
       - opened

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -5,9 +5,10 @@ on:
     branches:
       - main
       - release-*.*.*
-      - steady
-      - fast
-      - slow
+    tags:
+      - rrc_steady_*
+      - rrc_fast_*
+      - rrc_slow_*
   pull_request:
     types:
       - opened


### PR DESCRIPTION
Add RRC branch triggers (`steady`, `fast`, `slow`) to all critical CI test workflows to ensure the same test coverage for RRC patches as `main`/`release` branches.

Issue: https://github.com/grafana/hosted-grafana/issues/6845

deployment_tools sibling PR: https://github.com/grafana/deployment_tools/pull/370353