### PR TITLE
StateTimeline: Fix color display in tooltip

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3055,11 +3055,6 @@
       "count": 1
     }
   },
-  "public/app/features/explore/TraceView/components/utils/DraggableManager/demo/index.tsx": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
-    }
-  },
   "public/app/features/explore/TraceView/components/utils/sort.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/SeriesIcon.tsx
@@ -11,10 +11,11 @@ export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   color?: string;
   gradient?: string;
   lineStyle?: LineStyle;
+  noMargin?: boolean;
 }
 
 export const SeriesIcon = React.memo(
-  React.forwardRef<HTMLDivElement, Props>(({ color, className, gradient, lineStyle, ...restProps }, ref) => {
+  React.forwardRef<HTMLDivElement, Props>(({ color, className, gradient, lineStyle, noMargin, ...restProps }, ref) => {
     const theme = useTheme2();
     const styles = useStyles2(getStyles);
 
@@ -59,7 +60,7 @@ export const SeriesIcon = React.memo(
       <div
         data-testid="series-icon"
         ref={ref}
-        className={cx(className, styles.forcedColors, styles.container)}
+        className={cx(className, styles.forcedColors, styles.container, noMargin ? null : styles.margin)}
         style={customStyle}
         {...restProps}
       />
@@ -68,8 +69,10 @@ export const SeriesIcon = React.memo(
 );
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  container: css({
+  margin: css({
     marginRight: '8px',
+  }),
+  container: css({
     display: 'inline-block',
     width: '14px',
     height: '4px',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipColorIndicator.tsx
@@ -33,31 +33,23 @@ export const VizTooltipColorIndicator = ({
 }: Props) => {
   const styles = useStyles2(getStyles);
 
-  if (isHollow) {
+  if (colorIndicator === ColorIndicator.series && !isHollow) {
     return (
-      <div
-        style={{ border: `1px solid ${color}` }}
+      <SeriesIcon
+        color={color}
+        lineStyle={lineStyle}
+        noMargin
         className={cx(
           position === ColorIndicatorPosition.Leading ? styles.leading : styles.trailing,
-          getColorIndicatorClass(colorIndicator, styles)
+          styles.seriesIndicator
         )}
       />
     );
   }
 
-  if (colorIndicator === ColorIndicator.series) {
-    return (
-      <SeriesIcon
-        color={color}
-        lineStyle={lineStyle}
-        className={position === ColorIndicatorPosition.Leading ? styles.leading : styles.trailing}
-      />
-    );
-  }
-
   return (
-    <span
-      style={{ backgroundColor: color }}
+    <div
+      style={isHollow ? { border: `1px solid ${color}` } : { backgroundColor: color }}
       className={cx(
         position === ColorIndicatorPosition.Leading ? styles.leading : styles.trailing,
         getColorIndicatorClass(colorIndicator, styles)
@@ -73,6 +65,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   trailing: css({
     marginLeft: theme.spacing(0.5),
+  }),
+  seriesIndicator: css({
+    position: 'relative',
+    top: -2, // half the height of the color indicator, since the top is aligned with flex center.
   }),
   series: css({
     width: '14px',

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -248,6 +248,8 @@ const getStyles = (theme: GrafanaTheme2, justify = 'start', marginRight?: string
     fontWeight: 400,
   }),
   valueWrapper: css({
+    display: 'flex',
+    alignItems: 'center',
     flexShrink: 0,
     alignSelf: 'center',
     marginRight,

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -134,7 +134,7 @@ export const VizTooltipRow = ({
   return (
     <div className={styles.contentWrapper}>
       {color && colorPlacement === ColorPlacement.first && (
-        <div className={clsx(styles.colorWrapper, styles.colorIndicatorFirst)}>
+        <div className={styles.colorWrapper}>
           <VizTooltipColorIndicator
             color={color}
             colorIndicator={colorIndicator}

--- a/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
+++ b/packages/grafana-ui/src/components/VizTooltip/VizTooltipRow.tsx
@@ -134,7 +134,7 @@ export const VizTooltipRow = ({
   return (
     <div className={styles.contentWrapper}>
       {color && colorPlacement === ColorPlacement.first && (
-        <div className={styles.colorWrapper}>
+        <div className={clsx(styles.colorWrapper, styles.colorIndicatorFirst)}>
           <VizTooltipColorIndicator
             color={color}
             colorIndicator={colorIndicator}
@@ -225,7 +225,7 @@ const getStyles = (theme: GrafanaTheme2, justify = 'start', marginRight?: string
     maxWidth: '100%',
     alignItems: 'start',
     justifyContent: justify,
-    columnGap: '6px',
+    columnGap: theme.spacing(0.75),
   }),
   label: css({ display: 'inline' }),
   value: css({
@@ -235,10 +235,7 @@ const getStyles = (theme: GrafanaTheme2, justify = 'start', marginRight?: string
   }),
   colorWrapper: css({
     alignSelf: 'center',
-    position: 'relative',
     flexShrink: 0,
-    top: -2, // half the height of the color indicator, since the top is aligned with flex center.
-    marginRight: '-6px', // account for the built-in column-gap in relation to the color indicator's margin
   }),
   labelWrapper: css({
     flexGrow: 1,


### PR DESCRIPTION
Fixes #112511 

When we addressed https://github.com/grafana/grafana/pull/112240, the case in StateTimeline broke, so this fixes it. The debug dashboard included also includes the test panel from that fix to confirm that we didn't re-regress that.

https://github.com/user-attachments/assets/1577b309-2a61-4927-a70d-9e2fb60f839e

<details>
    <summary>JSON for dashboard</summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 1893,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "thresholds"
          },
          "custom": {
            "axisPlacement": "auto",
            "fillOpacity": 70,
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineWidth": 0,
            "spanNulls": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 2,
      "options": {
        "alignValue": "left",
        "legend": {
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "mergeValues": true,
        "rowHeight": 0.9,
        "showValue": "auto",
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "12.3.0-pre",
      "targets": [
        {
          "max": 90,
          "min": 70,
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 10
        }
      ],
      "title": "Test that we fixed StateTimeline",
      "type": "state-timeline"
    },
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "barAlignment": 0,
            "barWidthFactor": 0.6,
            "drawStyle": "line",
            "fillOpacity": 0,
            "gradientMode": "none",
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "insertNulls": false,
            "lineInterpolation": "linear",
            "lineWidth": 1,
            "pointSize": 5,
            "scaleDistribution": {
              "type": "linear"
            },
            "showPoints": "auto",
            "showValues": false,
            "spanNulls": false,
            "stacking": {
              "group": "A",
              "mode": "none"
            },
            "thresholdsStyle": {
              "mode": "off"
            }
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 12,
        "y": 0
      },
      "id": 1,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "tooltip": {
          "hideZeros": false,
          "maxWidth": 200,
          "mode": "multi",
          "sort": "none"
        }
      },
      "pluginVersion": "12.3.0-pre",
      "targets": [
        {
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 20
        }
      ],
      "title": "Confirm we didn't regress timeseries",
      "transformations": [
        {
          "id": "merge",
          "options": {}
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {},
            "includeByName": {},
            "indexByName": {},
            "renameByName": {
              "A-series": "very-very-long-field-name-which-will-be-truncated",
              "A-series1": "another series which has spaces so it probably should wrap"
            }
          }
        }
      ],
      "type": "timeseries"
    },
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "color": {
            "mode": "palette-classic"
          },
          "custom": {
            "axisBorderShow": false,
            "axisCenteredZero": false,
            "axisColorMode": "text",
            "axisLabel": "",
            "axisPlacement": "auto",
            "fillOpacity": 50,
            "hideFrom": {
              "legend": false,
              "tooltip": false,
              "viz": false
            },
            "pointShape": "circle",
            "pointSize": {
              "fixed": 5
            },
            "pointStrokeWidth": 1,
            "scaleDistribution": {
              "type": "linear"
            },
            "show": "points"
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": []
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 12,
        "y": 8
      },
      "id": 3,
      "options": {
        "legend": {
          "calcs": [],
          "displayMode": "list",
          "placement": "bottom",
          "showLegend": true
        },
        "mapping": "auto",
        "series": [
          {}
        ],
        "tooltip": {
          "hideZeros": false,
          "mode": "single",
          "sort": "none"
        }
      },
      "pluginVersion": "12.3.0-pre",
      "targets": [
        {
          "refId": "A",
          "scenarioId": "random_walk",
          "seriesCount": 20
        }
      ],
      "title": "Confirm we didn't regress XY Chart header",
      "transformations": [
        {
          "id": "merge",
          "options": {}
        },
        {
          "id": "organize",
          "options": {
            "excludeByName": {},
            "includeByName": {},
            "indexByName": {},
            "renameByName": {
              "A-series": "very-very-long-field-name-which-will-be-truncated",
              "A-series1": "another series which has spaces so it probably should wrap"
            }
          }
        }
      ],
      "type": "xychart"
    }
  ],
  "preload": false,
  "refresh": "",
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "",
  "title": "New panel",
  "uid": "0232c94e-665c-4c32-86ba-b8e0210e6c5b",
  "version": 6
}
```
</details>