### PR TITLE
datasources: forward the x-forwarded-for header

### DIFF
--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -19,6 +19,9 @@ import (
 //
 // The usage of strings.ToLower is because the server would convert `FromAlert` to `Fromalert`. So the make matching
 // easier, we just match all headers in lower case.
+//
+// the headers X-Real-IP and X-Forwarded-For are used by the HostedGrafanaACHeaderMiddleware at
+// https://github.com/grafana/grafana/blob/f191acf8114ab79609fc631e0f01fe2b47371188/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go#L107
 var expectedHeaders = map[string]string{
 	strings.ToLower(models.FromAlertHeaderName):        models.FromAlertHeaderName,
 	strings.ToLower(models.CacheSkipHeaderName):        models.CacheSkipHeaderName,
@@ -38,6 +41,7 @@ var expectedHeaders = map[string]string{
 	strings.ToLower(queryService.HeaderDashboardTitle): queryService.HeaderDashboardTitle,
 	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
 	strings.ToLower("X-Real-IP"):                       "X-Real-IP",
+	strings.ToLower("X-Forwarded-For"):                 "X-Forwarded-For",
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {


### PR DESCRIPTION
a [middleware we need to support](https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go#L30) will ask for the "remote ip address" of the current request.

it does so by calling into this function: https://github.com/grafana/grafana/blob/f3eabbf588b227d26e00f7eb919d174254a54edb/pkg/web/context.go#L71

that function checks two http headers: `X-Real-IP` and `X-Forwarded-For`.

this PR handles the `X-Forwarded-For` header.
