### PR TITLE
ui(alerting): show correct tooltip when label search includes spaces

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
+++ b/public/app/features/alerting/unified/components/rules/Filter/RulesFilter.v1.tsx
@@ -368,7 +368,10 @@ function SearchQueryHelp() {
         />
         <HelpRow title={t('alerting.search-query-help.title-group', 'Group')} expr="group:cpu-usage" />
         <HelpRow title={t('alerting.search-query-help.title-rule', 'Rule')} expr='rule:"cpu 80%"' />
-        <HelpRow title={t('alerting.search-query-help.title-labels', 'Labels')} expr="label:team=A label:cluster=a1" />
+        <HelpRow
+          title={t('alerting.search-query-help.title-labels', 'Labels')}
+          expr='label:team=A label:"cluster=new york"'
+        />
         <HelpRow title={t('alerting.search-query-help.title-state', 'State')} expr="state:firing|normal|pending" />
         <HelpRow title={t('alerting.search-query-help.title-type', 'Type')} expr="type:alerting|recording" />
         <HelpRow title={t('alerting.search-query-help.title-health', 'Health')} expr="health:ok|nodata|error" />

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -729,7 +729,10 @@ function SearchQueryHelp() {
         />
         <HelpRow title={t('alerting.search-query-help.title-group', 'Group')} expr="group:cpu-usage" />
         <HelpRow title={t('alerting.search-query-help.title-rule', 'Rule')} expr='rule:"cpu 80%"' />
-        <HelpRow title={t('alerting.search-query-help.title-labels', 'Labels')} expr="label:team=A label:cluster=a1" />
+        <HelpRow
+          title={t('alerting.search-query-help.title-labels', 'Labels')}
+          expr='label:team=A label:"cluster=new york"'
+        />
         <HelpRow title={t('alerting.search-query-help.title-state', 'State')} expr="state:firing|normal|pending" />
         <HelpRow title={t('alerting.search-query-help.title-type', 'Type')} expr="type:alerting|recording" />
         <HelpRow title={t('alerting.search-query-help.title-health', 'Health')} expr="health:ok|nodata|error" />


### PR DESCRIPTION
Added an example tooltip for searching label values that contain spaces.

To search for a label value with a space, you need to wrap both the label and the value in double quotes:

```
label:"cluster=new york"
```

**Before**
<img width="411" height="317" alt="Screenshot 2025-10-27 at 12 18 54" src="https://github.com/user-attachments/assets/4fbecb4d-4fe7-4d0c-95d4-c2f64cd1eaac" />

**After**
<img width="473" height="366" alt="Screenshot 2025-10-27 at 12 19 14" src="https://github.com/user-attachments/assets/868eae23-2ea1-4edf-8550-bfaeee05175e" />

This makes it clear in the UI how to handle label values with spaces.


