### PR TITLE
OpenFeature: Fix instrumentation in OFREP API

### DIFF
--- a/pkg/registry/apis/ofrep/proxy.go
+++ b/pkg/registry/apis/ofrep/proxy.go
@@ -22,7 +22,7 @@ import (
 )
 
 func (b *APIBuilder) proxyAllFlagReq(ctx context.Context, isAuthedUser bool, w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracer.Start(ctx, "ofrep.proxy.evalAllFlags")
+	ctx, span := tracing.Start(ctx, "ofrep.proxy.evalAllFlags")
 	defer span.End()
 
 	r = r.WithContext(ctx)
@@ -70,7 +70,7 @@ func (b *APIBuilder) proxyAllFlagReq(ctx context.Context, isAuthedUser bool, w h
 }
 
 func (b *APIBuilder) proxyFlagReq(ctx context.Context, flagKey string, isAuthedUser bool, w http.ResponseWriter, r *http.Request) {
-	ctx, span := tracer.Start(ctx, "ofrep.proxy.evalFlag")
+	ctx, span := tracing.Start(ctx, "ofrep.proxy.evalFlag")
 	defer span.End()
 
 	r = r.WithContext(ctx)

--- a/pkg/registry/apis/ofrep/static.go
+++ b/pkg/registry/apis/ofrep/static.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (b *APIBuilder) evalAllFlagsStatic(ctx context.Context, isAuthedUser bool, w http.ResponseWriter) {
-	_, span := tracer.Start(ctx, "ofrep.static.evalAllFlags")
+	_, span := tracing.Start(ctx, "ofrep.static.evalAllFlags")
 	defer span.End()
 
 	result, err := b.staticEvaluator.EvalAllFlags(ctx)
@@ -40,7 +40,7 @@ func (b *APIBuilder) evalAllFlagsStatic(ctx context.Context, isAuthedUser bool, 
 }
 
 func (b *APIBuilder) evalFlagStatic(ctx context.Context, flagKey string, w http.ResponseWriter) {
-	_, span := tracer.Start(ctx, "ofrep.static.evalFlag")
+	_, span := tracing.Start(ctx, "ofrep.static.evalFlag")
 	defer span.End()
 
 	span.SetAttributes(attribute.String("flag_key", flagKey))


### PR DESCRIPTION
When running the OFREP API as a separate API server I didn’t receive any traces. It looks like `otel.Tracer()` creates a tracer from the global provider. This differs from the `tracing.Start()` function, which extracts the TracerProvider from the parent span context and works as expected within the K8s APIServer’s WithTracing middleware.

Thanks to @charandas for help 🧡