### PR TITLE
Plugins: Update docs with note for unix install ownership behaviour

### DIFF
--- a/docs/sources/administration/cli.md
+++ b/docs/sources/administration/cli.md
@@ -37,6 +37,8 @@ For example, on Linux `/usr/share/grafana/bin/grafana` and on Windows `C:\Progra
 {{< admonition type="note" >}}
 Some commands, such as installing or removing plugins, require `sudo` on Linux.
 If you're on Windows, run Windows PowerShell as Administrator.
+
+On Unix-like systems, when a plugin is installed, its directory inherits ownership from the plugins directory where it's being installed. This ensures proper file permissions are maintained.
 {{< /admonition >}}
 
 ## Grafana CLI command syntax
@@ -174,6 +176,10 @@ grafana cli plugins list-remote
 ```bash
 grafana cli plugins install <plugin-id>
 ```
+
+{{< admonition type="note" >}}
+On Unix-like systems (Linux, macOS), when a plugin is installed, its directory inherits ownership from the plugins directory where it's being installed. This ensures the plugin files have the correct permissions to run properly.
+{{< /admonition >}}
 
 ### Install a specific version of a plugin
 

--- a/docs/sources/administration/plugin-management/plugin-install.md
+++ b/docs/sources/administration/plugin-management/plugin-install.md
@@ -25,7 +25,11 @@ Besides the UI, you can use alternative methods to install a plugin depending on
 
 ## Install a plugin using Grafana CLI
 
-The Grafana CLI allows you to install, upgrade, and manage your Grafana plugins using a command line tool. For more information about Grafana CLI plugin commands, refer to [Plugin commands](/docs/grafana/<GRAFANA_VERSION>/cli/#plugins-commands).
+The Grafana CLI allows you to install, upgrade, and manage your Grafana plugins using a command line tool.
+
+On Unix-like systems, when a plugin is installed, its directory inherits ownership from the plugins directory where it's being installed, ensuring proper file permissions.
+
+For more information about Grafana CLI plugin commands, refer to [Plugin commands](/docs/grafana/<GRAFANA_VERSION>/cli/#plugins-commands).
 
 ## Install a plugin from a ZIP file
 


### PR DESCRIPTION
**What is this feature?**

Updates grafana cli plugin install docs to highlight file ownership logic updates

**Why do we need this feature?**

https://github.com/grafana/grafana/pull/109968

**Special notes for your reviewer:**


