### PR TITLE
MySQL: Make ssl_mode=skip-verify work without ca_cert_path for MySQL

### DIFF
--- a/pkg/services/sqlstore/tls_mysql.go
+++ b/pkg/services/sqlstore/tls_mysql.go
@@ -12,18 +12,47 @@ import (
 var tlslog = log.New("tls_mysql")
 
 func makeCert(config *DatabaseConfig) (*tls.Config, error) {
+	// Handle skip-verify mode first - no CA cert needed
+	if config.SslMode == "skip-verify" {
+		tlslog.Info("Using skip-verify mode for MySQL TLS connection")
+		tlsConfig := &tls.Config{
+			InsecureSkipVerify: true,
+		}
+		
+		// Still allow client certificates if provided
+		if config.ClientCertPath != "" && config.ClientKeyPath != "" {
+			tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
+				tlslog.Debug("Loading client certificate")
+				cert, err := tls.LoadX509KeyPair(config.ClientCertPath, config.ClientKeyPath)
+				return &cert, err
+			}
+		}
+		
+		if config.ServerCertName != "" {
+			tlsConfig.ServerName = config.ServerCertName
+		}
+		
+		return tlsConfig, nil
+	}
+	
+	// For non-skip-verify modes, CA cert is required
+	if config.CaCertPath == "" {
+		return nil, fmt.Errorf("CA cert path is required when ssl_mode=%s", config.SslMode)
+	}
+	
 	rootCertPool := x509.NewCertPool()
 	pem, err := os.ReadFile(config.CaCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("could not read DB CA Cert path %q: %w", config.CaCertPath, err)
 	}
 	if ok := rootCertPool.AppendCertsFromPEM(pem); !ok {
-		return nil, err
+		return nil, fmt.Errorf("failed to append CA certs from PEM")
 	}
-
+	
 	tlsConfig := &tls.Config{
 		RootCAs: rootCertPool,
 	}
+	
 	if config.ClientCertPath != "" && config.ClientKeyPath != "" {
 		tlsConfig.GetClientCertificate = func(*tls.CertificateRequestInfo) (*tls.Certificate, error) {
 			tlslog.Debug("Loading client certificate")
@@ -31,13 +60,13 @@ func makeCert(config *DatabaseConfig) (*tls.Config, error) {
 			return &cert, err
 		}
 	}
+	
 	tlsConfig.ServerName = config.ServerCertName
-	if config.SslMode == "skip-verify" {
-		tlsConfig.InsecureSkipVerify = true
-	}
+	
 	// Return more meaningful error before it is too late
 	if config.ServerCertName == "" && !tlsConfig.InsecureSkipVerify {
 		return nil, fmt.Errorf("server_cert_name is missing. Consider using ssl_mode = skip-verify")
 	}
+	
 	return tlsConfig, nil
 }

--- a/pkg/services/sqlstore/tls_mysql_test.go
+++ b/pkg/services/sqlstore/tls_mysql_test.go
@@ -1,0 +1,71 @@
+package sqlstore
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeCertWithSkipVerify(t *testing.T) {
+	t.Run("skip-verify without CA cert path should succeed", func(t *testing.T) {
+		config := &DatabaseConfig{
+			Type:       "mysql",
+			SslMode:    "skip-verify",
+			CaCertPath: "", // Empty - should not be required
+		}
+		
+		tlsConfig, err := makeCert(config)
+		
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.True(t, tlsConfig.InsecureSkipVerify)
+		require.Nil(t, tlsConfig.RootCAs)
+	})
+	
+	t.Run("skip-verify with client certs should work", func(t *testing.T) {
+		config := &DatabaseConfig{
+			Type:           "mysql",
+			SslMode:        "skip-verify",
+			CaCertPath:     "",
+			ClientCertPath: "/path/to/client.crt",
+			ClientKeyPath:  "/path/to/client.key",
+		}
+		
+		tlsConfig, err := makeCert(config)
+		
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.True(t, tlsConfig.InsecureSkipVerify)
+		require.NotNil(t, tlsConfig.GetClientCertificate)
+	})
+	
+	t.Run("skip-verify with server cert name should work", func(t *testing.T) {
+		config := &DatabaseConfig{
+			Type:           "mysql",
+			SslMode:        "skip-verify",
+			ServerCertName: "*.mysql.database.azure.com",
+		}
+		
+		tlsConfig, err := makeCert(config)
+		
+		require.NoError(t, err)
+		require.NotNil(t, tlsConfig)
+		require.True(t, tlsConfig.InsecureSkipVerify)
+		require.Equal(t, "*.mysql.database.azure.com", tlsConfig.ServerName)
+	})
+}
+
+func TestMakeCertWithoutSkipVerify(t *testing.T) {
+	t.Run("ssl_mode=true without CA cert should fail", func(t *testing.T) {
+		config := &DatabaseConfig{
+			Type:       "mysql",
+			SslMode:    "true",
+			CaCertPath: "",
+		}
+		
+		_, err := makeCert(config)
+		
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "CA cert path is required")
+	})
+}


### PR DESCRIPTION
## What this PR does
Fixes MySQL SSL configuration to allow `ssl_mode=skip-verify` to work without requiring a CA certificate path.

## Which issue(s) this PR fixes
Fixes #112792

## Changes
- Modified `makeCert()` in `tls_mysql.go` to check for `skip-verify` mode before attempting to read CA certificate
- Added test coverage for skip-verify mode without CA cert
- Improved error messages for missing CA certs in non-skip-verify modes

## Testing
- Created new test file `tls_mysql_test.go`
- Added unit tests in `tls_mysql_test.go`
