### PR TITLE
StateTimeline: Comment and metadata cleanup

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -485,6 +485,25 @@ module.exports = [
     },
   },
 
+  // dataviz prefers to use `clsx` over `cx` to compose classes as a rule for performance reasons
+  {
+    files: ['public/app/plugins/panel/state-timeline/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        withBaseRestrictedImportsConfig({
+          patterns: [
+            {
+              group: ['@emotion/css'],
+              importNames: ['cx'],
+              message: 'Do not use "cx" from @emotion/css. Instead, use `clsx` and compose together only strings.',
+            },
+          ],
+        }),
+      ],
+    },
+  },
+
   // Old betterer rules config:
   {
     files: ['**/*.{js,jsx,ts,tsx}'],

--- a/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
+++ b/public/app/plugins/panel/state-timeline/StateTimelinePanel.tsx
@@ -29,9 +29,6 @@ import { containerStyles } from './styles';
 
 interface TimelinePanelProps extends PanelProps<Options> {}
 
-/**
- * @alpha
- */
 export const StateTimelinePanel = ({
   data,
   timeRange,

--- a/public/app/plugins/panel/state-timeline/hooks.tsx
+++ b/public/app/plugins/panel/state-timeline/hooks.tsx
@@ -17,6 +17,13 @@ const paginationStyles = {
   }),
 };
 
+/**
+ * a React hook used to encapsulate the rendering and state for pagination in StateTimeline.
+ * @param frames DataFrames to paginate
+ * @param perPage number of series per page
+ * @returns the current frames rendered, the pagination element to render, the height of the pagination element,
+ *    and a paginationRev which GraphNG uses to trigger re-renders.
+ */
 export function usePagination(frames?: DataFrame[], perPage?: number) {
   const [currentPage, setCurrentPage] = useState(1);
 


### PR DESCRIPTION
Fixes #109630

- removes a comment which implies StateTimeline is `alpha`
  - I wanted to remove the `experimental` designation from the panelfg.cue, but that seems to be required. `maturity` values I saw elsewhere for non-panelcfgs, like "merged" or "stable", are not working. I'll look into this separately.
- adds a new ESLint rule which enforces that we never import `cx` from `@emotion/css`.
  - In general, we want to use `clsx` with only strings inside visualizations for performance reasons.
  - I want to figure out if I can override the type signature for `clsx` to have TypeScript yell for non-string usage.
  - I'll add more panels to this rule over time.
- adds a code comment to the `usePagination` hook.