### PR TITLE
kvstore: update storage backend to use batch get

### DIFF
--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -2949,3 +2949,148 @@ func TestDataStore_getGroupResources(t *testing.T) {
 		require.True(t, foundCombinations[expected], "Expected combination not found: %s", expected)
 	}
 }
+
+func TestDataStore_BatchGet(t *testing.T) {
+	ds := setupTestDataStore(t)
+	ctx := context.Background()
+
+	t.Run("batch get multiple existing keys", func(t *testing.T) {
+		// Create test data
+		keys := make([]DataKey, 5)
+		expectedContent := make(map[string]string)
+
+		for i := 0; i < 5; i++ {
+			rv := node.Generate().Int64()
+			keys[i] = DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            fmt.Sprintf("test-name-%d", i),
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+				Folder:          "test-folder",
+			}
+			content := fmt.Sprintf("test-value-%d", i)
+			expectedContent[keys[i].Name] = content
+			err := ds.Save(ctx, keys[i], bytes.NewReader([]byte(content)))
+			require.NoError(t, err)
+		}
+
+		// Batch get all keys
+		results := make([]DataObj, 0, 5)
+		for obj, err := range ds.BatchGet(ctx, keys) {
+			require.NoError(t, err)
+			results = append(results, obj)
+		}
+
+		// Verify all keys were returned
+		require.Len(t, results, 5)
+
+		// Verify content matches
+		for _, result := range results {
+			resultBytes, err := io.ReadAll(result.Value)
+			require.NoError(t, err)
+			expectedValue, ok := expectedContent[result.Key.Name]
+			require.True(t, ok, "Unexpected key in results: %s", result.Key.Name)
+			require.Equal(t, expectedValue, string(resultBytes))
+		}
+	})
+
+	t.Run("batch get with some non-existent keys", func(t *testing.T) {
+		// Create 3 existing keys
+		existingKeys := make([]DataKey, 3)
+		for i := 0; i < 3; i++ {
+			rv := node.Generate().Int64()
+			existingKeys[i] = DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            fmt.Sprintf("existing-%d", i),
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+				Folder:          "test-folder",
+			}
+			err := ds.Save(ctx, existingKeys[i], bytes.NewReader([]byte(fmt.Sprintf("value-%d", i))))
+			require.NoError(t, err)
+		}
+
+		// Create 2 non-existent keys (not saved to datastore)
+		nonExistentKeys := make([]DataKey, 2)
+		for i := 0; i < 2; i++ {
+			rv := node.Generate().Int64()
+			nonExistentKeys[i] = DataKey{
+				Namespace:       "test-namespace",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            fmt.Sprintf("non-existent-%d", i),
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+				Folder:          "test-folder",
+			}
+		}
+
+		// Combine existing and non-existent keys
+		allKeys := append(existingKeys, nonExistentKeys...)
+
+		// Batch get all keys
+		results := make([]DataObj, 0, 3)
+		for obj, err := range ds.BatchGet(ctx, allKeys) {
+			require.NoError(t, err)
+			results = append(results, obj)
+		}
+
+		// Should only return the 3 existing keys
+		require.Len(t, results, 3)
+
+		// Verify only existing keys are returned
+		for _, result := range results {
+			require.Contains(t, result.Key.Name, "existing-")
+			// Verify content
+			resultBytes, err := io.ReadAll(result.Value)
+			require.NoError(t, err)
+			require.NotEmpty(t, resultBytes)
+		}
+	})
+
+	t.Run("batch get with large number of keys to test batching", func(t *testing.T) {
+		numKeys := 150
+		keys := make([]DataKey, numKeys)
+		expectedContent := make(map[string]string)
+
+		for i := 0; i < numKeys; i++ {
+			rv := node.Generate().Int64()
+			keys[i] = DataKey{
+				Namespace:       "batch-test",
+				Group:           "test-group",
+				Resource:        "test-resource",
+				Name:            fmt.Sprintf("item-%d", i),
+				ResourceVersion: rv,
+				Action:          DataActionCreated,
+				Folder:          "test-folder",
+			}
+			content := fmt.Sprintf("content-%d", i)
+			expectedContent[keys[i].Name] = content
+			err := ds.Save(ctx, keys[i], bytes.NewReader([]byte(content)))
+			require.NoError(t, err)
+		}
+
+		// Batch get all keys
+		results := make([]DataObj, 0, numKeys)
+		for obj, err := range ds.BatchGet(ctx, keys) {
+			require.NoError(t, err)
+			results = append(results, obj)
+		}
+
+		// Verify all keys were returned
+		require.Len(t, results, numKeys)
+
+		// Verify content matches for all keys
+		for _, result := range results {
+			resultBytes, err := io.ReadAll(result.Value)
+			require.NoError(t, err)
+			expectedValue, ok := expectedContent[result.Key.Name]
+			require.True(t, ok, "Unexpected key in results: %s", result.Key.Name)
+			require.Equal(t, expectedValue, string(resultBytes))
+		}
+	})
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -392,6 +392,7 @@ type kvListIterator struct {
 	// current item state
 	currentDataObj *DataObj
 	value          []byte
+	err            error
 }
 
 func (i *kvListIterator) Next() bool {
@@ -401,14 +402,15 @@ func (i *kvListIterator) Next() bool {
 		return false
 	}
 	if err != nil {
+		i.err = err
 		return false
 	}
 
 	i.currentDataObj = &dataObj
 
-	var readErr error
-	i.value, readErr = readAndClose(dataObj.Value)
-	if readErr != nil {
+	i.value, err = readAndClose(dataObj.Value)
+	if err != nil {
+		i.err = err
 		return false
 	}
 
@@ -418,7 +420,7 @@ func (i *kvListIterator) Next() bool {
 }
 
 func (i *kvListIterator) Error() error {
-	return nil
+	return i.err
 }
 
 func (i *kvListIterator) ContinueToken() string {
@@ -924,6 +926,7 @@ type kvHistoryIterator struct {
 	currentDataObj *DataObj
 	value          []byte
 	folder         string
+	err            error
 }
 
 func (i *kvHistoryIterator) Next() bool {
@@ -933,14 +936,15 @@ func (i *kvHistoryIterator) Next() bool {
 		return false
 	}
 	if err != nil {
+		i.err = err
 		return false
 	}
 
 	i.currentDataObj = &dataObj
 
-	var readErr error
-	i.value, readErr = readAndClose(dataObj.Value)
-	if readErr != nil {
+	i.value, err = readAndClose(dataObj.Value)
+	if err != nil {
+		i.err = err
 		return false
 	}
 
@@ -948,11 +952,13 @@ func (i *kvHistoryIterator) Next() bool {
 	partial := &metav1.PartialObjectMetadata{}
 	err = json.Unmarshal(i.value, partial)
 	if err != nil {
+		i.err = err
 		return false
 	}
 
 	meta, err := utils.MetaAccessor(partial)
 	if err != nil {
+		i.err = err
 		return false
 	}
 	i.folder = meta.GetFolder()
@@ -966,7 +972,7 @@ func (i *kvHistoryIterator) Next() bool {
 }
 
 func (i *kvHistoryIterator) Error() error {
-	return nil
+	return i.err
 }
 
 func (i *kvHistoryIterator) ContinueToken() string {

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -370,7 +370,6 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 	iter := kvListIterator{
 		listRV: listRV,
 		offset: offset,
-		limit:  req.Limit + 1, // TODO: for now we need at least one more item. Fix the caller
 		next:   next,
 		stop:   stop,
 	}
@@ -386,10 +385,8 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 
 // kvListIterator implements ListIterator for KV storage
 type kvListIterator struct {
-	listRV    int64
-	offset    int64
-	limit     int64
-	itemsRead int64 // number of items read so far
+	listRV int64
+	offset int64
 
 	// pull-style iterator
 	next func() (DataObj, error, bool)
@@ -401,10 +398,6 @@ type kvListIterator struct {
 }
 
 func (i *kvListIterator) Next() bool {
-	if i.itemsRead >= i.limit {
-		return false
-	}
-
 	// Pull next item from the iterator
 	dataObj, err, ok := i.next()
 	if !ok {
@@ -423,7 +416,6 @@ func (i *kvListIterator) Next() bool {
 	}
 
 	i.offset++
-	i.itemsRead++
 
 	return true
 }

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -397,7 +397,6 @@ type kvListIterator struct {
 
 	// current item state
 	currentDataObj *DataObj
-	rv             int64
 	value          []byte
 }
 
@@ -416,7 +415,6 @@ func (i *kvListIterator) Next() bool {
 	}
 
 	i.currentDataObj = &dataObj
-	i.rv = dataObj.Key.ResourceVersion
 
 	var readErr error
 	i.value, readErr = readAndClose(dataObj.Value)
@@ -442,7 +440,10 @@ func (i *kvListIterator) ContinueToken() string {
 }
 
 func (i *kvListIterator) ResourceVersion() int64 {
-	return i.rv
+	if i.currentDataObj != nil {
+		return i.currentDataObj.Key.ResourceVersion
+	}
+	return 0
 }
 
 func (i *kvListIterator) Namespace() string {
@@ -937,7 +938,6 @@ type kvHistoryIterator struct {
 
 	// current item state
 	currentDataObj *DataObj
-	rv             int64
 	value          []byte
 	folder         string
 }
@@ -953,7 +953,6 @@ func (i *kvHistoryIterator) Next() bool {
 	}
 
 	i.currentDataObj = &dataObj
-	i.rv = dataObj.Key.ResourceVersion
 
 	var readErr error
 	i.value, readErr = readAndClose(dataObj.Value)
@@ -990,16 +989,20 @@ func (i *kvHistoryIterator) ContinueToken() string {
 	if i.currentDataObj == nil {
 		return ""
 	}
+	rv := i.currentDataObj.Key.ResourceVersion
 	token := ContinueToken{
-		StartOffset:     i.rv,
-		ResourceVersion: i.rv,
+		StartOffset:     rv,
+		ResourceVersion: rv,
 		SortAscending:   i.sortAscending,
 	}
 	return token.String()
 }
 
 func (i *kvHistoryIterator) ResourceVersion() int64 {
-	return i.rv
+	if i.currentDataObj != nil {
+		return i.currentDataObj.Key.ResourceVersion
+	}
+	return 0
 }
 
 func (i *kvHistoryIterator) Namespace() string {


### PR DESCRIPTION
Start using batchGet.

**Added BatchGet Method to DataStore (datastore.go)**
```golang
// BatchGet retrieves multiple data objects in batches.
// Keys are processed in batches (default 50) to balance efficiency and memory usage.
func (d *dataStore) BatchGet(ctx context.Context, keys []DataKey) iter.Seq2[DataObj, error]
```
- Takes []DataKey as input
- Returns a stream of DataObj using Go's iterator pattern
- Internally batches requests in chunks of 50 keys (configurable via dataBatchSize constant)
- Validates all keys before processing
- Skips non-existent entries (as per KV interface contract)

**Updated Storage Backend Iterators (storage_backend.go)**
Both kvListIterator and kvHistoryIterator were refactored to use lazy evaluation:
- Before: Made N individual Get() calls for N resources
- After: Use iter.Pull2(BatchGet()) for lazy, on-demand consumption