### PR TITLE
APIServer: Add Method for Installer-Based Apps to Self-Register with the APIRegistrar

### DIFF
--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -114,7 +114,7 @@ type APIRoutes struct {
 
 type APIRegistrar interface {
 	RegisterAPI(builder APIGroupBuilder)
-	RegisterAPIInstaller(installer appsdkapiserver.AppInstaller)
+	RegisterAppInstaller(installer appsdkapiserver.AppInstaller)
 }
 
 func getGroup(builder APIGroupBuilder) (string, error) {

--- a/pkg/services/apiserver/builder/common.go
+++ b/pkg/services/apiserver/builder/common.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
 
+	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/options"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
@@ -113,6 +114,7 @@ type APIRoutes struct {
 
 type APIRegistrar interface {
 	RegisterAPI(builder APIGroupBuilder)
+	RegisterAPIInstaller(installer appsdkapiserver.AppInstaller)
 }
 
 func getGroup(builder APIGroupBuilder) (string, error) {

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -248,7 +248,7 @@ func (s *service) RegisterAPI(b builder.APIGroupBuilder) {
 	s.builders = append(s.builders, b)
 }
 
-func (s *service) RegisterAPIInstaller(i appsdkapiserver.AppInstaller) {
+func (s *service) RegisterAppInstaller(i appsdkapiserver.AppInstaller) {
 	s.appInstallers = append(s.appInstallers, i)
 }
 

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -248,6 +248,10 @@ func (s *service) RegisterAPI(b builder.APIGroupBuilder) {
 	s.builders = append(s.builders, b)
 }
 
+func (s *service) RegisterAPIInstaller(i appsdkapiserver.AppInstaller) {
+	s.appInstallers = append(s.appInstallers, i)
+}
+
 // nolint:gocyclo
 func (s *service) start(ctx context.Context) error {
 	// Get the list of groups the server will support


### PR DESCRIPTION
**What is this feature?**

This PR adds the method `RegisterAPIInstaller` to the `builder.APIRegistrar` interface, and implements it in the `apiserver` service. 

**Why do we need this feature?**

app-sdk installer-based apps cannot register themselves in the `builder.APIRegistrar`, which is the only way to register APIs with the API Server in enterprise. This PR will allow enterprise apps to self-register when using the newer installer-based approach.

**Who is this feature for?**

Enterprise app developers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

~`RegisterAPIInstaller` is a slightly awkward name in camelCase, I'm open to better naming suggestions.~
Renamed to `RegisterAppInstaller` per suggestion from @\radiohead 

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
