### PR TITLE
Stat/BarGauge: Border radius tweak

### DIFF
--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -195,7 +195,7 @@ export class BarGauge extends PureComponent<Props> {
       const currentValue = minValue + (valueRange / cellCount) * i;
       const cellColor = getCellColor(currentValue, value, display);
       const cellStyles: CSSProperties = {
-        borderRadius: theme.shape.radius.default,
+        borderRadius: '2px',
       };
 
       if (cellColor.isLit) {
@@ -525,7 +525,7 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
   };
 
   const barStyles: CSSProperties = {
-    borderRadius: theme.shape.radius.default,
+    borderRadius: theme.shape.radius.sm,
     position: 'relative',
   };
 
@@ -533,7 +533,7 @@ export function getBasicAndGradientStyles(props: Props): BasicAndGradientStyles 
     background: theme.colors.background.secondary,
     flexGrow: 1,
     display: 'flex',
-    borderRadius: theme.shape.radius.default,
+    borderRadius: theme.shape.radius.sm,
     position: 'relative',
   };
 

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -147,7 +147,6 @@ export class BarGauge extends PureComponent<Props> {
       lcdCellWidth,
       text,
       valueDisplayMode,
-      theme,
       isOverflow,
     } = this.props;
     const { valueHeight, valueWidth, maxBarHeight, maxBarWidth, wrapperWidth, wrapperHeight } =

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -198,7 +198,6 @@ export abstract class BigValueLayout {
       width: `${width}px`,
       height: `${height}px`,
       padding: `${textMode === BigValueTextMode.None ? 2 : this.panelPadding}px`,
-      borderRadius: theme.shape.radius.default,
       position: 'relative',
       display: 'flex',
     };


### PR DESCRIPTION
Extracting the viz fix from https://github.com/grafana/grafana/pull/112267 

Also fixes/update BarGauge.

For bar gauge cells I think sm (4px) was too much, 0px looked a bit too sharp, while 2px is just right

4px
<img width="563" height="269" alt="Screenshot 2025-10-17 at 09 16 08" src="https://github.com/user-attachments/assets/9dee985a-3267-4b21-87f2-ce2e3228b6cb" />

2px: (In current PR)
<img width="570" height="272" alt="Screenshot 2025-10-17 at 09 15 56" src="https://github.com/user-attachments/assets/c63f0451-a64d-4691-aa0c-054239d3102a" />

0px:
<img width="560" height="269" alt="Screenshot 2025-10-17 at 09 20 33" src="https://github.com/user-attachments/assets/0b396d24-a4dc-42ba-afbc-52fe377f36dc" />

To fix the panel bottom left / right border radius issue we need to add overflow hidden to either [VizRepeater](https://github.com/grafana/grafana/pull/112267) or PanelChrome, will let others decide on which is best 