### PR TITLE
AccessControl: Fix flaky set resource permission integration test

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -909,7 +909,7 @@ func TestIntegrationStore_setResourcePermission(t *testing.T) {
 			permissions := retrievePermissionsHelper(store, t)
 			fmt.Println(permissions)
 
-			require.Equal(t, test.expectedPermissions, permissions)
+			require.ElementsMatch(t, test.expectedPermissions, permissions)
 		})
 	}
 }

--- a/pkg/services/accesscontrol/resourcepermissions/store_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/store_test.go
@@ -907,7 +907,6 @@ func TestIntegrationStore_setResourcePermission(t *testing.T) {
 
 			// Get permissions directly from DB to verify
 			permissions := retrievePermissionsHelper(store, t)
-			fmt.Println(permissions)
 
 			require.ElementsMatch(t, test.expectedPermissions, permissions)
 		})


### PR DESCRIPTION
Fix for this flaky test, `ElementsMatch` will ignore the order of the elements.

```
--- FAIL: TestIntegrationStore_setResourcePermission (1.72s)
    --- FAIL: TestIntegrationStore_setResourcePermission/when_updating_access_level,_should_not_touch_resource_permissions_on_other_resources (0.33s)
        store_test.go:912: 
            	Error Trace:	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/pkg/services/accesscontrol/resourcepermissions/store_test.go:912
            	Error:      	Not equal: 
            	            	expected: []resourcepermissions.orgPermission{resourcepermissions.orgPermission{OrgID:1, Action:"folders:admin", Scope:"folders:uid:2"}, resourcepermissions.orgPermission{OrgID:1, Action:"folders:delete", Scope:"folders:uid:2"}, resourcepermissions.orgPermission{OrgID:1, Action:"folders:view", Scope:"folders:uid:1"}}
            	            	actual  : []resourcepermissions.orgPermission{resourcepermissions.orgPermission{OrgID:1, Action:"folders:view", Scope:"folders:uid:1"}, resourcepermissions.orgPermission{OrgID:1, Action:"folders:delete", Scope:"folders:uid:2"}, resourcepermissions.orgPermission{OrgID:1, Action:"folders:admin", Scope:"folders:uid:2"}}
            	            	
            	            	Diff:
            	            	--- Expected
            	            	+++ Actual
            	            	@@ -3,4 +3,4 @@
            	            	   OrgID: (int64) 1,
            	            	-  Action: (string) (len=13) "folders:admin",
            	            	-  Scope: (string) (len=13) "folders:uid:2"
            	            	+  Action: (string) (len=12) "folders:view",
            	            	+  Scope: (string) (len=13) "folders:uid:1"
            	            	  },
            	            	@@ -13,4 +13,4 @@
            	            	   OrgID: (int64) 1,
            	            	-  Action: (string) (len=12) "folders:view",
            	            	-  Scope: (string) (len=13) "folders:uid:1"
            	            	+  Action: (string) (len=13) "folders:admin",
            	            	+  Scope: (string) (len=13) "folders:uid:2"
            	            	  }
            	Test:       	TestIntegrationStore_setResourcePermission/when_updating_access_level,_should_not_touch_resource_permissions_on_other_resources
FAIL
FAIL	github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions	18.089s
```