### PR TITLE
Slider: Expose prop to control visibility of input

### DIFF
--- a/packages/grafana-ui/src/components/Slider/Slider.test.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.test.tsx
@@ -33,6 +33,18 @@ describe('Slider', () => {
     expect(sliderInput).toHaveValue('10');
   });
 
+  it('hides the slider input if showInput is false', () => {
+    render(<Slider {...sliderProps} showInput={false} />);
+
+    const slider = screen.getByRole('slider');
+    const sliderInput = screen.queryByRole('textbox');
+
+    expect(slider).toHaveAttribute('aria-valuemin', '10');
+    expect(slider).toHaveAttribute('aria-valuemax', '20');
+    expect(slider).toHaveAttribute('aria-valuenow', '10');
+    expect(sliderInput).not.toBeInTheDocument();
+  });
+
   it('renders correct contents with a value', () => {
     render(<Slider {...sliderProps} value={15} />);
 

--- a/packages/grafana-ui/src/components/Slider/Slider.tsx
+++ b/packages/grafana-ui/src/components/Slider/Slider.tsx
@@ -27,6 +27,7 @@ export const Slider = ({
   marks,
   included,
   inputId,
+  showInput = true,
 }: SliderProps) => {
   const isHorizontal = orientation === 'horizontal';
   const styles = useStyles2(getStyles, isHorizontal, Boolean(marks));
@@ -112,17 +113,19 @@ export const Slider = ({
           included={included}
         />
 
-        <Input
-          type="text"
-          width={7.5}
-          className={cx(styles.sliderInputField, ...sliderInputFieldClassNames)}
-          value={sliderValue}
-          onChange={onSliderInputChange}
-          onBlur={onSliderInputBlur}
-          min={min}
-          max={max}
-          id={inputId}
-        />
+        {showInput && (
+          <Input
+            type="text"
+            width={7.5}
+            className={cx(styles.sliderInputField, ...sliderInputFieldClassNames)}
+            value={sliderValue}
+            onChange={onSliderInputChange}
+            onBlur={onSliderInputBlur}
+            min={min}
+            max={max}
+            id={inputId}
+          />
+        )}
       </div>
     </div>
   );

--- a/packages/grafana-ui/src/components/Slider/types.ts
+++ b/packages/grafana-ui/src/components/Slider/types.ts
@@ -14,6 +14,8 @@ interface CommonSliderProps {
   marks?: SliderMarks;
   /** If the value is true, it means a continuous value interval, otherwise, it is a independent value. */
   included?: boolean;
+  /** Controls visibility of the input field. Defaults to true. */
+  showInput?: boolean;
 }
 export interface SliderProps extends CommonSliderProps {
   value?: number;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Exposes a prop to control visibility of the Slider input

**Why do we need this feature?**

- better flexibility
- `business-variable` plugin uses a custom version that has this:
<img width="550" height="145" alt="image" src="https://github.com/user-attachments/assets/52cd0903-992f-4cee-bbb1-a3a4ea8f6a11" />


**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
