### PR TITLE
AuthZ service: Correctly evaluate action sets for dashboard creation

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -124,6 +124,13 @@ func newDashboardTranslation() translation {
 	actionSetMapping := make(map[string][]string)
 	for verb, rbacAction := range dashTranslation.verbMapping {
 		var dashActionSets []string
+
+		// Dashboard creation is only part of folder action sets, so we handle it separately
+		if rbacAction == "dashboards:create" {
+			dashActionSets = append(dashActionSets, "folders:edit")
+			dashActionSets = append(dashActionSets, "folders:admin")
+		}
+
 		if slices.Contains(ossaccesscontrol.DashboardViewActions, rbacAction) {
 			dashActionSets = append(dashActionSets, "dashboards:view")
 			dashActionSets = append(dashActionSets, "folders:view")


### PR DESCRIPTION
**What is this feature?**

We were not looking at action sets when evaluating access to create dashboards, this PR fixes it.

Follow-up to https://github.com/grafana/grafana/pull/112124

**Why do we need this feature?**

To allow non-Admin users that use dashboard mode 3+ to create dashboards in folders that they have been granted Edit access to.