### PR TITLE
Graphite: Update backend types

### DIFF
--- a/pkg/tsdb/graphite/types.go
+++ b/pkg/tsdb/graphite/types.go
@@ -21,13 +21,12 @@ type URLParams struct {
 }
 
 type GraphiteQuery struct {
-	QueryType       string   `json:"queryType"`
-	TextEditor      *bool    `json:"textEditor,omitempty"`
-	Target          string   `json:"target,omitempty"`
-	TargetFull      string   `json:"targetFull,omitempty"`
-	Tags            []string `json:"tags,omitempty"`
-	FromAnnotations *bool    `json:"fromAnnotations,omitempty"`
-	IsMetricTank    bool     `json:"isMetricTank,omitempty"`
+	QueryType       string `json:"queryType"`
+	TextEditor      *bool  `json:"textEditor,omitempty"`
+	Target          string `json:"target,omitempty"`
+	TargetFull      string `json:"targetFull,omitempty"`
+	FromAnnotations *bool  `json:"fromAnnotations,omitempty"`
+	IsMetricTank    bool   `json:"isMetricTank,omitempty"`
 }
 
 type GraphiteEventsRequest struct {


### PR DESCRIPTION
Tags are an unused field in the backend query path. Including them can cause unmarshalling errors and so the easiest solution is to ignore them.