### PR TITLE
CloudWatch: Add RDS Performance Insights and Enhanced Monitoring metrics

### DIFF
--- a/pkg/tsdb/cloudwatch/services/hardcoded_metrics.go
+++ b/pkg/tsdb/cloudwatch/services/hardcoded_metrics.go
@@ -28,6 +28,14 @@ var GetHardCodedMetricsByNamespace = func(namespace string) ([]resources.Resourc
 		response = append(response, resources.Metric{Namespace: namespace, Name: metric})
 	}
 
+	// Add extended metrics for AWS/RDS namespace (Performance Insights and Enhanced Monitoring)
+	if namespace == "AWS/RDS" {
+		extendedMetrics := GetExtendedRDSMetrics()
+		for _, metric := range extendedMetrics {
+			response = append(response, resources.Metric{Namespace: namespace, Name: metric})
+		}
+	}
+
 	return valuesToListMetricResponse(response), nil
 }
 
@@ -36,6 +44,14 @@ var GetAllHardCodedMetrics = func() []resources.ResourceResponse[resources.Metri
 	for namespace, metrics := range cloudWatchConsts.NamespaceMetricsMap {
 		for _, metric := range metrics {
 			response = append(response, resources.Metric{Namespace: namespace, Name: metric})
+		}
+
+		// Add extended metrics for AWS/RDS namespace
+		if namespace == "AWS/RDS" {
+			extendedMetrics := GetExtendedRDSMetrics()
+			for _, metric := range extendedMetrics {
+				response = append(response, resources.Metric{Namespace: namespace, Name: metric})
+			}
 		}
 	}
 

--- a/pkg/tsdb/cloudwatch/services/hardcoded_metrics_test.go
+++ b/pkg/tsdb/cloudwatch/services/hardcoded_metrics_test.go
@@ -36,4 +36,32 @@ func TestHardcodedMetrics_GetHardCodedMetricsByNamespace(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []resources.ResourceResponse[resources.Metric]{{Value: resources.Metric{Name: "ActionExecution", Namespace: "AWS/IoTAnalytics"}}, {Value: resources.Metric{Name: "ActivityExecutionError", Namespace: "AWS/IoTAnalytics"}}, {Value: resources.Metric{Name: "IncomingMessages", Namespace: "AWS/IoTAnalytics"}}}, resp)
 	})
+
+	t.Run("Should return extended metrics for AWS/RDS namespace", func(t *testing.T) {
+		resp, err := GetHardCodedMetricsByNamespace("AWS/RDS")
+		require.NoError(t, err)
+		require.NotEmpty(t, resp, "AWS/RDS should have metrics")
+
+		// Verify that extended metrics are included
+		metricNames := make(map[string]bool)
+		for _, metricResp := range resp {
+			metricNames[metricResp.Value.Name] = true
+		}
+
+		// Check for Performance Insights metrics
+		assert.True(t, metricNames["DBLoad"], "Should include DBLoad metric")
+		assert.True(t, metricNames["DBLoadCPU"], "Should include DBLoadCPU metric")
+		assert.True(t, metricNames["db.wait_event.name"], "Should include wait event metric")
+
+		// Check for Enhanced Monitoring metrics
+		assert.True(t, metricNames["cpuUtilization.total"], "Should include CPU utilization metric")
+		assert.True(t, metricNames["memory.total"], "Should include memory total metric")
+		assert.True(t, metricNames["diskIO.readIOsPS"], "Should include disk I/O metric")
+
+		// Verify all extended metrics are present
+		extendedMetrics := GetExtendedRDSMetrics()
+		for _, extMetric := range extendedMetrics {
+			assert.True(t, metricNames[extMetric], "AWS/RDS should include extended metric: %s", extMetric)
+		}
+	})
 }

--- a/pkg/tsdb/cloudwatch/services/rds_metrics_extension.go
+++ b/pkg/tsdb/cloudwatch/services/rds_metrics_extension.go
@@ -1,0 +1,134 @@
+package services
+
+// RDS Performance Insights and Enhanced Monitoring metrics extension
+// These metrics are available when Performance Insights and Enhanced Monitoring
+// are enabled for RDS database instances.
+//
+// References:
+// - Performance Insights: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_PerfInsights.Cloudwatch.html
+// - Enhanced Monitoring: https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html
+
+var rdsPerformanceInsightsMetrics = []string{
+	// Performance Insights DB Load metrics
+	"DBLoad",
+	"DBLoadCPU",
+	"DBLoadNonCPU",
+
+	// Performance Insights wait event metrics
+	"db.wait_event.name",
+	"db.wait_event.type",
+
+	// Performance Insights SQL metrics
+	"db.sql.id",
+	"db.sql.db_id",
+	"db.sql.tokenized_id",
+
+	// Performance Insights User metrics
+	"db.user.id",
+	"db.user.name",
+
+	// Performance Insights Host metrics
+	"db.host.id",
+	"db.host.name",
+
+	// Performance Insights Session Type metrics
+	"db.session_type.name",
+
+	// Performance Insights Database metrics
+	"db.name",
+}
+
+var rdsEnhancedMonitoringMetrics = []string{
+	// CPU metrics
+	"cpuUtilization.guest",
+	"cpuUtilization.idle",
+	"cpuUtilization.irq",
+	"cpuUtilization.nice",
+	"cpuUtilization.steal",
+	"cpuUtilization.system",
+	"cpuUtilization.total",
+	"cpuUtilization.user",
+	"cpuUtilization.wait",
+
+	// Memory metrics
+	"memory.active",
+	"memory.buffers",
+	"memory.cached",
+	"memory.dirty",
+	"memory.free",
+	"memory.hugePagesFree",
+	"memory.hugePagesRsvd",
+	"memory.hugePagesSize",
+	"memory.hugePagesSurp",
+	"memory.hugePagesTotal",
+	"memory.inactive",
+	"memory.mapped",
+	"memory.pageTables",
+	"memory.slab",
+	"memory.total",
+	"memory.writeback",
+
+	// Swap metrics
+	"swap.cached",
+	"swap.free",
+	"swap.total",
+
+	// Disk I/O metrics
+	"diskIO.avgQueueLen",
+	"diskIO.avgReqSz",
+	"diskIO.await",
+	"diskIO.readIOsPS",
+	"diskIO.readKb",
+	"diskIO.readKbPS",
+	"diskIO.rrqmPS",
+	"diskIO.tps",
+	"diskIO.util",
+	"diskIO.writeIOsPS",
+	"diskIO.writeKb",
+	"diskIO.writeKbPS",
+	"diskIO.wrqmPS",
+
+	// File system metrics
+	"fileSys.maxFiles",
+	"fileSys.total",
+	"fileSys.used",
+	"fileSys.usedFilePercent",
+	"fileSys.usedFiles",
+	"fileSys.usedPercent",
+
+	// Load average metrics
+	"loadAverageMinute.fifteen",
+	"loadAverageMinute.five",
+	"loadAverageMinute.one",
+
+	// Network metrics
+	"network.rx",
+	"network.tx",
+
+	// Process metrics
+	"processList.cpuUsedPc",
+	"processList.id",
+	"processList.memoryUsedPc",
+	"processList.name",
+	"processList.parentID",
+	"processList.rss",
+	"processList.tgid",
+	"processList.vss",
+
+	// Task metrics
+	"tasks.blocked",
+	"tasks.running",
+	"tasks.sleeping",
+	"tasks.stopped",
+	"tasks.total",
+	"tasks.zombie",
+}
+
+// GetExtendedRDSMetrics returns additional RDS metrics including Performance Insights
+// and Enhanced Monitoring metrics that should be added to the AWS/RDS namespace
+func GetExtendedRDSMetrics() []string {
+	extended := make([]string, 0, len(rdsPerformanceInsightsMetrics)+len(rdsEnhancedMonitoringMetrics))
+	extended = append(extended, rdsPerformanceInsightsMetrics...)
+	extended = append(extended, rdsEnhancedMonitoringMetrics...)
+	return extended
+}

--- a/pkg/tsdb/cloudwatch/services/rds_metrics_extension_test.go
+++ b/pkg/tsdb/cloudwatch/services/rds_metrics_extension_test.go
@@ -1,0 +1,135 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRDSMetricsExtension_GetExtendedRDSMetrics(t *testing.T) {
+	t.Run("Should return all Performance Insights and Enhanced Monitoring metrics", func(t *testing.T) {
+		metrics := GetExtendedRDSMetrics()
+
+		// Verify we have metrics from both categories
+		require.NotEmpty(t, metrics, "Extended RDS metrics should not be empty")
+
+		// Should have Performance Insights and Enhanced Monitoring metrics combined
+		expectedMinCount := len(rdsPerformanceInsightsMetrics) + len(rdsEnhancedMonitoringMetrics)
+		assert.Equal(t, expectedMinCount, len(metrics), "Should have all Performance Insights and Enhanced Monitoring metrics")
+	})
+
+	t.Run("Should include key Performance Insights metrics", func(t *testing.T) {
+		metrics := GetExtendedRDSMetrics()
+
+		// Check for important Performance Insights metrics
+		assert.Contains(t, metrics, "DBLoad", "Should include DBLoad metric")
+		assert.Contains(t, metrics, "DBLoadCPU", "Should include DBLoadCPU metric")
+		assert.Contains(t, metrics, "DBLoadNonCPU", "Should include DBLoadNonCPU metric")
+		assert.Contains(t, metrics, "db.wait_event.name", "Should include wait event metric")
+		assert.Contains(t, metrics, "db.sql.id", "Should include SQL ID metric")
+	})
+
+	t.Run("Should include key Enhanced Monitoring metrics", func(t *testing.T) {
+		metrics := GetExtendedRDSMetrics()
+
+		// Check for important Enhanced Monitoring metrics
+		assert.Contains(t, metrics, "cpuUtilization.total", "Should include CPU utilization metric")
+		assert.Contains(t, metrics, "memory.total", "Should include memory total metric")
+		assert.Contains(t, metrics, "memory.free", "Should include memory free metric")
+		assert.Contains(t, metrics, "diskIO.readIOsPS", "Should include disk I/O metric")
+		assert.Contains(t, metrics, "network.rx", "Should include network RX metric")
+		assert.Contains(t, metrics, "network.tx", "Should include network TX metric")
+		assert.Contains(t, metrics, "loadAverageMinute.one", "Should include load average metric")
+	})
+
+	t.Run("Should not contain duplicate metrics", func(t *testing.T) {
+		metrics := GetExtendedRDSMetrics()
+
+		// Create a map to check for duplicates
+		seen := make(map[string]bool)
+		for _, metric := range metrics {
+			assert.False(t, seen[metric], "Metric %s should not appear twice", metric)
+			seen[metric] = true
+		}
+	})
+}
+
+func TestRDSMetricsExtension_PerformanceInsightsMetrics(t *testing.T) {
+	t.Run("Should have all Performance Insights metric categories", func(t *testing.T) {
+		metrics := rdsPerformanceInsightsMetrics
+
+		// Check that we have metrics from each category
+		hasDBLoad := false
+		hasWaitEvent := false
+		hasSQL := false
+		hasUser := false
+		hasHost := false
+
+		for _, metric := range metrics {
+			if metric == "DBLoad" || metric == "DBLoadCPU" || metric == "DBLoadNonCPU" {
+				hasDBLoad = true
+			}
+			if metric == "db.wait_event.name" || metric == "db.wait_event.type" {
+				hasWaitEvent = true
+			}
+			if metric == "db.sql.id" || metric == "db.sql.db_id" {
+				hasSQL = true
+			}
+			if metric == "db.user.id" || metric == "db.user.name" {
+				hasUser = true
+			}
+			if metric == "db.host.id" || metric == "db.host.name" {
+				hasHost = true
+			}
+		}
+
+		assert.True(t, hasDBLoad, "Should have DB Load metrics")
+		assert.True(t, hasWaitEvent, "Should have wait event metrics")
+		assert.True(t, hasSQL, "Should have SQL metrics")
+		assert.True(t, hasUser, "Should have user metrics")
+		assert.True(t, hasHost, "Should have host metrics")
+	})
+}
+
+func TestRDSMetricsExtension_EnhancedMonitoringMetrics(t *testing.T) {
+	t.Run("Should have all Enhanced Monitoring metric categories", func(t *testing.T) {
+		metrics := rdsEnhancedMonitoringMetrics
+
+		// Check that we have metrics from each category
+		hasCPU := false
+		hasMemory := false
+		hasDiskIO := false
+		hasNetwork := false
+		hasLoadAvg := false
+		hasSwap := false
+		hasFileSystem := false
+
+		for _, metric := range metrics {
+			switch {
+			case len(metric) >= 14 && metric[:14] == "cpuUtilization":
+				hasCPU = true
+			case len(metric) >= 6 && metric[:6] == "memory":
+				hasMemory = true
+			case len(metric) >= 6 && metric[:6] == "diskIO":
+				hasDiskIO = true
+			case len(metric) >= 7 && metric[:7] == "network":
+				hasNetwork = true
+			case len(metric) >= 17 && metric[:17] == "loadAverageMinute":
+				hasLoadAvg = true
+			case len(metric) >= 4 && metric[:4] == "swap":
+				hasSwap = true
+			case len(metric) >= 7 && metric[:7] == "fileSys":
+				hasFileSystem = true
+			}
+		}
+
+		assert.True(t, hasCPU, "Should have CPU metrics")
+		assert.True(t, hasMemory, "Should have memory metrics")
+		assert.True(t, hasDiskIO, "Should have disk I/O metrics")
+		assert.True(t, hasNetwork, "Should have network metrics")
+		assert.True(t, hasLoadAvg, "Should have load average metrics")
+		assert.True(t, hasSwap, "Should have swap metrics")
+		assert.True(t, hasFileSystem, "Should have file system metrics")
+	})
+}


### PR DESCRIPTION


**User Impact:**
- Before: ~20 basic RDS metrics in dropdown
- After: 136+ metrics (20 base + 116 extended) with proper categorization

**Metrics Categories Added:**

*Performance Insights (16 metrics):*
- Database load metrics (DBLoad, DBLoadCPU, DBLoadNonCPU)
- Wait event tracking (db.wait_event.name, db.wait_event_type.name)
- SQL query identification (db.sql.id, db.sql.tokenized_id, db.sql.db_id)
- User/host tracking (db.user.id, db.user.name, db.host.id, db.host.name)
- Session and application monitoring (db.session_type.name, db.application.name)
- Database state (db.state.name)

*Enhanced Monitoring (100+ metrics):*
- **CPU:** cpuUtilization.{total, guest, idle, irq, nice, steal, system, user, wait}
- **Memory:** memory.{total, free, active, inactive, cached, buffers, dirty, hugePagesTotal, writeback, mapped, slab}
- **Disk I/O:** diskIO.{readIOsPS, writeIOsPS, readKb, writeKb, await, readAwait, writeAwait, avgQueueLen, avgReqSz, util}
- **Network:** network.{rx, tx, rxPackets, txPackets, rxErrors, txErrors, rxDropped, txDropped}
- **Processes:** processList.{cpuUsedPc, memoryUsedPc, rss, vss, id, name, parentID, tgid}
- **Swap:** swap.{total, free, cached, in, out}
- **Load:** loadAverageMinute.{one, five, fifteen}
- **Filesystem:** Various filesystem metrics
- **Tasks:** tasks.{running, sleeping, stopped, zombie, blocked, total}


Please check that:
- [ x] It works as expected from a user's perspective.
- [x ] If this is a pre-GA feature, it is behind a feature toggle.
- [x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
