### PR TITLE
Table: Support DataLinks and Actions in SparklineCell

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_sparkline_cell.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_sparkline_cell.v42.json
@@ -208,7 +208,27 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "actions": [
+            {
+              "fetch": {
+                "body": "{}",
+                "headers": [["Content-Type", "application/json"]],
+                "method": "GET",
+                "queryParams": [],
+                "url": "/api/health"
+              },
+              "title": "Get instance health",
+              "type": "fetch"
+            }
+          ],
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Google Grafana",
+              "url": "https://google.com/search?q=grafana"
+            }
+          ]
         },
         "overrides": []
       },

--- a/devenv/dev-dashboards/panel-table/table_sparkline_cell.json
+++ b/devenv/dev-dashboards/panel-table/table_sparkline_cell.json
@@ -204,7 +204,27 @@
                 "value": 80
               }
             ]
-          }
+          },
+          "actions": [
+            {
+              "fetch": {
+                "body": "{}",
+                "headers": [["Content-Type", "application/json"]],
+                "method": "GET",
+                "queryParams": [],
+                "url": "/api/health"
+              },
+              "title": "Get instance health",
+              "type": "fetch"
+            }
+          ],
+          "links": [
+            {
+              "targetBlank": true,
+              "title": "Google Grafana",
+              "url": "https://google.com/search?q=grafana"
+            }
+          ]
         },
         "overrides": []
       },

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -25,6 +25,7 @@ import {
 import { measureText } from '../../../../utils/measureText';
 import { FormattedValueDisplay } from '../../../FormattedValueDisplay/FormattedValueDisplay';
 import { Sparkline } from '../../../Sparkline/Sparkline';
+import { MaybeWrapWithLink } from '../components/MaybeWrapWithLink';
 import { SparklineCellProps, TableCellStyles } from '../types';
 import { getAlignmentFactor, getCellOptions } from '../utils';
 
@@ -46,7 +47,11 @@ export const SparklineCell = (props: SparklineCellProps) => {
   const sparkline = getSparkline(value, field);
 
   if (!sparkline) {
-    return <>{field.config.noValue || t('grafana-ui.table.sparkline.no-data', 'no data')}</>;
+    return (
+      <MaybeWrapWithLink field={field} rowIdx={rowIdx}>
+        {field.config.noValue || t('grafana-ui.table.sparkline.no-data', 'no data')}
+      </MaybeWrapWithLink>
+    );
   }
 
   // Get the step from the first two values to null-fill the x-axis based on timerange
@@ -95,10 +100,10 @@ export const SparklineCell = (props: SparklineCellProps) => {
   }
 
   return (
-    <>
+    <MaybeWrapWithLink field={field} rowIdx={rowIdx}>
       {valueElement}
       <Sparkline width={width - valueWidth} height={25} sparkline={sparkline} config={config} theme={theme} />
-    </>
+    </MaybeWrapWithLink>
   );
 };
 
@@ -139,8 +144,12 @@ function getTableSparklineCellOptions(field: Field): TableSparklineCellOptions {
 
 export const getStyles: TableCellStyles = (theme, { textAlign }) =>
   css({
-    width: '100%',
-    gap: theme.spacing(1),
-    justifyContent: 'space-between',
-    ...(textAlign === 'right' && { flexDirection: 'row-reverse' }),
+    '&, & > a': {
+      width: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1),
+      ...(textAlign === 'right' && { flexDirection: 'row-reverse' }),
+    },
   });

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -94,7 +94,6 @@ import {
   predicateByName,
   shouldTextOverflow,
   shouldTextWrap,
-  withDataLinksActionsTooltip,
   getSummaryCellTextAlign,
   parseStyleJson,
   IS_SAFARI_26,
@@ -406,7 +405,6 @@ export function TableNG(props: TableNGProps) {
       const result: FromFieldsResult = {
         columns: [],
         cellRootRenderers: {},
-        colsWithTooltip: {},
       };
 
       let lastRowIdx = -1;
@@ -464,7 +462,6 @@ export function TableNG(props: TableNGProps) {
         const shouldOverflow =
           !IS_SAFARI_26 && rowHeight !== 'auto' && (shouldTextOverflow(field) || Boolean(maxRowHeight));
         const textWrap = rowHeight === 'auto' || shouldTextWrap(field);
-        const withTooltip = withDataLinksActionsTooltip(field, cellType);
         const canBeColorized = canFieldBeColorized(cellType, applyToRowBgFn);
         const cellStyleOptions: TableCellStyleOptions = {
           textAlign,
@@ -472,8 +469,6 @@ export function TableNG(props: TableNGProps) {
           shouldOverflow,
           maxHeight: maxRowHeight,
         };
-
-        result.colsWithTooltip[displayName] = withTooltip;
 
         const defaultCellStyles = getDefaultCellStyles(theme, cellStyleOptions);
         const cellSpecificStyles = getCellSpecificStyles(cellType, field, theme, cellStyleOptions);
@@ -738,7 +733,7 @@ export function TableNG(props: TableNGProps) {
   );
   const [nestedFieldWidths] = useColWidths(firstRowNestedData?.fields ?? [], availableWidth);
 
-  const { columns, cellRootRenderers, colsWithTooltip } = useMemo(() => {
+  const { columns, cellRootRenderers } = useMemo(() => {
     const result = fromFields(visibleFields, widths);
 
     // if nested frames are present, augment the columns to include the nested table expander column.
@@ -806,7 +801,6 @@ export function TableNG(props: TableNGProps) {
           const field = columns[column.idx].field;
 
           if (
-            colsWithTooltip[getDisplayName(field)] &&
             target instanceof HTMLElement &&
             // this walks up the tree to find either a faux link wrapper or the cell root
             // it then only proceeds if we matched the faux link wrapper

--- a/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/MaybeWrapWithLink.tsx
@@ -34,4 +34,5 @@ export const MaybeWrapWithLink = memo(({ field, rowIdx, children }: MaybeWrapWit
   // raw value
   return children;
 });
+
 MaybeWrapWithLink.displayName = 'MaybeWrapWithLink';

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -308,7 +308,6 @@ export type CellRootRenderer = (key: React.Key, props: CellRendererProps<TableRo
 export interface FromFieldsResult {
   columns: TableColumn[];
   cellRootRenderers: Record<string, CellRootRenderer>;
-  colsWithTooltip: Record<string, boolean>;
 }
 
 export interface FooterFieldState extends FieldState {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -950,15 +950,6 @@ export function getApplyToRowBgFn(
 }
 
 /** @internal */
-export function withDataLinksActionsTooltip(field: Field, cellType: TableCellDisplayMode) {
-  return (
-    cellType !== TableCellDisplayMode.DataLinks &&
-    cellType !== TableCellDisplayMode.Actions &&
-    (field.config.links?.length ?? 0) + (field.config.actions?.length ?? 0) > 1
-  );
-}
-
-/** @internal */
 export function canFieldBeColorized(
   cellType: TableCellDisplayMode,
   applyToRowBgFn?: (rowIndex: number) => CSSProperties


### PR DESCRIPTION
Fixes [#81295](https://github.com/grafana/grafana/issues/81295)

When adding DataLinks or Actions to a Sparkline Cell, the SparklineCell now works as you'd expect, which is to inherit the same UX as all other cell types in the Table panel.

Test this using the existing Sparkline Table gdev dashboard - see the changes in this PR.