### PR TITLE
BarGauge/BarChart/Gauge: Removes option that does nothing

### DIFF
--- a/packages/grafana-ui/src/options/builder/text.tsx
+++ b/packages/grafana-ui/src/options/builder/text.tsx
@@ -5,15 +5,14 @@ import { OptionsWithTextFormatting } from '@grafana/schema';
 /**
  * Adds common text control options to a visualization options
  * @param builder
- * @param withTitle
  * @public
  */
 export function addTextSizeOptions<T extends OptionsWithTextFormatting>(
   builder: PanelOptionsEditorBuilder<T>,
-  withTitle = true
+  options: { withValue?: boolean; withTitle?: boolean; withPercentChange?: boolean }
 ) {
   const category = [t('grafana-ui.builder.text.category-text-size', 'Text size')];
-  if (withTitle) {
+  if (options.withTitle) {
     builder.addNumberInput({
       path: 'text.titleSize',
       category,
@@ -28,29 +27,33 @@ export function addTextSizeOptions<T extends OptionsWithTextFormatting>(
     });
   }
 
-  builder.addNumberInput({
-    path: 'text.valueSize',
-    category,
-    name: t('grafana-ui.builder.text.name-value', 'Value'),
-    settings: {
-      placeholder: t('grafana-ui.builder.text.placeholder-value', 'Auto'),
-      integer: false,
-      min: 1,
-      max: 200,
-    },
-    defaultValue: undefined,
-  });
+  if (options.withValue !== false) {
+    builder.addNumberInput({
+      path: 'text.valueSize',
+      category,
+      name: t('grafana-ui.builder.text.name-value', 'Value'),
+      settings: {
+        placeholder: t('grafana-ui.builder.text.placeholder-value', 'Auto'),
+        integer: false,
+        min: 1,
+        max: 200,
+      },
+      defaultValue: undefined,
+    });
+  }
 
-  builder.addNumberInput({
-    path: 'text.percentSize',
-    category,
-    name: t('grafana-ui.builder.text.name-percent-change', 'Percent change'),
-    settings: {
-      placeholder: t('grafana-ui.builder.text.placeholder-percent-change', 'Auto'),
-      integer: false,
-      min: 1,
-      max: 200,
-    },
-    defaultValue: undefined,
-  });
+  if (options.withPercentChange) {
+    builder.addNumberInput({
+      path: 'text.percentSize',
+      category,
+      name: t('grafana-ui.builder.text.name-percent-change', 'Percent change'),
+      settings: {
+        placeholder: t('grafana-ui.builder.text.placeholder-percent-change', 'Auto'),
+        integer: false,
+        min: 1,
+        max: 200,
+      },
+      defaultValue: undefined,
+    });
+  }
 }

--- a/public/app/plugins/panel/barchart/module.tsx
+++ b/public/app/plugins/panel/barchart/module.tsx
@@ -255,7 +255,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(BarChartPanel)
 
     commonOptionsBuilder.addTooltipOptions(builder, false, false, optsWithHideZeros);
     commonOptionsBuilder.addLegendOptions(builder);
-    commonOptionsBuilder.addTextSizeOptions(builder, false);
+    commonOptionsBuilder.addTextSizeOptions(builder, { withValue: true });
   })
   .setSuggestionsSupplier(new BarChartSuggestionsSupplier());
 

--- a/public/app/plugins/panel/bargauge/module.tsx
+++ b/public/app/plugins/panel/bargauge/module.tsx
@@ -17,7 +17,7 @@ export const plugin = new PanelPlugin<Options>(BarGaugePanel)
     addStandardDataReduceOptions(builder);
     addOrientationOption(builder, category);
     commonOptionsBuilder.addLegendOptions(builder, true, false);
-    commonOptionsBuilder.addTextSizeOptions(builder);
+    commonOptionsBuilder.addTextSizeOptions(builder, { withTitle: true, withValue: true });
 
     builder
       .addRadio({

--- a/public/app/plugins/panel/gauge/module.tsx
+++ b/public/app/plugins/panel/gauge/module.tsx
@@ -85,7 +85,7 @@ export const plugin = new PanelPlugin<Options>(GaugePanel)
           options.sizing === BarGaugeSizing.Manual && options.orientation === VizOrientation.Horizontal,
       });
 
-    commonOptionsBuilder.addTextSizeOptions(builder);
+    commonOptionsBuilder.addTextSizeOptions(builder, { withTitle: true, withValue: true });
   })
   .setPanelChangeHandler(gaugePanelChangedHandler)
   .setSuggestionsSupplier(new GaugeSuggestionsSupplier())

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -22,7 +22,7 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
 
     addStandardDataReduceOptions(builder);
     addOrientationOption(builder, mainCategory);
-    commonOptionsBuilder.addTextSizeOptions(builder);
+    commonOptionsBuilder.addTextSizeOptions(builder, { withTitle: true, withValue: true, withPercentChange: true });
 
     builder
       .addSelect({


### PR DESCRIPTION
The percent change option was added in a way that it shows up in bar chart and gauge panels where they do nothing. 

This fixes this issue by only adding options that are actually part of the panel. 