### PR TITLE
Dashboards: Fix preload field not being persisted via /v1beta1

### DIFF
--- a/apps/dashboard/pkg/migration/frontend_defaults.go
+++ b/apps/dashboard/pkg/migration/frontend_defaults.go
@@ -1061,7 +1061,6 @@ func cleanupDashboardDefaults(dashboard map[string]interface{}) {
 
 	// Remove transient properties that frontend filters out during getSaveModelClone()
 	// These properties are lost during frontend's property copying loop in getSaveModelCloneOld()
-	delete(dashboard, "preload")   // Transient dashboard loading state
 	delete(dashboard, "iteration") // Template variable iteration timestamp
 	delete(dashboard, "nav")       // Removed after V7 migration
 	delete(dashboard, "pulldowns") // Removed after V6 migration - frontend doesn't have this property

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/datasource-testdata/demo1.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/datasource-testdata/demo1.v42.json
@@ -1293,6 +1293,7 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": false,
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-canvas/canvas-connection-examples.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-canvas/canvas-connection-examples.v42.json
@@ -3941,6 +3941,7 @@
       "type": "canvas"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_footer.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_footer.v42.json
@@ -1537,6 +1537,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "schemaVersion": 42,
   "tags": [],
   "templating": {

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_kitchen_sink.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_kitchen_sink.v42.json
@@ -1848,6 +1848,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "schemaVersion": 42,
   "tags": [],
   "templating": {

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_markdown.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_markdown.v42.json
@@ -107,6 +107,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "schemaVersion": 42,
   "tags": [],
   "templating": {

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_sparkline_cell.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_sparkline_cell.v42.json
@@ -576,6 +576,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [],

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_tests_new.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_tests_new.v42.json
@@ -982,6 +982,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_v12_2_migrations.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-table/table_v12_2_migrations.v42.json
@@ -2172,6 +2172,7 @@
       "type": "table"
     }
   ],
+  "preload": false,
   "schemaVersion": 42,
   "tags": [],
   "templating": {

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-timeline/timeline-thresholds-mappings.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-timeline/timeline-thresholds-mappings.v42.json
@@ -1071,6 +1071,7 @@
       "type": "state-timeline"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-timeseries/timeseries-nulls.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-timeseries/timeseries-nulls.v42.json
@@ -3409,6 +3409,7 @@
       "type": "state-timeline"
     }
   ],
+  "preload": false,
   "refresh": false,
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-trend/trend_example.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-trend/trend_example.v42.json
@@ -196,6 +196,7 @@
       "type": "trend"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-xychart/xychart-demo.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-xychart/xychart-demo.v42.json
@@ -1433,6 +1433,7 @@
       "type": "xychart"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/scenarios/mostly-blank-dashboard.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/scenarios/mostly-blank-dashboard.v42.json
@@ -79,6 +79,7 @@
       "type": "debug"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [],

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/transforms/regression-analysis.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/transforms/regression-analysis.v42.json
@@ -1049,6 +1049,7 @@
       "type": "xychart"
     }
   ],
+  "preload": false,
   "refresh": "",
   "schemaVersion": 42,
   "tags": [

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -81,6 +81,7 @@ export class DashboardModel implements TimeModel {
   graphTooltip: DashboardCursorSync;
   time: any;
   liveNow?: boolean;
+  preload?: boolean;
   private originalTime: any;
   timepicker: any;
   templating: { list: any[] };
@@ -154,6 +155,7 @@ export class DashboardModel implements TimeModel {
     this.timezone = data.timezone ?? '';
     this.weekStart = data.weekStart ?? '';
     this.editable = data.editable !== false;
+    this.preload = data.preload;
     this.graphTooltip = data.graphTooltip || 0;
     this.time = data.time ?? { from: 'now-6h', to: 'now' };
     this.timepicker = data.timepicker ?? {};


### PR DESCRIPTION
**Problem**

The preload field was being deleted by the backend during dashboard save operations, even when explicitly set by the frontend. This happened because frontend_defaults.go incorrectly treated preload as a "transient dashboard loading state" and deleted it during cleanup.

This was badly fixed when we were matching frontend and backend behaviors. Because Frontend was not persisting through DashboardModel the feature, the backend was not doing it either. But this is because `preload` was added only for Scenes, so DashboardModel is not used to get the saved model. 

**Solution**

Removed the line in cleanupDashboardDefaults() that was deleting the preload field. The preload field is a legitimate dashboard configuration option that should be persisted when present in the input. I have also updated DashboardModel to keep consistency for the dashboard migration testing system

**How to test**

1. Create or edit a dashboard with preload explicitly set
2. Save the dashboard via the v1beta1 API endpoint
3. Verify that the preload field is preserved in the saved dashboard