### PR TITLE
Table: Demonstrate ad-hoc filtering error case with updated e2e test

### DIFF
--- a/e2e-playwright/dashboards/AdHocFilterTest.json
+++ b/e2e-playwright/dashboards/AdHocFilterTest.json
@@ -55,7 +55,20 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "slice"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Slice"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/19065

This can be a little tricky to simulate locally given that you need either a prometheus, loki, or Dashboard datasource running, so I've updated the e2e test for adhoc filters to make sure that the test tests the case that we care about, which proves that the case is broken on main right now for table.