### PR TITLE
Chore: CleanupTestDB in unifed storage tests

### DIFF
--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -69,6 +69,7 @@ func TestMain(m *testing.M) {
 
 func TestIntegrationStorageServer(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
+	t.Cleanup(db.CleanupTestDB)
 
 	unitest.RunStorageServerTest(t, func(ctx context.Context) resource.StorageBackend {
 		return newTestBackend(t, true, 0)
@@ -78,6 +79,7 @@ func TestIntegrationStorageServer(t *testing.T) {
 // TestStorageBackend is a test for the StorageBackend interface.
 func TestIntegrationSQLStorageBackend(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
+	t.Cleanup(db.CleanupTestDB)
 
 	t.Run("IsHA (polling notifier)", func(t *testing.T) {
 		unitest.RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {


### PR DESCRIPTION
Trying to avoid some flakey tests with:
```
--- FAIL: TestIntegrationSQLStorageBackend (1.41s)
    --- FAIL: TestIntegrationSQLStorageBackend/NotHA_(in_process_notifier) (0.16s)
        storage_backend.go:68: Running tests with namespace prefix: test-c4d43d5d-3
        integration_test.go:62: 
            	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/storage/unified/sql/test/integration_test.go:62
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/storage/unified/sql/test/integration_test.go:90
            	            				/opt/actions-runner/_work/grafana/grafana/pkg/storage/unified/testing/storage_backend.go:93
            	Error:      	Received unexpected error:
            	            	initialize resource DB: run migrations: migration failed (id = Add column previous_resource_version in resource_history): duplicate column name: previous_resource_version
            	Test:       	TestIntegrationSQLStorageBackend/NotHA_(in_process_notifier)
        --- FAIL: TestIntegrationSQLStorageBackend/NotHA_(in_process_notifier)/get_resource_stats (0.01s)
            testing.go:1811: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
FAIL
```

maybe this can help!  and should not hurt