### PR TITLE
SCIM: Remove SCIM config requirements from the Teams List page

### DIFF
--- a/public/app/features/teams/TeamList.tsx
+++ b/public/app/features/teams/TeamList.tsx
@@ -5,7 +5,6 @@ import { connect, ConnectedProps } from 'react-redux';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, getBackendSrv } from '@grafana/runtime';
 import {
   Avatar,
   CellProps,
@@ -66,7 +65,6 @@ export const TeamList = ({
   changeSort,
 }: Props) => {
   const [roleOptions, setRoleOptions] = useState<Role[]>([]);
-  const [scimGroupSyncEnabled, setScimGroupSyncEnabled] = useState(false);
   const styles = useStyles2(getStyles);
 
   useEffect(() => {
@@ -77,25 +75,6 @@ export const TeamList = ({
     if (contextSrv.licensedAccessControlEnabled() && contextSrv.hasPermission(AccessControlAction.ActionRolesList)) {
       fetchRoleOptions().then((roles) => setRoleOptions(roles));
     }
-  }, []);
-
-  useEffect(() => {
-    const checkSCIMSettings = async () => {
-      if (!config.featureToggles.enableSCIM) {
-        setScimGroupSyncEnabled(false);
-        return;
-      }
-      try {
-        const scimSettings = await getBackendSrv().get(
-          `/apis/scim.grafana.app/v0alpha1/namespaces/${config.namespace}/config`
-        );
-        setScimGroupSyncEnabled(scimSettings?.items[0]?.spec?.enableGroupSync || false);
-      } catch {
-        setScimGroupSyncEnabled(false);
-      }
-    };
-
-    checkSCIMSettings();
   }, []);
 
   const canCreate = contextSrv.hasPermission(AccessControlAction.ActionTeamsCreate);
@@ -217,9 +196,7 @@ export const TeamList = ({
           }
 
           const canReadTeam = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsRead, original);
-          const canDelete =
-            contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsDelete, original) &&
-            (!scimGroupSyncEnabled || !original.isProvisioned);
+          const canDelete = contextSrv.hasPermissionInMetadata(AccessControlAction.ActionTeamsDelete, original);
           return (
             <Stack direction="row" justifyContent="flex-end" gap={2}>
               {canReadTeam && (
@@ -247,7 +224,7 @@ export const TeamList = ({
         },
       },
     ],
-    [displayRolePicker, hasFetched, rolesLoading, roleOptions, deleteTeam, styles, scimGroupSyncEnabled]
+    [displayRolePicker, hasFetched, rolesLoading, roleOptions, deleteTeam, styles]
   );
 
   return (


### PR DESCRIPTION
**What is this feature?**

This PR removes the call to SCIM configuration from the Team List Page. Additionally, it removes the restriction of deleting a group based on provisioning status. This will be handled entirely on the backend.

**Why do we need this feature?**

Initially, the Team List page didn't allow provisioned teams to be deleted if SCIM groups sync was enabled.

A [PR](https://github.com/grafana/grafana/pull/111888) was developed to allow provisioned groups to be deleted if the SCIM groups sync was disabled. However, this PR introduced a SCIM config permission requirement where it wasn't needed.

**Who is this feature for?**

IAM

**Which issue(s) does this PR fix?**:

Related escalation https://github.com/grafana/support-escalations/issues/18928

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
