### PR TITLE
DashboardControls: Render UNSAFE hidden dashboard controls

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3055,11 +3055,6 @@
       "count": 1
     }
   },
-  "public/app/features/explore/TraceView/components/utils/DraggableManager/demo/index.tsx": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
-    }
-  },
   "public/app/features/explore/TraceView/components/utils/sort.ts": {
     "no-restricted-syntax": {
       "count": 1

--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -2,7 +2,6 @@ import { render } from '@testing-library/react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneVariableSet, ScopesVariable, TextBoxVariable } from '@grafana/scenes';
-import { defaultScopesServices, ScopesContextProvider } from 'app/features/scopes/ScopesContextProvider';
 
 import { DashboardControls, DashboardControlsState } from './DashboardControls';
 import { DashboardScene } from './DashboardScene';
@@ -120,7 +119,6 @@ describe('DashboardControls', () => {
       dashboard.activate();
 
       const controls = dashboard.state.controls as DashboardControls;
-      const services = defaultScopesServices();
 
       // Mock the Component getter - use 'as any' to bypass TypeScript's getter checking
       // Return a component function (not JSX directly) that renders our test element
@@ -129,11 +127,7 @@ describe('DashboardControls', () => {
         return <div>Mocked Component</div>;
       });
 
-      const renderer = render(
-        <ScopesContextProvider services={services}>
-          <controls.Component model={controls} />
-        </ScopesContextProvider>
-      );
+      const renderer = render(<controls.Component model={controls} />);
 
       // Verify UNSAFE_renderAsHidden is set (required for renderHiddenVariables to include it)
       expect(scopeVariable.UNSAFE_renderAsHidden).toBe(true);

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -202,7 +202,7 @@ function DataLayerControls({ dashboard }: { dashboard: DashboardScene }) {
 }
 
 function renderHiddenVariables(dashboard: DashboardScene) {
-  const { variables } = sceneGraph.getVariables(dashboard)!.useState();
+  const { variables } = sceneGraph.getVariables(dashboard).useState();
   const renderAsHiddenVariables = variables.filter((v) => v.UNSAFE_renderAsHidden);
   if (renderAsHiddenVariables && renderAsHiddenVariables.length > 0) {
     return (

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -14,9 +14,7 @@ import {
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
   CancelActivationHandler,
-  ScopesVariable,
 } from '@grafana/scenes';
-import { SCOPES_VARIABLE_NAME } from '@grafana/scenes/src/variables/constants';
 import { Box, Stack, useStyles2 } from '@grafana/ui';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -154,22 +154,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   if (!model.hasControls()) {
     // To still have spacing when no controls are rendered
 
-    // Render variables that should be hidden but still require rendering. This is needed for Scopes, in order to get the react context.
-    const renderAsHiddenVariables = sceneGraph
-      .getVariables(dashboard)
-      .useState()
-      .variables.filter((v) => v.UNSAFE_renderAsHidden);
-    if (renderAsHiddenVariables && renderAsHiddenVariables.length > 0) {
-      return (
-        <Box padding={1}>
-          {renderAsHiddenVariables.map((v) => (
-            <v.Component model={v} key={v.state.key} />
-          ))}
-        </Box>
-      );
-    }
-
-    return <Box padding={1} />;
+    return <Box padding={1}>{renderHiddenVariables(dashboard)}</Box>;
   }
 
   return (
@@ -214,6 +199,21 @@ function DataLayerControls({ dashboard }: { dashboard: DashboardScene }) {
       ))}
     </>
   );
+}
+
+function renderHiddenVariables(dashboard: DashboardScene) {
+  const { variables } = sceneGraph.getVariables(dashboard)!.useState();
+  const renderAsHiddenVariables = variables.filter((v) => v.UNSAFE_renderAsHidden);
+  if (renderAsHiddenVariables && renderAsHiddenVariables.length > 0) {
+    return (
+      <>
+        {renderAsHiddenVariables.map((v) => (
+          <v.Component model={v} key={v.state.key} />
+        ))}
+      </>
+    );
+  }
+  return null;
 }
 
 function getStyles(theme: GrafanaTheme2) {

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -14,7 +14,9 @@ import {
   SceneObjectUrlSyncConfig,
   SceneObjectUrlValues,
   CancelActivationHandler,
+  ScopesVariable,
 } from '@grafana/scenes';
+import { SCOPES_VARIABLE_NAME } from '@grafana/scenes/src/variables/constants';
 import { Box, Stack, useStyles2 } from '@grafana/ui';
 
 import { PanelEditControls } from '../panel-edit/PanelEditControls';
@@ -153,6 +155,22 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
 
   if (!model.hasControls()) {
     // To still have spacing when no controls are rendered
+
+    // Render variables that should be hidden but still require rendering. This is needed for Scopes, in order to get the react context.
+    const renderAsHiddenVariables = sceneGraph
+      .getVariables(dashboard)
+      .useState()
+      .variables.filter((v) => v.UNSAFE_renderAsHidden);
+    if (renderAsHiddenVariables && renderAsHiddenVariables.length > 0) {
+      return (
+        <Box padding={1}>
+          {renderAsHiddenVariables.map((v) => (
+            <v.Component model={v} key={v.state.key} />
+          ))}
+        </Box>
+      );
+    }
+
     return <Box padding={1} />;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Renders components, in this specific case Scopes, which needs to interact with the React context. 

**Why do we need this feature?**

For scopes to show up and not block loading.

**Who is this feature for?**

Instances with scopes.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/hyperion-planning/issues/305

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
