### PR TITLE
AccessControl: Include hidden roles in service account role display

### DIFF
--- a/public/app/core/components/RolePicker/api.ts
+++ b/public/app/core/components/RolePicker/api.ts
@@ -16,7 +16,7 @@ export const fetchRoleOptions = async (orgId?: number): Promise<Role[]> => {
 };
 
 export const fetchUserRoles = async (userId: number, orgId?: number): Promise<Role[]> => {
-  let userRolesUrl = `/api/access-control/users/${userId}/roles?includeMapped=true`;
+  let userRolesUrl = `/api/access-control/users/${userId}/roles?includeMapped=true&includeHidden=true`;
   if (orgId) {
     userRolesUrl += `&targetOrgId=${orgId}`;
   }

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -63,7 +63,7 @@ export function fetchServiceAccounts(
           dispatch(rolesFetchBegin());
           const orgId = contextSrv.user.orgId;
           const userIds = result?.serviceAccounts.map((u: ServiceAccountDTO) => u.id);
-          const roles = await getBackendSrv().post(`/api/access-control/users/roles/search`, { userIds, orgId });
+          const roles = await getBackendSrv().post(`/api/access-control/users/roles/search?includeHidden=true`, { userIds, orgId });
           result.serviceAccounts.forEach((u: ServiceAccountDTO) => {
             u.roles = roles ? roles[u.id] || [] : [];
           });

--- a/public/app/features/serviceaccounts/state/actions.ts
+++ b/public/app/features/serviceaccounts/state/actions.ts
@@ -63,7 +63,10 @@ export function fetchServiceAccounts(
           dispatch(rolesFetchBegin());
           const orgId = contextSrv.user.orgId;
           const userIds = result?.serviceAccounts.map((u: ServiceAccountDTO) => u.id);
-          const roles = await getBackendSrv().post(`/api/access-control/users/roles/search?includeHidden=true`, { userIds, orgId });
+          const roles = await getBackendSrv().post(`/api/access-control/users/roles/search?includeHidden=true`, {
+            userIds,
+            orgId,
+          });
           result.serviceAccounts.forEach((u: ServiceAccountDTO) => {
             u.roles = roles ? roles[u.id] || [] : [];
           });


### PR DESCRIPTION
**What is this feature?**

This update adds the \`includeHidden=true\` parameter to role API calls when fetching service account roles, ensuring that hidden roles are properly displayed in the UI.

**Why do we need this feature?**

Service accounts with hidden roles assigned were appearing to have no roles in the UI, even though querying the API directly with \`includeHidden=true\` showed the roles were assigned. This caused confusion as the service account page showed "no roles assigned" when roles were actually present.

**Who is this feature for?**

This fix is for administrators and users who view and manage service accounts in organizations where hidden roles are assigned to service accounts.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1647

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] Service accounts with hidden roles now show those roles in both the list view and detail view.
- [ ] Service accounts without hidden roles continue to work as expected.
- [ ] The role picker displays correctly for both editable and read-only service accounts.

**Changes made:**

- Added \`includeHidden=true\` query parameter to \`/api/access-control/users/roles/search\` in bulk role fetching for service accounts list
- Added \`includeHidden=true\` query parameter to \`/api/access-control/users/{userId}/roles\` in individual user role fetching