### PR TITLE
Grafana controllers: Add generic disable setting

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -57,5 +57,4 @@ import (
 	_ "github.com/grafana/tempo/pkg/traceql"
 
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
-	_ "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
 )

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -57,4 +57,5 @@ import (
 	_ "github.com/grafana/tempo/pkg/traceql"
 
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
+	_ "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
 )

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -248,7 +248,7 @@ func RegisterAPIService(
 	}
 
 	builder := NewAPIBuilder(
-		cfg.ProvisioningDisableControllers,
+		cfg.DisableControllers,
 		repoFactory,
 		features,
 		client,

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -134,8 +134,9 @@ type Cfg struct {
 	HomePath                   string
 	ProvisioningPath           string
 	PermittedProvisioningPaths []string
+	// Grafana API Server
+	DisableControllers bool
 	// Provisioning config
-	ProvisioningDisableControllers  bool
 	ProvisioningAllowedTargets      []string
 	ProvisioningAllowImageRendering bool
 	ProvisioningMinSyncInterval     time.Duration
@@ -2120,11 +2121,11 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 		}
 	}
 
-	cfg.ProvisioningDisableControllers = iniFile.Section("provisioning").Key("disable_controllers").MustBool(false)
+	cfg.DisableControllers = iniFile.Section("provisioning").Key("disable_controllers").MustBool(false)
 	// if disable_controllers is not set, check if grafana-apiserver.disable_controllers is set
 	// TODO: consolidate to just [grafana-apiserver]disable_controllers
-	if !cfg.ProvisioningDisableControllers {
-		cfg.ProvisioningDisableControllers = iniFile.Section("grafana-apiserver").Key("disable_controllers").MustBool(false)
+	if !cfg.DisableControllers {
+		cfg.DisableControllers = iniFile.Section("grafana-apiserver").Key("disable_controllers").MustBool(false)
 	}
 	cfg.ProvisioningAllowedTargets = iniFile.Section("provisioning").Key("allowed_targets").Strings("|")
 	if len(cfg.ProvisioningAllowedTargets) == 0 {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -2121,6 +2121,11 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	}
 
 	cfg.ProvisioningDisableControllers = iniFile.Section("provisioning").Key("disable_controllers").MustBool(false)
+	// if disable_controllers is not set, check if grafana-apiserver.disable_controllers is set
+	// TODO: consolidate to just [grafana-apiserver]disable_controllers
+	if !cfg.ProvisioningDisableControllers {
+		cfg.ProvisioningDisableControllers = iniFile.Section("grafana-apiserver").Key("disable_controllers").MustBool(false)
+	}
 	cfg.ProvisioningAllowedTargets = iniFile.Section("provisioning").Key("allowed_targets").Strings("|")
 	if len(cfg.ProvisioningAllowedTargets) == 0 {
 		cfg.ProvisioningAllowedTargets = []string{"instance", "folder"}

--- a/pkg/tests/apis/provisioning/job_conflict_test.go
+++ b/pkg/tests/apis/provisioning/job_conflict_test.go
@@ -21,7 +21,7 @@ func TestIntegrationProvisioning_JobConflict(t *testing.T) {
 
 	// disable the controllers so the jobs don't get auto-processed
 	helper := runGrafana(t, func(opts *testinfra.GrafanaOpts) {
-		opts.DisableProvisioningControllers = true
+		opts.DisableControllers = true
 	})
 	ctx := context.Background()
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -545,10 +545,10 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 		require.NoError(t, err)
 	}
 
-	if opts.DisableProvisioningControllers {
-		provisioningSection, err := getOrCreateSection("provisioning")
+	if opts.DisableControllers {
+		apiserverSection, err := getOrCreateSection("grafana-apiserver")
 		require.NoError(t, err)
-		_, err = provisioningSection.NewKey("disable_controllers", "true")
+		_, err = apiserverSection.NewKey("disable_controllers", "true")
 		require.NoError(t, err)
 	}
 
@@ -622,7 +622,7 @@ type GrafanaOpts struct {
 	EnableRecordingRules                  bool
 	EnableSCIM                            bool
 	APIServerRuntimeConfig                string
-	DisableProvisioningControllers        bool
+	DisableControllers                    bool
 
 	// When "unified-grpc" is selected it will also start the grpc server
 	APIServerStorageType options.StorageType


### PR DESCRIPTION
Originally we added
```
[provisioning]
disable_controllers = true
```
as a way to disable the provisioning controllers inside of Grafana. However, we will want a generic solution so each app doesnt have to add a separate config. 

This PR makes it generic with:
```
[grafana-apiserver]
disable_controllers = true
```

While we rollout the change, we will need both options, then we can clean up the provisioning one.