### PR TITLE
Alerting: Always initialize an empty slice of routes for the routingtree

### DIFF
--- a/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/routingtree/conversions.go
@@ -28,6 +28,7 @@ func ConvertToK8sResource(orgID int64, r definitions.Route, version string, name
 			RepeatInterval: optionalPrometheusDurationToString(r.RepeatInterval),
 			Receiver:       r.Receiver,
 		},
+		Routes: make([]model.RoutingTreeRoute, 0, len(r.Routes)),
 	}
 	for _, route := range r.Routes {
 		if route == nil {


### PR DESCRIPTION
**What is this feature?**

This fix ensures that the `Routes` field in the routing tree specification is always initialized as an empty slice rather than being set to `nil` when there are no routes.

This aligns it with the CUE definition.

**Why do we need this feature?**

When converting routing tree definitions to K8s resources, if the `Routes` field is not explicitly initialized, it may be serialized as `null` in JSON/YAML output instead of an empty array `[]`. This can cause issues with:
- API clients expecting consistent array types
- JSON schema validation that requires arrays (not null)
- Consistent serialization behavior across the codebase

By always initializing an empty slice with `make([]model.RoutingTreeRoute, 0, len(r.Routes))`, we ensure the field is always serialized as an empty array when there are no routes.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
- The change follows the same pattern already used in `convertRouteToK8sSubRoute` (line 50 of conversions.go)
- No functional behavior changes - only affects JSON/YAML serialization format (`null` → `[]`)
