### PR TITLE
Dashboards: Hide error notifications in kiosk mode on dashboards

### DIFF
--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -191,4 +191,3 @@ describe('AppNotificationList', () => {
     });
   });
 });
-

--- a/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.test.tsx
@@ -1,0 +1,194 @@
+import { act, render, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { MemoryRouter } from 'react-router-dom';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
+
+import { AppEvents, PageLayoutType } from '@grafana/data';
+import appEvents from 'app/core/app_events';
+import { GrafanaContext } from 'app/core/context/GrafanaContext';
+import { configureStore } from 'app/store/configureStore';
+import { KioskMode } from 'app/types/dashboard';
+
+import { AppChromeState } from '../AppChrome/AppChromeService';
+
+import { AppNotificationList } from './AppNotificationList';
+
+describe('AppNotificationList', () => {
+  const renderWithContext = (kioskMode?: KioskMode, pathname = '/') => {
+    const mockStore = configureStore(); // Fresh store for each test
+    const contextMock = getGrafanaContextMock();
+
+    // Replace chrome.state.getValue with a function that returns the kioskMode
+    const mockState: AppChromeState = {
+      chromeless: false,
+      sectionNav: { node: { text: '' }, main: { text: '' } },
+      megaMenuOpen: false,
+      megaMenuDocked: false,
+      kioskMode: kioskMode ?? null,
+      layout: PageLayoutType.Standard,
+    };
+    contextMock.chrome.state.getValue = () => mockState;
+
+    return {
+      ...render(
+        <Provider store={mockStore}>
+          <GrafanaContext.Provider value={contextMock}>
+            <MemoryRouter initialEntries={[pathname]}>
+              <AppNotificationList />
+            </MemoryRouter>
+          </GrafanaContext.Provider>
+        </Provider>
+      ),
+      contextMock,
+      mockStore,
+    };
+  };
+
+  describe('Error notifications', () => {
+    it('should show error notifications when not in kiosk mode', async () => {
+      const { container } = renderWithContext(undefined, '/d/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test error');
+      });
+    });
+
+    it('should hide error notifications in kiosk mode on dashboard page', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      // Wait a bit to ensure event handlers have run
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(container.textContent).not.toContain('Test error');
+    });
+
+    it('should show error notifications in kiosk mode on non-dashboard pages', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/alerting');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test error');
+      });
+    });
+
+    it('should hide error notifications in kiosk mode on home dashboard', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      // Wait a bit to ensure event handlers have run
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(container.textContent).not.toContain('Test error');
+    });
+
+    it('should show error notifications in kiosk mode on root page (not dashboard route)', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test error');
+      });
+    });
+  });
+
+  describe('Other notification types', () => {
+    it('should always show success notifications in kiosk mode on dashboard', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertSuccess, ['Test success']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test success');
+      });
+    });
+
+    it('should always show warning notifications in kiosk mode on dashboard', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertWarning, ['Test warning']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test warning');
+      });
+    });
+
+    it('should always show info notifications in kiosk mode on dashboard', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertInfo, ['Test info']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test info');
+      });
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should show error on dashboard page with uid and slug', async () => {
+      const { container } = renderWithContext(undefined, '/d/test-uid/test-slug');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test error');
+      });
+    });
+
+    it('should hide error in kiosk mode on dashboard page with uid and slug', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/d/test-uid/test-slug');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      // Wait a bit to ensure event handlers have run
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 100));
+      });
+
+      expect(container.textContent).not.toContain('Test error');
+    });
+
+    it('should show error on legacy dashboard route', async () => {
+      const { container } = renderWithContext(KioskMode.Full, '/dashboard/db/test-dashboard');
+
+      await act(async () => {
+        appEvents.emit(AppEvents.alertError, ['Test error']);
+      });
+
+      await waitFor(() => {
+        expect(container.textContent).toContain('Test error');
+      });
+    });
+  });
+});
+

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -27,7 +27,11 @@ export function AppNotificationList() {
   const location = useLocation();
 
   useEffect(() => {
-    
+    // Suppress error notifications in kiosk mode on dashboards.
+    // Kiosk mode is typically used for TV displays which are non-interactive.
+    // Backend errors like "Failed to fetch" cannot be dismissed and would remain visible,
+    // degrading the viewing experience. Other notification types (success, warning, info)
+    // are still shown as they indicate successful operations or important information.
     const handleErrorAlert = (payload: AlertErrorPayload) => {
       const isKioskDashboard = chrome.state.getValue().kioskMode && location.pathname.startsWith('/d/');
       

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -34,7 +34,7 @@ export function AppNotificationList() {
     // are still shown as they indicate successful operations or important information.
     const handleErrorAlert = (payload: AlertErrorPayload) => {
       const isKioskDashboard = chrome.state.getValue().kioskMode && location.pathname.startsWith('/d/');
-      
+
       if (!isKioskDashboard) {
         dispatch(notifyApp(createErrorNotification(...payload)));
       }

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -1,10 +1,12 @@
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
-import { AppEvents, GrafanaTheme2 } from '@grafana/data';
+import { AlertErrorPayload, AppEvents, GrafanaTheme2 } from '@grafana/data';
 import { useStyles2, Stack } from '@grafana/ui';
 import { notifyApp, hideAppNotification } from 'app/core/actions';
 import appEvents from 'app/core/app_events';
+import { useGrafana } from 'app/core/context/GrafanaContext';
 import { selectVisible } from 'app/core/reducers/appNotification';
 import { useSelector, useDispatch } from 'app/types/store';
 
@@ -21,13 +23,24 @@ export function AppNotificationList() {
   const appNotifications = useSelector((state) => selectVisible(state.appNotifications));
   const dispatch = useDispatch();
   const styles = useStyles2(getStyles);
+  const { chrome } = useGrafana();
+  const location = useLocation();
 
   useEffect(() => {
+    
+    const handleErrorAlert = (payload: AlertErrorPayload) => {
+      const isKioskDashboard = chrome.state.getValue().kioskMode && location.pathname.startsWith('/d/');
+      
+      if (!isKioskDashboard) {
+        dispatch(notifyApp(createErrorNotification(...payload)));
+      }
+    };
+
     appEvents.on(AppEvents.alertWarning, (payload) => dispatch(notifyApp(createWarningNotification(...payload))));
     appEvents.on(AppEvents.alertSuccess, (payload) => dispatch(notifyApp(createSuccessNotification(...payload))));
-    appEvents.on(AppEvents.alertError, (payload) => dispatch(notifyApp(createErrorNotification(...payload))));
+    appEvents.on(AppEvents.alertError, handleErrorAlert);
     appEvents.on(AppEvents.alertInfo, (payload) => dispatch(notifyApp(createInfoNotification(...payload))));
-  }, [dispatch]);
+  }, [dispatch, chrome, location.pathname]);
 
   const onClearAppNotification = (id: string) => {
     dispatch(hideAppNotification(id));


### PR DESCRIPTION
**Problem**

When dashboards are displayed in kiosk mode (typically on TV displays), uncontrolled backend errors like "Failed to fetch" and other service errors appear as toast notifications. Since kiosk mode is non-interactive and used for display purposes, these error messages cannot be dismissed and remain visible, degrading the user experience.

**Solution**

Suppress error notifications when a dashboard is viewed in kiosk mode. The implementation checks both the kiosk mode state and whether the current route is a dashboard (`/d/`) before deciding to show error alerts. Other notification types (success, warning, info) continue to display normally, as they typically indicate successful operations or important information that should be visible.

**How to test**

1. Navigate to any dashboard in kiosk mode
2. Trigger an error notification (e.g., through a failing data source query through dev tools network)
3. Verify that error notifications do not appear
4. Test that error notifications still appear when not in kiosk mode
5. Test that error notifications appear in kiosk mode on non-dashboard pages
6. Verify that success, warning, and info notifications still appear in kiosk mode