### PR TITLE
Fix: Clean up SigV4 auth properties when changing auth method

### DIFF
--- a/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx
@@ -162,16 +162,28 @@ export const DataSourcehttpSettingsOverhaul = (props: Props) => {
             azureAuthSettings.setAzureAuthEnabled(options, method === azureAuthId);
           }
 
+          // Clean up auth-specific properties when switching auth methods
+          const updatedJsonData = {
+            ...options.jsonData,
+            azureCredentials: method === azureAuthId ? options.jsonData.azureCredentials : undefined,
+            sigV4Auth: method === sigV4Id,
+            oauthPassThru: method === AuthMethod.OAuthForward,
+          };
+
+          // Clean up SigV4-specific properties when not using SigV4 auth
+          if (method !== sigV4Id) {
+            // Remove common SigV4 properties from jsonData
+            delete updatedJsonData.sigV4Region;
+            delete updatedJsonData.sigV4Service;
+            delete updatedJsonData.sigV4AccessKey;
+            // Note: sigV4SecretKey would be in secureJsonData and is handled separately by the backend
+          }
+
           onOptionsChange({
             ...options,
             basicAuth: method === AuthMethod.BasicAuth,
             withCredentials: method === AuthMethod.CrossSiteCredentials,
-            jsonData: {
-              ...options.jsonData,
-              azureCredentials: method === azureAuthId ? options.jsonData.azureCredentials : undefined,
-              sigV4Auth: method === sigV4Id,
-              oauthPassThru: method === AuthMethod.OAuthForward,
-            },
+            jsonData: updatedJsonData,
           });
         }}
         // If your method is selected pass its id to `selectedMethod`,


### PR DESCRIPTION
# Fix: Clean up SigV4 auth properties when changing auth method

## Description
When changing authentication method in Prometheus data source from SigV4 to another method, the SigV4-specific properties were not being removed from the configuration. This caused issues where stale SigV4 configuration would persist.

This fix ensures that when switching away from SigV4 authentication, the related properties (sigV4Region, sigV4Service, sigV4AccessKey) are properly removed from the jsonData.

Fixes grafana/grafana-prometheus-datasource#122

## Technical Details
- Modified the `onAuthMethodSelect` function in [DataSourceHttpSettingsOverhaulPackage.tsx](cci:7://file:///e:/grafana/public/app/plugins/datasource/prometheus/configuration/DataSourceHttpSettingsOverhaulPackage.tsx:0:0-0:0)
- Added logic to clean up SigV4-specific properties from `jsonData` when switching to a different authentication method
- Maintained backward compatibility and existing functionality

## Checklist
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if applicable)
- [ ] PR title follows [conventional commits](https://www.conventionalcommits.org/)

## How to Test
1. Create a Prometheus data source
2. Configure it to use SigV4 authentication and fill in SigV4 properties
3. Switch to a different authentication method (e.g., Basic Auth)
4. Verify that SigV4-specific properties are properly removed from the configuration

This change addresses a data cleanup issue that could potentially cause confusion or unexpected behavior when switching between authentication methods in the Prometheus data source.