### PR TITLE
CloudMonitoring: Fix 3h alignment period 

### DIFF
--- a/public/app/plugins/datasource/cloud-monitoring/constants.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/constants.ts
@@ -250,7 +250,7 @@ export const ALIGNMENT_PERIODS: periodOption[] = [
   { text: '10m', value: '+600s' },
   { text: '30m', value: '+1800s' },
   { text: '1h', value: '+3600s' },
-  { text: '3h', value: '+7200s' },
+  { text: '3h', value: '+10800s' },
   { text: '6h', value: '+21600s' },
   { text: '1d', value: '+86400s' },
   { text: '3d', value: '+259200s' },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR fixes an incorrect value in the Google Cloud Monitoring data source alignment period dropdown. The "3h" option was incorrectly set to 7200 seconds (2 hours) instead of 10800 seconds (3 hours).

**Why do we need this feature?**

Users selecting the "3h" alignment period expect their metrics to be grouped into 3-hour buckets, but the incorrect value was causing data to be grouped into 2-hour buckets instead. This leads to incorrect data visualization and potential misinterpretation of metrics.

**Who is this feature for?**

This fix is for all Grafana users who use the Google Cloud Monitoring data source and need accurate 3-hour alignment periods for their metric queries.

**Which issue(s) does this PR fix?**:

Fixes #112473

**Additional context:**

- This is a simple one-line fix changing `'+7200s'` to `'+10800s'`
- The bug has existed since 2019 when the 3h option was originally added
- No documentation updates needed as this is a bug fix that makes the existing feature work as intended
- Testing: Create a GCP metric visualization with 3h alignment period and verify buckets are now 3 hours (10800s) instead of 2 hours
