### PR TITLE
Loki: Fix merging responses would merge `null` notices

### DIFF
--- a/public/app/plugins/datasource/loki/mergeResponses.test.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.test.ts
@@ -661,12 +661,8 @@ describe('combineResponses', () => {
     });
 
     it('combines notices from both frames', () => {
-      const responseA = makeResponse([
-        { severity: 'warning', text: 'Warning from frame A' },
-      ]);
-      const responseB = makeResponse([
-        { severity: 'info', text: 'Info from frame B' },
-      ]);
+      const responseA = makeResponse([{ severity: 'warning', text: 'Warning from frame A' }]);
+      const responseB = makeResponse([{ severity: 'info', text: 'Info from frame B' }]);
 
       expect(combineResponses(responseA, responseB).data[0].meta?.notices).toStrictEqual([
         { severity: 'warning', text: 'Warning from frame A' },
@@ -675,12 +671,8 @@ describe('combineResponses', () => {
     });
 
     it('deduplicates identical notices', () => {
-      const responseA = makeResponse([
-        { severity: 'warning', text: 'Same warning' },
-      ]);
-      const responseB = makeResponse([
-        { severity: 'warning', text: 'Same warning' },
-      ]);
+      const responseA = makeResponse([{ severity: 'warning', text: 'Same warning' }]);
+      const responseB = makeResponse([{ severity: 'warning', text: 'Same warning' }]);
 
       expect(combineResponses(responseA, responseB).data[0].meta?.notices).toStrictEqual([
         { severity: 'warning', text: 'Same warning' },
@@ -688,12 +680,8 @@ describe('combineResponses', () => {
     });
 
     it('keeps notices with same text but different severity', () => {
-      const responseA = makeResponse([
-        { severity: 'warning', text: 'Message' },
-      ]);
-      const responseB = makeResponse([
-        { severity: 'info', text: 'Message' },
-      ]);
+      const responseA = makeResponse([{ severity: 'warning', text: 'Message' }]);
+      const responseB = makeResponse([{ severity: 'info', text: 'Message' }]);
 
       expect(combineResponses(responseA, responseB).data[0].meta?.notices).toStrictEqual([
         { severity: 'warning', text: 'Message' },
@@ -702,9 +690,7 @@ describe('combineResponses', () => {
     });
 
     it('handles one frame with notices and one without', () => {
-      const responseA = makeResponse([
-        { severity: 'warning', text: 'Warning message' },
-      ]);
+      const responseA = makeResponse([{ severity: 'warning', text: 'Warning message' }]);
       const responseB = makeResponse();
 
       expect(combineResponses(responseA, responseB).data[0].meta?.notices).toStrictEqual([
@@ -727,9 +713,7 @@ describe('combineResponses', () => {
         { severity: 'warning', text: 'Valid warning' },
         null as any, // Simulating the bug scenario
       ]);
-      const responseB = makeResponse([
-        { severity: 'info', text: 'Valid info' },
-      ]);
+      const responseB = makeResponse([{ severity: 'info', text: 'Valid info' }]);
 
       const result = combineResponses(responseA, responseB).data[0].meta?.notices;
       expect(result).toStrictEqual([

--- a/public/app/plugins/datasource/loki/mergeResponses.test.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.test.ts
@@ -711,7 +711,7 @@ describe('combineResponses', () => {
     it('filters out null values from notices arrays', () => {
       const responseA = makeResponse([
         { severity: 'warning', text: 'Valid warning' },
-        null as any, // Simulating the bug scenario
+        null as unknown as QueryResultMetaNotice, // Simulating the bug scenario
       ]);
       const responseB = makeResponse([{ severity: 'info', text: 'Valid info' }]);
 

--- a/public/app/plugins/datasource/loki/mergeResponses.test.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.test.ts
@@ -76,6 +76,7 @@ describe('combineResponses', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -154,6 +155,7 @@ describe('combineResponses', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -199,6 +201,7 @@ describe('combineResponses', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -244,6 +247,7 @@ describe('combineResponses', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -424,6 +428,7 @@ describe('combineResponses', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -499,6 +504,7 @@ describe('combineResponses', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -574,6 +580,7 @@ describe('combineResponses', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -824,6 +831,7 @@ describe('combineResponses', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -890,6 +898,7 @@ describe('combineResponses', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -937,6 +946,7 @@ describe('mergeFrames', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -986,6 +996,7 @@ describe('mergeFrames', () => {
           length: 3,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1031,6 +1042,7 @@ describe('mergeFrames', () => {
           length: 4,
           meta: {
             type: 'timeseries-multi',
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1110,6 +1122,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1192,6 +1205,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1223,6 +1237,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1302,6 +1317,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',
@@ -1336,6 +1352,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [{ displayName: 'Summary: total bytes processed', unit: 'decbytes', value: 22 }],
           },
           length: 2,
@@ -1361,6 +1378,7 @@ describe('mergeFrames', () => {
             custom: {
               frameType: 'LabeledTimeValues',
             },
+            notices: [],
             stats: [
               {
                 displayName: 'Summary: total bytes processed',

--- a/public/app/plugins/datasource/loki/mergeResponses.ts
+++ b/public/app/plugins/datasource/loki/mergeResponses.ts
@@ -7,6 +7,7 @@ import {
   Field,
   FieldType,
   LoadingState,
+  QueryResultMetaNotice,
   QueryResultMetaStat,
   shallowCompare,
 } from '@grafana/data';
@@ -163,6 +164,7 @@ export function mergeFrames(dest: DataFrame, source: DataFrame) {
   dest.meta = {
     ...dest.meta,
     stats: getCombinedMetadataStats(dest.meta?.stats ?? [], source.meta?.stats ?? []),
+    notices: getCombinedNotices(dest.meta?.notices ?? [], source.meta?.notices ?? []),
   };
 }
 
@@ -252,6 +254,27 @@ function getCombinedMetadataStats(
     }
   }
   return stats;
+}
+
+function getCombinedNotices(
+  destNotices: QueryResultMetaNotice[],
+  sourceNotices: QueryResultMetaNotice[]
+): QueryResultMetaNotice[] {
+  // Combine notices from both frames and filter out null/undefined values
+  const allNotices = [...destNotices, ...sourceNotices].filter(
+    (notice): notice is QueryResultMetaNotice => notice != null
+  );
+
+  // Deduplicate notices based on text to avoid showing the same warning twice
+  const uniqueNotices = allNotices.reduce((acc: QueryResultMetaNotice[], notice) => {
+    const exists = acc.some((n) => n.severity === notice.severity && n.text === notice.text);
+    if (!exists) {
+      acc.push(notice);
+    }
+    return acc;
+  }, []);
+
+  return uniqueNotices;
 }
 
 /**


### PR DESCRIPTION
**What is this feature?**

Loki's `mergeResponses` was wrongly merging `notices` and produced `null` entries in the array. 

This can be tested by looking at the produced DataFrame of this panel:
1. https://ops.grafana-ops.net/d/sv6qhnk/log-volume-bug?orgId=1&from=2025-10-23T12:58:40.855Z&to=2025-10-23T12:59:09.934Z&timezone=utc&editPanel=1
2. Take a look at the data frame and find `null` in the `notices` array
3. Toggle visibility of the two queries and run the one with `do-not-chunk`
4. Take a look at the data frame and do NOT find `null` in the `notices` array