### PR TITLE
Elasticsearch: Update documentation to state that Elastic Cloud Serverless is not supported

### DIFF
--- a/docs/sources/datasources/elasticsearch/_index.md
+++ b/docs/sources/datasources/elasticsearch/_index.md
@@ -53,6 +53,10 @@ The following will help you get started working with Elasticsearch and Grafana:
 
 ## Supported Elasticsearch versions
 
+{{< admonition type="warning" >}}
+The Elasticsearch data source plugin currently does not support Elastic Cloud Serverless, or any other serverless variant of Elasticsearch.
+{{< /admonition >}}
+
 This data source supports these versions of Elasticsearch:
 
 - ≥ v7.17


### PR DESCRIPTION
This PR adds a warning about Elastic Cloud Serverless being not supported in the Elasticsearch datasource. Some APIs are not exposed on a serverless ES. The Elasticsearch datasource calls the `_cluster/health` endpoint which the connector uses to test the connection, which is not available in the serverless variant of ES.