### PR TITLE
Chore: Disable webpack cache for noMinify builds

### DIFF
--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -63,13 +63,16 @@ module.exports = (env = {}) =>
     },
 
     // enable persistent cache for faster builds
-    cache: {
-      type: 'filesystem',
-      name: 'grafana-default-production',
-      buildDependencies: {
-        config: [__filename],
-      },
-    },
+    cache:
+      parseInt(env.noMinify, 10) === 1
+        ? false
+        : {
+          type: 'filesystem',
+          name: 'grafana-default-production',
+          buildDependencies: {
+            config: [__filename],
+          },
+        },
 
     plugins: [
       new MiniCssExtractPlugin({

--- a/scripts/webpack/webpack.prod.js
+++ b/scripts/webpack/webpack.prod.js
@@ -67,12 +67,12 @@ module.exports = (env = {}) =>
       parseInt(env.noMinify, 10) === 1
         ? false
         : {
-          type: 'filesystem',
-          name: 'grafana-default-production',
-          buildDependencies: {
-            config: [__filename],
+            type: 'filesystem',
+            name: 'grafana-default-production',
+            buildDependencies: {
+              config: [__filename],
+            },
           },
-        },
 
     plugins: [
       new MiniCssExtractPlugin({


### PR DESCRIPTION
- avoids writing 50GB+ per day to disk when running `yarn build:nominify`
- prevents premature death of my SSD