### PR TITLE
feat(alerting): Add shareable URL link to silence rules

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencedAlertsTableRow.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedAlertsTableRow.tsx
@@ -4,6 +4,7 @@ import { AlertLabels } from '@grafana/alerting/unstable';
 import { intervalToAbbreviatedDurationString } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { AlertmanagerAlert } from 'app/plugins/datasource/alertmanager/types';
+import { Link } from '@grafana/ui';
 
 import { CollapseToggle } from '../CollapseToggle';
 
@@ -27,6 +28,10 @@ export const SilencedAlertsTableRow = ({ alert, className }: Props) => {
     }
     return name;
   }, '');
+
+  const silenceId = alert.fingerprint; // Using a unique ID (fingerprint) as the link target
+  const shareableUrl = `/alerting/silences/edit?silenceId=${silenceId}`; 
+
   return (
     <>
       <tr className={className}>
@@ -39,7 +44,11 @@ export const SilencedAlertsTableRow = ({ alert, className }: Props) => {
         <td>
           <Trans i18nKey="alerting.silenced-alerts-table-row.silenced-for">for {{ duration }}</Trans>
         </td>
-        <td>{alertName}</td>
+        <td>
+          <Link href={shareableUrl} title="Go to Silence Edit Page">
+            {alertName}
+          </Link>
+        </td>
       </tr>
       {!isCollapsed && (
         <tr className={className}>


### PR DESCRIPTION
**Fixes #82552**

**What is this feature?**

This feature adds a new shareable link to the **Silence List** view in Unified Alerting. This link allows a user to quickly generate a URL that points directly to the **Edit Silence** configuration page for a specific silence rule.

**Why do we need this feature?**

Currently, there is no simple way for a user to grab a direct link to a silence rule to share with teammates or to bookmark. This enhancement improves the workflow by allowing easy sharing and navigation to the specific configuration.

**Who is this feature for?**

Users who manage and collaborate on **Alerting Silence Rules**, particularly those who need to quickly share or bookmark specific silence configurations for troubleshooting or maintenance.

**Which issue(s) does this PR fix?**:

Fixes #82552

**Special notes for your reviewer:**

The feature was implemented in `public/app/features/alerting/unified/components/silences/SilencedAlertsTableRow.tsx` by defining the `shareableUrl` using `alert.fingerprint` and wrapping the alert name in a `<Link>` component.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A)
- [ ] The docs are updated, and if this is a notable improvement... (N/A for this minor feature/enhancement)