### PR TITLE
Dashboard: Add variable button in dashboard controls

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -5,7 +5,6 @@ import { BusEventWithPayload } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   LocalValueVariable,
-  sceneGraph,
   SceneGridRow,
   SceneObject,
   SceneVariable,
@@ -123,7 +122,7 @@ export interface RemoveElementActionHelperProps {
 
 export interface AddVariableActionHelperProps {
   addedObject: SceneVariable;
-  source: VariableAdd;
+  source: SceneVariableSet;
 }
 
 export interface RemoveVariableActionHelperProps {
@@ -208,19 +207,16 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const dashboard = source.state.dashboardRef.resolve();
-    const variables = sceneGraph.getVariables(dashboard);
-
-    const varsBeforeAddition = [...(variables.state.variables ?? [])];
+    const varsBeforeAddition = [...(source.state.variables ?? [])];
 
     dashboardEditActions.addElement({
       source,
       addedObject,
       perform() {
-        variables.setState({ variables: [...varsBeforeAddition, addedObject] });
+        source.setState({ variables: [...varsBeforeAddition, addedObject] });
       },
       undo() {
-        variables.setState({ variables: [...varsBeforeAddition] });
+        source.setState({ variables: [...varsBeforeAddition] });
       },
     });
   },

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -5,6 +5,7 @@ import { BusEventWithPayload } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   LocalValueVariable,
+  sceneGraph,
   SceneGridRow,
   SceneObject,
   SceneVariable,
@@ -207,16 +208,19 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.$variables?.state.variables ?? [])];
+    const dashboard = source.state.dashboardRef.resolve();
+    const variables = sceneGraph.getVariables(dashboard);
+
+    const varsBeforeAddition = [...(variables.state.variables ?? [])];
 
     dashboardEditActions.addElement({
       source,
       addedObject,
       perform() {
-        source.state.$variables?.setState({ variables: [...varsBeforeAddition, addedObject] });
+        variables.setState({ variables: [...varsBeforeAddition, addedObject] });
       },
       undo() {
-        source.state.$variables?.setState({ variables: [...varsBeforeAddition] });
+        variables.setState({ variables: [...varsBeforeAddition] });
       },
     });
   },

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -17,6 +17,7 @@ import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRo
 import { redoButtonId, undoButtonID } from '../scene/new-toolbar/RightActions';
 import { EditableDashboardElement, isEditableDashboardElement } from '../scene/types/EditableDashboardElement';
 import { LocalVariableEditableElement } from '../settings/variables/LocalVariableEditableElement';
+import { VariableAdd, VariableAddEditableElement } from '../settings/variables/VariableAddEditableElement';
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
@@ -59,6 +60,10 @@ export function getEditableElementFor(sceneObj: SceneObject | undefined): Editab
 
   if (isSceneVariable(sceneObj)) {
     return new VariableEditableElement(sceneObj);
+  }
+
+  if (sceneObj instanceof VariableAdd) {
+    return new VariableAddEditableElement(sceneObj);
   }
 
   return undefined;
@@ -117,7 +122,7 @@ export interface RemoveElementActionHelperProps {
 
 export interface AddVariableActionHelperProps {
   addedObject: SceneVariable;
-  source: SceneVariableSet;
+  source: VariableAdd;
 }
 
 export interface RemoveVariableActionHelperProps {
@@ -202,16 +207,16 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...source.state.variables];
+    const varsBeforeAddition = [...(source.state.$variables?.state.variables ?? [])];
 
     dashboardEditActions.addElement({
       source,
       addedObject,
       perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
+        source.state.$variables?.setState({ variables: [...varsBeforeAddition, addedObject] });
       },
       undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
+        source.state.$variables?.setState({ variables: [...varsBeforeAddition] });
       },
     });
   },

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 
 import { VariableHide, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import {
   sceneGraph,
   useSceneObjectState,
@@ -14,6 +15,7 @@ import {
 import { useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { DashboardScene } from './DashboardScene';
+import { AddVariableButton } from './VariableControlsAddButton';
 
 export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   const { variables } = sceneGraph.getVariables(dashboard)!.useState();
@@ -25,6 +27,7 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
         .map((variable) => (
           <VariableValueSelectWrapper key={variable.state.key} variable={variable} />
         ))}
+      {config.featureToggles.dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
     </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
@@ -25,7 +25,7 @@ export function AddVariableButton({ dashboard }: { dashboard: DashboardScene }) 
   }
 
   return (
-    <Button icon="plus" variant="secondary" fill="text" onPointerDown={handlePointerDown}>
+    <Button icon="plus" variant="primary" fill="text" onPointerDown={handlePointerDown}>
       <Trans i18nKey="dashboard-scene.variable-controls.add-variable">Add</Trans>
     </Button>
   );

--- a/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
@@ -1,0 +1,32 @@
+import { PointerEventHandler, useCallback } from 'react';
+
+import { Trans } from '@grafana/i18n';
+import { Button } from '@grafana/ui';
+
+import { openAddVariablePane } from '../settings/variables/VariableAddEditableElement';
+import { DashboardInteractions } from '../utils/interactions';
+
+import { DashboardScene } from './DashboardScene';
+
+export function AddVariableButton({ dashboard }: { dashboard: DashboardScene }) {
+  const { isEditing } = dashboard.useState();
+
+  const handlePointerDown: PointerEventHandler = useCallback(
+    (evt) => {
+      evt.stopPropagation();
+      openAddVariablePane(dashboard);
+      DashboardInteractions.addVariableButtonClicked({ source: 'variable_controls' });
+    },
+    [dashboard]
+  );
+
+  if (!isEditing) {
+    return null;
+  }
+
+  return (
+    <Button icon="plus" variant="secondary" fill="text" onPointerDown={handlePointerDown}>
+      <Trans i18nKey="dashboard-scene.variable-controls.add-variable">Add</Trans>
+    </Button>
+  );
+}

--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/css';
+import { useCallback, useId, useMemo } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Trans, t } from '@grafana/i18n';
+import { SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
+import { Box, Card, Stack, useStyles2 } from '@grafana/ui';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+
+import { dashboardEditActions } from '../../edit-pane/shared';
+import { DashboardScene } from '../../scene/DashboardScene';
+import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
+import { DashboardInteractions } from '../../utils/interactions';
+
+import { EditableVariableType, getNextAvailableId, getVariableScene, getVariableTypeSelectOptions } from './utils';
+
+export function openAddVariablePane(dashboard: DashboardScene) {
+  const element = new VariableAdd({ dashboardRef: dashboard.getRef() });
+  dashboard.state.editPane.selectObject(element, element.state.key!, { force: true, multi: false });
+}
+
+export interface VariableAddState extends SceneObjectState {
+  dashboardRef: SceneObjectRef<DashboardScene>;
+}
+
+export class VariableAdd extends SceneObjectBase<VariableAddState> {}
+
+function useEditPaneOptions(
+  this: VariableAddEditableElement,
+  variableAdd: VariableAdd
+): OptionsPaneCategoryDescriptor[] {
+  const id = useId();
+  const options = useMemo(() => {
+    return new OptionsPaneCategoryDescriptor({ title: '', id: 'variables' }).addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id,
+        skipField: true,
+        render: () => <VariableTypeSelection variableAdd={variableAdd} />,
+      })
+    );
+  }, [variableAdd, id]);
+
+  return [options];
+}
+
+export class VariableAddEditableElement implements EditableDashboardElement {
+  public readonly isEditableDashboardElement = true;
+  public readonly typeName = 'Variable';
+
+  public constructor(private variableAdd: VariableAdd) {}
+
+  public getEditableElementInfo(): EditableDashboardElementInfo {
+    return {
+      typeName: t('dashboard.edit-pane.elements.variable-set', 'Variables'),
+      icon: 'x',
+      instanceName: t('dashboard.edit-pane.elements.variable-set', 'Variables'),
+    };
+  }
+
+  public useEditPaneOptions = useEditPaneOptions.bind(this, this.variableAdd);
+}
+
+function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
+  const options = useMemo(() => getVariableTypeSelectOptions(), []);
+  const styles = useStyles2(getStyles);
+
+  const onAddVariable = useCallback(
+    (type: EditableVariableType) => {
+      const { variables } = variableAdd.state.dashboardRef.resolve().state.$variables?.state ?? { variables: [] };
+      const nextName = getNextAvailableId(type, variables);
+      const newVar = getVariableScene(type, { name: nextName });
+
+      dashboardEditActions.addVariable({
+        source: variableAdd,
+        addedObject: newVar,
+      });
+
+      DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
+    },
+    [variableAdd]
+  );
+
+  return (
+    <Stack direction="column" gap={0}>
+      <Box paddingBottom={1} display={'flex'}>
+        <Trans i18nKey="dashboard.edit-pane.variables.select-type">Choose variable type</Trans>
+      </Box>
+      <Stack direction="column" gap={1}>
+        {options.map((option) => (
+          <Card
+            noMargin
+            isCompact
+            onClick={() => onAddVariable(option.value!)}
+            key={option.value}
+            title={t('dashboard.edit-pane.variables.select-type-card-tooltip', 'Click to select type')}
+            data-testid={selectors.components.PanelEditor.ElementEditPane.variableType(option.value!)}
+          >
+            <Card.Heading>{option.label}</Card.Heading>
+            <Card.Description className={styles.cardDescription}>{option.description}</Card.Description>
+          </Card>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    cardDescription: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      marginTop: theme.spacing(0),
+    }),
+  };
+}

--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -4,7 +4,7 @@ import { useCallback, useId, useMemo } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
+import { sceneGraph, SceneObjectBase, SceneObjectRef, SceneObjectState } from '@grafana/scenes';
 import { Box, Card, Stack, useStyles2 } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -70,18 +70,11 @@ function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
   const onAddVariable = useCallback(
     (type: EditableVariableType) => {
       const dashboard = variableAdd.state.dashboardRef.resolve();
-      const { editPane, $variables } = dashboard.state;
-      const { variables } = $variables?.state ?? { variables: [] };
-      const nextName = getNextAvailableId(type, variables);
-      const newVar = getVariableScene(type, { name: nextName });
-
-      dashboardEditActions.addVariable({
-        source: variableAdd,
-        addedObject: newVar,
+      const newVar = getVariableScene(type, {
+        name: getNextAvailableId(type, dashboard.state.$variables?.state?.variables ?? []),
       });
-
-      editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
-
+      dashboardEditActions.addVariable({ source: sceneGraph.getVariables(dashboard), addedObject: newVar });
+      dashboard.state.editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
       DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
     },
     [variableAdd]

--- a/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableAddEditableElement.tsx
@@ -69,7 +69,9 @@ function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
 
   const onAddVariable = useCallback(
     (type: EditableVariableType) => {
-      const { variables } = variableAdd.state.dashboardRef.resolve().state.$variables?.state ?? { variables: [] };
+      const dashboard = variableAdd.state.dashboardRef.resolve();
+      const { editPane, $variables } = dashboard.state;
+      const { variables } = $variables?.state ?? { variables: [] };
       const nextName = getNextAvailableId(type, variables);
       const newVar = getVariableScene(type, { name: nextName });
 
@@ -77,6 +79,8 @@ function VariableTypeSelection({ variableAdd }: { variableAdd: VariableAdd }) {
         source: variableAdd,
         addedObject: newVar,
       });
+
+      editPane.selectObject(newVar, newVar.state.key!, { force: true, multi: false });
 
       DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
     },

--- a/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableSetEditableElement.tsx
@@ -1,22 +1,20 @@
 import { css } from '@emotion/css';
-import { useId, useMemo } from 'react';
-import { useToggle } from 'react-use';
+import { useCallback, useId, useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { SceneVariable, SceneVariableSet } from '@grafana/scenes';
-import { Box, Button, Card, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Box, Button, Stack, Text, useStyles2 } from '@grafana/ui';
 import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
-import { dashboardEditActions } from '../../edit-pane/shared';
 import { DashboardScene } from '../../scene/DashboardScene';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../../scene/types/EditableDashboardElement';
 import { DashboardInteractions } from '../../utils/interactions';
 import { getDashboardSceneFor } from '../../utils/utils';
 
-import { EditableVariableType, getNextAvailableId, getVariableScene, getVariableTypeSelectOptions } from './utils';
+import { openAddVariablePane } from './VariableAddEditableElement';
 
 function useEditPaneOptions(this: VariableSetEditableElement, set: SceneVariableSet): OptionsPaneCategoryDescriptor[] {
   const variableListId = useId();
@@ -33,6 +31,7 @@ function useEditPaneOptions(this: VariableSetEditableElement, set: SceneVariable
 
   return [options];
 }
+
 export class VariableSetEditableElement implements EditableDashboardElement {
   public readonly isEditableDashboardElement = true;
   public readonly typeName = 'Variable';
@@ -57,30 +56,20 @@ export class VariableSetEditableElement implements EditableDashboardElement {
 export function VariableList({ set }: { set: SceneVariableSet }) {
   const { variables } = set.useState();
   const styles = useStyles2(getStyles);
-  const [isAdding, setIsAdding] = useToggle(false);
   const canAdd = set.parent instanceof DashboardScene;
 
-  const onEditVariable = (variable: SceneVariable) => {
-    const { editPane } = getDashboardSceneFor(set).state;
-    editPane.selectObject(variable, variable.state.key!);
-  };
+  const onEditVariable = useCallback(
+    (variable: SceneVariable) => {
+      const { editPane } = getDashboardSceneFor(set).state;
+      editPane.selectObject(variable, variable.state.key!);
+    },
+    [set]
+  );
 
-  const onAddVariable = (type: EditableVariableType) => {
-    const { variables } = set.state;
-    const nextName = getNextAvailableId(type, variables);
-    const newVar = getVariableScene(type, { name: nextName });
-
-    dashboardEditActions.addVariable({
-      source: set,
-      addedObject: newVar,
-    });
-
-    setIsAdding(false);
-  };
-
-  if (isAdding) {
-    return <VariableTypeSelection onAddVariable={onAddVariable} />;
-  }
+  const onAddVariable = useCallback(() => {
+    openAddVariablePane(getDashboardSceneFor(set));
+    DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
+  }, [set]);
 
   return (
     <Stack direction="column" gap={0}>
@@ -103,48 +92,13 @@ export function VariableList({ set }: { set: SceneVariableSet }) {
             icon="plus"
             size="sm"
             variant="secondary"
-            onClick={() => {
-              DashboardInteractions.addVariableButtonClicked({ source: 'edit_pane' });
-              setIsAdding();
-            }}
+            onClick={onAddVariable}
             data-testid={selectors.components.PanelEditor.ElementEditPane.addVariableButton}
           >
             <Trans i18nKey="dashboard.edit-pane.variables.add-variable">Add variable</Trans>
           </Button>
         </Box>
       )}
-    </Stack>
-  );
-}
-
-interface VariableTypeSelectionProps {
-  onAddVariable: (type: EditableVariableType) => void;
-}
-
-function VariableTypeSelection({ onAddVariable }: VariableTypeSelectionProps) {
-  const options = getVariableTypeSelectOptions();
-  const styles = useStyles2(getStyles);
-
-  return (
-    <Stack direction={'column'} gap={0}>
-      <Box paddingBottom={1} display={'flex'}>
-        <Trans i18nKey="dashboard.edit-pane.variables.select-type">Choose variable type</Trans>
-      </Box>
-      <Stack direction="column">
-        {options.map((option) => (
-          <Card
-            isCompact
-            noMargin
-            onClick={() => onAddVariable(option.value!)}
-            key={option.value}
-            title={t('dashboard.edit-pane.variables.select-type-card-tooltip', 'Click to select type')}
-            data-testid={selectors.components.PanelEditor.ElementEditPane.variableType(option.value!)}
-          >
-            <Card.Heading>{option.label}</Card.Heading>
-            <Card.Description className={styles.cardDescription}>{option.description}</Card.Description>
-          </Card>
-        ))}
-      </Stack>
     </Stack>
   );
 }
@@ -176,10 +130,6 @@ function getStyles(theme: GrafanaTheme2) {
           visibility: 'visible',
         },
       },
-    }),
-    cardDescription: css({
-      fontSize: theme.typography.bodySmall.fontSize,
-      marginTop: theme.spacing(0),
     }),
   };
 }

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -69,7 +69,7 @@ export const DashboardInteractions = {
 
   // dashboards_add_variable_button_clicked
   // when a user clicks on ‘Add Variable’ or ‘New Variable’
-  addVariableButtonClicked: (properties: { source: 'edit_pane' | 'settings_pane' }) => {
+  addVariableButtonClicked: (properties: { source: 'edit_pane' | 'settings_pane' | 'variable_controls' }) => {
     reportDashboardInteraction('add_variable_button_clicked', properties);
   },
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6294,6 +6294,9 @@
       "content-variable-not-referenced-other-variables-dashboard": "This variable is not referenced by other variables or dashboard.",
       "content-variable-referenced-other-variables-dashboard": "This variable is referenced by other variables or dashboard."
     },
+    "variable-controls": {
+      "add-variable": "Add"
+    },
     "variable-editor-form": {
       "aria-label-variable-editor-form": "Variable editor form",
       "back-to-list": "Back to list",


### PR DESCRIPTION
**What is this feature?**

Introduce an "add variable" control in dynamic dashboards.

In the future we can enhance this to add new controls as well (

**Why do we need this feature?**

-

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

https://github.com/user-attachments/assets/3d3751c3-b4cf-43ee-901a-70ab5d18c38a



Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
