### PR TITLE
Provisioning: discontinue use of service identity based background tasks when onlyApiServer is true

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -648,11 +648,6 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				return err
 			}
 
-			// Informer with resync interval used for health check and reconciliation
-			sharedInformerFactory := informers.NewSharedInformerFactory(c, 60*time.Second)
-			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()
-			jobInformer := sharedInformerFactory.Provisioning().V0alpha1().Jobs()
-
 			b.client = c.ProvisioningV0alpha1()
 
 			// Initialize the API client-based job store
@@ -669,6 +664,10 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				return nil
 			}
 
+			// Informer with resync interval used for health check and reconciliation
+			sharedInformerFactory := informers.NewSharedInformerFactory(c, 60*time.Second)
+			repoInformer := sharedInformerFactory.Provisioning().V0alpha1().Repositories()
+			jobInformer := sharedInformerFactory.Provisioning().V0alpha1().Jobs()
 			go repoInformer.Informer().Run(postStartHookCtx.Done())
 			go jobInformer.Informer().Run(postStartHookCtx.Done())
 

--- a/pkg/services/apiserver/restconfig.go
+++ b/pkg/services/apiserver/restconfig.go
@@ -11,6 +11,9 @@ import (
 )
 
 type RestConfigProvider interface {
+	// GetRestConfig returns a k8s client configuration that is used to provide connection info and auth for the loopback transport.
+	// context is only available for tracing in this immediate function and is not to be confused with the context seen by any client verb actions that are invoked with the retrieved rest config.
+	// - those client verb actions have the ability to specify their own context.
 	GetRestConfig(context.Context) (*clientrest.Config, error)
 }
 
@@ -50,6 +53,7 @@ var (
 // eventualRestConfigProvider is a RestConfigProvider that will not return a rest config until the ready channel is closed.
 // This exists to alleviate a circular dependency between the apiserver.server's dependencies and their dependencies wanting a rest config.
 // Importantly, this is handled by wire as opposed to a mutable global.
+// NOTE: this implementation's GetRestConfig can't be used in (wire-based) Provide functions, or a function called by Provide functions. TODO: determine why that is. @charandas: in one such attempt, the GetRestConfig waits forever and Grafana doesn't start.
 type eventualRestConfigProvider struct {
 	// When this channel is closed, we can start returning the rest config.
 	ready chan struct{}

--- a/pkg/services/live/features/watch.go
+++ b/pkg/services/live/features/watch.go
@@ -87,8 +87,9 @@ func (b *WatchRunner) OnSubscribe(ctx context.Context, u identity.Requester, e m
 			fmt.Errorf("watching provisioned resources is OK allowed (for now)")
 	}
 
-	requester := types.WithAuthInfo(context.Background(), u)
-	cfg, err := b.configProvider.GetRestConfig(requester)
+	ctx = types.WithAuthInfo(context.Background(), u)
+	ctx = identity.WithRequester(ctx, u)
+	cfg, err := b.configProvider.GetRestConfig(ctx)
 	if err != nil {
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusNotFound, err
 	}
@@ -102,7 +103,7 @@ func (b *WatchRunner) OnSubscribe(ctx context.Context, u identity.Requester, e m
 	if len(name) > 1 {
 		opts.FieldSelector = "metadata.name=" + name
 	}
-	watch, err := client.Watch(requester, opts)
+	watch, err := client.Watch(ctx, opts)
 	if err != nil {
 		return model.SubscribeReply{}, backend.SubscribeStreamStatusNotFound, err
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR is to make provisioning aggregation ready, which requires the two following things:

* Skip informers initialization when `disable_controllers` is set to true.
* Fix a bug in Grafana Live watch implementation where the requester wasn't properly being hydrated before calling Watch on the APIServer

**Why do we need this feature?**

To avoid hitting the APIs unnecessarily when controllers are disabled. This was simply a mistake in the original implementation of the `disable_controllers` flag.

To propagate the true identity of requester, especially when the API is running remotely.

**Who is this feature for?**

Users of Git Sync in Cloud.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates to <https://github.com/grafana/git-ui-sync-project/issues/614>

**Special notes for your reviewer:**

Please check that:

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
