### PR TITLE
Alerting: Add warning when datasource query is set as alert condition

### DIFF
--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2201,6 +2201,10 @@
       "max-data-points": "MD = {{maxDataPoints}}",
       "min-interval": "Min. Interval = {{minInterval}}"
     },
+    "query-wrapper": {
+      "warning-body": "This query will trigger an alert when it returns any non-zero value. Consider using an expression below for more precise alert control.",
+      "warning-title": "Data source query set as alert condition"
+    },
     "queryAndExpressionsStep": {
       "disableAdvancedOptions": {
         "text": "The selected queries and expressions cannot be converted to default. If you deactivate advanced options, your query and condition will be reset to default settings."


### PR DESCRIPTION
**What is this feature?**

Adds a warning message when users accidentally set a datasource query as the alert condition instead of using an available expression (Threshold or Classic Condition).


**Why do we need this feature?**

Based on a real production incident, we discovered that users can easily miss setting expressions as alert conditions. When a datasource query is directly used as the condition, alerts trigger on **any non-zero value** rather than based on meaningful thresholds.

### Real-world scenario:
```
Query A: sum(debezium_metrics_Connected{name!~".*backup.*"}) → returns 20
Expression B: A < 20 (Threshold)
User accidentally sets: A as alert condition ❌

Result: Alert fires when value = 20, resolves when value = 0, 
        causing continuous firing/resolve cycles
```

**Who is this feature for?**

- **Prevent mistakes**: Catch the error immediately when setting the condition
- **Self-service**: Understand why datasource queries shouldn't be used directly
- **Learn best practices**: Discover that expressions provide better control

### What are the specific use cases?

#### Use Case 1: Preventing unintended alert behavior
When creating alert rules with both datasource queries and expressions, users might accidentally click "Set as alert condition" on the wrong query. The warning appears immediately to guide them.

#### Use Case 2: Educational guidance
New users learning Grafana alerting will see contextual help explaining:
- Why datasource queries trigger on non-zero values
- How to use expressions for threshold-based alerting

#### Use Case 3: Reducing operational incidents
Prevents production issues like:
- Alerts firing/resolving repeatedly
- Alert fatigue from false positives
- Time wasted debugging alert configurations

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
