### PR TITLE
Cleanup old entries from resource_last_import_time table.

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -981,7 +981,7 @@ func (b *backend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[reso
 	defer span.End()
 
 	// Delete old entries, if configured, and if enough time has passed since last deletion.
-	if b.lastImportTimeMaxAge > 0 && b.lastImportTimeDeletionTime.Load().Before(time.Now().Add(-limitLastImportTimesDeletion)) {
+	if b.lastImportTimeMaxAge > 0 && time.Since(b.lastImportTimeDeletionTime.Load()) > limitLastImportTimesDeletion {
 		now := time.Now()
 
 		res, err := dbutil.Exec(ctx, b.db, sqlResourceLastImportTimeDelete, &sqlResourceLastImportTimeDeleteRequest{

--- a/pkg/storage/unified/sql/data/resource_last_import_time_delete.sql
+++ b/pkg/storage/unified/sql/data/resource_last_import_time_delete.sql
@@ -1,0 +1,3 @@
+DELETE FROM {{ .Ident "resource_last_import_time" }}
+WHERE {{ .Ident "last_import_time" }} <= {{ .Arg .Threshold }}
+;

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -125,6 +125,13 @@ func initResourceTables(mg *migrator.Migrator) string {
 			{Name: "last_import_time", Type: migrator.DB_DateTime, Nullable: false},
 		},
 		PrimaryKeys: []string{"group", "resource", "namespace"},
+		Indices: []*migrator.Index{
+			{
+				Cols: []string{"last_import_time"},
+				Type: migrator.IndexType,
+				Name: "UQE_resource_last_import_time_last_import_time",
+			},
+		},
 	})
 
 	// Initialize all tables

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -116,7 +116,7 @@ func initResourceTables(mg *migrator.Migrator) string {
 		},
 	})
 
-	tables = append(tables, migrator.Table{
+	resource_last_import_time := migrator.Table{
 		Name: "resource_last_import_time",
 		Columns: []*migrator.Column{
 			{Name: "group", Type: migrator.DB_NVarchar, Length: 190, Nullable: false},
@@ -125,14 +125,8 @@ func initResourceTables(mg *migrator.Migrator) string {
 			{Name: "last_import_time", Type: migrator.DB_DateTime, Nullable: false},
 		},
 		PrimaryKeys: []string{"group", "resource", "namespace"},
-		Indices: []*migrator.Index{
-			{
-				Cols: []string{"last_import_time"},
-				Type: migrator.IndexType,
-				Name: "UQE_resource_last_import_time_last_import_time",
-			},
-		},
-	})
+	}
+	tables = append(tables, resource_last_import_time)
 
 	// Initialize all tables
 	for t := range tables {
@@ -183,6 +177,12 @@ func initResourceTables(mg *migrator.Migrator) string {
 		Cols: []string{"namespace", "group", "resource", "name", "generation"},
 		Type: migrator.IndexType,
 		Name: "IDX_resource_history_namespace_group_resource_name_generation",
+	}))
+
+	mg.AddMigration("Add UQE_resource_last_import_time_last_import_time index", migrator.NewAddIndexMigration(resource_last_import_time, &migrator.Index{
+		Cols: []string{"last_import_time"},
+		Type: migrator.IndexType,
+		Name: "UQE_resource_last_import_time_last_import_time",
 	}))
 
 	return marker

--- a/pkg/storage/unified/sql/queries.go
+++ b/pkg/storage/unified/sql/queries.go
@@ -61,6 +61,7 @@ var (
 
 	sqlResourceLastImportTimeInsert = mustTemplate("resource_last_import_time_insert.sql")
 	sqlResourceLastImportTimeQuery  = mustTemplate("resource_last_import_time_query.sql")
+	sqlResourceLastImportTimeDelete = mustTemplate("resource_last_import_time_delete.sql")
 )
 
 // TxOptions.
@@ -487,5 +488,14 @@ type sqlResourceLastImportTimeQueryRequest struct {
 }
 
 func (r *sqlResourceLastImportTimeQueryRequest) Validate() error {
+	return nil
+}
+
+type sqlResourceLastImportTimeDeleteRequest struct {
+	sqltemplate.SQLTemplate
+	Threshold time.Time
+}
+
+func (r *sqlResourceLastImportTimeDeleteRequest) Validate() error {
 	return nil
 }

--- a/pkg/storage/unified/sql/queries_test.go
+++ b/pkg/storage/unified/sql/queries_test.go
@@ -515,5 +515,14 @@ func TestUnifiedStorageQueries(t *testing.T) {
 					},
 				},
 			},
+			sqlResourceLastImportTimeDelete: {
+				{
+					Name: "delete",
+					Data: &sqlResourceLastImportTimeDeleteRequest{
+						SQLTemplate: mocks.NewTestingSQLTemplate(),
+						Threshold:   time.Date(2025, 10, 15, 14, 30, 05, 0, time.UTC),
+					},
+				},
+			},
 		}})
 }

--- a/pkg/storage/unified/sql/server.go
+++ b/pkg/storage/unified/sql/server.go
@@ -102,12 +102,13 @@ func NewResourceServer(opts ServerOptions) (resource.ResourceServer, error) {
 		withPruner := opts.Features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageHistoryPruner)
 
 		backend, err := NewBackend(BackendOptions{
-			DBProvider:     eDB,
-			Tracer:         opts.Tracer,
-			Reg:            opts.Reg,
-			IsHA:           isHA,
-			withPruner:     withPruner,
-			storageMetrics: opts.StorageMetrics,
+			DBProvider:           eDB,
+			Tracer:               opts.Tracer,
+			Reg:                  opts.Reg,
+			IsHA:                 isHA,
+			withPruner:           withPruner,
+			storageMetrics:       opts.StorageMetrics,
+			LastImportTimeMaxAge: opts.SearchOptions.MaxIndexAge, // No need to keep last_import_times older than max index age.
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -53,6 +53,7 @@ func newTestBackend(t *testing.T, isHA bool, simulatedNetworkLatency time.Durati
 		DBProvider:              eDB,
 		IsHA:                    isHA,
 		SimulatedNetworkLatency: simulatedNetworkLatency,
+		LastImportTimeMaxAge:    24 * time.Hour,
 	})
 	require.NoError(t, err)
 	require.NotNil(t, backend)

--- a/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_delete-delete.sql
+++ b/pkg/storage/unified/sql/testdata/mysql--resource_last_import_time_delete-delete.sql
@@ -1,0 +1,3 @@
+DELETE FROM `resource_last_import_time`
+WHERE `last_import_time` <= '2025-10-15 14:30:05 +0000 UTC'
+;

--- a/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_delete-delete.sql
+++ b/pkg/storage/unified/sql/testdata/postgres--resource_last_import_time_delete-delete.sql
@@ -1,0 +1,3 @@
+DELETE FROM "resource_last_import_time"
+WHERE "last_import_time" <= '2025-10-15 14:30:05 +0000 UTC'
+;

--- a/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_delete-delete.sql
+++ b/pkg/storage/unified/sql/testdata/sqlite--resource_last_import_time_delete-delete.sql
@@ -1,0 +1,3 @@
+DELETE FROM "resource_last_import_time"
+WHERE "last_import_time" <= '2025-10-15 14:30:05 +0000 UTC'
+;


### PR DESCRIPTION
This PR implements cleanup of `resource_last_import_time` table, by reusing existing `max_file_index_age` option.

Cleanup is done during `GetResourceLastImportTimes` call, but not more often than once per hour.