### PR TITLE
FS: Fix tempo-init not working in devenv

### DIFF
--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -124,7 +124,7 @@ services:
       - 'alloy.logs=true'
 
   tempo-init:
-    image: grafana/tempo
+    image: busybox
     user: root
     entrypoint:
       - 'chown'


### PR DESCRIPTION
The Tempo image no longer has `chown` in it, so new people who pulled this would get an error when tempo tried to start.