### PR TITLE
TimeSeries: X-axis (time range) click-and-drag panning in panel

### DIFF
--- a/e2e-playwright/panels-suite/timeseries.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries.spec.ts
@@ -1,0 +1,119 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = '1KxMUdE7k';
+
+test.use({
+  featureToggles: {
+    timeRangePan: true,
+  },
+});
+
+test.describe('Panels test: TimeSeries X-axis panning', { tag: ['@panels', '@timeseries'] }, () => {
+  test('cursor changes to grab hand over x-axis', async ({ gotoDashboardPage, page }) => {
+    await test.step('Load dashboard and verify cursor changes to grab', async () => {
+      const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
+
+      const timeseriesPanel = page.locator('.uplot').first();
+      await expect(timeseriesPanel, 'panel rendered').toBeVisible();
+
+      const xAxis = timeseriesPanel.locator('.u-axis').first();
+      await expect(xAxis, 'x-axis rendered').toBeVisible();
+
+      await xAxis.hover();
+
+      const cursorStyle = await xAxis.evaluate((el: HTMLElement) => window.getComputedStyle(el).cursor);
+      expect(cursorStyle, 'cursor is grab').toBe('grab');
+    });
+  });
+
+  test('drag right pans backward in time, drag left pans forward', async ({ gotoDashboardPage, page, selectors }) => {
+    let centerX: number;
+    let centerY: number;
+    let initialFromTime: number;
+    let initialToTime: number;
+
+    const dashboardPage = await test.step('Load dashboard and capture initial time range', async () => {
+      const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
+
+      const timeseriesPanel = page.locator('.uplot').first();
+      await expect(timeseriesPanel, 'panel rendered').toBeVisible();
+
+      const xAxis = timeseriesPanel.locator('.u-axis').first();
+      await expect(xAxis, 'x-axis rendered').toBeVisible();
+
+      const timePickerButton = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.openButton);
+      await timePickerButton.click();
+
+      const fromField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.fromField);
+      const toField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.toField);
+
+      const initialFrom = await fromField.inputValue();
+      const initialTo = await toField.inputValue();
+      initialFromTime = new Date(initialFrom).getTime();
+      initialToTime = new Date(initialTo).getTime();
+
+      await page.keyboard.press('Escape');
+
+      const axisBox = await xAxis.boundingBox();
+      if (!axisBox) {
+        throw new Error('X-axis bounding box not found');
+      }
+
+      centerX = axisBox.x + axisBox.width / 2;
+      centerY = axisBox.y + axisBox.height / 2;
+
+      return dashboardPage;
+    });
+
+    await test.step('Drag right pans backward in time', async () => {
+      await page.mouse.move(centerX, centerY);
+      await page.mouse.down();
+      await page.mouse.move(centerX + 100, centerY);
+      await page.mouse.up();
+
+      await page.waitForTimeout(1000);
+
+      const timePickerButton = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.openButton);
+      await timePickerButton.click();
+
+      const fromField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.fromField);
+      const toField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.toField);
+
+      const afterRightFrom = await fromField.inputValue();
+      const afterRightTo = await toField.inputValue();
+      const afterRightFromTime = new Date(afterRightFrom).getTime();
+      const afterRightToTime = new Date(afterRightTo).getTime();
+
+      expect(afterRightFromTime, 'panned backward').toBeLessThan(initialFromTime);
+      expect(afterRightToTime, 'panned backward').toBeLessThan(initialToTime);
+
+      await page.keyboard.press('Escape');
+
+      initialFromTime = afterRightFromTime;
+      initialToTime = afterRightToTime;
+    });
+
+    await test.step('Drag left pans forward in time', async () => {
+      await page.mouse.move(centerX, centerY);
+      await page.mouse.down();
+      await page.mouse.move(centerX - 100, centerY);
+      await page.mouse.up();
+
+      await page.waitForTimeout(1000);
+
+      const timePickerButton = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.openButton);
+      await timePickerButton.click();
+
+      const fromField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.fromField);
+      const toField = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.toField);
+
+      const afterLeftFrom = await fromField.inputValue();
+      const afterLeftTo = await toField.inputValue();
+      const afterLeftFromTime = new Date(afterLeftFrom).getTime();
+      const afterLeftToTime = new Date(afterLeftTo).getTime();
+
+      expect(afterLeftFromTime, 'panned forward').toBeGreaterThan(initialFromTime);
+      expect(afterLeftToTime, 'panned forward').toBeGreaterThan(initialToTime);
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -29,11 +29,7 @@ const cursorDefaults: Cursor = {
 type PrepData = (frames: DataFrame[]) => AlignedData | FacetedData;
 type PreDataStacked = (frames: DataFrame[], stackingGroups: StackingGroup[]) => AlignedData | FacetedData;
 
-type PlotState = {
-  isPanning: boolean;
-  min?: number;
-  max?: number;
-};
+type PlotState = { isPanning: false } | { isPanning: true; min: number; max: number };
 
 export class UPlotConfigBuilder {
   readonly uid = Math.random().toString(36).slice(2);
@@ -53,7 +49,7 @@ export class UPlotConfigBuilder {
   // to prevent more than one threshold per scale
   private thresholds: Record<string, UPlotThresholdOptions> = {};
   private padding?: Padding = undefined;
-  private state = { isPanning: false, min: 0, max: 0 };
+  private state: PlotState = { isPanning: false };
 
   private cachedConfig?: PlotConfig;
 

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -47,6 +47,7 @@ export class UPlotConfigBuilder {
   // to prevent more than one threshold per scale
   private thresholds: Record<string, UPlotThresholdOptions> = {};
   private padding?: Padding = undefined;
+  private state = { isPanning: false, min: 0, max: 0 };
 
   private cachedConfig?: PlotConfig;
 
@@ -58,6 +59,20 @@ export class UPlotConfigBuilder {
 
   // Exposed to let the container know the primary scale keys
   scaleKeys: [string, string] = ['', ''];
+
+  setState(isPanning: boolean, min?: number, max?: number) {
+    this.state.isPanning = isPanning;
+    if (min !== undefined) {
+      this.state.min = min;
+    }
+    if (max !== undefined) {
+      this.state.max = max;
+    }
+  }
+
+  getState() {
+    return this.state;
+  }
 
   addHook<T extends keyof Hooks.Defs>(type: T, hook: Hooks.Defs[T]) {
     pluginLog('UPlotConfigBuilder', false, 'addHook', type);

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -29,6 +29,12 @@ const cursorDefaults: Cursor = {
 type PrepData = (frames: DataFrame[]) => AlignedData | FacetedData;
 type PreDataStacked = (frames: DataFrame[], stackingGroups: StackingGroup[]) => AlignedData | FacetedData;
 
+type PlotState = {
+  isPanning: boolean;
+  min?: number;
+  max?: number;
+};
+
 export class UPlotConfigBuilder {
   readonly uid = Math.random().toString(36).slice(2);
 
@@ -60,14 +66,8 @@ export class UPlotConfigBuilder {
   // Exposed to let the container know the primary scale keys
   scaleKeys: [string, string] = ['', ''];
 
-  setState(isPanning: boolean, min?: number, max?: number) {
-    this.state.isPanning = isPanning;
-    if (min !== undefined) {
-      this.state.min = min;
-    }
-    if (max !== undefined) {
-      this.state.max = max;
-    }
+  setState(state: PlotState) {
+    this.state = merge({}, this.state, state);
   }
 
   getState() {

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -16,7 +16,7 @@ const createMockXAxis = () => {
 const createMockConfigBuilder = () => {
   return {
     setState: jest.fn(),
-    getState: jest.fn(() => ({ isPanning: false, min: 0, max: 0 })),
+    getState: jest.fn(() => ({ isPanning: false })),
   } satisfies Partial<UPlotConfigBuilder>;
 };
 

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -146,11 +146,15 @@ describe('XAxisInteractionAreaPlugin', () => {
         xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
         document.dispatchEvent(new MouseEvent('mousemove', { clientX: 350, bubbles: true }));
 
-        expect(mockConfigBuilder.setState).toHaveBeenCalledWith(true, expect.any(Number), expect.any(Number));
+        expect(mockConfigBuilder.setState).toHaveBeenCalledWith({
+          isPanning: true,
+          min: expect.any(Number),
+          max: expect.any(Number),
+        });
 
         document.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, bubbles: true }));
 
-        expect(mockConfigBuilder.setState).toHaveBeenCalledWith(false);
+        expect(mockConfigBuilder.setState).toHaveBeenCalledWith({ isPanning: false });
       });
     });
   });

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -1,0 +1,157 @@
+import uPlot from 'uplot';
+
+import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
+
+import { setupXAxisPan } from './XAxisInteractionAreaPlugin';
+
+const asUPlot = (partial: Partial<uPlot>) => partial as uPlot;
+const asConfigBuilder = (partial: Partial<UPlotConfigBuilder>) => partial as UPlotConfigBuilder;
+
+const createMockXAxis = () => {
+  const element = document.createElement('div');
+  element.classList.add('u-axis');
+  return element;
+};
+
+const createMockConfigBuilder = () => {
+  return {
+    setState: jest.fn(),
+    getState: jest.fn(() => ({ isPanning: false, min: 0, max: 0 })),
+  } satisfies Partial<UPlotConfigBuilder>;
+};
+
+const createMockUPlot = (xAxisElement: HTMLElement) => {
+  const root = document.createElement('div');
+  root.appendChild(xAxisElement);
+
+  const over = document.createElement('div');
+  Object.defineProperty(over, 'getBoundingClientRect', {
+    value: () => ({ left: 0, top: 0, width: 800, height: 400 }),
+  });
+
+  return {
+    root,
+    over,
+    bbox: { width: 800, height: 400, left: 0, top: 0 },
+    scales: {
+      x: {
+        min: 1000,
+        max: 2000,
+        range: () => [1000, 2000],
+      },
+    },
+    setScale: jest.fn(),
+  } satisfies Partial<uPlot>;
+};
+
+describe('XAxisInteractionAreaPlugin', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('setupXAxisPan', () => {
+    let mockQueryZoom: jest.Mock;
+    let mockConfigBuilder: ReturnType<typeof createMockConfigBuilder>;
+    let xAxisElement: HTMLElement;
+    let mockUPlot: ReturnType<typeof createMockUPlot>;
+
+    beforeEach(() => {
+      mockQueryZoom = jest.fn();
+      mockConfigBuilder = createMockConfigBuilder();
+      xAxisElement = createMockXAxis();
+      mockUPlot = createMockUPlot(xAxisElement);
+      document.body.appendChild(mockUPlot.root!);
+    });
+
+    afterEach(() => {
+      document.body.innerHTML = '';
+      jest.clearAllMocks();
+    });
+
+    describe('Initialization', () => {
+      it('should set up x-axis panning when called', () => {
+        setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+        xAxisElement.dispatchEvent(new MouseEvent('mouseenter'));
+        expect(xAxisElement).toHaveStyle({ cursor: 'grab' });
+      });
+
+      it('should handle missing x-axis element gracefully', () => {
+        const emptyRoot = document.createElement('div');
+        const emptyUPlot = { ...mockUPlot, root: emptyRoot };
+
+        expect(() =>
+          setupXAxisPan(asUPlot(emptyUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom)
+        ).not.toThrow();
+      });
+    });
+
+    describe('Cursor States', () => {
+      it('should transition through hover, drag, and leave states', () => {
+        setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+        xAxisElement.dispatchEvent(new MouseEvent('mouseenter'));
+        expect(xAxisElement).toHaveStyle({ cursor: 'grab' });
+
+        xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
+        expect(xAxisElement).toHaveStyle({ cursor: 'grabbing' });
+
+        document.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, bubbles: true }));
+        expect(xAxisElement).toHaveStyle({ cursor: 'grab' });
+
+        xAxisElement.dispatchEvent(new MouseEvent('mouseleave'));
+        expect(xAxisElement).toHaveStyle({ cursor: '' });
+      });
+    });
+
+    describe('Drag Interaction', () => {
+      it('should update scale in real-time and call queryZoom on completion', () => {
+        setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+        xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 350, bubbles: true }));
+
+        expect(mockUPlot.setScale).toHaveBeenCalledWith(
+          'x',
+          expect.objectContaining({
+            min: expect.any(Number),
+            max: expect.any(Number),
+          })
+        );
+
+        document.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, bubbles: true }));
+
+        expect(mockQueryZoom).toHaveBeenCalledWith(
+          expect.objectContaining({
+            from: expect.any(Number),
+            to: expect.any(Number),
+          })
+        );
+      });
+
+      it('should not call queryZoom when drag distance is below MIN_ZOOM_DIST threshold', () => {
+        setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+        xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
+        document.dispatchEvent(new MouseEvent('mouseup', { clientX: 402, bubbles: true }));
+
+        expect(mockQueryZoom).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('State Management', () => {
+      it('should call setState during drag and restore on mouseup', () => {
+        setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+        xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
+        document.dispatchEvent(new MouseEvent('mousemove', { clientX: 350, bubbles: true }));
+
+        expect(mockConfigBuilder.setState).toHaveBeenCalledWith(true, expect.any(Number), expect.any(Number));
+
+        document.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, bubbles: true }));
+
+        expect(mockConfigBuilder.setState).toHaveBeenCalledWith(false);
+      });
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
@@ -59,7 +59,7 @@ export const setupXAxisPan = (
       let panMin = startMin - shiftBy;
       let panMax = startMax - shiftBy;
 
-      config.setState(true, panMin, panMax);
+      config.setState({ isPanning: true, min: panMin, max: panMax });
 
       u.setScale('x', {
         min: panMin,
@@ -73,7 +73,7 @@ export const setupXAxisPan = (
 
       xAxisEl.style.cursor = 'grab';
 
-      config.setState(false);
+      config.setState({ isPanning: false });
 
       if (Math.abs(dx) >= MIN_PAN_DIST) {
         let shiftBy = dx * unitsPerPx;

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
@@ -1,0 +1,114 @@
+import { useLayoutEffect } from 'react';
+import uPlot from 'uplot';
+
+import { getFeatureToggle } from '../../../utils/featureToggle';
+import { UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
+
+const MIN_PAN_DIST = 5;
+
+/**
+ * Enables panning the time range by click and dragging x-axis labels with the mouse.
+ * Provides visual feedback (grab/grabbing cursor) and real-time grid updates during drag.
+ * @internal - exported for testing only
+ */
+export const setupXAxisPan = (
+  u: uPlot,
+  config: UPlotConfigBuilder,
+  queryZoom: (range: { from: number; to: number }) => void
+) => {
+  let xAxes = u.root.querySelectorAll('.u-axis');
+  let xAxis = xAxes[0];
+
+  if (!xAxis || !(xAxis instanceof HTMLElement)) {
+    return;
+  }
+
+  const xAxisEl = xAxis;
+
+  xAxisEl.addEventListener('mouseenter', () => {
+    xAxisEl.style.cursor = 'grab';
+  });
+
+  xAxisEl.addEventListener('mouseleave', () => {
+    xAxisEl.style.cursor = '';
+  });
+
+  xAxisEl.addEventListener('mousedown', (e: Event) => {
+    if (!(e instanceof MouseEvent)) {
+      return;
+    }
+    e.preventDefault();
+
+    xAxisEl.style.cursor = 'grabbing';
+
+    let xScale = u.scales.x;
+
+    let rect = u.over.getBoundingClientRect();
+    let startX = e.clientX - rect.left;
+    let startMin = xScale.min!;
+    let startMax = xScale.max!;
+    let unitsPerPx = (startMax - startMin) / (u.bbox.width / uPlot.pxRatio);
+
+    let onMove = (e: MouseEvent) => {
+      e.preventDefault();
+
+      let currentX = e.clientX - rect.left;
+      let dx = currentX - startX;
+      let shiftBy = dx * unitsPerPx;
+
+      let panMin = startMin - shiftBy;
+      let panMax = startMax - shiftBy;
+
+      config.setState(true, panMin, panMax);
+
+      u.setScale('x', {
+        min: panMin,
+        max: panMax,
+      });
+    };
+
+    let onUp = (e: MouseEvent) => {
+      let endX = e.clientX - rect.left;
+      let dx = endX - startX;
+
+      xAxisEl.style.cursor = 'grab';
+
+      config.setState(false);
+
+      if (Math.abs(dx) >= MIN_PAN_DIST) {
+        let shiftBy = dx * unitsPerPx;
+
+        queryZoom({
+          from: startMin - shiftBy,
+          to: startMax - shiftBy,
+        });
+      }
+
+      document.removeEventListener('mousemove', onMove);
+      document.removeEventListener('mouseup', onUp);
+    };
+
+    document.addEventListener('mousemove', onMove);
+    document.addEventListener('mouseup', onUp);
+  });
+};
+
+export interface XAxisInteractionAreaPluginProps {
+  config: UPlotConfigBuilder;
+  queryZoom?: (range: { from: number; to: number }) => void;
+}
+
+/**
+ * Plugin for handling x-axis area interactions, such as time range panning.
+ */
+export const XAxisInteractionAreaPlugin = ({ config, queryZoom }: XAxisInteractionAreaPluginProps) => {
+  useLayoutEffect(() => {
+    config.addHook('init', (u) => {
+      if (queryZoom != null && getFeatureToggle('timeRangePan')) {
+        setupXAxisPan(u, config, queryZoom);
+      }
+    });
+  }, [config, queryZoom]);
+
+  return null;
+};

--- a/packages/grafana-ui/src/index.ts
+++ b/packages/grafana-ui/src/index.ts
@@ -353,6 +353,7 @@ export { EventsCanvas } from './components/uPlot/geometries/EventsCanvas';
 export { TooltipPlugin2 } from './components/uPlot/plugins/TooltipPlugin2';
 export { EventBusPlugin } from './components/uPlot/plugins/EventBusPlugin';
 export { KeyboardPlugin } from './components/uPlot/plugins/KeyboardPlugin';
+export { XAxisInteractionAreaPlugin } from './components/uPlot/plugins/XAxisInteractionAreaPlugin';
 
 export { type PlotTooltipInterpolator, type PlotSelection, FIXED_UNIT } from './components/uPlot/types';
 export { type UPlotConfigPrepFn } from './components/uPlot/config/UPlotConfigBuilder';

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -136,6 +136,10 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       direction: isHorizontal ? ScaleDirection.Right : ScaleDirection.Up,
       isTime: true,
       range: () => {
+        const panState = builder.getPanState();
+        if (panState.isPanning) {
+          return [panState.min, panState.max];
+        }
         const r = getTimeRange();
         return [r.from.valueOf(), r.to.valueOf()];
       },

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -136,9 +136,9 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       direction: isHorizontal ? ScaleDirection.Right : ScaleDirection.Up,
       isTime: true,
       range: () => {
-        const panState = builder.getPanState();
-        if (panState.isPanning) {
-          return [panState.min, panState.max];
+        const state = builder.getState();
+        if (state.isPanning) {
+          return [state.min, state.max];
         }
         const r = getTimeRange();
         return [r.from.valueOf(), r.to.valueOf()];

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -12,7 +12,13 @@ import {
 } from '@grafana/data';
 import { PanelDataErrorView } from '@grafana/runtime';
 import { TooltipDisplayMode, VizOrientation } from '@grafana/schema';
-import { EventBusPlugin, KeyboardPlugin, TooltipPlugin2, usePanelContext } from '@grafana/ui';
+import {
+  EventBusPlugin,
+  KeyboardPlugin,
+  TooltipPlugin2,
+  XAxisInteractionAreaPlugin,
+  usePanelContext,
+} from '@grafana/ui';
 import { TimeRange2, TooltipHoverMode } from '@grafana/ui/internal';
 import { TimeSeries } from 'app/core/components/TimeSeries/TimeSeries';
 import { config } from 'app/core/config';
@@ -141,6 +147,7 @@ export const TimeSeriesPanel = ({
             {cursorSync !== DashboardCursorSync.Off && (
               <EventBusPlugin config={uplotConfig} eventBus={eventBus} frame={alignedFrame} />
             )}
+            <XAxisInteractionAreaPlugin config={uplotConfig} queryZoom={onChangeTimeRange} />
             {options.tooltip.mode !== TooltipDisplayMode.None && (
               <TooltipPlugin2
                 config={uplotConfig}


### PR DESCRIPTION
**What is this feature?**

This prototype introduces an experimental way to pan the time range of one or more panels in a dashboard via mouse click-and-drag interaction on the x-axis.

https://github.com/user-attachments/assets/c5aab4aa-ae46-4065-98d6-2e9a4e21d6a7


**Why do we need this feature?**

Allows a fine grained, and tactile way to adjust time range at the panel level.


**Who is this feature for?**

Ultimately, it might be for all users of Grafana, for now it's experimental.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/112966


**Special notes for your reviewer:**

 🎏 Remember to enable the experimental flag: `timeRangePan`
 
 🧪 Unit test coverage for new code is pretty alright, the remaining gap is covered but Playwright browser tests, should be 90+% in total.

<img width="1509" height="214" alt="Screenshot 2025-11-06 at 19 55 11" src="https://github.com/user-attachments/assets/5d89bbfc-7962-48e0-9831-f3c2991cd931" />


Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
