### PR TITLE
Secrets: Add decrypter to decrypt duration metric

### DIFF
--- a/pkg/storage/secret/metadata/decrypt_store.go
+++ b/pkg/storage/secret/metadata/decrypt_store.go
@@ -109,7 +109,7 @@ func (s *decryptStorage) Decrypt(ctx context.Context, namespace xkube.Namespace,
 
 		logging.FromContext(ctx).Info("Secrets Audit Log", args...)
 
-		s.metrics.DecryptDuration.WithLabelValues(decryptResultLabel).Observe(time.Since(start).Seconds())
+		s.metrics.DecryptDuration.WithLabelValues(decryptResultLabel, cmp.Or(decrypterIdentity, "unknown")).Observe(time.Since(start).Seconds())
 
 		// Do not leak error details to caller, return only the wrapped domain errors.
 		if decryptErr != nil {

--- a/pkg/storage/secret/metadata/metrics/metrics.go
+++ b/pkg/storage/secret/metadata/metrics/metrics.go
@@ -12,8 +12,9 @@ const (
 	namespace = "grafana_secrets_manager"
 	subsystem = "storage"
 	// labels
-	successLabel = "success"
-	resultLabel  = "result"
+	successLabel   = "success"
+	resultLabel    = "result"
+	decrypterLabel = "decrypter"
 )
 
 // StorageMetrics is a struct that contains all the metrics for all operations of secrets storage.
@@ -132,7 +133,7 @@ func newStorageMetrics() *StorageMetrics {
 			Name:      "decrypt_duration_seconds",
 			Help:      "Duration of decrypt operations",
 			Buckets:   prometheus.DefBuckets,
-		}, []string{resultLabel}),
+		}, []string{resultLabel, decrypterLabel}),
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Adds a `decrypter` label to the decrypt duration metric.

**Why do we need this feature?**

Better observe which decrypters are decrypting secrets

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
