### PR TITLE
GenAI: Fix uncaught error when panel title is missing

### DIFF
--- a/public/app/features/dashboard/components/GenAI/utils.ts
+++ b/public/app/features/dashboard/components/GenAI/utils.ts
@@ -164,9 +164,7 @@ export const DASHBOARD_NEED_PANEL_TITLES_AND_DESCRIPTIONS_MESSAGE =
 export function getPanelStrings(dashboard: DashboardModel): string[] {
   const panelStrings = dashboard.panels
     .filter(
-      (panel) =>
-        (panel.title.length > 0 && panel.title !== NEW_PANEL_TITLE) ||
-        (panel.description && panel.description.length > 0)
+      (panel) => (panel.title && panel.title !== NEW_PANEL_TITLE) || (panel.description && panel.description.length > 0)
     )
     .map(getPanelString);
 


### PR DESCRIPTION
**What is this feature?**

For various reasons, `panel.title` can be missing from the dashboard schema sometimes. This causes an uncaught exception when evaluating `panel.title.length`.

**Why do we need this feature?**

Fix uncaught errors.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
