### PR TITLE
Secrets: Try to get the service identity from the context if not found in errors

### DIFF
--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -43,13 +43,27 @@ func TestIntegrationDecrypt(t *testing.T) {
 		t.Cleanup(cancel)
 
 		// Create auth context with proper permissions
-		authCtx := createAuthContext(ctx, "default", []string{"secret.grafana.app/securevalues/group1:decrypt"}, "svc", types.TypeUser)
+		svcIdentity := "svc"
+		authCtx := createAuthContext(ctx, "default", []string{"secret.grafana.app/securevalues/group1:decrypt"}, svcIdentity, types.TypeUser)
+
+		fakeLogger := &mockLogger{}
+		loggerCtx := logging.Context(authCtx, fakeLogger)
 
 		sut := testutils.Setup(t)
 
-		exposed, err := sut.DecryptStorage.Decrypt(authCtx, "default", "non-existent-value")
+		exposed, err := sut.DecryptStorage.Decrypt(loggerCtx, "default", "non-existent-value")
 		require.Equal(t, err.Error(), contracts.ErrDecryptNotFound.Error()) // make sure we are stripping the error details
 		require.Empty(t, exposed)
+
+		require.Len(t, fakeLogger.InfoArgs, 2)
+		// we only want to check the audit log args
+		args := fakeLogger.InfoArgs[1]
+		require.Contains(t, args, "decrypter_identity")
+		for i, arg := range args {
+			if arg == "decrypter_identity" {
+				require.Equal(t, svcIdentity, args[i+1].(string))
+			}
+		}
 	})
 
 	t.Run("when happy path with valid auth and permissions, it returns decrypted value", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

If the `decrypterIdentity` is empty by the time we return the function, try to populate it with the auth from the context. Better debuggability.

**Why do we need this feature?**

Reduce cases where the identity is empty in error scenarios. 

**Who is this feature for?**

Operators.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
