### PR TITLE
Chore: Remove reference to image renderer plugin in renderer not found log message

### DIFF
--- a/pkg/services/rendering/rendering.go
+++ b/pkg/services/rendering/rendering.go
@@ -199,7 +199,7 @@ func (rs *RenderingService) Run(ctx context.Context) error {
 	}
 
 	rs.log.Debug("No image renderer found/installed. " +
-		"For image rendering support please install the grafana-image-renderer plugin. " +
+		"For image rendering support please use the Grafana Image Renderer remote rendering service. " +
 		"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
 
 	<-ctx.Done()
@@ -271,7 +271,7 @@ func (rs *RenderingService) render(ctx context.Context, renderType RenderType, o
 
 	if !rs.IsAvailable(ctx) {
 		logger.Warn("Could not render image, no image renderer found/installed. " +
-			"For image rendering support please install the grafana-image-renderer plugin. " +
+			"For image rendering support please use the Grafana Image Renderer remote rendering service. " +
 			"Read more at https://grafana.com/docs/grafana/latest/administration/image_rendering/")
 		if opts.ErrorRenderUnavailable {
 			return nil, ErrRenderUnavailable


### PR DESCRIPTION
**What is this feature?**

Since the image renderer plugin is deprecated, we should update the log to reflect the most up to date information.