### PR TITLE
Fix code editor width in dashboard export dialog

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ExportAsCode.tsx
@@ -83,8 +83,8 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
       )}
 
       <div className={styles.codeEditorBox}>
-        <AutoSizer data-testid={selector.codeEditor}>
-          {({ width, height }) => {
+        <AutoSizer data-testid={selector.codeEditor} disableWidth>
+          {({ height }) => {
             if (stringifiedDashboard) {
               return (
                 <CodeEditor
@@ -93,7 +93,7 @@ function ExportAsCodeRenderer({ model }: SceneComponentProps<ExportAsCode>) {
                   showLineNumbers={true}
                   showMiniMap={false}
                   height={height}
-                  width={width}
+                  width="100%"
                   readOnly={true}
                 />
               );


### PR DESCRIPTION
Fixes an issue of code editor not being show in the export dashboard modal. 