### PR TITLE
[release-12.1.3] CI: Remove OIDC debug step from npm publish

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -123,11 +123,6 @@ jobs:
       - name: Validate packages
         run: ./scripts/validate-npm-packages.sh
 
-      - name: Debug OIDC Claims
-        uses: github/actions-oidc-debugger@2e9ba5d3f4bebaad1f91a2cede055115738b7ae8
-        with:
-          audience: '${{ github.server_url }}/${{ github.repository_owner }}'
-
       - name: Publish packages
         env:
           NPM_TAG: ${{ steps.npm-tag.outputs.NPM_TAG }}


### PR DESCRIPTION
Backport b0acfd1189f8f63a19c1d746829b7fd8f63383da from #112631

---

Removes the OIDC debug step from the NPM publish workflow as its no longer needed, and its currently failing
