### PR TITLE
Alerting: Turn off decryption of contact point values for exporting by default

### DIFF
--- a/public/app/features/alerting/unified/components/contact-points/useExportContactPoint.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useExportContactPoint.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 
-import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
 import { GrafanaReceiverExporter } from '../export/GrafanaReceiverExporter';
 import { GrafanaReceiversExporter } from '../export/GrafanaReceiversExporter';
 
@@ -12,9 +11,6 @@ type ExportProps = [JSX.Element | null, (receiver: string | typeof ALL_CONTACT_P
 export const useExportContactPoint = (): ExportProps => {
   const [receiverName, setReceiverName] = useState<string | typeof ALL_CONTACT_POINTS | null>(null);
   const [isExportDrawerOpen, toggleShowExportDrawer] = useToggle(false);
-  const [decryptSecretsSupported, decryptSecretsAllowed] = useAlertmanagerAbility(AlertmanagerAction.DecryptSecrets);
-
-  const canReadSecrets = decryptSecretsSupported && decryptSecretsAllowed;
 
   const handleClose = useCallback(() => {
     setReceiverName(null);
@@ -33,12 +29,12 @@ export const useExportContactPoint = (): ExportProps => {
 
     if (receiverName === ALL_CONTACT_POINTS) {
       // use this drawer when we want to export all contact points
-      return <GrafanaReceiversExporter decrypt={canReadSecrets} onClose={handleClose} />;
+      return <GrafanaReceiversExporter onClose={handleClose} />;
     } else {
       // use this one for exporting a single contact point
-      return <GrafanaReceiverExporter receiverName={receiverName} decrypt={canReadSecrets} onClose={handleClose} />;
+      return <GrafanaReceiverExporter receiverName={receiverName} onClose={handleClose} />;
     }
-  }, [canReadSecrets, isExportDrawerOpen, handleClose, receiverName]);
+  }, [isExportDrawerOpen, handleClose, receiverName]);
 
   return [drawer, handleOpen];
 };

--- a/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
+++ b/public/app/features/alerting/unified/components/export/FileExportPreview.tsx
@@ -6,22 +6,7 @@ import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import {
-  Alert,
-  Button,
-  ClipboardButton,
-  CodeEditor,
-  Field,
-  InlineField,
-  InlineFieldRow,
-  InlineFormLabel,
-  InlineLabel,
-  Label,
-  Stack,
-  Switch,
-  TextLink,
-  useStyles2,
-} from '@grafana/ui';
+import { Alert, Button, ClipboardButton, CodeEditor, Stack, Switch, TextLink, useStyles2 } from '@grafana/ui';
 
 import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
 import { Spacer } from '../Spacer';

--- a/public/app/features/alerting/unified/components/export/GrafanaReceiverExporter.tsx
+++ b/public/app/features/alerting/unified/components/export/GrafanaReceiverExporter.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react';
 import { useToggle } from 'react-use';
 
+import { t } from '@grafana/i18n';
+
 import { alertRuleApi } from '../../api/alertRuleApi';
 
 import { FileExportPreview } from './FileExportPreview';

--- a/public/app/features/alerting/unified/components/receivers/ReceiversSection.tsx
+++ b/public/app/features/alerting/unified/components/receivers/ReceiversSection.tsx
@@ -16,7 +16,6 @@ interface Props {
   addButtonTo: string;
   className?: string;
   showButton?: boolean;
-  canReadSecrets?: boolean;
   showExport?: boolean;
 }
 
@@ -28,7 +27,6 @@ export const ReceiversSection = ({
   addButtonTo,
   children,
   showButton = true,
-  canReadSecrets = false,
   showExport = false,
 }: React.PropsWithChildren<Props>) => {
   const styles = useStyles2(getStyles);
@@ -72,7 +70,7 @@ export const ReceiversSection = ({
         </Stack>
       </div>
       {children}
-      {showExportDrawer && <GrafanaReceiversExporter decrypt={canReadSecrets} onClose={toggleShowExportDrawer} />}
+      {showExportDrawer && <GrafanaReceiversExporter onClose={toggleShowExportDrawer} />}
     </Stack>
   );
 };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1231,7 +1231,8 @@
     },
     "file-export-preview": {
       "copy-code": "Copy code",
-      "download": "Download"
+      "download": "Download",
+      "label-decrypt-values": "Show secret values"
     },
     "filter-view-results": {
       "aria-label-filteredrulelist": "filtered-rule-list"
@@ -1434,9 +1435,6 @@
       "text-loading": "Loading...."
     },
     "grafana-policies-exporter-preview": {
-      "text-loading": "Loading...."
-    },
-    "grafana-receiver-export-preview": {
       "text-loading": "Loading...."
     },
     "grafana-receiver-form": {


### PR DESCRIPTION
You can still toggle this on for administrators or users with appropriate permissions.

<img width="239" height="171" alt="image" src="https://github.com/user-attachments/assets/b166d91c-2ded-4c8f-9a5d-828f63033691" />

