### PR TITLE
Annotations: Refactor clean-up to remove all expired annotations in one go

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -124,7 +124,7 @@ jobs:
       MYSQL_HOST: 127.0.0.1
     services:
       mysql:
-        image: mysql:8.0.43
+        image: mysql:9.4.0
         env:
           MYSQL_ROOT_PASSWORD: rootpass
           MYSQL_DATABASE: grafana_tests

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -101,7 +101,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          CGO_ENABLED=0 go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -tags=sqlite -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
   mysql:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
@@ -151,7 +151,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          CGO_ENABLED=0 go test -p=1 -tags=mysql -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -tags=mysql -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
   postgres:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
@@ -200,7 +200,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          CGO_ENABLED=0 go test -p=1 -tags=postgres -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -tags=postgres -timeout=20m -run '^TestIntegration' "${PACKAGES[@]}"
 
   # This is the job that is actually required by rulesets.
   # We want to only require one job instead of all the individual tests and shards.

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -594,9 +594,7 @@ func (r *xormRepositoryImpl) CleanAnnotations(ctx context.Context, cfg setting.A
 				limit = "-1"
 			}
 
-			query := `WITH delete_ids AS (
-				SELECT id FROM annotation WHERE ` + annotationType + ` ORDER BY id DESC LIMIT ` + limit + ` OFFSET ?
-			) DELETE FROM annotation WHERE id IN (SELECT id FROM delete_ids)`
+			query := `DELETE FROM annotation WHERE id IN (SELECT id FROM annotation WHERE ` + annotationType + ` ORDER BY id DESC LIMIT ` + limit + ` OFFSET ?)`
 
 			res, err := sess.Exec(query, cfg.MaxCount)
 			if err != nil {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -341,7 +341,6 @@ type Cfg struct {
 	SATokenExpirationDayLimit int
 
 	// Annotations
-	AnnotationCleanupJobBatchSize      int64
 	AnnotationMaximumTagsLength        int64
 	AlertingAnnotationCleanupSetting   AnnotationCleanupSettings
 	DashboardAnnotationCleanupSettings AnnotationCleanupSettings
@@ -788,7 +787,6 @@ func (cfg *Cfg) readGrafanaEnvironmentMetrics() error {
 
 func (cfg *Cfg) readAnnotationSettings() error {
 	section := cfg.Raw.Section("annotations")
-	cfg.AnnotationCleanupJobBatchSize = section.Key("cleanupjob_batchsize").MustInt64(100)
 	cfg.AnnotationMaximumTagsLength = section.Key("tags_length").MustInt64(500)
 	switch {
 	case cfg.AnnotationMaximumTagsLength > 4096:


### PR DESCRIPTION
<!--
**What is this feature?**

This changes how annotation cleanup works: No longer batches queries, all expired annotations get deleted in a single query, so the batch config setting has no effect

For example, deleting 9 million annotations (18 million annotation tags), took ~30s with the new approach on my machine :tm: . With the old approach, I gave up waiting.
```go
{
  name:                 "very large number",
  createAnnotationsNum: 12_000_000, // 4m of each type
  cfg: &setting.Cfg{
    AlertingAnnotationCleanupSetting:   settingsFn(0, 3_000_000),
    DashboardAnnotationCleanupSettings: settingsFn(0, 3_000_000),
    APIAnnotationCleanupSettings:       settingsFn(0, 3_000_000),
  },
  alertAnnotationCount:     3_000_000,
  dashboardAnnotationCount: 3_000_000,
  APIAnnotationCount:       3_000_000,
  affectedAnnotations:      3_000_000, // 1m of each type (keep max 3m of each type)
},
```

**Why do we need this feature?**

Simpler automatic clean-up of annotations, which can handle deletion of millions of annotations in a few seconds, that previously would take minutes and eventually time out, meaning the annotations would keep piling up and never get deleted.

**Who is this feature for?**

Users of annotations

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
--!>