### PR TITLE
Chore: Add Bytespider to frontend bot list

### DIFF
--- a/public/app/core/services/echo/backends/grafana-javascript-agent/beforeSendHandler.ts
+++ b/public/app/core/services/echo/backends/grafana-javascript-agent/beforeSendHandler.ts
@@ -24,7 +24,7 @@ const bots =
   'twitterbot|cxensebot|smtbot|bnf.fr_bot|a6-indexer|admantx|facebot|orangebot|' +
   'memorybot|advbot|megaindex|semanticscholarbot|ltx71|nerdybot|xovibot|bubing|' +
   'qwantify|archive.org_bot|applebot|tweetmemebot|crawler4j|findxbot|semrushbot|' +
-  'yoozbot|lipperhey|y!j-asr|domain re-animator bot|addthis)';
+  'yoozbot|lipperhey|y!j-asr|domain re-animator bot|addthis|bytespider)';
 
 const botsRegex = new RegExp(bots);
 


### PR DESCRIPTION
**What is this feature?**

I've noticed a periodical crawling from ByteDance's [Bytespider](https://ops.grafana-ops.net/goto/ef20kkt6gd4hsb?orgId=1) on https://play.grafana.org 

**Why do we need this feature?**

To minimize the logging from crawlers / bots

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
