### PR TITLE
Bugfix: Adding support for resolving panel plugins that expose a Promise<PanelPlugin>

### DIFF
--- a/public/app/features/plugins/importer/pluginImporter.test.ts
+++ b/public/app/features/plugins/importer/pluginImporter.test.ts
@@ -47,6 +47,25 @@ describe('pluginImporter', () => {
       expect(result).toEqual({ ...panelPlugin, meta: { ...panelPlugin } });
     });
 
+    it('should import a panel plugin returning a Promise<PanelPlugin> successfully', async () => {
+      const spy = jest
+        .spyOn(importPluginModule, 'importPluginModule')
+        .mockResolvedValue({ plugin: Promise.resolve({ ...panelPlugin }) });
+
+      const result = await pluginImporter.importPanel({ ...panelPlugin });
+
+      expect(spy).toHaveBeenCalledWith({
+        path: 'public/plugins/test-plugin/module.js',
+        version: '1.0.0',
+        loadingStrategy: 'fetch',
+        pluginId: 'test-plugin',
+        moduleHash: 'cc3e6f370520e1efc6043f1874d735fabc710d4b',
+        translations: { 'en-US': 'public/plugins/test-plugin/locales/en-US/test-plugin.json' },
+      });
+
+      expect(result).toEqual({ ...panelPlugin, meta: { ...panelPlugin } });
+    });
+
     it('should set correct loading strategy', async () => {
       const spy = jest
         .spyOn(importPluginModule, 'importPluginModule')

--- a/public/app/features/plugins/importer/pluginImporter.ts
+++ b/public/app/features/plugins/importer/pluginImporter.ts
@@ -48,7 +48,8 @@ const panelPluginPostImport: PostImportStrategy<PanelPlugin, PanelPluginMeta> = 
     const pluginExports = await module;
 
     if (pluginExports.plugin) {
-      const plugin: PanelPlugin = pluginExports.plugin;
+      // pluginExports.plugin can either be a Promise<PanelPlugin> or a PanelPlugin
+      const plugin: PanelPlugin = await pluginExports.plugin;
       plugin.meta = meta;
       pluginsCache.set(meta.id, plugin);
       return plugin;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

It seems like we use to support panel plugins (maybe other plugins as well?) that exposes a Promise<PanelPlugin> from the module.ts(x) file. Previous we returned the `pluginExports.plugin` which got `.then(plugin =>  {...})`. This made it possible to expose a Promise<PanelPlugin>.

**Why do we need this feature?**

After the refactoring of the plugin importer logic this support got removed which made plugins such as `marcusolsson-gantt-panel` to stop working.

See example [here](https://github.com/marcusolsson/grafana-gantt-panel/blob/main/src/module.ts#L7) (`getPanelPluginOrFallback`):

And the helper function is available [here](https://github.com/marcusolsson/grafana-plugin-support/blob/main/src/utils/dependency.tsx#L20).

**Who is this feature for?**

Everyone using panel plugins in Grafana.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**
I guess we don't need to backport this since we should be able to disable the feature toggle enabling the new plugin importer, right?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
