### PR TITLE
Update developer-guide

### DIFF
--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -150,7 +150,8 @@ When you log in for the first time, Grafana asks you to change your password.
 
 #### Build on Windows
 
-The Grafana backend includes SQLite, a database which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC. We recommend [TDM-GCC](http://tdm-gcc.tdragon.net/download). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
+The Grafana backend includes SQLite, a database which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC with binutils version 2.37 or later.
+We recommend [MinGW x64](). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
 
 You can build the back-end as follows:
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -151,7 +151,7 @@ When you log in for the first time, Grafana asks you to change your password.
 #### Build on Windows
 
 The Grafana backend includes SQLite, a database which requires GCC to compile. So in order to compile Grafana on Windows you need to install GCC with binutils version 2.37 or later.
-We recommend [MinGW x64](). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
+We recommend [MinGW x64](https://www.mingw-w64.org/downloads). Eventually, if you use [Scoop](https://scoop.sh), you can install GCC through that.
 
 You can build the back-end as follows:
 


### PR DESCRIPTION
Since upgrade to Go 1.25 the build on Windows stop working (see https://github.com/golang/go/issues/75077). The recommended C compiler for windows does not work anymore because it has outdated tool chain. This PR updates the guide to use another distribution of GCC with more modern tool chain.