### PR TITLE
LBAC for data sources: Refactor for readablitity

### DIFF
--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -242,10 +242,10 @@ func TestAddDataSourceTeamHTTPHeaders(t *testing.T) {
 	jsonData := simplejson.New()
 	jsonData.Set("teamHttpHeaders", datasources.TeamHTTPHeaders{
 		Headers: datasources.TeamHeaders{
-			tenantID: []datasources.TeamHTTPHeader{
+			tenantID: []datasources.AccessRule{
 				{
-					Header: "Authorization",
-					Value:  "foo!=bar",
+					Header:   "Authorization",
+					LBACRule: "foo!=bar",
 				},
 			},
 		},

--- a/pkg/services/cleanup/cleanup.go
+++ b/pkg/services/cleanup/cleanup.go
@@ -480,7 +480,7 @@ func (srv *CleanUpService) cleanupStaleLBACRules(ctx context.Context) {
 
 func (srv *CleanUpService) getLBACRulesForTeamsStillExisting(ctx context.Context, teamHeaders *datasources.TeamHTTPHeaders, orgID int64) (*datasources.TeamHTTPHeaders, int) {
 	logger := srv.log.FromContext(ctx)
-	cleanedHeaders := &datasources.TeamHTTPHeaders{Headers: make(map[string][]datasources.TeamHTTPHeader)}
+	cleanedHeaders := &datasources.TeamHTTPHeaders{Headers: make(map[string][]datasources.AccessRule)}
 	removedCount := 0
 
 	allTeams, err := srv.teamService.SearchTeams(ctx, &team.SearchTeamsQuery{

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -89,8 +89,7 @@ type TeamHTTPHeadersJSONData struct {
 }
 
 type TeamHTTPHeaders struct {
-	Headers        TeamHeaders `json:"headers"`
-	RestrictAccess bool        `json:"restrictAccess"`
+	Headers TeamHeaders `json:"headers"`
 }
 
 type TeamHeaders map[string][]AccessRule

--- a/pkg/services/datasources/models.go
+++ b/pkg/services/datasources/models.go
@@ -93,11 +93,18 @@ type TeamHTTPHeaders struct {
 	RestrictAccess bool        `json:"restrictAccess"`
 }
 
-type TeamHeaders map[string][]TeamHTTPHeader
+type TeamHeaders map[string][]AccessRule
 
-type TeamHTTPHeader struct {
+// a header is composed of a key:value. the key is the headername X-Prom-Label-Policy
+// a header value is composed of a tenantID:rule. the tenantID is the tenantID of the tenant that the rule is for.
+// the value is taken from https://grafana.com/docs/mimir/latest/manage/tools/mimirtool/#acl
+// and each rule is
+type AccessRule struct {
 	Header string `json:"header"`
-	Value  string `json:"value"`
+	// the LBACRule is the rule that is used to restrict access to the data source
+	// currently <tenantid>:<promqlrule>
+	// LBAC rule (e.g., "tenant:{ label=value }")
+	LBACRule string `json:"value"`
 }
 
 func GetTeamHTTPHeaders(jsonData *simplejson.Json) (*TeamHTTPHeaders, error) {
@@ -126,7 +133,7 @@ func GetTeamHTTPHeaders(jsonData *simplejson.Json) (*TeamHTTPHeaders, error) {
 			if header.Header == "" {
 				return nil, errors.New("header name is missing or empty")
 			}
-			if header.Value == "" {
+			if header.LBACRule == "" {
 				return nil, errors.New("header value is missing or empty")
 			}
 		}

--- a/pkg/services/datasources/models_test.go
+++ b/pkg/services/datasources/models_test.go
@@ -71,7 +71,7 @@ func TestTeamHTTPHeaders(t *testing.T) {
 			want: &TeamHTTPHeaders{
 				Headers: TeamHeaders{
 					"101": {
-						{Header: "X-CUSTOM-HEADER", Value: "foo"},
+						{Header: "X-CUSTOM-HEADER", LBACRule: "foo"},
 					},
 				},
 			},


### PR DESCRIPTION
- removes the `restrictAccess` which is not being used.
- renames `Value` to `LBACRule`
- renames `TeamHTTPRule` -> `AccessRule`