### PR TITLE
chore: execute devenv from any directory

### DIFF
--- a/devenv/create_docker_compose.sh
+++ b/devenv/create_docker_compose.sh
@@ -2,15 +2,18 @@
 
 shopt -s nullglob # Enable nullglob
 
-blocks_dir=docker/blocks
-docker_dir=docker
-template_dir=templates
+# Get the directory where this script is located (works from any execution directory)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+blocks_dir="${SCRIPT_DIR}/docker/blocks"
+docker_dir="${SCRIPT_DIR}/docker"
+template_dir="${SCRIPT_DIR}/templates"
 
 grafana_config_file=conf.tmp
 grafana_config=config
 
-compose_header_file=docker/compose_header.yml
-compose_volume_section_file=docker/compose_volume_section.yml
+compose_header_file="${SCRIPT_DIR}/docker/compose_header.yml"
+compose_volume_section_file="${SCRIPT_DIR}/docker/compose_volume_section.yml"
 compose_volume_section_create_flag=docker_volume_create_true
 compose_file=docker-compose.yaml
 env_file=.env


### PR DESCRIPTION
Currently if you run devenv docker compose create from another dir, as in project root, it breaks:
```
./devenv/create_docker_compose.sh "mt-db" "auth/signer"
Deleting docker-compose.yaml
Adding Compose header to docker-compose.yaml
cat: docker/compose_header.yml: No such file or directory
docker/blocks/mt-db is not a directory
```

Now it gets file location and prefixes path to work from any directory.