### PR TITLE
Alerting: Rename triage to alerts

### DIFF
--- a/pkg/services/navtree/navtreeimpl/navtree.go
+++ b/pkg/services/navtree/navtreeimpl/navtree.go
@@ -443,7 +443,7 @@ func (s *ServiceImpl) buildAlertNavLinks(c *contextmodel.ReqContext) *navtree.Na
 	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAlertingTriage) {
 		if hasAccess(ac.EvalAny(ac.EvalPermission(ac.ActionAlertingRuleRead), ac.EvalPermission(ac.ActionAlertingRuleExternalRead))) {
 			alertChildNavs = append(alertChildNavs, &navtree.NavLink{
-				Text: "Triage", SubTitle: "Triage alerts", Id: "alert-triage", Url: s.cfg.AppSubURL + "/alerting/triage", Icon: "medkit", IsNew: true,
+				Text: "Alerts", SubTitle: "Visualize active and pending alerts", Id: "alert-alerts", Url: s.cfg.AppSubURL + "/alerting/alerts", Icon: "bell", IsNew: true,
 			})
 		}
 	}

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -335,7 +335,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
 
   if (cfg.featureToggles.alertingTriage) {
     routes.push({
-      path: '/alerting/triage',
+      path: '/alerting/alerts',
       roles: evaluateAccess([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleExternalRead]),
       component: importAlertingComponent(
         () => import(/* webpackChunkName: "AlertingTriage" */ 'app/features/alerting/unified/triage/Triage')

--- a/public/app/features/alerting/unified/triage/Triage.tsx
+++ b/public/app/features/alerting/unified/triage/Triage.tsx
@@ -9,10 +9,13 @@ import { TriageScene, triageScene } from './scene/TriageScene';
 export const TriagePage = () => {
   return (
     <AlertingPageWrapper
-      navId="alerting"
-      subTitle={t('alerting.pages.triage.subtitle', 'Learn about problems in your systems moments after they occur')}
+      navId="alert-alerts"
+      subTitle={t(
+        'alerting.pages.triage.subtitle',
+        'See what is currently alerting and explore historical data to investigate current or past issues.'
+      )}
       pageNav={{
-        text: t('alerting.pages.triage.title', 'Triage'),
+        text: t('alerting.pages.triage.title', 'Alerts'),
       }}
     >
       <UrlSyncContextProvider scene={triageScene} updateUrlOnInit={true} createBrowserHistorySteps={true}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2043,8 +2043,8 @@
     },
     "pages": {
       "triage": {
-        "subtitle": "Learn about problems in your systems moments after they occur",
-        "title": "Triage"
+        "subtitle": "See what is currently alerting and explore historical data to investigate current or past issues.",
+        "title": "Alerts"
       }
     },
     "panel-alert-tab-content": {


### PR DESCRIPTION
**What is this feature?**

Renames the new triage feature to "alerts"