### PR TITLE
CloudWatch Logs: Don't add console link to every field in the logs response

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -306,7 +306,7 @@ describe('datasource', () => {
       });
     });
 
-    it('should add links to log queries', async () => {
+    it('should add a data link field to log queries', async () => {
       const { datasource } = setupForLogs();
 
       const observable = datasource.query({
@@ -344,7 +344,7 @@ describe('datasource', () => {
         },
       ]);
 
-      expect(emits[0].data[0].fields.find((f: Field) => f.name === '@message').config.links).toMatchObject([
+      expect(emits[0].data[0].fields.find((f: Field) => f.name === '').config.links).toMatchObject([
         {
           title: 'View in CloudWatch console',
           url: "https://us-west-1.console.aws.amazon.com/cloudwatch/home?region=us-west-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'some*20query~isLiveTail~false~source~(~'test))",

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -161,7 +161,7 @@ describe('addDataLinksToLogsResponse', () => {
                   },
                 ],
               },
-            }
+            },
           ],
           refId: 'A',
         },

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -104,7 +104,7 @@ describe('addDataLinksToLogsResponse', () => {
     });
   });
 
-  it('should add data links to response from log groups, trimming :*', async () => {
+  it('should add a data link field to response from log groups, trimming :*', async () => {
     const mockResponse: DataQueryResponse = {
       data: [
         {
@@ -148,6 +148,11 @@ describe('addDataLinksToLogsResponse', () => {
           fields: [
             {
               name: '@message',
+            },
+            {
+              name: '',
+              type: FieldType.string,
+              values: [],
               config: {
                 links: [
                   {
@@ -156,7 +161,7 @@ describe('addDataLinksToLogsResponse', () => {
                   },
                 ],
               },
-            },
+            }
           ],
           refId: 'A',
         },

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.test.ts
@@ -1,4 +1,4 @@
-import { DataQueryRequest, DataQueryResponse, dateMath } from '@grafana/data';
+import { DataQueryRequest, DataQueryResponse, dateMath, FieldType } from '@grafana/data';
 import { setDataSourceSrv } from '@grafana/runtime';
 import { DatasourceSrv } from 'app/features/plugins/datasource_srv';
 
@@ -19,10 +19,12 @@ describe('addDataLinksToLogsResponse', () => {
             {
               name: '@message',
               config: {},
+              values: ['log message one', 'log message two'],
             },
             {
               name: '@xrayTraceId',
               config: {},
+              values: ['id1', 'id2'],
             },
           ],
           refId: 'A',
@@ -65,14 +67,6 @@ describe('addDataLinksToLogsResponse', () => {
           fields: [
             {
               name: '@message',
-              config: {
-                links: [
-                  {
-                    url: "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'stats*20count*28*40message*29*20by*20bin*281h*29~isLiveTail~false~source~(~'fake-log-group-one~'fake-log-group-two))",
-                    title: 'View in CloudWatch console',
-                  },
-                ],
-              },
             },
             {
               name: '@xrayTraceId',
@@ -86,6 +80,19 @@ describe('addDataLinksToLogsResponse', () => {
                       datasourceUid: 'xrayUid',
                       datasourceName: 'Xray',
                     },
+                  },
+                ],
+              },
+            },
+            {
+              name: '',
+              type: FieldType.string,
+              values: ['View this query in CloudWatch console', 'View this query in CloudWatch console'],
+              config: {
+                links: [
+                  {
+                    url: "https://us-east-1.console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs-insights:queryDetail=~(end~'2016-12-31T16*3a00*3a00.000Z~start~'2016-12-31T15*3a00*3a00.000Z~timeType~'ABSOLUTE~tz~'UTC~editorString~'stats*20count*28*40message*29*20by*20bin*281h*29~isLiveTail~false~source~(~'fake-log-group-one~'fake-log-group-two))",
+                    title: 'View in CloudWatch console',
                   },
                 ],
               },
@@ -198,6 +205,11 @@ describe('addDataLinksToLogsResponse', () => {
           fields: [
             {
               name: '@message',
+            },
+            {
+              name: '',
+              type: FieldType.string,
+              values: [],
               config: {
                 links: [
                   {

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -1,4 +1,12 @@
-import { DataFrame, DataLink, DataQueryRequest, DataQueryResponse, ScopedVars, TimeRange } from '@grafana/data';
+import {
+  DataFrame,
+  DataLink,
+  DataQueryRequest,
+  DataQueryResponse,
+  FieldType,
+  ScopedVars,
+  TimeRange,
+} from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { AwsUrl, encodeUrl } from '../aws_url';
@@ -33,13 +41,21 @@ export async function addDataLinksToLogsResponse(
         if (xrayLink) {
           field.config.links = [xrayLink];
         }
-      } else {
-        // Right now we add generic link to open the query in xray console to every field so it shows in the logs row
-        // details. Unfortunately this also creates link for all values inside table which look weird.
-        field.config.links = [
-          createAwsConsoleLink(curTarget, request.range, interpolatedRegion, replace, getVariableValue),
-        ];
       }
+    }
+
+    // add a link to the cloudwatch console as a separate field that will be displayed as a link
+    if (dataFrame.fields.length) {
+      dataFrame.fields.push({
+        name: '',
+        type: FieldType.string,
+        values: dataFrame.fields[0]?.values?.length
+          ? new Array(dataFrame.fields[0].values.length).fill('View this query in CloudWatch console')
+          : [],
+        config: {
+          links: [createAwsConsoleLink(curTarget, request.range, interpolatedRegion, replace, getVariableValue)],
+        },
+      });
     }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/111862

We're adding a link to the CW console to all extra fields in the logs response, which is not necessary, since they're all the same. The new logs visualization doesn't display the link label so it ends us not displaying values for any fields that aren't timestamp or message: 

<img width="415" height="371" alt="495963182-30066ccd-7806-49ae-91dc-cca4f0337b98" src="https://github.com/user-attachments/assets/0a529653-379c-491e-94cd-38459c198a31" />

This PR removes all those and adds just one additional field instead that contains a button to the end of the response

This is what the new field looks like in the old and the new logs visualizations: 

<img width="900" height="291" alt="Screenshot 2025-10-09 at 18 06 47" src="https://github.com/user-attachments/assets/039fc974-109a-4574-a611-6ed9b46c9447" />
<img width="900" height="280" alt="Screenshot 2025-10-09 at 18 31 23" src="https://github.com/user-attachments/assets/b9bcd460-820e-4e6a-8531-15cdc6d0e3a2" />


The old visualization looks a bit strange, but I didn't want to have the "view in console" string for both name and value, and since it looks better in the new visualization, long term it will look better like this. 