### PR TITLE
Nav: Update Observability section nav to phase 2

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -26,7 +26,6 @@ const (
 	WeightCloudServiceProviders
 	WeightInfrastructure
 	WeightApplication
-	WeightFrontend
 	WeightAsserts
 	WeightDataConnections
 	WeightApps
@@ -48,7 +47,6 @@ const (
 	NavIDAlerting             = "alerting"
 	NavIDObservability        = "observability"
 	NavIDInfrastructure       = "infrastructure"
-	NavIDFrontend             = "frontend"
 	NavIDReporting            = "reports"
 	NavIDApps                 = "apps"
 	NavIDCfgGeneral           = "cfg/general"

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -4,6 +4,7 @@ import (
 	"path"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/grafana/grafana/pkg/plugins"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -268,6 +269,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 		// keep current sorting if the pages, but above all the other apps
 		for _, child := range sectionChildren {
 			child.SortWeight = -100 + child.SortWeight
+			child.Id = "standalone-plugin-page-" + strings.ReplaceAll(strings.ToLower(child.Text), " ", "-")
 		}
 	}
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -260,10 +260,21 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 		}
 	}
 
+	sectionChildren := []*navtree.NavLink{appLink}
+	// asserts pages expand to root Observability section instead of it's own node
+	if plugin.ID == "grafana-asserts-app" {
+		sectionChildren = appLink.Children
+
+		// keep current sorting if the pages, but above all the other apps
+		for _, child := range sectionChildren {
+			child.SortWeight = -100 + child.SortWeight
+		}
+	}
+
 	if sectionID == navtree.NavIDRoot {
 		treeRoot.AddSection(appLink)
 	} else if navNode := treeRoot.FindById(sectionID); navNode != nil {
-		navNode.Children = append(navNode.Children, appLink)
+		navNode.Children = append(navNode.Children, sectionChildren...)
 	} else {
 		switch sectionID {
 		case navtree.NavIDApps:
@@ -272,7 +283,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				Icon:       "layer-group",
 				SubTitle:   "App plugins that extend the Grafana experience",
 				Id:         navtree.NavIDApps,
-				Children:   []*navtree.NavLink{appLink},
+				Children:   sectionChildren,
 				SortWeight: navtree.WeightApps,
 				Url:        s.cfg.AppSubURL + "/apps",
 			})
@@ -283,7 +294,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				SubTitle:   "Monitor infrastructure and applications in real time with Grafana Cloud's fully managed observability suite",
 				Icon:       "heart-rate",
 				SortWeight: navtree.WeightObservability,
-				Children:   []*navtree.NavLink{appLink},
+				Children:   sectionChildren,
 				Url:        s.cfg.AppSubURL + "/observability",
 			})
 		case navtree.NavIDInfrastructure:
@@ -293,18 +304,8 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				SubTitle:   "Understand your infrastructure's health",
 				Icon:       "heart-rate",
 				SortWeight: navtree.WeightInfrastructure,
-				Children:   []*navtree.NavLink{appLink},
+				Children:   sectionChildren,
 				Url:        s.cfg.AppSubURL + "/infrastructure",
-			})
-		case navtree.NavIDFrontend:
-			treeRoot.AddSection(&navtree.NavLink{
-				Text:       "Frontend",
-				Id:         navtree.NavIDFrontend,
-				SubTitle:   "Gain real user monitoring insights",
-				Icon:       "frontend-observability",
-				SortWeight: navtree.WeightFrontend,
-				Children:   []*navtree.NavLink{appLink},
-				Url:        s.cfg.AppSubURL + "/frontend",
 			})
 		case navtree.NavIDAlertsAndIncidents:
 			alertsAndIncidentsChildren := []*navtree.NavLink{}
@@ -332,7 +333,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				SubTitle:   "Optimize performance with k6 and Synthetic Monitoring insights",
 				Icon:       "k6",
 				SortWeight: navtree.WeightTestingAndSynthetics,
-				Children:   []*navtree.NavLink{appLink},
+				Children:   sectionChildren,
 				Url:        s.cfg.AppSubURL + "/testing-and-synthetics",
 			})
 		case navtree.NavIDAdaptiveTelemetry:
@@ -342,7 +343,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				SubTitle:   "Reduce noise, cut costs, and accelerate troubleshooting by intelligently ingesting only the telemetry data that matters most.",
 				Icon:       "adaptive-telemetry",
 				SortWeight: navtree.WeightAIAndML + 1, // Place under "AI & Machine Learning"
-				Children:   []*navtree.NavLink{appLink},
+				Children:   sectionChildren,
 				Url:        "adaptive-telemetry",
 				// Use the icon URL from the first "Adaptive Telemetry" plugin in the list (they will all be the same)
 				Img:   s.cfg.AppSubURL + plugin.Info.Logos.Large,


### PR DESCRIPTION
Let's try again the change for updating the Observability nav section to [phase 2](https://docs.google.com/document/d/1oYGJ5NxBxirpaQ_j9Eh6QzOEbjSVZkg83H1_w5zKyrY/edit?tab=t.0#heading=h.e7qy0ec3473k), which makes Knowledge graph plugin pages have Observability section as root.

We had to rollback the original PR ([this one](https://github.com/grafana/grafana/pull/109347)) because it was causing problems with highlighting active items in the mega menu. Let's deploy this branch to a new stack and try to figure out what went wrong.

Demo:
<img width="1615" height="1034" alt="Screenshot 2025-10-22 at 15 13 31" src="https://github.com/user-attachments/assets/06a8c912-a969-4368-a689-1225496da19a" />
<img width="652" height="1041" alt="Screenshot 2025-10-22 at 15 13 03" src="https://github.com/user-attachments/assets/e6d567b9-da64-4fd3-b38e-97e4530a626d" />

Fixes https://github.com/grafana/asserts-app-plugin/issues/1970