### PR TITLE
feat: allow service_name override

### DIFF
--- a/pkg/infra/tracing/tracing_config.go
+++ b/pkg/infra/tracing/tracing_config.go
@@ -92,6 +92,12 @@ func ParseTracingConfig(cfg *setting.Cfg) (*TracingConfig, error) {
 		return nil, err
 	}
 
+	// Allow overriding service name via configuration
+	serviceName := section.Key("service_name").MustString("")
+	if serviceName != "" {
+		tc.ServiceName = serviceName
+	}
+
 	// if sampler_type is set in tracing.opentelemetry, we ignore the config in tracing.jaeger
 	sampler := section.Key("sampler_type").MustString("")
 	if sampler != "" {


### PR DESCRIPTION
Follow up from this PR:
https://github.com/grafana/deployment_tools/pull/385099

Currently operators use the tracing package which does not allow for `service_name` override, as we allow with standalone API servers:
```
--grafana.tracing.service-name
```

The apiserver is using:
https://github.com/grafana/grafana-enterprise/blob/main/src/pkg/extensions/apiserver/options/tracing.go