### PR TITLE
FileDropzone: expose `id` to underlying input, fix story a11y violations

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -671,11 +671,6 @@
       "count": 1
     }
   },
-  "packages/grafana-ui/src/components/FileDropzone/FileDropzone.story.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/FormField/FormField.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.story.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.story.tsx
@@ -19,8 +19,8 @@ const meta: Meta<typeof FileDropzone> = {
 const Template: StoryFn<typeof FileDropzone> = (args) => {
   const inputId = useId();
   return (
-    <Field label="Test JSON file" htmlFor={inputId}>
-      <FileDropzone {...args} inputId={inputId} />
+    <Field label="Test JSON file">
+      <FileDropzone {...args} id={inputId} />
     </Field>
   );
 };

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.story.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.story.tsx
@@ -1,4 +1,7 @@
 import { Meta, StoryFn } from '@storybook/react';
+import { useId } from 'react';
+
+import { Field } from '../Forms/Field';
 
 import { FileDropzone } from './FileDropzone';
 import mdx from './FileDropzone.mdx';
@@ -10,12 +13,17 @@ const meta: Meta<typeof FileDropzone> = {
     docs: {
       page: mdx,
     },
-    // TODO fix a11y issue in story and remove this
-    a11y: { test: 'off' },
   },
 };
 
-const Template: StoryFn<typeof FileDropzone> = (args) => <FileDropzone {...args} />;
+const Template: StoryFn<typeof FileDropzone> = (args) => {
+  const inputId = useId();
+  return (
+    <Field label="Test JSON file" htmlFor={inputId}>
+      <FileDropzone {...args} inputId={inputId} />
+    </Field>
+  );
+};
 
 export const Basic = Template.bind({});
 

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -51,7 +51,7 @@ export interface FileDropzoneProps {
    * Optional id attribute for the underlying input element
    * Use to link a label to the input for accessibility
    */
-  inputId?: string;
+  id?: string;
 }
 
 export interface DropzoneFile {
@@ -70,7 +70,7 @@ export function FileDropzone({
   onLoad,
   fileListRenderer,
   onFileRemove,
-  inputId,
+  id,
 }: FileDropzoneProps) {
   const [files, setFiles] = useState<DropzoneFile[]>([]);
   const [fileErrors, setErrorMessages] = useState<FileError[]>([]);
@@ -231,7 +231,7 @@ export function FileDropzone({
   return (
     <div className={styles.container}>
       <div data-testid="dropzone" {...getRootProps({ className: styles.dropzone })}>
-        <input {...getInputProps()} id={inputId} />
+        <input {...getInputProps()} id={id} />
         {children ?? <FileDropzoneDefaultChildren primaryText={getPrimaryText(files, options)} />}
       </div>
       {fileErrors.length > 0 && renderErrorMessages(fileErrors)}

--- a/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
+++ b/packages/grafana-ui/src/components/FileDropzone/FileDropzone.tsx
@@ -47,6 +47,11 @@ export interface FileDropzoneProps {
    */
   fileListRenderer?: (file: DropzoneFile, removeFile: (file: DropzoneFile) => void) => ReactNode;
   onFileRemove?: (file: DropzoneFile) => void;
+  /**
+   * Optional id attribute for the underlying input element
+   * Use to link a label to the input for accessibility
+   */
+  inputId?: string;
 }
 
 export interface DropzoneFile {
@@ -58,7 +63,15 @@ export interface DropzoneFile {
   retryUpload?: () => void;
 }
 
-export function FileDropzone({ options, children, readAs, onLoad, fileListRenderer, onFileRemove }: FileDropzoneProps) {
+export function FileDropzone({
+  options,
+  children,
+  readAs,
+  onLoad,
+  fileListRenderer,
+  onFileRemove,
+  inputId,
+}: FileDropzoneProps) {
   const [files, setFiles] = useState<DropzoneFile[]>([]);
   const [fileErrors, setErrorMessages] = useState<FileError[]>([]);
 
@@ -218,7 +231,7 @@ export function FileDropzone({ options, children, readAs, onLoad, fileListRender
   return (
     <div className={styles.container}>
       <div data-testid="dropzone" {...getRootProps({ className: styles.dropzone })}>
-        <input {...getInputProps()} />
+        <input {...getInputProps()} id={inputId} />
         {children ?? <FileDropzoneDefaultChildren primaryText={getPrimaryText(files, options)} />}
       </div>
       {fileErrors.length > 0 && renderErrorMessages(fileErrors)}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- exposes an `id` prop to hook up field labels to `FileDropzone`

**Why do we need this feature?**

- better a11y

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/109450

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
