### PR TITLE
[Elasticsearch] Adding support to runtime fields

### DIFF
--- a/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
+++ b/docs/sources/datasources/elasticsearch/configure-elasticsearch-data-source.md
@@ -174,6 +174,8 @@ You can also override this setting in a dashboard panel under its data source op
 Frozen indices are [deprecated in Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/frozen-indices.html) since v7.14.
 {{< /admonition >}}
 
+- **Default query mode** - Default query mode to use for the data source. Options: `Metrics`, `Logs`, `Raw Data` or `Raw Document`, default value: `Metrics`.
+
 ### Logs
 
 In this section you can configure which fields the data source uses for log messages and log levels.

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -107,13 +107,10 @@ func (b *SearchRequestBuilder) Sort(order SortOrder, field string, unmappedType 
 	return b
 }
 
-// AddTimeFieldWithStandardizedFormat adds a time field to fields with standardized time format
-func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string, addWildcard bool) *SearchRequestBuilder {
-	fields := []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
-	if addWildcard {
-		fields = append(fields, map[string]string{"field": "*"})
-	}
-	b.customProps["fields"] = fields
+// AddFieldsOption adds a time field to fields with standardized time format and all fields
+func (b *SearchRequestBuilder) AddFieldsOption(timeField string) *SearchRequestBuilder {
+	b.customProps["fields"] = []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}, {"field": "*"}}
+
 	return b
 }
 

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -108,8 +108,17 @@ func (b *SearchRequestBuilder) Sort(order SortOrder, field string, unmappedType 
 }
 
 // AddTimeFieldWithStandardizedFormat adds a time field to fields with standardized time format
-func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string) *SearchRequestBuilder {
-	b.customProps["fields"] = []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
+func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string, addWildcard bool) *SearchRequestBuilder {
+	fields := []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
+	if addWildcard {
+		fields = append(fields, map[string]string{"field": "*"})
+	}
+	b.customProps["fields"] = fields
+	return b
+}
+
+func (b *SearchRequestBuilder) DisableSource() *SearchRequestBuilder {
+	b.customProps["_source"] = false
 	return b
 }
 

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -384,7 +384,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.AddDocValueField(defaultTimeField)
 	// We need to add timeField as field with standardized time format to not receive
 	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+	b.AddFieldsOption(defaultTimeField)
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
@@ -420,7 +420,7 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	if isRawDataQuery(q) {
 		// For raw_data queries we need to add timeField as field with standardized time format to not receive
 		// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-		b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+		b.AddFieldsOption(defaultTimeField)
 		// Disables _source for raw_data queries as all fields will be returned in the fields property
 		b.DisableSource()
 	}

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -384,7 +384,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.AddDocValueField(defaultTimeField)
 	// We need to add timeField as field with standardized time format to not receive
 	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
@@ -420,7 +420,9 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	if isRawDataQuery(q) {
 		// For raw_data queries we need to add timeField as field with standardized time format to not receive
 		// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-		b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+		b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+		// Disables _source for raw_data queries as all fields will be returned in the fields property
+		b.DisableSource()
 	}
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("size").MustString(), defaultSize))
 }

--- a/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
@@ -61,6 +61,9 @@
       {
         "field": "testtime",
         "format": "strict_date_optional_time_nanos"
+      },
+      {
+        "field": "*"
       }
     ]
 }

--- a/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
@@ -1,4 +1,5 @@
 {
+  "_source": false,
   "docvalue_fields": [
     "testtime"
   ],
@@ -32,6 +33,9 @@
       {
         "field": "testtime",
         "format": "strict_date_optional_time_nanos"
+      },
+      {
+        "field": "*"
       }
     ]
 }

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/ElasticsearchQueryContext.tsx
@@ -62,10 +62,10 @@ export const ElasticsearchProvider = ({
   // useStatelessReducer will then call `onChange` with the newly generated query
   useEffect(() => {
     if (shouldRunInit && isUninitialized) {
-      dispatch(initQuery());
+      dispatch(initQuery(datasource.defaultQueryMode));
       setShouldRunInit(false);
     }
-  }, [shouldRunInit, dispatch, isUninitialized]);
+  }, [shouldRunInit, dispatch, isUninitialized, datasource.defaultQueryMode]);
 
   if (isUninitialized) {
     return null;

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
@@ -2,7 +2,7 @@ import { Action } from '@reduxjs/toolkit';
 
 import { ElasticsearchDataQuery, MetricAggregation } from 'app/plugins/datasource/elasticsearch/dataquery.gen';
 
-import { defaultMetricAgg } from '../../../../queryDef';
+import { defaultMetricAgg, queryTypeToMetricType } from '../../../../queryDef';
 import { removeEmpty } from '../../../../utils';
 import { initQuery } from '../../state';
 import { isMetricAggregationWithMeta, isMetricAggregationWithSettings, isPipelineAggregation } from '../aggregations';
@@ -162,7 +162,8 @@ export const reducer = (
     if (state && state.length > 0) {
       return state;
     }
-    return [defaultMetricAgg('1')];
+    const metricType = queryTypeToMetricType(action.payload);
+    return [{ type: metricType, id: '1' } as MetricAggregation];
   }
 
   return state;

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.test.tsx
@@ -1,0 +1,178 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { ElasticsearchDataQuery } from '../../dataquery.gen';
+import { ElasticDatasource } from '../../datasource';
+import { useDispatch } from '../../hooks/useStatelessReducer';
+import { renderWithESProvider } from '../../test-helpers/render';
+
+import { changeMetricType } from './MetricAggregationsEditor/state/actions';
+import { QueryTypeSelector } from './QueryTypeSelector';
+
+jest.mock('../../hooks/useStatelessReducer');
+
+describe('QueryTypeSelector', () => {
+  let dispatch: jest.Mock;
+
+  beforeEach(() => {
+    dispatch = jest.fn();
+    jest.mocked(useDispatch).mockReturnValue(dispatch);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render radio buttons with correct options', () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    expect(screen.getByRole('radio', { name: 'Metrics' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Logs' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Raw Data' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Raw Document' })).toBeInTheDocument();
+  });
+
+  it('should select the correct radio button based on defaultQueryMode', () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'logs' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const logsRadio = screen.getByRole('radio', { name: 'Logs' });
+    expect(logsRadio).toBeChecked();
+  });
+
+  it('should fallback to impliedQueryType when defaultQueryMode is undefined', () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = {} as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const metricsRadio = screen.getByRole('radio', { name: 'Metrics' });
+    expect(metricsRadio).toBeChecked();
+  });
+
+  it('should fallback to impliedQueryType when defaultQueryMode is explicitly undefined', () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'logs' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: undefined } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const logsRadio = screen.getByRole('radio', { name: 'Logs' });
+    expect(logsRadio).toBeChecked();
+  });
+
+  it('should dispatch changeMetricType action when radio button is changed', async () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const logsRadio = screen.getByRole('radio', { name: 'Logs' });
+    await userEvent.click(logsRadio);
+
+    expect(dispatch).toHaveBeenCalledWith(changeMetricType({ id: '1', type: 'logs' }));
+  });
+
+  it('should convert query type to metric type correctly for raw_data', async () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const rawDataRadio = screen.getByRole('radio', { name: 'Raw Data' });
+    await userEvent.click(rawDataRadio);
+
+    expect(dispatch).toHaveBeenCalledWith(changeMetricType({ id: '1', type: 'raw_data' }));
+  });
+
+  it('should convert query type to metric type correctly for raw_document', async () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'count' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const rawDocumentRadio = screen.getByRole('radio', { name: 'Raw Document' });
+    await userEvent.click(rawDocumentRadio);
+
+    expect(dispatch).toHaveBeenCalledWith(changeMetricType({ id: '1', type: 'raw_document' }));
+  });
+
+  it('should convert metrics query type to count metric type', async () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [{ id: '1', type: 'logs' }],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'logs' } as ElasticDatasource;
+
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    const metricsRadio = screen.getByRole('radio', { name: 'Metrics' });
+    await userEvent.click(metricsRadio);
+
+    expect(dispatch).toHaveBeenCalledWith(changeMetricType({ id: '1', type: 'count' }));
+  });
+
+  it('should return null when query has no metrics', () => {
+    const query: ElasticsearchDataQuery = {
+      refId: 'A',
+      query: '',
+      metrics: [],
+      bucketAggs: [{ type: 'date_histogram', id: '2' }],
+    };
+
+    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
+
+    const { container } = renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.test.tsx
@@ -2,7 +2,6 @@ import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
-import { ElasticDatasource } from '../../datasource';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 import { renderWithESProvider } from '../../test-helpers/render';
 
@@ -31,62 +30,12 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     expect(screen.getByRole('radio', { name: 'Metrics' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Logs' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Raw Data' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'Raw Document' })).toBeInTheDocument();
-  });
-
-  it('should select the correct radio button based on defaultQueryMode', () => {
-    const query: ElasticsearchDataQuery = {
-      refId: 'A',
-      query: '',
-      metrics: [{ id: '1', type: 'count' }],
-      bucketAggs: [{ type: 'date_histogram', id: '2' }],
-    };
-
-    const datasource = { defaultQueryMode: 'logs' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
-
-    const logsRadio = screen.getByRole('radio', { name: 'Logs' });
-    expect(logsRadio).toBeChecked();
-  });
-
-  it('should fallback to impliedQueryType when defaultQueryMode is undefined', () => {
-    const query: ElasticsearchDataQuery = {
-      refId: 'A',
-      query: '',
-      metrics: [{ id: '1', type: 'count' }],
-      bucketAggs: [{ type: 'date_histogram', id: '2' }],
-    };
-
-    const datasource = {} as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
-
-    const metricsRadio = screen.getByRole('radio', { name: 'Metrics' });
-    expect(metricsRadio).toBeChecked();
-  });
-
-  it('should fallback to impliedQueryType when defaultQueryMode is explicitly undefined', () => {
-    const query: ElasticsearchDataQuery = {
-      refId: 'A',
-      query: '',
-      metrics: [{ id: '1', type: 'logs' }],
-      bucketAggs: [{ type: 'date_histogram', id: '2' }],
-    };
-
-    const datasource = { defaultQueryMode: undefined } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
-
-    const logsRadio = screen.getByRole('radio', { name: 'Logs' });
-    expect(logsRadio).toBeChecked();
   });
 
   it('should dispatch changeMetricType action when radio button is changed', async () => {
@@ -97,9 +46,7 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     const logsRadio = screen.getByRole('radio', { name: 'Logs' });
     await userEvent.click(logsRadio);
@@ -115,9 +62,7 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     const rawDataRadio = screen.getByRole('radio', { name: 'Raw Data' });
     await userEvent.click(rawDataRadio);
@@ -133,9 +78,7 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     const rawDocumentRadio = screen.getByRole('radio', { name: 'Raw Document' });
     await userEvent.click(rawDocumentRadio);
@@ -151,9 +94,7 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'logs' } as ElasticDatasource;
-
-    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     const metricsRadio = screen.getByRole('radio', { name: 'Metrics' });
     await userEvent.click(metricsRadio);
@@ -169,9 +110,7 @@ describe('QueryTypeSelector', () => {
       bucketAggs: [{ type: 'date_histogram', id: '2' }],
     };
 
-    const datasource = { defaultQueryMode: 'metrics' } as ElasticDatasource;
-
-    const { container } = renderWithESProvider(<QueryTypeSelector />, { providerProps: { query, datasource } });
+    const { container } = renderWithESProvider(<QueryTypeSelector />, { providerProps: { query } });
 
     expect(container.firstChild).toBeNull();
   });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
@@ -5,11 +5,11 @@ import { MetricAggregation } from '../../dataquery.gen';
 import { useDispatch } from '../../hooks/useStatelessReducer';
 import { QueryType } from '../../types';
 
-import { useQuery } from './ElasticsearchQueryContext';
+import { useDatasource, useQuery } from './ElasticsearchQueryContext';
 import { changeMetricType } from './MetricAggregationsEditor/state/actions';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 
-const OPTIONS: Array<SelectableValue<QueryType>> = [
+export const OPTIONS: Array<SelectableValue<QueryType>> = [
   { value: 'metrics', label: 'Metrics' },
   { value: 'logs', label: 'Logs' },
   { value: 'raw_data', label: 'Raw Data' },
@@ -31,6 +31,7 @@ function queryTypeToMetricType(type: QueryType): MetricAggregation['type'] {
 }
 
 export const QueryTypeSelector = () => {
+  const datasource = useDatasource();
   const query = useQuery();
   const dispatch = useDispatch();
 
@@ -41,7 +42,7 @@ export const QueryTypeSelector = () => {
     return null;
   }
 
-  const queryType = metricAggregationConfig[firstMetric.type].impliedQueryType;
+  const queryType = datasource.defaultQueryMode ?? metricAggregationConfig[firstMetric.type].impliedQueryType;
 
   const onChange = (newQueryType: QueryType) => {
     dispatch(changeMetricType({ id: firstMetric.id, type: queryTypeToMetricType(newQueryType) }));

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/QueryTypeSelector.tsx
@@ -1,11 +1,11 @@
 import { SelectableValue } from '@grafana/data';
 import { RadioButtonGroup } from '@grafana/ui';
 
-import { MetricAggregation } from '../../dataquery.gen';
 import { useDispatch } from '../../hooks/useStatelessReducer';
+import { queryTypeToMetricType } from '../../queryDef';
 import { QueryType } from '../../types';
 
-import { useDatasource, useQuery } from './ElasticsearchQueryContext';
+import { useQuery } from './ElasticsearchQueryContext';
 import { changeMetricType } from './MetricAggregationsEditor/state/actions';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 
@@ -16,22 +16,7 @@ export const OPTIONS: Array<SelectableValue<QueryType>> = [
   { value: 'raw_document', label: 'Raw Document' },
 ];
 
-function queryTypeToMetricType(type: QueryType): MetricAggregation['type'] {
-  switch (type) {
-    case 'logs':
-    case 'raw_data':
-    case 'raw_document':
-      return type;
-    case 'metrics':
-      return 'count';
-    default:
-      // should never happen
-      throw new Error(`invalid query type: ${type}`);
-  }
-}
-
 export const QueryTypeSelector = () => {
-  const datasource = useDatasource();
   const query = useQuery();
   const dispatch = useDispatch();
 
@@ -42,7 +27,7 @@ export const QueryTypeSelector = () => {
     return null;
   }
 
-  const queryType = datasource.defaultQueryMode ?? metricAggregationConfig[firstMetric.type].impliedQueryType;
+  const queryType = metricAggregationConfig[firstMetric.type].impliedQueryType;
 
   const onChange = (newQueryType: QueryType) => {
     dispatch(changeMetricType({ id: firstMetric.id, type: queryTypeToMetricType(newQueryType) }));

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
@@ -1,12 +1,13 @@
 import { Action, createAction } from '@reduxjs/toolkit';
 
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
+import { QueryType } from '../../types';
 
 /**
  * When the `initQuery` Action is dispatched, the query gets populated with default values where values are not present.
  * This means it won't override any existing value in place, but just ensure the query is in a "runnable" state.
  */
-export const initQuery = createAction('init');
+export const initQuery = createAction<QueryType | undefined>('init');
 
 export const changeQuery = createAction<ElasticsearchDataQuery['query']>('change_query');
 

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.test.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.test.tsx
@@ -41,4 +41,16 @@ describe('ElasticDetails', () => {
       })
     );
   });
+
+  it('should change default query mode when selected', async () => {
+    const onChangeMock = jest.fn();
+    render(<ElasticDetails onChange={onChangeMock} value={createDefaultConfigOptions()} />);
+    const selectEl = screen.getByLabelText('Default query mode');
+
+    await selectEvent.select(selectEl, 'Logs', { container: document.body });
+
+    expect(onChangeMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ jsonData: expect.objectContaining({ defaultQueryMode: 'logs' }) })
+    );
+  });
 });

--- a/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
+++ b/public/app/plugins/datasource/elasticsearch/configuration/ElasticDetails.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 
-import { DataSourceSettings, SelectableValue } from '@grafana/data';
+import type { DataSourceSettings, SelectableValue } from '@grafana/data';
 import { ConfigDescriptionLink, ConfigSubSection } from '@grafana/plugin-ui';
 import { InlineField, Input, Select, InlineSwitch } from '@grafana/ui';
 
-import { ElasticsearchOptions, Interval } from '../types';
+import { OPTIONS as DEFAULT_QUERY_MODE_OPTIONS } from '../components/QueryEditor/QueryTypeSelector';
+import type { ElasticsearchOptions, Interval, QueryType } from '../types';
 
 const indexPatternTypes: Array<SelectableValue<'none' | Interval>> = [
   { label: 'No pattern', value: 'none' },
@@ -127,6 +128,29 @@ export const ElasticDetails = ({ value, onChange }: Props) => {
           onChange={jsonDataSwitchChangeHandler('includeFrozen', value, onChange)}
         />
       </InlineField>
+
+      <InlineField
+        label="Default query mode"
+        htmlFor="es_config_defaultQueryMode"
+        labelWidth={29}
+        tooltip="Default query mode to use for the data source. Defaults to 'Metrics'."
+      >
+        <Select
+          inputId="es_config_defaultQueryMode"
+          value={value.jsonData.defaultQueryMode}
+          options={DEFAULT_QUERY_MODE_OPTIONS}
+          onChange={(selectedMode) => {
+            onChange({
+              ...value,
+              jsonData: {
+                ...value.jsonData,
+                defaultQueryMode: selectedMode.value,
+              },
+            });
+          }}
+          width={24}
+        />
+      </InlineField>
     </ConfigSubSection>
   );
 };
@@ -208,4 +232,7 @@ const intervalHandler =
 
 export function defaultMaxConcurrentShardRequests() {
   return 5;
+}
+export function defaultQueryMode(): QueryType {
+  return 'metrics';
 }

--- a/public/app/plugins/datasource/elasticsearch/configuration/mocks/configOptions.ts
+++ b/public/app/plugins/datasource/elasticsearch/configuration/mocks/configOptions.ts
@@ -11,6 +11,7 @@ export function createDefaultConfigOptions(): DataSourceSettings<ElasticsearchOp
       maxConcurrentShardRequests: 300,
       logMessageField: 'test.message',
       logLevelField: 'test.level',
+      defaultQueryMode: 'metrics',
     },
     secureJsonFields: {},
   } as DataSourceSettings<ElasticsearchOptions>;

--- a/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
+++ b/public/app/plugins/datasource/elasticsearch/configuration/utils.ts
@@ -2,7 +2,7 @@ import { DataSourceSettings } from '@grafana/data';
 
 import { ElasticsearchOptions } from '../types';
 
-import { defaultMaxConcurrentShardRequests } from './ElasticDetails';
+import { defaultMaxConcurrentShardRequests, defaultQueryMode } from './ElasticDetails';
 
 export const coerceOptions = (
   options: DataSourceSettings<ElasticsearchOptions, {}>
@@ -16,6 +16,7 @@ export const coerceOptions = (
       logMessageField: options.jsonData.logMessageField || '',
       logLevelField: options.jsonData.logLevelField || '',
       includeFrozen: options.jsonData.includeFrozen ?? false,
+      defaultQueryMode: options.jsonData.defaultQueryMode ?? defaultQueryMode(),
     },
   };
 };

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -788,6 +788,23 @@ export class ElasticDatasource
           fieldNameParts.pop();
         }
 
+        // Process runtime fields
+        function getRuntimeFields(mapping: { runtime: Record<string, { type: string }> }) {
+          if (!mapping.runtime) {
+            return;
+          }
+
+          for (const key in mapping.runtime) {
+            const runtimeField = mapping.runtime[key];
+            if (shouldAddField(runtimeField, key)) {
+              fields[key] = {
+                text: key,
+                type: runtimeField.type,
+              };
+            }
+          }
+        }
+
         for (const indexName in result) {
           const index = result[indexName];
           if (index && index.mappings) {
@@ -795,6 +812,7 @@ export class ElasticDatasource
 
             const properties = mappings.properties;
             getFieldsRecursively(properties);
+            getRuntimeFields(mappings);
           }
         }
 

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -148,9 +148,6 @@ export class ElasticDatasource
     this.intervalPattern = settingsData.interval;
     this.interval = settingsData.timeInterval;
     this.maxConcurrentShardRequests = settingsData.maxConcurrentShardRequests;
-    this.queryBuilder = new ElasticQueryBuilder({
-      timeField: this.timeField,
-    });
     this.logLevelField = settingsData.logLevelField || '';
     this.dataLinks = settingsData.dataLinks || [];
     this.includeFrozen = settingsData.includeFrozen ?? false;
@@ -160,6 +157,10 @@ export class ElasticDatasource
       QueryEditor: ElasticsearchAnnotationsQueryEditor,
     };
     this.defaultQueryMode = settingsData.defaultQueryMode;
+    this.queryBuilder = new ElasticQueryBuilder({
+      timeField: this.timeField,
+      defaultQueryMode: this.defaultQueryMode,
+    });
     if (this.logLevelField === '') {
       this.logLevelField = undefined;
     }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -81,6 +81,7 @@ import {
   isElasticsearchResponseWithAggregations,
   isElasticsearchResponseWithHits,
   ElasticsearchHits,
+  QueryType,
 } from './types';
 import { getScriptValue, isTimeSeriesQuery } from './utils';
 
@@ -127,6 +128,7 @@ export class ElasticDatasource
   includeFrozen: boolean;
   isProxyAccess: boolean;
   databaseVersion: SemVer | null;
+  defaultQueryMode?: QueryType;
 
   constructor(
     instanceSettings: DataSourceInstanceSettings<ElasticsearchOptions>,
@@ -157,7 +159,7 @@ export class ElasticDatasource
     this.annotations = {
       QueryEditor: ElasticsearchAnnotationsQueryEditor,
     };
-
+    this.defaultQueryMode = settingsData.defaultQueryMode;
     if (this.logLevelField === '') {
       this.logLevelField = undefined;
     }

--- a/public/app/plugins/datasource/elasticsearch/queryDef.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/queryDef.test.ts
@@ -1,4 +1,5 @@
-import { isPipelineAgg, isPipelineAggWithMultipleBucketPaths } from './queryDef';
+import { isPipelineAgg, isPipelineAggWithMultipleBucketPaths, queryTypeToMetricType } from './queryDef';
+import type { QueryType } from './types';
 
 describe('ElasticQueryDef', () => {
   describe('isPipelineMetric', () => {
@@ -33,6 +34,51 @@ describe('ElasticQueryDef', () => {
 
       test('should not have multiple bucket paths support', () => {
         expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('queryTypeToMetricType', () => {
+    describe('when type is undefined', () => {
+      test('should return count as default', () => {
+        const result = queryTypeToMetricType(undefined);
+        expect(result).toBe('count');
+      });
+    });
+
+    describe('when type is metrics', () => {
+      test('should return count', () => {
+        const result = queryTypeToMetricType('metrics' as QueryType);
+        expect(result).toBe('count');
+      });
+    });
+
+    describe('when type is logs', () => {
+      test('should return logs', () => {
+        const result = queryTypeToMetricType('logs' as QueryType);
+        expect(result).toBe('logs');
+      });
+    });
+
+    describe('when type is raw_data', () => {
+      test('should return raw_data', () => {
+        const result = queryTypeToMetricType('raw_data' as QueryType);
+        expect(result).toBe('raw_data');
+      });
+    });
+
+    describe('when type is raw_document', () => {
+      test('should return raw_document', () => {
+        const result = queryTypeToMetricType('raw_document' as QueryType);
+        expect(result).toBe('raw_document');
+      });
+    });
+
+    describe('when type is invalid', () => {
+      test('should throw an error', () => {
+        expect(() => {
+          queryTypeToMetricType('invalid_type' as QueryType);
+        }).toThrow('invalid query type: invalid_type');
       });
     });
   });

--- a/public/app/plugins/datasource/elasticsearch/queryDef.ts
+++ b/public/app/plugins/datasource/elasticsearch/queryDef.ts
@@ -7,6 +7,7 @@ import {
   MetricAggregationType,
   MovingAverageModelOption,
 } from './dataquery.gen';
+import type { QueryType } from './types';
 
 export const extendedStats: ExtendedStat[] = [
   { label: 'Avg', value: 'avg' },
@@ -40,6 +41,24 @@ export function defaultMetricAgg(id = '1'): MetricAggregation {
 
 export function defaultBucketAgg(id = '1'): DateHistogram {
   return { type: 'date_histogram', id, settings: { interval: 'auto' } };
+}
+
+export function queryTypeToMetricType(type?: QueryType): MetricAggregation['type'] {
+  if (!type) {
+    return 'count'; // Default fallback
+  }
+
+  switch (type) {
+    case 'logs':
+    case 'raw_data':
+    case 'raw_document':
+      return type;
+    case 'metrics':
+      return 'count';
+    default:
+      // should never happen
+      throw new Error(`invalid query type: ${type}`);
+  }
 }
 
 export const findMetricById = (metrics: MetricAggregation[], id: MetricAggregation['id']) =>

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -63,6 +63,7 @@ export interface ElasticsearchOptions extends DataSourceJsonData {
   index?: string;
   sigV4Auth?: boolean;
   oauthPassThru?: boolean;
+  defaultQueryMode?: QueryType;
 }
 
 export type QueryType = 'metrics' | 'logs' | 'raw_data' | 'raw_document';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds support to runtime fields by using the `fields` property to retrieve the fields in ES instead of using the `_source` property.

**Why do we need this feature?**

Runtime fields offer enhanced flexibility to index on ES.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

Everyone that uses runtime fields on ES.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/96028

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
