### PR TITLE
Chore: Fix broken test after markdown move

### DIFF
--- a/scripts/docs/generate-transformations.ts
+++ b/scripts/docs/generate-transformations.ts
@@ -7,7 +7,7 @@ import {
   ImageRenderType,
 } from '../../public/app/features/transformers/docs/content';
 
-const WRITE_PATH = 'docs/sources/panels-visualizations/query-transform-data/transform-data/index.md';
+const WRITE_PATH = 'docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md';
 
 export const readMeContent = `
   To update this Markdown, navigate to the following Typescript files and edit them based on what you need to update:


### PR DESCRIPTION
**What is this feature?**
Fixes a test that's broken in main

**Why do we need this feature?**
https://github.com/grafana/grafana/pull/112393 moved some files around, but because only Markdown files were moved, it didn't trigger the frontend unit tests - this test was failing