### PR TITLE
Datasources: Add service function to get by group, name, and namespace

### DIFF
--- a/pkg/services/datasources/datasources.go
+++ b/pkg/services/datasources/datasources.go
@@ -15,8 +15,8 @@ type DataSourceService interface {
 	// GetDataSource gets a datasource.
 	GetDataSource(ctx context.Context, query *GetDataSourceQuery) (*DataSource, error)
 
-	// GetDataSourceWithType gets a datasource by UID and orgID of a given datasource type.
-	GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*DataSource, error)
+	// GetDataSourceInNamespace gets a datasource by namespace, name (datasource uid), and group (datasource type).
+	GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*DataSource, error)
 
 	// GetDataSources gets datasources.
 	GetDataSources(ctx context.Context, query *GetDataSourcesQuery) ([]*DataSource, error)

--- a/pkg/services/datasources/datasources.go
+++ b/pkg/services/datasources/datasources.go
@@ -15,6 +15,9 @@ type DataSourceService interface {
 	// GetDataSource gets a datasource.
 	GetDataSource(ctx context.Context, query *GetDataSourceQuery) (*DataSource, error)
 
+	// GetDataSourceWithType gets a datasource by UID and orgID of a given datasource type.
+	GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*DataSource, error)
+
 	// GetDataSources gets datasources.
 	GetDataSources(ctx context.Context, query *GetDataSourcesQuery) ([]*DataSource, error)
 

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/grafana/authlib/types"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 
 	"github.com/grafana/grafana/pkg/infra/httpclient"
@@ -30,9 +31,13 @@ func (s *FakeDataSourceService) GetDataSource(ctx context.Context, query *dataso
 	return nil, datasources.ErrDataSourceNotFound
 }
 
-func (s *FakeDataSourceService) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
+func (s *FakeDataSourceService) GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*datasources.DataSource, error) {
+	ns, err := types.ParseNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
 	for _, dataSource := range s.DataSources {
-		if uid == dataSource.UID && orgID == dataSource.OrgID && dsType == dataSource.Type {
+		if name == dataSource.UID && ns.OrgID == dataSource.OrgID && group == dataSource.Type {
 			return dataSource, nil
 		}
 	}

--- a/pkg/services/datasources/fakes/fake_datasource_service.go
+++ b/pkg/services/datasources/fakes/fake_datasource_service.go
@@ -30,6 +30,15 @@ func (s *FakeDataSourceService) GetDataSource(ctx context.Context, query *dataso
 	return nil, datasources.ErrDataSourceNotFound
 }
 
+func (s *FakeDataSourceService) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
+	for _, dataSource := range s.DataSources {
+		if uid == dataSource.UID && orgID == dataSource.OrgID && dsType == dataSource.Type {
+			return dataSource, nil
+		}
+	}
+	return nil, datasources.ErrDataSourceNotFound
+}
+
 func (s *FakeDataSourceService) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {
 	var dataSources []*datasources.DataSource
 	for _, datasource := range s.DataSources {

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
@@ -180,11 +179,7 @@ func (s *Service) GetDataSource(ctx context.Context, query *datasources.GetDataS
 }
 
 func (s *Service) GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*datasources.DataSource, error) {
-	ns, err := types.ParseNamespace(namespace)
-	if err != nil {
-		return nil, err
-	}
-	return s.SQLStore.GetDataSourceInGroup(ctx, ns.OrgID, name, group)
+	return s.SQLStore.GetDataSourceInNamespace(ctx, namespace, name, group)
 }
 
 func (s *Service) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -117,6 +117,8 @@ func (s *Service) Usage(ctx context.Context, scopeParams *quota.ScopeParameters)
 type DataSourceRetriever interface {
 	// GetDataSource gets a datasource.
 	GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error)
+	// GetDataSourceWithType gets a datasource by UID and orgID of a given datasource type.
+	GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error)
 }
 
 // NewNameScopeResolver provides an ScopeAttributeResolver able to
@@ -174,6 +176,10 @@ func NewIDScopeResolver(db DataSourceRetriever) (string, accesscontrol.ScopeAttr
 
 func (s *Service) GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error) {
 	return s.SQLStore.GetDataSource(ctx, query)
+}
+
+func (s *Service) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
+	return s.SQLStore.GetDataSourceWithType(ctx, uid, orgID, dsType)
 }
 
 func (s *Service) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {

--- a/pkg/services/datasources/service/datasource.go
+++ b/pkg/services/datasources/service/datasource.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	sdkproxy "github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
@@ -117,8 +118,8 @@ func (s *Service) Usage(ctx context.Context, scopeParams *quota.ScopeParameters)
 type DataSourceRetriever interface {
 	// GetDataSource gets a datasource.
 	GetDataSource(ctx context.Context, query *datasources.GetDataSourceQuery) (*datasources.DataSource, error)
-	// GetDataSourceWithType gets a datasource by UID and orgID of a given datasource type.
-	GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error)
+	// GetDataSourceInNamespace gets a datasource by namespace, name (datasource uid), and group (datasource type).
+	GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*datasources.DataSource, error)
 }
 
 // NewNameScopeResolver provides an ScopeAttributeResolver able to
@@ -178,8 +179,12 @@ func (s *Service) GetDataSource(ctx context.Context, query *datasources.GetDataS
 	return s.SQLStore.GetDataSource(ctx, query)
 }
 
-func (s *Service) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
-	return s.SQLStore.GetDataSourceWithType(ctx, uid, orgID, dsType)
+func (s *Service) GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*datasources.DataSource, error) {
+	ns, err := types.ParseNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
+	return s.SQLStore.GetDataSourceInGroup(ctx, ns.OrgID, name, group)
 }
 
 func (s *Service) GetDataSources(ctx context.Context, query *datasources.GetDataSourcesQuery) ([]*datasources.DataSource, error) {

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/ini.v1"
 
+	"github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/grafana/grafana/pkg/components/simplejson"
@@ -63,9 +64,13 @@ func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *data
 	return nil, datasources.ErrDataSourceNotFound
 }
 
-func (d *dataSourceMockRetriever) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
+func (d *dataSourceMockRetriever) GetDataSourceInNamespace(ctx context.Context, namespace, name, group string) (*datasources.DataSource, error) {
+	ns, err := types.ParseNamespace(namespace)
+	if err != nil {
+		return nil, err
+	}
 	for _, dataSource := range d.res {
-		if uid == dataSource.UID && orgID == dataSource.OrgID && dsType == dataSource.Type {
+		if name == dataSource.UID && ns.OrgID == dataSource.OrgID && group == dataSource.Type {
 			return dataSource, nil
 		}
 	}

--- a/pkg/services/datasources/service/datasource_test.go
+++ b/pkg/services/datasources/service/datasource_test.go
@@ -63,6 +63,15 @@ func (d *dataSourceMockRetriever) GetDataSource(ctx context.Context, query *data
 	return nil, datasources.ErrDataSourceNotFound
 }
 
+func (d *dataSourceMockRetriever) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
+	for _, dataSource := range d.res {
+		if uid == dataSource.UID && orgID == dataSource.OrgID && dsType == dataSource.Type {
+			return dataSource, nil
+		}
+	}
+	return nil, datasources.ErrDataSourceNotFound
+}
+
 func TestIntegrationService_AddDataSource(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 

--- a/pkg/services/datasources/service/store.go
+++ b/pkg/services/datasources/service/store.go
@@ -92,8 +92,6 @@ func (ss *SqlStore) getDataSource(_ context.Context, query *datasources.GetDataS
 }
 
 func (ss *SqlStore) GetDataSourceWithType(ctx context.Context, uid string, orgID int64, dsType string) (*datasources.DataSource, error) {
-	metrics.MDBDataSourceQueryByID.Inc()
-
 	var (
 		dataSource *datasources.DataSource
 		err        error
@@ -116,7 +114,7 @@ func (ss *SqlStore) getDataSourceWithType(_ context.Context, uid string, orgID i
 		ss.logger.Error("Failed getting data source", "err", err, "uid", uid, "orgId", orgID, "dsType", dsType)
 		return nil, err
 	} else if !has {
-		ss.logger.Error("Failed getting data source", "err", err, "uid", uid, "orgId", orgID, "dsType", dsType)
+		ss.logger.Debug("Data source not found", "uid", uid, "orgId", orgID, "dsType", dsType)
 		return nil, datasources.ErrDataSourceNotFound
 	}
 

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -407,6 +407,44 @@ func TestIntegrationDataAccess(t *testing.T) {
 		})
 	})
 
+	t.Run("GetDataSourceWithType", func(t *testing.T) {
+		t.Run("Only returns datasource of specified type", func(t *testing.T) {
+			db := db.InitTestDB(t)
+			ss := SqlStore{db: db}
+
+			ds, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+				OrgID:    10,
+				Name:     "Elasticsearch",
+				Type:     datasources.DS_ES,
+				Access:   datasources.DS_ACCESS_DIRECT,
+				URL:      "http://test",
+				Database: "site",
+				ReadOnly: true,
+			})
+			require.NoError(t, err)
+
+			ds2, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
+				OrgID:    10,
+				Name:     "Graphite",
+				Type:     datasources.DS_GRAPHITE,
+				Access:   datasources.DS_ACCESS_DIRECT,
+				URL:      "http://test",
+				Database: "site",
+				ReadOnly: true,
+			})
+			require.NoError(t, err)
+
+			dataSource, err := ss.GetDataSourceWithType(context.Background(), ds.UID, ds.OrgID, datasources.DS_ES)
+			require.NoError(t, err)
+			require.Equal(t, ds.UID, dataSource.UID)
+
+			dataSource2, err := ss.GetDataSourceWithType(context.Background(), ds.UID, ds.OrgID, datasources.DS_ES)
+			require.NoError(t, err)
+			require.Equal(t, dataSource2.UID, "")
+		})
+
+	})
+
 	t.Run("GetDataSourcesByType", func(t *testing.T) {
 		t.Run("Only returns datasources of specified type", func(t *testing.T) {
 			db := db.InitTestDB(t)

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -410,7 +410,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 	t.Run("GetDataSourceWithType", func(t *testing.T) {
 		t.Run("Only returns datasource of specified type", func(t *testing.T) {
 			db := db.InitTestDB(t)
-			ss := SqlStore{db: db}
+			ss := SqlStore{db: db, logger: log.NewNopLogger()}
 
 			ds, err := ss.AddDataSource(context.Background(), &datasources.AddDataSourceCommand{
 				OrgID:    10,
@@ -438,9 +438,9 @@ func TestIntegrationDataAccess(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, ds.UID, dataSource.UID)
 
-			dataSource2, err := ss.GetDataSourceWithType(context.Background(), ds.UID, ds.OrgID, datasources.DS_ES)
-			require.NoError(t, err)
-			require.Equal(t, dataSource2.UID, "")
+			_, err = ss.GetDataSourceWithType(context.Background(), ds2.UID, ds2.OrgID, datasources.DS_ES)
+			require.Error(t, err)
+			require.IsType(t, datasources.ErrDataSourceNotFound, err)
 		})
 
 	})

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -442,7 +442,6 @@ func TestIntegrationDataAccess(t *testing.T) {
 			require.Error(t, err)
 			require.IsType(t, datasources.ErrDataSourceNotFound, err)
 		})
-
 	})
 
 	t.Run("GetDataSourcesByType", func(t *testing.T) {

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -434,11 +434,11 @@ func TestIntegrationDataAccess(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			dataSource, err := ss.GetDataSourceInGroup(context.Background(), ds.OrgID, ds.UID, datasources.DS_ES)
+			dataSource, err := ss.GetDataSourceInNamespace(context.Background(), "org-10", ds.UID, datasources.DS_ES)
 			require.NoError(t, err)
 			require.Equal(t, ds.UID, dataSource.UID)
 
-			_, err = ss.GetDataSourceInGroup(context.Background(), ds2.OrgID, ds2.UID, datasources.DS_ES)
+			_, err = ss.GetDataSourceInNamespace(context.Background(), "org-10", ds2.UID, datasources.DS_ES)
 			require.Error(t, err)
 			require.IsType(t, datasources.ErrDataSourceNotFound, err)
 		})

--- a/pkg/services/datasources/service/store_test.go
+++ b/pkg/services/datasources/service/store_test.go
@@ -407,7 +407,7 @@ func TestIntegrationDataAccess(t *testing.T) {
 		})
 	})
 
-	t.Run("GetDataSourceWithType", func(t *testing.T) {
+	t.Run("GetDataSourceInGroup", func(t *testing.T) {
 		t.Run("Only returns datasource of specified type", func(t *testing.T) {
 			db := db.InitTestDB(t)
 			ss := SqlStore{db: db, logger: log.NewNopLogger()}
@@ -434,11 +434,11 @@ func TestIntegrationDataAccess(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			dataSource, err := ss.GetDataSourceWithType(context.Background(), ds.UID, ds.OrgID, datasources.DS_ES)
+			dataSource, err := ss.GetDataSourceInGroup(context.Background(), ds.OrgID, ds.UID, datasources.DS_ES)
 			require.NoError(t, err)
 			require.Equal(t, ds.UID, dataSource.UID)
 
-			_, err = ss.GetDataSourceWithType(context.Background(), ds2.UID, ds2.OrgID, datasources.DS_ES)
+			_, err = ss.GetDataSourceInGroup(context.Background(), ds2.OrgID, ds2.UID, datasources.DS_ES)
 			require.Error(t, err)
 			require.IsType(t, datasources.ErrDataSourceNotFound, err)
 		})


### PR DESCRIPTION
This PR adds a new function to get datasources by their uid along with passing in the datasource group & the namespace, to make it more future proof