### PR TITLE
Provisioning: Ensure name and email are always set for the AuthorSignature

### DIFF
--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -774,14 +774,8 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 		author.Time = time.Now()
 	}
 
-	// Author and committer are always the same
-	committer := nanogit.Committer{
-		Name:  author.Name,
-		Email: author.Email,
-		Time:  author.Time,
-	}
-
-	return author, committer
+	// Author and committer are always the same (for now)
+	return author, nanogit.Committer(author)
 }
 
 func (r *gitRepository) commit(ctx context.Context, writer nanogit.StagedWriter, comment string) error {

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -756,25 +756,29 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 		Email: "noreply@grafana.com",
 		Time:  time.Now(),
 	}
-	committer := nanogit.Committer{
-		Name:  "Grafana",
-		Email: "noreply@grafana.com",
-		Time:  time.Now(),
-	}
 
 	// Use signature from context if available
-	if sig := repository.GetAuthorSignature(ctx); sig != nil && sig.Name != "" {
-		author.Name = sig.Name
-		author.Email = sig.Email
-		author.Time = sig.When
-		committer.Name = sig.Name
-		committer.Email = sig.Email
-		committer.Time = sig.When
+	if sig := repository.GetAuthorSignature(ctx); sig != nil {
+		if sig.Name != "" {
+			author.Name = sig.Name
+		}
+		if sig.Email != "" {
+			author.Email = sig.Email
+		}
+		if !sig.When.IsZero() {
+			author.Time = sig.When
+		}
 	}
 
 	if author.Time.IsZero() {
 		author.Time = time.Now()
-		committer.Time = time.Now()
+	}
+
+	// Author and committer are always the same
+	committer := nanogit.Committer{
+		Name:  author.Name,
+		Email: author.Email,
+		Time:  author.Time,
 	}
 
 	return author, committer

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -346,25 +346,6 @@ func TestCreateSignature(t *testing.T) {
 		require.Equal(t, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), committer.Time)
 	})
 
-	t.Run("should fallback to default when context signature has empty name", func(t *testing.T) {
-		sig := repository.CommitSignature{
-			Name:  "",
-			Email: "john@example.com",
-			When:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
-		}
-		ctx := repository.WithAuthorSignature(context.Background(), sig)
-
-		author, committer := gitRepo.createSignature(ctx)
-
-		require.Equal(t, "Grafana", author.Name)
-		require.Equal(t, "noreply@grafana.com", author.Email)
-		require.False(t, author.Time.IsZero())
-
-		require.Equal(t, "Grafana", committer.Name)
-		require.Equal(t, "noreply@grafana.com", committer.Email)
-		require.False(t, committer.Time.IsZero())
-	})
-
 	t.Run("should use current time when signature time is zero", func(t *testing.T) {
 		sig := repository.CommitSignature{
 			Name:  "John Doe",
@@ -1787,23 +1768,22 @@ func TestGitRepository_createSignature(t *testing.T) {
 		require.Equal(t, time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC), committer.Time)
 	})
 
-	t.Run("should fallback to default when context signature has empty name", func(t *testing.T) {
+	t.Run("should fill in missing signature properties from default values", func(t *testing.T) {
 		sig := repository.CommitSignature{
 			Name:  "",
 			Email: "john@example.com",
-			When:  time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC),
 		}
 		ctx := repository.WithAuthorSignature(context.Background(), sig)
 
 		author, committer := gitRepo.createSignature(ctx)
 
-		require.Equal(t, "Grafana", author.Name)
-		require.Equal(t, "noreply@grafana.com", author.Email)
+		require.Equal(t, "Grafana", author.Name) // The default name
+		require.Equal(t, sig.Email, author.Email)
 		require.False(t, author.Time.IsZero())
 
 		require.Equal(t, "Grafana", committer.Name)
-		require.Equal(t, "noreply@grafana.com", committer.Email)
-		require.False(t, committer.Time.IsZero())
+		require.Equal(t, sig.Email, author.Email)
+		require.False(t, author.Time.IsZero())
 	})
 
 	t.Run("should use current time when signature time is zero", func(t *testing.T) {


### PR DESCRIPTION
Make sure the name+email are always set.  Previously something could have an name without an email.

Potential fix for: https://github.com/grafana/grafana/issues/106249