### PR TITLE
Chore: Add logsdrilldown replace to apps/iam/go.mod

### DIFF
--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -24,6 +24,8 @@ replace github.com/grafana/grafana/apps/correlations => ../correlations
 
 replace github.com/grafana/grafana/apps/investigations => ../investigations
 
+replace github.com/grafana/grafana/apps/logsdrilldown => ../logsdrilldown
+
 replace github.com/grafana/grafana/apps/playlist => ../playlist
 
 replace github.com/grafana/grafana/apps/plugins => ../plugins


### PR DESCRIPTION
**What is this feature?**
`make update-workspace` currently fails in main. This fixes that.
