### PR TITLE
kvstore: fix events lookback + startkey

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -746,7 +746,7 @@ func (k *kvStorageBackend) listModifiedSinceEventStore(ctx context.Context, key 
 	return func(yield func(*ModifiedResource, error) bool) {
 		// store all events ordered by RV for the given tenant here
 		eventKeys := make([]EventKey, 0)
-		for evtKeyStr, err := range k.eventStore.ListKeysSince(ctx, sinceRv-defaultLookbackPeriod.Nanoseconds()) {
+		for evtKeyStr, err := range k.eventStore.ListKeysSince(ctx, subtractDurationFromSnowflake(sinceRv, defaultLookbackPeriod)) {
 			if err != nil {
 				yield(&ModifiedResource{}, err)
 				return

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/bwmarrin/snowflake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -764,24 +763,10 @@ func randomStringGenerator() func() string {
 
 // creates 2 hour old snowflake for testing
 func generateOldSnowflake(t *testing.T) int64 {
-	// Generate a current snowflake first
-	node, err := snowflake.NewNode(1)
-	require.NoError(t, err)
-	currentSnowflake := node.Generate().Int64()
-
-	// Extract its timestamp component by shifting right
-	currentTimestamp := currentSnowflake >> 22
-
-	// Subtract 2 hours (in milliseconds) from the timestamp
-	twoHoursMs := int64(2 * time.Hour / time.Millisecond)
-	oldTimestamp := currentTimestamp - twoHoursMs
-
-	// Reconstruct snowflake: [timestamp:41][node:10][sequence:12]
-	// Keep the original node and sequence bits
-	nodeAndSequence := currentSnowflake & 0x3FFFFF // Bottom 22 bits (10 node + 12 sequence)
-	snowflakeID := (oldTimestamp << 22) | nodeAndSequence
-
-	return snowflakeID
+	// Generate a snowflake for 2 hours ago using the snowflakeFromTime utility
+	// which properly handles the epoch
+	twoHoursAgo := time.Now().Add(-2 * time.Hour)
+	return snowflakeFromTime(twoHoursAgo)
 }
 
 // seedBackend seeds the kvstore with data and return the expected result for ListModifiedSince calls


### PR DESCRIPTION
Fixes 2 issues with events +  snowflake.


**Problem 1**

The event store's ListKeysSince was using EventKey{ResourceVersion: sinceRV}.String() as the StartKey, which produces keys like `1500~~~~~~`. Due to lexicographic sorting, the tilde character (`~`) sorts after alphanumeric characters, causing events at the exact RV boundary to be incorrectly filtered out (e.g., `1500~~~~~~` sorts after `1500~default~...`).

**Problem 2**
substracting RVs with Lookbackperiod was inaccurate. Introducing subtractDurationFromSnowflake to fix.
