### PR TITLE
Alerting: Add missing dependencies

### DIFF
--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -86,7 +86,6 @@
     "@grafana/data": ">=11.6 <= 12.x",
     "@grafana/runtime": ">=11.6 <= 12.x",
     "@grafana/ui": ">=11.6 <= 12.x",
-    "@reduxjs/toolkit": "^2.8.0",
     "msw": "^2.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0"
@@ -95,6 +94,7 @@
     "@emotion/css": "11.13.5",
     "@faker-js/faker": "^9.8.0",
     "@grafana/i18n": "12.3.0-pre",
+    "@reduxjs/toolkit": "^2.9.0",
     "fishery": "^2.3.1",
     "lodash": "^4.17.21",
     "tinycolor2": "^1.6.0"

--- a/packages/grafana-alerting/package.json
+++ b/packages/grafana-alerting/package.json
@@ -70,6 +70,7 @@
     "@types/lodash": "^4",
     "@types/react": "18.3.18",
     "@types/react-dom": "18.3.5",
+    "@types/tinycolor2": "^1",
     "i18next": "^25.5.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
@@ -95,6 +96,7 @@
     "@faker-js/faker": "^9.8.0",
     "@grafana/i18n": "12.3.0-pre",
     "fishery": "^2.3.1",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "tinycolor2": "^1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2961,6 +2961,7 @@ __metadata:
     "@faker-js/faker": "npm:^9.8.0"
     "@grafana/i18n": "npm:12.3.0-pre"
     "@grafana/test-utils": "workspace:*"
+    "@reduxjs/toolkit": "npm:^2.9.0"
     "@rtk-query/codegen-openapi": "npm:^2.0.0"
     "@testing-library/jest-dom": "npm:^6.6.3"
     "@testing-library/react": "npm:^16.3.0"
@@ -2986,7 +2987,6 @@ __metadata:
     "@grafana/data": ">=11.6 <= 12.x"
     "@grafana/runtime": ">=11.6 <= 12.x"
     "@grafana/ui": ">=11.6 <= 12.x"
-    "@reduxjs/toolkit": ^2.8.0
     msw: ^2.0.0
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -6769,7 +6769,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@reduxjs/toolkit@npm:2.9.0":
+"@reduxjs/toolkit@npm:2.9.0, @reduxjs/toolkit@npm:^2.9.0":
   version: 2.9.0
   resolution: "@reduxjs/toolkit@npm:2.9.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2968,6 +2968,7 @@ __metadata:
     "@types/lodash": "npm:^4"
     "@types/react": "npm:18.3.18"
     "@types/react-dom": "npm:18.3.5"
+    "@types/tinycolor2": "npm:^1"
     fishery: "npm:^2.3.1"
     i18next: "npm:^25.5.2"
     lodash: "npm:^4.17.21"
@@ -2978,6 +2979,7 @@ __metadata:
     rollup: "npm:^4.22.4"
     rollup-plugin-esbuild: "npm:6.2.1"
     rollup-plugin-node-externals: "npm:^8.0.0"
+    tinycolor2: "npm:^1.6.0"
     type-fest: "npm:^4.40.0"
     typescript: "npm:5.9.2"
   peerDependencies:
@@ -10178,7 +10180,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/tinycolor2@npm:1.4.6":
+"@types/tinycolor2@npm:1.4.6, @types/tinycolor2@npm:^1":
   version: 1.4.6
   resolution: "@types/tinycolor2@npm:1.4.6"
   checksum: 10/a662fd177135d27779b7ccba39881a85167f969787c71c7bf51903d288a519ad5b9526e0a4af7bde6444df6b7abe88bae893d569c6d804108c03dfec9509bdf6


### PR DESCRIPTION
Causes issues with consumers where the `tinycolor2` dependency can't be resolved. Also adds `@reduxjs/toolkit`.