### PR TITLE
FolderPermissions: Return 404 error when folder does not exist instead of 500

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -111,7 +111,10 @@ func ProvideFolderPermissions(
 
 			if err != nil {
 				switch {
-				case errors.As(err, &errutil.Error{}):
+				case func() bool {
+					var errUtilErr errutil.Error
+					return errors.As(err, &errUtilErr)
+				}():
 					return err
 				case errors.Is(err, dashboards.ErrFolderNotFound):
 					return folder.ErrFolderNotFound.Errorf("folder not found")

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -24,7 +24,7 @@ type FolderPermissionsService struct {
 	*resourcepermissions.Service
 }
 
-var ErrFolderUnhandledError = errutil.BadRequest("folder.unhandled-error", errutil.WithPublicMessage("Unhandled folder error"))
+var ErrFolderUnhandledError = errutil.Internal("folder.unhandled-error", errutil.WithPublicMessage("Unhandled folder error"))
 
 var FolderViewActions = []string{dashboards.ActionFoldersRead, accesscontrol.ActionAlertingRuleRead, libraryelements.ActionLibraryPanelsRead, accesscontrol.ActionAlertingSilencesRead}
 var FolderEditActions = append(FolderViewActions, []string{

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -2,8 +2,10 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"errors"
 
 	"github.com/grafana/grafana/pkg/api/routing"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -21,6 +23,8 @@ import (
 type FolderPermissionsService struct {
 	*resourcepermissions.Service
 }
+
+var ErrFolderUnhandledError = errutil.BadRequest("folder.unhandled-error", errutil.WithPublicMessage("Unhandled folder error"))
 
 var FolderViewActions = []string{dashboards.ActionFoldersRead, accesscontrol.ActionAlertingRuleRead, libraryelements.ActionLibraryPanelsRead, accesscontrol.ActionAlertingSilencesRead}
 var FolderEditActions = append(FolderViewActions, []string{
@@ -106,7 +110,13 @@ func ProvideFolderPermissions(
 			})
 
 			if err != nil {
-				return err
+				switch {
+				case errors.As(err, &errutil.Error{}):
+					return err
+				case errors.Is(err, dashboards.ErrFolderNotFound):
+					return folder.ErrFolderNotFound.Errorf("folder not found")
+				}
+				return ErrFolderUnhandledError.Errorf("unhandled folder error: %w", err)
 			}
 
 			return nil


### PR DESCRIPTION
**What is this feature?**

Improves error handling in the folder permissions service to properly categorize and handle different error types.

**Why do we need this feature?**

The current implementation doesn't properly handle different error types when checking folder permissions. This can lead to generic errors being returned to users instead of specific, actionable error messages. By properly categorizing errors, we can provide better error messages and improve debugging.

**Who is this feature for?**

This is for developers and system administrators who work with Grafana folder permissions and need clear error messages for troubleshooting.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/109328

**Script to test bug presence on a clean instance:**

```sh
#!/usr/bin/env bash
# Test for bug: POST /api/access-control/folders/:resourceID/teams/:teamID returns 500 instead of 404 for non-existent folder

set -euo pipefail

BASE_URL="${BASE_URL:-https://localhost:3000}"
GF_USER="${GF_USER:-admin}"
GF_PASS="${GF_PASS:-admin}"

# Non-existent folder UID (12 chars)
FOLDER_UID="${FOLDER_UID:-zzzzzzzzzzzz}"
PERMISSION="${PERMISSION:-View}"

# Create a temporary team to ensure the team exists
TEAM_NAME="ac-bug-test-$(date +%s)"
create_team_resp="$(curl -sk -u "$GF_USER:$GF_PASS" \
  -H "Content-Type: application/json" \
  -X POST "$BASE_URL/api/teams" \
  -d "{\"name\":\"$TEAM_NAME\"}")"

TEAM_ID="$(printf '%s\n' "$create_team_resp" | sed -n 's/.*"teamId":\([0-9][0-9]*\).*/\1/p')"
if [[ -z "${TEAM_ID:-}" ]]; then
  echo "Failed to create team. Response: $create_team_resp"
  exit 2
fi

cleanup() {
  curl -sk -u "$GF_USER:$GF_PASS" -X DELETE "$BASE_URL/api/teams/$TEAM_ID" >/dev/null 2>&1 || true
}
trap cleanup EXIT

tmp_body="$(mktemp)"
status="$(curl -sk -u "$GF_USER:$GF_PASS" \
  -H "Content-Type: application/json" \
  -o "$tmp_body" -w "%{http_code}" \
  -X POST "$BASE_URL/api/access-control/folders/$FOLDER_UID/teams/$TEAM_ID" \
  -d "{\"permission\":\"$PERMISSION\"}")"

echo "HTTP $status"
cat "$tmp_body" || true
echo

if [[ "$status" == "500" ]]; then
  echo "BUG PRESENT: expected 404 Not Found, got 500 Internal Server Error"
  exit 1
elif [[ "$status" == "404" ]]; then
  echo "FIXED: got 404 Not Found for non-existent folder"
  exit 0
else
  echo "Unexpected status: $status (expected 404 if fixed, 500 if bug persists)"
  exit 3
fi
```
