### PR TITLE
Table: Update ad-hoc filter to use name instead of displayName

### DIFF
--- a/e2e-playwright/dashboards/AdHocFilterTest.json
+++ b/e2e-playwright/dashboards/AdHocFilterTest.json
@@ -55,7 +55,20 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "slice"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Slice"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -59,7 +59,7 @@ export const TableCellActions = memo(
             aria-label={t('grafana-ui.table.cell-filter-on', 'Filter for value')}
             onClick={() => {
               onCellFilterAdded?.({
-                key: displayName,
+                key: field.name,
                 operator: FILTER_FOR_OPERATOR,
                 value: String(value ?? ''),
               });
@@ -70,7 +70,7 @@ export const TableCellActions = memo(
             aria-label={t('grafana-ui.table.cell-filter-out', 'Filter out value')}
             onClick={() => {
               onCellFilterAdded?.({
-                key: displayName,
+                key: field.name,
                 operator: FILTER_OUT_OPERATOR,
                 value: String(value ?? ''),
               });


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/19065 

This fixes an issue with the table introduced in Grafana 12.2, where the `onCellFilterAdded` function was incorrectly being called with `displayName` instead of `field.name`. As we can see in the o.g. table code, we need to call it with field.name.

https://github.com/grafana/grafana/blob/a07f63fbef98ed361bb65633aa2c74b831e33529/packages/grafana-ui/src/components/Table/CellActions.tsx#L43

I've also opened https://github.com/grafana/grafana/pull/112814 as a draft to demonstrate that, against main, the updated e2e test fails.