### PR TITLE
fix: retry with backoff busy/locked errors on SQLite TruncateDBTables

### DIFF
--- a/pkg/services/sqlstore/migrator/sqlite_dialect.go
+++ b/pkg/services/sqlstore/migrator/sqlite_dialect.go
@@ -126,15 +126,13 @@ func (db *SQLite3) TruncateDBTables(engine *xorm.Engine) error {
 			MaxBackoff: time.Second,
 			MaxRetries: 5,
 		})
-		attempts := 0
 		var lastErr error
 		for b.Ongoing() {
-			attempts++
 			_, lastErr = sess.Exec(query)
 			if !sqlite.IsBusyOrLocked(lastErr) {
 				break
 			}
-			sqliteLogger.Warn(fmt.Sprintf("retrying busy or locked error: query=%s, error=%s, attempts=%d", query, lastErr, attempts))
+			sqliteLogger.Warn(fmt.Sprintf("retrying busy or locked error: query=%s, error=%s", query, lastErr))
 			b.Wait()
 		}
 		return errors.Join(lastErr, b.Err())

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -48,8 +48,6 @@ var gvr = schema.GroupVersionResource{
 }
 
 func TestIntegrationFoldersApp(t *testing.T) {
-	t.Skip("Skipping flaky test")
-
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	if !db.IsTestDbSQLite() {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds retries and backoff to SQLite `TruncateDBTables` on busy/locked errors, which is used during cleanup of integration tests.

**Why do we need this feature?**

Improves stability of CI/CD, allows us to re-enable tests in `TestIntegrationFoldersApp`, and mitigates the issue in other places where similar issues have been seen like `TestIntegrationOptimisticConcurrency`. 

**Who is this feature for?**

Internal Grafana teams, improves stability of CI/CD

**Which issue(s) does this PR fix?**:

Fixes [#search-and-storage-team/issues/546](https://github.com/grafana/search-and-storage-team/issues/546)


**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
  - It's unclear how often it happens, but I ran the flaky tests with the changes 4 times in the CI and none of the times failed. I ran a couple of times without any retries locally but couldn't reproduce it, same in the CI. 
<img width="1488" height="348" alt="image" src="https://github.com/user-attachments/assets/56e35b8e-b2d5-4f3b-9a36-2dece3edaa55" />

- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
