### PR TITLE
Fix missing kind and apiVersion in Dashboard list after version conversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -286,7 +286,7 @@ run: ## Build and run backend, and watch for changes. See .air.toml for configur
 
 .PHONY: run-go
 run-go: ## Build and run web server immediately.
-	$(GO) run -race $(if $(GO_BUILD_TAGS),-build-tags=$(GO_BUILD_TAGS)) \
+	$(GO) run -race $(if $(GO_BUILD_TAGS),-tags=$(GO_BUILD_TAGS)) \
 		./pkg/cmd/grafana -- server -profile -profile-addr=127.0.0.1 -profile-port=6000 -packaging=dev cfg:app_mode=development
 
 .PHONY: run-frontend

--- a/apps/dashboard/pkg/migration/conversion/v1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1.go
@@ -56,6 +56,8 @@ func Convert_V1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboard, s
 }
 
 func Convert_V1_to_V2beta1(in *dashv1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope) error {
+	out.TypeMeta.Kind = "Dashboard"
+	out.TypeMeta.APIVersion = dashv2beta1.GroupVersion.String()
 	out.ObjectMeta = in.ObjectMeta
 
 	// TODO: implement V1 to v2beta1 conversion

--- a/pkg/registry/apis/dashboard/legacy_storage.go
+++ b/pkg/registry/apis/dashboard/legacy_storage.go
@@ -43,7 +43,7 @@ func (s *DashboardStorage) NewStore(dash utils.ResourceInfo, scheme *runtime.Sch
 	}
 	client := legacy.NewDirectResourceClient(server) // same context
 	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil,
-		defaultOpts.StorageConfig.Config, nil,
+		defaultOpts.StorageConfig.Config, scheme, nil,
 	)
 	optsGetter.RegisterOptions(dash.GroupResource(), apistore.StorageOptions{
 		EnableFolderSupport:         true,

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -410,7 +410,7 @@ func NewLocalStore(resourceInfo utils.ResourceInfo, scheme *runtime.Scheme, defa
 	}
 
 	client := resource.NewLocalResourceClient(server)
-	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, nil)
+	optsGetter := apistore.NewRESTOptionsGetterForClient(client, nil, defaultOpts.StorageConfig.Config, scheme, nil)
 
 	store, err := grafanaregistry.NewRegistryStore(scheme, resourceInfo, optsGetter)
 	return store, err

--- a/pkg/services/apiserver/options/grafana-aggregator.go
+++ b/pkg/services/apiserver/options/grafana-aggregator.go
@@ -75,7 +75,7 @@ func (o *GrafanaAggregatorOptions) ApplyTo(aggregatorConfig *aggregatorapiserver
 		return err
 	}
 	// override the RESTOptionsGetter to use the in memory storage options
-	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil)
+	restOptionsGetter, err := apistore.NewRESTOptionsGetterMemory(etcdOptions.StorageConfig, nil, aggregatorscheme.Scheme)
 	if err != nil {
 		return err
 	}

--- a/pkg/services/apiserver/options/storage.go
+++ b/pkg/services/apiserver/options/storage.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
+	"k8s.io/apimachinery/pkg/runtime"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	"k8s.io/apiserver/pkg/server/options"
 	"k8s.io/client-go/rest"
@@ -165,7 +166,7 @@ func (o *StorageOptions) Validate() []error {
 	return errs
 }
 
-func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfig, etcdOptions *options.EtcdOptions, tracer tracing.Tracer, secureServing *options.SecureServingOptions) error {
+func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfig, etcdOptions *options.EtcdOptions, scheme *runtime.Scheme, tracer tracing.Tracer, secureServing *options.SecureServingOptions) error {
 	if o.StorageType != StorageTypeUnifiedGrpc {
 		return nil
 	}
@@ -225,7 +226,7 @@ func (o *StorageOptions) ApplyTo(serverConfig *genericapiserver.RecommendedConfi
 		o.InlineSecrets = inlineSecureValueService
 	}
 
-	getter := apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, o.ConfigProvider)
+	getter := apistore.NewRESTOptionsGetterForClient(unified, o.InlineSecrets, etcdOptions.StorageConfig, scheme, o.ConfigProvider)
 	serverConfig.RESTOptionsGetter = getter
 	return nil
 }

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -336,7 +336,7 @@ func (s *service) start(ctx context.Context) error {
 			return err
 		}
 	} else {
-		getter := apistore.NewRESTOptionsGetterForClient(s.unified, s.secrets, o.RecommendedOptions.Etcd.StorageConfig, s.restConfigProvider)
+		getter := apistore.NewRESTOptionsGetterForClient(s.unified, s.secrets, o.RecommendedOptions.Etcd.StorageConfig, s.scheme, s.restConfigProvider)
 		optsregister = getter.RegisterOptions
 		serverConfig.RESTOptionsGetter = getter
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Preserve TypeMeta fields set by decoder/converter during version conversion
- Modified convertToObject() in pkg/storage/unified/apistore/store.go to check if TypeMeta is already populated after decoding before overwriting it
- Added runtime.Scheme parameter to RESTOptionsGetter and propagated through the storage initialization chain to enable proper GVK handling
- Set TypeMeta fields in dashboard v1->v2beta1 conversion as defensive measure
- Fixed Makefile run-go target to use -tags instead of -build-tags for Go 1.25

**Why do we need this feature?**

- Dashboard objects stored in v1beta1 need conversion to v2beta1 when clients request the v2beta1 API
- The Kubernetes codec correctly performs conversion and sets TypeMeta with the target version (v2beta1)
- Previous code unconditionally called SetGroupVersionKind() with actualGVK (the stored version), overwriting the correct converted values
- This caused Dashboard items in list responses to have missing kind and apiVersion fields, breaking API clients that depend on these fields
- The fix ensures TypeMeta is only set when empty, preserving values set by the converter and ensuring all Dashboard objects have proper type information

**Who is this feature for?**

Grafana Dashboards API users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
