### PR TITLE
Alerting: Fix enrichment tab to be rendered only for grafana alerting rules

### DIFF
--- a/public/app/features/alerting/unified/enterprise-components/rule-view-page/navigation.test.ts
+++ b/public/app/features/alerting/unified/enterprise-components/rule-view-page/navigation.test.ts
@@ -10,14 +10,14 @@ describe('rule-view-page navigation', () => {
   });
 
   it('does not include Alert enrichment tab when not registered', () => {
-    const tabs = getRuleViewExtensionTabs({ activeTab: 'query', setActiveTab: () => {} });
+    const tabs = getRuleViewExtensionTabs({ activeTab: 'query', setActiveTab: () => {} }, true);
     const hasEnrichment = tabs.some((t) => t.text === 'Alert enrichment');
     expect(hasEnrichment).toBe(false);
   });
 
   it('includes Alert enrichment tab when registered (enterprise + toggle on)', () => {
     addEnrichmentSection();
-    const tabs = getRuleViewExtensionTabs({ activeTab: 'query', setActiveTab: () => {} });
+    const tabs = getRuleViewExtensionTabs({ activeTab: 'query', setActiveTab: () => {} }, true);
     const enrichment = tabs.find((t) => t.text === 'Alert enrichment');
     expect(enrichment).toBeTruthy();
     expect(enrichment!.active).toBe(false);
@@ -25,10 +25,17 @@ describe('rule-view-page navigation', () => {
 
   it('marks Alert enrichment tab active when selected', () => {
     addEnrichmentSection();
-    const tabs = getRuleViewExtensionTabs({ activeTab: 'enrichment', setActiveTab: () => {} });
+    const tabs = getRuleViewExtensionTabs({ activeTab: 'enrichment', setActiveTab: () => {} }, true);
     const enrichment = tabs.find((t) => t.text === 'Alert enrichment');
     expect(enrichment).toBeTruthy();
     expect(enrichment!.active).toBe(true);
+  });
+
+  it('excludes Alert enrichment tab when not a Grafana alert rule', () => {
+    addEnrichmentSection();
+    const tabs = getRuleViewExtensionTabs({ activeTab: 'query', setActiveTab: () => {} }, false);
+    const enrichment = tabs.find((t) => t.text === 'Alert enrichment');
+    expect(enrichment).toBeUndefined();
   });
 
   describe('enrichment section registration', () => {

--- a/public/app/features/alerting/unified/enterprise-components/rule-view-page/navigation.ts
+++ b/public/app/features/alerting/unified/enterprise-components/rule-view-page/navigation.ts
@@ -1,7 +1,7 @@
 import { NavModelItem } from '@grafana/data';
 
-import { getRuleViewExtensionTabs } from './extensions';
+import { useRuleViewExtensionTabs } from './extensions';
 
 export function useRuleViewExtensionsNav(activeTab: string, setActiveTab: (tab: string) => void): NavModelItem[] {
-  return getRuleViewExtensionTabs({ activeTab, setActiveTab });
+  return useRuleViewExtensionTabs({ activeTab, setActiveTab });
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes rendering the enrichment tab in the details page only when the alert rule is an Grafana alerting rule. 

**Why do we need this feature?**

Enrichments only work for Grafana alerting rules.

**Who is this feature for?**

Alerting users.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
