### PR TITLE
TimeComparison: Move control to panel menu

### DIFF
--- a/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
+++ b/public/app/features/dashboard-scene/scene/CustomTimeRangeCompare.tsx
@@ -1,8 +1,8 @@
 import { reportInteraction } from '@grafana/runtime';
-import { SceneTimeRangeCompare, SceneComponentProps, VizPanel, sceneGraph } from '@grafana/scenes';
+import { SceneTimeRangeCompare, VizPanel, sceneGraph } from '@grafana/scenes';
 import { TimeCompareOptions } from '@grafana/schema';
 
-function hasTimeCompare(options: unknown): options is TimeCompareOptions {
+export function hasTimeCompare(options: unknown): options is TimeCompareOptions {
   return options != null && typeof options === 'object' && 'timeCompare' in options;
 }
 
@@ -14,7 +14,6 @@ export class CustomTimeRangeCompare extends SceneTimeRangeCompare {
       ...state,
       compareWith: undefined,
       compareOptions: [],
-      hideCheckbox: true,
     });
 
     this.parentOnCompareWithChanged = this.onCompareWithChanged.bind(this);
@@ -59,21 +58,4 @@ export class CustomTimeRangeCompare extends SceneTimeRangeCompare {
       });
     }
   }
-
-  static Component = function CustomTimeRangeCompareRenderer({ model }: SceneComponentProps<SceneTimeRangeCompare>) {
-    const vizPanel = sceneGraph.getAncestor(model, VizPanel);
-    const { options } = vizPanel.useState();
-
-    const isTimeCompareEnabled = hasTimeCompare(options) && options.timeCompare;
-
-    if (!isTimeCompareEnabled) {
-      return <></>;
-    }
-
-    return (
-      <div className="show-on-hover">
-        <SceneTimeRangeCompare.Component model={model} />
-      </div>
-    );
-  };
 }

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.test.ts
@@ -42,7 +42,7 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-// Mock only what's essential for header actions tests
+// Mock what's essential for behaviors tests
 jest.mock('../../scene/CustomTimeRangeCompare', () => ({
   CustomTimeRangeCompare: jest.fn(),
 }));
@@ -76,12 +76,12 @@ const createTestPanel = (): PanelKind => ({
 });
 
 describe('buildVizPanel', () => {
-  describe('header actions', () => {
+  describe('behaviors', () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    it('should include CustomTimeRangeCompare in headerActions when timeComparison feature toggle is enabled', () => {
+    it('should include CustomTimeRangeCompare in $behaviors when timeComparison feature toggle is enabled', () => {
       // Mock config with timeComparison enabled
       const mockConfig = require('@grafana/runtime').config;
       mockConfig.featureToggles.timeComparison = true;
@@ -89,16 +89,15 @@ describe('buildVizPanel', () => {
       const panel = createTestPanel();
       const vizPanel = buildVizPanel(panel);
 
-      expect(vizPanel.state.headerActions).toBeDefined();
-      expect(vizPanel.state.headerActions).toHaveLength(1);
+      expect(vizPanel.state.$behaviors).toBeDefined();
+      expect(vizPanel.state.$behaviors).toHaveLength(1);
       expect(CustomTimeRangeCompare).toHaveBeenCalledWith({
-        key: 'time-compare',
         compareWith: undefined,
         compareOptions: [],
       });
     });
 
-    it('should not include headerActions when timeComparison feature toggle is disabled', () => {
+    it('should have empty $behaviors array when timeComparison feature toggle is disabled', () => {
       // Mock config with timeComparison disabled
       const mockConfig = require('@grafana/runtime').config;
       mockConfig.featureToggles.timeComparison = false;
@@ -106,7 +105,8 @@ describe('buildVizPanel', () => {
       const panel = createTestPanel();
       const vizPanel = buildVizPanel(panel);
 
-      expect(vizPanel.state.headerActions).toBeUndefined();
+      expect(vizPanel.state.$behaviors).toBeDefined();
+      expect(vizPanel.state.$behaviors).toHaveLength(0);
       expect(CustomTimeRangeCompare).not.toHaveBeenCalled();
     });
   });

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -70,12 +70,11 @@ export function buildVizPanel(panel: PanelKind, id?: number): VizPanel {
     seriesLimit: config.panelSeriesLimit,
     $data: createPanelDataProvider(panel),
     titleItems,
-    $behaviors: [],
+    $behaviors: config.featureToggles.timeComparison
+      ? [new CustomTimeRangeCompare({ compareWith: undefined, compareOptions: [] })]
+      : [],
     extendPanelContext: setDashboardPanelContext,
     // _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel), //FIXME: Angular Migration
-    headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
-      : undefined,
   };
 
   if (!config.publicDashboardAccessToken) {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.test.ts
@@ -811,12 +811,12 @@ describe('transformSaveModelToScene', () => {
       expect(gridItem.state.body.state.title).toEqual(panel.title);
     });
 
-    describe('header actions', () => {
+    describe('behaviors', () => {
       beforeEach(() => {
         jest.clearAllMocks();
       });
 
-      it('should include headerActions when timeComparison feature toggle is enabled', () => {
+      it('should include CustomTimeRangeCompare in $behaviors when timeComparison feature toggle is enabled', () => {
         config.featureToggles.timeComparison = true;
 
         const panel = {
@@ -827,11 +827,11 @@ describe('transformSaveModelToScene', () => {
 
         const { vizPanel } = buildGridItemForTest(panel);
 
-        expect(vizPanel.state.headerActions).toBeDefined();
-        expect(vizPanel.state.headerActions).toHaveLength(1);
+        expect(vizPanel.state.$behaviors).toBeDefined();
+        expect(vizPanel.state.$behaviors).toHaveLength(1);
       });
 
-      it('should not include headerActions when timeComparison feature toggle is disabled', () => {
+      it('should have empty $behaviors array when timeComparison feature toggle is disabled', () => {
         config.featureToggles.timeComparison = false;
 
         const panel = {
@@ -842,7 +842,8 @@ describe('transformSaveModelToScene', () => {
 
         const { vizPanel } = buildGridItemForTest(panel);
 
-        expect(vizPanel.state.headerActions).toBeUndefined();
+        expect(vizPanel.state.$behaviors).toBeDefined();
+        expect(vizPanel.state.$behaviors).toHaveLength(0);
       });
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -425,12 +425,11 @@ export function buildGridItemForPanel(panel: PanelModel): DashboardGridItem {
     hoverHeaderOffset: 0,
     $data: createPanelDataProvider(panel),
     titleItems,
-    $behaviors: [],
+    $behaviors: config.featureToggles.timeComparison
+      ? [new CustomTimeRangeCompare({ compareWith: undefined, compareOptions: [] })]
+      : [],
     extendPanelContext: setDashboardPanelContext,
     _UNSAFE_customMigrationHandler: getAngularPanelMigrationHandler(panel),
-    headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
-      : undefined,
   };
 
   if (panel.libraryPanel) {

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -251,14 +251,13 @@ export function getDefaultVizPanel(): VizPanel {
     seriesLimit: config.panelSeriesLimit,
     titleItems: [new VizPanelLinks({ menu: new VizPanelLinksMenu({}) })],
     hoverHeaderOffset: 0,
-    $behaviors: [],
+    $behaviors: config.featureToggles.timeComparison
+      ? [new CustomTimeRangeCompare({ compareWith: undefined, compareOptions: [] })]
+      : [],
     extendPanelContext: setDashboardPanelContext,
     menu: new VizPanelMenu({
       $behaviors: [panelMenuBehavior],
     }),
-    headerActions: config.featureToggles.timeComparison
-      ? [new CustomTimeRangeCompare({ key: 'time-compare', compareWith: undefined, compareOptions: [] })]
-      : undefined,
     $data: new SceneDataTransformer({
       $data: new SceneQueryRunner({
         queries: [{ refId: 'A' }],


### PR DESCRIPTION
For Time Comparison, to simplify integration into existing panel UI, it was decided to move the comparison control to the panel menu. This moves implementation out of headerActions and instead integrates it as a panel viz behavior. I also removed keys because scenes should handle that automatically.

Before:
![Oct-23-2025 13-00-04](https://github.com/user-attachments/assets/4c450219-d188-40fb-8a63-9b39220e84a9)

After:
![Oct-23-2025 12-53-35](https://github.com/user-attachments/assets/17043cef-a668-4d8f-9875-acd8ada1b85b)

Depends on https://github.com/grafana/grafana/pull/112762 which will make comparison selection apparent to the user without the need to hover or navigate the panel menu.

Remember the feature toggle `timeComparison = true`
