### PR TITLE
SaveProvisionedDashboardForm: Show preview banner when pushing to non-configured existing branch

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 import { Controller, useForm, FormProvider } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom-v5-compat';
 
@@ -70,59 +70,35 @@ export function SaveProvisionedDashboardForm({
     });
   };
 
-  const handleNewDashboard = (upsert: Resource<Dashboard>) => {
-    // Navigation for new dashboards
-    const url = locationUtil.assureBaseUrl(
-      getDashboardUrl({
-        uid: upsert.metadata.name,
-        slug: kbn.slugifyForUrl(upsert.spec.title ?? ''),
-        currentQueryParams: window.location.search,
-      })
-    );
-    navigate(url);
-  };
+  const handleNewDashboard = useCallback(
+    (upsert: Resource<Dashboard>) => {
+      // Navigation for new dashboards
+      const url = locationUtil.assureBaseUrl(
+        getDashboardUrl({
+          uid: upsert.metadata.name,
+          slug: kbn.slugifyForUrl(upsert.spec.title ?? ''),
+          currentQueryParams: window.location.search,
+        })
+      );
+      navigate(url);
+    },
+    [navigate]
+  );
 
-  const onWriteSuccess = ({ repoType }: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
-    handleDismiss();
-    if (isNew && upsert?.metadata.name) {
-      handleNewDashboard(upsert);
-      return;
-    }
-
-    // if pushed to an existing but non-configured branch, navigate to preview page
-    if (ref !== repository?.branch) {
+  const navigateToPreview = useCallback(
+    (ref: string, path: string, repoType: string) => {
       const url = buildResourceBranchRedirectUrl({
         baseUrl: `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}`,
         paramName: 'ref',
         paramValue: ref,
-        repoType: repoType,
+        repoType,
       });
       navigate(url);
-      return;
-    }
+    },
+    [navigate, defaultValues.repo]
+  );
 
-    locationService.partial({
-      viewPanel: null,
-      editPanel: null,
-    });
-  };
-
-  const onBranchSuccess = (ref: string, path: string, info: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
-    handleDismiss();
-    if (isNew && upsert?.metadata?.name) {
-      handleNewDashboard(upsert);
-    } else {
-      const url = buildResourceBranchRedirectUrl({
-        baseUrl: `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}`,
-        paramName: 'ref',
-        paramValue: ref,
-        repoType: info.repoType,
-      });
-      navigate(url);
-    }
-  };
-
-  const handleDismiss = () => {
+  const handleDismiss = useCallback(() => {
     panelEditor?.onDiscard();
 
     const model = dashboard.getSaveModel();
@@ -131,7 +107,40 @@ export function SaveProvisionedDashboardForm({
     dashboard.saveCompleted(model, saveResponse, defaultValues.folder?.uid);
 
     drawer.onClose();
-  };
+  }, [dashboard, defaultValues.folder?.uid, drawer, panelEditor, request?.data?.resource]);
+
+  const onWriteSuccess = useCallback(
+    ({ repoType }: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
+      handleDismiss();
+      if (isNew && upsert?.metadata.name) {
+        handleNewDashboard(upsert);
+      }
+
+      // if pushed to an existing but non-configured branch, navigate to preview page
+      if (ref !== repository?.branch && ref) {
+        navigateToPreview(ref, path, repoType);
+        return;
+      }
+
+      locationService.partial({
+        viewPanel: null,
+        editPanel: null,
+      });
+    },
+    [isNew, path, ref, repository?.branch, handleDismiss, handleNewDashboard, navigateToPreview]
+  );
+
+  const onBranchSuccess = useCallback(
+    (ref: string, path: string, info: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
+      handleDismiss();
+      if (isNew && upsert?.metadata?.name) {
+        handleNewDashboard(upsert);
+      } else {
+        navigateToPreview(ref, path, info.repoType);
+      }
+    },
+    [isNew, navigateToPreview, handleNewDashboard, handleDismiss]
+  );
 
   useProvisionedRequestHandler<Dashboard>({
     folderUID: defaultValues.folder?.uid,

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -56,7 +56,7 @@ export function SaveProvisionedDashboardForm({
 
   const methods = useForm<ProvisionedDashboardFormData>({ defaultValues });
   const { handleSubmit, watch, control, reset, register } = methods;
-  const [workflow] = watch(['workflow']);
+  const [workflow, ref, path] = watch(['workflow', 'ref', 'path']);
 
   // Update the form if default values change
   useEffect(() => {
@@ -82,16 +82,29 @@ export function SaveProvisionedDashboardForm({
     navigate(url);
   };
 
-  const onWriteSuccess = (_: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
+  const onWriteSuccess = ({ repoType }: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
     handleDismiss();
     if (isNew && upsert?.metadata.name) {
       handleNewDashboard(upsert);
-    } else {
-      locationService.partial({
-        viewPanel: null,
-        editPanel: null,
-      });
+      return;
     }
+
+    // if pushed to an existing but non-configured branch, navigate to preview page
+    if (ref !== repository?.branch) {
+      const url = buildResourceBranchRedirectUrl({
+        baseUrl: `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}`,
+        paramName: 'ref',
+        paramValue: ref,
+        repoType: repoType,
+      });
+      navigate(url);
+      return;
+    }
+
+    locationService.partial({
+      viewPanel: null,
+      editPanel: null,
+    });
   };
 
   const onBranchSuccess = (ref: string, path: string, info: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -74,6 +74,7 @@ export function useProvisionedRequestHandler<T>({
   resourceType,
 }: Props<T>) {
   const dispatch = useDispatch();
+  // useRef to ensure handlers are only called once per request
   const hasHandled = useRef(false);
 
   useEffect(() => {

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -74,6 +74,8 @@ export function useProvisionedRequestHandler<T>({
   resourceType,
 }: Props<T>) {
   const dispatch = useDispatch();
+  const hasHandled = useRef(false);
+
   useEffect(() => {
     const repoType = repository?.type || 'git';
     const info: ProvisionedOperationInfo = {
@@ -83,11 +85,13 @@ export function useProvisionedRequestHandler<T>({
     };
 
     if (request.isError) {
+      hasHandled.current = true;
       handlers.onError?.(request.error, info);
       return;
     }
 
-    if (request.isSuccess && request.data) {
+    if (request.isSuccess && request.data && !hasHandled.current) {
+      hasHandled.current = true;
       const { ref, path, urls, resource } = request.data;
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       const resourceData = resource.upsert as Resource<T>;


### PR DESCRIPTION
**What is this feature?**

`SaveProvisionedDashboardForm`: Show a preview banner when pushing to existing (non-configured) branch. 

**Push to existing non-configured branch:**  
https://github.com/user-attachments/assets/d2311445-9cd0-4e68-a002-ca9f954eb43d. 

**Push to main:**  
https://github.com/user-attachments/assets/3c86e02f-f02f-4fd3-9764-3f830fe7e007


**Push to new branch:**  
https://github.com/user-attachments/assets/1212d266-6179-44b0-8c8e-ee17aead487b





**Why do we need this feature?**

So user know they are seeing a preview dashboard after saving to branch

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/500

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
