### PR TITLE
clean up home dashboard preference on deletion

### DIFF
--- a/pkg/api/folder_bench_test.go
+++ b/pkg/api/folder_bench_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/licensing/licensingtest"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/preference/preftest"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/search"
 	"github.com/grafana/grafana/pkg/services/search/sort"
@@ -457,6 +458,7 @@ func setupServer(b testing.TB, sc benchScenario, features featuremgmt.FeatureTog
 		nil,
 		nil,
 		dualwrite.ProvideTestService(),
+		preftest.NewPreferenceServiceFake(),
 		serverlock.ProvideService(sc.db, tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -555,8 +555,9 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
+	prefService := prefimpl.ProvideService(sqlStore, cfg)
 	k8sHandlerWithFallback := client.ProvideK8sClientWithFallback(cfg, eventualRestConfigProvider, dashboardsStore, userService, resourceClient, featureToggles, dualwriteService, sortService, registerer)
-	dashboardServiceImpl, err := service7.ProvideDashboardServiceImpl(cfg, dashboardsStore, featureToggles, folderPermissionsService, accessControl, acimplService, folderimplService, registerer, quotaService, orgService, publicDashboardServiceWrapperImpl, dualwriteService, serverLockService, kvStore, k8sHandlerWithFallback)
+	dashboardServiceImpl, err := service7.ProvideDashboardServiceImpl(cfg, dashboardsStore, featureToggles, folderPermissionsService, accessControl, acimplService, folderimplService, registerer, quotaService, orgService, publicDashboardServiceWrapperImpl, dualwriteService, prefService, serverLockService, kvStore, k8sHandlerWithFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -680,7 +681,6 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	pluginscdnService := pluginscdn.ProvideService(pluginManagementCfg)
 	pluginassetsService := pluginassets2.ProvideService(pluginManagementCfg, pluginscdnService, signatureSignature, pluginstoreService)
 	avatarCacheServer := avatar.ProvideAvatarCacheServer(cfg)
-	prefService := prefimpl.ProvideService(sqlStore, cfg)
 	dashboardPermissionsService, err := ossaccesscontrol.ProvideDashboardPermissions(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, dashboardService, folderimplService, acimplService, teamService, userService, actionSetService, dashboardServiceImpl)
 	if err != nil {
 		return nil, err
@@ -1157,8 +1157,9 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
+	prefService := prefimpl.ProvideService(sqlStore, cfg)
 	k8sHandlerWithFallback := client.ProvideK8sClientWithFallback(cfg, eventualRestConfigProvider, dashboardsStore, userService, resourceClient, featureToggles, dualwriteService, sortService, registerer)
-	dashboardServiceImpl, err := service7.ProvideDashboardServiceImpl(cfg, dashboardsStore, featureToggles, folderPermissionsService, accessControl, acimplService, folderimplService, registerer, quotaService, orgService, publicDashboardServiceWrapperImpl, dualwriteService, serverLockService, kvStore, k8sHandlerWithFallback)
+	dashboardServiceImpl, err := service7.ProvideDashboardServiceImpl(cfg, dashboardsStore, featureToggles, folderPermissionsService, accessControl, acimplService, folderimplService, registerer, quotaService, orgService, publicDashboardServiceWrapperImpl, dualwriteService, prefService, serverLockService, kvStore, k8sHandlerWithFallback)
 	if err != nil {
 		return nil, err
 	}
@@ -1284,7 +1285,6 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	pluginscdnService := pluginscdn.ProvideService(pluginManagementCfg)
 	pluginassetsService := pluginassets2.ProvideService(pluginManagementCfg, pluginscdnService, signatureSignature, pluginstoreService)
 	avatarCacheServer := avatar.ProvideAvatarCacheServer(cfg)
-	prefService := prefimpl.ProvideService(sqlStore, cfg)
 	dashboardPermissionsService, err := ossaccesscontrol.ProvideDashboardPermissions(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, dashboardService, folderimplService, acimplService, teamService, userService, actionSetService, dashboardServiceImpl)
 	if err != nil {
 		return nil, err

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -579,6 +579,7 @@ func (d *dashboardStore) deleteDashboard(cmd *dashboards.DeleteDashboardCommand,
 		{SQL: "DELETE FROM dashboard_version WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_provisioning WHERE dashboard_id = ?", args: []any{dashboard.ID}},
 		{SQL: "DELETE FROM dashboard_acl WHERE dashboard_id = ?", args: []any{dashboard.ID}},
+		{SQL: "UPDATE preferences SET home_dashboard_uid='', home_dashboard_id=0 WHERE home_dashboard_uid = ? OR (home_dashboard_id=? AND org_id=?)", args: []any{dashboard.UID, dashboard.ID, dashboard.OrgID}},
 	}
 
 	if dashboard.IsFolder {

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
+	"github.com/grafana/grafana/pkg/services/preference/preftest"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/search/model"
@@ -2231,6 +2232,7 @@ func TestCleanUpDashboard(t *testing.T) {
 				cfg:                    setting.NewCfg(),
 				dashboardStore:         &fakeStore,
 				publicDashboardService: fakePublicDashboardService,
+				preferenceService:      preftest.NewPreferenceServiceFake(),
 			}
 
 			ctx := context.Background()
@@ -2456,6 +2458,7 @@ func TestIntegrationK8sDashboardCleanupJob(t *testing.T) {
 				kvstore:                kv,
 				features:               features,
 				dual:                   dual,
+				preferenceService:      preftest.NewPreferenceServiceFake(),
 			}
 
 			ctx, k8sCliMock := setupK8sDashboardTests(service)

--- a/pkg/services/ngalert/testutil/testutil.go
+++ b/pkg/services/ngalert/testutil/testutil.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgimpl"
+	"github.com/grafana/grafana/pkg/services/preference/preftest"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/search/sort"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
@@ -68,6 +69,7 @@ func SetupDashboardService(tb testing.TB, sqlStore db.DB, cfg *setting.Cfg) (*da
 		nil,
 		nil,
 		dualwrite.ProvideTestService(),
+		preftest.NewPreferenceServiceFake(),
 		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(

--- a/pkg/services/preference/model.go
+++ b/pkg/services/preference/model.go
@@ -56,6 +56,10 @@ type GetPreferenceQuery struct {
 	TeamID int64
 }
 
+type FindPreferenceQuery struct {
+	HomeDashboardUID string
+}
+
 type SavePreferenceCommand struct {
 	UserID int64
 	OrgID  int64

--- a/pkg/services/preference/pref.go
+++ b/pkg/services/preference/pref.go
@@ -9,6 +9,7 @@ type Service interface {
 	Get(context.Context, *GetPreferenceQuery) (*Preference, error)
 	Save(context.Context, *SavePreferenceCommand) error
 	Patch(context.Context, *PatchPreferenceCommand) error
+	Find(context.Context, *FindPreferenceQuery) ([]*Preference, error)
 	GetDefaults() *Preference
 	Delete(context.Context, *DeleteCommand) error
 }

--- a/pkg/services/preference/prefimpl/inmemory_test.go
+++ b/pkg/services/preference/prefimpl/inmemory_test.go
@@ -124,3 +124,13 @@ func (s *inmemStore) Update(ctx context.Context, preference *pref.Preference) er
 func (s *inmemStore) Delete(context.Context, *pref.DeleteCommand) error {
 	panic("not yet implemented")
 }
+
+func (s *inmemStore) Find(ctx context.Context, query *pref.FindPreferenceQuery) ([]*pref.Preference, error) {
+	out := []*pref.Preference{}
+	for _, pref := range s.preference {
+		if pref.HomeDashboardUID == query.HomeDashboardUID {
+			out = append(out, &pref)
+		}
+	}
+	return out, nil
+}

--- a/pkg/services/preference/prefimpl/pref.go
+++ b/pkg/services/preference/prefimpl/pref.go
@@ -109,6 +109,10 @@ func (s *Service) Get(ctx context.Context, query *pref.GetPreferenceQuery) (*pre
 	return prefs, nil
 }
 
+func (s *Service) Find(ctx context.Context, query *pref.FindPreferenceQuery) ([]*pref.Preference, error) {
+	return s.store.Find(ctx, query)
+}
+
 func (s *Service) Save(ctx context.Context, cmd *pref.SavePreferenceCommand) error {
 	jsonData, err := preferenceData(cmd)
 	if err != nil {

--- a/pkg/services/preference/prefimpl/store.go
+++ b/pkg/services/preference/prefimpl/store.go
@@ -9,6 +9,7 @@ import (
 type store interface {
 	Get(context.Context, *pref.Preference) (*pref.Preference, error)
 	List(context.Context, *pref.Preference) ([]*pref.Preference, error)
+	Find(context.Context, *pref.FindPreferenceQuery) ([]*pref.Preference, error)
 	// Insert adds a new preference and returns its sequential ID
 	Insert(context.Context, *pref.Preference) (int64, error)
 	Update(context.Context, *pref.Preference) error

--- a/pkg/services/preference/prefimpl/xorm_store.go
+++ b/pkg/services/preference/prefimpl/xorm_store.go
@@ -63,6 +63,27 @@ func (s *sqlStore) List(ctx context.Context, query *pref.Preference) ([]*pref.Pr
 	return prefs, err
 }
 
+func (s *sqlStore) Find(ctx context.Context, query *pref.FindPreferenceQuery) ([]*pref.Preference, error) {
+	prefs := make([]*pref.Preference, 0)
+	params := make([]any, 0)
+	filter := ""
+	if query.HomeDashboardUID != "" {
+		filter += "home_dashboard_uid=?"
+		params = append(params, query.HomeDashboardUID)
+	}
+	err := s.db.WithDbSession(ctx, func(dbSession *db.Session) error {
+		err := dbSession.Where(filter, params...).
+			Find(&prefs)
+
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	return prefs, err
+}
+
 func (s *sqlStore) Update(ctx context.Context, cmd *pref.Preference) error {
 	return s.db.WithDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.ID(cmd.ID).AllCols().Update(cmd)

--- a/pkg/services/preference/preftest/fake.go
+++ b/pkg/services/preference/preftest/fake.go
@@ -38,3 +38,10 @@ func (f *FakePreferenceService) Patch(ctx context.Context, cmd *pref.PatchPrefer
 func (f *FakePreferenceService) Delete(context.Context, *pref.DeleteCommand) error {
 	return f.ExpectedError
 }
+
+func (f *FakePreferenceService) Find(context.Context, *pref.FindPreferenceQuery) ([]*pref.Preference, error) {
+	if f.ExpectedPreference != nil {
+		return []*pref.Preference{f.ExpectedPreference}, f.ExpectedError
+	}
+	return nil, f.ExpectedError
+}

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginconfig"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/plugincontext"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
+	"github.com/grafana/grafana/pkg/services/preference/preftest"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/search/sort"
@@ -524,6 +525,7 @@ func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaSe
 		orgService,
 		nil,
 		dualwrite.ProvideTestService(),
+		preftest.NewPreferenceServiceFake(),
 		serverlock.ProvideService(sqlStore, tracing.InitializeTracerForTest()),
 		kvstore.NewFakeKVStore(),
 		dashclient.NewK8sClientWithFallback(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This fix updates any existing home dashboard preferences to be reset upon dashboard deletion

**Why do we need this feature?**

If a custom homepage is set but the dashboard cannot be found, the user is presented with the default embedded home dashboard. #99498 approaches this at resolution time while this fixes it at the source

**Who is this feature for?**

Grafana instances with custom home pages

**Special notes for your reviewer:**

IMHO #99498 is still needed for instances which are currently affected by this and as a fallback until the async app-platform dashboard cleanup runs

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
