### PR TITLE
[Elasticsearch] Adding support to runtime fields

### DIFF
--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -107,13 +107,10 @@ func (b *SearchRequestBuilder) Sort(order SortOrder, field string, unmappedType 
 	return b
 }
 
-// AddTimeFieldWithStandardizedFormat adds a time field to fields with standardized time format
-func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string, addWildcard bool) *SearchRequestBuilder {
-	fields := []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
-	if addWildcard {
-		fields = append(fields, map[string]string{"field": "*"})
-	}
-	b.customProps["fields"] = fields
+// AddFieldsOption adds a time field to fields with standardized time format and all fields
+func (b *SearchRequestBuilder) AddFieldsOption(timeField string) *SearchRequestBuilder {
+	b.customProps["fields"] = []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}, {"field": "*"}}
+
 	return b
 }
 

--- a/pkg/tsdb/elasticsearch/client/search_request.go
+++ b/pkg/tsdb/elasticsearch/client/search_request.go
@@ -108,8 +108,17 @@ func (b *SearchRequestBuilder) Sort(order SortOrder, field string, unmappedType 
 }
 
 // AddTimeFieldWithStandardizedFormat adds a time field to fields with standardized time format
-func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string) *SearchRequestBuilder {
-	b.customProps["fields"] = []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
+func (b *SearchRequestBuilder) AddTimeFieldWithStandardizedFormat(timeField string, addWildcard bool) *SearchRequestBuilder {
+	fields := []map[string]string{{"field": timeField, "format": "strict_date_optional_time_nanos"}}
+	if addWildcard {
+		fields = append(fields, map[string]string{"field": "*"})
+	}
+	b.customProps["fields"] = fields
+	return b
+}
+
+func (b *SearchRequestBuilder) DisableSource() *SearchRequestBuilder {
+	b.customProps["_source"] = false
 	return b
 }
 

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -384,7 +384,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.AddDocValueField(defaultTimeField)
 	// We need to add timeField as field with standardized time format to not receive
 	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+	b.AddFieldsOption(defaultTimeField)
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
@@ -420,7 +420,7 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	if isRawDataQuery(q) {
 		// For raw_data queries we need to add timeField as field with standardized time format to not receive
 		// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-		b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+		b.AddFieldsOption(defaultTimeField)
 		// Disables _source for raw_data queries as all fields will be returned in the fields property
 		b.DisableSource()
 	}

--- a/pkg/tsdb/elasticsearch/data_query.go
+++ b/pkg/tsdb/elasticsearch/data_query.go
@@ -384,7 +384,7 @@ func processLogsQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, defa
 	b.AddDocValueField(defaultTimeField)
 	// We need to add timeField as field with standardized time format to not receive
 	// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-	b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+	b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("limit").MustString(), defaultSize))
 	b.AddHighlight()
 
@@ -420,7 +420,9 @@ func processDocumentQuery(q *Query, b *es.SearchRequestBuilder, from, to int64, 
 	if isRawDataQuery(q) {
 		// For raw_data queries we need to add timeField as field with standardized time format to not receive
 		// invalid formats that elasticsearch can parse, but our frontend can't (e.g. yyyy_MM_dd_HH_mm_ss)
-		b.AddTimeFieldWithStandardizedFormat(defaultTimeField)
+		b.AddTimeFieldWithStandardizedFormat(defaultTimeField, true)
+		// Disables _source for raw_data queries as all fields will be returned in the fields property
+		b.DisableSource()
 	}
 	b.Size(stringToIntWithDefaultValue(metric.Settings.Get("size").MustString(), defaultSize))
 }

--- a/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/logs.request.line1.json
@@ -61,6 +61,9 @@
       {
         "field": "testtime",
         "format": "strict_date_optional_time_nanos"
+      },
+      {
+        "field": "*"
       }
     ]
 }

--- a/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
+++ b/pkg/tsdb/elasticsearch/testdata_request/raw_data.request.line1.json
@@ -1,4 +1,5 @@
 {
+  "_source": false,
   "docvalue_fields": [
     "testtime"
   ],
@@ -32,6 +33,9 @@
       {
         "field": "testtime",
         "format": "strict_date_optional_time_nanos"
+      },
+      {
+        "field": "*"
       }
     ]
 }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -785,6 +785,23 @@ export class ElasticDatasource
           fieldNameParts.pop();
         }
 
+        // Process runtime fields
+        function getRuntimeFields(mapping: { runtime: Record<string, { type: string }> }) {
+          if (!mapping.runtime) {
+            return;
+          }
+
+          for (const key in mapping.runtime) {
+            const runtimeField = mapping.runtime[key];
+            if (shouldAddField(runtimeField, key)) {
+              fields[key] = {
+                text: key,
+                type: runtimeField.type,
+              };
+            }
+          }
+        }
+
         for (const indexName in result) {
           const index = result[indexName];
           if (index && index.mappings) {
@@ -792,6 +809,7 @@ export class ElasticDatasource
 
             const properties = mappings.properties;
             getFieldsRecursively(properties);
+            getRuntimeFields(mappings);
           }
         }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds support to runtime fields by using the `fields` property to retrieve the fields in ES instead of using the `_source` property.

**Why do we need this feature?**

Runtime fields offer enhanced flexibility to index on ES.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

Everyone that uses runtime fields on ES.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/96028

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---
- `is_adult` is a runtime field:

<img width="1538" height="472" alt="Screenshot 2025-10-20 at 16 17 09" src="https://github.com/user-attachments/assets/1e2cb95a-cd34-4efc-9e98-f570a9c7352c" />
<img width="1440" height="1013" alt="Screenshot 2025-10-20 at 16 17 44" src="https://github.com/user-attachments/assets/b4f7e915-8fc3-446a-90fe-6409fefea950" />
<img width="1442" height="437" alt="Screenshot 2025-10-20 at 16 17 52" src="https://github.com/user-attachments/assets/331dc458-b592-455f-84ee-a86ac5c99cd1" />
<img width="1436" height="467" alt="Screenshot 2025-10-20 at 16 28 28" src="https://github.com/user-attachments/assets/84e3079a-05d3-4633-8d6d-00b2ab77cfa2" />

