### PR TITLE
Fix v16 grid position calculation for fractional spans 

### DIFF
--- a/apps/dashboard/pkg/migration/schemaversion/v16.go
+++ b/apps/dashboard/pkg/migration/schemaversion/v16.go
@@ -338,7 +338,9 @@ func calculatePanelDimensionsFromSpan(span float64, panel map[string]interface{}
 		}
 	}
 
-	panelWidth := int(math.Floor(span * widthFactor))
+	// Match frontend logic: Math.floor(panel.span) * widthFactor (line 914 in DashboardMigrator.ts)
+	// Frontend floors the span FIRST, then multiplies by widthFactor
+	panelWidth := int(math.Floor(span)) * int(widthFactor)
 	panelHeight := defaultHeight
 
 	if panelHeightValue, hasHeight := panel["height"]; hasHeight {


### PR DESCRIPTION
## Fix v16 grid position calculation for fractional spans

### Problem

Dashboard layout inconsistencies between backend and frontend migration paths for panels with fractional spans discovered in comprehensive migration testing ([#112421](https://github.com/grafana/grafana/pull/112421)).

Backend and frontend calculate panel widths differently from fractional spans:
- **Backend (incorrect)**: `Math.floor(span * widthFactor)`
- **Frontend (correct)**: `Math.floor(span) * widthFactor`

This creates different panel widths for the same dashboard when migrated through different paths.

### Solution

Updated backend v16 migration to match frontend logic by flooring the span **first**, then multiplying by width factor.

**Example fix:**
- Span: `5.929860088365242`, widthFactor: `2`
- **Old backend**: `Math.floor(5.93 * 2) = Math.floor(11.86) = 11`
- **New backend**: `Math.floor(5.93) * 2 = 5 * 2 = 10` ✅ (matches frontend)

### How to test

The included unit test verifies the fix with real fractional span values from historical dashboards:

```bash
go test ./apps/dashboard/pkg/migration/schemaversion/ -run "TestV16/should_correctly_calculate_panel_width_from_fractional_spans" -v
```

---

**Source**: Issue discovered during comprehensive migration testing in [#112421](https://github.com/grafana/grafana/pull/112421)