### PR TITLE
CI: End process if e2e tests fail in daggerbuild

### DIFF
--- a/pkg/build/daggerbuild/e2e/validate_package.go
+++ b/pkg/build/daggerbuild/e2e/validate_package.go
@@ -15,5 +15,6 @@ func ValidatePackage(ctx context.Context, d *dagger.Client, service *dagger.Serv
 
 	return c.WithServiceBinding("grafana", service).
 		WithEnvVariable("GRAFANA_URL", "http://grafana:3000").
+		WithEnvVariable("PW_TEST_HTML_REPORT_OPEN", "never").
 		WithExec([]string{"yarn", "e2e:acceptance"}), nil
 }


### PR DESCRIPTION
If the acceptance tests fail in the daggerbuild then they currently open a browser and wait for it to be closed, resulting in workflows that never exit until terminated externally.