### PR TITLE
Docs: Add batch_wait_duration and batch_size_bytes to usage insights Loki exporter

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -115,17 +115,17 @@ Set the tenant ID for Loki communication, which is disabled by default. The tena
 ### batch_wait_duration
 
 How long to wait before sending a request to Loki with the batch of events. Uses duration format: e.g. 5s, 1m. Defaults to 5s.
-  
+
 Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
-  
+
 If the wait duration is very long and the `batch_size_bytes` is very high, events may take a long time to be sent.
 
 ### batch_size_bytes
 
 How many events (in bytes) to accumulate in a single batch before sending it to Loki. Defaults to 100 KiB.
-  
+
 Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
-  
+
 If you wish to always wait for the `batch_wait_duration`, set this to a very high number.
 
 ## [analytics.summaries]

--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -112,6 +112,22 @@ Decide whether or not to enable the TLS (Transport Layer Security) protocol when
 
 Set the tenant ID for Loki communication, which is disabled by default. The tenant ID is required to interact with Loki running in [multi-tenant mode](/docs/loki/latest/operations/multi-tenancy/).
 
+### batch_wait_duration
+
+How long to wait before sending a request to Loki with the batch of events. Uses duration format: e.g. 5s, 1m. Defaults to 5s.
+  
+Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
+  
+If the wait duration is very long and the `batch_size_bytes` is very high, events may take a long time to be sent.
+
+### batch_size_bytes
+
+How many events (in bytes) to accumulate in a single batch before sending it to Loki. Defaults to 100 KiB.
+  
+Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
+  
+If you wish to always wait for the `batch_wait_duration`, set this to a very high number.
+
 ## [analytics.summaries]
 
 ### buffer_write_interval

--- a/docs/sources/setup-grafana/configure-security/export-logs.md
+++ b/docs/sources/setup-grafana/configure-security/export-logs.md
@@ -94,6 +94,14 @@ tls = true
 # Set the tenant ID for Loki communication, which is disabled by default.
 # The tenant ID is required to interact with Loki running in multi-tenant mode.
 tenant_id =
+# How long to wait before sending a request to Loki with the batch of events. Uses duration format: e.g. 5s, 1m
+# Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
+# If the wait duration is very long and the `batch_size_bytes` is very high, events may take a long time to be sent.
+batch_wait_duration = 5s
+# How many events (in bytes) to accumulate in a single batch before sending it to Loki.
+# Whatever happens first between `batch_wait_duration` and `batch_size_bytes` will trigger the batch to be sent to Loki.
+# If you wish to always wait for the `batch_wait_duration`, set this to a very high number.
+batch_size_bytes = 102400 # 100KiB
 ```
 
 Using `logger` will print usage insights to your [Grafana server log](../../configure-grafana/#log).


### PR DESCRIPTION
Documenting the new options added in https://github.com/grafana/grafana-enterprise/pull/9905