### PR TITLE
Alerting: Prohibit receivers with empty name

### DIFF
--- a/pkg/services/ngalert/models/receivers.go
+++ b/pkg/services/ngalert/models/receivers.go
@@ -130,6 +130,9 @@ func (r *Receiver) WithExistingSecureFields(existing *Receiver, integrationSecur
 // Validate validates all integration settings, ensuring that the integrations are correctly configured.
 func (r *Receiver) Validate(decryptFn DecryptFn) error {
 	var errs []error
+	if r.Name == "" {
+		errs = append(errs, fmt.Errorf("name should not be an empty string"))
+	}
 	for _, integration := range r.Integrations {
 		if err := integration.Validate(decryptFn); err != nil {
 			errs = append(errs, err)

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -476,6 +476,12 @@ func TestReceiverService_Create(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:        "receiver with empty name fails",
+			user:        writer,
+			receiver:    models.CopyReceiverWith(baseReceiver, models.ReceiverMuts.WithName("")),
+			expectedErr: legacy_storage.ErrReceiverInvalid,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			sut := createReceiverServiceSut(t, &secretsService)
@@ -900,6 +906,16 @@ func TestReceiverService_UpdateReceiverName(t *testing.T) {
 		assert.Equal(t, newReceiverName, ruleStore.Calls[0].Args[3])
 		assert.NotNil(t, ruleStore.Calls[0].Args[4])
 		assert.Falsef(t, ruleStore.Calls[0].Args[5].(bool), "dryrun expected to be false")
+	})
+
+	t.Run("returns ErrReceiverInvalid if empty name", func(t *testing.T) {
+		ruleStore := &fakeAlertRuleNotificationStore{}
+		sut := createReceiverServiceSut(t, &secretsService)
+		sut.ruleNotificationsStore = ruleStore
+		baseReceiver.Name = ""
+
+		_, err := sut.UpdateReceiver(context.Background(), &baseReceiver, nil, writer.GetOrgID(), writer)
+		require.ErrorIs(t, err, legacy_storage.ErrReceiverInvalid)
 	})
 }
 

--- a/pkg/services/ngalert/provisioning/contactpoints_test.go
+++ b/pkg/services/ngalert/provisioning/contactpoints_test.go
@@ -625,7 +625,7 @@ func TestStitchReceivers(t *testing.T) {
 		initial            *definitions.PostableUserConfig
 		new                *definitions.PostableGrafanaReceiver
 		expCfg             definitions.PostableApiAlertingConfig
-		expOldReceiver     string
+		expOldReceiver     *string
 		expCreatedReceiver bool
 		expFullRemoval     bool
 	}
@@ -636,7 +636,7 @@ func TestStitchReceivers(t *testing.T) {
 			new: &definitions.PostableGrafanaReceiver{
 				UID: "does not exist",
 			},
-			expOldReceiver: "",
+			expOldReceiver: nil,
 			expCfg:         createTestConfigWithReceivers().AlertmanagerConfig,
 		},
 		{
@@ -646,7 +646,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "receiver-2",
 				Type: "teams",
 			},
-			expOldReceiver: "receiver-2",
+			expOldReceiver: util.Pointer("receiver-2"),
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
 					Route: &definitions.Route{
@@ -707,7 +707,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "new-receiver",
 				Type: "slack",
 			},
-			expOldReceiver:     "receiver-1",
+			expOldReceiver:     util.Pointer("receiver-1"),
 			expCreatedReceiver: true,
 			expFullRemoval:     true,
 			expCfg: definitions.PostableApiAlertingConfig{
@@ -770,7 +770,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "receiver-1",
 				Type: "slack",
 			},
-			expOldReceiver:     "receiver-2",
+			expOldReceiver:     util.Pointer("receiver-2"),
 			expCreatedReceiver: false,
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
@@ -891,7 +891,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "receiver-2",
 				Type: "slack",
 			},
-			expOldReceiver:     "receiver-1",
+			expOldReceiver:     util.Pointer("receiver-1"),
 			expCreatedReceiver: false,
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
@@ -1035,7 +1035,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "receiver-4",
 				Type: "slack",
 			},
-			expOldReceiver:     "receiver-1",
+			expOldReceiver:     util.Pointer("receiver-1"),
 			expCreatedReceiver: false,
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
@@ -1120,7 +1120,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "brand-new-group",
 				Type: "opsgenie",
 			},
-			expOldReceiver:     "receiver-2",
+			expOldReceiver:     util.Pointer("receiver-2"),
 			expCreatedReceiver: true,
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
@@ -1192,7 +1192,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "brand-new-group",
 				Type: "opsgenie",
 			},
-			expOldReceiver:     "receiver-2", // Not the inconsistent receiver-3?
+			expOldReceiver:     util.Pointer("receiver-2"), // Not the inconsistent receiver-3?
 			expCreatedReceiver: true,
 			expCfg: definitions.PostableApiAlertingConfig{
 				Config: definitions.Config{
@@ -1315,7 +1315,7 @@ func TestStitchReceivers(t *testing.T) {
 				Name: "receiver-1",
 				Type: "slack",
 			},
-			expOldReceiver:     "receiver-2",
+			expOldReceiver:     util.Pointer("receiver-2"),
 			expCreatedReceiver: false,
 			expFullRemoval:     true,
 			expCfg: definitions.PostableApiAlertingConfig{
@@ -1370,8 +1370,7 @@ func TestStitchReceivers(t *testing.T) {
 			}
 
 			renamedReceiver, fullRemoval, createdReceiver := stitchReceiver(cfg, c.new)
-			require.NotNil(t, renamedReceiver)
-			assert.Equalf(t, c.expOldReceiver, *renamedReceiver, "expected old receiver to be %s, got %s", c.expOldReceiver, renamedReceiver)
+			assert.EqualValuesf(t, c.expOldReceiver, renamedReceiver, "expected old receiver to be %v, got %v", c.expOldReceiver, renamedReceiver)
 			assert.Equalf(t, c.expFullRemoval, fullRemoval, "expected full removal to be %t, got %t", c.expFullRemoval, fullRemoval)
 			assert.Equalf(t, c.expCreatedReceiver, createdReceiver, "expected created receiver to be %t, got %t", c.expCreatedReceiver, createdReceiver)
 			require.Equal(t, c.expCfg, cfg.AlertmanagerConfig)


### PR DESCRIPTION
**What is this feature?**
This PR fixes receivers (contact points) API to reject requests with empty name. 

**Why do we need this feature?**
Empty name receivers are not allowed in Grafana because UID of receivers is based on name + empty receiver name in routing means inherited route. 


Existing receivers with empty name can be deleted via provisioning API using integration's UID 
```
DELETE {{baseUrl}}/api/v1/provisioning/contact-points/{{UID}}
```
