### PR TITLE
UnitPicker/Cascader: Fixes type to search for unit feature

### DIFF
--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -211,11 +211,19 @@ class UnthemedCascader extends PureComponent<CascaderProps, CascaderState> {
     if (['ArrowDown', 'ArrowUp', 'Enter', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
       return;
     }
-    const { activeLabel } = this.state;
+
+    const selectionStart = e.currentTarget.selectionStart;
+    const selectionEnd = e.currentTarget.selectionEnd;
+    let inputValue = e.currentTarget.value;
+
+    if (selectionStart !== selectionEnd) {
+      inputValue = inputValue.substring(0, selectionStart ?? 0) + inputValue.substring(selectionEnd ?? 0);
+    }
+
     this.setState({
       focusCascade: false,
       isSearching: true,
-      inputValue: activeLabel,
+      inputValue: inputValue,
     });
   };
 
@@ -280,6 +288,9 @@ class UnthemedCascader extends PureComponent<CascaderProps, CascaderState> {
                 placeholder={placeholder}
                 onBlur={this.onBlurCascade}
                 value={activeLabel}
+                onFocus={(e) => {
+                  e.target.select();
+                }}
                 onKeyDown={this.onInputKeyDown}
                 onChange={() => {}}
                 suffix={

--- a/packages/grafana-ui/src/components/Cascader/Cascader.tsx
+++ b/packages/grafana-ui/src/components/Cascader/Cascader.tsx
@@ -289,7 +289,7 @@ class UnthemedCascader extends PureComponent<CascaderProps, CascaderState> {
                 onBlur={this.onBlurCascade}
                 value={activeLabel}
                 onFocus={(e) => {
-                  e.target.select();
+                  e.currentTarget.select();
                 }}
                 onKeyDown={this.onInputKeyDown}
                 onChange={() => {}}


### PR DESCRIPTION
Not being able to search for units without having to first hit backspace one character at a time has been super frustating. 

This does not revert the PR that introduced this problem but fixes it so that the cascader can still support easy changing of custom units but still allow just typing to start searching. 

It does this by selecting the current value, and if start typing with text selected that text will be removed (like standard inputs). This has always been the solution to this problem going back to Grafana v1 (in the old angular metric segment / dropdowns) 