### PR TITLE
Logs context: fix position on small viewports

### DIFF
--- a/public/app/features/logs/components/log-context/LogRowContextModal.tsx
+++ b/public/app/features/logs/components/log-context/LogRowContextModal.tsx
@@ -40,9 +40,6 @@ const getStyles = (theme: GrafanaTheme2) => {
       [theme.breakpoints.down('md')]: {
         width: '100%',
       },
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
     }),
     sticky: css({
       position: 'sticky',

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -431,14 +431,11 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     modal: css({
       width: '85vw',
-      height: '80%',
+      height: '80vh',
       [theme.breakpoints.down('md')]: {
         width: '100%',
-        minHeight: '100%',
+        height: '100vh',
       },
-      top: '50%',
-      left: '50%',
-      transform: 'translate(-50%, -50%)',
     }),
     loadingIndicator: css({
       height: theme.spacing(3),


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/112113

To reproduce, open Log Context with a browser height of less than 750px.