### PR TITLE
Dashboard History: Fix service account parsing

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -460,7 +460,7 @@ func (a *dashboardSqlAccess) buildSaveDashboardCommand(ctx context.Context, orgI
 	}
 
 	var userID int64
-	if claims.IsIdentityType(user.GetIdentityType(), claims.TypeUser) {
+	if claims.IsIdentityType(user.GetIdentityType(), claims.TypeUser) || claims.IsIdentityType(user.GetIdentityType(), claims.TypeServiceAccount) {
 		var err error
 		userID, err = identity.UserIdentifier(user.GetSubject())
 		if err != nil {

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -593,19 +593,19 @@ func unstructuredToLegacyDashboardVersionWithUsers(
 
 	obj := vspec.MetaAccessor
 
-	var createdBy *user.User
+	createdByID := int64(0)
 	if creator, ok := users[obj.GetCreatedBy()]; ok {
-		createdBy = creator
+		createdByID = creator.ID
 	}
 	// if updated by is set, then this version of the dashboard was "created"
-	// by that user
-	if updater, ok := users[obj.GetUpdatedBy()]; ok {
-		createdBy = updater
-	}
-
-	createdByID := int64(0)
-	if createdBy != nil {
-		createdByID = createdBy.ID
+	// by that user. note: this will be empty for the first version of a dashboard in unistore,
+	// but will be set in legacy
+	if obj.GetUpdatedBy() != "" {
+		if updater, ok := users[obj.GetUpdatedBy()]; ok {
+			createdByID = updater.ID
+		} else {
+			createdByID = -1
+		}
 	}
 
 	created := obj.GetCreationTimestamp().Time


### PR DESCRIPTION
This PR fixes two bugs with how service accounts were parsed in the dashboard version history:

1. On dashboard saves, the service accounts were not being parsed as users for the dashboard save command. This resulted in the dashboard being saved as created by userID -1, which shows up as "Anonymous" in the dashboard history page. `identity.UserIdentifier` can get both service accounts and users, so we should parse both.

Before:
<img width="755" height="239" alt="Screenshot 2025-10-10 at 1 00 50 PM" src="https://github.com/user-attachments/assets/18eb9bd9-a779-415b-9139-7103fef9975a" />

After (**note**: this `after` is a new dashboard, as -1 is saved to the DB for the before. This means dashboards with this bug currently will continue to show Anonymous from service account changes before this is merged, but future changes will be attributed correctly):
<img width="756" height="254" alt="Screenshot 2025-10-10 at 1 02 50 PM" src="https://github.com/user-attachments/assets/334eeaf4-62d2-4db8-b3b5-cb6438ab7e5b" />

2. In the dashboard version page, if the updated at was not set, it would use the creator as the person/account that updated that version. This is needed for unistore, as on initial create, the dashboard only has the created by annotation, but in legacy storage, we need to set it to -1 if the updated at is -1 (i.e. anonymous).

Before:
<img width="1153" height="395" alt="Screenshot 2025-10-10 at 1 40 48 PM" src="https://github.com/user-attachments/assets/b61e838e-8838-4f1b-9007-0d442db2fdac" />

After (this was not due to the data saved, so this will be fixed when this is merged):
<img width="1152" height="393" alt="Screenshot 2025-10-10 at 1 40 28 PM" src="https://github.com/user-attachments/assets/55630ddd-d9cc-4e39-944f-c04a4c0bab9f" />


Fixes https://github.com/grafana/grafana/issues/88400
Fixes https://github.com/grafana/support-escalations/issues/18595