### PR TITLE
MegaMenu: Spacing alignment tweaks

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -175,7 +175,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   menuItem: css({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(1.5),
     height: theme.spacing(4),
     paddingLeft: theme.spacing(0.5),
     position: 'relative',
@@ -215,13 +215,13 @@ const getStyles = (theme: GrafanaTheme2) => ({
   labelWrapper: css({
     display: 'flex',
     alignItems: 'center',
-    gap: theme.spacing(2),
+    gap: theme.spacing(0.75),
     minWidth: 0,
     paddingLeft: theme.spacing(1),
   }),
   labelWrapperWithIcon: css({
     paddingLeft: theme.spacing(0.5),
-    gap: theme.spacing(0.5),
+    gap: theme.spacing(0.75),
   }),
   hasActiveChild: css({
     color: theme.colors.text.primary,

--- a/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
+++ b/public/app/core/components/AppChrome/OrganizationSwitcher/OrganizationSwitcher.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { Space, Text } from '@grafana/ui';
+import { Text } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getUserOrganizations, setUserOrganization } from 'app/features/org/state/actions';
 import { useDispatch, useSelector } from 'app/types/store';
@@ -33,12 +33,7 @@ export function OrganizationSwitcher() {
   }, [dispatch]);
 
   if (orgs?.length <= 1) {
-    return (
-      <>
-        <Space h={1} />
-        <Text truncate>{Branding.AppTitle}</Text>
-      </>
-    );
+    return <Text truncate>{Branding.AppTitle}</Text>;
   }
 
   return <OrganizationSelect orgs={orgs} onSelectChange={onSelectChange} />;


### PR DESCRIPTION
**What is this feature?**
`MegaMenu`: 
- Align MegaMenu header `Grafana` text label with menu item first level items. 
- Increase second level items left padding
- Make sure `New` badge left spacing are consistent


**After:**  
<img width="301" height="647" alt="image" src="https://github.com/user-attachments/assets/5fe666a1-7383-4b07-b5b0-011b5973e8e3" />

**Before:**  
<img width="299" height="788" alt="image" src="https://github.com/user-attachments/assets/a4e3d63e-f8f0-407f-b7b3-317fbf5891da" />


**Why do we need this feature?**

UI consistency 

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes N/A, from slack thread [here](https://raintank-corp.slack.com/archives/C08TB7QN19D/p1761585900924609)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
