### PR TITLE
Chore: replace feature toggle filterOutBotsFromFrontendLogs with config

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1229,6 +1229,9 @@ internal_logger_level = 0
 # Api Key, only applies to Grafana Javascript Agent provider
 api_key =
 
+# Enable bot filter for Grafana Javascript Agent
+bot_filter_enabled = false
+
 #################################### Usage Quotas ########################
 [quota]
 enabled = false

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1234,7 +1234,7 @@ log_endpoint_requests_per_second_limit = 3
 # Max requests accepted per short interval of time for Grafana backend log ingestion endpoint (/log)
 log_endpoint_burst_limit = 15
 
-# Enable bot filter for Grafana Javascript Agent
+# Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
 bot_filter_enabled = false
 
 #################################### Usage Quotas ########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1234,7 +1234,7 @@ log_endpoint_requests_per_second_limit = 3
 # Max requests accepted per short interval of time for Grafana backend log ingestion endpoint (/log)
 log_endpoint_burst_limit = 15
 
-# Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
+# Enables the bot filter for the Grafana Faro JavaScript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
 bot_filter_enabled = false
 
 #################################### Usage Quotas ########################

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1234,7 +1234,6 @@ log_endpoint_requests_per_second_limit = 3
 # Max requests accepted per short interval of time for Grafana backend log ingestion endpoint (/log)
 log_endpoint_burst_limit = 15
 
-
 # Enable bot filter for Grafana Javascript Agent
 bot_filter_enabled = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1206,6 +1206,9 @@
 # See https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/web-vitals/#web-vitals-attribution-data
 ;web_vitals_attribution_enabled = true
 
+# Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
+;bot_filter_enabled = false
+
 #################################### Usage Quotas ########################
 [quota]
 ; enabled = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1206,7 +1206,7 @@
 # See https://grafana.com/docs/grafana-cloud/monitor-applications/frontend-observability/instrument/web-vitals/#web-vitals-attribution-data
 ;web_vitals_attribution_enabled = true
 
-# Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
+# Enables the bot filter for the Grafana Faro JavaScript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
 ;bot_filter_enabled = false
 
 #################################### Usage Quotas ########################

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1681,7 +1681,7 @@ Maximum requests accepted per short interval of time for Grafana backend log ing
 
 #### `bot_filter_enabled`
 
-Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
+Enables the bot filter for the Grafana Faro JavaScript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1679,6 +1679,10 @@ Requests per second limit enforced per an extended period, for Grafana backend l
 
 Maximum requests accepted per short interval of time for Grafana backend log ingestion endpoint, `/log-grafana-javascript-agent`. Default is `15`.
 
+#### `bot_filter_enabled`
+
+Enables the bot filter for the Grafana Faro javascript agent integration. Default is `false`. When enabled, it will filter out requests from known bots and crawlers.
+
 <hr>
 
 ### `[quota]`

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1192,11 +1192,6 @@ export interface FeatureToggles {
   */
   tempoSearchBackendMigration?: boolean;
   /**
-  * Filter out bots from collecting data for Frontend Observability
-  * @default false
-  */
-  filterOutBotsFromFrontendLogs?: boolean;
-  /**
   * Prioritize loading plugins from the CDN before other sources
   * @default false
   */

--- a/packages/grafana-runtime/src/config.ts
+++ b/packages/grafana-runtime/src/config.ts
@@ -160,6 +160,7 @@ export class GrafanaBootConfig {
     consoleInstrumentalizationEnabled: false,
     webVitalsInstrumentalizationEnabled: false,
     tracingInstrumentalizationEnabled: false,
+    botFilterEnabled: false,
   };
   pluginCatalogURL = 'https://grafana.com/grafana/plugins/';
   pluginAdminEnabled = true;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2067,14 +2067,6 @@ var (
 			RequiresRestart: true,
 		},
 		{
-			Name:         "filterOutBotsFromFrontendLogs",
-			Description:  "Filter out bots from collecting data for Frontend Observability",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: true,
-			Owner:        grafanaPluginsPlatformSquad,
-			Expression:   "false",
-		},
-		{
 			Name:         "cdnPluginsLoadFirst",
 			Description:  "Prioritize loading plugins from the CDN before other sources",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -265,6 +265,5 @@ azureResourcePickerUpdates,preview,@grafana/partner-datasources,false,false,true
 prometheusTypeMigration,experimental,@grafana/partner-datasources,false,true,false
 pluginContainers,privatePreview,@grafana/plugins-platform-backend,false,true,false
 tempoSearchBackendMigration,GA,@grafana/oss-big-tent,false,true,false
-filterOutBotsFromFrontendLogs,experimental,@grafana/plugins-platform-backend,false,false,true
 cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -1070,10 +1070,6 @@ const (
 	// Run search queries through the tempo backend
 	FlagTempoSearchBackendMigration = "tempoSearchBackendMigration"
 
-	// FlagFilterOutBotsFromFrontendLogs
-	// Filter out bots from collecting data for Frontend Observability
-	FlagFilterOutBotsFromFrontendLogs = "filterOutBotsFromFrontendLogs"
-
 	// FlagCdnPluginsLoadFirst
 	// Prioritize loading plugins from the CDN before other sources
 	FlagCdnPluginsLoadFirst = "cdnPluginsLoadFirst"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1690,7 +1690,8 @@
       "metadata": {
         "name": "filterOutBotsFromFrontendLogs",
         "resourceVersion": "1758000919535",
-        "creationTimestamp": "2025-09-16T05:35:19Z"
+        "creationTimestamp": "2025-09-16T05:35:19Z",
+        "deletionTimestamp": "2025-10-13T11:09:22Z"
       },
       "spec": {
         "description": "Filter out bots from collecting data for Frontend Observability",
@@ -3172,7 +3173,8 @@
       "metadata": {
         "name": "queryServiceWithConnections",
         "resourceVersion": "1756367172351",
-        "creationTimestamp": "2025-08-28T07:46:12Z"
+        "creationTimestamp": "2025-08-28T19:28:26Z",
+        "deletionTimestamp": "2025-08-29T12:49:57Z"
       },
       "spec": {
         "description": "Adds datasource connections to the query service",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3205,8 +3205,7 @@
       "metadata": {
         "name": "queryServiceWithConnections",
         "resourceVersion": "1756367172351",
-        "creationTimestamp": "2025-08-28T19:28:26Z",
-        "deletionTimestamp": "2025-08-29T12:49:57Z"
+        "creationTimestamp": "2025-08-28T07:46:12Z"
       },
       "spec": {
         "description": "Adds datasource connections to the query service",

--- a/pkg/setting/setting_grafana_javascript_agent.go
+++ b/pkg/setting/setting_grafana_javascript_agent.go
@@ -12,6 +12,7 @@ type GrafanaJavascriptAgent struct {
 	TracingInstrumentalizationEnabled   bool   `json:"tracingInstrumentalizationEnabled"`
 	InternalLoggerLevel                 int    `json:"internalLoggerLevel"`
 	ApiKey                              string `json:"apiKey"`
+	BotFilterEnabled                    bool   `json:"botFilterEnabled"`
 }
 
 func (cfg *Cfg) readGrafanaJavascriptAgentConfig() {
@@ -28,5 +29,6 @@ func (cfg *Cfg) readGrafanaJavascriptAgentConfig() {
 		TracingInstrumentalizationEnabled:   raw.Key("instrumentations_tracing_enabled").MustBool(true),
 		InternalLoggerLevel:                 raw.Key("internal_logger_level").MustInt(0),
 		ApiKey:                              raw.Key("api_key").String(),
+		BotFilterEnabled:                    raw.Key("bot_filter_enabled").MustBool(false),
 	}
 }

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.test.ts
@@ -4,14 +4,10 @@ import { Faro, Instrumentation } from '@grafana/faro-core';
 import * as faroWebSdkModule from '@grafana/faro-web-sdk';
 import { BrowserConfig, FetchTransport, SessionInstrumentation } from '@grafana/faro-web-sdk';
 import { TracingInstrumentation } from '@grafana/faro-web-tracing';
-import { config } from '@grafana/runtime';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
-import {
-  GrafanaJavascriptAgentBackend,
-  GrafanaJavascriptAgentBackendOptions,
-  TRACKING_URLS,
-} from './GrafanaJavascriptAgentBackend';
+import { GrafanaJavascriptAgentBackend, TRACKING_URLS } from './GrafanaJavascriptAgentBackend';
+import { GrafanaJavascriptAgentBackendOptions } from './types';
 
 describe('GrafanaJavascriptAgentEchoBackend', () => {
   let mockedSetUser: jest.Mock;
@@ -47,8 +43,6 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
       instrumentations: mockedInstrumentations,
       internalLogger: mockedInternalLogger,
     });
-
-    config.featureToggles.filterOutBotsFromFrontendLogs = false;
   });
 
   afterEach(() => {
@@ -87,6 +81,7 @@ describe('GrafanaJavascriptAgentEchoBackend', () => {
       orgId: 1,
     },
     ignoreUrls: [],
+    botFilterEnabled: false,
   };
 
   it('will set up FetchTransport if customEndpoint is provided', () => {

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/GrafanaJavascriptAgentBackend.ts
@@ -1,4 +1,4 @@
-import { BuildInfo, escapeRegex } from '@grafana/data';
+import { escapeRegex } from '@grafana/data';
 import { BaseTransport, defaultInternalLoggerLevel } from '@grafana/faro-core';
 import {
   initializeFaro,
@@ -17,7 +17,7 @@ import { EchoBackend, EchoEvent, EchoEventType } from '@grafana/runtime';
 
 import { EchoSrvTransport } from './EchoSrvTransport';
 import { beforeSendHandler } from './beforeSendHandler';
-import { GrafanaJavascriptAgentEchoEvent, User } from './types';
+import { GrafanaJavascriptAgentBackendOptions, GrafanaJavascriptAgentEchoEvent } from './types';
 
 function isCrossOriginIframe() {
   try {
@@ -25,18 +25,6 @@ function isCrossOriginIframe() {
   } catch (e) {
     return true;
   }
-}
-
-export interface GrafanaJavascriptAgentBackendOptions extends BrowserConfig {
-  buildInfo: BuildInfo;
-  customEndpoint: string;
-  user: User;
-  allInstrumentationsEnabled: boolean;
-  errorInstrumentalizationEnabled: boolean;
-  consoleInstrumentalizationEnabled: boolean;
-  webVitalsInstrumentalizationEnabled: boolean;
-  tracingInstrumentalizationEnabled: boolean;
-  ignoreUrls: RegExp[];
 }
 
 export const TRACKING_URLS = [
@@ -119,7 +107,7 @@ export class GrafanaJavascriptAgentBackend
         sendTimeout: 1000,
       },
       internalLoggerLevel: options.internalLoggerLevel || defaultInternalLoggerLevel,
-      beforeSend: beforeSendHandler,
+      beforeSend: (item) => beforeSendHandler(options.botFilterEnabled, item),
     };
     this.faroInstance = initializeFaro(grafanaJavaScriptAgentOptions);
 

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/beforeSendHandler.test.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/beforeSendHandler.test.ts
@@ -1,5 +1,4 @@
 import { TransportItem, TransportItemType } from '@grafana/faro-core';
-import { config } from '@grafana/runtime';
 
 import { beforeSendHandler } from './beforeSendHandler';
 
@@ -11,43 +10,53 @@ const getTransportationItem = (userAgent: string | undefined): TransportItem => 
 
 describe('beforeSendHandler', () => {
   beforeEach(() => {
-    config.featureToggles.filterOutBotsFromFrontendLogs = false;
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
-  it('should return item when feature toggle is disabled', () => {
-    const botUserAgent = 'Googlebot/2.1 (+http://www.google.com/bot.html)';
-    const item = getTransportationItem(botUserAgent);
-    expect(beforeSendHandler(item)).toBe(item);
+  describe('when botFilterEnabled is false', () => {
+    it('should return item', () => {
+      const botUserAgent = 'Googlebot/2.1 (+http://www.google.com/bot.html)';
+      const item = getTransportationItem(botUserAgent);
+      expect(beforeSendHandler(false, item)).toBe(item);
+    });
   });
 
-  it('should return item for regular user agents', () => {
-    config.featureToggles.filterOutBotsFromFrontendLogs = true;
-    const regularUserAgent =
-      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36';
-    const item = getTransportationItem(regularUserAgent);
-    expect(beforeSendHandler(item)).toBe(item);
-  });
+  describe('when botFilterEnabled is true', () => {
+    const userUserAgents = [
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15',
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:120.0) Gecko/20100101 Firefox/120.0',
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:120.0) Gecko/20100101 Firefox/120.0',
+    ];
+    const invalidUserAgents = ['', ' ', undefined, null, 0, 1, {}, [], () => {}];
+    const maliciousUserAgents = userUserAgents.map((ua) => ua + 'a'.repeat(600));
 
-  it.each(['', undefined])('should return item when user agent is %s', (userAgent) => {
-    config.featureToggles.filterOutBotsFromFrontendLogs = true;
-    const item = getTransportationItem(userAgent);
-    expect(beforeSendHandler(item)).toBe(item);
-  });
+    it.each(userUserAgents)('should return item for bot user agent: %s', (userAgent) => {
+      const item = getTransportationItem(userAgent);
+      expect(beforeSendHandler(true, item)).toBe(item);
+    });
 
-  it.each([
-    'Googlebot/2.1 (+http://www.google.com/bot.html)',
-    'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
-    'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
-    'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
-    'Twitterbot/1.0',
-    'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
-    'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
-    'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)',
-    'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
-    'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
-  ])('should return 0 for bot user agent: %s', (userAgent) => {
-    config.featureToggles.filterOutBotsFromFrontendLogs = true;
-    const item = getTransportationItem(userAgent);
-    expect(beforeSendHandler(item)).toBe(null);
+    it.each([
+      ...invalidUserAgents,
+      ...maliciousUserAgents,
+      'Googlebot/2.1 (+http://www.google.com/bot.html)',
+      'Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)',
+      'Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)',
+      'facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)',
+      'Twitterbot/1.0',
+      'Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)',
+      'Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)',
+      'Mozilla/5.0 (compatible; DuckDuckBot-Https/1.1; https://duckduckgo.com/duckduckbot)',
+      'Mozilla/5.0 (compatible; SemrushBot/7~bl; +http://www.semrush.com/bot.html)',
+      'Mozilla/5.0 (compatible; AhrefsBot/7.0; +http://ahrefs.com/robot/)',
+      'Mozilla/5.0 (compatible; NOTgooglebot/2.1)',
+      'Mozilla/5.0 (compatible; googlebotbypass/2.1)',
+      'Mozilla/5.0 (compatible; notbingbot/2.0; +http://www.bing.com/notbingbot.htm)',
+    ])('should return null for bot user agent: %s', (userAgent) => {
+      const item = getTransportationItem(userAgent as string);
+      expect(beforeSendHandler(true, item)).toBe(null);
+    });
   });
 });

--- a/public/app/core/services/echo/backends/grafana-javascript-agent/types.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/types.ts
@@ -1,4 +1,5 @@
-import { CurrentUserDTO } from '@grafana/data';
+import { BuildInfo, CurrentUserDTO } from '@grafana/data';
+import { BrowserConfig } from '@grafana/faro-web-sdk';
 import { EchoEvent, EchoEventType } from '@grafana/runtime';
 
 export interface BaseTransport {
@@ -10,4 +11,17 @@ export type GrafanaJavascriptAgentEchoEvent = EchoEvent<EchoEventType.GrafanaJav
 export interface User extends Pick<CurrentUserDTO, 'email'> {
   id: string;
   orgId?: number;
+}
+
+export interface GrafanaJavascriptAgentBackendOptions extends BrowserConfig {
+  buildInfo: BuildInfo;
+  customEndpoint: string;
+  user: User;
+  allInstrumentationsEnabled: boolean;
+  errorInstrumentalizationEnabled: boolean;
+  consoleInstrumentalizationEnabled: boolean;
+  webVitalsInstrumentalizationEnabled: boolean;
+  tracingInstrumentalizationEnabled: boolean;
+  ignoreUrls: RegExp[];
+  botFilterEnabled: boolean;
 }


### PR DESCRIPTION
**What is this feature?**

This pull request removes the experimental feature toggle for filtering out bots from frontend observability data and replaces it with a stable, configuration-driven option (`bot_filter_enabled`). The change simplifies the mechanism for enabling/disabling bot filtering and improves testability and maintainability.

**Why do we need this feature?**

We've proven this works for the feature toggle so now we need a proper config setting instead

**Who is this feature for?**

Grafana admins

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #112095

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
