### PR TITLE
Pass parseTime=true parameter to mysql driver

### DIFF
--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -146,7 +146,7 @@ func (dbCfg *DatabaseConfig) buildConnectionString(cfg *setting.Cfg, features fe
 			protocol = "unix"
 		}
 
-		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		cnnstr = fmt.Sprintf("%s:%s@%s(%s)/%s?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true",
 			dbCfg.User, dbCfg.Pwd, protocol, dbCfg.Host, dbCfg.Name)
 
 		if dbCfg.SslMode == "true" || dbCfg.SslMode == "skip-verify" {

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -31,7 +31,7 @@ var databaseConfigTestCases = []databaseConfigTest{
 		name:       "MySQL IPv4",
 		dbType:     "mysql",
 		dbHost:     "1.2.3.4:5678",
-		expConnStr: ":@tcp(1.2.3.4:5678)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		expConnStr: ":@tcp(1.2.3.4:5678)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true",
 	},
 	{
 		name:       "Postgres IPv4",
@@ -65,13 +65,13 @@ var databaseConfigTestCases = []databaseConfigTest{
 		name:       "MySQL IPv4 (Default Port)",
 		dbType:     "mysql",
 		dbHost:     "1.2.3.4",
-		expConnStr: ":@tcp(1.2.3.4)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		expConnStr: ":@tcp(1.2.3.4)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true",
 	},
 	{
 		name:       "MySQL IPv6",
 		dbType:     "mysql",
 		dbHost:     "[fe80::24e8:31b2:91df:b177]:1234",
-		expConnStr: ":@tcp([fe80::24e8:31b2:91df:b177]:1234)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		expConnStr: ":@tcp([fe80::24e8:31b2:91df:b177]:1234)/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true",
 	},
 	{
 		name:       "Postgres IPv6",
@@ -83,7 +83,7 @@ var databaseConfigTestCases = []databaseConfigTest{
 		name:       "MySQL IPv6 (Default Port)",
 		dbType:     "mysql",
 		dbHost:     "[::1]",
-		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true",
+		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true",
 	},
 	{
 		name:       "Postgres IPv6 (Default Port)",
@@ -101,7 +101,7 @@ var databaseConfigTestCases = []databaseConfigTest{
 		dbType:     "mysql",
 		dbHost:     "[::1]",
 		features:   featuremgmt.WithFeatures(featuremgmt.FlagMysqlAnsiQuotes),
-		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&sql_mode='ANSI_QUOTES'",
+		expConnStr: ":@tcp([::1])/test_db?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true&sql_mode='ANSI_QUOTES'",
 	},
 }
 

--- a/pkg/services/sqlstore/sqlstore_test.go
+++ b/pkg/services/sqlstore/sqlstore_test.go
@@ -85,19 +85,19 @@ func TestInitEngine_ParseTimeInConnectionString(t *testing.T) {
 			name:               "MySQL with parseTime already present",
 			connectionString:   "mysql://user:password@localhost:3306/alreadypresent?parseTime=false",
 			dbType:             "mysql",
-			expectedConnection: "user:password@tcp(localhost:3306)/alreadypresent?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=false",
+			expectedConnection: "user:password@tcp(localhost:3306)/alreadypresent?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true&parseTime=false",
 		},
 		{
 			name:               "MySQL with feature enabled",
 			connectionString:   "mysql://user:password@localhost:3306/existingparams?charset=utf8",
 			dbType:             "mysql",
-			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&charset=utf8&parseTime=true",
+			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true&charset=utf8",
 		},
 		{
 			name:               "MySQL with feature enabled",
 			connectionString:   "mysql://user:password@localhost:3306/existingparams?charset=utf8",
 			dbType:             "mysqlWithHooks",
-			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&charset=utf8&parseTime=true",
+			expectedConnection: "user:password@tcp(localhost:3306)/existingparams?collation=utf8mb4_unicode_ci&allowNativePasswords=true&clientFoundRows=true&parseTime=true&charset=utf8",
 		},
 		{
 			name:               "Postgres",


### PR DESCRIPTION
We pass the same `parseTime=true` parameter when running integration tests, so it makes sense that we also pass it when building "real" connection string.

https://github.com/grafana/grafana/blob/f3ca49f2b3d3a0d06a04c26a61431f468c806fb3/pkg/services/sqlstore/sqlutil/sqlutil.go#L127-L147

Without this flag, mysql driver doesn't parse `DATETIME` type into `*time.Time`: https://github.com/go-sql-driver/mysql?tab=readme-ov-file#timetime-support