### PR TITLE
Plugins: Add pluginStoreServiceLoading feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1218,4 +1218,9 @@ export interface FeatureToggles {
   * @default true
   */
   preventPanelChromeOverflow?: boolean;
+  /**
+  * Load plugins during store service startup instead of wire provider
+  * @default false
+  */
+  pluginStoreServiceLoading?: boolean;
 }

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -549,7 +549,10 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	errorRegistry := pluginerrs.ProvideErrorTracker()
 	loaderLoader := loader.ProvideService(pluginManagementCfg, discovery, bootstrap, validate, initialize, terminate, errorRegistry)
-	pluginstoreService := pluginstore.ProvideService(inMemory, sourcesService, loaderLoader)
+	pluginstoreService, err := pluginstore.ProvideService(inMemory, sourcesService, loaderLoader, featureToggles)
+	if err != nil {
+		return nil, err
+	}
 	filestoreService := filestore.ProvideService(inMemory)
 	fileStoreManager := dashboards.ProvideFileStoreManager(pluginstoreService, filestoreService)
 	folderPermissionsService, err := ossaccesscontrol.ProvideFolderPermissions(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, folderimplService, acimplService, teamService, userService, actionSetService)
@@ -1155,7 +1158,10 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	errorRegistry := pluginerrs.ProvideErrorTracker()
 	loaderLoader := loader.ProvideService(pluginManagementCfg, discovery, bootstrap, validate, initialize, terminate, errorRegistry)
-	pluginstoreService := pluginstore.ProvideService(inMemory, sourcesService, loaderLoader)
+	pluginstoreService, err := pluginstore.ProvideService(inMemory, sourcesService, loaderLoader, featureToggles)
+	if err != nil {
+		return nil, err
+	}
 	filestoreService := filestore.ProvideService(inMemory)
 	fileStoreManager := dashboards.ProvideFileStoreManager(pluginstoreService, filestoreService)
 	folderPermissionsService, err := ossaccesscontrol.ProvideFolderPermissions(cfg, featureToggles, routeRegisterImpl, sqlStore, accessControl, ossLicensingService, folderimplService, acimplService, teamService, userService, actionSetService)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2111,6 +2111,14 @@ var (
 			Owner:        grafanaFrontendPlatformSquad,
 			Expression:   "true",
 		},
+		{
+			Name:         "pluginStoreServiceLoading",
+			Description:  "Load plugins during store service startup instead of wire provider",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: false,
+			Owner:        grafanaPluginsPlatformSquad,
+			Expression:   "false",
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -271,3 +271,4 @@ tempoSearchBackendMigration,GA,@grafana/oss-big-tent,false,true,false
 cdnPluginsLoadFirst,experimental,@grafana/plugins-platform-backend,false,false,false
 cdnPluginsUrls,experimental,@grafana/plugins-platform-backend,false,false,false
 preventPanelChromeOverflow,preview,@grafana/grafana-frontend-platform,false,false,true
+pluginStoreServiceLoading,experimental,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -1093,4 +1093,8 @@ const (
 	// FlagPreventPanelChromeOverflow
 	// Restrict PanelChrome contents with overflow: hidden;
 	FlagPreventPanelChromeOverflow = "preventPanelChromeOverflow"
+
+	// FlagPluginStoreServiceLoading
+	// Load plugins during store service startup instead of wire provider
+	FlagPluginStoreServiceLoading = "pluginStoreServiceLoading"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2938,6 +2938,19 @@
     },
     {
       "metadata": {
+        "name": "pluginStoreServiceLoading",
+        "resourceVersion": "1760712768362",
+        "creationTimestamp": "2025-10-17T14:52:48Z"
+      },
+      "spec": {
+        "description": "Load plugins during store service startup instead of wire provider",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "pluginsAutoUpdate",
         "resourceVersion": "1753448760331",
         "creationTimestamp": "2025-04-16T11:44:39Z"

--- a/pkg/services/pluginsintegration/pluginstore/store.go
+++ b/pkg/services/pluginsintegration/pluginstore/store.go
@@ -11,6 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/plugins/manager/loader"
 	"github.com/grafana/grafana/pkg/plugins/manager/registry"
 	"github.com/grafana/grafana/pkg/plugins/manager/sources"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -33,11 +34,36 @@ type Service struct {
 	pluginRegistry registry.Service
 	pluginLoader   loader.Service
 	pluginSources  sources.Registry
+	loadOnStartup  bool
 }
 
 func ProvideService(pluginRegistry registry.Service, pluginSources sources.Registry,
-	pluginLoader loader.Service) *Service {
-	return New(pluginRegistry, pluginLoader, pluginSources)
+	pluginLoader loader.Service, features featuremgmt.FeatureToggles) (*Service, error) {
+	if features.IsEnabledGlobally(featuremgmt.FlagPluginStoreServiceLoading) {
+		s := New(pluginRegistry, pluginLoader, pluginSources)
+		s.loadOnStartup = true
+		return s, nil
+	}
+
+	ctx := context.Background()
+	start := time.Now()
+	totalPlugins := 0
+	logger := log.New("plugin.store")
+	logger.Info("Loading plugins...")
+
+	for _, ps := range pluginSources.List(ctx) {
+		loadedPlugins, err := pluginLoader.Load(ctx, ps)
+		if err != nil {
+			logger.Error("Loading plugin source failed", "source", ps.PluginClass(ctx), "error", err)
+			return nil, err
+		}
+
+		totalPlugins += len(loadedPlugins)
+	}
+
+	logger.Info("Plugins loaded", "count", totalPlugins, "duration", time.Since(start))
+
+	return New(pluginRegistry, pluginLoader, pluginSources), nil
 }
 
 func (s *Service) Run(ctx context.Context) error {
@@ -50,6 +76,7 @@ func (s *Service) Run(ctx context.Context) error {
 
 func NewPluginStoreForTest(pluginRegistry registry.Service, pluginLoader loader.Service, pluginSources sources.Registry) (*Service, error) {
 	s := New(pluginRegistry, pluginLoader, pluginSources)
+	s.loadOnStartup = true
 	if err := s.StartAsync(context.Background()); err != nil {
 		return nil, err
 	}
@@ -70,6 +97,9 @@ func New(pluginRegistry registry.Service, pluginLoader loader.Service, pluginSou
 }
 
 func (s *Service) starting(ctx context.Context) error {
+	if !s.loadOnStartup {
+		return nil
+	}
 	start := time.Now()
 	totalPlugins := 0
 	logger := log.New(ServiceName)
@@ -85,7 +115,6 @@ func (s *Service) starting(ctx context.Context) error {
 	}
 
 	logger.Info("Plugins loaded", "count", totalPlugins, "duration", time.Since(start))
-
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This adds `pluginStoreServiceLoading` feature toggle to control if plugins load in store service startup, or in the wire provider.

**Why do we need this feature?**

This is a temporary fix for plugin role load order in enterprise.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
