### PR TITLE
fix(accesscontrol): Reduce memory usage in GroupScopesByActionContext

### DIFF
--- a/pkg/services/accesscontrol/accesscontrol.go
+++ b/pkg/services/accesscontrol/accesscontrol.go
@@ -244,10 +244,59 @@ func GroupScopesByActionContext(ctx context.Context, permissions []Permission) m
 	))
 	defer span.End()
 
-	m := make(map[string][]string)
-	for i := range permissions {
-		m[permissions[i].Action] = append(m[permissions[i].Action], permissions[i].Scope)
+	// Note: this has been optimized to improve memory usage in large instances
+	// where there are lots of permissions. This isn't quite as fast as it can
+	// be, but we should prioritize memory over speed in this case.
+
+	if len(permissions) == 0 {
+		return make(map[string][]string)
 	}
+
+	// Use index-based approach with cached lookups for better performance
+	// First pass: assign and cache indices for each permission
+	actionIndex := make(map[string]int)
+	indices := make([]int, len(permissions))
+
+	for i := range permissions {
+		action := permissions[i].Action
+		if idx, ok := actionIndex[action]; ok {
+			indices[i] = idx
+		} else {
+			idx = len(actionIndex)
+			actionIndex[action] = idx
+			indices[i] = idx
+		}
+	}
+
+	// Count scopes per action using cached indices
+	actionCounts := make([]int, len(actionIndex))
+	for i := range indices {
+		actionCounts[indices[i]]++
+	}
+
+	// Preallocate slice array with exact capacities
+	scopes := make([][]string, len(actionCounts))
+	for i, count := range actionCounts {
+		scopes[i] = make([]string, 0, count)
+	}
+
+	// Second pass: append scopes using cached indices (no map lookups!)
+	for i := range permissions {
+		idx := indices[i]
+		scopes[idx] = append(scopes[idx], permissions[i].Scope)
+	}
+
+	// Build result map
+	m := make(map[string][]string, len(actionIndex))
+	for action, idx := range actionIndex {
+		m[action] = scopes[idx]
+	}
+
+	span.SetAttributes(
+		attribute.Int("unique_actions", len(actionIndex)),
+		attribute.Float64("avg_scopes_per_action", float64(len(permissions))/float64(len(actionIndex))),
+	)
+
 	return m
 }
 

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -5,9 +5,11 @@ import (
 	"errors"
 	"strings"
 
+	claims "github.com/grafana/authlib/types"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/exp/maps"
 
-	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -43,7 +45,9 @@ type RBACSync struct {
 }
 
 func (s *RBACSync) SyncPermissionsHook(ctx context.Context, ident *authn.Identity, _ *authn.Request) error {
-	ctx, span := s.tracer.Start(ctx, "rbac.sync.SyncPermissionsHook")
+	ctx, span := s.tracer.Start(ctx, "rbac.sync.SyncPermissionsHook", trace.WithAttributes(
+		attribute.String("ident_uid", ident.UID),
+	))
 	defer span.End()
 
 	if !ident.ClientParams.SyncPermissions {


### PR DESCRIPTION
**What is this feature?**

In a few extreme cases, memory usage from `accesscontrol.GroupScopesByActionContext` can cause OOMs.

Here's one such case (from Drilldown Profiles) on an installation where some users have ~70,000 permissions.

<img width="1015" height="256" alt="image" src="https://github.com/user-attachments/assets/9e7470b9-dc25-4958-b2ce-0334d12d7802" />

Looking at the profile, the main culprit is map and slice resizing (they're not currently pre-sized).

My initial approach (as hinted by the Assistant in Drilldown Profiles!) was something like:

```go
    actionCounts := make(map[string]int)
    for i := range permissions {
        actionCounts[permissions[i].Action]++
    }
    m := make(map[string][]string, len(actionCounts))
    for action, count := range actionCounts {
        m[action] = make([]string, 0, count)
    }
    for i := range permissions {
        action := permissions[i].Action
        m[action] = append(m[action], permissions[i].Scope)
    }
```

This results in a worst-case ~56% reduction in memory use and a ~89% reduction in allocations, but unfortunately comes at a CPU time cost (~62% increase):
```console
$ benchstat old.txt new.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/accesscontrol
cpu: Apple M3 Pro
                              │   old.txt   │              new.txt               │
                              │   sec/op    │   sec/op     vs base               │
GroupScopesByAction/small-12    16.55µ ± 2%   20.92µ ± 5%  +26.38% (p=0.000 n=8)
GroupScopesByAction/medium-12   157.2µ ± 4%   226.3µ ± 2%  +43.98% (p=0.000 n=8)
GroupScopesByAction/large-12    1.007m ± 3%   1.571m ± 3%  +55.96% (p=0.000 n=8)
geomean                         137.9µ        195.2µ       +41.58%

                              │   old.txt    │               new.txt               │
                              │     B/op     │     B/op      vs base               │
GroupScopesByAction/small-12    46.20Ki ± 0%   19.15Ki ± 0%  -58.56% (p=0.000 n=8)
GroupScopesByAction/medium-12   461.8Ki ± 0%   170.6Ki ± 0%  -63.06% (p=0.000 n=8)
GroupScopesByAction/large-12    3.115Mi ± 0%   1.184Mi ± 0%  -61.99% (p=0.000 n=8)
geomean                         408.3Ki        158.2Ki       -61.25%

                              │   old.txt   │              new.txt              │
                              │  allocs/op  │ allocs/op   vs base               │
GroupScopesByAction/small-12     77.00 ± 0%   23.00 ± 0%  -70.13% (p=0.000 n=8)
GroupScopesByAction/medium-12   383.00 ± 0%   58.00 ± 0%  -84.86% (p=0.000 n=8)
GroupScopesByAction/large-12    903.00 ± 0%   99.00 ± 0%  -89.04% (p=0.000 n=8)
geomean                          298.6        50.92       -82.95%
```

I'm not entirely sure that's a _bad_ tradeoff, given we're still around 1ms/op, but I'm not sure how hot this particular call is.

However, I dug a little deeper and came up with the change in this PR. The benchmark shows slightly less improvement on memory use (~44%), but a much less drastic speed impact (only 7% increase overall):

```console
$ benchstat old.txt new2.txt
goos: darwin
goarch: arm64
pkg: github.com/grafana/grafana/pkg/services/accesscontrol
cpu: Apple M3 Pro
                              │   old.txt    │              new2.txt              │
                              │    sec/op    │   sec/op     vs base               │
GroupScopesByAction/small-12     16.55µ ± 2%   14.55µ ± 1%  -12.07% (p=0.000 n=8)
GroupScopesByAction/medium-12    157.2µ ± 4%   141.7µ ± 3%   -9.84% (p=0.000 n=8)
GroupScopesByAction/large-12    1007.5µ ± 3%   991.8µ ± 4%        ~ (p=0.279 n=8)
geomean                          137.9µ        126.9µ        -7.93%

                              │   old.txt    │              new2.txt               │
                              │     B/op     │     B/op      vs base               │
GroupScopesByAction/small-12    46.20Ki ± 0%   26.23Ki ± 0%  -43.24% (p=0.000 n=8)
GroupScopesByAction/medium-12   461.8Ki ± 0%   251.9Ki ± 0%  -45.46% (p=0.000 n=8)
GroupScopesByAction/large-12    3.115Mi ± 0%   1.726Mi ± 0%  -44.60% (p=0.000 n=8)
geomean                         408.3Ki        226.8Ki       -44.44%

                              │   old.txt   │             new2.txt              │
                              │  allocs/op  │ allocs/op   vs base               │
GroupScopesByAction/small-12     77.00 ± 0%   20.00 ± 0%  -74.03% (p=0.000 n=8)
GroupScopesByAction/medium-12   383.00 ± 0%   61.00 ± 0%  -84.07% (p=0.000 n=8)
GroupScopesByAction/large-12     903.0 ± 0%   102.0 ± 0%  -88.70% (p=0.000 n=8)
geomean                          298.6        49.93       -83.28%
```

Another advantage of this optimized approach is the current most significant use of CPU time from this code is the string hashing algorithm used for map lookups, and this avoids repeated map lookups:

<img width="741" height="270" alt="image" src="https://github.com/user-attachments/assets/af5e44a4-a7ef-47ae-a709-e9718a592fcb" />

From a local profile, time spent in `aeshashbody` is reduced from ~45% to ~2.5%
