### PR TITLE
Unified Storage: Match all included tags

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1937,7 +1937,7 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	if len(query.Tags) > 0 {
 		req := []*resourcepb.Requirement{{
 			Key:      resource.SEARCH_FIELD_TAGS,
-			Operator: string(selection.In),
+			Operator: "=",
 			Values:   query.Tags,
 		}}
 		request.Options.Fields = append(request.Options.Fields, req...)

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1008,8 +1008,8 @@ func TestGetDashboardsByPluginID(t *testing.T) {
 	k8sCliMock.On("GetUsersFromMeta", mock.Anything, mock.Anything).Return(map[string]*user.User{}, nil)
 	k8sCliMock.On("Search", mock.Anything, mock.Anything, mock.MatchedBy(func(req *resourcepb.ResourceSearchRequest) bool {
 		return ( // gofmt comment helper
-			req.Options.Fields[0].Key == "manager.kind" && req.Options.Fields[0].Values[0] == string(utils.ManagerKindPlugin) &&
-				req.Options.Fields[1].Key == "manager.id" && req.Options.Fields[1].Values[0] == "testing")
+		req.Options.Fields[0].Key == "manager.kind" && req.Options.Fields[0].Values[0] == string(utils.ManagerKindPlugin) &&
+			req.Options.Fields[1].Key == "manager.id" && req.Options.Fields[1].Values[0] == "testing")
 	})).Return(&resourcepb.ResourceSearchResponse{
 		Results: &resourcepb.ResourceTable{
 			Columns: []*resourcepb.ResourceTableColumnDefinition{
@@ -2084,7 +2084,7 @@ func TestSearchProvisionedDashboardsThroughK8sRaw(t *testing.T) {
 				Updated:    provisioningTimestamp,
 			},
 		},
-	}, res)                                // only should return the one provisioned dashboard
+	}, res) // only should return the one provisioned dashboard
 	assert.Equal(t, "dash-db", query.Type) // query type should be added as dashboards only
 }
 


### PR DESCRIPTION
**Bug**
In the dashboard service, if multiple tags were included `/api/search?tag=cats&tag=dogs`, we would look for them with OR logic.

**Fix**
When multiple tags are present, match them all. This is the same behaviour as our k8s [search handler](https://github.com/grafana/grafana/blob/3dceaac5dc24c3b2b2f7c8eb0c12b3d38808792c/pkg/registry/apis/dashboard/search.go#L361).