### PR TITLE
Codeowners: Add search nav org team to codeowners for navtree

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,7 +166,7 @@
 /pkg/services/kmsproviders/ @grafana/grafana-operator-experience-squad
 /pkg/services/licensing/ @grafana/grafana-operator-experience-squad
 /pkg/services/dsquerierclient/ @grafana/grafana-datasources-core-services
-/pkg/services/navtree/ @grafana/grafana-backend-group
+/pkg/services/navtree/ @grafana/grafana-backend-group @grafana/grafana-search-navigate-organise
 /pkg/services/notifications/ @grafana/grafana-backend-group
 /pkg/services/org/ @grafana/grafana-backend-group
 /pkg/services/playlist/ @grafana/grafana-app-platform-squad


### PR DESCRIPTION
**What is this feature?**
Adds SNO team to codeowners for navtree code

**Why do we need this feature?**
So we're aware of changes to the navtree 😌 

**Who is this feature for?**
`@grafana/grafana-search-navigate-organise`