### PR TITLE
Chore: Refine side nav item layout

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -175,7 +175,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   menuItem: css({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(1),
+    gap: theme.spacing(0.5),
     height: theme.spacing(4),
     paddingLeft: theme.spacing(0.5),
     position: 'relative',
@@ -221,6 +221,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   labelWrapperWithIcon: css({
     paddingLeft: theme.spacing(0.5),
+    gap: theme.spacing(0.5),
   }),
   hasActiveChild: css({
     color: theme.colors.text.primary,


### PR DESCRIPTION
This PR makes 2 minor adjustments to the spacing of sidebar menu items:
- it reduces the padding between icons and the corresponding label, which has the effect of creating a visual difference in the indent level between first and second-level items
- it reduces the left padding of 3rd-level items

These changes are subtle, but help better define the structure of the menu items, whereas today the first and second-level items blend together.

The impact of this change can be seen below, with `main` on the left and this branch on the right.

<img width="716" height="625" alt="image" src="https://github.com/user-attachments/assets/f9ac2e65-c4eb-4c17-b113-bf61b98593e1" />
