### PR TITLE
Chore: Add more metrics to annotation service to see its usage

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -600,7 +600,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	deleteExpiredService := image.ProvideDeleteExpiredService(dBstore)
 	tempuserService := tempuserimpl.ProvideService(sqlStore, cfg)
-	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg)
+	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg, registerer)
 	secretsKVStore, err := kvstore2.ProvideService(sqlStore, secretsService)
 	if err != nil {
 		return nil, err
@@ -1205,7 +1205,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	deleteExpiredService := image.ProvideDeleteExpiredService(dBstore)
 	tempuserService := tempuserimpl.ProvideService(sqlStore, cfg)
-	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg)
+	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg, registerer)
 	secretsKVStore, err := kvstore2.ProvideService(sqlStore, secretsService)
 	if err != nil {
 		return nil, err

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -600,7 +600,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	}
 	deleteExpiredService := image.ProvideDeleteExpiredService(dBstore)
 	tempuserService := tempuserimpl.ProvideService(sqlStore, cfg)
-	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg, registerer)
+	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg)
 	secretsKVStore, err := kvstore2.ProvideService(sqlStore, secretsService)
 	if err != nil {
 		return nil, err
@@ -1205,7 +1205,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	}
 	deleteExpiredService := image.ProvideDeleteExpiredService(dBstore)
 	tempuserService := tempuserimpl.ProvideService(sqlStore, cfg)
-	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg, registerer)
+	cleanupServiceImpl := annotationsimpl.ProvideCleanupService(sqlStore, cfg)
 	secretsKVStore, err := kvstore2.ProvideService(sqlStore, secretsService)
 	if err != nil {
 		return nil, err

--- a/pkg/services/annotations/annotationsimpl/annotations.go
+++ b/pkg/services/annotations/annotationsimpl/annotations.go
@@ -40,7 +40,7 @@ func ProvideService(
 	l := log.New("annotations")
 	l.Debug("Initializing annotations service")
 
-	xormStore := NewXormStore(cfg, log.New("annotations.sql"), db, tagService)
+	xormStore := NewXormStore(cfg, log.New("annotations.sql"), db, tagService, reg)
 	write := xormStore
 
 	var read readStore

--- a/pkg/services/annotations/annotationsimpl/cleanup.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // CleanupServiceImpl is responsible for cleaning old annotations.
@@ -13,9 +14,9 @@ type CleanupServiceImpl struct {
 	store store
 }
 
-func ProvideCleanupService(db db.DB, cfg *setting.Cfg) *CleanupServiceImpl {
+func ProvideCleanupService(db db.DB, cfg *setting.Cfg, registerer prometheus.Registerer) *CleanupServiceImpl {
 	return &CleanupServiceImpl{
-		store: NewXormStore(cfg, log.New("annotations"), db, nil),
+		store: NewXormStore(cfg, log.New("annotations"), db, nil, registerer),
 	}
 }
 

--- a/pkg/services/annotations/annotationsimpl/cleanup.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup.go
@@ -6,7 +6,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // CleanupServiceImpl is responsible for cleaning old annotations.
@@ -14,9 +13,9 @@ type CleanupServiceImpl struct {
 	store store
 }
 
-func ProvideCleanupService(db db.DB, cfg *setting.Cfg, registerer prometheus.Registerer) *CleanupServiceImpl {
+func ProvideCleanupService(db db.DB, cfg *setting.Cfg) *CleanupServiceImpl {
 	return &CleanupServiceImpl{
-		store: NewXormStore(cfg, log.New("annotations"), db, nil, registerer),
+		store: NewXormStore(cfg, log.New("annotations"), db, nil, nil),
 	}
 }
 

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -129,7 +129,7 @@ func TestIntegrationAnnotationCleanUp(t *testing.T) {
 
 			cfg := setting.NewCfg()
 			cfg.AnnotationCleanupJobBatchSize = int64(test.annotationCleanupJobBatchSize)
-			cleaner := ProvideCleanupService(fakeSQL, cfg)
+			cleaner := ProvideCleanupService(fakeSQL, cfg, prometheus.NewRegistry())
 			affectedAnnotations, affectedAnnotationTags, err := cleaner.Run(context.Background(), test.cfg)
 			require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -185,7 +186,7 @@ func TestIntegrationOldAnnotationsAreDeletedFirst(t *testing.T) {
 		// run the clean up task to keep one annotation.
 		cfg := setting.NewCfg()
 		cfg.AnnotationCleanupJobBatchSize = 1
-		cleaner := NewXormStore(cfg, log.New("annotation.test"), fakeSQL, nil)
+		cleaner := NewXormStore(cfg, log.New("annotation.test"), fakeSQL, nil, prometheus.NewRegistry())
 		_, err = cleaner.CleanAnnotations(context.Background(), setting.AnnotationCleanupSettings{MaxCount: 1}, alertAnnotationType)
 		require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsimpl/cleanup_test.go
+++ b/pkg/services/annotations/annotationsimpl/cleanup_test.go
@@ -129,7 +129,7 @@ func TestIntegrationAnnotationCleanUp(t *testing.T) {
 
 			cfg := setting.NewCfg()
 			cfg.AnnotationCleanupJobBatchSize = int64(test.annotationCleanupJobBatchSize)
-			cleaner := ProvideCleanupService(fakeSQL, cfg, prometheus.NewRegistry())
+			cleaner := ProvideCleanupService(fakeSQL, cfg)
 			affectedAnnotations, affectedAnnotationTags, err := cleaner.Run(context.Background(), test.cfg)
 			require.NoError(t, err)
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -56,12 +56,15 @@ func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Servi
 		l.Error("failed to populate dashboard_uid for annotations", "error", err)
 	}
 
-	return &xormRepositoryImpl{
+	repo := &xormRepositoryImpl{
 		cfg:        cfg,
 		db:         db,
 		log:        l,
 		tagService: tagService,
-		queryRangeStart: promauto.With(reg).NewHistogramVec(
+	}
+
+	if reg != nil {
+		repo.queryRangeStart = promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "grafana",
 				Subsystem: "annotations",
@@ -70,8 +73,8 @@ func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Servi
 				Buckets:   []float64{1, 6, 12, 24, 48, 168, 336, 720, 2160, 4320, 8760},
 			},
 			[]string{"query_type"},
-		),
-		queryRangeDuration: promauto.With(reg).NewHistogramVec(
+		)
+		repo.queryRangeDuration = promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "grafana",
 				Subsystem: "annotations",
@@ -80,8 +83,8 @@ func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Servi
 				Buckets:   []float64{0.25, 1, 6, 12, 24, 48, 168, 336, 720, 2160},
 			},
 			[]string{"query_type"},
-		),
-		queryResultsCount: promauto.With(reg).NewHistogramVec(
+		)
+		repo.queryResultsCount = promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "grafana",
 				Subsystem: "annotations",
@@ -90,8 +93,9 @@ func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Servi
 				Buckets:   []float64{0, 1, 10, 50, 100, 500, 1000, 5000, 10000, 50000},
 			},
 			[]string{"query_type"},
-		),
+		)
 	}
+	return repo
 }
 
 func (r *xormRepositoryImpl) Type() string {

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -292,6 +292,7 @@ func tagSet[T any](fn func(T) int64, list []T) map[int64]struct{} {
 	return set
 }
 
+//nolint:gocyclo
 func (r *xormRepositoryImpl) Get(ctx context.Context, query annotations.ItemQuery, accessResources *accesscontrol.AccessResources) ([]*annotations.ItemDTO, error) {
 	var sql bytes.Buffer
 	params := make([]interface{}, 0)

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -439,7 +439,7 @@ func (r *xormRepositoryImpl) Get(ctx context.Context, query annotations.ItemQuer
 		}
 
 		if query.From > 0 && query.To > 0 {
-			startOffsetHours := float64(now-query.To) / (1000.0 * 3600.0)
+			startOffsetHours := float64(time.Duration(now-query.To)*time.Millisecond / time.Hour)
 			if startOffsetHours < 0 {
 				startOffsetHours = 0
 			}

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -39,7 +40,7 @@ func TestIntegrationAnnotations(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.AnnotationMaximumTagsLength = 60
 
-	store := NewXormStore(cfg, log.New("annotation.test"), sql, tagimpl.ProvideService(sql))
+	store := NewXormStore(cfg, log.New("annotation.test"), sql, tagimpl.ProvideService(sql), prometheus.NewRegistry())
 
 	testUser := &user.SignedInUser{
 		OrgID: 1,


### PR DESCRIPTION
This introduces some extra logs and 3 new metrics to understand better how annotations are used to pick the right storage interface and implementations.

These metrics are useful to understand how annotations are typically queried, to design the new API + storage better.

Somehow the linter got triggered on the code unrelated to the PR, so I'm disabling it for now.