### PR TITLE
TimeSeries: Fix memory leak with boolean fields

### DIFF
--- a/public/app/plugins/panel/timeseries/utils.ts
+++ b/public/app/plugins/panel/timeseries/utils.ts
@@ -176,12 +176,12 @@ export function prepareGraphableFields(
             ...field.config,
             max: 1,
             min: 0,
-            custom,
+            custom: { ...custom },
           };
 
           // smooth and linear do not make sense
-          if (custom.lineInterpolation !== LineInterpolation.StepBefore) {
-            custom.lineInterpolation = LineInterpolation.StepAfter;
+          if (config.custom.lineInterpolation !== LineInterpolation.StepBefore) {
+            config.custom.lineInterpolation = LineInterpolation.StepAfter;
           }
 
           copy = {


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/112194

for as long as we've supported boolean fields in TimeSeries ([over 4 years](https://github.com/grafana/grafana/pull/34168)) we were mutating `field.config.custom.lineInterpolation` when prepping boolean fields. this caused the schema diff to fail the sameness test and would cause the plot to be destroyed and re-initialized on every data update.

https://github.com/grafana/grafana/blob/01ec8e3a4aa74ae730281876031a2a97f85bf2cb/packages/grafana-data/src/field/fieldOverrides.ts#L605

though we're fixing the mutation here, fundamentally there is still a memory leak possible in TimeSeries that happens whenever the panel is reconfigured with a new schema (panel edit, different field structure from query response, legend toggle). this tends to be much more rare, but we will root-cause and fix this separately.