### PR TITLE
Chore: Use renovate to update docker-compose files

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   extends: ["config:recommended"],
-  enabledManagers: ["npm"],
+  enabledManagers: ["npm", "docker-compose"],
   ignorePresets: [
     "github>grafana/grafana-renovate-config//presets/labels",
   ],


### PR DESCRIPTION
Updates Renovate to update docker compose files. Intention is to use specific versions in `devenv/frontend-service/docker-compose.yaml` rather than just the `:latest` tag which doesn't get updated locally.