### PR TITLE
Docs: Update plugin.schema.json for clarity and completeness

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -106,6 +106,11 @@
                 "type": "string",
                 "format": "uri",
                 "description": "URL value to use for this specific link."
+              },
+              "target": {
+                "type": "string",
+                "description": "A string that indicates where to display the linked resource",
+                "enum": ["_blank", "_self", "_parent", "_top"]
               }
             }
           }
@@ -499,8 +504,8 @@
     },
     "state": {
       "type": "string",
-      "description": "Marks a plugin as a pre-release.",
-      "enum": ["alpha", "beta"]
+      "description": "Describes plugins life cycle status",
+      "enum": ["alpha", "beta", "stable", "deprecated"]
     },
     "streaming": {
       "type": "boolean",
@@ -588,7 +593,7 @@
       "properties": {
         "addedComponents": {
           "type": "array",
-          "description": "This list must contain all component extensions that your plugin registers to other extension points using [`.addComponent()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#addcomponent). **Components that are not listed here won't work.**",
+          "description": "This list must contain all component extensions that your plugin registers to other extension points using [`.addComponent()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#addcomponent). **Components that are not listed here won't work.**",
           "items": {
             "type": "object",
             "properties": {
@@ -614,7 +619,33 @@
         },
         "addedLinks": {
           "type": "array",
-          "description": "This list must contain all link extensions that your plugin registers to other extension points using [`.addLink()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#addlink). **Links that are not listed here won't work.**",
+          "description": "This list must contain all link extensions that your plugin registers to other extension points using [`.addLink()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#addlink). **Links that are not listed here won't work.**",
+          "items": {
+            "type": "object",
+            "properties": {
+              "targets": {
+                "type": "array",
+                "description": "The extension point ids your plugin registers the extension to, e.g. `[\"grafana/dashboard/panel/menu\"]`",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "title": {
+                "type": "string",
+                "description": "The title of your link extension.",
+                "minLength": 10
+              },
+              "description": {
+                "type": "string",
+                "description": "Additional information about your link extension."
+              }
+            },
+            "required": ["targets", "title"]
+          }
+        },
+        "addedFunctions": {
+          "type": "array",
+          "description": "This list must contain all function extensions that your plugin registers to other extension points using [`.addedFunctions()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#addfunction). **Functions that are not listed here won't work.**",
           "items": {
             "type": "object",
             "properties": {
@@ -640,7 +671,7 @@
         },
         "exposedComponents": {
           "type": "array",
-          "description": "This list must contain all components that your plugin exposes using [`.exposeComponent()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#exposecomponent). **Components that are not listed here won't work.**",
+          "description": "This list must contain all components that your plugin exposes using [`.exposeComponent()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#exposecomponent). **Components that are not listed here won't work.**",
           "items": {
             "type": "object",
             "properties": {
@@ -663,7 +694,7 @@
         },
         "extensionPoints": {
           "type": "array",
-          "description": "This list must contain all extension points that your plugin defines using [`usePluginLinks()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#usepluginlinks) or [`usePluginComponents()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions#useplugincomponents). **Extension points that are not listed in here won't work.**",
+          "description": "This list must contain all extension points that your plugin defines using [`usePluginLinks()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#usepluginlinks) or [`usePluginComponents()`](https://grafana.com/developers/plugin-tools/reference/ui-extensions-reference/ui-extensions#useplugincomponents). **Extension points that are not listed in here won't work.**",
           "items": {
             "type": "object",
             "properties": {

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -658,12 +658,12 @@
               },
               "title": {
                 "type": "string",
-                "description": "The title of your link extension.",
+                "description": "The title of your function extension.",
                 "minLength": 10
               },
               "description": {
                 "type": "string",
-                "description": "Additional information about your link extension."
+                "description": "Additional information about your function extension."
               }
             },
             "required": ["targets", "title"]


### PR DESCRIPTION
**What is this feature?**

This pull request updates the `plugin.schema.json` file to expand plugin metadata capabilities, improve documentation links, and enhance the structure for registering plugin extensions. The changes add new fields for describing plugin lifecycle status, support for additional extension types, and clarify how plugin extensions should be registered and documented.

**Why do we need this feature?**

So the plugin schema is up to date

**Who is this feature for?**

Grafana maintainers and plugin-platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
