### PR TITLE
tempo: Use the correct filter separator for negative selector

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
@@ -155,4 +155,42 @@ describe('filterToQuerySection returns the correct query section for a filter', 
     const result = filterToQuerySection(filter, [], lp);
     expect(result).toBe('span.foo=~"bar|baz"');
   });
+
+  it('filter with multiple values and != operator', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '!=',
+      value: ['bar', 'baz'],
+      scope: TraceqlSearchScope.Span,
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('(span.foo!=bar && span.foo!=baz)');
+  });
+
+  it('filter with multiple string values and != operator', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '!=',
+      value: ['bar', 'baz'],
+      scope: TraceqlSearchScope.Span,
+      valueType: 'string',
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('(span.foo!="bar" && span.foo!="baz")');
+  });
+
+  it('filter with multiple string values and !~ operator', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '!~',
+      value: ['bar', 'baz'],
+      scope: TraceqlSearchScope.Span,
+      valueType: 'string',
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('span.foo!~"bar|baz"');
+  });
 });

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -81,7 +81,9 @@ export const tagHelper = (f: TraceqlFilter, filters: TraceqlFilter[]) => {
 
 export const filterToQuerySection = (f: TraceqlFilter, filters: TraceqlFilter[], lp: TempoLanguageProvider) => {
   if (Array.isArray(f.value) && f.value.length > 1 && !isRegExpOperator(f.operator!)) {
-    return `(${f.value.map((v) => `${scopeHelper(f, lp)}${tagHelper(f, filters)}${f.operator}${valueHelper({ ...f, value: v })}`).join(' || ')})`;
+    // For negative operators (!=), use && instead of ||
+    const joinOperator = f.operator === '!=' ? ' && ' : ' || ';
+    return `(${f.value.map((v) => `${scopeHelper(f, lp)}${tagHelper(f, filters)}${f.operator}${valueHelper({ ...f, value: v })}`).join(joinOperator)})`;
   }
 
   return `${scopeHelper(f, lp)}${tagHelper(f, filters)}${f.operator}${valueHelper(f)}`;


### PR DESCRIPTION
Before it was generating: `{ (name !="authenticate" || name!="query-articles" || name!=" select-articles")}` which is the wrong separator for `!=`

Now it does this:

<img width="1398" height="826" alt="Screenshot 2025-10-10 at 18 12 58" src="https://github.com/user-attachments/assets/db30923a-f051-4be3-8c76-d7b6488ccdac" />


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
