### PR TITLE
Alerting: Provisioning to fix contact point type on save

### DIFF
--- a/pkg/services/ngalert/provisioning/compat.go
+++ b/pkg/services/ngalert/provisioning/compat.go
@@ -10,7 +10,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func EmbeddedContactPointToGrafanaIntegrationConfig(e definitions.EmbeddedContactPoint) (alertingModels.IntegrationConfig, error) {
+func EmbeddedContactPointToGrafanaIntegrationConfig(e *definitions.EmbeddedContactPoint) (alertingModels.IntegrationConfig, error) {
 	data, err := e.Settings.MarshalJSON()
 	if err != nil {
 		return alertingModels.IntegrationConfig{}, err

--- a/pkg/services/provisioning/alerting/contact_point_types.go
+++ b/pkg/services/provisioning/alerting/contact_point_types.go
@@ -95,7 +95,7 @@ func (config *ReceiverV1) mapToModel(name string) (definitions.EmbeddedContactPo
 	}
 	// As the values are not encrypted when coming from disk files,
 	// we can simply return the fallback for validation.
-	err := provisioning.ValidateContactPoint(context.Background(), cp, func(_ context.Context, _ map[string][]byte, _, fallback string) string {
+	err := provisioning.ValidateContactPoint(context.Background(), &cp, func(_ context.Context, _ map[string][]byte, _, fallback string) string {
 		return fallback
 	})
 	if err != nil {


### PR DESCRIPTION
**What is this feature?**
This PR updates the provisioning API to match the behavior of the regular API that persists type of the integrations exactly as they are defined in the code. 
Now on create and update operations if contact point type is defined in a different case, on read it the response will contain normalized string.

**Why do we need this feature?**
Although the code of resolving schema by type is case-insensitive, it is better to store correct information in the database. 