### PR TITLE
TimeComparison:Show the compared time as panel subtitle

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelTimeCompareLabel.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeCompareLabel.tsx
@@ -1,0 +1,71 @@
+import { Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
+import { SceneComponentProps, SceneObjectBase, VizPanel } from '@grafana/scenes';
+import { Icon, PanelChrome, Text } from '@grafana/ui';
+
+import { CustomTimeRangeCompare } from './CustomTimeRangeCompare';
+
+/**
+ * Displays the current time comparison selection as subdued text in the panel title.
+ */
+export class PanelTimeCompareLabel extends SceneObjectBase {
+  static Component = PanelTimeCompareLabelRenderer;
+
+  constructor() {
+    super({});
+    this.addActivationHandler(this.onActivate);
+  }
+
+  private onActivate = () => {
+    const panel = this.parent;
+    if (!panel || !(panel instanceof VizPanel)) {
+      throw new Error('PanelTimeCompareLabel can be used only as title items for VizPanel');
+    }
+  };
+
+  public getPanel() {
+    const panel = this.parent;
+
+    if (panel && panel instanceof VizPanel) {
+      return panel;
+    }
+
+    return null;
+  }
+}
+
+function PanelTimeCompareLabelRenderer({ model }: SceneComponentProps<PanelTimeCompareLabel>) {
+  const panel = model.getPanel();
+
+  if (!panel || !config.featureToggles.timeComparison) {
+    return null;
+  }
+
+  const headerActions = panel.state.headerActions;
+  if (!headerActions || !Array.isArray(headerActions)) {
+    return null;
+  }
+
+  const timeCompare = headerActions.find((action) => action instanceof CustomTimeRangeCompare);
+  if (!timeCompare) {
+    return null;
+  }
+
+  const { compareWith, compareOptions } = timeCompare.useState();
+
+  if (!compareWith || compareWith === '__noPeriod') {
+    return null;
+  }
+
+  const option = compareOptions.find((opt) => opt.value === compareWith);
+  const label = option?.label || compareWith;
+
+  return (
+    <PanelChrome.TitleItem>
+      <Icon name="clock-nine" size="sm" />
+      <Text variant="bodySmall">
+        <Trans i18nKey="dashboard-scene.panel-time-compare-label.comparison-text">{{ label }} (comparison)</Trans>
+      </Text>
+    </PanelChrome.TitleItem>
+  );
+}

--- a/public/app/features/dashboard-scene/scene/PanelTimeCompareLabel.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelTimeCompareLabel.tsx
@@ -1,7 +1,7 @@
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase, VizPanel } from '@grafana/scenes';
-import { Icon, PanelChrome, Text } from '@grafana/ui';
+import { Icon, PanelChrome, Tooltip } from '@grafana/ui';
 
 import { CustomTimeRangeCompare } from './CustomTimeRangeCompare';
 
@@ -61,11 +61,14 @@ function PanelTimeCompareLabelRenderer({ model }: SceneComponentProps<PanelTimeC
   const label = option?.label || compareWith;
 
   return (
-    <PanelChrome.TitleItem>
-      <Icon name="clock-nine" size="sm" />
-      <Text variant="bodySmall">
+    <Tooltip
+      content={
         <Trans i18nKey="dashboard-scene.panel-time-compare-label.comparison-text">{{ label }} (comparison)</Trans>
-      </Text>
-    </PanelChrome.TitleItem>
+      }
+    >
+      <PanelChrome.TitleItem>
+        <Icon name="clock-nine" size="sm" />
+      </PanelChrome.TitleItem>
+    </Tooltip>
   );
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -31,6 +31,7 @@ import { LibraryPanelBehavior } from '../../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../../scene/PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from '../../scene/PanelMenuBehavior';
 import { PanelNotices } from '../../scene/PanelNotices';
+import { PanelTimeCompareLabel } from '../../scene/PanelTimeCompareLabel';
 import { PanelTimeRange } from '../../scene/PanelTimeRange';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
@@ -43,6 +44,8 @@ import { transformDataTopic } from '../transformToV2TypesUtils';
 
 export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
   const titleItems: SceneObject[] = [];
+
+  titleItems.push(new PanelTimeCompareLabel());
 
   titleItems.push(
     new VizPanelLinks({
@@ -97,6 +100,8 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
 
 export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPanel {
   const titleItems: SceneObject[] = [];
+
+  titleItems.push(new PanelTimeCompareLabel());
 
   titleItems.push(
     new VizPanelLinks({

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -44,6 +44,7 @@ import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelLinksBehavior, panelMenuBehavior } from '../scene/PanelMenuBehavior';
 import { PanelNotices } from '../scene/PanelNotices';
+import { PanelTimeCompareLabel } from '../scene/PanelTimeCompareLabel';
 import { PanelTimeRange } from '../scene/PanelTimeRange';
 import { DashboardGridItem, RepeatDirection } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
@@ -398,6 +399,8 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     : {};
 
   const titleItems: SceneObject[] = [];
+
+  titleItems.push(new PanelTimeCompareLabel());
 
   titleItems.push(
     new VizPanelLinks({

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -24,6 +24,7 @@ import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
 import { LibraryPanelBehavior } from '../scene/LibraryPanelBehavior';
 import { VizPanelLinks, VizPanelLinksMenu } from '../scene/PanelLinks';
 import { panelMenuBehavior } from '../scene/PanelMenuBehavior';
+import { PanelTimeCompareLabel } from '../scene/PanelTimeCompareLabel';
 import { UNCONFIGURED_PANEL_PLUGIN_ID } from '../scene/UnconfiguredPanel';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { setDashboardPanelContext } from '../scene/setDashboardPanelContext';
@@ -249,7 +250,7 @@ export function getDefaultVizPanel(): VizPanel {
     title: newPanelTitle,
     pluginId: defaultPluginId,
     seriesLimit: config.panelSeriesLimit,
-    titleItems: [new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })],
+    titleItems: [new PanelTimeCompareLabel(), new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })],
     hoverHeaderOffset: 0,
     $behaviors: [],
     extendPanelContext: setDashboardPanelContext,


### PR DESCRIPTION
**What is this feature?**

This change adds a panel subtitle (between the panel title and panel level links), which shows the time comparison being made in the panel, using terminology that ties the menu selection to the legend.

For example: `🕑 Week before (comparison)`. 

https://github.com/user-attachments/assets/9886ba99-4469-4b4f-b5a8-9a4965be6fd1

> [!NOTE]
> There was a previous intentional choice made in `@grafana/scenes` around the `(comparison)` label suffix in the legend.
> SEE: https://github.com/grafana/grafana/pull/71129#discussion_r1255864843


**Why do we need this feature?**

We now automatically show/hide the time comparison menu on panel hover (as of https://github.com/grafana/grafana/pull/112750). When the time comparison menu is hidden the user may become disoriented when their selection is not visible, and the legend labels saying `X (comparison)` becomes less meaningful.

**Who is this feature for?**

Everyone using the new time comparison feature.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/112546

**Special notes for your reviewer:**

🎏 Remember the feature toggle `timeComparison = true`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
