### PR TITLE
LogsPanel: Add z/OS syslog level mapping 

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -288,11 +288,11 @@ var (
 		},
 		{
 			Name:         "zosSyslogLevelMapping",
-			Description:  "Map z/OS syslog message severity letters (for example messages ending in I/W/E/S) to standard log levels in the UI",
-			Stage:        FeatureStageGeneralAvailability,
+			Description:  "Experimental: Map z/OS syslog message severity letters (for example messages ending in I/W/E/S) to standard log levels in the UI",
+			Stage:        FeatureStageExperimental,
 			FrontendOnly: true,
 			Owner:        grafanaObservabilityLogsSquad,
-			Expression:   "true", // enabled by default
+			Expression:   "false", // disabled by default
 		},
 		{
 			Name:        "awsDatasourcesTempCredentials",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -287,12 +287,12 @@ var (
 			Owner:        grafanaObservabilityLogsSquad,
 		},
 		{
-			Name:           "zosSyslogLevelMapping",
-			Description:    "Map z/OS syslog message severity letters (for example messages ending in I/W/E/S) to standard log levels in the UI",
-			Stage:          FeatureStageGeneralAvailability,
-			FrontendOnly:   true,
-			Owner:          grafanaObservabilityLogsSquad,
-			Expression:     "true", // enabled by default
+			Name:         "zosSyslogLevelMapping",
+			Description:  "Map z/OS syslog message severity letters (for example messages ending in I/W/E/S) to standard log levels in the UI",
+			Stage:        FeatureStageGeneralAvailability,
+			FrontendOnly: true,
+			Owner:        grafanaObservabilityLogsSquad,
+			Expression:   "true", // enabled by default
 		},
 		{
 			Name:        "awsDatasourcesTempCredentials",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -287,6 +287,14 @@ var (
 			Owner:        grafanaObservabilityLogsSquad,
 		},
 		{
+			Name:           "zosSyslogLevelMapping",
+			Description:    "Map z/OS syslog message severity letters (for example messages ending in I/W/E/S) to standard log levels in the UI",
+			Stage:          FeatureStageGeneralAvailability,
+			FrontendOnly:   true,
+			Owner:          grafanaObservabilityLogsSquad,
+			Expression:     "true", // enabled by default
+		},
+		{
 			Name:        "awsDatasourcesTempCredentials",
 			Description: "Support temporary security credentials in AWS plugins for Grafana Cloud customers",
 			Stage:       FeatureStageGeneralAvailability,

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -55,6 +55,17 @@ describe('getLoglevel()', () => {
     expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
     expect(getLogLevel('WARN this is a non-critical message')).toBe(LogLevel.warn);
   });
+
+  it('detects z/OS single-letter severities', () => {
+    // informational
+    expect(getLogLevel('MSG1234 I')).toBe(LogLevel.info);
+    // warning
+    expect(getLogLevel('MSG9999 (W) Some warning text')).toBe(LogLevel.warning);
+    // error
+    expect(getLogLevel('Some failure occurred E')).toBe(LogLevel.error);
+    // severe/critical
+    expect(getLogLevel('Very bad S')).toBe(LogLevel.critical);
+  });
 });
 
 describe('getLogLevelFromKey()', () => {
@@ -63,6 +74,13 @@ describe('getLogLevelFromKey()', () => {
   });
   it('returns correct log level when level is capitalized', () => {
     expect(getLogLevelFromKey('INFO')).toBe(LogLevel.info);
+  });
+  it('parses z/OS single-letter keys', () => {
+    expect(getLogLevelFromKey('I')).toBe(LogLevel.info);
+    expect(getLogLevelFromKey('W')).toBe(LogLevel.warning);
+    expect(getLogLevelFromKey('E')).toBe(LogLevel.error);
+    expect(getLogLevelFromKey('S')).toBe(LogLevel.critical);
+    expect(getLogLevelFromKey('C')).toBe(LogLevel.critical);
   });
   describe('Numeric log levels', () => {
     it('returns critical', () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This features adds native mapping of z/OS syslog message levels to standard log levels (info, warn, error, etc.) in Grafana. Updates log utilities to recognize z/OS severity indicators and includes unit tests for this mapping.

**Why do we need this feature?**

This feature helps enterprises running mainframes on z/OS make sense of their syslog firehose by categorizing messages into standard log levels. It enables better log filtering, visualization, and integration with Grafana and Loki, supporting enterprise observability needs.

**Who is this feature for?**

This feature is for enterprises and Grafana customers who operate mainframes, especially those using z/OS systems. It benefits users who need unified log analysis and visualization across diverse infrastructure.

**Which issue(s) does this PR fix?**:
Fixes #111990

