### PR TITLE
Docs: Add contact point specific text formatting examples

### DIFF
--- a/docs/sources/alerting/configure-notifications/template-notifications/examples.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/examples.md
@@ -89,7 +89,55 @@ This page provides various examples illustrating how to template common notifica
 
 Notification templates can access the [notification data](ref:reference-notification-data) using the dot (`.`). The following examples demonstrate some basic uses of the [template language](ref:language).
 
-For instance, to check if there are common labels (`.CommonLabels`) for all alerts in the notification, use `if`:
+### Text formatting examples
+
+Text formatting in notification templates varies by contact point type. Each platform has its own formatting syntax:
+
+#### Slack formatting
+
+For Slack contact points, you can use:
+
+```go
+{{ define "slack_formatted_message" -}}
+*This text will be bold in Slack*
+_This text will be italic in Slack_
+Regular text without formatting
+{{ end }}
+```
+
+Execute the template:
+
+```go
+{{ template "slack_formatted_message" . }}
+```
+
+```template_output
+*This text will be bold in Slack*
+_This text will be italic in Slack_
+Regular text without formatting
+```
+
+#### Additional contact point types
+
+{{< admonition type="note" >}}
+**Coming soon**: More formatting examples for additional contact point types including Teams, Discord, and other integrations will be added to this documentation.
+
+Each contact point type has its own formatting requirements:
+
+- Some support Markdown-style formatting
+- Others use HTML tags
+- Some may not support formatting at all
+
+Check your specific contact point's documentation for supported formatting syntax.
+{{< /admonition >}}
+
+## Template logic examples
+
+Beyond text formatting, you can use template logic to create dynamic notification content. The following examples demonstrate basic template operations:
+
+### Conditional logic
+
+To check if there are common labels (`.CommonLabels`) for all alerts in the notification, use `if`:
 
 ```go
 {{ define "custom_message" -}}
@@ -100,6 +148,8 @@ There are no common labels
 {{ end }}
 {{ end }}
 ```
+
+### Iterating over alerts
 
 To iterate on the alerts in the notification and print a specific label, use `range` and `index`:
 

--- a/docs/sources/alerting/configure-notifications/template-notifications/examples.md
+++ b/docs/sources/alerting/configure-notifications/template-notifications/examples.md
@@ -120,8 +120,6 @@ Regular text without formatting
 #### Additional contact point types
 
 {{< admonition type="note" >}}
-**Coming soon**: More formatting examples for additional contact point types including Teams, Discord, and other integrations will be added to this documentation.
-
 Each contact point type has its own formatting requirements:
 
 - Some support Markdown-style formatting


### PR DESCRIPTION
**What is this feature?**

This PR adds text formatting examples to the notification template documentation, specifically showing how to use bold and italic formatting in Slack notifications. It also clarifies that formatting syntax varies by contact point type and provides guidance for users about platform-specific requirements.

**Why do we need this feature?**

The current documentation mentions that users can "Format text with bold and italic styles" but doesn't provide concrete examples of how to do this. This has led to user confusion, as reported in [grafana/alerting#373](https://github.com/grafana/alerting/issues/373), where users tried various formatting approaches without success. The documentation needed to clarify that formatting support depends on the specific contact point type being used.

**Who is this feature for?**

This feature is for Grafana users who create custom notification templates and want to format their alert messages with bold and italic text. It's particularly helpful for users working with Slack notifications and those who need to understand the differences in formatting support across various contact point types.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting/issues/373

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
