### PR TITLE
QueryEditorRow: Fix accessing `null` when reading `notices`

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -315,7 +315,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
         return acc;
       }
 
-      const warnings = filter(serie.meta.notices, (item: QueryResultMetaNotice) => item.severity === type) ?? [];
+      const warnings = filter(serie.meta.notices, (item: QueryResultMetaNotice | null) => item?.severity === type) ?? [];
       return acc.concat(warnings);
     }, []);
 


### PR DESCRIPTION
In some situations `notices` could be `null`. This fixes an edge case that stops Grafana from crashing.

Ref: https://raintank-corp.slack.com/archives/C04J73AAQ87/p1761247075161839?thread_ts=1761231300.674009&cid=C04J73AAQ87
