### PR TITLE
Plugins: Add metric for tracking plugin asset info

### DIFF
--- a/pkg/infra/metrics/metrics.go
+++ b/pkg/infra/metrics/metrics.go
@@ -204,6 +204,8 @@ var (
 
 	grafanaPluginFileSystemInfoDesc *prometheus.GaugeVec
 
+	grafanaPluginAssetInfoDesc *prometheus.GaugeVec
+
 	grafanaPluginProvisioningInfoDesc *prometheus.GaugeVec
 
 	// StatsTotalLibraryPanels is a metric of total number of library panels stored in Grafana.
@@ -588,6 +590,12 @@ func init() {
 		Namespace: ExporterName,
 	}, []string{"plugin_id", "filesystem_type"})
 
+	grafanaPluginAssetInfoDesc = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name:      "plugin_asset_info",
+		Help:      "A metric with a constant '1' value labeled by pluginId and asset source",
+		Namespace: ExporterName,
+	}, []string{"plugin_id", "asset_source"})
+
 	grafanaPluginProvisioningInfoDesc = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name:      "plugin_provisioning_info",
 		Help:      "A metric with a constant '1' value labeled by pluginId and cloud provisioning method",
@@ -742,6 +750,10 @@ func SetPluginFSInformation(pluginID, fsType string) {
 	grafanaPluginFileSystemInfoDesc.WithLabelValues(pluginID, fsType).Set(1)
 }
 
+func SetPluginAssetInformation(pluginID, assetSrc string) {
+	grafanaPluginAssetInfoDesc.WithLabelValues(pluginID, assetSrc).Set(1)
+}
+
 func SetPluginProvisioningInformation(pluginID, provisioningMethod string) {
 	grafanaPluginProvisioningInfoDesc.WithLabelValues(pluginID, provisioningMethod).Set(1)
 }
@@ -802,6 +814,7 @@ func initMetricVars(reg prometheus.Registerer) {
 		grafanaPluginBuildInfoDesc,
 		grafanaPluginTargetInfoDesc,
 		grafanaPluginFileSystemInfoDesc,
+		grafanaPluginAssetInfoDesc,
 		grafanaPluginProvisioningInfoDesc,
 		StatsTotalDashboardVersions,
 		StatsTotalAnnotations,

--- a/pkg/services/pluginsintegration/pipeline/pipeline.go
+++ b/pkg/services/pluginsintegration/pipeline/pipeline.go
@@ -81,6 +81,7 @@ func ProvideInitializationStage(cfg *config.PluginManagementCfg, pr registry.Ser
 			ReportBuildMetrics,
 			ReportTargetMetrics,
 			ReportFSMetrics,
+			ReportAssetMetrics,
 			ReportCloudProvisioningMetrics(provisionedPluginsManager),
 			initialization.PluginRegistrationStep(pr),
 		},

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"slices"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -149,6 +150,23 @@ func ReportFSMetrics(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, err
 	}
 
 	metrics.SetPluginFSInformation(p.ID, p.FS.Type())
+	return p, nil
+}
+
+// ReportAssetMetrics reports plugin asset information for all non-core plugins.
+func ReportAssetMetrics(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, error) {
+	if p.IsCorePlugin() {
+		// No metrics for core plugins
+		return p, nil
+	}
+
+	_, err := url.ParseRequestURI(p.BaseURL)
+	if err == nil {
+		metrics.SetPluginAssetInformation(p.ID, "remote")
+		return p, nil
+	}
+
+	metrics.SetPluginAssetInformation(p.ID, "local")
 	return p, nil
 }
 

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -160,8 +160,8 @@ func ReportAssetMetrics(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, 
 		return p, nil
 	}
 
-	_, err := url.ParseRequestURI(p.BaseURL)
-	if err == nil {
+	u, err := url.ParseRequestURI(p.BaseURL)
+	if err == nil && u.IsAbs() {
 		metrics.SetPluginAssetInformation(p.ID, "remote")
 		return p, nil
 	}

--- a/pkg/services/pluginsintegration/pipeline/steps.go
+++ b/pkg/services/pluginsintegration/pipeline/steps.go
@@ -161,7 +161,7 @@ func ReportAssetMetrics(_ context.Context, p *plugins.Plugin) (*plugins.Plugin, 
 	}
 
 	u, err := url.ParseRequestURI(p.BaseURL)
-	if err == nil && u.IsAbs() {
+	if err == nil && u.Host != "" {
 		metrics.SetPluginAssetInformation(p.ID, "remote")
 		return p, nil
 	}


### PR DESCRIPTION
**What is this feature?**

Adds a metric that illustrates whether a given plugin's asset sources are `remote` or `local`
