### PR TITLE
mergeResponses: use map to find frames to combine

### DIFF
--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -13,18 +13,53 @@ import {
 
 import { LOADING_FRAME_NAME } from './querySplitting';
 
+function getFrameKey(frame: DataFrame): string | undefined {
+  console.log('get key!');
+  // Metric range query data
+  if (frame.meta?.type === DataFrameType.TimeSeriesMulti) {
+    const field = frame.fields.find((f) => f.type === FieldType.number);
+    if (!field) {
+      throw new Error(`Unable to find number field on sharded dataframe!`);
+    }
+    let key = '';
+    if (frame.refId) {
+      key += frame.refId;
+    }
+    if (frame.name) {
+      key += frame.name;
+    }
+    if (field.labels) {
+      key += JSON.stringify(field.labels);
+    }
+    return key !== '' ? key : undefined;
+  }
+  return frame.refId ?? frame.name;
+}
+
 export function combineResponses(currentResponse: DataQueryResponse | null, newResponse: DataQueryResponse) {
   if (!currentResponse) {
     return cloneQueryResponse(newResponse);
   }
 
-  newResponse.data.forEach((newFrame) => {
-    const currentFrame = currentResponse.data.find((frame) => shouldCombine(frame, newFrame));
-    if (!currentFrame) {
-      currentResponse.data.push(cloneDataFrame(newFrame));
-      return;
+  const currentResponseLabelsMap = new Map<string, DataFrame>();
+  currentResponse.data.forEach((frame: DataFrame) => {
+    const key = getFrameKey(frame);
+    // It is expected that all frames contain a refId or a name, but since the type allows for it
+    // we need to account for possibly undefined cases.
+    if (key) {
+      currentResponseLabelsMap.set(key, frame);
     }
-    mergeFrames(currentFrame, newFrame);
+  });
+
+  newResponse.data.forEach((newFrame: DataFrame) => {
+    let currentFrame: DataFrame | undefined = undefined;
+    const key = getFrameKey(newFrame);
+    if (key !== undefined && currentResponseLabelsMap.has(key)) {
+      currentFrame = currentResponseLabelsMap.get(key);
+      mergeFrames(currentFrame!, newFrame);
+    } else {
+      currentResponse.data.push(cloneDataFrame(newFrame));
+    }
   });
 
   const mergedErrors = [...(currentResponse.errors ?? []), ...(newResponse.errors ?? [])];

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -14,7 +14,6 @@ import {
 import { LOADING_FRAME_NAME } from './querySplitting';
 
 function getFrameKey(frame: DataFrame): string | undefined {
-  console.log('get key!');
   // Metric range query data
   if (frame.meta?.type === DataFrameType.TimeSeriesMulti) {
     const field = frame.fields.find((f) => f.type === FieldType.number);


### PR DESCRIPTION
Analog to https://github.com/grafana/logs-drilldown/pull/1472, instead of looping over the previous responses * updated responses calling `shouldCombine()` between pairs, we now use a map to find data frames by key.

A minor difference with https://github.com/grafana/logs-drilldown/pull/1472 is that we don't mutate the name when combining, which might be acceptable in Logs Drilldown but could cause unexpected/undesired effects in core Grafana.

B:

<img width="549" height="85" alt="imagen" src="https://github.com/user-attachments/assets/10cca589-302e-44f9-920d-63691c653a72" />

A:

<img width="716" height="73" alt="imagen" src="https://github.com/user-attachments/assets/283dacd5-f18f-42a6-ae15-50495c536fc7" />

### How to test

Run a heavy query, over 2 days, that produce multiple series. For example:

`count_over_time({service_name="flux-commit-tracker"}[$__auto])`
`count_over_time({service_name="tempo/ingester"}[$__auto])`

The browser should not freeze or crash.