### PR TITLE
Gauge: Fix migration version targeting and gdev dashboard

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json
@@ -36,8 +36,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -95,13 +94,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -117,8 +115,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -176,13 +173,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -198,8 +194,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -257,13 +252,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -279,8 +273,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -338,13 +331,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -360,8 +352,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -419,13 +410,12 @@
         "showThresholdMarkers": false,
         "sparkline": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -441,8 +431,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -500,13 +489,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -522,8 +510,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -581,13 +568,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -616,8 +602,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -675,13 +660,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -697,8 +681,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -756,13 +739,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -778,8 +760,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -837,13 +818,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -859,8 +839,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -918,13 +897,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -953,8 +931,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1016,13 +993,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1034,8 +1010,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1097,13 +1072,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1115,8 +1089,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1178,13 +1151,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1196,8 +1168,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1259,13 +1230,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1277,8 +1247,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1340,13 +1309,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1371,8 +1339,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1438,13 +1405,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1456,8 +1422,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1523,13 +1488,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1541,8 +1505,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1608,13 +1571,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1639,8 +1601,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1704,12 +1665,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 98,
@@ -1727,8 +1687,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1792,12 +1751,11 @@
         "sparkline": true,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 98,
@@ -1828,8 +1786,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1894,12 +1851,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 8,
@@ -1917,8 +1873,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1984,12 +1939,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 12,
@@ -2007,8 +1961,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -2072,12 +2025,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 100,
@@ -2095,8 +2047,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -2160,12 +2111,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 100,

--- a/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
+++ b/devenv/dev-dashboards/panel-gauge/gauge_tests_new.json
@@ -36,8 +36,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -93,13 +92,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -115,8 +113,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -172,13 +169,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -194,8 +190,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -251,13 +246,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -273,8 +267,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -330,13 +323,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -352,8 +344,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -409,13 +400,12 @@
         "showThresholdMarkers": false,
         "sparkline": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -431,8 +421,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -488,13 +477,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -510,8 +498,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -567,13 +554,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -602,8 +588,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -659,13 +644,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -681,8 +665,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -738,13 +721,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -760,8 +742,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -817,13 +798,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -839,8 +819,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -896,13 +875,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "max": 100,
           "min": 1,
@@ -931,8 +909,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -992,13 +969,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1010,8 +986,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1071,13 +1046,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1089,8 +1063,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1150,13 +1123,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1168,8 +1140,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1229,13 +1200,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1247,8 +1217,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1308,13 +1277,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1339,8 +1307,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1404,13 +1371,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1422,8 +1388,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1487,13 +1452,12 @@
         "showThresholdMarkers": false,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1505,8 +1469,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "fieldConfig": {
         "defaults": {
@@ -1570,13 +1533,12 @@
         "showThresholdMarkers": true,
         "sparkline": false
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "alias": "1",
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "refId": "A",
           "scenarioId": "csv_metric_values",
@@ -1601,8 +1563,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1664,12 +1625,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 98,
@@ -1687,8 +1647,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1750,12 +1709,11 @@
         "sparkline": true,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 98,
@@ -1786,8 +1744,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1850,12 +1807,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 8,
@@ -1873,8 +1829,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -1938,12 +1893,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 12,
@@ -1961,8 +1915,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -2024,12 +1977,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 100,
@@ -2047,8 +1999,7 @@
     },
     {
       "datasource": {
-        "type": "grafana-testdata-datasource",
-        "uid": "PD8C576611E62080A"
+        "type": "grafana-testdata-datasource"
       },
       "description": "",
       "fieldConfig": {
@@ -2110,12 +2061,11 @@
         "sparkline": false,
         "spotlight": true
       },
-      "pluginVersion": "12.2.0-pre",
+      "pluginVersion": "13.0.0-pre",
       "targets": [
         {
           "datasource": {
-            "type": "grafana-testdata-datasource",
-            "uid": "PD8C576611E62080A"
+            "type": "grafana-testdata-datasource"
           },
           "hide": false,
           "max": 100,

--- a/public/app/plugins/panel/radialbar/GaugeMigrations.test.ts
+++ b/public/app/plugins/panel/radialbar/GaugeMigrations.test.ts
@@ -32,6 +32,34 @@ describe('Gauge Panel Migrations', () => {
     expect(result.sparkline).toBe(false);
   });
 
+  it('does not overwrite new gauge', () => {
+    const panel = {
+      id: 2,
+      options: {
+        reduceOptions: {
+          calcs: ['lastNotNull'],
+        },
+        showThresholdLabels: false,
+        showThresholdMarkers: true,
+        sparkline: true,
+      },
+      fieldConfig: {
+        defaults: {
+          color: {
+            mode: FieldColorModeId.Fixed,
+            fixedColor: 'blue',
+          },
+        },
+        overrides: [],
+      },
+      pluginVersion: '13.0.0',
+      type: 'gauge',
+    } as Omit<PanelModel, 'fieldConfig'>;
+
+    const result = gaugePanelMigrationHandler(panel as PanelModel);
+    expect(result.sparkline).toBe(true);
+  });
+
   it('from 6.1.1', () => {
     const panel = {
       datasource: '-- Grafana --',

--- a/public/app/plugins/panel/radialbar/GaugeMigrations.ts
+++ b/public/app/plugins/panel/radialbar/GaugeMigrations.ts
@@ -9,10 +9,9 @@ export function gaugePanelMigrationHandler(panel: PanelModel<Options>): Partial<
   const sharedOptions = sharedSingleStatMigrationHandler(panel);
   const newOptions: Partial<Options> = { ...sharedOptions };
 
-  const previousVersion = parseFloat(panel.pluginVersion || '8');
-  const fieldConfig = panel.fieldConfig;
+  if (shouldMigrateGauge(panel)) {
+    const fieldConfig = panel.fieldConfig;
 
-  if (previousVersion <= 12.3) {
     // This option had no effect in old gauge unless color mode was 'From thresholds'
     if (newOptions.showThresholdMarkers && fieldConfig?.defaults?.color?.mode !== FieldColorModeId.Thresholds) {
       newOptions.showThresholdMarkers = false;
@@ -41,7 +40,7 @@ export function gaugePanelMigrationHandler(panel: PanelModel<Options>): Partial<
 
 export function shouldMigrateGauge(panel: PanelModel): boolean {
   const previousVersion = parseFloat(panel.pluginVersion ?? '8');
-  return previousVersion <= 12.3;
+  return previousVersion < 13;
 }
 
 // This is called when the panel changes from another panel


### PR DESCRIPTION
The new Gauge's migration is incorrectly targeting the panels in the Gauge gdev dashboard.

- I've updated the logic in the migration to target 13.0.0 panels (since this will not go GA in OSS until that version)
- I've updated this gdev dashboard to set the version to 13.0.0-pre for the panels
- I've also removed the datasource uids, which should no longer be stored in gdev dashboards

### Before

The migration would run on the Sparkline panel, for example, and write over the panel's sparkline value.

<img width="316" height="261" alt="Screenshot 2025-10-24 at 2 22 24 PM" src="https://github.com/user-attachments/assets/8443ce76-7d10-423a-a92e-84b82de887cd" />

### After

The panel's sparkline value is used.

<img width="318" height="259" alt="Screenshot 2025-10-24 at 2 19 33 PM" src="https://github.com/user-attachments/assets/094e30e1-5dec-40ea-9fbb-52d71e41a706" />
