### PR TITLE
Authz: Fix issue with permission tab infinite reload

### DIFF
--- a/public/app/core/components/AccessControl/Permissions.tsx
+++ b/public/app/core/components/AccessControl/Permissions.tsx
@@ -68,7 +68,8 @@ export const Permissions = ({
       setDesc(r);
       return fetchPermissions();
     });
-  }, [resource, fetchPermissions]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchPermissions changes on every render due to parent component re-renders
+  }, [resource, resourceId]);
 
   const onAdd = (state: SetPermission) => {
     let promise: Promise<void> | null = null;


### PR DESCRIPTION
**What is this feature?**
An issue introduced in https://github.com/grafana/grafana/pull/111962 caused the permissions tab to reload infinitely if Team LBAC was enabled.  