### PR TITLE
Switch variable type: Add docs

### DIFF
--- a/docs/sources/observability-as-code/schema-v2/variables-schema.md
+++ b/docs/sources/observability-as-code/schema-v2/variables-schema.md
@@ -372,7 +372,7 @@ The following table explains the usage of the switch variable JSON fields:
 | Name           | Usage                                                                                                                            |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | name           | string. Name of the variable.                                                                                                    |
-| current        | string. Current value of the switch variable (either enabledValue or disabledValue).                                            |
+| current        | string. Current value of the switch variable (either `enabledValue` or `disabledValue`).                                            |
 | enabledValue   | string. Value when the switch is in the enabled state.                                                                       |
 | disabledValue  | string. Value when the switch is in the disabled state.                                                                     |
 | label?         | string                                                                                                                           |

--- a/docs/sources/observability-as-code/schema-v2/variables-schema.md
+++ b/docs/sources/observability-as-code/schema-v2/variables-schema.md
@@ -29,6 +29,7 @@ The available variable types described in the following sections:
 - [DatasourceVariableKind](#datasourcevariablekind)
 - [IntervalVariableKind](#intervalvariablekind)
 - [CustomVariableKind](#customvariablekind)
+- [SwitchVariableKind](#switchvariablekind)
 - [GroupByVariableKind](#groupbyvariablekind)
 - [AdhocVariableKind](#adhocvariablekind)
 
@@ -336,6 +337,50 @@ The following table explains the usage of the custom variable JSON fields:
 | hide         | `VariableHide`. Options are: `dontHide`, `hideLabel`, and `hideVariable`.                                                        |
 | skipUrlSync  | bool. Default is `false`.                                                                                                        |
 | description? | string                                                                                                                           |
+
+## `SwitchVariableKind`
+
+Following is the JSON for a default switch variable:
+
+```json
+  "variables": [
+    {
+      "kind": "SwitchVariable",
+      "spec": {
+        "current": "false",
+        "enabledValue": "true",
+        "disabledValue": "false",
+        "hide": "dontHide",
+        "name": "",
+        "skipUrlSync": false
+      }
+    }
+  ]
+```
+
+`SwitchVariableKind` consists of:
+
+- kind: "SwitchVariable"
+- spec: [SwitchVariableSpec](#switchvariablespec)
+
+### `SwitchVariableSpec`
+
+The following table explains the usage of the switch variable JSON fields:
+
+<!-- prettier-ignore-start -->
+
+| Name           | Usage                                                                                                                            |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| name           | string. Name of the variable.                                                                                                    |
+| current        | string. Current value of the switch variable (either enabledValue or disabledValue).                                            |
+| enabledValue   | string. Value when the switch is in the enabled state.                                                                       |
+| disabledValue  | string. Value when the switch is in the disabled state.                                                                     |
+| label?         | string                                                                                                                           |
+| hide           | `VariableHide`. Options are: `dontHide`, `hideLabel`, and `hideVariable`.                                                        |
+| skipUrlSync    | bool. Default is `false`.                                                                                                        |
+| description?   | string                                                                                                                           |
+
+<!-- prettier-ignore-end -->
 
 ## `GroupByVariableKind`
 

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -103,8 +103,8 @@ The following table lists the types of variables shipped with Grafana.
 | Constant          | Define a hidden constant. [Add a constant variable](#add-a-constant-variable).                                                                                                          |
 | Data source       | Quickly change the data source for an entire dashboard. [Add a data source variable](#add-a-data-source-variable).                                                                      |
 | Interval          | Interval variables represent time spans. [Add an interval variable](#add-an-interval-variable).                                                                                         |
-| Switch            | Display a toggle switch with two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                                                  |
 | Ad hoc filters    | Key/value filters that are automatically added to all metric queries for a data source (Prometheus, Loki, InfluxDB, and Elasticsearch only). [Add ad hoc filters](#add-ad-hoc-filters). |
+| Switch            | Display a switch that allows you to toggle between two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                                                  |
 | Global variables  | Built-in variables that can be used in expressions in the query editor. Refer to [Global variables](#global-variables).                                                                 |
 | Chained variables | Variable queries can contain other variables. Refer to [Chained variables](#chained-variables).                                                                                         |
 
@@ -135,8 +135,8 @@ To create a variable, follow these steps:
    - [Constant](#add-a-constant-variable)
    - [Data source](#add-a-data-source-variable)
    - [Interval](#add-an-interval-variable)
-   - [Switch](#add-a-switch-variable)
    - [Ad hoc filters](#add-ad-hoc-filters)
+   - [Switch](#add-a-switch-variable)
 
 <!-- vale Grafana.Spelling = YES -->
 
@@ -297,14 +297,12 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 
 ## Add a switch variable
 
-_Switch_ variables display a toggle switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to toggle between two specific values in your queries, such as enabling or disabling a feature, switching between different modes, or controlling boolean conditions.
+_Switch_ variables display a switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to:
 
-Switch variables are particularly effective for:
-
-- Toggling between different query conditions
-- Enabling or disabling specific filters
-- Switching between different visualization modes
-- Controlling boolean parameters in your data sources
+- Toggle between different query conditions
+- Enable or disable specific filters
+- Switch between different visualization modes
+- Control boolean parameters in your data sources
 
 1. [Enter general options](#enter-general-options).
 1. Under the **Switch options** section of the page, configure the switch values:
@@ -316,8 +314,8 @@ Switch variables are particularly effective for:
    - **Custom** - Allows you to define custom values for both enabled and disabled states
 
 1. If you selected **Custom** in the previous step, configure the custom values:
-   - **Enabled value** - Enter the value that represents the enabled state (e.g. "on")
-   - **Disabled value** - Enter the value that represents the disabled state (e.g. "off")
+   - **Enabled value** - Enter the value that represents the enabled state (for example, "on")
+   - **Disabled value** - Enter the value that represents the disabled state (for example, "off")
 
 1. Click **Save dashboard**.
 1. Click **Back to dashboard** and **Exit edit**.

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -386,9 +386,6 @@ If one of the panels in the dashboard using that data source doesn't include tha
 In cases where the data source you're using doesn't support ad hoc filtering, consider using the special Dashboard data source.
 For more information, refer to [Filter any data using the Dashboard data source](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/add-template-variables/#filter-any-data-using-the-dashboard-data-source).
 
-<!-- vale Grafana.Spelling = YES -->
-<!-- vale Grafana.WordList = YES -->
-
 ## Add a switch variable
 
 _Switch_ variables display a switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to:
@@ -433,6 +430,9 @@ You can also use switch variables in panel titles and other dashboard elements:
 ```
 {{#if debug_mode}}Debug Mode: {{/if}}Application Metrics
 ```
+
+<!-- vale Grafana.Spelling = YES -->
+<!-- vale Grafana.WordList = YES -->
 
 ## Configure variable selection options
 

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -103,6 +103,7 @@ The following table lists the types of variables shipped with Grafana.
 | Constant          | Define a hidden constant. [Add a constant variable](#add-a-constant-variable).                                                                                                          |
 | Data source       | Quickly change the data source for an entire dashboard. [Add a data source variable](#add-a-data-source-variable).                                                                      |
 | Interval          | Interval variables represent time spans. [Add an interval variable](#add-an-interval-variable).                                                                                         |
+| Switch            | Display a toggle switch with two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                                                  |
 | Ad hoc filters    | Key/value filters that are automatically added to all metric queries for a data source (Prometheus, Loki, InfluxDB, and Elasticsearch only). [Add ad hoc filters](#add-ad-hoc-filters). |
 | Global variables  | Built-in variables that can be used in expressions in the query editor. Refer to [Global variables](#global-variables).                                                                 |
 | Chained variables | Variable queries can contain other variables. Refer to [Chained variables](#chained-variables).                                                                                         |
@@ -134,6 +135,7 @@ To create a variable, follow these steps:
    - [Constant](#add-a-constant-variable)
    - [Data source](#add-a-data-source-variable)
    - [Interval](#add-an-interval-variable)
+   - [Switch](#add-a-switch-variable)
    - [Ad hoc filters](#add-ad-hoc-filters)
 
 <!-- vale Grafana.Spelling = YES -->
@@ -291,6 +293,53 @@ The following example shows a more complex Graphite example, from the [Graphite 
 
 ```
 groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5), '$interval', 'sum', false), 2, 'sum')
+```
+
+## Add a switch variable
+
+_Switch_ variables display a toggle switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to toggle between two specific values in your queries, such as enabling or disabling a feature, switching between different modes, or controlling boolean conditions.
+
+Switch variables are particularly effective for:
+- Toggling between different query conditions
+- Enabling or disabling specific filters
+- Switching between different visualization modes
+- Controlling boolean parameters in your data sources
+
+1. [Enter general options](#enter-general-options).
+1. Under the **Switch options** section of the page, configure the switch values:
+
+   In the **Value pair type** drop-down list, select one of the following predefined options or choose **Custom** to define your own values:
+   - **True / False** - Uses boolean values `true` and `false`
+   - **1 / 0** - Uses numeric values `1` and `0`
+   - **Yes / No** - Uses string values `yes` and `no`
+   - **Custom** - Allows you to define custom values for both enabled and disabled states
+
+1. If you selected **Custom** in the previous step, configure the custom values:
+   - **Enabled value** - Enter the value that represents the enabled or "on" state
+   - **Disabled value** - Enter the value that represents the disabled or "off" state
+
+1. In the **Preview of values** section, Grafana displays the current switch state and available values. Review them to ensure they match what you expect.
+1. Click **Save dashboard**.
+1. Click **Back to dashboard** and **Exit edit**.
+
+### Switch variable examples
+
+The following example shows a switch variable `$debug_mode` used in a Prometheus query to conditionally include debug labels:
+
+```
+up{job="my-service"} and ($debug_mode == "true" or on() vector(0))
+```
+
+The following example shows a switch variable `$show_errors` used to filter log entries:
+
+```
+{job="application"} |= ($show_errors == "1" ? "ERROR" : "")
+```
+
+You can also use switch variables in panel titles and other dashboard elements:
+
+```
+{{#if debug_mode}}Debug Mode: {{/if}}Application Metrics
 ```
 
 <!-- vale Grafana.WordList = NO -->

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -104,7 +104,7 @@ The following table lists the types of variables shipped with Grafana.
 | Data source       | Quickly change the data source for an entire dashboard. [Add a data source variable](#add-a-data-source-variable).                                                                      |
 | Interval          | Interval variables represent time spans. [Add an interval variable](#add-an-interval-variable).                                                                                         |
 | Ad hoc filters    | Key/value filters that are automatically added to all metric queries for a data source (Prometheus, Loki, InfluxDB, and Elasticsearch only). [Add ad hoc filters](#add-ad-hoc-filters). |
-| Switch            | Display a switch that allows you to toggle between two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                                                  |
+| Switch            | Display a switch that allows you to toggle between two configurable values for enabled and disabled states. [Add a switch variable](#add-a-switch-variable).                            |
 | Global variables  | Built-in variables that can be used in expressions in the query editor. Refer to [Global variables](#global-variables).                                                                 |
 | Chained variables | Variable queries can contain other variables. Refer to [Chained variables](#chained-variables).                                                                                         |
 
@@ -295,51 +295,6 @@ The following example shows a more complex Graphite example, from the [Graphite 
 groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5), '$interval', 'sum', false), 2, 'sum')
 ```
 
-## Add a switch variable
-
-_Switch_ variables display a switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to:
-
-- Toggle between different query conditions
-- Enable or disable specific filters
-- Switch between different visualization modes
-- Control boolean parameters in your data sources
-
-1. [Enter general options](#enter-general-options).
-1. Under the **Switch options** section of the page, configure the switch values:
-
-   In the **Value pair type** drop-down list, select one of the following predefined options or choose **Custom** to define your own values:
-   - **True / False** - Uses boolean values `true` and `false`
-   - **1 / 0** - Uses numeric values `1` and `0`
-   - **Yes / No** - Uses string values `yes` and `no`
-   - **Custom** - Allows you to define custom values for both enabled and disabled states
-
-1. If you selected **Custom** in the previous step, configure the custom values:
-   - **Enabled value** - Enter the value that represents the enabled state (for example, "on")
-   - **Disabled value** - Enter the value that represents the disabled state (for example, "off")
-
-1. Click **Save dashboard**.
-1. Click **Back to dashboard** and **Exit edit**.
-
-### Switch variable examples
-
-The following example shows a switch variable `$debug_mode` used in a Prometheus query to conditionally include debug labels:
-
-```
-up{job="my-service"} and ($debug_mode == "true" or on() vector(0))
-```
-
-The following example shows a switch variable `$show_errors` used to filter log entries:
-
-```
-{job="application"} |= ($show_errors == "1" ? "ERROR" : "")
-```
-
-You can also use switch variables in panel titles and other dashboard elements:
-
-```
-{{#if debug_mode}}Debug Mode: {{/if}}Application Metrics
-```
-
 <!-- vale Grafana.WordList = NO -->
 <!-- vale Grafana.Spelling = NO -->
 
@@ -433,6 +388,51 @@ For more information, refer to [Filter any data using the Dashboard data source]
 
 <!-- vale Grafana.Spelling = YES -->
 <!-- vale Grafana.WordList = YES -->
+
+## Add a switch variable
+
+_Switch_ variables display a switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to:
+
+- Toggle between different query conditions
+- Enable or disable specific filters
+- Switch between different visualization modes
+- Control boolean parameters in your data sources
+
+1. [Enter general options](#enter-general-options).
+1. Under the **Switch options** section of the page, configure the switch values:
+
+   In the **Value pair type** drop-down list, select one of the following predefined options or choose **Custom** to define your own values:
+   - **True / False** - Uses boolean values `true` and `false`
+   - **1 / 0** - Uses numeric values `1` and `0`
+   - **Yes / No** - Uses string values `yes` and `no`
+   - **Custom** - Allows you to define custom values for both enabled and disabled states
+
+1. If you selected **Custom** in the previous step, configure the custom values:
+   - **Enabled value** - Enter the value that represents the enabled state (for example, "on")
+   - **Disabled value** - Enter the value that represents the disabled state (for example, "off")
+
+1. Click **Save dashboard**.
+1. Click **Back to dashboard** and **Exit edit**.
+
+### Switch variable examples
+
+The following example shows a switch variable `$debug_mode` used in a Prometheus query to conditionally include debug labels:
+
+```
+up{job="my-service"} and ($debug_mode == "true" or on() vector(0))
+```
+
+The following example shows a switch variable `$show_errors` used to filter log entries:
+
+```
+{job="application"} |= ($show_errors == "1" ? "ERROR" : "")
+```
+
+You can also use switch variables in panel titles and other dashboard elements:
+
+```
+{{#if debug_mode}}Debug Mode: {{/if}}Application Metrics
+```
 
 ## Configure variable selection options
 

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -316,10 +316,9 @@ Switch variables are particularly effective for:
    - **Custom** - Allows you to define custom values for both enabled and disabled states
 
 1. If you selected **Custom** in the previous step, configure the custom values:
-   - **Enabled value** - Enter the value that represents the enabled or "on" state
-   - **Disabled value** - Enter the value that represents the disabled or "off" state
+   - **Enabled value** - Enter the value that represents the enabled state (e.g. "on")
+   - **Disabled value** - Enter the value that represents the disabled state (e.g. "off")
 
-1. In the **Preview of values** section, Grafana displays the current switch state and available values. Review them to ensure they match what you expect.
 1. Click **Save dashboard**.
 1. Click **Back to dashboard** and **Exit edit**.
 

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -300,6 +300,7 @@ groupByNode(summarize(movingAverage(apps.$app.$server.counters.requests.count, 5
 _Switch_ variables display a toggle switch with two configurable values representing enabled and disabled states. This variable type is useful when you need to toggle between two specific values in your queries, such as enabling or disabling a feature, switching between different modes, or controlling boolean conditions.
 
 Switch variables are particularly effective for:
+
 - Toggling between different query conditions
 - Enabling or disabling specific filters
 - Switching between different visualization modes

--- a/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
+++ b/docs/sources/visualizations/dashboards/variables/add-template-variables/index.md
@@ -405,8 +405,8 @@ _Switch_ variables display a switch with two configurable values representing en
    - **Custom** - Allows you to define custom values for both enabled and disabled states
 
 1. If you selected **Custom** in the previous step, configure the custom values:
-   - **Enabled value** - Enter the value that represents the enabled state (for example, "on")
-   - **Disabled value** - Enter the value that represents the disabled state (for example, "off")
+   - **Enabled value** - Enter the value that represents the enabled state (for example, "on").
+   - **Disabled value** - Enter the value that represents the disabled state (for example, "off").
 
 1. Click **Save dashboard**.
 1. Click **Back to dashboard** and **Exit edit**.


### PR DESCRIPTION
### What changed?
This PR adds documentation for the [newly added switch variable type](https://github.com/grafana/grafana/pull/111366).


https://github.com/user-attachments/assets/4587920a-3d42-4b30-9b9d-9691025baac0



**Who is this feature for?**
Grafana users and developers.