### PR TITLE
TimeComparison: Automatically show/hide menu on hover

### DIFF
--- a/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
+++ b/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
@@ -61,17 +61,19 @@ export class CustomTimeRangeCompare extends SceneTimeRangeCompare {
   }
 
   static Component = function CustomTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeRangeCompare>) {
-    // Get the parent VizPanel to check timeCompare option
     const vizPanel = sceneGraph.getAncestor(model, VizPanel);
     const { options } = vizPanel.useState();
 
-    // Check if timeCompare is enabled
     const isTimeCompareEnabled = hasTimeCompare(options) && options.timeCompare;
 
     if (!isTimeCompareEnabled) {
       return <></>;
     }
 
-    return <SceneTimeRangeCompare.Component model={model} />;
+    return (
+      <div className="show-on-hover">
+        <SceneTimeRangeCompare.Component model={model} />
+      </div>
+    );
   };
 }


### PR DESCRIPTION
**What is this feature?**

This change makes the time comparison selector automatically show/hide in the same way that the "three dots" panel level contextual menu does next door.

https://github.com/user-attachments/assets/7e066cec-970f-4e71-a010-e2b6883aafd4

**Why do we need this feature?**

Consistency with the "three dots" panel menu, previously this was always shown, which left a whitespace "hole" to the right of this menu when the "three dots" menu was hidden on mouse out of the panel.

**Who is this feature for?**

All users of the new time comparison feature.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/grafana/issues/112545

**Special notes for your reviewer:**

🎏 Remember to set the feature toggle `timeComparison = true` to try this out.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
