### PR TITLE
BackendMySQL: Backtick hyphenated dataset/table names to prevent minus parsing

### DIFF
--- a/public/app/plugins/datasource/mysql/sqlUtil.test.ts
+++ b/public/app/plugins/datasource/mysql/sqlUtil.test.ts
@@ -1,4 +1,5 @@
 import { isValidIdentifier } from './sqlUtil';
+import { toRawSql } from './sqlUtil';
 
 describe('isValidIdentifier', () => {
   test.each([
@@ -14,5 +15,19 @@ describe('isValidIdentifier', () => {
     { value: 'table_name', expected: true },
   ])('should return $expected when value is $value', ({ value, expected }) => {
     expect(isValidIdentifier(value)).toBe(expected);
+  });
+});
+
+describe('toRawSql', () => {
+  it('quotes dataset and table identifiers when they contain prohibited characters', () => {
+    const query = {
+      sql: { columns: [{ type: 'column', name: '*' } as any] },
+      dataset: 'se-backoffice',
+      table: 'action_title',
+    } as any;
+
+    const result = toRawSql(query);
+    // dataset contains a hyphen and should be backticked
+    expect(result).toContain('FROM `se-backoffice`.action_title');
   });
 });

--- a/public/app/plugins/datasource/mysql/sqlUtil.test.ts
+++ b/public/app/plugins/datasource/mysql/sqlUtil.test.ts
@@ -21,10 +21,10 @@ describe('isValidIdentifier', () => {
 describe('toRawSql', () => {
   it('quotes dataset and table identifiers when they contain prohibited characters', () => {
     const query = {
-      sql: { columns: [{ type: 'column', name: '*' } as any] },
+      sql: { columns: [{ type: 'column', name: '*' }] },
       dataset: 'se-backoffice',
       table: 'action_title',
-    } as any;
+    };
 
     const result = toRawSql(query);
     // dataset contains a hyphen and should be backticked

--- a/public/app/plugins/datasource/mysql/sqlUtil.test.ts
+++ b/public/app/plugins/datasource/mysql/sqlUtil.test.ts
@@ -1,5 +1,5 @@
-import { isValidIdentifier } from './sqlUtil';
-import { toRawSql } from './sqlUtil';
+import { isValidIdentifier, toRawSql } from './sqlUtil';
+
 
 describe('isValidIdentifier', () => {
   test.each([

--- a/public/app/plugins/datasource/mysql/sqlUtil.ts
+++ b/public/app/plugins/datasource/mysql/sqlUtil.ts
@@ -13,7 +13,10 @@ export function toRawSql({ sql, dataset, table }: SQLQuery): string {
   rawQuery += createSelectClause(sql.columns);
 
   if (dataset && table) {
-    rawQuery += `FROM ${dataset}.${table} `;
+    // Quote dataset and table identifiers when necessary (for example names with hyphens)
+    const ds = quoteIdentifierIfNecessary(dataset);
+    const tbl = quoteIdentifierIfNecessary(table);
+    rawQuery += `FROM ${ds}.${tbl} `;
   }
 
   if (sql.whereString) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This change ensures MySQL dataset and table identifiers that contain prohibited characters (for example, a hyphen `-`) are rendered with backticks when building SQL in the MySQL query editor. Previously, hyphenated names could be interpreted as a subtraction expression (e.g., `se - backoffice.action_title`), causing incorrect SQL to be sent to MySQL. The fix quotes identifiers that require it so they render as \se-backoffice`.action_title` (or similar), matching the documented behavior.

**Why do we need this feature?**

Without quoting, identifiers that include reserved or prohibited characters are parsed as SQL operators or tokens instead of a single identifier. That leads to incorrect queries, confusing results, and broken dashboards when dataset/table names contain characters like hyphens. This change restores expected behavior (matches Grafana 12.0) and aligns the editor with the MySQL datasource docs that state identifiers containing prohibited characters should be wrapped in backticks.

**Who is this feature for?**

- Dashboard authors and data engineers who use the MySQL datasource in Grafana and have database, schema, or table names containing prohibited characters (for example, hyphens).
- Teams upgrading from Grafana 12.0+ who expect identifiers to be auto-quoted in the query editor.
- Plugin maintainers and QA who need consistent rendering of user-selected datasets/tables.


**Which issue(s) does this PR fix?**:

Fixes #111980  — MySQL query renderer treats hyphenated dataset/table names as subtraction instead of quoting them.

**Additional notes:**

- Tests: Unit tests were added/updated in `sqlUtil.test.ts` to cover hyphenated identifiers and ensure they are wrapped with backticks when rendering.
- Backward compatibility: Restores behavior present in Grafana 12.0; should be non-breaking for users without prohibited characters in identifiers.
- Documentation: This change aligns with the MySQL datasource query editor docs which say hyphenated names will be quoted with backticks