### PR TITLE
Alerts: Make success toast notifications opt-in instead of opt-out

### DIFF
--- a/packages/grafana-runtime/src/services/backendSrv.ts
+++ b/packages/grafana-runtime/src/services/backendSrv.ts
@@ -29,7 +29,8 @@ export type BackendSrvRequest = {
   method?: string;
 
   /**
-   * Set to false an success application alert box will not be shown for successful PUT, DELETE, POST requests
+   * Set to true to show a success application alert box for successful requests.
+   * By default, success alerts are not shown (opt-in behavior).
    */
   showSuccessAlert?: boolean;
 
@@ -154,6 +155,8 @@ export function isFetchError<T = any>(e: unknown): e is FetchError<T> {
  * @remarks
  * By default, Grafana displays an error message alert if the remote call fails. To prevent this from
  * happening `showErrorAlert = false` on the options object.
+ * 
+ * Success alerts are opt-in. To show a success alert, set `showSuccessAlert = true` on the options object.
  *
  * @public
  */

--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -362,15 +362,8 @@ export class BackendSrv implements BackendService {
   showSuccessAlert<T>(response: FetchResponse<T>) {
     const { config } = response;
 
-    if (config.showSuccessAlert === false) {
-      return;
-    }
-
-    // if showSuccessAlert is undefined we only show alerts non GET request, non data query and local api requests
-    if (
-      config.showSuccessAlert === undefined &&
-      (config.method === 'GET' || isDataQuery(config.url) || !isLocalUrl(config.url))
-    ) {
+    // Only show success alert if explicitly requested (opt-in behavior)
+    if (config.showSuccessAlert !== true) {
       return;
     }
 

--- a/public/app/core/specs/backend_srv.test.ts
+++ b/public/app/core/specs/backend_srv.test.ts
@@ -133,7 +133,21 @@ describe('backendSrv', () => {
     const testMessage = 'Datasource updated';
     const errorMessage = 'UnAuthorized';
 
-    describe('when making a successful call and conditions for showSuccessAlert are not favorable', () => {
+    describe('when making a successful call and showSuccessAlert is not explicitly set', () => {
+      it('then it should return correct result and not emit anything', async () => {
+        const { backendSrv, appEventsMock, expectRequestCallChain } = getTestContext({
+          data: { message: testMessage },
+        });
+        const url = '/api/dashboard/';
+        const result = await backendSrv.request({ url, method: 'DELETE' });
+
+        expect(result).toEqual({ message: testMessage });
+        expect(appEventsMock.emit).not.toHaveBeenCalled();
+        expectRequestCallChain({ url, method: 'DELETE' });
+      });
+    });
+
+    describe('when making a successful call and showSuccessAlert is explicitly set to false', () => {
       it('then it should return correct result and not emit anything', async () => {
         const { backendSrv, appEventsMock, expectRequestCallChain } = getTestContext({
           data: { message: testMessage },
@@ -147,7 +161,7 @@ describe('backendSrv', () => {
       });
     });
 
-    describe('when making a successful call and conditions for showSuccessAlert are favorable', () => {
+    describe('when making a successful call and showSuccessAlert is explicitly set to true', () => {
       it('then it should emit correct message', async () => {
         const { backendSrv, appEventsMock, expectRequestCallChain } = getTestContext({
           data: { message: testMessage },


### PR DESCRIPTION
Fixes #112324

Problem:
Currently, toast notifications are shown by default for certain backend service requests in Grafana. This can lead to an excessive number of notifications that may not be desired by all teams or use cases.


Solution:
This PR changes the behavior of success toast notifications to be opt-in instead of opt-out. Now, success alerts will only be shown when explicitly requested by setting showSuccessAlert: true in the request options.Changes Made:
Modified the [showSuccessAlert](file:///E:/grafana/public/app/core/services/backend_srv.ts#L361-L374) method in backend_srv.ts to only show alerts when explicitly requested
Updated the documentation in the [BackendSrvRequest](file:///E:/grafana/packages/grafana-runtime/src/services/backendSrv.ts#L7-L94) interface to reflect the new opt-in behavior
Updated the backend service tests to match the new behavior


Impact:
Existing code that explicitly sets showSuccessAlert: false will continue to work as before
Existing code that explicitly sets showSuccessAlert: true will continue to work as before
Existing code that doesn't set [showSuccessAlert](file:///E:/grafana/public/app/core/services/backend_srv.ts#L361-L374) will no longer show success alerts (new behavior)
This change gives teams more control over the user experience in their respective parts of the Grafana application, allowing them to decide on a per-request basis whether or not to show a notification.Testing:
Updated unit tests to reflect the new opt-in behavior
Verified that existing explicit settings continue to work as expected



Migration:
Teams that want to maintain the previous behavior of showing success alerts for certain requests will need to explicitly set showSuccessAlert: true in their backend requests.