### PR TITLE
Chore: Add Namespace Support To Grafana-i18n ESLint Rule

### DIFF
--- a/packages/grafana-i18n/src/eslint/README.md
+++ b/packages/grafana-i18n/src/eslint/README.md
@@ -70,6 +70,32 @@ const bar = {
 };
 ```
 
+#### `namespace`
+
+Allows specifying a namespace prefix that will be added to all auto-generated translation keys when using ESLint's auto-fix feature. The namespace is separated from the key with a colon (:).
+
+This is useful for organizing translation keys by feature area or preventing key collisions between different parts of the application.
+
+#### Example:
+
+```tsx
+// Configuration:
+{
+  '@grafana/i18n/no-untranslated-strings': ['error', { namespace: 'dashboard' }],
+}
+
+// For a file located at src/features/search/EmptyState.tsx
+
+// Without namespace, auto-fix generates:
+<Trans i18nKey="features.search.empty-state.no-results-found">No results found</Trans>
+
+// With namespace: 'dashboard', auto-fix generates:
+<Trans i18nKey="dashboard:features.search.empty-state.no-results-found">No results found</Trans>
+
+// For JSX attributes, auto-fix generates:
+<div title={t("dashboard:features.search.empty-state.title-no-results", "No results")} />
+```
+
 #### JSXText
 
 ```tsx

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.cjs
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.cjs
@@ -2,8 +2,8 @@
 /** @typedef {import('@typescript-eslint/utils').TSESTree.Node} Node */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.JSXElement} JSXElement */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.JSXFragment} JSXFragment */
-/** @typedef {import('@typescript-eslint/utils').TSESLint.RuleModule<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties', [{ forceFix: string[] , calleesToIgnore: string[], basePaths: string[] }]>} RuleDefinition */
-/** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties',  [{forceFix: string[], calleesToIgnore: string[], basePaths: string[]}]>} RuleContextWithOptions */
+/** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleModule<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties', [{ forceFix: string[] , calleesToIgnore: string[], basePaths: string[], namespace?: string }]>} RuleDefinition */
+/** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT' | 'noUntranslatedStringsProperties',  [{forceFix: string[], calleesToIgnore: string[], basePaths: string[], namespace?: string}]>} RuleContextWithOptions */
 
 const {
   getNodeValue,
@@ -307,6 +307,10 @@ const noUntranslatedStrings = createRule({
               type: 'string',
             },
             default: ['src'],
+          },
+          namespace: {
+            type: 'string',
+            description: 'Namespace to prepend to translation keys',
           },
         },
         additionalProperties: false,

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/no-untranslated-strings.test.js
@@ -1082,6 +1082,99 @@ const Foo = () => {
       errors: [{ messageId: 'noUntranslatedStringsProp' }],
     },
 
+    // NAMESPACE FUNCTIONALITY TESTS
+    {
+      name: 'Basic untranslated text with namespace configuration',
+      code: `
+const Foo = () => <div>Untranslated text</div>`,
+      filename,
+      options: [{ namespace: 'my-namespace' }],
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithTrans',
+              output: `
+${TRANS_IMPORT}
+const Foo = () => <div><Trans i18nKey="my-namespace:some-feature.foo.untranslated-text">Untranslated text</Trans></div>`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Prop fix with namespace configuration',
+      code: `
+const Foo = () => {
+  return (
+    <div title="foo" />
+  )
+}`,
+      filename,
+      options: [{ namespace: 'alerts' }],
+      errors: [
+        {
+          messageId: 'noUntranslatedStringsProp',
+          suggestions: [
+            {
+              messageId: 'wrapWithT',
+              output: `
+${T_IMPORT}
+const Foo = () => {
+  return (
+    <div title={t("alerts:some-feature.foo.title-foo", "foo")} />
+  )
+}`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Empty namespace should not add prefix',
+      code: `
+const Foo = () => <div>Test text</div>`,
+      filename,
+      options: [{ namespace: '' }],
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithTrans',
+              output: `
+${TRANS_IMPORT}
+const Foo = () => <div><Trans i18nKey="some-feature.foo.test-text">Test text</Trans></div>`,
+            },
+          ],
+        },
+      ],
+    },
+
+    {
+      name: 'Namespace with special characters gets used as-is',
+      code: `
+const Foo = () => <div>Test content</div>`,
+      filename,
+      options: [{ namespace: 'feature.sub-module' }],
+      errors: [
+        {
+          messageId: 'noUntranslatedStrings',
+          suggestions: [
+            {
+              messageId: 'wrapWithTrans',
+              output: `
+${TRANS_IMPORT}
+const Foo = () => <div><Trans i18nKey="feature.sub-module:some-feature.foo.test-content">Test content</Trans></div>`,
+            },
+          ],
+        },
+      ],
+    },
+
     // TODO: Enable test once all top-level issues have been fixed
     // and rule is enabled again
     //     {

--- a/packages/grafana-i18n/src/eslint/no-untranslated-strings/translation-utils.cjs
+++ b/packages/grafana-i18n/src/eslint/no-untranslated-strings/translation-utils.cjs
@@ -7,7 +7,7 @@
 /** @typedef {import('@typescript-eslint/utils').TSESTree.JSXChild} JSXChild */
 /** @typedef {import('@typescript-eslint/utils').TSESTree.Property} Property */
 /** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleFixer} RuleFixer */
-/** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT',  [{forceFix: string[], calleesToIgnore: string[], basePaths: string[]}]>} RuleContextWithOptions */
+/** @typedef {import('@typescript-eslint/utils/ts-eslint').RuleContext<'noUntranslatedStrings' | 'noUntranslatedStringsProp' | 'wrapWithTrans' | 'wrapWithT',  [{forceFix: string[], calleesToIgnore: string[], basePaths: string[], namespace?: string}]>} RuleContextWithOptions */
 const { AST_NODE_TYPES } = require('@typescript-eslint/utils');
 
 /**
@@ -168,6 +168,7 @@ function getTranslationPrefix(context) {
  */
 const getI18nKey = (node, context) => {
   const prefixFromFilePath = getTranslationPrefix(context);
+  const namespace = context.options[0]?.namespace;
   const stringValue = getNodeValue(node);
 
   const componentNames = getComponentNames(node, context);
@@ -214,7 +215,8 @@ const getI18nKey = (node, context) => {
 
   const fullPrefix = [prefixFromFilePath, ...componentNames, propertyName, kebabString].filter(Boolean).join('.');
 
-  return fullPrefix;
+  // Prepend namespace if provided
+  return namespace ? `${namespace}:${fullPrefix}` : fullPrefix;
 };
 
 /**


### PR DESCRIPTION
Allows users to configure a namespace option that prefixes translation keys with 'namespace:' when auto-fixing violations.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds a `namespace` configuration option to the grafana-i18n ESLint rule that prefixes translation keys with "namespace:" when auto-fixing violations.

**Why do we need this feature?**
To help organize translation keys by feature or component area, making the codebase more maintainable and reducing key collision risks.

**Who is this feature for?**
Developers using the grafana-i18n ESLint plugin who want to organize their translation keys with namespaces.

**Which issue(s) does this PR fix?:**
None - this is an enhancement to existing tooling.

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
