### PR TITLE
Stat: Fix math for percent change value heights when sparkline is not rendered

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.test.tsx
@@ -100,6 +100,28 @@ describe('BigValueLayout', () => {
       );
       expect(layout).toBeInstanceOf(WideWithChartLayout);
     });
+
+    it.each([
+      ['wide layout', {}],
+      ['non-wide layout', { disableWideLayout: true }],
+    ])('should shrink the value if percent change is shown for %s', (_, propsOverride) => {
+      const baseProps: Partial<Props> = {
+        width: 300,
+        height: 100,
+        sparkline: undefined,
+        alignmentFactors: {
+          text: '1000',
+          title: '12',
+        },
+        ...propsOverride,
+      };
+      const layout = buildLayout(getProps(baseProps));
+      const layoutWithPercentChange = buildLayout(
+        getProps({ ...baseProps, value: { text: '25', numeric: 25, percentChange: 20 } })
+      );
+
+      expect(layoutWithPercentChange.valueFontSize).toBeLessThan(layout.valueFontSize);
+    });
   });
 
   describe('percentChangeColor', () => {

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -171,7 +171,7 @@ export abstract class BigValueLayout {
 
     return {
       containerStyles,
-      iconSize: iconSize,
+      iconSize,
     };
   }
 
@@ -295,11 +295,16 @@ export class WideNoChartLayout extends BigValueLayout {
     const valueWidthPercent = this.titleToAlignTo?.length ? 0.3 : 1.0;
 
     if (this.valueToAlignTo.length) {
+      let valueHeight = this.maxTextHeight;
+      if (props.value.percentChange != null) {
+        // percent change uses 40% of value height, so we want to scale the value font size accordingly
+        valueHeight = valueHeight * 0.75;
+      }
       // initial value size
       this.valueFontSize = calculateFontSize(
         this.valueToAlignTo,
         this.maxTextWidth * valueWidthPercent,
-        this.maxTextHeight,
+        valueHeight,
         LINE_HEIGHT,
         undefined,
         VALUE_FONT_WEIGHT
@@ -480,10 +485,15 @@ export class StackedWithNoChartLayout extends BigValueLayout {
     }
 
     if (this.valueToAlignTo.length) {
+      let valueHeight = this.maxTextHeight - titleHeight;
+      if (props.value.percentChange != null) {
+        // percent change uses 40% of value height, so we want to scale the value font size accordingly
+        valueHeight = valueHeight * 0.75;
+      }
       this.valueFontSize = calculateFontSize(
         this.valueToAlignTo,
         this.maxTextWidth,
-        this.maxTextHeight - titleHeight,
+        valueHeight,
         LINE_HEIGHT,
         undefined,
         VALUE_FONT_WEIGHT


### PR DESCRIPTION
Reported internally.

The main issue here was that the math to calculate the font height of each element in a `BigValue` is handled manually based on the props, but the calculation is not accounting for percentage change. For sparkline, the math works out fine because of the positioning, but when sparklines are off there is a high likelihood of the number of pixels exceeding the max height in the auto-height calculation.

### Before

https://github.com/user-attachments/assets/db545e8b-dc41-4c71-9511-3a578e312e69

### After


https://github.com/user-attachments/assets/d7b9a916-79ce-4073-937d-e5c8bc53bb22

