### PR TITLE
Chore: Use go-version-file again instead of an explicit version

### DIFF
--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -48,10 +48,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5.5.0
         with:
-          # Explicitly set Go version to 1.24.1 to ensure consistent OpenAPI spec generation
-          # The crypto/x509 package has additional fields in Go 1.24.1 that affect the generated specs
-          # This ensures the GHAs environment matches what we use in the Drone pipeline
-          go-version: 1.24.1
+          go-version-file: go.mod
           cache: true
 
       - name: Verify code generation

--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@v6.0.0
         with:
           go-version-file: go.mod
           cache: true


### PR DESCRIPTION
Had to change setup-go to trigger the workflow, seems to work