### PR TITLE
Logs volume: set line width to 0

### DIFF
--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -608,7 +608,7 @@ function getLogVolumeFieldConfig(level: LogLevel, oneLevelDetected: boolean) {
       lineColor: color,
       pointColor: color,
       fillColor: color,
-      lineWidth: 1,
+      lineWidth: 0,
       fillOpacity: 100,
       stacking: {
         mode: StackingMode.Normal,


### PR DESCRIPTION
This PR removes a lineWidth definition from the Logs Volume field config, which was causing a lines to appear in timestamps where the series had no values.

Before:

<img width="1440" height="229" alt="imagen" src="https://github.com/user-attachments/assets/c82fe0f0-b014-4abe-b5f5-83d1203d4591" />

After:

<img width="1443" height="227" alt="imagen" src="https://github.com/user-attachments/assets/c0eacae0-999d-4f81-8099-662a90eb7eb8" />
