### PR TITLE
ci(dependabot): Update config and add groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    commit-message:
+      prefix: deps(actions)
     directory: "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "gomod"
+    commit-message:
+      prefix: deps(go)
     directories:
       - "/"
       - "/apps/playlist"
@@ -25,8 +29,22 @@ updates:
       interval: "daily"
       time: "02:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
+    # group some updates together for easier review
+    groups:
+      go.opentelemetry.io:
+        patterns:
+          - "go.opentelemetry.io/*"
+      k8s.io:
+        patterns:
+          - "k8s.io/*"
+      aws-sdk-go:
+        patterns:
+          - "github.com/aws/aws-sdk-go*"
+          - "github.com/aws/smithy-go"
   - package-ecosystem: "docker"
+    commit-message:
+      prefix: deps(docker)
     directories:
       - "/"
       - "/packaging/docker/custom"
@@ -35,4 +53,4 @@ updates:
       interval: "daily"
       time: "02:00"
       timezone: Etc/UTC
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Let's make life easier for maintainers by grouping related dependencies together in the same PRs...

Also increasing the max # of PRs since they tend to pile up, and normalizing commit message prefixes.