### PR TITLE
datasources: allow underscore-prefixed local time range

### DIFF
--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -331,9 +331,12 @@ func (s *ServiceImpl) handleQuerySingleDatasource(ctx context.Context, user iden
 }
 
 func getTimeRange(query *simplejson.Json, globalFrom string, globalTo string) (string, string, error) {
-	tr, ok := query.CheckGet("timeRange")
-	if !ok { // timeRange json node does not exist, use global from/to
-		return globalFrom, globalTo, nil
+	tr, ok := query.CheckGet("_timeRange")
+	if !ok { // timeRange json node does not exist
+		tr, ok = query.CheckGet("timeRange") // try the old name for backward compatibility
+		if !ok {                             // timeRange json node does not exist, use global from/to
+			return globalFrom, globalTo, nil
+		}
 	}
 	from, err := tr.Get("from").String()
 	if err != nil {


### PR DESCRIPTION
(part of https://github.com/grafana/grafana-plugin-sdk-go/issues/1419)

when a data source request is sent to Grafana, it may contain multiple queries in it. in certain scenarios, we permit to have per-query time-ranges.
until now this was done using the `timeRange` json attribute name. but we realised some existing plugins have certain assumptions about that field, and that field should not exist in the JSON, to provide compatibility.
for this reason, we are adjusting it's name to `_timeRange`. we chose the underscore-prefix because it is often used to mark a field system/internal.

in this phase, we:
- read from both `_timeRange` and `timeRange`
- write `_timerange`

we do this to allow services that call us, to still function correctly, while they migrate to the new field-name.

NOTE: this should be merged only after Grafana's grafana-plugin-sdk-go includes https://github.com/grafana/grafana-plugin-sdk-go/pull/1420 .