### PR TITLE
TimeComparison: Add interval to displayName

### DIFF
--- a/packages/grafana-data/src/field/fieldState.test.ts
+++ b/packages/grafana-data/src/field/fieldState.test.ts
@@ -50,9 +50,9 @@ describe('getFieldDisplayName', () => {
       ],
     });
 
-    expect(getFieldDisplayName(frame.fields[1], frame)).toBe('ServerA (comparison)');
-    expect(getFieldDisplayName(frame.fields[2], frame)).toBe('ServerB (comparison)');
-    expect(getFieldDisplayName(frame.fields[3], frame)).toBe('Value 3 (comparison)');
+    expect(getFieldDisplayName(frame.fields[1], frame)).toBe('ServerA (-1d)');
+    expect(getFieldDisplayName(frame.fields[2], frame)).toBe('ServerB (-1d)');
+    expect(getFieldDisplayName(frame.fields[3], frame)).toBe('Value 3 (-1d)');
   });
 });
 

--- a/packages/grafana-data/src/field/fieldState.ts
+++ b/packages/grafana-data/src/field/fieldState.ts
@@ -1,3 +1,4 @@
+import { secondsToHms } from '../datetime/rangeutil';
 import { getFieldMatcher } from '../transformations/matchers';
 import {
   DataFrame,
@@ -130,12 +131,23 @@ export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFr
   const isComparisonSeries = Boolean(frame?.meta?.timeCompare?.isTimeShiftQuery);
   let displayName = hasConfigTitle ? field.config!.displayName! : field.name;
 
+  let displayNameSuffix = '';
+
+  if (isComparisonSeries) {
+    const diffMs = frame?.meta?.timeCompare?.diffMs ?? 0;
+    displayNameSuffix = ' (comparison)';
+    if (diffMs !== 0) {
+      const intervalStr = secondsToHms(Math.abs(diffMs) / 1000);
+      displayNameSuffix = ` (-${intervalStr})`;
+    }
+  }
+
   if (hasConfigTitle) {
-    return isComparisonSeries ? `${displayName} (comparison)` : displayName;
+    return `${displayName}${displayNameSuffix}`;
   }
 
   if (frame && field.config?.displayNameFromDS) {
-    return isComparisonSeries ? `${field.config.displayNameFromDS} (comparison)` : field.config.displayNameFromDS;
+    return `${field.config.displayNameFromDS}${displayNameSuffix}`;
   }
 
   // This is an ugly exception for time field
@@ -207,7 +219,7 @@ export function calculateFieldDisplayName(field: Field, frame?: DataFrame, allFr
   }
 
   if (isComparisonSeries) {
-    displayName = `${displayName} (comparison)`;
+    displayName = `${displayName}${displayNameSuffix}`;
   }
   return displayName;
 }


### PR DESCRIPTION
An alternative (or complimentary) approach to https://github.com/grafana/grafana/pull/112762 to indicate which time comparison is currently being displayed in a panel without using a subtitle by displaying the comparison interval (in short form) in the field display name. Note, it is possible that both approaches add value in conjunction.

Before:
<img width="847" height="384" alt="image" src="https://github.com/user-attachments/assets/ea929672-4118-48b5-8587-8d87a2048e0a" />


After:
<img width="848" height="380" alt="image" src="https://github.com/user-attachments/assets/70aec7de-ca0f-4ed8-85e5-641ca777c1e3" />

Fixes https://github.com/grafana/grafana/issues/112546