### PR TITLE
Frontend service: Update boot failure request to GET

### DIFF
--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -164,7 +164,9 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	})
 
 	// Frontend boot error reporting endpoint
-	s.routePost(m, "/-/fe-boot-error", s.handleBootError)
+	// GET because all POST requests are passed to the backend, even though POST is more correct. The frontend
+	// uses cache busting to ensure requests aren't cached.
+	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
 
 	// All other requests return index.html
 	s.routeGet(m, "/*", s.index.HandleRequest)

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -127,11 +127,6 @@ func (s *frontendService) routeGet(m *web.Mux, pattern string, h ...web.Handler)
 	m.Get(pattern, handlers...)
 }
 
-func (s *frontendService) routePost(m *web.Mux, pattern string, h ...web.Handler) {
-	handlers := append([]web.Handler{middleware.ProvideRouteOperationName(pattern)}, h...)
-	m.Post(pattern, handlers...)
-}
-
 // Apply the same middleware patterns as the main HTTP server
 func (s *frontendService) addMiddlewares(m *web.Mux) {
 	loggermiddleware := loggermw.Provide(s.cfg, s.features)

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -180,9 +180,6 @@
             // This "should" be a POST request, but we must use GET to interact with the correct service.
             // no-store and ?ts=_ are used to ensure the request isn't cached.
             method: 'GET',
-            headers: {
-              'Content-Type': 'application/json',
-            },
             cache: "no-store",
           }).catch(err => {
             console.error('Failed to report boot error to backend: ', err);

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -174,15 +174,16 @@
           document.querySelector('.fs-variant-loader').classList.add('fs-hidden');
           document.querySelector('.fs-variant-error').classList.remove('fs-hidden');
 
-          // Report the error to the backend
-          const errorMessage = err ? err.message : 'Unknown error';
-
-          fetch('/-/fe-boot-error', {
-            method: 'POST',
+          // not a secure random value, but collisions are highly unlikely and 1/1000_000_000 lost requests
+          // doesn't make a difference.
+          fetch(`/-/fe-boot-error?ts=${Date.now()}${Math.random()}`, {
+            // This "should" be a POST request, but we must use GET to interact with the correct service.
+            // no-store and ?ts=_ are used to ensure the request isn't cached.
+            method: 'GET',
             headers: {
               'Content-Type': 'application/json',
             },
-            body: errorMessage,
+            cache: "no-store",
           }).catch(err => {
             console.error('Failed to report boot error to backend: ', err);
           });


### PR DESCRIPTION
**What is this feature?**

Update's `/-/fe-boot-error` to expect a GET request, and frontend code to send a GET request

Includes notes in the code why it needs to be a GET request, even though semantically it should remain a POST.

**Why do we need this feature?**

The frontend service forwards all non-GET requests to the backend, but needs to handle this request.

**Who is this feature for?**

- Grafana devs

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-frontend-platform/issues/64

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
