### PR TITLE
Alerting: Use common labels tooltip in Triage

### DIFF
--- a/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, useStyles2 } from '@grafana/ui';
+import { Button, Stack, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { findCommonLabels, isPrivateLabel } from '../../utils/labels';
 
@@ -16,9 +16,17 @@ export interface AlertLabelsProps {
   labelSets?: Array<Record<string, string>>;
   size?: LabelSize;
   onClick?: ([value, key]: [string | undefined, string | undefined]) => void;
+  commonLabelsMode?: 'expand' | 'tooltip';
 }
 
-export const AlertLabels = ({ labels, displayCommonLabels, labelSets, size, onClick }: AlertLabelsProps) => {
+export const AlertLabels = ({
+  labels,
+  displayCommonLabels,
+  labelSets,
+  size,
+  onClick,
+  commonLabelsMode = 'expand',
+}: AlertLabelsProps) => {
   const styles = useStyles2(getStyles, size);
   const [showCommonLabels, setShowCommonLabels] = useState(false);
 
@@ -34,6 +42,16 @@ export const AlertLabels = ({ labels, displayCommonLabels, labelSets, size, onCl
   const commonLabelsCount = Object.keys(computedCommonLabels).length;
   const hasCommonLabels = commonLabelsCount > 0;
   const tooltip = t('alert-labels.button.show.tooltip', 'Show common labels');
+
+  const commonLabelsTooltip = (
+    <Stack role="list" direction="column" gap={1}>
+      {Object.entries(computedCommonLabels).map(([label, value]) => {
+        return (
+          <AlertLabel key={label + value} size={size} labelKey={label} value={value} colorBy="key" role="listitem" />
+        );
+      })}
+    </Stack>
+  );
 
   return (
     <div className={styles.wrapper} role="list" aria-label={t('alerting.alert-labels.aria-label-labels', 'Labels')}>
@@ -53,18 +71,28 @@ export const AlertLabels = ({ labels, displayCommonLabels, labelSets, size, onCl
 
       {!showCommonLabels && hasCommonLabels && (
         <div role="listitem">
-          <Button
-            variant="secondary"
-            fill="text"
-            onClick={() => setShowCommonLabels(true)}
-            tooltip={tooltip}
-            tooltipPlacement="top"
-            size="sm"
-          >
-            <Trans i18nKey="alerting.alert-labels.common-labels-count" count={commonLabelsCount}>
-              +{'{{count}}'} common labels
-            </Trans>
-          </Button>
+          {commonLabelsMode === 'expand' ? (
+            <Button
+              variant="secondary"
+              fill="text"
+              onClick={() => setShowCommonLabels(true)}
+              tooltip={tooltip}
+              tooltipPlacement="top"
+              size="sm"
+            >
+              <Trans i18nKey="alerting.alert-labels.common-labels-count" count={commonLabelsCount}>
+                +{'{{count}}'} common labels
+              </Trans>
+            </Button>
+          ) : (
+            <Tooltip content={commonLabelsTooltip} placement="top">
+              <Button variant="secondary" fill="text" size="sm">
+                <Trans i18nKey="alerting.alert-labels.common-labels-count" count={commonLabelsCount}>
+                  +{'{{count}}'} common labels
+                </Trans>
+              </Button>
+            </Tooltip>
+          )}
         </div>
       )}
       {showCommonLabels && hasCommonLabels && (

--- a/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
+++ b/packages/grafana-alerting/src/grafana/rules/components/labels/AlertLabels.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
 import { chain } from 'lodash';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { Button, Stack, Toggletip, useStyles2 } from '@grafana/ui';
 
 import { findCommonLabels, isPrivateLabel } from '../../utils/labels';
 
@@ -30,8 +30,10 @@ export const AlertLabels = ({
   const styles = useStyles2(getStyles, size);
   const [showCommonLabels, setShowCommonLabels] = useState(false);
 
-  const computedCommonLabels =
-    displayCommonLabels && Array.isArray(labelSets) && labelSets.length > 1 ? findCommonLabels(labelSets) : {};
+  const computedCommonLabels = useMemo(
+    () => (displayCommonLabels && Array.isArray(labelSets) && labelSets.length > 1 ? findCommonLabels(labelSets) : {}),
+    [displayCommonLabels, labelSets]
+  );
 
   const labelsToShow = chain(labels)
     .toPairs()
@@ -43,14 +45,15 @@ export const AlertLabels = ({
   const hasCommonLabels = commonLabelsCount > 0;
   const tooltip = t('alert-labels.button.show.tooltip', 'Show common labels');
 
-  const commonLabelsTooltip = (
-    <Stack role="list" direction="column" gap={1}>
-      {Object.entries(computedCommonLabels).map(([label, value]) => {
-        return (
+  const commonLabelsTooltip = useMemo(
+    () => (
+      <Stack data-testid="common-labels-tooltip-content" role="list" direction="row" wrap="wrap" gap={1} width={48}>
+        {Object.entries(computedCommonLabels).map(([label, value]) => (
           <AlertLabel key={label + value} size={size} labelKey={label} value={value} colorBy="key" role="listitem" />
-        );
-      })}
-    </Stack>
+        ))}
+      </Stack>
+    ),
+    [computedCommonLabels, size]
   );
 
   return (
@@ -85,13 +88,13 @@ export const AlertLabels = ({
               </Trans>
             </Button>
           ) : (
-            <Tooltip content={commonLabelsTooltip} placement="top">
-              <Button variant="secondary" fill="text" size="sm">
+            <Toggletip content={commonLabelsTooltip} closeButton={false} fitContent={true}>
+              <Button data-testid="common-labels-tooltip-trigger" variant="secondary" fill="text" size="sm">
                 <Trans i18nKey="alerting.alert-labels.common-labels-count" count={commonLabelsCount}>
                   +{'{{count}}'} common labels
                 </Trans>
               </Button>
-            </Tooltip>
+            </Toggletip>
           )}
         </div>
       )}

--- a/public/app/features/alerting/unified/triage/rows/InstanceRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/InstanceRow.tsx
@@ -112,6 +112,7 @@ export function InstanceRow({
               displayCommonLabels={true}
               labelSets={[instance.labels, commonLabels]}
               size="xs"
+              commonLabelsMode="tooltip"
             />
           )
         }


### PR DESCRIPTION
Add tooltip mode for common labels in Alert Labels component and use it in Triage

  This PR introduces a new display mode for common labels in the AlertLabels component to improve space efficiency in
  dense UI areas.

  Changes:

  - Added a new commonLabelsMode prop to AlertLabels component with two modes:
    - `expand` (default) - existing behavior that expands common labels inline when clicked
    - `tooltip` - displays common labels in a tooltip on hover
  - Implemented tooltip rendering with proper label styling and spacing
  - Applied tooltip mode to the Triage workbench InstanceRow for a more compact display

  Benefits:

  - Reduces visual clutter in the Triage workbench
  - Maintains accessibility with proper ARIA roles
  - Backward compatible with existing usage (defaults to expand mode)