### PR TITLE
AuthZ: ignore duplicates on write and missing on delete in OpenFGA

### DIFF
--- a/pkg/services/authz/zanzana/server/server_write.go
+++ b/pkg/services/authz/zanzana/server/server_write.go
@@ -55,12 +55,14 @@ func (s *Server) write(ctx context.Context, req *authzextv1.WriteRequest) (*auth
 	}
 	if len(writeTuples) > 0 {
 		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys: writeTuples,
+			TupleKeys:   writeTuples,
+			OnDuplicate: "ignore",
 		}
 	}
 	if len(deleteTuples) > 0 {
 		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
 			TupleKeys: deleteTuples,
+			OnMissing: "ignore",
 		}
 	}
 


### PR DESCRIPTION
When writing to openFGA ignore duplicates written or missing removals.
New feature introduced in 1.10.

This should make it simpler to write reconcilers. 
The other option to this and the default is "error"

Did not find any constant upstream to use so string it is.