### PR TITLE
Plugins: use plugin schema in types

### DIFF
--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -84,6 +84,7 @@
     "xss": "^1.0.14"
   },
   "devDependencies": {
+    "@grafana/plugin-types": "^0.0.46",
     "@grafana/scenes": "6.38.0",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@testing-library/react": "16.3.0",

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -1,5 +1,7 @@
 import { ComponentType } from 'react';
 
+import { PluginSchema } from '@grafana/plugin-types/plugin-schema';
+
 import { KeyValue } from './data';
 import { IconName } from './icon';
 
@@ -122,34 +124,25 @@ export interface PluginDependencies {
   };
 }
 
+type Extensions = NonNullable<PluginSchema['extensions']>;
+type AddedComponents = NonNullable<Extensions['addedComponents']>;
+type AddedFunctions = NonNullable<Extensions['addedFunctions']>;
+type AddedLinks = NonNullable<Extensions['addedLinks']>;
+type ExposedComponents = NonNullable<Extensions['exposedComponents']>;
+type ExtensionPoints = NonNullable<Extensions['extensionPoints']>;
+
 export type ExtensionInfo = {
   targets: string | string[];
   title: string;
   description?: string;
 };
 
-export interface PluginExtensions {
-  // The component extensions that the plugin registers
-  addedComponents: ExtensionInfo[];
-
-  addedFunctions: ExtensionInfo[];
-
-  // The link extensions that the plugin registers
-  addedLinks: ExtensionInfo[];
-
-  // The React components that the plugin exposes
-  exposedComponents: Array<{
-    id: string;
-    title: string;
-    description?: string;
-  }>;
-
-  // The extension points that the plugin provides
-  extensionPoints: Array<{
-    id: string;
-    title: string;
-    description?: string;
-  }>;
+export interface PluginExtensions extends Extensions {
+  addedComponents: AddedComponents;
+  addedFunctions: AddedFunctions;
+  addedLinks: AddedLinks;
+  exposedComponents: ExposedComponents;
+  extensionPoints: ExtensionPoints;
 }
 
 export enum PluginIncludeType {

--- a/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
@@ -321,7 +321,7 @@ describe('usePluginFunctions()', () => {
     jest.mocked(isGrafanaDevMode).mockReturnValue(true);
 
     const functionConfig = {
-      targets: extensionPointId,
+      targets: [extensionPointId],
       title: '1',
       description: '1',
       fn: () => 'function1',

--- a/public/app/features/plugins/extensions/usePluginLinks.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.test.tsx
@@ -258,7 +258,7 @@ describe('usePluginLinks()', () => {
     jest.mocked(isGrafanaDevMode).mockReturnValue(true);
 
     const linkConfig = {
-      targets: extensionPointId,
+      targets: [extensionPointId],
       title: '1',
       description: '1',
       path: `/a/${pluginId}/2`,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3066,6 +3066,7 @@ __metadata:
   dependencies:
     "@braintree/sanitize-url": "npm:7.0.1"
     "@grafana/i18n": "npm:12.3.0-pre"
+    "@grafana/plugin-types": "npm:^0.0.46"
     "@grafana/scenes": "npm:6.38.0"
     "@grafana/schema": "npm:12.3.0-pre"
     "@leeoniya/ufuzzy": "npm:1.0.19"
@@ -3408,6 +3409,13 @@ __metadata:
   peerDependencies:
     "@playwright/test": ^1.52.0
   checksum: 10/4e14bda1c6304c89a1ffca972dda18d3ab1fad59ee30e6735112d75f7c5c40856091e2e17f46451aec5261b6368f67c245edb112072d98c9067723f4ca2c71c3
+  languageName: node
+  linkType: hard
+
+"@grafana/plugin-types@npm:^0.0.46":
+  version: 0.0.46
+  resolution: "@grafana/plugin-types@npm:0.0.46"
+  checksum: 10/f21b42356a8bf8010c38eb2f5f40651c2cb36e982738860f1212eb4a672d210a42b0c0de2aa534ec918bcb189a21a31808c905da49932541b9f9e3d9e1202a53
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

This pull request refactors how plugin extension metadata is handled across the codebase, focusing on type safety and improved compatibility with the latest plugin schema. The main changes include updating the `PluginExtensions` type to match the canonical schema, making access to extension arrays safer by using optional chaining, and updating tests and utility functions to reflect these changes. This helps prevent runtime errors when extension arrays are missing or undefined and keeps the codebase aligned with evolving plugin definitions.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #112195

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
