### PR TITLE
Add Feature Toggle Support for Dashboard V1 to V2 Conversions

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -1,6 +1,8 @@
 package conversion
 
 import (
+	"context"
+
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -8,9 +10,11 @@ import (
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
-func RegisterConversions(s *runtime.Scheme) error {
+func RegisterConversions(s *runtime.Scheme, features featuremgmt.FeatureToggles) error {
+	config := NewConversionConfig(context.Background(), features)
 	// v0 conversions
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
@@ -40,13 +44,13 @@ func RegisterConversions(s *runtime.Scheme) error {
 	}
 	if err := s.AddConversionFunc((*dashv1.Dashboard)(nil), (*dashv2alpha1.Dashboard)(nil),
 		withConversionMetrics(dashv1.APIVERSION, dashv2alpha1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V1beta1_to_V2alpha1(a.(*dashv1.Dashboard), b.(*dashv2alpha1.Dashboard), scope)
+			return Convert_V1beta1_to_V2alpha1(a.(*dashv1.Dashboard), b.(*dashv2alpha1.Dashboard), scope, config)
 		})); err != nil {
 		return err
 	}
 	if err := s.AddConversionFunc((*dashv1.Dashboard)(nil), (*dashv2beta1.Dashboard)(nil),
 		withConversionMetrics(dashv1.APIVERSION, dashv2beta1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V1beta1_to_V2beta1(a.(*dashv1.Dashboard), b.(*dashv2beta1.Dashboard), scope)
+			return Convert_V1beta1_to_V2beta1(a.(*dashv1.Dashboard), b.(*dashv2beta1.Dashboard), scope, config)
 		})); err != nil {
 		return err
 	}

--- a/apps/dashboard/pkg/migration/conversion/conversion_config.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_config.go
@@ -1,0 +1,40 @@
+package conversion
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// ConversionConfig holds the configuration for which conversions are enabled
+type ConversionConfig struct {
+	// V1 to V2 conversions
+	V1ToV2Alpha1Enabled bool
+	V1ToV2Beta1Enabled  bool
+
+	// V0 to V2 conversions
+	V0ToV2Alpha1Enabled bool
+	V0ToV2Beta1Enabled  bool
+
+	// V2 to V1 conversions
+	V2Alpha1ToV1Enabled bool
+	V2Beta1ToV1Enabled  bool
+
+	// V2 to V0 conversions
+	V2Alpha1ToV0Enabled bool
+	V2Beta1ToV0Enabled  bool
+}
+
+// NewConversionConfig creates a new conversion config based on feature toggles
+func NewConversionConfig(ctx context.Context, features featuremgmt.FeatureToggles) *ConversionConfig {
+	return &ConversionConfig{
+		V1ToV2Alpha1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V1ToV2Beta1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V0ToV2Alpha1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V0ToV2Beta1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V2Alpha1ToV1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V2Beta1ToV1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V2Alpha1ToV0Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		V2Beta1ToV0Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+	}
+}

--- a/apps/dashboard/pkg/migration/conversion/conversion_config.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_config.go
@@ -8,33 +8,12 @@ import (
 
 // ConversionConfig holds the configuration for which conversions are enabled
 type ConversionConfig struct {
-	// V1 to V2 conversions
-	V1ToV2Alpha1Enabled bool
-	V1ToV2Beta1Enabled  bool
-
-	// V0 to V2 conversions
-	V0ToV2Alpha1Enabled bool
-	V0ToV2Beta1Enabled  bool
-
-	// V2 to V1 conversions
-	V2Alpha1ToV1Enabled bool
-	V2Beta1ToV1Enabled  bool
-
-	// V2 to V0 conversions
-	V2Alpha1ToV0Enabled bool
-	V2Beta1ToV0Enabled  bool
+	dashboardV2SchemaAPIEnabled bool
 }
 
 // NewConversionConfig creates a new conversion config based on feature toggles
 func NewConversionConfig(ctx context.Context, features featuremgmt.FeatureToggles) *ConversionConfig {
 	return &ConversionConfig{
-		V1ToV2Alpha1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V1ToV2Beta1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V0ToV2Alpha1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V0ToV2Beta1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V2Alpha1ToV1Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V2Beta1ToV1Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V2Alpha1ToV0Enabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
-		V2Beta1ToV0Enabled:  features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
+		dashboardV2SchemaAPIEnabled: features.IsEnabled(ctx, featuremgmt.FlagDashboardV2SchemaAPI),
 	}
 }

--- a/apps/dashboard/pkg/migration/conversion/v1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1.go
@@ -25,7 +25,7 @@ func Convert_V1beta1_to_V0(in *dashv1.Dashboard, out *dashv0.Dashboard, scope co
 }
 
 func Convert_V1beta1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope, config *ConversionConfig) error {
-	if config.V1ToV2Alpha1Enabled {
+	if !config.dashboardV2SchemaAPIEnabled {
 		if err := ConvertDashboard_V1beta1_to_V2alpha1(in, out, scope); err != nil {
 			out.Status = dashv2alpha1.DashboardStatus{
 				Conversion: &dashv2alpha1.DashboardConversionStatus{
@@ -59,7 +59,7 @@ func Convert_V1beta1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboa
 }
 
 func Convert_V1beta1_to_V2beta1(in *dashv1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope, config *ConversionConfig) error {
-	if config.V1ToV2Beta1Enabled {
+	if config.dashboardV2SchemaAPIEnabled {
 		v2alpha1 := &dashv2alpha1.Dashboard{}
 		if err := ConvertDashboard_V1beta1_to_V2alpha1(in, v2alpha1, scope); err != nil {
 			out.Status = dashv2beta1.DashboardStatus{

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -400,6 +400,10 @@ export interface FeatureToggles {
   */
   dashboardNewLayouts?: boolean;
   /**
+  * Enables the usage of the V2 schema API to retrieve and update dashboards
+  */
+  dashboardV2SchemaAPI?: boolean;
+  /**
   * Enables undo/redo in dynamic dashboards
   */
   dashboardUndoRedo?: boolean;

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -185,6 +185,10 @@ func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles,
 	}
 }
 
+func (b *DashboardsAPIBuilder) GetFeatures() featuremgmt.FeatureToggles {
+	return b.features
+}
+
 func (b *DashboardsAPIBuilder) GetGroupVersions() []schema.GroupVersion {
 	if featuremgmt.AnyEnabled(b.features, featuremgmt.FlagDashboardNewLayouts) {
 		// If dashboards v2 is enabled, we want to use v2beta1 as the default API version.
@@ -221,7 +225,7 @@ func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	}
 
 	// Register the explicit conversions
-	if err := conversion.RegisterConversions(scheme); err != nil {
+	if err := conversion.RegisterConversions(scheme, b.GetFeatures()); err != nil {
 		return err
 	}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -665,6 +665,12 @@ var (
 			Owner:        grafanaDashboardsSquad,
 		},
 		{
+			Name:        "dashboardV2SchemaAPI",
+			Description: "Enables the usage of the V2 schema API to retrieve and update dashboards",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaDashboardsSquad,
+		},
+		{
 			Name:         "dashboardUndoRedo",
 			Description:  "Enables undo/redo in dynamic dashboards",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -88,6 +88,7 @@ dashboardSceneForViewers,GA,@grafana/dashboards-squad,false,false,true
 dashboardSceneSolo,GA,@grafana/dashboards-squad,false,false,true
 dashboardScene,GA,@grafana/dashboards-squad,false,false,true
 dashboardNewLayouts,experimental,@grafana/dashboards-squad,false,false,true
+dashboardV2SchemaAPI,experimental,@grafana/dashboards-squad,false,false,false
 dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true
 unlimitedLayoutsNesting,experimental,@grafana/dashboards-squad,false,false,true
 panelFilterVariable,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -363,6 +363,10 @@ const (
 	// Enables experimental new dashboard layouts
 	FlagDashboardNewLayouts = "dashboardNewLayouts"
 
+	// FlagDashboardV2SchemaAPI
+	// Enables the usage of the V2 schema API to retrieve and update dashboards
+	FlagDashboardV2SchemaAPI = "dashboardV2SchemaAPI"
+
 	// FlagDashboardUndoRedo
 	// Enables undo/redo in dynamic dashboards
 	FlagDashboardUndoRedo = "dashboardUndoRedo"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1176,6 +1176,21 @@
     },
     {
       "metadata": {
+        "name": "dashboardV2SchemaAPI",
+        "resourceVersion": "1761316256063",
+        "creationTimestamp": "2025-10-24T14:29:56Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2025-10-24 14:30:56.063544 +0000 UTC"
+        }
+      },
+      "spec": {
+        "description": "Enables the usage of the V2 schema API to retrieve and update dashboards",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashgpt",
         "resourceVersion": "1753448760331",
         "creationTimestamp": "2023-08-30T20:22:05Z"


### PR DESCRIPTION
Adds feature toggle support to control dashboard conversions from v1 to v2 schemas, ensuring conversions only occur when the `FlagDashboardV2SchemaAPI` feature toggle is enabled.

We created a config struct to save the enabled conversions based on the feature toggles enabled at that moment. 

This helps us keep the following logic:
- If `FlagDashboardV2SchemaAPI` is enabled: When requesting a v1 dashboard from v2 endpoint, the conversion is run and it returns the result of it
- If `FlagDashboardV2SchemaAPI` is disabled: When requesting a v1 dashboard from v2 endpoint, the conversion returns a conversion error, triggering the redirection mechanism in the frontend to keep the system working as of today.

This feature toggle helps us to work on the conversion from v1 to v2 without updating the redirection mechanism in the frontend. Once the conversion is ready, we will make the following changes in the frontend logic:
1. If FlagDashboardV2SchemaAPI is enabled, the frontend will use only v2 endpoint to CRUD any dashboard
2. If FlagDashboardV2SchemaAPI is disabled, the frontend will use only v1 endpoint to CRUD any dashboard. If the v2 to v1 conversion is not yet in place, when FlagDashboardV2SchemaAPI is disabled, we will continue to use the redirect mechanism, where we utilize the v2 endpoint for the v2 dashboard and the v1 endpoint for the v0 & v1 dashboards.