### PR TITLE
Event Tracking: Add tracking for expression query removal

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3412,23 +3412,6 @@
       "count": 2
     }
   },
-  "public/app/features/query/components/QueryEditorRow.tsx": {
-    "@grafana/no-aria-label-selectors": {
-      "count": 1
-    },
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 1
-    },
-    "react-hooks/rules-of-hooks": {
-      "count": 1
-    },
-    "react-prefer-function-component/react-prefer-function-component": {
-      "count": 1
-    }
-  },
   "public/app/features/query/components/QueryEditorRowHeader.tsx": {
     "@grafana/no-aria-label-selectors": {
       "count": 1

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -34,7 +34,7 @@ import {
 } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 
 import { useQueryLibraryContext } from '../../explore/QueryLibrary/QueryLibraryContext';
-import { ExpressionDatasourceUID } from '../../expressions/types';
+import { ExpressionDatasourceUID, ExpressionQuery } from '../../expressions/types';
 
 import { QueryActionComponent, RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
@@ -85,6 +85,7 @@ interface State<TQuery extends DataQuery> {
   showingHelp: boolean;
 }
 
+// eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
 export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Props<TQuery>, State<TQuery>> {
   dataSourceSrv = getDataSourceSrv();
   id = '';
@@ -135,6 +136,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     }
 
     this.setState({
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       datasource: datasource as unknown as DataSourceApi<TQuery>,
       queriedDataSourceIdentifier: interpolatedUID,
     });
@@ -230,6 +232,19 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   onRemoveQuery = () => {
     const { onRemoveQuery, query, onQueryRemoved } = this.props;
+
+    // Track expression query removal
+    const isExpressionQuery = query.datasource?.uid === ExpressionDatasourceUID;
+    if (isExpressionQuery && 'type' in query) {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      const expressionQuery = query as ExpressionQuery;
+      reportInteraction('dashboards_expression_interaction', {
+        action: 'remove_expression',
+        expression_type: expressionQuery.type,
+        context: 'panel_query_section',
+      });
+    }
+
     onRemoveQuery(query);
 
     if (onQueryRemoved) {
@@ -365,6 +380,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
           query,
           queries,
           timeRange: data.timeRange,
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           onAddQuery: onAddQuery as (query: DataQuery) => void,
           dataSource,
           key: index,
@@ -480,6 +496,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       data?.error && data.error.refId === query.refId ? data.error : data?.errors?.find((e) => e.refId === query.refId);
     const rowClasses = classNames('query-editor-row', {
       'query-editor-row--disabled': isHidden,
+      // eslint-disable-next-line no-restricted-syntax
       'gf-form-disabled': isHidden,
     });
 
@@ -521,6 +538,7 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     );
 
     return (
+      // eslint-disable-next-line @grafana/no-aria-label-selectors
       <div data-testid="query-editor-row" aria-label={selectors.components.QueryEditorRows.rows}>
         {queryLibraryRef && (
           <MaybeQueryLibraryEditingHeader
@@ -617,6 +635,7 @@ function MaybeQueryLibraryEditingHeader(props: {
 
 function AdaptiveTelemetryQueryActions({ query }: { query: DataQuery }) {
   try {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { isLoading, components } = usePluginComponents<PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context>({
       extensionPointId: PluginExtensionPoints.QueryEditorRowAdaptiveTelemetryV1,
     });

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -34,7 +34,7 @@ import {
 } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 
 import { useQueryLibraryContext } from '../../explore/QueryLibrary/QueryLibraryContext';
-import { ExpressionDatasourceUID, ExpressionQuery } from '../../expressions/types';
+import { ExpressionDatasourceUID } from '../../expressions/types';
 
 import { QueryActionComponent, RowActionComponents } from './QueryActionComponent';
 import { QueryEditorRowHeader } from './QueryEditorRowHeader';
@@ -235,12 +235,10 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
     // Track expression query removal
     const isExpressionQuery = query.datasource?.uid === ExpressionDatasourceUID;
-    if (isExpressionQuery && 'type' in query) {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      const expressionQuery = query as ExpressionQuery;
+    if (isExpressionQuery && 'type' in query && query.type) {
       reportInteraction('dashboards_expression_interaction', {
         action: 'remove_expression',
-        expression_type: expressionQuery.type,
+        expression_type: query.type,
         context: 'panel_query_section',
       });
     }


### PR DESCRIPTION
This PR adds analytics event tracking when users remove/delete expression queries.