### PR TITLE
API Clients: Fix exports for correlations API

### DIFF
--- a/packages/grafana-api-clients/package.json
+++ b/packages/grafana-api-clients/package.json
@@ -32,6 +32,10 @@
       "import": "./src/clients/rtkq/advisor/v0alpha1/index.ts",
       "require": "./src/clients/rtkq/advisor/v0alpha1/index.ts"
     },
+    "./rtkq/correlations/v0alpha1": {
+      "import": "./src/clients/rtkq/correlations/v0alpha1/index.ts",
+      "require": "./src/clients/rtkq/correlations/v0alpha1/index.ts"
+    },
     "./rtkq/dashboard/v0alpha1": {
       "import": "./src/clients/rtkq/dashboard/v0alpha1/index.ts",
       "require": "./src/clients/rtkq/dashboard/v0alpha1/index.ts"


### PR DESCRIPTION
**What is this feature?**
Exports for correlations API were missed by me as the API went into `main` whilst the api clients PR was still ongoing

Thanks @gelicia for spotting it wasn't working