### PR TITLE
Checkbox: Improve accessibility of the `indeterminate` state

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -650,11 +650,6 @@
       "count": 3
     }
   },
-  "packages/grafana-ui/src/components/Forms/Checkbox.story.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/Forms/Form.story.tsx": {
     "react-hooks/rules-of-hooks": {
       "count": 9

--- a/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.story.tsx
@@ -18,8 +18,6 @@ const meta: Meta<typeof Checkbox> = {
     controls: {
       exclude: ['value', 'htmlValue'],
     },
-    // TODO fix a11y issue in story and remove this
-    a11y: { test: 'off' },
   },
 };
 
@@ -94,7 +92,7 @@ export const AllStates: StoryFn<typeof Checkbox> = (args) => {
         <Checkbox value={checked} onChange={onChange} {...args} />
         <Checkbox value={true} label="Checked" />
         <Checkbox value={false} label="Unchecked" />
-        <Checkbox value={false} indeterminate={true} label="Interdeterminate" />
+        <Checkbox value={false} indeterminate={true} label="Indeterminate" />
         <Checkbox value={false} invalid={true} label="Invalid and unchecked" />
         <Checkbox value={true} invalid={true} label="Invalid and checked" />
       </Stack>

--- a/packages/grafana-ui/src/components/Forms/Checkbox.tsx
+++ b/packages/grafana-ui/src/components/Forms/Checkbox.tsx
@@ -18,7 +18,7 @@ export interface CheckboxProps extends Omit<HTMLProps<HTMLInputElement>, 'value'
   value?: boolean;
   /** htmlValue allows to specify the input "value" attribute */
   htmlValue?: string | number;
-  /** Sets the checkbox into a "mixed" state. This is only a visual change and does not affect the value. */
+  /** Sets the checkbox into a "mixed" state */
   indeterminate?: boolean;
   /** Show an invalid state around the input */
   invalid?: boolean;
@@ -39,8 +39,6 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
     );
     const styles = useStyles2(getCheckboxStyles, invalid);
 
-    const ariaChecked = indeterminate ? 'mixed' : undefined;
-
     return (
       <label className={cx(styles.wrapper, className)}>
         <div className={styles.checkboxWrapper}>
@@ -51,9 +49,21 @@ export const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
             disabled={disabled}
             onChange={handleOnChange}
             value={htmlValue}
-            aria-checked={ariaChecked}
             {...inputProps}
-            ref={ref}
+            ref={(element) => {
+              if (element && indeterminate) {
+                element.indeterminate = true;
+              }
+
+              // we have to manually assign the ref since we need to modify the indeterminate property
+              if (ref) {
+                if (typeof ref === 'function') {
+                  ref(element);
+                } else {
+                  ref.current = element;
+                }
+              }
+            }}
           />
           <span className={styles.checkmark} />
         </div>
@@ -139,7 +149,7 @@ export const getCheckboxStyles = (theme: GrafanaTheme2, invalid = false) => {
     }),
 
     inputIndeterminate: css({
-      "&[aria-checked='mixed'] + span": {
+      '&:indeterminate + span': {
         border: `1px solid ${getBorderColor(theme.colors.primary.main)}`,
         background: theme.colors.primary.main,
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- removes `aria-checked` in favour of using the native  `checked` and `indeterminate` properties available on `<input>`
  - we were mixing `aria-checked` with native `<input>` options which can lead to inconsistent behaviour depending on screenreader/browser combo
  - the recommendation is to either use the native `<input>` options, or use a custom element with `role="checkbox"` and `aria-checked` properties
  - see https://dequeuniversity.com/rules/axe/4.10/aria-conditional-attr?application=axeAPI
- reenables the storybook a11y tests for checkbox
- fixes a minor typo in the story itself

**Why do we need this feature?**

- better checkbox a11y

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/109450

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
