### PR TITLE
K8s: an attempt to propagate true actor for getrestconfig

### DIFF
--- a/pkg/apiserver/endpoints/filters/requester.go
+++ b/pkg/apiserver/endpoints/filters/requester.go
@@ -1,6 +1,7 @@
 package filters
 
 import (
+	"fmt"
 	"net/http"
 	"slices"
 
@@ -16,7 +17,8 @@ import (
 func WithRequester(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		_, err := identity.GetRequester(ctx)
+		id, err := identity.GetRequester(ctx)
+		fmt.Println("id", id)
 		if err == nil {
 			handler.ServeHTTP(w, req)
 			return

--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -248,6 +248,7 @@ func (s *service) GetRestConfig(ctx context.Context) (*clientrest.Config, error)
 	if err := s.AwaitRunning(ctx); err != nil {
 		return nil, fmt.Errorf("unable to get rest config: %w", err)
 	}
+	s.restConfig.BearerToken = ""
 	s.restConfig.WrapTransport = func(rt http.RoundTripper) http.RoundTripper {
 		return newPreserveContextRoundTripper(ctx, rt)
 	}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Grafana Live uses LoopbackConfig via GetRestConfig and thereby uses system level access for provisioning. While it enforces its own [authz](https://github.com/grafana/grafana/blob/main/pkg/services/live/features/watch.go#L51-L64), in aggregation scenarios, its a bit weird to not just propagate the actor.

The context for propagating the actor is that when we don't do that, we can't require that all actions coming over aggregation are only user-actions, because in places, we lose the `idToken` on context when using loopback config.

This is an exploration of what it will take, but given there are many uses of GetRestConfig, it really isn't a solution.

**Why do we need this feature?**

**Pros**

The only pro of such an approach is that we don't have to inherently trust that Grafana monolith is performing authz correctly for any aggregated resources.

**Cons**

* The benefit of code-sharing with OSS/on-prem use-cases that heavily make use of loopback config for background tasks with cloud use-cases goes away.
* You can't use the kubeconfig dumped by `grafanaAPIServerEnsureKubectlAccess` to access aggregated resources because that too uses the LoopbackConfig.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
