### PR TITLE
Grammar: wrap in try/catch in case regex creation fails

### DIFF
--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -52,21 +52,30 @@ export const generateLogGrammar = (log: LogListModel) => {
   };
 };
 
-export const generateTextMatchGrammar = (
-  highlightWords: string[] | undefined = [],
-  search: string | undefined
-): Grammar => {
+export const generateTextMatchGrammar = (highlightWords: string[] | undefined = [], search?: string): Grammar => {
   /**
    * See:
    * - https://github.com/grafana/grafana/blob/96f1582c36f94cf4ac7621b7af86bc9e2ad626fb/public/app/features/logs/components/LogRowMessage.tsx#L67
    * - https://github.com/grafana/grafana/blob/96f1582c36f94cf4ac7621b7af86bc9e2ad626fb/packages/grafana-data/src/text/text.ts#L12
    */
-  const expressions = highlightWords.map((word) => {
-    const { cleaned, flags } = parseFlags(cleanNeedle(word));
-    return new RegExp(`(?:${cleaned})`, flags);
-  });
+  const expressions = highlightWords
+    .map((word) => {
+      const { cleaned, flags } = parseFlags(cleanNeedle(word));
+      try {
+        return new RegExp(`(?:${cleaned})`, flags);
+      } catch (e) {
+        console.error(e);
+      }
+      return undefined;
+    })
+    .filter((expression) => expression !== undefined);
+
   if (search) {
-    expressions.push(new RegExp(escapeRegex(search), 'gi'));
+    try {
+      expressions.push(new RegExp(escapeRegex(search), 'gi'));
+    } catch (e) {
+      console.error(e);
+    }
   }
   if (!expressions.length) {
     return {};

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -64,7 +64,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
       try {
         return new RegExp(`(?:${cleaned})`, flags);
       } catch (e) {
-        console.error(e);
+        console.error(`generateTextMatchGrammar: cannot generate regular expression from /${cleaned}/${flags}`, e);
       }
       return undefined;
     })
@@ -74,7 +74,7 @@ export const generateTextMatchGrammar = (highlightWords: string[] | undefined = 
     try {
       expressions.push(new RegExp(escapeRegex(search), 'gi'));
     } catch (e) {
-      console.error(e);
+      console.error(`generateTextMatchGrammar: cannot generate regular expression from /${search}/gi`, e);
     }
   }
   if (!expressions.length) {


### PR DESCRIPTION
When a line filter is used in a Loki query, the data source returns the searched strings as "search words" to match. When a regular expression line filter is used, search words contain the used regular expression.

If, in the process of turning the re2 regular expression into a JS regular expression, the generated expression is not valid, it was throwing an error resulting in a visible exception for the user.

These changes wrap regular expression instantiation in a try/catch block to gracefully handle these situations.

Can be tested with OPS logs and a query like `{service_name="grafana-assistant"} |~ "(?i)(?P<filtered_log_level>TRACE|DEBUG|INFO|WARN|ERROR|OTHER)"`

Created https://github.com/grafana/grafana/issues/112596 to take a closer look at the regular expression parser.