### PR TITLE
Graphite: Fix legacy response unmarshalling

### DIFF
--- a/pkg/tsdb/graphite/query_test.go
+++ b/pkg/tsdb/graphite/query_test.go
@@ -225,6 +225,70 @@ func TestConvertResponses(t *testing.T) {
 			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
 		}
 	})
+
+	t.Run("Converts legacy response with no series", func(*testing.T) {
+		body := `
+		{
+			"version": "v0.1",
+			"meta": {
+				"stats": {}
+			},
+			"series": []
+		}`
+		refId := "A"
+		expectedFrames := data.Frames{}
+
+		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
+
+		require.NoError(t, err)
+		if !reflect.DeepEqual(expectedFrames, dataFrames) {
+			expectedFramesJSON, _ := json.Marshal(expectedFrames)
+			dataFramesJSON, _ := json.Marshal(dataFrames)
+			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
+		}
+	})
+
+	t.Run("Converts legacy response with series", func(*testing.T) {
+		body := `
+		{
+			"version": "v0.1",
+			"meta": {
+				"stats": {
+				}
+			},
+			"series": [
+				{
+				"target": "target",
+				"tags": { "fooTag": "fooValue", "barTag": "barValue", "int": 100, "float": 3.14 },
+				"datapoints": [[50, 1], [null, 2], [100, 3]]
+				}
+			]
+		}`
+		refId := "A"
+		a := 50.0
+		b := 100.0
+		expectedFrame := data.NewFrame("A",
+			data.NewField("time", nil, []time.Time{time.Unix(1, 0).UTC(), time.Unix(2, 0).UTC(), time.Unix(3, 0).UTC()}),
+			data.NewField("value", data.Labels{
+				"fooTag": "fooValue",
+				"barTag": "barValue",
+				"int":    "100",
+				"float":  "3.14",
+			}, []*float64{&a, nil, &b}).SetConfig(&data.FieldConfig{DisplayNameFromDS: "target"}),
+		).SetMeta(&data.FrameMeta{Type: data.FrameTypeTimeSeriesMulti})
+		expectedFrames := data.Frames{expectedFrame}
+
+		httpResponse := &http.Response{StatusCode: 200, Body: io.NopCloser(strings.NewReader(body))}
+		dataFrames, err := service.toDataFrames(httpResponse, refId)
+
+		require.NoError(t, err)
+		if !reflect.DeepEqual(expectedFrames, dataFrames) {
+			expectedFramesJSON, _ := json.Marshal(expectedFrames)
+			dataFramesJSON, _ := json.Marshal(dataFrames)
+			t.Errorf("Data frames should have been equal but was, expected:\n%s\nactual:\n%s", expectedFramesJSON, dataFramesJSON)
+		}
+	})
 }
 
 func TestFixIntervalFormat(t *testing.T) {

--- a/pkg/tsdb/graphite/types.go
+++ b/pkg/tsdb/graphite/types.go
@@ -9,6 +9,12 @@ type TargetResponseDTO struct {
 	Tags map[string]any `json:"tags"`
 }
 
+type LegacyTargetResponseDTO struct {
+	Version string              `json:"version"`
+	Meta    map[string]any      `json:"meta"`
+	Series  []TargetResponseDTO `json:"series"`
+}
+
 type DataTimePoint [2]Float
 type DataTimeSeriesPoints []DataTimePoint
 


### PR DESCRIPTION
The backend logic does not correctly account for queries from older versions of Graphite. This can lead to the response failing to unmarshal and queries failing.

The logic has been updated to attempt to unmarshal in the latest format and then unmarshal in the legacy format if that fails. If both fail then an error is returned. I've marked this error as a plugin error, I believe it's incorrect for this to be a downstream error as we're not correctly handling the response.