### PR TITLE
LogLineContext: add copy link to log line support

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -786,6 +786,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           logOptionsStorageKey={SETTING_KEY_ROOT}
           timeZone={timeZone}
           displayedFields={displayedFields}
+          onPermalinkClick={onPermalinkClick}
           onClickShowField={showField}
           onClickHideField={hideField}
         />

--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -75,7 +75,7 @@ export const InfiniteScroll = ({
   const styles = useStyles2(getStyles, virtualization);
   const resetStateTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scrollToLogLineRef = useRef<LogListModel | undefined>(undefined);
-  const noScrollRef = useRef(false);
+  const noScrollRef = useRef<undefined | boolean>(undefined);
 
   useEffect(() => {
     // Logs have not changed, ignore effect
@@ -144,7 +144,13 @@ export const InfiniteScroll = ({
     }
 
     function handleScroll(event: Event | WheelEvent) {
-      if (!scrollElement || !loadMore || !logs.length) {
+      if (
+        !scrollElement ||
+        !loadMore ||
+        !logs.length ||
+        noScrollRef.current === undefined ||
+        noScrollRef.current === true
+      ) {
         return;
       }
       const scrollDirection = shouldLoadMore(event, lastEvent.current, countRef, scrollElement, lastScroll.current);

--- a/public/app/features/logs/components/panel/LogLineContext.tsx
+++ b/public/app/features/logs/components/panel/LogLineContext.tsx
@@ -36,6 +36,7 @@ import { ScrollDirection } from '../InfiniteScroll';
 import { LoadingIndicator } from '../LoadingIndicator';
 
 import { LogLineDetailsLog } from './LogLineDetailsLog';
+import { LogLineMenuCustomItem } from './LogLineMenu';
 import { LogList } from './LogList';
 import { LogListModel } from './processing';
 import { ScrollToLogsEvent } from './virtualization';
@@ -56,6 +57,8 @@ interface LogLineContextProps {
   runContextQuery?: () => void;
   getLogRowContextUi?: DataSourceWithLogsContextSupport['getLogRowContextUi'];
   displayedFields?: string[];
+  logLineMenuCustomItems?: LogLineMenuCustomItem[];
+  onPermalinkClick?: (row: LogRowModel) => Promise<void>;
   onClickShowField?: (key: string) => void;
   onClickHideField?: (key: string) => void;
 }
@@ -77,6 +80,8 @@ export const LogLineContext = memo(
     onClose,
     getRowContext,
     displayedFields = [],
+    logLineMenuCustomItems,
+    onPermalinkClick,
     onClickShowField,
     onClickHideField,
   }: LogLineContextProps) => {
@@ -391,9 +396,11 @@ export const LogLineContext = memo(
                 eventBus={eventBusRef.current}
                 infiniteScrollMode="unlimited"
                 loadMore={handleLoadMore}
+                logLineMenuCustomItems={logLineMenuCustomItems}
                 logs={allLogs}
                 loading={aboveState === LoadingState.Loading || belowState === LoadingState.Loading}
                 permalinkedLogId={log.uid}
+                onPermalinkClick={onPermalinkClick}
                 onClickHideField={onClickHideField}
                 onClickShowField={onClickShowField}
                 showControls

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -562,9 +562,7 @@ export const LogsPanel = ({
           getRowContext={(row, options) => getLogRowContext(row, contextRow, options)}
           getLogRowContextUi={getLogRowContextUi}
           logOptionsStorageKey={controlsStorageKey}
-          logLineMenuCustomItems={
-            isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined
-          }
+          logLineMenuCustomItems={isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined}
           timeZone={timeZone}
           displayedFields={displayedFields}
           onPermalinkClick={showPermaLink() ? onPermalinkClick : undefined}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -562,8 +562,12 @@ export const LogsPanel = ({
           getRowContext={(row, options) => getLogRowContext(row, contextRow, options)}
           getLogRowContextUi={getLogRowContextUi}
           logOptionsStorageKey={controlsStorageKey}
+          logLineMenuCustomItems={
+            isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined
+          }
           timeZone={timeZone}
           displayedFields={displayedFields}
+          onPermalinkClick={showPermaLink() ? onPermalinkClick : undefined}
           onClickShowField={showField}
           onClickHideField={hideField}
         />


### PR DESCRIPTION
Integrating "copy link to log line" into the new Log Context implementation.

Additionally, added an extra check to InfiniteScrolling to prevent infinite scroll requests with no scroll in Log Context. To reproduce, use a sparse logs source and pick small context window times, such as 100ms. Infinite scrolling should not be triggered without having a scroll in the list.

Part of #112372

From Drilldown Logs, and from Explore, the "copy link to log line" option should be visible from Log Context.