### PR TITLE
Plugins: Export time range variables from State Timeline to use in DataLinks

### DIFF
--- a/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelineTooltip2.tsx
@@ -11,11 +11,13 @@ import {
   getContentItems,
   VizTooltipItem,
 } from '@grafana/ui/internal';
-import { findNextStateIndex, fmtDuration } from 'app/core/components/TimelineChart/utils';
+import { fmtDuration } from 'app/core/components/TimelineChart/utils';
 
 import { getFieldActions } from '../status-history/utils';
 import { TimeSeriesTooltipProps } from '../timeseries/TimeSeriesTooltip';
 import { isTooltipScrollable } from '../timeseries/utils';
+
+import { getStateTimeRange } from './utils';
 
 interface StateTimelineTooltip2Props extends TimeSeriesTooltipProps {
   timeRange: TimeRange;
@@ -48,27 +50,14 @@ export const StateTimelineTooltip2 = ({
   let endTime = null;
 
   // append duration in single mode
-  if (withDuration && mode === TooltipDisplayMode.Single) {
-    const field = series.fields[seriesIdx!];
-    const nextStateIdx = findNextStateIndex(field, dataIdx!);
-    let nextStateTs;
-    if (nextStateIdx) {
-      nextStateTs = xField.values[nextStateIdx!];
+  if (withDuration && mode === TooltipDisplayMode.Single && seriesIdx != null && dataIdx != null) {
+    const field = series.fields[seriesIdx];
+    const stateTimeRange = getStateTimeRange(series, field, dataIdx, timeRange);
+
+    if (stateTimeRange) {
+      endTime = stateTimeRange.endTime;
+      contentItems.push({ label: 'Duration', value: fmtDuration(stateTimeRange.duration) });
     }
-
-    const stateTs = xField.values[dataIdx!];
-    let duration: string;
-
-    if (nextStateTs) {
-      duration = nextStateTs && fmtDuration(nextStateTs - stateTs);
-      endTime = nextStateTs;
-    } else {
-      const to = timeRange.to.valueOf();
-      duration = fmtDuration(to - stateTs);
-      endTime = to;
-    }
-
-    contentItems.push({ label: 'Duration', value: duration });
   }
 
   let footer: ReactNode;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature extends the State Timeline panel to support Data Links that dynamically use the selected state’s time range. When a user clicks a specific state segment, Grafana can now open another dashboard (or external link) with the time range automatically set to that segment’s start and end times.

New template variables introduced:
- `${__state.startTime}` – timestamp of the segment start
- `${__state.endTime}` – timestamp of the segment end
- `${__statte.duration}` – duration of the segment in milliseconds

**Why do we need this feature?**

Currently, Data Links in the State Timeline panel cannot reference the start or end times of individual states, preventing users from performing context-aware drilldowns.

With this enhancement, operators and engineers can directly navigate to dashboards focused on the exact time window of a specific state (e.g., a failure period), significantly improving incident investigation and observability workflows.

**Who is this feature for?**

This feature benefits operators, SREs, and developers who use the State Timeline panel for monitoring systems, pipelines, or workflow executions and need to analyze a particular state’s duration in greater detail.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #112208

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
