### PR TITLE
FS: Apply versionString in help menu in frontend

### DIFF
--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -216,7 +216,6 @@ func (hs *HTTPServer) setIndexViewData(c *contextmodel.ReqContext) (*dtos.IndexV
 	hs.HooksService.RunIndexDataHooks(&data, c)
 
 	data.NavTree.ApplyCostManagementIA()
-	data.NavTree.ApplyHelpVersion(data.Settings.BuildInfo.VersionString) // RunIndexDataHooks can modify the version string
 	data.NavTree.Sort()
 
 	return &data, nil

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -158,14 +158,6 @@ func Sort(nodes []*NavLink) {
 	}
 }
 
-func (root *NavTreeRoot) ApplyHelpVersion(version string) {
-	helpNode := root.FindById("help")
-
-	if helpNode != nil {
-		helpNode.SubTitle = version
-	}
-}
-
 func (root *NavTreeRoot) ApplyCostManagementIA() {
 	orgAdminNode := root.FindById(NavIDCfg)
 	var costManagementApp *NavLink

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -13,14 +13,21 @@ import { HelpModal } from '../../help/HelpModal';
 
 import { DOCK_MENU_BUTTON_ID, MEGA_MENU_HEADER_TOGGLE_ID } from './MegaMenuHeader';
 
-export const enrichHelpItem = (helpItem: NavModelItem) => {
+const emitOpenShortcutsModal = () => {
+  appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
+};
+
+export const getEnrichedHelpItem = (helpItem: NavModelItem): NavModelItem => {
   let menuItems = helpItem.children || [];
 
-  if (helpItem.id === 'help') {
-    const onOpenShortcuts = () => {
-      appEvents.publish(new ShowModalReactEvent({ component: HelpModal }));
-    };
-    helpItem.children = [
+  if (helpItem.id !== 'help') {
+    return helpItem;
+  }
+
+  return {
+    ...helpItem,
+    subTitle: config.buildInfo.versionString,
+    children: [
       ...menuItems,
       ...getFooterLinks(),
       ...getEditionAndUpdateLinks(),
@@ -28,11 +35,10 @@ export const enrichHelpItem = (helpItem: NavModelItem) => {
         id: 'keyboard-shortcuts',
         text: t('nav.help/keyboard-shortcuts', 'Keyboard shortcuts'),
         icon: 'keyboard',
-        onClick: onOpenShortcuts,
+        onClick: emitOpenShortcutsModal,
       },
-    ];
-  }
-  return helpItem;
+    ],
+  };
 };
 
 export const enrichWithInteractionTracking = (

--- a/public/app/core/components/AppChrome/TopBar/useHelpNode.tsx
+++ b/public/app/core/components/AppChrome/TopBar/useHelpNode.tsx
@@ -1,11 +1,18 @@
 import { cloneDeep } from 'lodash';
+import { useMemo } from 'react';
 
+import { NavModelItem } from '@grafana/data';
 import { useSelector } from 'app/types/store';
 
-import { enrichHelpItem } from '../MegaMenu/utils';
+import { getEnrichedHelpItem } from '../MegaMenu/utils';
 
-export function useHelpNode() {
+export function useHelpNode(): NavModelItem | undefined {
   const navIndex = useSelector((state) => state.navIndex);
-  const helpNode = cloneDeep(navIndex['help']);
-  return helpNode ? enrichHelpItem(helpNode) : undefined;
+
+  const helpNode = useMemo(() => {
+    const helpNode = cloneDeep(navIndex['help']);
+    return helpNode ? getEnrichedHelpItem(helpNode) : undefined;
+  }, [navIndex]);
+
+  return helpNode;
 }

--- a/public/app/features/commandPalette/actions/staticActions.ts
+++ b/public/app/features/commandPalette/actions/staticActions.ts
@@ -2,7 +2,7 @@ import { useMemo } from 'react';
 
 import { NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { enrichHelpItem } from 'app/core/components/AppChrome/MegaMenu/utils';
+import { getEnrichedHelpItem } from 'app/core/components/AppChrome/MegaMenu/utils';
 import {
   shouldRenderInviteUserButton,
   performInviteUserClick,
@@ -25,7 +25,7 @@ function navTreeToActions(navTree: NavModelItem[], parents: NavModelItem[] = [])
   for (let navItem of navTree) {
     // help node needs enriching with the frontend links
     if (navItem.id === 'help') {
-      navItem = enrichHelpItem({ ...navItem });
+      navItem = getEnrichedHelpItem({ ...navItem });
       delete navItem.url;
     }
     const { url, target, text, isCreateAction, children, onClick, keywords } = navItem;


### PR DESCRIPTION
As a follow up from https://github.com/grafana/grafana/pull/112670, this ensures the help menu shows the custom version string by setting it on the help menu navItem node in the frontend instead of the backend.


In Grafana, the help menu is a navTree item which we render in the top nav. That nav item's "subtitle" is used to show the version of Grafana, which can be overridden via enterprise custom branding.

Previously, the backend would set the help menu's subtitle to the version string. This did not work with frontend-service, because the nav tree comes from the ST backend, but with fs we want to display the versionString from the frontend-service itself.

 - remove setting the help item's subtitle in the backend (api/index.go), setting it in the frontend with `getEnrichedHelpItem`
 - refactors `enrichHelpItem` to `getEnrichedHelpItem`, not mutating the input object
 - refactors `useHelpNode` to return a stable object by not cloning it on every render

Fixes https://github.com/grafana/grafana-frontend-platform/issues/55