### PR TITLE
Access Control: Fix the permission checks for saving/updating/deleting annotations

### DIFF
--- a/pkg/registry/apis/dashboard/sub_dto.go
+++ b/pkg/registry/apis/dashboard/sub_dto.go
@@ -147,7 +147,7 @@ func (r *DTOConnector) Connect(ctx context.Context, name string, opts runtime.Ob
 		access.CanStar = user.IsIdentityType(authlib.TypeUser)
 
 		access.AnnotationsPermissions = &dashboard.AnnotationPermission{}
-		r.getAnnotationPermissionsByScope(ctx, user, &access.AnnotationsPermissions.Dashboard, accesscontrol.ScopeAnnotationsTypeDashboard)
+		r.getAnnotationPermissionsByScope(ctx, user, &access.AnnotationsPermissions.Dashboard, dashScope)
 		r.getAnnotationPermissionsByScope(ctx, user, &access.AnnotationsPermissions.Organization, accesscontrol.ScopeAnnotationsTypeOrganization)
 
 		title := obj.FindTitle("")


### PR DESCRIPTION
**What is this feature?**

Correctly set the metadata for whether a user is allowed to save/update/delete annotations on a dashboard.

**Why do we need this feature?**

Without the fix some users who had been granted Edit or Admin access to a dashboard could not create, edit or update annotations on it. 

**Who is this feature for?**

Anyone using annotations and allowing non-Editor users Edit access to any dashboards.