### PR TITLE
FS: Update devenv docker images with renovate

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -31,6 +31,9 @@ outputs:
   dockerfile:
     description: Whether the dockerfile or self have changed in any way
     value: ${{ steps.changed-files.outputs.dockerfile_any_changed || 'true' }}
+  devenv:
+    description: Whether the devenv or self have changed in any way
+    value: ${{ steps.changed-files.outputs.devenv_any_changed || 'true' }}
 runs:
   using: composite
   steps:
@@ -136,6 +139,9 @@ runs:
             - '.vale.ini'
             - '.github/actions/change-detection/**'
             - '${{ inputs.self }}'
+          devenv:
+            - 'devenv/**'
+            - '${{ inputs.self }}'
     - name: Print all change groups
       shell: bash
       run: |
@@ -157,3 +163,5 @@ runs:
         echo " --> ${{ steps.changed-files.outputs.docs_all_changed_files }}"
         echo "Dockerfile: ${{ steps.changed-files.outputs.dockerfile_any_changed || 'true' }}"
         echo " --> ${{ steps.changed-files.outputs.dockerfile_all_changed_files }}"
+        echo "devenv: ${{ steps.changed-files.outputs.devenv_any_changed || 'true' }}"
+        echo " --> ${{ steps.changed-files.outputs.devenv_all_changed_files }}"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   extends: ["config:recommended"],
-  enabledManagers: ["npm"],
+  enabledManagers: ["npm", "docker-compose"],
   ignorePresets: [
     "github>grafana/grafana-renovate-config//presets/labels",
   ],
@@ -26,7 +26,7 @@
     "@types/slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
     "@types/slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
   ],
-  includePaths: ["package.json", "packages/**", "public/app/plugins/**"],
+  includePaths: ["package.json", "packages/**", "public/app/plugins/**", "devenv/frontend-service/docker-compose.yaml"],
   ignorePaths: ["emails/**", "**/mocks/**"],
   labels: ["area/frontend", "dependencies", "no-changelog"],
   postUpdateOptions: ["yarnDedupeHighest"],

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -187,5 +187,9 @@ jobs:
       uses: ./.github/actions/setup-node
     - name: Install Tilt
       run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+    - name: Create empty config files # TODO: the tiltfile should conditionally mount these only if they exist, like the enterprise license
+      run: |
+        touch devenv/frontend-service/configs/grafana-api.local.ini
+        touch devenv/frontend-service/configs/frontend-service.local.ini
     - name: Test frontend-service Tiltfile
       run: tilt ci --file devenv/frontend-service/Tiltfile

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -183,6 +183,8 @@ jobs:
         persist-credentials: false
     - name: Setup Docker
       uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
+    - name: Setup Node.js
+      uses: ./.github/actions/setup-node
     - name: Install Tilt
       run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
     - name: Test frontend-service Tiltfile

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -18,6 +18,7 @@ jobs:
       contents: read
     outputs:
       changed: ${{ steps.detect-changes.outputs.frontend }}
+      devenv-changed: ${{ steps.detect-changes.outputs.devenv }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -169,3 +170,20 @@ jobs:
           needs: ${{ toJson(needs) }}
           failure-message: "One or more unit test jobs have failed"
           success-message: "All unit tests completed successfully"
+
+  devenv:
+    needs:
+      - detect-changes
+    if: needs.detect-changes.outputs.devenv-changed == 'true'
+    runs-on: ubuntu-x64-large
+    name: "Devenv frontend-service build"
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+    - name: Setup Docker
+      uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
+    - name: Install Tilt
+      run: curl -fsSL https://raw.githubusercontent.com/tilt-dev/tilt/master/scripts/install.sh | bash
+    - name: Test frontend-service Tiltfile
+      run: tilt ci --file devenv/frontend-service/Tiltfile

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       - 'alloy.logs=true'
 
   alloy:
-    image: grafana/alloy:1.11.2
+    image: grafana/alloy:v1.11.2
     volumes:
       - ./configs/alloy:/alloy-config
       - /var/run/docker.sock:/var/run/docker.sock # To scrape Docker container logs

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       - 'alloy.logs=true'
 
   alloy:
-    image: grafana/alloy:latest
+    image: grafana/alloy:1.11.2
     volumes:
       - ./configs/alloy:/alloy-config
       - /var/run/docker.sock:/var/run/docker.sock # To scrape Docker container logs
@@ -104,7 +104,7 @@ services:
       - 'alloy.logs=true'
 
   prometheus:
-    image: prom/prometheus
+    image: prom/prometheus:v3.7.2
     volumes:
       - prometheus-data:/prometheus
     command:
@@ -116,7 +116,7 @@ services:
       - 'alloy.logs=true'
 
   loki:
-    image: grafana/loki
+    image: grafana/loki:3.5.7
     volumes:
       - loki-data:/loki
     command: -config.file=/etc/loki/local-config.yaml
@@ -124,7 +124,7 @@ services:
       - 'alloy.logs=true'
 
   tempo-init:
-    image: busybox
+    image: busybox:1.37.0
     user: root
     entrypoint:
       - 'chown'
@@ -134,7 +134,7 @@ services:
       - tempo-data:/var/tempo
 
   tempo:
-    image: grafana/tempo
+    image: grafana/tempo:2.9.0
     volumes:
       - tempo-data:/var/lib/tempo
       - ./configs/tempo.yaml:/etc/tempo/tempo.yaml


### PR DESCRIPTION
Recently had an error where the `:latest` tag for a docker image used in Tilt broke the dev setup.

This PR aims to address this moving forward with a few things:
 - pins the docker images in docker-compose.yaml to explicit versions
 - configures renovate to update the images when they're available
 - adds a CI check (non-mandatory for now) to test that the tiltfile works correctly