### PR TITLE
fix: sqlite nocgo with ionice and parallel flag

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -101,7 +101,8 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          CGO_ENABLED=0 go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          # ionice since tests are IO intensive
+          CGO_ENABLED=0 ionice -c2 -n7 go test -p=4 -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
   mysql:
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -103,7 +103,7 @@ func StartGrafanaEnv(t *testing.T, grafDir, cfgPath string) (string, *server.Tes
 	dbCfg.Key("password").SetValue(testDB.Password)
 	dbCfg.Key("name").SetValue(testDB.Database)
 
-	t.Log("Using test database", "type", testDB.DriverName, "host", testDB.Host, "port", testDB.Port, "user", testDB.User, "name", testDB.Database)
+	t.Log("Using test database", "type", testDB.DriverName, "host", testDB.Host, "port", testDB.Port, "user", testDB.User, "name", testDB.Database, "path", testDB.Path)
 
 	env, err := server.InitializeForTest(ctx, t, t, cfg, serverOpts, apiServerOpts)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This is another try at fixing the flaky nocgo integration tests. I suspect that the bottleneck is on the runner IO, so I wanna try using less parallelism and `ionice` to reduce IO contention.

My previous try was here: https://github.com/grafana/grafana/pull/112667 , but we saw it happen again afterwards:
https://github.com/grafana/grafana/actions/runs/18735429814/job/53440988233

```
runner/_work/grafana/grafana/pkg/tests/apis/dashboard/dashboards_test.go:155
            	Error:      	Received unexpected error:
            	            	failed to truncate table "user": database is locked (5) (SQLITE_BUSY)
            	            	terminated after 5 retries
            	Test:       	TestIntegrationDashboardsAppV1/v1beta1_with_dual_writer_mode_4
```


**Why do we need this feature?**

Improves stability of CI/CD.


**Who is this feature for?**

Internal Grafana teams

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/search-and-storage-team/issues/546

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.

Job durations is similar as before without the changes.

With changes:

<img width="664" height="333" alt="image" src="https://github.com/user-attachments/assets/5d9884ec-39e6-44d2-a876-c8fe9032ee33" />

From another recent run:
<img width="564" height="266" alt="image" src="https://github.com/user-attachments/assets/a4696f5a-40a7-4df4-8ac1-0f1e0be229f0" />

- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
