### PR TITLE
Annotations: Add panel configuration options

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -502,11 +502,27 @@ export enum VizOrientation {
   Vertical = 'vertical',
 }
 
-/**
- * Breaks out each annotation frame into multiple lanes on the x-axis
- */
 export interface VizAnnotations {
+  /**
+   * @internal: Toggles the display of the annotation marker — for "xymark" annotations
+   */
+  hideMarker?: boolean;
+  /**
+   * Breaks out each annotation frame into multiple lanes on the x-axis
+   */
   multiLane?: boolean;
+  /**
+   * Sets opacity of shaded annotation region
+   */
+  regionOpacity?: number;
+  /**
+   * Toggles showing the dotted line above annotation markers
+   */
+  showLine?: boolean;
+  /**
+   * Hides shaded area above annotation region marker
+   */
+  showRegions?: boolean;
 }
 
 /**

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -158,9 +158,17 @@ ReduceDataOptions: {
 // TODO docs
 VizOrientation: "auto" | "vertical" | "horizontal" @cuetsy(kind="enum")
 
-// Breaks out each annotation frame into multiple lanes on the x-axis
 VizAnnotations: {
+	// Breaks out each annotation frame into multiple lanes on the x-axis
 	multiLane?: bool
+	// Hides shaded area above annotation region marker
+	showRegions?: bool
+	// Sets opacity of shaded annotation region
+	regionOpacity?: number
+	// Toggles showing the dotted line above annotation markers
+	showLine?: bool
+	// @internal: Toggles the display of the annotation marker — for "xymark" annotations
+	hideMarker?: bool
 } @cuetsy(kind="interface")
 
 // TODO docs

--- a/packages/grafana-ui/src/options/builder/annotations.ts
+++ b/packages/grafana-ui/src/options/builder/annotations.ts
@@ -1,12 +1,19 @@
 import { PanelOptionsEditorBuilder } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { Options as CandlestickOptions } from '@grafana/schema/src/raw/composable/candlestick/panelcfg/x/CandlestickPanelCfg_types.gen';
+import { Options as HeatmapOptions } from '@grafana/schema/src/raw/composable/heatmap/panelcfg/x/HeatmapPanelCfg_types.gen';
+import { Options as StatetimelineOptions } from '@grafana/schema/src/raw/composable/statetimeline/panelcfg/x/StateTimelinePanelCfg_types.gen';
+import { Options as StatusHistoryOptions } from '@grafana/schema/src/raw/composable/statushistory/panelcfg/x/StatusHistoryPanelCfg_types.gen';
+import { Options as TimeseriesOptions } from '@grafana/schema/src/raw/composable/timeseries/panelcfg/x/TimeSeriesPanelCfg_types.gen';
 
 /**
  * Adds common text control options to a visualization options
  * @param builder
  * @public
  */
-export function addAnnotationOptions<T>(builder: PanelOptionsEditorBuilder<T>) {
+export function addAnnotationOptions<
+  T extends HeatmapOptions | TimeseriesOptions | StatusHistoryOptions | StatetimelineOptions | CandlestickOptions,
+>(builder: PanelOptionsEditorBuilder<T>) {
   const category = [t('grafana-ui.builder.annotations', 'Annotations')];
 
   builder.addBooleanSwitch({
@@ -18,5 +25,41 @@ export function addAnnotationOptions<T>(builder: PanelOptionsEditorBuilder<T>) {
       'Breaks each annotation frame into a separate row in the visualization'
     ),
     defaultValue: false,
+  });
+
+  builder.addBooleanSwitch({
+    path: 'annotations.showLine',
+    category,
+    name: t('grafana-ui.builder.annotations.show-line-marker', 'Enable annotation indicator line'),
+    description: t(
+      'grafana-ui.builder.annotations.desc.show-line-marker',
+      'Toggles the vertical annotation indicator line in the visualization'
+    ),
+    defaultValue: true,
+  });
+
+  builder.addBooleanSwitch({
+    path: 'annotations.showRegions',
+    category,
+    name: t('grafana-ui.builder.annotations.show-regions', 'Enable region overlay'),
+    description: t(
+      'grafana-ui.builder.annotations.desc.show-regions',
+      'Toggles the region overlay in the visualization'
+    ),
+    defaultValue: true,
+  });
+
+  builder.addSliderInput({
+    path: 'annotations.regionOpacity',
+    category,
+    name: t('grafana-ui.builder.annotations.region-opacity', 'Region opacity'),
+    description: t('grafana-ui.builder.annotations.desc.region-opacity', 'Sets the annotation region opacity'),
+    showIf: (currentOptions) => currentOptions.annotations?.showRegions,
+    defaultValue: 10,
+    settings: {
+      min: 1,
+      max: 100,
+      step: 2,
+    },
   });
 }

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2.tsx
@@ -130,9 +130,10 @@ export const AnnotationsPlugin2 = ({
       ctx.save();
 
       ctx.beginPath();
-      // @todo rename
-      const additionalHeight = annotationsConfig?.multiLane ? annos.length * ANNOTATION_LANE_SIZE * uPlot.pxRatio : 0;
-      ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height + additionalHeight);
+      const multiLaneRowsHeight = annotationsConfig?.multiLane
+        ? annos.length * ANNOTATION_LANE_SIZE * uPlot.pxRatio
+        : 0;
+      ctx.rect(u.bbox.left, u.bbox.top, u.bbox.width, u.bbox.height + multiLaneRowsHeight);
       ctx.clip();
 
       // Multi-lane annotations do not support vertical lines or shaded regions


### PR DESCRIPTION
**What is this feature?**

Adding annotation options to panel edit UI for the following options:

```
/**
 * Breaks out each annotation frame into multiple lanes on the x-axis
 */
multiLane?: boolean;

/**
 * Sets opacity of shaded annotation region
 */
regionOpacity?: number;

/**
 * Toggles showing the dotted line above annotation markers
 */
showLine?: boolean;

/**
 * Hides shaded area above annotation region marker
 */
showRegions?: boolean;
```

<img width="1723" height="413" alt="image" src="https://github.com/user-attachments/assets/80fceaf2-0bd9-418e-8b17-75fb686b9d96" />

Also adding support for annotations.hideMarker (specifically for xymark), which will hide the interactive annotation marker, and allow panels to only show the annotation region/line indicators
```
/**
 * @internal: Toggles the display of the annotation marker — for "xymark" annotations
 */
hideMarker?: boolean;
```

**Why do we need this feature?**
To allow users to customize the display options of annotations.

**Who is this feature for?**
Annotation users in dashboards. 

**Special notes for your reviewer:**
Parent branch: https://github.com/grafana/grafana/pull/112183
Grand parent branch: https://github.com/grafana/grafana/pull/111559
We could easily unwed this from the annotation lane PR if that makes things easier.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
