### PR TITLE
Saved Queries: Hide save button when user is not an editor

### DIFF
--- a/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.test.tsx
@@ -1,7 +1,6 @@
 import { screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
 
-import { OrgRole } from '@grafana/data';
 import { contextSrv } from 'app/core/core';
 
 import { QueryLibraryContextProviderMock } from '../QueryLibrary/mocks';
@@ -10,6 +9,7 @@ import { RichHistoryAddToLibrary } from './RichHistoryAddToLibrary';
 
 describe('RichHistoryAddToLibrary', () => {
   it('should render button when save query is enabled', () => {
+    contextSrv.isEditor = true;
     render(
       <QueryLibraryContextProviderMock queryLibraryEnabled={true}>
         <RichHistoryAddToLibrary query={{ refId: 'A' }} />
@@ -28,7 +28,7 @@ describe('RichHistoryAddToLibrary', () => {
     expect(screen.queryByRole('button', { name: /Save query/i })).not.toBeInTheDocument();
   });
   it('should not render button when user has Viewer role', () => {
-    contextSrv.user.orgRole = OrgRole.Viewer;
+    contextSrv.isEditor = false;
     render(
       <QueryLibraryContextProviderMock queryLibraryEnabled={true}>
         <RichHistoryAddToLibrary query={{ refId: 'A' }} />

--- a/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryAddToLibrary.tsx
@@ -31,7 +31,7 @@ export const RichHistoryAddToLibrary = ({ query }: Props) => {
 
   const buttonLabel = t('explore.rich-history-card.add-to-library', 'Save query');
 
-  if (contextSrv.hasRole('Viewer')) {
+  if (!contextSrv.isEditor) {
     return null;
   }
 


### PR DESCRIPTION
**What is this feature?**
We were using the role Viewer to render/hide the Save query button but there are other roles like none which we didn't take into account.
This PR changes how we evaluate when to render the button and uses the boolean contextSrv.isEditor instead.

**Which issue(s) does this PR fix?**:
[Related enterprise PR](https://github.com/grafana/grafana-enterprise/pull/9930)
Fixes https://github.com/grafana/support-escalations/issues/18979

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
