### PR TITLE
Dashboard: Fix dropping panels in tabs nested in rows

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -114,12 +114,15 @@ interface TabItemLayoutRendererProps {
 }
 
 export function TabItemLayoutRenderer({ tab, isEditing }: TabItemLayoutRendererProps) {
-  const { layout } = tab.useState();
+  const { layout, key } = tab.useState();
   const styles = useStyles2(getStyles);
   const [_, conditionalRenderingClass, conditionalRenderingOverlay] = useIsConditionallyHidden(tab);
 
   return (
-    <TabContent className={cx(styles.tabContentContainer, isEditing && conditionalRenderingClass)}>
+    <TabContent
+      className={cx(styles.tabContentContainer, isEditing && conditionalRenderingClass)}
+      data-dashboard-drop-target-key={key}
+    >
       <layout.Component model={layout} />
       {isEditing && conditionalRenderingOverlay}
     </TabContent>


### PR DESCRIPTION
**What is this feature?**

Add `data-dashboard-drop-target-key` attribute to the dashboard tab content.

**Why do we need this feature?**

Fix an issue where a user couldn't reliably drag and drop a panel within a tab that's placed in a row.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
