### PR TITLE
Add `thumbs-down` to `availableIconIndex` 

### DIFF
--- a/packages/grafana-data/src/types/icon.ts
+++ b/packages/grafana-data/src/types/icon.ts
@@ -255,6 +255,7 @@ export const availableIconsIndex = {
   'tag-alt': true,
   'telegram-alt': true,
   'text-fields': true,
+  'thumbs-down': true,
   'thumbs-up': true,
   times: true,
   'times-circle': true,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds `thumbs-down` to `availableIconIndex`

**Why do we need this feature?**

Attempting to use `thumbs-down` now results in a TS error

<img width="1121" height="315" alt="image" src="https://github.com/user-attachments/assets/07e8c35c-a6d4-4a83-8fe4-167d7a304878" />

Despite this error, the icon renders as expected

<img width="183" height="40" alt="image" src="https://github.com/user-attachments/assets/1eea2bba-a6e5-4cbf-9157-0483fecb18f0" />



**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
