### PR TITLE
Alerting: Fix DS configured header ignored

### DIFF
--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -74,12 +74,13 @@ func (s *FakeDataSourceService) AddDataSource(ctx context.Context, cmd *datasour
 		s.lastID = int64(len(s.DataSources) - 1)
 	}
 	dataSource := &datasources.DataSource{
-		ID:       s.lastID + 1,
-		Name:     cmd.Name,
-		Type:     cmd.Type,
-		UID:      cmd.UID,
-		OrgID:    cmd.OrgID,
-		JsonData: cmd.JsonData,
+		ID:             s.lastID + 1,
+		Name:           cmd.Name,
+		Type:           cmd.Type,
+		UID:            cmd.UID,
+		OrgID:          cmd.OrgID,
+		JsonData:       cmd.JsonData,
+		SecureJsonData: cmd.EncryptedSecureJsonData,
 	}
 	s.DataSources = append(s.DataSources, dataSource)
 	return dataSource, nil
@@ -122,7 +123,11 @@ func (s *FakeDataSourceService) GetHTTPTransport(ctx context.Context, ds *dataso
 }
 
 func (s *FakeDataSourceService) DecryptedValues(ctx context.Context, ds *datasources.DataSource) (map[string]string, error) {
-	return make(map[string]string), nil
+	output := make(map[string]string)
+	for key, value := range ds.SecureJsonData {
+		output[key] = string(value)
+	}
+	return output, nil
 }
 
 func (s *FakeDataSourceService) DecryptedValue(ctx context.Context, ds *datasources.DataSource, key string) (string, bool, error) {

--- a/pkg/services/ngalert/writer/datasourcewriter.go
+++ b/pkg/services/ngalert/writer/datasourcewriter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"net/url"
 	"path"
 	"strings"
@@ -205,9 +204,9 @@ func (w *DatasourceWriter) makeWriter(ctx context.Context, orgID int64, dsUID st
 		return nil, err
 	}
 
-	headers := make(http.Header)
+	headers := ho.Header
 	for k, v := range w.cfg.CustomHeaders {
-		headers.Add(k, v)
+		headers.Set(k, v)
 	}
 
 	var backend backendType


### PR DESCRIPTION
**What is this feature?**

When metrics are pushed from grafana managed recording rule, datasource configured header are ignored. 
Header are needed to push to multi tenant mimir instance notably.


**Which issue(s) does this PR fix?**:

Fixes #105967
Fixes #103059
Fixes [4843](https://github.com/grafana/mimir/discussions/4843)

**Special notes for your reviewer:**

Please check that:
- [ X ] It works as expected from a user's perspective.
- [ X ] If this is a pre-GA feature, it is behind a feature toggle.
- [ X ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.



