### PR TITLE
Unistore: Propagate DeprecatedLegacyID on upsert

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -119,8 +119,13 @@ func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.Writ
 				}
 
 				// dashboard version is the RV in legacy storage
+				// and deprecatedInternalID must be set here (as SaveDashboard does below for non-provisioned dashboards)
 				if after != nil {
 					rv = int64(after.Version)
+					access := GetLegacyAccess(ctx)
+					if access != nil {
+						access.DashboardID = after.ID
+					}
 				}
 			} else {
 				failOnExisting := event.Type == resourcepb.WatchEvent_ADDED

--- a/pkg/registry/apis/dashboard/legacy/storage_test.go
+++ b/pkg/registry/apis/dashboard/legacy/storage_test.go
@@ -83,6 +83,7 @@ func TestWriteProvisioningEvent(t *testing.T) {
 	dashData := &dashboards.Dashboard{
 		Title:   "Test Dashboard",
 		Version: 2,
+		ID:      3,
 	}
 	dashBytes, err := json.Marshal(dashData)
 	require.NoError(t, err)
@@ -125,8 +126,12 @@ func TestWriteProvisioningEvent(t *testing.T) {
 	}
 
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{})
+	ctx = WithLegacyAccess(ctx)
 	rv, err := access.WriteEvent(ctx, event)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), rv)
+	a := GetLegacyAccess(ctx)
+	require.NotNil(t, a)
+	require.Equal(t, int64(3), a.DashboardID)
 	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes two bugs:
1. `Upsert` in the dual writer does not propagate the annotation and labels returned by legacy. This means that the deprecatedInternalID set by legacy is not used in unified storage (so the internal IDs are mismatching on upsert).
2. Newly created dashboards via the classic file based provisioning were not returning their deprecated internal IDs after being created, as we do for regular dashboards [here](https://github.com/grafana/grafana/blob/main/pkg/registry/apis/dashboard/legacy/sql_dashboards.go#L543). Which means after the above was fixed, it still was broken on provisioned dashboards

This PR fixes both of those bugs, so that the deprecated internal ID will match on upsert (including for provisioned dashboards). 

**Why do we need this feature?**

The internal IDs need to match

Fixes https://github.com/grafana/support-escalations/issues/18980
