### PR TITLE
Dynamic dashboards: Make sure tab is selected when creating a new tab inside a row

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManagerRenderer.tsx
@@ -67,6 +67,7 @@ export function RowLayoutManagerRenderer({ model }: SceneComponentProps<RowsLayo
                   variant="primary"
                   fill="text"
                   onClick={() => model.addNewRow()}
+                  onPointerUp={(evt) => evt.stopPropagation()}
                   data-testid={selectors.components.CanvasGridAddActions.addRow}
                 >
                   <Trans i18nKey="dashboard.canvas-actions.new-row">New row</Trans>
@@ -77,6 +78,7 @@ export function RowLayoutManagerRenderer({ model }: SceneComponentProps<RowsLayo
                     variant="primary"
                     fill="text"
                     onClick={() => model.pasteRow()}
+                    onPointerUp={(evt) => evt.stopPropagation()}
                     data-testid={selectors.components.CanvasGridAddActions.pasteRow}
                   >
                     <Trans i18nKey="dashboard.canvas-actions.paste-row">Paste row</Trans>

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManagerRenderer.tsx
@@ -77,6 +77,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
                   variant="primary"
                   fill="text"
                   onClick={() => model.addNewTab()}
+                  onPointerUp={(evt) => evt.stopPropagation()}
                   data-testid={selectors.components.CanvasGridAddActions.addTab}
                 >
                   <Trans i18nKey="dashboard.canvas-actions.new-tab">New tab</Trans>
@@ -87,6 +88,7 @@ export function TabsLayoutManagerRenderer({ model }: SceneComponentProps<TabsLay
                     variant="primary"
                     fill="text"
                     onClick={() => model.pasteTab()}
+                    onPointerUp={(evt) => evt.stopPropagation()}
                     data-testid={selectors.components.CanvasGridAddActions.pasteTab}
                   >
                     <Trans i18nKey="dashboard.canvas-actions.paste-tab">Paste tab</Trans>


### PR DESCRIPTION
**What is this feature?**

Stops the propagation of the onPointerUp event on the buttons since it's causing the layout to be selected not the newly created row or tab.

Fixes: https://github.com/grafana/grafana-org/issues/681