### PR TITLE
[release-11.5.11] CI: Windows builds with CGO cross-compiler toolchain

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -156,16 +156,16 @@ jobs:
             artifacts: targz:grafana:linux/arm/v6,deb:grafana:linux/arm/v6
             verify: true
           - name: windows-amd64
-            artifacts: targz:grafana:windows/amd64:nocgo,zip:grafana:windows/amd64:nocgo,msi:grafana:windows/amd64:nocgo
+            artifacts: targz:grafana:windows/amd64,zip:grafana:windows/amd64,msi:grafana:windows/amd64
             verify: true
           - name: windows-arm64
-            artifacts: targz:grafana:windows/arm64:nocgo,zip:grafana:windows/arm64:nocgo
+            artifacts: targz:grafana:windows/arm64,zip:grafana:windows/arm64
             verify: true
           - name: darwin-amd64
-            artifacts: targz:grafana:darwin/amd64:nocgo
+            artifacts: targz:grafana:darwin/amd64
             verify: true
           - name: darwin-arm64
-            artifacts: targz:grafana:darwin/arm64:nocgo
+            artifacts: targz:grafana:darwin/arm64
             verify: true
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2

--- a/pkg/build/daggerbuild/backend/builder.go
+++ b/pkg/build/daggerbuild/backend/builder.go
@@ -105,8 +105,8 @@ func GolangContainer(
 	opts *BuildOpts,
 ) (*dagger.Container, error) {
 	os, _ := OSAndArch(distro)
-	// Only use viceroy for all darwin and only windows/amd64
-	if opts.CGOEnabled && (os == "darwin" || distro == DistWindowsAMD64) {
+	// Only use viceroy for all darwin builds
+	if opts.CGOEnabled && os == "darwin" {
 		return ViceroyContainer(d, log, distro, goVersion, viceroyVersion, opts)
 	}
 
@@ -124,7 +124,9 @@ func GolangContainer(
 			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/s390x-linux-musl-cross.tgz", "-P", "/toolchain"}).
 			WithExec([]string{"tar", "-xf", "/toolchain/s390x-linux-musl-cross.tgz", "-C", "/toolchain"}).
 			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/riscv64-linux-musl-cross.tgz", "-P", "/toolchain"}).
-			WithExec([]string{"tar", "-xf", "/toolchain/riscv64-linux-musl-cross.tgz", "-C", "/toolchain"})
+			WithExec([]string{"tar", "-xf", "/toolchain/riscv64-linux-musl-cross.tgz", "-C", "/toolchain"}).
+			WithExec([]string{"wget", "-q", "https://dl.grafana.com/ci/x86_64-w64-mingw32-cross.tgz", "-P", "/toolchain"}).
+			WithExec([]string{"tar", "-xf", "/toolchain/x86_64-w64-mingw32-cross.tgz", "-C", "/toolchain"})
 	}
 	return WithGoEnv(log, container, distro, opts)
 }

--- a/pkg/build/daggerbuild/backend/distributions.go
+++ b/pkg/build/daggerbuild/backend/distributions.go
@@ -264,6 +264,38 @@ func BuildOptsStaticS390X(distro Distribution, experiments []string, tags []stri
 	}
 }
 
+// BuildOptsStaticRiscv64 builds Grafana statically for the riscv64 arch
+func BuildOptsStaticRiscv64(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
+	var (
+		os, _ = OSAndArch(distro)
+	)
+
+	return &GoBuildOpts{
+		CC:                "/toolchain/riscv64-linux-musl-cross/bin/riscv64-linux-musl-gcc",
+		CXX:               "/toolchain/riscv64-linux-musl-cross/bin/riscv64-linux-musl-cpp",
+		ExperimentalFlags: experiments,
+		OS:                os,
+		Arch:              "riscv64",
+		CGOEnabled:        true,
+	}
+}
+
+// BuildOptsStaticWindows builds Grafana statically for Windows on amd64
+func BuildOptsStaticWindows(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
+	var (
+		os, _ = OSAndArch(distro)
+	)
+
+	return &GoBuildOpts{
+		CC:                "/toolchain/x86_64-w64-mingw32-cross/bin/x86_64-w64-mingw32-gcc",
+		CXX:               "/toolchain/x86_64-w64-mingw32-cross/bin/x86_64-w64-mingw32-cpp",
+		ExperimentalFlags: experiments,
+		OS:                os,
+		Arch:              "amd64",
+		CGOEnabled:        true,
+	}
+}
+
 func StdZigBuildOpts(distro Distribution, experiments []string, tags []string) *GoBuildOpts {
 	var (
 		os, arch = OSAndArch(distro)
@@ -344,11 +376,11 @@ var DistributionGoOpts = map[Distribution]DistroBuildOptsFunc{
 	DistLinuxAMD64:        StdZigBuildOpts,
 	DistLinuxAMD64Dynamic: StdZigBuildOpts,
 	DistPlan9AMD64:        StdZigBuildOpts,
-	DistLinuxRISCV64:      StdZigBuildOpts,
+	DistLinuxRISCV64:      BuildOptsStaticRiscv64,
 
 	// Non-Linux distros can have whatever they want in CC and CXX; it'll get overridden
 	// but it's probably not best to rely on that.
-	DistWindowsAMD64: ViceroyBuildOpts,
+	DistWindowsAMD64: BuildOptsStaticWindows,
 	DistWindowsARM64: StdZigBuildOpts,
 	DistDarwinAMD64:  ViceroyBuildOpts,
 	DistDarwinARM64:  ViceroyBuildOpts,


### PR DESCRIPTION
Backport e7a49fc4721950e35d99a3923846a8fe7d07947f from #112922

---
