### PR TITLE
TimeComparison: Fix url syncing

### DIFF
--- a/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
+++ b/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
@@ -12,6 +12,7 @@ export class CustomTimeRangeCompare extends SceneTimeRangeCompare {
   constructor(state: Partial<SceneTimeRangeCompare['state']> = {}) {
     super({
       ...state,
+      key: state.key || 'compareWith',
       compareWith: undefined,
       compareOptions: [],
       hideCheckbox: true,

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -92,7 +92,7 @@ describe('buildVizPanel', () => {
       expect(vizPanel.state.headerActions).toBeDefined();
       expect(vizPanel.state.headerActions).toHaveLength(1);
       expect(CustomTimeRangeCompare).toHaveBeenCalledWith({
-        key: 'time-compare',
+        key: `compareWith-${panel.spec.id}`,
         compareWith: undefined,
         compareOptions: [],
       });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -74,7 +74,13 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     extendPanelContext: setDashboardPanelContext,
     // _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel), //FIXME: Angular Migration
     headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
+      ? [
+          new CustomTimeRangeCompare({
+            key: `compareWith-${panel.spec.id}`,
+            compareWith: undefined,
+            compareOptions: [],
+          }),
+        ]
       : undefined,
   };
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -429,7 +429,7 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     extendPanelContext: setDashboardPanelContext,
     _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel),
     headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
+      ? [new CustomTimeRangeCompare({ key: `compareWith-${panel.id}`, compareWith: undefined, compareOptions: [] })]
       : undefined,
   };
 

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -257,7 +257,7 @@ export function getDefaultVizPanel(): VizPanel {
       $behaviors: [panelMenuBehavior],
     }),
     headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
+      ? [new CustomTimeRangeCompare({ key: 'compareWith', compareWith: undefined, compareOptions: [] })]
       : undefined,
     $data: new SceneDataTransformer({
       $data: new SceneQueryRunner({


### PR DESCRIPTION
Depends on https://github.com/grafana/scenes/pull/1277

1. Makes the key for panel header action custom time range comparison dynamic based on panel id.
2. Passes key into SceneTimeRangeCompare to fix url syncing during page refresh

Before:
![Oct-15-2025 16-48-58](https://github.com/user-attachments/assets/f7fc40fd-961b-4cbc-af98-46a6c6191827)

After:
![Oct-15-2025 16-36-33](https://github.com/user-attachments/assets/dcf663e6-8415-4f55-9bd5-4825655a30f4)

Fixes https://github.com/grafana/grafana/issues/112274