### PR TITLE
Logs Panel: Improve search terms highlighting for highlighted JSON logs

### DIFF
--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -36,17 +36,17 @@ const jsonGrammar: Grammar = {
 
 export const generateLogGrammar = (log: LogListModel) => {
   const labels = Object.keys(log.labels).concat(log.fields.map((field) => field.keys[0]));
-  const logGrammar: Grammar = {
+  const labelGrammar: Grammar = {
     'log-token-label': new RegExp(`\\b(${labels.join('|')})(?:[=:]{1})\\b`, 'g'),
   };
   if (log.isJSON) {
     return {
-      ...logGrammar,
+      ...labelGrammar,
       ...jsonGrammar,
     };
   }
   return {
-    ...logGrammar,
+    ...labelGrammar,
     ...tokensGrammar,
     ...logsGrammar,
   };

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -21,12 +21,10 @@ const jsonGrammar: Grammar = {
   'log-token-json-key': {
     pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?=\s*:)/,
     lookbehind: true,
-    greedy: true,
   },
   'log-token-string': {
     pattern: /(^|[^\\])"(?:\\.|[^\\"\r\n])*"(?!\s*:)/,
     lookbehind: true,
-    greedy: true,
     inside: {
       ...tokensGrammar,
     },


### PR DESCRIPTION
The JSON grammar definition for highlighting set the greedy flag to true, overriding the highlight of search words and the current client-side search within the panel.

### How to test

Looking at JSON logs with highlighting enabled, both search words (using line filters) and client-side search matches should be highlighted.

With highlighting disabled, search words should not be highlighted, but client-side search matches should be highlighted.