### PR TITLE
Make frontend-service settings overwrite those that come from /bootdata

### DIFF
--- a/pkg/services/frontend/frontend_settings.go
+++ b/pkg/services/frontend/frontend_settings.go
@@ -1,0 +1,43 @@
+package frontend
+
+import "github.com/grafana/grafana/pkg/setting"
+
+// This is a copy of dtos.FrontendSettingsDTO with only the fields that the frontend-service
+// sends, to prevent default values from overriding what comes from the /bootdata call.
+//
+// It's important the JSON names for these fields match dtos.FrontendSettingsDTO
+// so the frontend can merge the two together correctly.
+type FSFrontendSettings struct {
+	AuthProxyEnabled   bool   `json:"authProxyEnabled,omitempty"`
+	LdapEnabled        bool   `json:"ldapEnabled,omitempty"`
+	JwtHeaderName      string `json:"jwtHeaderName,omitempty"`
+	JwtUrlLogin        bool   `json:"jwtUrlLogin,omitempty"`
+	AutoAssignOrg      bool   `json:"autoAssignOrg,omitempty"`
+	VerifyEmailEnabled bool   `json:"verifyEmailEnabled,omitempty"`
+	DisableLoginForm   bool   `json:"disableLoginForm,omitempty"`
+	DisableUserSignUp  bool   `json:"disableUserSignUp,omitempty"`
+	LoginHint          string `json:"loginHint,omitempty"`
+	PasswordHint       string `json:"passwordHint,omitempty"`
+	AnonymousEnabled   bool   `json:"anonymousEnabled,omitempty"`
+
+	GoogleAnalyticsId                   string `json:"googleAnalyticsId,omitempty"`
+	GoogleAnalytics4Id                  string `json:"googleAnalytics4Id,omitempty"`
+	GoogleAnalytics4SendManualPageViews bool   `json:"GoogleAnalytics4SendManualPageViews,omitempty"`
+
+	RudderstackWriteKey        string `json:"rudderstackWriteKey,omitempty"`
+	RudderstackDataPlaneUrl    string `json:"rudderstackDataPlaneUrl,omitempty"`
+	RudderstackSdkUrl          string `json:"rudderstackSdkUrl,omitempty"`
+	RudderstackConfigUrl       string `json:"rudderstackConfigUrl,omitempty"`
+	RudderstackIntegrationsUrl string `json:"rudderstackIntegrationsUrl,omitempty"`
+
+	AnalyticsConsoleReporting bool                           `json:"analyticsConsoleReporting,omitempty"`
+	GrafanaJavascriptAgent    setting.GrafanaJavascriptAgent `json:"grafanaJavascriptAgent,omitempty"`
+
+	ApplicationInsightsConnectionString string `json:"applicationInsightsConnectionString,omitempty"`
+	ApplicationInsightsEndpointUrl      string `json:"applicationInsightsEndpointUrl,omitempty"`
+
+	TrustedTypesDefaultPolicyEnabled bool              `json:"trustedTypesDefaultPolicyEnabled,omitempty"`
+	CSPReportOnlyEnabled             bool              `json:"cspReportOnlyEnabled,omitempty"`
+	Http2Enabled                     bool              `json:"http2Enabled,omitempty"`
+	ReportingStaticContext           map[string]string `json:"reportingStaticContext,omitempty"`
+}

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -35,7 +35,7 @@ type IndexViewData struct {
 	AppTitle     string
 
 	Assets      dtos.EntryPointAssets // Includes CDN info
-	Settings    dtos.FrontendSettingsDTO
+	Settings    FSFrontendSettings
 	DefaultUser dtos.CurrentUser
 
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
@@ -59,7 +59,7 @@ func NewIndexProvider(cfg *setting.Cfg, assetsManifest dtos.EntryPointAssets) (*
 
 	// subset of frontend settings needed for the login page
 	// TODO what about enterprise settings here?
-	frontendSettings := dtos.FrontendSettingsDTO{
+	frontendSettings := FSFrontendSettings{
 		AnalyticsConsoleReporting:           cfg.FrontendAnalyticsConsoleReporting,
 		AnonymousEnabled:                    cfg.Anonymous.Enabled,
 		ApplicationInsightsConnectionString: cfg.ApplicationInsightsConnectionString,

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -261,7 +261,11 @@
           // tenant-specific config
           // TODO split this into separate API calls
           const { navTree, settings, user } = await loadBootData();
-          window.grafanaBootData.settings = settings;
+
+          window.grafanaBootData.settings = {
+            ...settings,
+            ...window.grafanaBootData.settings, // preserve frontend-service settings
+          }
           window.grafanaBootData.navTree = navTree;
           window.grafanaBootData.user = user;
 


### PR DESCRIPTION
The frontend-service can be configured with its own settings. While they are injected into the HTML page, they're immediately overwritten by the settings from `/bootdata`.

We cannot just spread the settings together, as the FrontendSettingsDTO go type contains many default values that would overwrite those that come from `/bootdata`.

This PR fixes it by creating a new struct FSFrontendSettings to contain _just_ the settings we're configuring directly, and then spreading those together. 

Part of https://github.com/grafana/grafana-frontend-platform/issues/30