### PR TITLE
AuthZService: Add a metric to count folder app requests

### DIFF
--- a/pkg/services/authz/rbac.go
+++ b/pkg/services/authz/rbac.go
@@ -90,7 +90,7 @@ func ProvideAuthZClient(
 			// When running in-proc we get a injection cycle between
 			// authz client, resource client and apiserver so we need to use
 			// package level function to get rest config
-			store.NewAPIFolderStore(tracer, restConfig.GetRestConfig),
+			store.NewAPIFolderStore(tracer, reg, restConfig.GetRestConfig),
 			legacy.NewLegacySQLStores(sql),
 			store.NewUnionPermissionStore(
 				store.NewStaticPermissionStore(acService),
@@ -224,7 +224,7 @@ func RegisterRBACAuthZService(
 	if cfg.Folder.Host == "" {
 		folderStore = store.NewSQLFolderStore(db, tracer)
 	} else {
-		folderStore = store.NewAPIFolderStore(tracer, func(ctx context.Context) (*rest.Config, error) {
+		folderStore = store.NewAPIFolderStore(tracer, reg, func(ctx context.Context) (*rest.Config, error) {
 			return &rest.Config{
 				Host: cfg.Folder.Host,
 				WrapTransport: func(rt http.RoundTripper) http.RoundTripper {


### PR DESCRIPTION
This pull request introduces a new metric to the AuthZ Service folder API store to monitor the volume of outgoing requests. This will provide us with help us identify any unusual patterns in request traffic, such as unexpected spikes or drops.

I implemented a counter metric to track the number of outgoing requests.
I chose a counter as a more performant and cost-effective option than a histogram, as the primary goal is to monitor request volume patterns rather than latency.