### PR TITLE
ConnectStep: Provisioning connect step input error highlighted

### DIFF
--- a/public/app/features/provisioning/Wizard/ConnectStep.tsx
+++ b/public/app/features/provisioning/Wizard/ConnectStep.tsx
@@ -71,6 +71,7 @@ export const ConnectStep = memo(function ConnectStep() {
                   id="token"
                   placeholder={gitFields.tokenConfig.placeholder}
                   isConfigured={tokenConfigured}
+                  invalid={!!errors?.repository?.token?.message}
                   onReset={() => {
                     setValue('repository.token', '');
                     setTokenConfigured(false);


### PR DESCRIPTION
**What is this feature?**

In provisioning `ConnectStep`, highlight token input box when there's error. 

After:  
<img width="677" height="477" alt="image" src="https://github.com/user-attachments/assets/4f1c8a7c-9e82-451e-9560-413ddfbb9792" />. 

Before (input is not highlighted)

<img width="693" height="154" alt="image" src="https://github.com/user-attachments/assets/91f00470-daf5-4e33-98a2-6ba375e086e8" />



**Why do we need this feature?**

Better UX to alert user where has error

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
