### PR TITLE
Faro: Manually set page ID

### DIFF
--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -1,7 +1,7 @@
 import { Suspense, useEffect, useLayoutEffect } from 'react';
 import { Navigate, useLocation } from 'react-router-dom-v5-compat';
 
-import { config, locationSearchToObject, navigationLogger, reportPageview } from '@grafana/runtime';
+import { config, locationSearchToObject, navigationLogger } from '@grafana/runtime';
 import { ErrorBoundary } from '@grafana/ui';
 import { isFrontendService } from 'app/core/utils/isFrontendService';
 
@@ -38,7 +38,6 @@ export function GrafanaRoute(props: Props) {
 
   useEffect(() => {
     cleanupDOM();
-    reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', props);
   });
 

--- a/public/app/core/services/echo/EchoSrvLocation.ts
+++ b/public/app/core/services/echo/EchoSrvLocation.ts
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+import { matchPath, useLocation } from 'react-router-dom-v5-compat';
+
+import { faro } from '@grafana/faro-web-sdk';
+import { reportPageview } from '@grafana/runtime';
+import { RouteDescriptor } from 'app/core/navigation/types';
+
+import { getAppRoutes } from '../../../routes/routes';
+
+export function EchoSrvLocationReporter() {
+  const appRoutesRef = useRef<RouteDescriptor[]>();
+
+  const location = useLocation();
+
+  useEffect(() => {
+    if (!appRoutesRef.current) {
+      appRoutesRef.current = getAppRoutes();
+    }
+    const routes = appRoutesRef.current;
+
+    // Find the matching route
+    const matchedRoute = routes.find((route) => {
+      return matchPath({ path: route.path, end: true }, location.pathname);
+    });
+
+    const pageId = matchedRoute?.path || location.pathname;
+
+    // [FIXME] Pass the pageID into reportPageview, and get GrafanaJavascriptBackend to pick that up
+    // and call faro.api.setPage there instead.
+    console.log('Reporting pageview to EchoSrv for location:', { pageId, ...location });
+    faro.api.setPage({
+      url: location.pathname + location.search + location.hash,
+      id: pageId,
+    });
+    reportPageview();
+  }, [location]);
+
+  return null;
+}

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -9,6 +9,7 @@ import { AppChrome } from '../core/components/AppChrome/AppChrome';
 import { AppChromeExtensionPoint } from '../core/components/AppChrome/AppChromeExtensionPoint';
 import { AppNotificationList } from '../core/components/AppNotifications/AppNotificationList';
 import { ModalsContextProvider } from '../core/context/ModalsContextProvider';
+import { EchoSrvLocationReporter } from '../core/services/echo/EchoSrvLocation';
 import { QueriesDrawerContextProvider } from '../features/explore/QueriesDrawer/QueriesDrawerContext';
 
 function ExtraProviders(props: { children: ReactNode; providers: Array<ComponentType<{ children: ReactNode }>> }) {
@@ -28,6 +29,8 @@ export function RouterWrapper(props: RouterWrapperProps) {
     <Router history={locationService.getHistory()}>
       <LocationServiceProvider service={locationService}>
         <CompatRouter>
+          <EchoSrvLocationReporter />
+
           <QueriesDrawerContextProvider>
             <ExtraProviders providers={props.providers}>
               <ModalsContextProvider>


### PR DESCRIPTION
 - first stab at trying to have better page IDs in faro
 - there doesn't appear to be a way to get the matched react router route from outside the route itself
 - unsure whether this is the right approach to take or not. alternatively, maybe we could contain a set of regex's for how we process urls? dunno.