### PR TITLE
Server Lock: Handle context cancellation

### DIFF
--- a/pkg/infra/serverlock/serverlock_integration_test.go
+++ b/pkg/infra/serverlock/serverlock_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/util/testutil"
 	"github.com/stretchr/testify/require"
 )
@@ -40,86 +41,139 @@ func TestIntegrationServerLock_LockAndExecute(t *testing.T) {
 func TestIntegrationServerLock_LockExecuteAndRelease(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	sl := createTestableServerLock(t)
+	t.Run("lock is released", func(t *testing.T) {
+		sl := createTestableServerLock(t)
 
-	counter := 0
-	fn := func(context.Context) { counter++ }
-	atInterval := time.Hour
-	ctx := context.Background()
+		counter := 0
+		fn := func(context.Context) { counter++ }
+		atInterval := time.Hour
+		ctx := context.Background()
 
-	//
-	err := sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
-	require.NoError(t, err)
-	require.Equal(t, 1, counter)
+		err := sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
+		require.NoError(t, err)
+		require.Equal(t, 1, counter)
 
-	// the function will be executed again, as everytime the lock is released
-	err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
-	require.NoError(t, err)
-	err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
-	require.NoError(t, err)
-	err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
-	require.NoError(t, err)
+		// the function will be executed again, as everytime the lock is released
+		err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
+		require.NoError(t, err)
+		err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
+		require.NoError(t, err)
+		err = sl.LockExecuteAndRelease(ctx, "test-operation", atInterval, fn)
+		require.NoError(t, err)
 
-	require.Equal(t, 4, counter)
+		require.Equal(t, 4, counter)
+	})
+
+	t.Run("lock is released when context is cancelled", func(t *testing.T) {
+		sl := createTestableServerLock(t)
+		operationUID := "test-operation-context-cancel"
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err := sl.LockExecuteAndRelease(ctx, operationUID, time.Hour, func(ctx context.Context) {
+			cancel()
+		})
+		require.NoError(t, err)
+
+		err = sl.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			lockRows := []*serverLock{}
+			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(lockRows), "Lock should be released even when context is cancelled")
+			return nil
+		})
+		require.NoError(t, err)
+	})
 }
 
 func TestIntegrationServerLock_LockExecuteAndReleaseWithRetries(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
-	sl := createTestableServerLock(t)
+	t.Run("retries when lock is already taken", func(t *testing.T) {
+		sl := createTestableServerLock(t)
 
-	retries := 0
-	expectedRetries := 10
-	funcRuns := 0
-	fn := func(context.Context) {
-		funcRuns++
-	}
-	lockTimeConfig := LockTimeConfig{
-		MaxInterval: time.Hour,
-		MinWait:     0 * time.Millisecond,
-		MaxWait:     1 * time.Millisecond,
-	}
-	ctx := context.Background()
-	actionName := "test-operation"
-
-	// Acquire lock so that when `LockExecuteAndReleaseWithRetries` runs, it is forced
-	// to retry
-	err := sl.acquireForRelease(ctx, actionName, lockTimeConfig.MaxInterval)
-	require.NoError(t, err)
-
-	wgRetries := sync.WaitGroup{}
-	wgRetries.Add(expectedRetries)
-	wgRelease := sync.WaitGroup{}
-	wgRelease.Add(1)
-	wgCompleted := sync.WaitGroup{}
-	wgCompleted.Add(1)
-
-	onRetryFn := func(int) error {
-		retries++
-		wgRetries.Done()
-		if retries == expectedRetries {
-			// When we reach `expectedRetries`, wait for the lock to be released
-			// to guarantee that next try will succeed
-			wgRelease.Wait()
+		retries := 0
+		expectedRetries := 10
+		funcRuns := 0
+		fn := func(context.Context) {
+			funcRuns++
 		}
-		return nil
-	}
+		lockTimeConfig := LockTimeConfig{
+			MaxInterval: time.Hour,
+			MinWait:     0 * time.Millisecond,
+			MaxWait:     1 * time.Millisecond,
+		}
+		ctx := context.Background()
+		actionName := "test-operation"
 
-	go func() {
-		err := sl.LockExecuteAndReleaseWithRetries(ctx, actionName, lockTimeConfig, fn, onRetryFn)
+		// Acquire lock so that when `LockExecuteAndReleaseWithRetries` runs, it is forced
+		// to retry
+		err := sl.acquireForRelease(ctx, actionName, lockTimeConfig.MaxInterval)
 		require.NoError(t, err)
-		wgCompleted.Done()
-	}()
 
-	// Wait to release the lock until `LockExecuteAndReleaseWithRetries` has retried `expectedRetries` times.
-	wgRetries.Wait()
-	err = sl.releaseLock(ctx, actionName)
-	require.NoError(t, err)
-	wgRelease.Done()
+		wgRetries := sync.WaitGroup{}
+		wgRetries.Add(expectedRetries)
+		wgRelease := sync.WaitGroup{}
+		wgRelease.Add(1)
+		wgCompleted := sync.WaitGroup{}
+		wgCompleted.Add(1)
 
-	// `LockExecuteAndReleaseWithRetries` has run completely.
-	// Check that it had to retry because the lock was already taken.
-	wgCompleted.Wait()
-	require.Equal(t, expectedRetries, retries)
-	require.Equal(t, 1, funcRuns)
+		onRetryFn := func(int) error {
+			retries++
+			wgRetries.Done()
+			if retries == expectedRetries {
+				// When we reach `expectedRetries`, wait for the lock to be released
+				// to guarantee that next try will succeed
+				wgRelease.Wait()
+			}
+			return nil
+		}
+
+		go func() {
+			err := sl.LockExecuteAndReleaseWithRetries(ctx, actionName, lockTimeConfig, fn, onRetryFn)
+			require.NoError(t, err)
+			wgCompleted.Done()
+		}()
+
+		// Wait to release the lock until `LockExecuteAndReleaseWithRetries` has retried `expectedRetries` times.
+		wgRetries.Wait()
+		err = sl.releaseLock(ctx, actionName)
+		require.NoError(t, err)
+		wgRelease.Done()
+
+		// `LockExecuteAndReleaseWithRetries` has run completely.
+		// Check that it had to retry because the lock was already taken.
+		wgCompleted.Wait()
+		require.Equal(t, expectedRetries, retries)
+		require.Equal(t, 1, funcRuns)
+	})
+
+	t.Run("lock is released when context is cancelled", func(t *testing.T) {
+		sl := createTestableServerLock(t)
+		operationUID := "test-operation-context-cancel-retries"
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		lockTimeConfig := LockTimeConfig{
+			MaxInterval: time.Hour,
+			MinWait:     0 * time.Millisecond,
+			MaxWait:     1 * time.Millisecond,
+		}
+
+		err := sl.LockExecuteAndReleaseWithRetries(ctx, operationUID, lockTimeConfig, func(ctx context.Context) {
+			cancel()
+		})
+		require.NoError(t, err)
+
+		err = sl.SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			lockRows := []*serverLock{}
+			err := sess.Where("operation_uid = ?", operationUID).Find(&lockRows)
+			require.NoError(t, err)
+			require.Equal(t, 0, len(lockRows), "Lock should be released even when context is cancelled")
+			return nil
+		})
+		require.NoError(t, err)
+	})
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Release the lock if context is cancelled before `releaseLock` is called.

**Why do we need this feature?**

Currently, if context is cancelled (server shutdown) before a lock has been released, other instances will need to wait for the lock TTL to expire.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
