### PR TITLE
Alerting: Normalize health when filtering rules

### DIFF
--- a/packages/grafana-alerting/src/grafana/rules/components/state/types.ts
+++ b/packages/grafana-alerting/src/grafana/rules/components/state/types.ts
@@ -1,3 +1,3 @@
-export type Health = 'nodata' | 'error';
+export type Health = 'ok' | 'nodata' | 'error';
 export type State = 'normal' | 'firing' | 'pending' | 'unknown' | 'recovering';
 export type Type = 'alerting' | 'recording';

--- a/public/app/features/alerting/unified/rule-list/components/util.ts
+++ b/public/app/features/alerting/unified/rule-list/components/util.ts
@@ -93,7 +93,7 @@ export function normalizeHealth(health?: RuleHealth): NormalizedHealth {
 }
 
 function isValidHealth(health: string): health is NonNullable<NormalizedHealth> {
-  const valid: Array<NonNullable<NormalizedHealth>> = ['nodata', 'error'] as const;
+  const valid: Array<NonNullable<NormalizedHealth>> = ['ok', 'nodata', 'error'] as const;
   return valid.some((v) => v === health);
 }
 

--- a/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
@@ -143,6 +143,17 @@ describe('ruleFilter', () => {
     expect(ruleFilter(errorRule, getFilter({ ruleHealth: RuleHealth.Error }))).toBe(true);
   });
 
+  it('should normalize legacy health values when filtering', () => {
+    // Legacy Prometheus health value 'err' should be normalized to 'error'
+    const legacyErrorRule = mockPromAlertingRule({
+      name: 'Legacy Error Rule',
+      health: 'err' as RuleHealth,
+    });
+
+    // When filtering for 'error', it should match rules with health 'err' (legacy) or 'error'
+    expect(ruleFilter(legacyErrorRule, getFilter({ ruleHealth: RuleHealth.Error }))).toBe(true);
+  });
+
   it('should filter by dashboard UID', () => {
     const ruleDashboardA = mockPromAlertingRule({
       name: 'Dashboard A Rule',

--- a/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
@@ -138,16 +138,22 @@ describe('ruleFilter', () => {
       health: RuleHealth.Error,
     });
 
+    const prometheusErrorRule = mockPromAlertingRule({
+      name: 'Error Rule',
+      health: 'err',
+    });
+
     expect(ruleFilter(healthyRule, getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(true);
     expect(ruleFilter(healthyRule, getFilter({ ruleHealth: RuleHealth.Error }))).toBe(false);
     expect(ruleFilter(errorRule, getFilter({ ruleHealth: RuleHealth.Error }))).toBe(true);
+    expect(ruleFilter(prometheusErrorRule, getFilter({ ruleHealth: RuleHealth.Error }))).toBe(true);
   });
 
-  it('should normalize legacy health values when filtering', () => {
+  it('should normalize health values when filtering', () => {
     // Legacy Prometheus health value 'err' should be normalized to 'error'
     const legacyErrorRule = mockPromAlertingRule({
       name: 'Legacy Error Rule',
-      health: 'err' as RuleHealth,
+      health: 'err',
     });
 
     // When filtering for 'error', it should match rules with health 'err' (legacy) or 'error'

--- a/public/app/features/alerting/unified/rule-list/hooks/filters.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/filters.ts
@@ -11,6 +11,7 @@ import { getDatasourceAPIUid } from '../../utils/datasource';
 import { fuzzyMatches } from '../../utils/fuzzySearch';
 import { parseMatcher } from '../../utils/matchers';
 import { isPluginProvidedRule, prometheusRuleType } from '../../utils/rules';
+import { normalizeHealth } from '../components/util';
 
 /**
  * @returns True if the group matches the filter, false otherwise. Keeps rules intact
@@ -79,7 +80,7 @@ export function ruleFilter(rule: PromRuleDTO, filterState: RulesFilter) {
     }
   }
 
-  if (filterState.ruleHealth && health !== filterState.ruleHealth) {
+  if (filterState.ruleHealth && normalizeHealth(health) !== filterState.ruleHealth) {
     return false;
   }
 


### PR DESCRIPTION
**What is this feature?**

This PR fixes rule health filtering to properly handle Prometheus health values. When filtering alerting rules by health status, the filter now normalizes the rule's health value before comparison, ensuring that `'err'` values from Prometheus are correctly matched when filtering for `'error'` status.

**Why do we need this feature?**

Prometheus uses `'err'` as the health status value (https://github.com/prometheus/prometheus/blob/531868904600d0a1e7ac6e020f0d3752a32f0f9e/rules/rule.go#L30-L34), while Grafana's unified alerting use `'error'`. 

Without normalization, rules with the Prometheus `'err'` health status would not match when users filter for error health, leading to incomplete or confusing search results.

**Who is this feature for?**

This feature is for users who:
- Work with alerting rules from different Prometheus versions
- Filter rules by health status in the unified alerting UI
- Have migrated from older Prometheus installations

**Special notes for your reviewer:**

Includes a regression test