### PR TITLE
Check that we see less calls than allowed maximum.

### DIFF
--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1506,8 +1506,8 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	cancel()
 	wg.Wait()
 
-	expectedUpdateCalls := int64(testTime / minInterval)
-	require.InDelta(t, expectedUpdateCalls, updateCalls.Load(), float64(expectedUpdateCalls/2))
+	expectedMaxCalls := int64(testTime / minInterval)
+	require.LessOrEqual(t, updateCalls.Load(), expectedMaxCalls+1)
 	require.Greater(t, attemptedUpdates.Load(), updateCalls.Load())
 
 	t.Log("Attempted updates:", attemptedUpdates.Load(), "update calls:", updateCalls.Load())


### PR DESCRIPTION
Previously we tested that number of calls was between 5 and 15 (for 1s test with 100ms min time between updates), but what we really want to test is that min time betwen updates is honored, and that there were less (or equal) than 10 calls. On slow CI machines sometimes [we see as few as 3 update calls only.](https://github.com/grafana/grafana-enterprise/actions/runs/18709423764/job/53354062147?pr=9989)