### PR TITLE
Library Panels: Cancel in flight previous search requests

### DIFF
--- a/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.test.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.test.tsx
@@ -120,6 +120,7 @@ describe('LibraryPanelsSearch', () => {
             page: 0,
             typeFilter: [],
             perPage: 40,
+            signal: expect.any(AbortSignal),
           })
         );
       });
@@ -148,6 +149,7 @@ describe('LibraryPanelsSearch', () => {
             page: 0,
             typeFilter: [],
             perPage: 40,
+            signal: expect.any(AbortSignal),
           })
         );
       });
@@ -176,6 +178,7 @@ describe('LibraryPanelsSearch', () => {
             page: 0,
             typeFilter: ['graph', 'timeseries'],
             perPage: 40,
+            signal: expect.any(AbortSignal),
           })
         );
       });
@@ -234,6 +237,7 @@ describe('LibraryPanelsSearch', () => {
             page: 0,
             typeFilter: [],
             perPage: 40,
+            signal: expect.any(AbortSignal),
           });
         });
       });

--- a/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
+++ b/public/app/features/library-panels/components/LibraryPanelsView/actions.ts
@@ -7,7 +7,8 @@ import { deleteLibraryPanel as apiDeleteLibraryPanel, getLibraryPanels } from '.
 
 import { initialLibraryPanelsViewState, initSearch, searchCompleted } from './reducer';
 
-type DispatchResult = (dispatch: Dispatch<AnyAction>) => void;
+type SearchDispatchResult = (dispatch: Dispatch<AnyAction>, abortController?: AbortController) => void;
+
 interface SearchArgs {
   perPage: number;
   page: number;
@@ -18,10 +19,10 @@ interface SearchArgs {
   currentPanelId?: string;
 }
 
-export function searchForLibraryPanels(args: SearchArgs): DispatchResult {
+export function searchForLibraryPanels(args: SearchArgs): SearchDispatchResult {
   // Functions to support filtering out library panels per plugin type that have skipDataQuery set to true
 
-  return function (dispatch) {
+  return function (dispatch, abortController) {
     const subscription = new Subscription();
     const dataObservable = from(
       getLibraryPanels({
@@ -32,6 +33,7 @@ export function searchForLibraryPanels(args: SearchArgs): DispatchResult {
         sortDirection: args.sortDirection,
         typeFilter: args.panelFilter,
         folderFilterUIDs: args.folderFilterUIDs,
+        signal: abortController?.signal,
       })
     ).pipe(
       //filter out library panels per plugin type that have skipDataQuery set to true
@@ -43,7 +45,18 @@ export function searchForLibraryPanels(args: SearchArgs): DispatchResult {
         of(searchCompleted({ libraryPanels, page, perPage, totalCount }))
       ),
       catchError((err) => {
-        console.error(err);
+        // Check if this is an aborted request - if so, silently ignore it
+        const isAbortError =
+          err.name === 'AbortError' || err.cancelled === true || err.statusText === 'Request was aborted';
+
+        if (isAbortError) {
+          return of(); // Silently ignore aborted requests
+        }
+
+        // For real errors, log and show error to user
+        console.error('Error fetching library panels:', err);
+
+        // Update state to show empty results
         return of(searchCompleted({ ...initialLibraryPanelsViewState, page: args.page, perPage: args.perPage }));
       }),
       finalize(() => subscription.unsubscribe()), // make sure we unsubscribe
@@ -59,10 +72,11 @@ export function searchForLibraryPanels(args: SearchArgs): DispatchResult {
   };
 }
 
-export function deleteLibraryPanel(uid: string, args: SearchArgs): DispatchResult {
-  return async function (dispatch) {
+export function deleteLibraryPanel(uid: string, args: SearchArgs) {
+  return async function (dispatch: Dispatch<AnyAction>) {
     try {
       await apiDeleteLibraryPanel(uid);
+      // No need for abort controller - this is a one-time search after delete
       searchForLibraryPanels(args)(dispatch);
     } catch (e) {
       console.error(e);
@@ -71,10 +85,14 @@ export function deleteLibraryPanel(uid: string, args: SearchArgs): DispatchResul
 }
 
 export function asyncDispatcher(dispatch: Dispatch<AnyAction>) {
-  return function (action: AnyAction | DispatchResult) {
-    if (action instanceof Function) {
-      return action(dispatch);
+  return function (action: AnyAction | SearchDispatchResult | Function, abortController?: AbortController) {
+    if (!(action instanceof Function)) {
+      // Plain action
+      dispatch(action);
+      return;
     }
-    return dispatch(action);
+    // Function action - pass abort controller if provided (search with cancellation)
+    // or just dispatch (delete, or search without cancellation)
+    return action(dispatch, abortController);
   };
 }

--- a/public/app/features/library-panels/state/api.ts
+++ b/public/app/features/library-panels/state/api.ts
@@ -25,6 +25,7 @@ export interface GetLibraryPanelsOptions {
   sortDirection?: string;
   typeFilter?: string[];
   folderFilterUIDs?: string[];
+  signal?: AbortSignal;
 }
 
 export async function getLibraryPanels({
@@ -35,6 +36,7 @@ export async function getLibraryPanels({
   sortDirection = '',
   typeFilter = [],
   folderFilterUIDs = [],
+  signal,
 }: GetLibraryPanelsOptions = {}): Promise<LibraryElementsSearchResult> {
   const params = new URLSearchParams();
   params.append('searchString', searchString);
@@ -46,10 +48,15 @@ export async function getLibraryPanels({
   params.append('page', page.toString(10));
   params.append('kind', LibraryElementKind.Panel.toString(10));
 
-  const { result } = await getBackendSrv().get<{ result: LibraryElementsSearchResult }>(
-    `/api/library-elements?${params.toString()}`
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<{ result: LibraryElementsSearchResult }>({
+      method: 'GET',
+      url: `/api/library-elements?${params.toString()}`,
+      abortSignal: signal,
+      showErrorAlert: false,
+    })
   );
-  return result;
+  return response.data.result;
 }
 
 export async function getLibraryPanel(uid: string, isHandled = false): Promise<LibraryElementDTO> {


### PR DESCRIPTION
**What is this feature?**
Library panels search dispatch one request per input change with a debounce. 
If the request does not return quickly, N requests get executed in parallel, producing a "latest-wins” race condition from overlapping requests and in some cases rendering wrong results.
This PR cancels any in-flight requests when a new one starts.

**Previous behavior**

https://github.com/user-attachments/assets/555582d2-23ef-4a4b-a17f-554078348ded

**New behavior**

https://github.com/user-attachments/assets/8b98f0a5-36d6-4807-85f5-d11f01edc799


**Which issue(s) does this PR fix?**:
Fixes https://github.com/grafana/support-escalations/issues/19000

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
