### PR TITLE
Log TLS handshake EOF error as DEBUG instead INFO

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -12,6 +12,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
+	stdlog "log"
 	"math/big"
 	"net"
 	"net/http"
@@ -399,6 +400,26 @@ func (hs *HTTPServer) AddNamedMiddleware(middleware routing.RegisterNamedMiddlew
 	hs.namedMiddlewares = append(hs.namedMiddlewares, middleware)
 }
 
+type customErrorLogger struct {
+	log log.Logger
+}
+
+const tlsHandshakeErrorPrefix = "http: TLS handshake error from"
+const tlsHandshakeErrorSuffix = "EOF"
+
+func (w *customErrorLogger) Write(msg []byte) (int, error) {
+	// checks if the error is a TLS handshake error that ends with EOF
+	if strings.Contains(string(msg), tlsHandshakeErrorPrefix) && strings.Contains(string(msg), tlsHandshakeErrorSuffix) {
+		// log at debug level and remove new lines
+		w.log.Debug(strings.Replace(string(msg), "\n", "", -1))
+	} else {
+		// log the error as is using the standard logger (the same way as the default http server does)
+		stdlog.Print(string(msg))
+	}
+
+	return len(msg), nil
+}
+
 func (hs *HTTPServer) Run(ctx context.Context) error {
 	hs.context = ctx
 
@@ -411,6 +432,12 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 		Handler:     hs.web,
 		ReadTimeout: hs.Cfg.ReadTimeout,
 	}
+
+	customErrorLogger := &customErrorLogger{
+		log: hs.log,
+	}
+	hs.httpSrv.ErrorLog = stdlog.New(customErrorLogger, "", 0)
+
 	switch hs.Cfg.Protocol {
 	case setting.HTTP2Scheme, setting.HTTPSScheme:
 		if err := hs.configureTLS(); err != nil {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -411,7 +411,7 @@ func (w *customErrorLogger) Write(msg []byte) (int, error) {
 	// checks if the error is a TLS handshake error that ends with EOF
 	if strings.Contains(string(msg), tlsHandshakeErrorPrefix) && strings.Contains(string(msg), tlsHandshakeErrorSuffix) {
 		// log at debug level and remove new lines
-		w.log.Debug(strings.Replace(string(msg), "\n", "", -1))
+		w.log.Debug(strings.ReplaceAll(string(msg), "\n", ""))
 	} else {
 		// log the error as is using the standard logger (the same way as the default http server does)
 		stdlog.Print(string(msg))


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Raise log level of errors `TLS handshake: EOF` errors to `DEBUG` instead `INFO` (default).

**Why do we need this feature?**

When running Grafana with TLS enabled behind Network Load Balancers on AWS, users are getting their logs flooded with messages like this:

```
level=info msg="http: TLS handshake error from 173.17.18.6:16037: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.23:26037: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.6:14455: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.6:23603: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.70:16037: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.6:36037: EOF"   
level=info msg="http: TLS handshake error from 173.17.18.6:16037: EOF"   
```

This happens because the NLB Health Checks terminates the TLS Connection and then establishes a new TCP connection to instance targets, without any data.

This new TCP connection, withou any data, gets a valid TCP handshake, and then immediately closes it.
No TLS, no HTTP, just SYN/SYN-ACK/FIN/ACK.  The connection gets closed before the TLS handshake even starts, that's why we see `TLS Handshake: EOF` error messages

This is benign and does not cause any harm to Grafana execution. To avoid flooding Grafana logs with `TLS Handshake: EOF` error messages, we are raising the log level to `DEBUG`

> If you add a TLS listener to your Network Load Balancer, we perform a listener connectivity test. As TLS termination also terminates a TCP connection, a new TCP connection is established between your load balancer and your targets. Therefore, you might see the TCP connections for this test sent from your load balancer to the targets that are registered with your TLS listener. You can identify these TCP connections because they have the source IP address of your Network Load Balancer and the connections do not contain data packets.

From: https://docs.aws.amazon.com/elasticloadbalancing/latest/network/target-group-health-checks.html


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/18736

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
