### PR TITLE
ConfigForm: Add field-specific error handling

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -142,15 +142,16 @@ export function ConfigForm({ data }: ConfigFormProps) {
       await submitData(spec, form.token);
     } catch (err) {
       if (isFetchError(err)) {
-        const [field, errorMessage] = getConfigFormErrors(err.data.errors);
+        const [field, errorMessage] = getConfigFormErrors(err.data?.errors);
+
         if (field && errorMessage) {
           setError(field, errorMessage);
+          return;
         }
       }
-      getAppEvents().publish({
-        type: AppEvents.alertError.name,
-        payload: [t('provisioning.wizard-content.error-save-repository-setting', 'Failed to save repository setting')],
-      });
+
+      // fallback for non-fetch errors or unmapped fields
+      defaultAlert();
     } finally {
       setIsLoading(false);
     }
@@ -394,3 +395,10 @@ export function ConfigForm({ data }: ConfigFormProps) {
     </form>
   );
 }
+
+const defaultAlert = () => {
+  getAppEvents().publish({
+    type: AppEvents.alertError.name,
+    payload: [t('provisioning.wizard-content.error-save-repository-setting', 'Failed to save repository setting')],
+  });
+};

--- a/public/app/features/provisioning/utils/getFormErrors.ts
+++ b/public/app/features/provisioning/utils/getFormErrors.ts
@@ -1,6 +1,9 @@
+import { Path } from 'react-hook-form';
+
 import { ErrorDetails } from 'app/api/clients/provisioning/v0alpha1';
 
 import { WizardFormData } from '../Wizard/types';
+import { RepositoryFormData } from '../types';
 
 export type RepositoryField = keyof WizardFormData['repository'];
 export type RepositoryFormPath = `repository.${RepositoryField}` | `repository.sync.intervalSeconds`;
@@ -55,6 +58,48 @@ export const getFormErrors = (errors: ErrorDetails[]): FormErrorTuple => {
         if (lastPart in fieldMap) {
           return [fieldMap[lastPart], { message: error.detail || `Invalid ${lastPart}` }];
         }
+      }
+    }
+  }
+
+  return [null, null];
+};
+
+/**
+ * Maps API error details to form error fields for ConfigForm
+ *
+ * @param errors Array of error details from the API response
+ * @returns Tuple with form field path and error message
+ */
+export type ConfigFormPath = Path<RepositoryFormData>;
+export type ConfigFormErrorTuple = [ConfigFormPath | null, { message: string } | null];
+export const getConfigFormErrors = (errors?: ErrorDetails[]): ConfigFormErrorTuple => {
+  if (!errors || errors.length === 0) {
+    return [null, null];
+  }
+
+  const fieldMap: Record<string, ConfigFormPath> = {
+    path: 'path',
+    branch: 'branch',
+    url: 'url',
+    token: 'token',
+    tokenUser: 'tokenUser',
+    'sync.intervalSeconds': 'sync.intervalSeconds',
+  };
+
+  for (const error of errors) {
+    if (error.field) {
+      const cleanField = error.field.replace('spec.', '').split('.').pop(); // Get last part
+      const fullField = error.field.replace('spec.', '');
+
+      // Check if it's a nested field like sync.intervalSeconds
+      if (fullField in fieldMap) {
+        return [fieldMap[fullField], { message: error.detail || `Invalid ${fullField}` }];
+      }
+
+      // Otherwise just use the last part
+      if (cleanField && cleanField in fieldMap) {
+        return [fieldMap[cleanField], { message: error.detail || `Invalid ${cleanField}` }];
       }
     }
   }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11821,7 +11821,8 @@
       "button-cancelling": "Cancelling...",
       "button-previous": "Previous",
       "button-submitting": "Submitting...",
-      "error-instance-repository-exists": "Instance repository already exists"
+      "error-instance-repository-exists": "Instance repository already exists",
+      "error-save-repository-setting": "Failed to save repository setting"
     },
     "workflow-options-label": {
       "push-to-a-new-branch": "Push to a new branch",


### PR DESCRIPTION
**What is this feature?**

in `ConfigForm`, adds proper error handling. Previously, when saving repository settings failed due to validation errors, no feedback was displayed to users on the specific input fields that had issues.


**Why do we need this feature?**

Users were not getting feedback when repository configuration validation failed. This made it difficult to troubleshoot issues like incorrect URLs, invalid tokens, or other configuration problems.

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/609

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
