### PR TITLE
Dashboards: Set limit to default if negative; document functionality

### DIFF
--- a/docs/sources/developers/http_api/dashboard_versions.md
+++ b/docs/sources/developers/http_api/dashboard_versions.md
@@ -24,7 +24,7 @@ title: 'Dashboard Versions HTTP API '
 
 Query parameters:
 
-- **limit** - Maximum number of results to return
+- **limit** - Maximum number of results to return. Defaults to 1000 if not set, or if an invalid value is passed in.
 - **start** - Version to start from when returning queries
 
 `GET /api/dashboards/uid/:uid/versions`

--- a/docs/sources/developers/http_api/snapshot.md
+++ b/docs/sources/developers/http_api/snapshot.md
@@ -99,7 +99,7 @@ Keys:
 Query parameters:
 
 - **query** – Search Query
-- **limit** – Limit the number of returned results
+- **limit** – Limit the number of returned results. Default is 1000 is not set or provided an invalid value.
 
 **Example Request**:
 

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -266,7 +266,7 @@ func (hs *HTTPServer) SearchDashboardSnapshots(c *contextmodel.ReqContext) respo
 	query := c.Query("query")
 	limit := c.QueryInt("limit")
 
-	if limit == 0 {
+	if limit <= 0 {
 		limit = 1000
 	}
 

--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -129,7 +129,7 @@ func (s *Service) List(
 		query.DashboardUID = u
 	}
 
-	if query.Limit == 0 {
+	if query.Limit <= 0 {
 		query.Limit = 1000
 	}
 


### PR DESCRIPTION
This PR documents the behavior of the limit parameter in the dashboard version & dashboard snapshot endpoints, where the limit is set to 1000 if not provided _or_ if an invalid value is provided. It also updates the code to use the default if a negative number is passed in now

Fixes https://github.com/grafana/support-escalations/issues/18957