### PR TITLE
TimeComparison: Fix legend toggle mismatch

### DIFF
--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -58,7 +58,7 @@ const fieldNameMatcher: FieldMatcherInfo<string> = {
         return false;
       }
 
-      return name === field.name || Boolean(fallback && fallback(field, frame, allFrames));
+      return name === field.name || Boolean(fallback?.(field, frame, allFrames));
     };
   },
 


### PR DESCRIPTION
For Time Comparison, field names of the original and comparison series match, but display names don't. When toggling legend display, the matcher is returning true for both the original and comparison fields because of the matching field names. For comparison fields, it should bypass this and look only at display name.

Before:
![Oct-08-2025 22-28-10](https://github.com/user-attachments/assets/edb004d9-f863-4e4a-bddb-0701f1ea1f93)

After:
![Oct-08-2025 22-29-00](https://github.com/user-attachments/assets/92241c9e-c6e4-415e-ab37-fad98488bfda)


Fixes https://github.com/grafana/grafana/issues/111429