### PR TITLE
[release-11.5.11] pkg/build: Add nocgo option

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -156,16 +156,16 @@ jobs:
             artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
             verify: true
           - name: windows-amd64
-            artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
+            artifacts: targz:grafana:windows/amd64:nocgo,zip:grafana:windows/amd64:nocgo,msi:grafana:windows/amd64:nocgo
             verify: true
           - name: windows-arm64
-            artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
+            artifacts: targz:grafana:windows/arm64:nocgo,zip:grafana:windows/arm64:nocgo
             verify: true
           - name: darwin-amd64
-            artifacts: targz:grafana:darwin/amd64
+            artifacts: targz:grafana:darwin/amd64:nocgo
             verify: true
           - name: darwin-arm64
-            artifacts: targz:grafana:darwin/arm64
+            artifacts: targz:grafana:darwin/arm64:nocgo
             verify: true
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2

--- a/pkg/build/daggerbuild/artifacts/backend.go
+++ b/pkg/build/daggerbuild/artifacts/backend.go
@@ -132,6 +132,7 @@ type NewBackendOpts struct {
 	Tags           []string
 	Static         bool
 	WireTag        string
+	CGOEnabled     bool
 	GoBuildCache   *dagger.CacheVolume
 	GoModCache     *dagger.CacheVolume
 }
@@ -198,6 +199,12 @@ func NewBackendFromString(ctx context.Context, log *slog.Logger, artifact string
 		goCacheProg = val
 	}
 
+	cgoDisabled, err := options.Bool(flags.CGODisabled)
+	if err != nil {
+		return nil, err
+	}
+	cgoEnabled := !cgoDisabled
+
 	bopts := &backend.BuildOpts{
 		Version:           p.Version,
 		Enterprise:        p.Enterprise,
@@ -206,6 +213,7 @@ func NewBackendFromString(ctx context.Context, log *slog.Logger, artifact string
 		Static:            static,
 		WireTag:           wireTag,
 		Tags:              tags,
+		CGOEnabled:        cgoEnabled,
 	}
 
 	return pipeline.ArtifactWithLogging(ctx, log, &pipeline.Artifact{
@@ -233,9 +241,10 @@ func NewBackend(ctx context.Context, log *slog.Logger, artifact string, opts *Ne
 		Tags:              opts.Tags,
 		Static:            opts.Static,
 		WireTag:           opts.WireTag,
+		CGOEnabled:        opts.CGOEnabled,
 	}
 
-	log.Info("Initializing backend artifact with options", "static", opts.Static, "version", opts.Version, "name", opts.Name, "distro", opts.Distribution)
+	log.Info("Initializing backend artifact with options", "static", opts.Static, "version", opts.Version, "name", opts.Name, "distro", opts.Distribution, "cgo enabled", opts.CGOEnabled)
 	return pipeline.ArtifactWithLogging(ctx, log, &pipeline.Artifact{
 		ArtifactString: artifact,
 		Type:           pipeline.ArtifactTypeDirectory,

--- a/pkg/build/daggerbuild/artifacts/package_targz.go
+++ b/pkg/build/daggerbuild/artifacts/package_targz.go
@@ -121,7 +121,12 @@ func NewTarballFromString(ctx context.Context, log *slog.Logger, artifact string
 	if err != nil {
 		return nil, err
 	}
-	return NewTarball(ctx, log, artifact, p.Distribution, p.Enterprise, p.Name, p.Version, p.BuildID, src, yarnCache, goModCache, goBuildCache, static, wireTag, tags, goVersion, viceroyVersion, experiments)
+	cgoDisabled, err := options.Bool(flags.CGODisabled)
+	if err != nil {
+		return nil, err
+	}
+	cgoEnabled := !cgoDisabled
+	return NewTarball(ctx, log, artifact, p.Distribution, p.Enterprise, p.Name, p.Version, p.BuildID, src, yarnCache, goModCache, goBuildCache, static, wireTag, tags, goVersion, viceroyVersion, experiments, cgoEnabled)
 }
 
 // NewTarball returns a properly initialized Tarball artifact.
@@ -145,6 +150,7 @@ func NewTarball(
 	goVersion string,
 	viceroyVersion string,
 	experiments []string,
+	cgoEnabled bool,
 ) (*pipeline.Artifact, error) {
 	backendArtifact, err := NewBackend(ctx, log, artifact, &NewBackendOpts{
 		Name:           name,
@@ -160,6 +166,7 @@ func NewTarball(
 		Enterprise:     enterprise,
 		GoBuildCache:   goBuildCache,
 		GoModCache:     goModCache,
+		CGOEnabled:     cgoEnabled,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/build/daggerbuild/backend/build.go
+++ b/pkg/build/daggerbuild/backend/build.go
@@ -62,7 +62,7 @@ func Build(
 
 	ldflags := LDFlagsDynamic(vcsinfo)
 
-	if opts.Static {
+	if opts.Static && opts.CGOEnabled {
 		ldflags = LDFlagsStatic(vcsinfo)
 	}
 

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -19,9 +19,23 @@ type BuildOpts struct {
 	GoCacheProg       string
 	Static            bool
 	Enterprise        bool
+	CGOEnabled        bool
 }
 
-func distroOptsFunc(log *slog.Logger, distro Distribution) (DistroBuildOptsFunc, error) {
+func distroOptsFunc(log *slog.Logger, distro Distribution, opts *BuildOpts) (DistroBuildOptsFunc, error) {
+	if !opts.CGOEnabled {
+		return func(distro Distribution, experiments, tags []string) *GoBuildOpts {
+			os, arch := OSAndArch(distro)
+			archv := ArchVersion(distro)
+			return &GoBuildOpts{
+				OS:         os,
+				Arch:       arch,
+				GoARM:      GoARM(archv),
+				CGOEnabled: false,
+			}
+		}, nil
+	}
+
 	if val, ok := DistributionGoOpts[distro]; ok {
 		return DistroOptsLogger(log, val), nil
 	}
@@ -29,7 +43,7 @@ func distroOptsFunc(log *slog.Logger, distro Distribution) (DistroBuildOptsFunc,
 }
 
 func WithGoEnv(log *slog.Logger, container *dagger.Container, distro Distribution, opts *BuildOpts) (*dagger.Container, error) {
-	fn, err := distroOptsFunc(log, distro)
+	fn, err := distroOptsFunc(log, distro, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +53,7 @@ func WithGoEnv(log *slog.Logger, container *dagger.Container, distro Distributio
 }
 
 func WithViceroyEnv(log *slog.Logger, container *dagger.Container, distro Distribution, opts *BuildOpts) (*dagger.Container, error) {
-	fn, err := distroOptsFunc(log, distro)
+	fn, err := distroOptsFunc(log, distro, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -92,22 +106,26 @@ func GolangContainer(
 ) (*dagger.Container, error) {
 	os, _ := OSAndArch(distro)
 	// Only use viceroy for all darwin and only windows/amd64
-	if os == "darwin" || distro == DistWindowsAMD64 {
+	if opts.CGOEnabled && (os == "darwin" || distro == DistWindowsAMD64) {
 		return ViceroyContainer(d, log, distro, goVersion, viceroyVersion, opts)
 	}
 
-	container := golang.Container(d, platform, goVersion).
-		WithExec([]string{"apk", "add", "--update", "wget", "build-base", "alpine-sdk", "musl", "musl-dev", "xz"}).
-		WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/zig-linux-x86_64-0.11.0.tar.xz"}).
-		WithExec([]string{"tar", "--strip-components=1", "-C", "/", "-xf", "zig-linux-x86_64-0.11.0.tar.xz"}).
-		WithExec([]string{"mv", "/zig", "/bin/zig"}).
-		// Install the toolchain specifically for armv7 until we figure out why it's crashing w/ zig container = container.
-		WithExec([]string{"mkdir", "/toolchain"}).
-		WithExec([]string{"wget", "-q", "http://dl.grafana.com/ci/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
-		WithExec([]string{"tar", "-xf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
-		WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
-		WithExec([]string{"tar", "-xf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"})
-
+	container := golang.Container(d, platform, goVersion)
+	if opts.CGOEnabled {
+		container = container.
+			WithExec([]string{"apk", "add", "--update", "wget", "build-base", "alpine-sdk", "musl", "musl-dev", "xz"}).
+			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/zig-linux-x86_64-0.11.0.tar.xz"}).
+			WithExec([]string{"tar", "--strip-components=1", "-C", "/", "-xf", "zig-linux-x86_64-0.11.0.tar.xz"}).
+			WithExec([]string{"mv", "/zig", "/bin/zig"}).
+			// Install the toolchain specifically for armv7 until we figure out why it's crashing w/ zig container = container.
+			WithExec([]string{"mkdir", "/toolchain"}).
+			WithExec([]string{"wget", "-q", "http://dl.grafana.com/ci/arm-linux-musleabihf-cross.tgz", "-P", "/toolchain"}).
+			WithExec([]string{"tar", "-xf", "/toolchain/arm-linux-musleabihf-cross.tgz", "-C", "/toolchain"}).
+			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
+			WithExec([]string{"tar", "-xf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"}).
+			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/riscv64-linux-musl-cross.tgz", "-P", "/toolchain"}).
+			WithExec([]string{"tar", "-xf", "/toolchain/riscv64-linux-musl-cross.tgz", "-C", "/toolchain"})
+	}
 	return WithGoEnv(log, container, distro, opts)
 }
 

--- a/pkg/build/daggerbuild/backend/distributions.go
+++ b/pkg/build/daggerbuild/backend/distributions.go
@@ -306,6 +306,19 @@ func ViceroyBuildOpts(distro Distribution, experiments []string, tags []string) 
 	}
 }
 
+func BuildOptsNoCGO(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
+	var (
+		os, arch = OSAndArch(distro)
+	)
+
+	return &GoBuildOpts{
+		ExperimentalFlags: experiments,
+		OS:                os,
+		Arch:              arch,
+		CGOEnabled:        false,
+	}
+}
+
 var ZigTargets = map[Distribution]string{
 	DistLinuxAMD64:            "x86_64-linux-musl",
 	DistLinuxAMD64Dynamic:     "x86_64-linux-gnu",

--- a/pkg/build/daggerbuild/backend/env.go
+++ b/pkg/build/daggerbuild/backend/env.go
@@ -82,20 +82,19 @@ func GoBuildEnv(opts *GoBuildOpts) []containers.Env {
 
 		// https://github.com/mattn/go-sqlite3/issues/1164#issuecomment-1635253695
 		env = append(env, containers.EnvVar("CGO_CFLAGS", "-D_LARGEFILE64_SOURCE"))
+		if opts.CC != "" {
+			env = append(env, containers.EnvVar("CC", opts.CC))
+		}
+
+		if opts.CXX != "" {
+			env = append(env, containers.EnvVar("CXX", opts.CXX))
+		}
 	} else {
 		env = append(env, containers.EnvVar("CGO_ENABLED", "0"))
 	}
 
 	if opts.ExperimentalFlags != nil {
 		env = append(env, containers.EnvVar("GOEXPERIMENT", strings.Join(opts.ExperimentalFlags, ",")))
-	}
-
-	if opts.CC != "" {
-		env = append(env, containers.EnvVar("CC", opts.CC))
-	}
-
-	if opts.CXX != "" {
-		env = append(env, containers.EnvVar("CXX", opts.CXX))
 	}
 
 	return env

--- a/pkg/build/daggerbuild/flags/packages.go
+++ b/pkg/build/daggerbuild/flags/packages.go
@@ -103,5 +103,8 @@ func StdPackageFlags() []pipeline.Flag {
 	return JoinFlags(
 		distros,
 		names,
+		[]pipeline.Flag{
+			CGODisabledFlag,
+		},
 	)
 }

--- a/pkg/build/daggerbuild/flags/packages.go
+++ b/pkg/build/daggerbuild/flags/packages.go
@@ -19,6 +19,7 @@ const (
 	GoTags        pipeline.FlagOption = "go-tag"
 	GoExperiments pipeline.FlagOption = "go-experiments"
 	Sign          pipeline.FlagOption = "sign"
+	CGODisabled   pipeline.FlagOption = "nocgo"
 
 	// Pretty much only used to set the deb or RPM internal package name (and file name) to `{}-nightly` and/or `{}-rpi`
 	Nightly pipeline.FlagOption = "nightly"
@@ -78,6 +79,13 @@ var SignFlag = pipeline.Flag{
 	Name: "sign",
 	Options: map[pipeline.FlagOption]any{
 		Sign: true,
+	},
+}
+
+var CGODisabledFlag = pipeline.Flag{
+	Name: "nocgo",
+	Options: map[pipeline.FlagOption]any{
+		CGODisabled: true,
 	},
 }
 


### PR DESCRIPTION
Backport 2a0f149a6356af4356bca0d72b81993867b80071 from #112834

---

Merging this won't affect anything; to use it, add the `:nocgo` flag to artifact strings (ex `dagger run go run ./pkg/build/cmd artifacts -a grafana:windows/amd64:nocgo:msi` )
