### PR TITLE
Alerting: Create alert rule drawer dashboard panel

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -193,6 +193,22 @@ export const trackNewGrafanaAlertRuleFormError = () => {
   reportInteraction('grafana_alerting_grafana_rule_creation_new_error');
 };
 
+export const trackCreateRuleFromPanelDrawerOpened = () => {
+  reportInteraction('grafana_alerting_create_rule_from_panel_drawer_opened');
+};
+
+export const trackCreateRuleFromPanelDrawerRuleCreated = () => {
+  reportInteraction('grafana_alerting_create_rule_from_panel_drawer_rule_created');
+};
+
+export const trackCreateRuleFromPanelDrawerContinueInAlertingClicked = () => {
+  reportInteraction('grafana_alerting_create_rule_from_panel_drawer_continue_in_alerting_clicked');
+};
+
+export const trackCreateRuleFromPanelDrawerClosedWithoutSaving = () => {
+  reportInteraction('grafana_alerting_create_rule_from_panel_drawer_closed_without_saving');
+};
+
 export const trackInsightsFeedback = async (props: { useful: boolean; panel: string }) => {
   const defaults = {
     grafana_version: config.buildInfo.version,

--- a/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
+++ b/public/app/features/alerting/unified/PanelAlertTabContent.test.tsx
@@ -214,6 +214,7 @@ describe('PanelAlertTabContent', () => {
     mockAlertRuleApi(server).prometheusRuleNamespaces(GRAFANA_RULES_SOURCE_NAME, promResponse);
     mockAlertRuleApi(server).rulerRules(GRAFANA_RULES_SOURCE_NAME, rulerResponse);
     config.unifiedAlertingEnabled = true;
+    config.featureToggles.createAlertRuleFromPanel = false;
   });
 
   it('Will take into account panel maxDataPoints', async () => {

--- a/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
+++ b/public/app/features/alerting/unified/__snapshots__/PanelAlertTabContent.test.tsx.snap
@@ -70,7 +70,7 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
         "refId": "B",
         "type": "reduce",
       },
-      "queryType": "",
+      "queryType": "expression",
       "refId": "B",
     },
     {
@@ -88,7 +88,9 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
               "type": "and",
             },
             "query": {
-              "params": [],
+              "params": [
+                "C",
+              ],
             },
             "reducer": {
               "params": [],
@@ -105,7 +107,7 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
         "refId": "C",
         "type": "threshold",
       },
-      "queryType": "",
+      "queryType": "expression",
       "refId": "C",
     },
   ],

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
@@ -1,0 +1,287 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { GrafanaGroupUpdatedResponse } from '../api/alertRuleModel';
+import { ContactPoint, RuleFormType, RuleFormValues } from '../types/rule-form';
+
+import { AlertRuleDrawerForm, AlertRuleDrawerFormProps } from './AlertRuleDrawerForm';
+
+setupMswServer();
+
+// Mock the hooks
+const mockExecute = jest.fn();
+jest.mock('../hooks/ruleGroup/useUpsertRuleFromRuleGroup', () => ({
+  useAddRuleToRuleGroup: () => [{ execute: mockExecute }],
+}));
+
+// Mock notification hooks
+const mockError = jest.fn();
+const mockSuccess = jest.fn();
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: mockError,
+    success: mockSuccess,
+  }),
+}));
+
+const defaultProps: AlertRuleDrawerFormProps = {
+  isOpen: true,
+  onClose: jest.fn(),
+};
+
+const renderDrawer = (props: Partial<AlertRuleDrawerFormProps> = {}) => {
+  const user = userEvent.setup();
+  const view = render(<AlertRuleDrawerForm {...defaultProps} {...props} />);
+  return { ...view, user };
+};
+
+describe('AlertRuleDrawerForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    grantUserPermissions([
+      AccessControlAction.AlertingRuleCreate,
+      AccessControlAction.AlertingRuleRead,
+      AccessControlAction.AlertingRuleUpdate,
+      AccessControlAction.AlertingRuleDelete,
+    ]);
+  });
+
+  describe('Rendering', () => {
+    it('should not render when isOpen is false', () => {
+      renderDrawer({ isOpen: false });
+      expect(screen.queryByRole('button', { name: /Create/i })).not.toBeInTheDocument();
+    });
+
+    it('should render "Continue in Alerting" button when callback is provided', () => {
+      renderDrawer({ onContinueInAlerting: jest.fn() });
+      expect(screen.getByRole('button', { name: /Continue in Alerting/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Cancel button', () => {
+    it('should call onClose when Cancel is clicked', async () => {
+      const onClose = jest.fn();
+      const { user } = renderDrawer({ onClose });
+
+      await user.click(screen.getByRole('button', { name: /Cancel/i }));
+
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('should reset form when Cancel is clicked with prefill', async () => {
+      const onClose = jest.fn();
+      const prefill: Partial<RuleFormValues> = {
+        name: 'Prefilled Rule Name',
+      };
+      const { user, rerender } = renderDrawer({ onClose, prefill });
+
+      // Verify prefilled value is present
+      const nameInput = screen.getByLabelText(/Name/i);
+      expect(nameInput).toHaveValue('Prefilled Rule Name');
+
+      // Modify the field
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Changed Name');
+      expect(nameInput).toHaveValue('Changed Name');
+
+      // Click cancel - this triggers reset to prefill
+      await user.click(screen.getByRole('button', { name: /Cancel/i }));
+      expect(onClose).toHaveBeenCalled();
+
+      // Reopen to verify reset happened
+      rerender(<AlertRuleDrawerForm {...defaultProps} onClose={onClose} prefill={prefill} isOpen={true} />);
+      expect(screen.getByLabelText(/Name/i)).toHaveValue('Prefilled Rule Name');
+    });
+  });
+
+  describe('Continue in Alerting button', () => {
+    it('should call onContinueInAlerting with current form values', async () => {
+      const onContinueInAlerting = jest.fn();
+      const onClose = jest.fn();
+      const { user } = renderDrawer({ onContinueInAlerting, onClose });
+
+      // Fill in a field
+      const nameInput = screen.getByLabelText(/Name/i);
+      await user.type(nameInput, 'Test Rule');
+
+      // Click Continue in Alerting
+      await user.click(screen.getByRole('button', { name: /Continue in Alerting/i }));
+
+      await waitFor(() => {
+        expect(onContinueInAlerting).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'Test Rule',
+          })
+        );
+      });
+    });
+
+    it('should normalize contact points when calling onContinueInAlerting', async () => {
+      const onContinueInAlerting = jest.fn();
+      const onClose = jest.fn();
+
+      // Provide prefill with partial contact point data
+      // We intentionally create an incomplete ContactPoint to test that normalizeContactPoints fills in the missing optional fields with defaults
+      const prefill: Partial<RuleFormValues> = {
+        name: 'Test',
+        contactPoints: {
+          grafana: {
+            selectedContactPoint: 'test-contact',
+          } as ContactPoint,
+        },
+      };
+
+      const { user } = renderDrawer({ onContinueInAlerting, onClose, prefill });
+
+      // Click Continue in Alerting
+      await user.click(screen.getByRole('button', { name: /Continue in Alerting/i }));
+
+      await waitFor(() => {
+        expect(onContinueInAlerting).toHaveBeenCalledWith(
+          expect.objectContaining({
+            contactPoints: expect.objectContaining({
+              grafana: expect.objectContaining({
+                selectedContactPoint: 'test-contact',
+                // Verify normalization added default values
+                overrideGrouping: false,
+                groupBy: [],
+                overrideTimings: false,
+                groupWaitValue: '',
+                groupIntervalValue: '',
+                repeatIntervalValue: '',
+                muteTimeIntervals: [],
+                activeTimeIntervals: [],
+              }),
+            }),
+          })
+        );
+      });
+    });
+
+    it('should close drawer after calling onContinueInAlerting', async () => {
+      const onContinueInAlerting = jest.fn();
+      const onClose = jest.fn();
+      const { user } = renderDrawer({ onContinueInAlerting, onClose });
+
+      // Click Continue in Alerting
+      await user.click(screen.getByRole('button', { name: /Continue in Alerting/i }));
+
+      await waitFor(() => {
+        expect(onContinueInAlerting).toHaveBeenCalled();
+      });
+      expect(onClose).toHaveBeenCalled();
+    });
+  });
+
+  describe('Prefill behavior', () => {
+    it('should initialize form with prefill values', () => {
+      const prefill: Partial<RuleFormValues> = {
+        name: 'Prefilled Rule',
+        type: RuleFormType.grafana,
+      };
+      renderDrawer({ prefill });
+
+      expect(screen.getByLabelText(/Name/i)).toHaveValue('Prefilled Rule');
+    });
+
+    it('should reset form when prefill changes', async () => {
+      const prefill1: Partial<RuleFormValues> = {
+        name: 'First Rule',
+      };
+      const { rerender } = render(<AlertRuleDrawerForm {...defaultProps} prefill={prefill1} />);
+
+      expect(screen.getByLabelText(/Name/i)).toHaveValue('First Rule');
+
+      // Update prefill
+      const prefill2: Partial<RuleFormValues> = {
+        name: 'Second Rule',
+      };
+      rerender(<AlertRuleDrawerForm {...defaultProps} prefill={prefill2} />);
+
+      // Wait for the useEffect to trigger the reset
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Name/i)).toHaveValue('Second Rule');
+      });
+    });
+
+    it('should reset to defaults when prefill becomes undefined', async () => {
+      const prefill: Partial<RuleFormValues> = {
+        name: 'Prefilled Rule',
+      };
+      const { rerender } = render(<AlertRuleDrawerForm {...defaultProps} prefill={prefill} />);
+
+      expect(screen.getByLabelText(/Name/i)).toHaveValue('Prefilled Rule');
+
+      // Clear prefill
+      rerender(<AlertRuleDrawerForm {...defaultProps} prefill={undefined} />);
+
+      // Wait for the useEffect to trigger the reset
+      await waitFor(() => {
+        expect(screen.getByLabelText(/Name/i)).toHaveValue('');
+      });
+    });
+  });
+
+  describe('Create button and submission', () => {
+    it('should close drawer on successful rule creation', async () => {
+      const onClose = jest.fn();
+      const mockResponse: GrafanaGroupUpdatedResponse = {
+        message: 'Rule created successfully',
+        created: ['rule-uid'],
+      };
+      mockExecute.mockResolvedValue(mockResponse);
+
+      // Prefill with required fields (folder and group are required for form submission)
+      const prefill: Partial<RuleFormValues> = {
+        name: 'Test Alert Rule',
+        folder: { title: 'Test Folder', uid: 'test-folder-uid' },
+        group: 'test-group',
+        evaluateEvery: '1m',
+        type: RuleFormType.grafana,
+        queries: [
+          {
+            refId: 'A',
+            datasourceUid: 'test-ds',
+            queryType: '',
+            model: { refId: 'A' },
+          },
+        ],
+        condition: 'A',
+      };
+
+      const { user } = renderDrawer({ onClose, prefill });
+
+      // Click Create
+      await user.click(screen.getByRole('button', { name: /Create/i }));
+
+      // Wait for the execute function to be called
+      await waitFor(() => {
+        expect(mockExecute).toHaveBeenCalled();
+      });
+
+      // Drawer should close on success
+      await waitFor(() => {
+        expect(onClose).toHaveBeenCalled();
+      });
+    });
+
+    it('should show validation error when form is invalid', async () => {
+      const { user } = renderDrawer();
+
+      // Try to submit without filling required fields (name, folder, group are required)
+      await user.click(screen.getByRole('button', { name: /Create/i }));
+
+      await waitFor(() => {
+        expect(mockError).toHaveBeenCalledWith(
+          'Validation error',
+          'Please correct the errors in the form and try again.'
+        );
+      });
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
@@ -1,0 +1,194 @@
+import { css } from '@emotion/css';
+import { useEffect, useMemo, useRef } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Button, Drawer, Stack, useStyles2 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import { getMessageFromError } from 'app/core/utils/errors';
+import { RuleDefinitionSection } from 'app/features/alerting/unified/components/RuleDefinitionSection';
+
+import {
+  logError,
+  trackCreateRuleFromPanelDrawerClosedWithoutSaving,
+  trackCreateRuleFromPanelDrawerContinueInAlertingClicked,
+  trackCreateRuleFromPanelDrawerRuleCreated,
+} from '../Analytics';
+import { isCloudGroupUpdatedResponse, isGrafanaGroupUpdatedResponse } from '../api/alertRuleModel';
+import { useAddRuleToRuleGroup } from '../hooks/ruleGroup/useUpsertRuleFromRuleGroup';
+import { getDefaultFormValues } from '../rule-editor/formDefaults';
+import { RuleFormType, RuleFormValues } from '../types/rule-form';
+import { formValuesToRulerGrafanaRuleDTO, normalizeContactPoints } from '../utils/rule-form';
+import { getRuleGroupLocationFromFormValues } from '../utils/rules';
+
+import { RuleConditionSection } from './RuleConditionSection';
+import { RuleNotificationSection } from './RuleNotificationSection';
+
+export interface AlertRuleDrawerFormProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  onContinueInAlerting?: (values: RuleFormValues) => void;
+  prefill?: Partial<RuleFormValues>;
+}
+
+export function AlertRuleDrawerForm({
+  isOpen,
+  onClose,
+  title,
+  onContinueInAlerting,
+  prefill,
+}: AlertRuleDrawerFormProps) {
+  const baseDefaults = useMemo(() => getDefaultFormValues(RuleFormType.grafana), []);
+  const methods = useForm<RuleFormValues>({
+    defaultValues: prefill ? { ...baseDefaults, ...prefill } : baseDefaults,
+  });
+  const styles = useStyles2(getStyles);
+  const [addRuleToRuleGroup] = useAddRuleToRuleGroup();
+  const notifyApp = useAppNotification();
+  const ruleCreatedRef = useRef(false);
+
+  // Keep form in sync if prefill changes between openings
+  useEffect(() => {
+    if (isOpen) {
+      ruleCreatedRef.current = false;
+    }
+    methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
+  }, [prefill, methods, baseDefaults, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleClose = () => {
+    if (!ruleCreatedRef.current) {
+      trackCreateRuleFromPanelDrawerClosedWithoutSaving();
+    }
+    onClose();
+  };
+
+  const submit = async (values: RuleFormValues) => {
+    try {
+      // The drawer doesn't expose a group field to keep the UX simple.
+      // We derive the group name from the rule name as a sensible default.
+      // The 'default' fallback should rarely occur since 'name' is a required field.
+      const groupName =
+        values.group && values.group.trim().length > 0 ? values.group : values.name?.trim() || 'default';
+      const effectiveValues: RuleFormValues = { ...values, group: groupName };
+
+      const dto = formValuesToRulerGrafanaRuleDTO(effectiveValues);
+      const groupIdentifier = getRuleGroupLocationFromFormValues(effectiveValues);
+      const result = await addRuleToRuleGroup.execute(groupIdentifier, dto, effectiveValues.evaluateEvery);
+
+      if (isGrafanaGroupUpdatedResponse(result)) {
+        ruleCreatedRef.current = true;
+        trackCreateRuleFromPanelDrawerRuleCreated();
+        notifyApp.success(
+          t('alerting.alert-rule-drawer.success-title', 'Alert rule created'),
+          t('alerting.alert-rule-drawer.success-message', 'Your alert rule has been created successfully.')
+        );
+        onClose();
+        return;
+      }
+
+      // This drawer only supports Grafana-managed rules, so cloud responses indicate an error
+      if (isCloudGroupUpdatedResponse(result)) {
+        notifyApp.error(
+          t('alerting.alert-rule-drawer.error-title', 'Failed to create alert rule'),
+          result.error || t('alerting.alert-rule-drawer.error-unknown', 'An unexpected error occurred.')
+        );
+      } else {
+        // Unexpected response type - log for debugging
+        logError(new Error('Unexpected response type from addRuleToRuleGroup'), { result });
+        notifyApp.error(
+          t('alerting.alert-rule-drawer.error-title', 'Failed to create alert rule'),
+          t('alerting.alert-rule-drawer.error-unexpected', 'Received an unexpected response. Please try again.')
+        );
+      }
+    } catch (err) {
+      const errorMessage = getMessageFromError(err);
+      notifyApp.error(t('alerting.alert-rule-drawer.error-title', 'Failed to create alert rule'), errorMessage);
+    }
+  };
+
+  const onInvalid = () => {
+    notifyApp.error(
+      t('alerting.alert-rule-drawer.validation-error-title', 'Validation error'),
+      t('alerting.alert-rule-drawer.validation-error-message', 'Please correct the errors in the form and try again.')
+    );
+  };
+
+  return (
+    <Drawer
+      title={title ?? t('alerting.new-rule-from-panel-button.new-alert-rule', 'New alert rule')}
+      onClose={handleClose}
+    >
+      <div className={styles.outer}>
+        <FormProvider {...methods}>
+          <RuleDefinitionSection />
+          <div className={styles.divider} aria-hidden="true" />
+          <RuleConditionSection />
+          <div className={styles.divider} aria-hidden="true" />
+          <RuleNotificationSection />
+          <div className={styles.footer}>
+            <Stack direction="row" gap={1} alignItems="center" justifyContent="flex-end">
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={() => {
+                  methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
+                  handleClose();
+                }}
+              >
+                {t('alerting.common.cancel', 'Cancel')}
+              </Button>
+              {onContinueInAlerting && (
+                <Button
+                  variant="secondary"
+                  type="button"
+                  onClick={() => {
+                    trackCreateRuleFromPanelDrawerContinueInAlertingClicked();
+                    const currentValues = methods.getValues();
+                    onContinueInAlerting({
+                      ...currentValues,
+                      contactPoints: normalizeContactPoints(currentValues.contactPoints),
+                    });
+                    onClose();
+                  }}
+                >
+                  {t('alerting.simplified.continue-in-alerting', 'Continue in Alerting')}
+                </Button>
+              )}
+              <Button
+                variant="primary"
+                type="button"
+                onClick={methods.handleSubmit((values) => submit(values), onInvalid)}
+                disabled={methods.formState.isSubmitting}
+                icon={methods.formState.isSubmitting ? 'spinner' : undefined}
+              >
+                {t('alerting.simplified.create', 'Create')}
+              </Button>
+            </Stack>
+          </div>
+        </FormProvider>
+      </div>
+    </Drawer>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    outer: css({
+      paddingLeft: theme.spacing(1),
+    }),
+    divider: css({
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+      margin: `${theme.spacing(3)} 0`,
+      width: '100%',
+    }),
+    footer: css({
+      marginTop: theme.spacing(3),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
@@ -49,13 +49,13 @@ export function AlertRuleDrawerForm({
   const notifyApp = useAppNotification();
   const ruleCreatedRef = useRef(false);
 
-  // Keep form in sync if prefill changes between openings
+  // Reset form and ref when drawer opens
   useEffect(() => {
     if (isOpen) {
       ruleCreatedRef.current = false;
+      methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
     }
-    methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
-  }, [prefill, methods, baseDefaults, isOpen]);
+  }, [isOpen, prefill, methods, baseDefaults]);
 
   if (!isOpen) {
     return null;

--- a/public/app/features/alerting/unified/components/RuleConditionSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleConditionSection.tsx
@@ -1,0 +1,203 @@
+import { css } from '@emotion/css';
+import { useCallback, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { GrafanaTheme2, ReducerID, SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import {
+  Combobox,
+  ComboboxOption,
+  Icon,
+  InlineField,
+  InlineFieldRow,
+  Input,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
+import { ThresholdSelect } from 'app/features/expressions/components/ThresholdSelect';
+import { ToLabel } from 'app/features/expressions/components/ToLabel';
+import { ExpressionDatasourceUID, reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
+import { isRangeEvaluator } from 'app/features/expressions/utils/expressionTypes';
+
+import { createSimpleConditionExpressions } from '../rule-editor/formProcessing';
+import { RuleFormValues, SimpleCondition } from '../types/rule-form';
+
+import { EvaluationGroupFieldRow } from './rule-editor/EvaluationGroupFieldRow';
+
+const DEFAULT_SIMPLE_CONDITION: SimpleCondition = {
+  whenField: ReducerID.last,
+  evaluator: { params: [0], type: EvalFunction.IsAbove },
+};
+
+export function RuleConditionSection() {
+  const base = useStyles2(getStyles);
+  const { watch, setValue, getValues } = useFormContext<RuleFormValues>();
+  const evaluateFor = watch('evaluateFor') || '0s';
+
+  const [simpleCondition, setSimpleCondition] = useState<SimpleCondition>(DEFAULT_SIMPLE_CONDITION);
+
+  /**
+   * Updates the form's queries and condition based on the current simple condition.
+   * Called directly from onChange handlers to avoid the complexity of syncing
+   * local state to form state via useEffect.
+   */
+  const updateFormQueries = useCallback(
+    (newCondition: SimpleCondition) => {
+      const currentQueries = getValues('queries');
+      const dataQueries = currentQueries.filter((q) => q.datasourceUid !== ExpressionDatasourceUID);
+
+      if (dataQueries.length === 0) {
+        return;
+      }
+
+      const { queries: newQueries, condition } = createSimpleConditionExpressions(newCondition, dataQueries);
+      setValue('queries', newQueries, { shouldDirty: false, shouldValidate: false });
+      setValue('condition', condition, { shouldDirty: false, shouldValidate: false });
+    },
+    [getValues, setValue]
+  );
+
+  const reducerOptions: Array<ComboboxOption<string>> = reducerTypes
+    .filter((o) => typeof o.value === 'string')
+    .map((o) => ({ value: o.value ?? '', label: o.label ?? String(o.value) }));
+
+  const onReducerTypeChange = useCallback(
+    (v: ComboboxOption<string> | null) => {
+      const value = v?.value ?? ReducerID.last;
+      const newCondition: SimpleCondition = { ...simpleCondition, whenField: value };
+      setSimpleCondition(newCondition);
+      updateFormQueries(newCondition);
+    },
+    [simpleCondition, updateFormQueries]
+  );
+
+  const isRange = isRangeEvaluator(simpleCondition.evaluator.type);
+  const thresholdFunction = thresholdFunctions.find((fn) => fn.value === simpleCondition.evaluator?.type);
+
+  const onEvalFunctionChange = useCallback(
+    (v: SelectableValue<EvalFunction>) => {
+      const newCondition: SimpleCondition = {
+        ...simpleCondition,
+        evaluator: { ...simpleCondition.evaluator, type: v.value ?? EvalFunction.IsAbove },
+      };
+      setSimpleCondition(newCondition);
+      updateFormQueries(newCondition);
+    },
+    [simpleCondition, updateFormQueries]
+  );
+
+  const onEvaluateValueChange = useCallback(
+    (e: React.FormEvent<HTMLInputElement>, index = 0) => {
+      const value = parseFloat(e.currentTarget.value) || 0;
+      const newParams =
+        index === 0 ? [value, simpleCondition.evaluator.params[1]] : [simpleCondition.evaluator.params[0], value];
+      const newCondition: SimpleCondition = {
+        ...simpleCondition,
+        evaluator: { ...simpleCondition.evaluator, params: newParams },
+      };
+      setSimpleCondition(newCondition);
+      updateFormQueries(newCondition);
+    },
+    [simpleCondition, updateFormQueries]
+  );
+
+  return (
+    <section className={base.section} aria-labelledby="condition-section-heading">
+      <div className={base.sectionHeaderRow}>
+        <Text element="h3" variant="h4" id="condition-section-heading">
+          {`2. `}
+          <Trans i18nKey="alerting.simplified.condition.title">Condition</Trans>
+        </Text>
+      </div>
+
+      <div>
+        <Stack direction="column" gap={2}>
+          <InlineFieldRow>
+            {simpleCondition.whenField && (
+              <InlineField label={t('alerting.simple-condition-editor.label-when', 'WHEN')}>
+                <Combobox
+                  options={reducerOptions}
+                  value={simpleCondition.whenField}
+                  onChange={onReducerTypeChange}
+                  width={20}
+                  aria-label={t('alerting.simple-condition-editor.aria-label-reducer', 'Select reducer function')}
+                />
+              </InlineField>
+            )}
+            <InlineField
+              label={
+                simpleCondition.whenField
+                  ? t('alerting.simple-condition-editor.label-of-query', 'OF QUERY')
+                  : t('alerting.simple-condition-editor.label-when-query', 'WHEN QUERY')
+              }
+            >
+              <Stack direction="row" gap={1} alignItems="center">
+                <ThresholdSelect onChange={onEvalFunctionChange} value={thresholdFunction} />
+                {isRange ? (
+                  <>
+                    <Input
+                      type="number"
+                      width={10}
+                      key={simpleCondition.evaluator.params[0]}
+                      defaultValue={simpleCondition.evaluator.params[0] ?? ''}
+                      onBlur={(event) => onEvaluateValueChange(event, 0)}
+                      aria-label={t(
+                        'alerting.simple-condition-editor.aria-label-threshold-from',
+                        'Threshold from value'
+                      )}
+                    />
+                    <ToLabel />
+                    <Input
+                      type="number"
+                      width={10}
+                      key={simpleCondition.evaluator.params[1]}
+                      defaultValue={simpleCondition.evaluator.params[1] ?? ''}
+                      onBlur={(event) => onEvaluateValueChange(event, 1)}
+                      aria-label={t('alerting.simple-condition-editor.aria-label-threshold-to', 'Threshold to value')}
+                    />
+                  </>
+                ) : (
+                  <Input
+                    type="number"
+                    width={10}
+                    key={simpleCondition.evaluator.params[0]}
+                    defaultValue={simpleCondition.evaluator.params[0] ?? ''}
+                    onBlur={(event) => onEvaluateValueChange(event, 0)}
+                    aria-label={t('alerting.simple-condition-editor.aria-label-threshold', 'Threshold value')}
+                  />
+                )}
+              </Stack>
+            </InlineField>
+          </InlineFieldRow>
+
+          <EvaluationGroupFieldRow enableProvisionedGroups={false} />
+
+          {evaluateFor === '0s' && (
+            <Stack direction="row" gap={0.5} alignItems="center">
+              <Icon name="exclamation-triangle" aria-hidden="true" />
+              <Text variant="bodySmall" color="secondary">
+                <Trans i18nKey="alerting.simplified.evaluation.immediate-warning">
+                  Immediate firing might lead to unnecessary alerts being sent for temporary issues
+                </Trans>
+              </Text>
+            </Stack>
+          )}
+        </Stack>
+      </div>
+    </section>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    section: css({ width: '100%' }),
+    sectionHeaderRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/components/RuleDefinitionSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleDefinitionSection.tsx
@@ -1,0 +1,99 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
+import { Trans, t } from '@grafana/i18n';
+import { Field, Input, Stack, Text, useStyles2 } from '@grafana/ui';
+
+import { RuleFormValues } from '../types/rule-form';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+
+import { FolderSelectorV2 } from './rule-editor/FolderSelectorV2';
+import { LabelsEditorModal } from './rule-editor/labels/LabelsEditorModal';
+import { LabelsFieldInFormV2 } from './rule-editor/labels/LabelsFieldInFormV2';
+
+/**
+ * Rule definition section (name, folder, labels) for the alert rule drawer. Drawer only supports GMA.
+ */
+export function RuleDefinitionSection() {
+  const styles = useStyles2(getStyles);
+  const {
+    register,
+    formState: { errors },
+    setValue,
+    getValues,
+  } = useFormContext<RuleFormValues>();
+  const [showLabelsEditor, setShowLabelsEditor] = useState(false);
+
+  return (
+    <section className={styles.section} aria-labelledby="rule-definition-section-heading">
+      <div className={styles.sectionHeaderRow}>
+        <Text element="h3" variant="h4" id="rule-definition-section-heading">
+          {`1. `}
+          <Trans i18nKey="alerting.simplified.rule-definition">Rule Definition</Trans>
+        </Text>
+      </div>
+      <div>
+        <Stack direction="column" gap={2}>
+          <Field
+            noMargin
+            label={
+              <Text variant="bodySmall" weight="medium">
+                <Trans i18nKey="alerting.alert-rule-name-and-metric.label-name">Name</Trans>
+              </Text>
+            }
+            error={errors?.name?.message}
+            invalid={!!errors.name?.message}
+          >
+            <Input
+              data-testid={selectors.components.AlertRules.ruleNameField}
+              id="name"
+              width={38}
+              {...register('name', {
+                required: {
+                  value: true,
+                  message: t('alerting.alert-rule-name-and-metric.message.must-enter-a-name', 'Must enter a name'),
+                },
+              })}
+              aria-label={t('alerting.alert-rule-name-and-metric.aria-label-name', 'name')}
+              placeholder={t(
+                'alerting.alert-rule-name-and-metric.placeholder-name',
+                'Give your {{namePlaceholder}} a name',
+                { namePlaceholder: 'alert rule' }
+              )}
+            />
+          </Field>
+
+          <FolderSelectorV2 />
+          <LabelsFieldInFormV2 onEditClick={() => setShowLabelsEditor(true)} />
+          <LabelsEditorModal
+            isOpen={showLabelsEditor}
+            onClose={(labelsToUpdate) => {
+              if (labelsToUpdate) {
+                const filtered = labelsToUpdate.filter((l) => (l?.key ?? '').length > 0 || (l?.value ?? '').length > 0);
+                setValue('labels', filtered, { shouldDirty: true, shouldValidate: true });
+              }
+              setShowLabelsEditor(false);
+            }}
+            dataSourceName={GRAFANA_RULES_SOURCE_NAME}
+            initialLabels={getValues('labels')}
+          />
+        </Stack>
+      </div>
+    </section>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    section: css({ width: '100%' }),
+    sectionHeaderRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
@@ -1,0 +1,342 @@
+import { css } from '@emotion/css';
+import { useCallback, useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { notificationsAPIv0alpha1 } from '@grafana/alerting/unstable';
+import { type GrafanaTheme2, textUtil } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import {
+  Button,
+  Combobox,
+  ComboboxOption,
+  Field,
+  Input,
+  Label,
+  RadioButtonGroup,
+  Stack,
+  Text,
+  TextArea,
+  TextLink,
+  useStyles2,
+} from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
+
+import { RuleFormValues } from '../types/rule-form';
+import { Annotation } from '../utils/constants';
+import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
+
+import { NeedHelpInfoForNotificationPolicy } from './rule-editor/NotificationsStep';
+
+// Form path for selected contact point, using the Grafana alert manager name
+const CONTACT_POINT_PATH = `contactPoints.${GRAFANA_RULES_SOURCE_NAME}.selectedContactPoint` as const;
+
+/**
+ * Validates a URL string and returns an error message if invalid.
+ * Uses the URL constructor for parsing and rejects dangerous protocols.
+ * Returns undefined if the URL is valid or empty.
+ */
+function validateRunbookUrl(value: string): string | undefined {
+  const trimmedValue = value.trim();
+
+  // Empty values are allowed (field is optional)
+  if (!trimmedValue) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(trimmedValue);
+    // Reject dangerous URL schemes per F4 frontend security rule
+    if (url.protocol === 'javascript:' || url.protocol === 'data:' || url.protocol === 'vbscript:') {
+      return t(
+        'alerting.simplified.notification.runbook-url.invalid-protocol',
+        'Invalid URL protocol. Please use http or https.'
+      );
+    }
+    return undefined;
+  } catch {
+    return t(
+      'alerting.simplified.notification.runbook-url.invalid-format',
+      'Invalid URL format. Please enter a valid URL.'
+    );
+  }
+}
+
+/**
+ * Sanitizes a URL value before storing it in the form.
+ * Uses textUtil.sanitizeUrl to ensure safe URL handling.
+ */
+function sanitizeRunbookUrl(value: string): string {
+  const trimmedValue = value.trim();
+  if (!trimmedValue) {
+    return '';
+  }
+
+  // Use textUtil.sanitizeUrl for consistent URL sanitization across the codebase
+  return textUtil.sanitizeUrl(trimmedValue);
+}
+
+export function RuleNotificationSection() {
+  const styles = useStyles2(getStyles);
+  const notifyApp = useAppNotification();
+
+  const { watch, setValue } = useFormContext<RuleFormValues>();
+  const manualRouting = watch('manualRouting');
+  const useNotificationPolicy = !manualRouting;
+  const selectedContactPoint = watch(CONTACT_POINT_PATH);
+  const annotations = watch('annotations');
+
+  // Fetch contact points from Alerting API v0alpha1
+  const { currentData, status, refetch } = notificationsAPIv0alpha1.endpoints.listReceiver.useQuery({});
+  const options = useMemo<Array<ComboboxOption<string>>>(
+    () =>
+      (currentData?.items ?? []).map((item) => ({
+        value: item?.spec?.title ?? '',
+        label: item?.spec?.title ?? '',
+      })),
+    [currentData]
+  );
+
+  // Helper functions to get and set annotation values
+  const getAnnotationValue = useCallback(
+    (key: string) => {
+      return annotations.find((a) => a.key === key)?.value ?? '';
+    },
+    [annotations]
+  );
+
+  const updateAnnotationValue = useCallback(
+    (key: string, value: string) => {
+      const updatedAnnotations = [...annotations];
+      const index = updatedAnnotations.findIndex((a) => a.key === key);
+
+      if (index >= 0) {
+        updatedAnnotations[index] = { key, value };
+      } else {
+        updatedAnnotations.push({ key, value });
+      }
+
+      setValue('annotations', updatedAnnotations, { shouldDirty: true, shouldValidate: true });
+    },
+    [annotations, setValue]
+  );
+
+  const summaryValue = getAnnotationValue(Annotation.summary);
+  const descriptionValue = getAnnotationValue(Annotation.description);
+  const runbookUrlValue = getAnnotationValue(Annotation.runbookURL);
+
+  // Validate runbook URL for form-level validation feedback
+  const runbookUrlError = useMemo(() => validateRunbookUrl(runbookUrlValue), [runbookUrlValue]);
+
+  const recipientLabelId = 'recipient-label';
+
+  return (
+    <section className={styles.section} aria-labelledby="notification-section-heading">
+      <div className={styles.sectionHeaderRow}>
+        <Text element="h3" variant="h4" id="notification-section-heading">
+          {`3. `}
+          <Trans i18nKey="alerting.simplified.notification.title">Notification</Trans>
+        </Text>
+      </div>
+
+      <div>
+        <Stack direction="column" gap={2}>
+          <Stack direction="column" gap={1}>
+            <Stack direction="column" gap={1}>
+              <Stack direction="row" alignItems="end" justifyContent="space-between" gap={1}>
+                <Label htmlFor={recipientLabelId}>
+                  <span id={recipientLabelId}>
+                    {t('alerting.simplified.notification.recipient.label', 'Recipient')}
+                  </span>
+                </Label>
+                <div className={styles.manualRoutingInline}>
+                  <RadioButtonGroup
+                    size="sm"
+                    options={[
+                      {
+                        label: t(
+                          'alerting.manual-and-automatic-routing.routing-options.label.contact-point',
+                          'Contact point'
+                        ),
+                        value: 'contact',
+                      },
+                      {
+                        label: t(
+                          'alerting.manual-and-automatic-routing.routing-options.label.notification-policy',
+                          'Notification policy'
+                        ),
+                        value: 'policy',
+                      },
+                    ]}
+                    value={manualRouting ? 'contact' : 'policy'}
+                    onChange={(val: 'contact' | 'policy') => {
+                      const next = val === 'contact';
+                      setValue('manualRouting', next, { shouldDirty: true, shouldValidate: true });
+                      setValue('editorSettings.simplifiedNotificationEditor', next, {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      });
+                    }}
+                    aria-label={t('alerting.simplified.notification.manual-routing.aria', 'Toggle manual routing')}
+                  />
+                </div>
+              </Stack>
+              <Text variant="bodySmall" color="secondary">
+                {useNotificationPolicy ? (
+                  <Trans i18nKey="alerting.simplified.notification.policy-selected">
+                    Notifications for firing alerts are routed to contact points based on matching labels and the
+                    notification policy tree.
+                  </Trans>
+                ) : (
+                  <Trans i18nKey="alerting.simplified.notification.contact-point-selected">
+                    Notifications for firing alerts are routed to a selected contact point.
+                  </Trans>
+                )}
+              </Text>
+            </Stack>
+            {useNotificationPolicy ? (
+              <div className={styles.contentTopSpacer}>
+                <NeedHelpInfoForNotificationPolicy />
+              </div>
+            ) : (
+              <div className={styles.contentTopSpacer}>
+                <Stack direction="row" gap={1} alignItems="center">
+                  <Combobox<ComboboxOption<string>['value']>
+                    options={options}
+                    value={
+                      selectedContactPoint ? (options.find((o) => o.value === selectedContactPoint) ?? null) : null
+                    }
+                    onChange={(opt) =>
+                      setValue(CONTACT_POINT_PATH, opt?.value ?? '', {
+                        shouldDirty: true,
+                        shouldValidate: true,
+                      })
+                    }
+                    width={30}
+                    placeholder={t(
+                      'alerting.simplified.notification.select-contact-point',
+                      'Select a contact point...'
+                    )}
+                    isClearable
+                    data-testid="contact-point"
+                    loading={status === 'pending'}
+                  />
+                  <Button
+                    icon="sync"
+                    variant="secondary"
+                    fill="text"
+                    size="sm"
+                    aria-label={t('alerting.common.refresh', 'Refresh')}
+                    onClick={async () => {
+                      try {
+                        await refetch();
+                      } catch (error) {
+                        notifyApp.error(
+                          t('alerting.simplified.notification.refresh-error', 'Failed to refresh contact points')
+                        );
+                      }
+                    }}
+                  />
+                  <TextLink
+                    href={'/alerting/notifications'}
+                    aria-label={t(
+                      'alerting.link-to-contact-points.aria-label-view-or-create-contact-points',
+                      'View or create contact points'
+                    )}
+                  >
+                    <Trans i18nKey="alerting.link-to-contact-points.view-or-create-contact-points">
+                      View or create contact points
+                    </Trans>
+                  </TextLink>
+                </Stack>
+              </div>
+            )}
+          </Stack>
+
+          <Field label={t('alerting.simplified.notification.summary.label', 'Summary (optional)')} noMargin>
+            <TextArea
+              id="summary-text-area"
+              value={summaryValue}
+              onChange={(e) => updateAnnotationValue(Annotation.summary, e.currentTarget.value)}
+              placeholder={t(
+                'alerting.simplified.notification.summary.placeholder',
+                'Enter a summary of what happened and why…'
+              )}
+              aria-label={t('alerting.simplified.notification.summary.aria-label', 'Summary')}
+            />
+          </Field>
+
+          <Field label={t('alerting.simplified.notification.description.label', 'Description (optional)')} noMargin>
+            <TextArea
+              id="description-text-area"
+              value={descriptionValue}
+              onChange={(e) => updateAnnotationValue(Annotation.description, e.currentTarget.value)}
+              placeholder={t(
+                'alerting.simplified.notification.description.placeholder',
+                'Enter a description of what the alert rule does…'
+              )}
+              aria-label={t('alerting.simplified.notification.description.aria-label', 'Description')}
+            />
+          </Field>
+
+          <Field
+            label={t('alerting.simplified.notification.runbook-url.label', 'Runbook URL (optional)')}
+            noMargin
+            invalid={!!runbookUrlError}
+            error={runbookUrlError}
+          >
+            <Input
+              id="runbook-url-input"
+              type="url"
+              value={runbookUrlValue}
+              onChange={(e) => {
+                const value = e.currentTarget.value;
+                updateAnnotationValue(Annotation.runbookURL, value);
+              }}
+              onBlur={(e) => {
+                const value = e.currentTarget.value.trim();
+                // Sanitize and update the URL on blur if it's valid
+                if (value) {
+                  const error = validateRunbookUrl(value);
+                  if (!error) {
+                    // Sanitize the URL before storing
+                    const sanitizedUrl = sanitizeRunbookUrl(value);
+                    if (sanitizedUrl !== value) {
+                      updateAnnotationValue(Annotation.runbookURL, sanitizedUrl);
+                    }
+                  }
+                }
+              }}
+              placeholder={t(
+                'alerting.simplified.notification.runbook-url.placeholder',
+                'Enter the webpage where you keep your runbook for the alert…'
+              )}
+              aria-label={t('alerting.simplified.notification.runbook-url.aria-label', 'Runbook URL')}
+              aria-invalid={!!runbookUrlError}
+              aria-describedby={runbookUrlError ? 'runbook-url-error' : undefined}
+            />
+          </Field>
+        </Stack>
+      </div>
+    </section>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    section: css({ width: '100%' }),
+    sectionHeaderRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+    }),
+    contentTopSpacer: css({ marginTop: theme.spacing(0.5) }),
+    manualRoutingInline: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      whiteSpace: 'nowrap',
+      maxWidth: '100%',
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleNotificationSection.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useId, useMemo } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { notificationsAPIv0alpha1 } from '@grafana/alerting/unstable';
@@ -10,6 +10,7 @@ import {
   Combobox,
   ComboboxOption,
   Field,
+  FieldValidationMessage,
   Input,
   Label,
   RadioButtonGroup,
@@ -126,8 +127,7 @@ export function RuleNotificationSection() {
 
   // Validate runbook URL for form-level validation feedback
   const runbookUrlError = useMemo(() => validateRunbookUrl(runbookUrlValue), [runbookUrlValue]);
-
-  const recipientLabelId = 'recipient-label';
+  const runbookUrlErrorId = useId();
 
   return (
     <section className={styles.section} aria-labelledby="notification-section-heading">
@@ -143,11 +143,7 @@ export function RuleNotificationSection() {
           <Stack direction="column" gap={1}>
             <Stack direction="column" gap={1}>
               <Stack direction="row" alignItems="end" justifyContent="space-between" gap={1}>
-                <Label htmlFor={recipientLabelId}>
-                  <span id={recipientLabelId}>
-                    {t('alerting.simplified.notification.recipient.label', 'Recipient')}
-                  </span>
-                </Label>
+                <Label>{t('alerting.simplified.notification.recipient.label', 'Recipient')}</Label>
                 <div className={styles.manualRoutingInline}>
                   <RadioButtonGroup
                     size="sm"
@@ -282,38 +278,45 @@ export function RuleNotificationSection() {
             label={t('alerting.simplified.notification.runbook-url.label', 'Runbook URL (optional)')}
             noMargin
             invalid={!!runbookUrlError}
-            error={runbookUrlError}
+            htmlFor="runbook-url-input"
           >
-            <Input
-              id="runbook-url-input"
-              type="url"
-              value={runbookUrlValue}
-              onChange={(e) => {
-                const value = e.currentTarget.value;
-                updateAnnotationValue(Annotation.runbookURL, value);
-              }}
-              onBlur={(e) => {
-                const value = e.currentTarget.value.trim();
-                // Sanitize and update the URL on blur if it's valid
-                if (value) {
-                  const error = validateRunbookUrl(value);
-                  if (!error) {
-                    // Sanitize the URL before storing
-                    const sanitizedUrl = sanitizeRunbookUrl(value);
-                    if (sanitizedUrl !== value) {
-                      updateAnnotationValue(Annotation.runbookURL, sanitizedUrl);
+            <>
+              <Input
+                id="runbook-url-input"
+                type="url"
+                value={runbookUrlValue}
+                onChange={(e) => {
+                  const value = e.currentTarget.value;
+                  updateAnnotationValue(Annotation.runbookURL, value);
+                }}
+                onBlur={(e) => {
+                  const value = e.currentTarget.value.trim();
+                  // Sanitize and update the URL on blur if it's valid
+                  if (value) {
+                    const error = validateRunbookUrl(value);
+                    if (!error) {
+                      // Sanitize the URL before storing
+                      const sanitizedUrl = sanitizeRunbookUrl(value);
+                      if (sanitizedUrl !== value) {
+                        updateAnnotationValue(Annotation.runbookURL, sanitizedUrl);
+                      }
                     }
                   }
-                }
-              }}
-              placeholder={t(
-                'alerting.simplified.notification.runbook-url.placeholder',
-                'Enter the webpage where you keep your runbook for the alert…'
+                }}
+                placeholder={t(
+                  'alerting.simplified.notification.runbook-url.placeholder',
+                  'Enter the webpage where you keep your runbook for the alert…'
+                )}
+                aria-label={t('alerting.simplified.notification.runbook-url.aria-label', 'Runbook URL')}
+                aria-invalid={!!runbookUrlError}
+                aria-describedby={runbookUrlError ? runbookUrlErrorId : undefined}
+              />
+              {runbookUrlError && (
+                <div id={runbookUrlErrorId} role="alert" className={styles.runbookUrlError}>
+                  <FieldValidationMessage>{runbookUrlError}</FieldValidationMessage>
+                </div>
               )}
-              aria-label={t('alerting.simplified.notification.runbook-url.aria-label', 'Runbook URL')}
-              aria-invalid={!!runbookUrlError}
-              aria-describedby={runbookUrlError ? 'runbook-url-error' : undefined}
-            />
+            </>
           </Field>
         </Stack>
       </div>
@@ -337,6 +340,9 @@ function getStyles(theme: GrafanaTheme2) {
       gap: theme.spacing(0.5),
       whiteSpace: 'nowrap',
       maxWidth: '100%',
+    }),
+    runbookUrlError: css({
+      marginTop: theme.spacing(0.5),
     }),
   };
 }

--- a/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
+++ b/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
@@ -27,8 +27,8 @@ export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => vo
         onClick={() => setIsCreatingFolder(true)}
         type="button"
         icon="plus"
-        fill="outline"
         variant="secondary"
+        size="sm"
         disabled={!contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
       >
         <Trans i18nKey="alerting.create-new-folder.new-folder">New folder</Trans>

--- a/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
+++ b/public/app/features/alerting/unified/components/create-folder/CreateNewFolder.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Button, Field, Input, Label, Modal, Stack, useStyles2 } from '@grafana/ui';
+import { Button, type ComponentSize, Field, Input, Label, Modal, Stack, useStyles2 } from '@grafana/ui';
 import { useCreateFolder } from 'app/api/clients/folder/v1beta1/hooks';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
@@ -12,10 +12,18 @@ import { AccessControlAction } from 'app/types/accessControl';
 
 import { Folder } from '../../types/rule-form';
 
+export type ButtonFill = 'solid' | 'outline' | 'text';
+
+export interface CreateNewFolderProps {
+  onCreate: (folder: Folder) => void;
+  fill?: ButtonFill;
+  size?: ComponentSize;
+}
+
 /**
  * Provides a button and associated modal for creating a new folder
  */
-export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => void }) => {
+export const CreateNewFolder = ({ onCreate, fill = 'outline', size = 'md' }: CreateNewFolderProps) => {
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const handleCreate = (folder: Folder) => {
     onCreate(folder);
@@ -28,7 +36,8 @@ export const CreateNewFolder = ({ onCreate }: { onCreate: (folder: Folder) => vo
         type="button"
         icon="plus"
         variant="secondary"
-        size="sm"
+        fill={fill}
+        size={size}
         disabled={!contextSrv.hasPermission(AccessControlAction.FoldersCreate)}
       >
         <Trans i18nKey="alerting.create-new-folder.new-folder">New folder</Trans>

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.test.tsx
@@ -24,6 +24,20 @@ jest.mock('react-use', () => ({
   useAsync: () => ({ loading: false, value: {} }),
 }));
 
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    ...jest.requireActual('@grafana/runtime').config,
+    featureToggles: {
+      createAlertRuleFromPanel: true,
+    },
+  },
+}));
+
+jest.mock('../../components/AlertRuleDrawerForm', () => ({
+  AlertRuleDrawerForm: () => null,
+}));
+
 describe('Analytics', () => {
   it('Sends log info when creating an alert rule from a panel', async () => {
     const panel = new PanelModel({

--- a/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
+++ b/public/app/features/alerting/unified/components/panel-alerts-tab/NewRuleFromPanelButton.tsx
@@ -1,14 +1,18 @@
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
 import { urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Alert, Button, LinkButton } from '@grafana/ui';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { useSelector } from 'app/types/store';
 
-import { LogMessages, logInfo } from '../../Analytics';
+import { LogMessages, logInfo, trackCreateRuleFromPanelDrawerOpened } from '../../Analytics';
+import { AlertRuleDrawerForm } from '../../components/AlertRuleDrawerForm';
+import { createPanelAlertRuleNavigation } from '../../utils/navigation';
 import { panelToRuleFormValues } from '../../utils/rule-form';
 
 interface Props {
@@ -29,6 +33,7 @@ export const NewRuleFromPanelButton = ({ dashboard, panel, className }: Props) =
     // Templating variables are required to update formValues on each variable's change. It's used implicitly by the templating engine
     [panel, dashboard, templating]
   );
+  const [isOpen, setIsOpen] = useState(false);
 
   if (loading) {
     return (
@@ -51,6 +56,38 @@ export const NewRuleFromPanelButton = ({ dashboard, panel, className }: Props) =
           Cannot create alerts from this panel because no query to an alerting capable datasource is found.
         </Trans>
       </Alert>
+    );
+  }
+
+  const shouldUseDrawer = config.featureToggles.createAlertRuleFromPanel;
+
+  if (shouldUseDrawer) {
+    const { onContinueInAlertingFromDrawer } = createPanelAlertRuleNavigation(
+      () => panelToRuleFormValues(panel, dashboard),
+      location
+    );
+
+    return (
+      <>
+        <Button
+          icon="bell"
+          className={className}
+          data-testid="create-alert-rule-button-drawer"
+          onClick={() => {
+            logInfo(LogMessages.alertRuleFromPanel);
+            trackCreateRuleFromPanelDrawerOpened();
+            setIsOpen(true);
+          }}
+        >
+          <Trans i18nKey="alerting.new-rule-from-panel-button.new-alert-rule">New alert rule</Trans>
+        </Button>
+        <AlertRuleDrawerForm
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onContinueInAlerting={onContinueInAlertingFromDrawer}
+          prefill={formValues ?? undefined}
+        />
+      </>
     );
   }
 

--- a/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupFieldRow.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupFieldRow.tsx
@@ -1,0 +1,194 @@
+import { css } from '@emotion/css';
+import { useId, useMemo, useState } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Box, Button, Field, Select, Stack, Text, useStyles2 } from '@grafana/ui';
+import { RulerRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { useFetchGroupsForFolder } from '../../hooks/useFetchGroupsForFolder';
+import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../rule-editor/formDefaults';
+import { RuleFormValues } from '../../types/rule-form';
+import { isProvisionedRuleGroup } from '../../utils/rules';
+import { ProvisioningBadge } from '../Provisioning';
+
+import { EvaluationGroupCreationModal } from './GrafanaEvaluationBehavior';
+
+export type GroupOption = SelectableValue<string> & { isProvisioned?: boolean };
+
+export function EvaluationGroupFieldRow({ enableProvisionedGroups }: { enableProvisionedGroups: boolean }) {
+  const styles = useStyles2(getStyles);
+  const groupInputId = useId();
+
+  const {
+    watch,
+    setValue,
+    getValues,
+    formState: { errors },
+    control,
+  } = useFormContext<RuleFormValues>();
+
+  const [group, folder] = watch(['group', 'folder']);
+  const { currentData: rulerNamespace, isLoading: loadingGroups } = useFetchGroupsForFolder(folder?.uid ?? '');
+
+  const collator = useMemo(() => new Intl.Collator(), []);
+  const groupOptions = useMemo<GroupOption[]>(() => {
+    if (!rulerNamespace) {
+      return [];
+    }
+    const folderGroups = Object.values(rulerNamespace).flat();
+    return folderGroups
+      .map<GroupOption>((g: RulerRuleGroupDTO) => {
+        const provisioned = isProvisionedRuleGroup(g);
+        return {
+          label: g.name,
+          value: g.name,
+          description: g.interval ?? DEFAULT_GROUP_EVALUATION_INTERVAL,
+          isDisabled: !enableProvisionedGroups ? provisioned : false,
+          isProvisioned: provisioned,
+        };
+      })
+      .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
+  }, [collator, enableProvisionedGroups, rulerNamespace]);
+
+  const defaultGroupValue = group ? { value: group, label: group } : undefined;
+
+  const [isCreatingEvaluationGroup, setIsCreatingEvaluationGroup] = useState(false);
+  const onOpenEvaluationGroupCreationModal = () => setIsCreatingEvaluationGroup(true);
+
+  const handleEvalGroupCreation = (groupName: string, evaluationInterval: string) => {
+    setValue('group', groupName);
+    setValue('evaluateEvery', evaluationInterval);
+    setIsCreatingEvaluationGroup(false);
+  };
+
+  const label = !folder?.uid
+    ? t(
+        'alerting.rule-form.evaluation.select-folder-before',
+        'Select a folder before setting evaluation group and interval'
+      )
+    : t('alerting.rule-form.evaluation.evaluation-group-and-interval', 'Evaluation group and interval');
+
+  return (
+    <Stack alignItems="end">
+      <div className={styles.formContainer}>
+        <Field
+          noMargin
+          label={label}
+          data-testid="group-picker"
+          className={styles.formInput}
+          error={errors.group?.message}
+          invalid={!!errors.group?.message}
+          htmlFor="group"
+        >
+          <Controller
+            render={({ field: { ref, ...field }, fieldState }) => (
+              <Select
+                disabled={!folder?.uid || loadingGroups}
+                inputId={groupInputId}
+                {...field}
+                onChange={(group) => {
+                  field.onChange(group.label ?? '');
+                }}
+                isLoading={loadingGroups}
+                invalid={Boolean(folder?.uid) && !group && Boolean(fieldState.error)}
+                cacheOptions
+                loadingMessage={t(
+                  'alerting.grafana-evaluation-behavior-step.loadingMessage-loading-groups',
+                  'Loading groups...'
+                )}
+                defaultValue={defaultGroupValue}
+                options={groupOptions}
+                getOptionLabel={(option: GroupOption) => (
+                  <div>
+                    <span>{option.label}</span>
+                    {option.isProvisioned && (
+                      <>
+                        {' '}
+                        <ProvisioningBadge />
+                      </>
+                    )}
+                  </div>
+                )}
+                placeholder={t(
+                  'alerting.grafana-evaluation-behavior-step.placeholder-select-an-evaluation-group',
+                  'Select an evaluation group...'
+                )}
+              />
+            )}
+            name="group"
+            control={control}
+            rules={{
+              required: {
+                value: true,
+                message: t(
+                  'alerting.grafana-evaluation-behavior-step.message.must-enter-a-group-name',
+                  'Must enter a group name'
+                ),
+              },
+            }}
+          />
+        </Field>
+      </div>
+      <Box gap={1} display={'flex'} alignItems={'center'}>
+        <Text color="secondary">
+          <Trans i18nKey="alerting.grafana-evaluation-behavior-step.or">or</Trans>
+        </Text>
+        <Button
+          onClick={onOpenEvaluationGroupCreationModal}
+          type="button"
+          icon="plus"
+          fill="outline"
+          variant="secondary"
+          disabled={!folder?.uid}
+          data-testid={'new-evaluation-group-button'}
+        >
+          <Trans i18nKey="alerting.rule-form.evaluation.new-group">New evaluation group</Trans>
+        </Button>
+      </Box>
+      {isCreatingEvaluationGroup && (
+        <EvaluationGroupCreationModal
+          onCreate={handleEvalGroupCreation}
+          onClose={() => setIsCreatingEvaluationGroup(false)}
+        />
+      )}
+      {getValues('group') && getValues('evaluateEvery') && (
+        <div className={styles.evaluationContainer}>
+          <Stack direction="column" gap={0}>
+            <div className={styles.marginTop}>
+              <Stack direction="column" gap={1}>
+                <Trans
+                  i18nKey="alerting.rule-form.evaluation.group-text"
+                  values={{ evaluateEvery: getValues('evaluateEvery') }}
+                >
+                  All rules in the selected group are evaluated every {{ evaluateEvery: getValues('evaluateEvery') }}.
+                </Trans>
+              </Stack>
+            </div>
+          </Stack>
+        </div>
+      )}
+    </Stack>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    formContainer: css({
+      width: '100%',
+      maxWidth: theme.breakpoints.values.sm,
+    }),
+    formInput: css({
+      flexGrow: 1,
+    }),
+    evaluationContainer: css({
+      color: theme.colors.text.secondary,
+      maxWidth: `${theme.breakpoints.values.sm}px`,
+      fontSize: theme.typography.size.sm,
+    }),
+    marginTop: css({
+      marginTop: theme.spacing(1),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupQuickPick.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/EvaluationGroupQuickPick.tsx
@@ -5,7 +5,7 @@ import { Button, Stack } from '@grafana/ui';
 
 import { formatPrometheusDuration, parsePrometheusDuration, safeParsePrometheusDuration } from '../../utils/time';
 
-const MIN_INTERVAl = config.unifiedAlerting.minInterval ?? '10s';
+const MIN_INTERVAl = config.unifiedAlerting?.minInterval ?? '10s';
 export const getEvaluationGroupOptions = (minInterval = MIN_INTERVAl) => {
   const MIN_OPTIONS_TO_SHOW = 8;
   const DEFAULT_INTERVAL_OPTIONS: number[] = [

--- a/public/app/features/alerting/unified/components/rule-editor/FolderSelectorV2.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderSelectorV2.tsx
@@ -1,0 +1,94 @@
+import { useCallback } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Field, Icon, Label, Stack, Tooltip } from '@grafana/ui';
+import { NestedFolderPicker } from 'app/core/components/NestedFolderPicker/NestedFolderPicker';
+
+import { Folder, RuleFormValues } from '../../types/rule-form';
+import { CreateNewFolder } from '../create-folder/CreateNewFolder';
+
+export function FolderSelectorV2() {
+  const {
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext<RuleFormValues>();
+
+  const resetGroup = useCallback(() => {
+    setValue('group', '');
+  }, [setValue]);
+
+  const folder = watch('folder');
+
+  const handleFolderCreation = (folder: Folder) => {
+    resetGroup();
+    setValue('folder', folder);
+  };
+
+  return (
+    <Stack alignItems="center">
+      {
+        <Field
+          noMargin
+          label={
+            <Label
+              htmlFor="folder"
+              description={t(
+                'alerting.folder-selector.description-select-folder',
+                'Select a folder to store your rule in.'
+              )}
+            >
+              <Stack direction="row" alignItems="center" gap={0.5}>
+                <Trans i18nKey="alerting.rule-form.folder.label">Folder</Trans>
+                <Tooltip
+                  content={t(
+                    'alerting.rule-form.folders.help-info',
+                    'Folders are used for storing alert rules. You can extend the access provided by a role to alert rules and assign permissions to individual folders.'
+                  )}
+                >
+                  <Icon name="info-circle" size="sm" />
+                </Tooltip>
+              </Stack>
+            </Label>
+          }
+          error={errors.folder?.message}
+          data-testid="folder-picker"
+        >
+          <Stack direction="column" alignItems="flex-start" gap={1}>
+            <Controller
+              render={({ field: { ref, ...field } }) => (
+                <div style={{ width: 420 }}>
+                  <NestedFolderPicker
+                    permission="view"
+                    showRootFolder={false}
+                    invalid={!!errors.folder?.message}
+                    {...field}
+                    value={folder?.uid}
+                    onChange={(uid, title) => {
+                      if (uid && title) {
+                        setValue('folder', { title, uid });
+                      } else {
+                        setValue('folder', undefined);
+                      }
+
+                      resetGroup();
+                    }}
+                  />
+                </div>
+              )}
+              name="folder"
+              rules={{
+                required: {
+                  value: true,
+                  message: t('alerting.folder-selector.message.select-a-folder', 'Select a folder'),
+                },
+              }}
+            />
+            <CreateNewFolder onCreate={handleFolderCreation} />
+          </Stack>
+        </Field>
+      }
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/FolderSelectorV2.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/FolderSelectorV2.tsx
@@ -85,7 +85,7 @@ export function FolderSelectorV2() {
                 },
               }}
             />
-            <CreateNewFolder onCreate={handleFolderCreation} />
+            <CreateNewFolder onCreate={handleFolderCreation} fill="solid" size="sm" />
           </Stack>
         </Field>
       }

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -50,9 +50,6 @@ import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
 
-export const MIN_TIME_RANGE_STEP_S = 10; // 10 seconds
-export const MAX_GROUP_RESULTS = 1000;
-
 const namespaceToGroupOptions = (rulerNamespace: RulerRulesConfigDTO, enableProvisionedGroups: boolean) => {
   const folderGroups = Object.values(rulerNamespace).flat();
 
@@ -456,7 +453,7 @@ export function GrafanaEvaluationBehaviorStep({
   );
 }
 
-function EvaluationGroupCreationModal({
+export function EvaluationGroupCreationModal({
   onClose,
   onCreate,
 }: {

--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -261,7 +261,7 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
 }
 
 // Auxiliar components to build the texts and descriptions in the NotificationsStep
-function NeedHelpInfoForNotificationPolicy() {
+export function NeedHelpInfoForNotificationPolicy() {
   return (
     <NeedHelpInfo
       contentText={

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`Can create a new grafana managed alert using simplified routing can cre
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -115,7 +115,9 @@ exports[`Can create a new grafana managed alert using simplified routing can cre
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -132,7 +134,7 @@ exports[`Can create a new grafana managed alert using simplified routing can cre
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],
@@ -263,7 +265,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -281,7 +283,9 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -298,7 +302,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],
@@ -432,7 +436,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -450,7 +454,9 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -467,7 +473,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],
@@ -604,7 +610,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -622,7 +628,9 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -639,7 +647,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],
@@ -773,7 +781,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -791,7 +799,9 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -808,7 +818,7 @@ exports[`Can create a new grafana managed alert using simplified routing switch 
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/contactPoint/ContactPointSelector.tsx
@@ -97,7 +97,7 @@ export function ContactPointSelector({ alertManager }: ContactPointSelectorProps
     </Stack>
   );
 }
-function LinkToContactPoints() {
+export function LinkToContactPoints() {
   const hrefToContactPoints = '/alerting/notifications';
   return (
     <TextLink

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsField.tsx
@@ -40,11 +40,12 @@ function mapLabelsToOptions(
 }
 
 export interface LabelsInRuleProps {
-  labels: Array<{ key: string; value: string }>;
+  labels: Array<{ key: string; value: string }> | undefined | null;
 }
 
 export const LabelsInRule = ({ labels }: LabelsInRuleProps) => {
-  const labelsObj: Record<string, string> = labels.reduce((acc: Record<string, string>, label) => {
+  const safeLabels = Array.isArray(labels) ? labels : [];
+  const labelsObj: Record<string, string> = safeLabels.reduce((acc: Record<string, string>, label) => {
     if (label.key) {
       acc[label.key] = label.value;
     }

--- a/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInFormV2.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/labels/LabelsFieldInFormV2.tsx
@@ -1,0 +1,86 @@
+import { useFormContext, useWatch } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Button, Field, Stack, Text } from '@grafana/ui';
+
+import { AIImproveLabelsButtonComponent } from '../../../enterprise-components/AI/AIGenImproveLabelsButton/addAIImproveLabelsButton';
+import { RuleFormValues } from '../../../types/rule-form';
+import { isGrafanaManagedRuleByType, isRecordingRuleByType } from '../../../utils/rules';
+
+import { LabelsInRule } from './LabelsField';
+
+interface LabelsFieldInFormProps {
+  onEditClick: () => void;
+}
+export function LabelsFieldInFormV2({ onEditClick }: LabelsFieldInFormProps) {
+  const { control, watch } = useFormContext<RuleFormValues>();
+
+  // Subscribe to label changes so UI updates when modal saves
+  const labels = useWatch({ control, name: 'labels' }) ?? [];
+  const type = watch('type');
+
+  const isRecordingRule = type ? isRecordingRuleByType(type) : false;
+  const isGrafanaManaged = type ? isGrafanaManagedRuleByType(type) : false;
+
+  const text = isRecordingRule
+    ? t('alerting.alertform.labels.recording', 'Add labels to your rule.')
+    : t(
+        'alerting.alertform.labels.alerting',
+        'Add labels to your rule for searching, silencing, or routing to a notification policy.'
+      );
+
+  const hasLabels = Array.isArray(labels) && labels.length > 0 && labels.some((label) => label?.key || label?.value);
+
+  return (
+    <Field
+      noMargin
+      label={
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Text variant="bodySmall">
+            <Trans i18nKey="alerting.labels-field-in-form.labels">Labels</Trans>
+          </Text>
+          <Text variant="bodySmall" color="secondary">
+            {t('alerting.common.optional', '(optional)')}
+          </Text>
+        </Stack>
+      }
+    >
+      <Stack direction={'column'} gap={2}>
+        <Stack direction={'column'} gap={1}>
+          <Stack direction={'row'} gap={1}>
+            <Text variant="bodySmall" color="secondary">
+              {text}
+            </Text>
+          </Stack>
+          {isGrafanaManaged && <AIImproveLabelsButtonComponent />}
+        </Stack>
+        <Stack>
+          {hasLabels ? (
+            <Stack direction="row" gap={1} alignItems="center">
+              <LabelsInRule labels={labels} />
+              <Button variant="secondary" type="button" onClick={onEditClick} size="sm">
+                <Trans i18nKey="alerting.labels-field-in-form.edit-labels">Edit labels</Trans>
+              </Button>
+            </Stack>
+          ) : (
+            <Stack direction="column" gap={0.5} alignItems="start">
+              <Text color="secondary">
+                <Trans i18nKey="alerting.labels-field-in-form.no-labels-selected">No labels selected</Trans>
+              </Text>
+              <Button
+                icon="plus"
+                type="button"
+                variant="secondary"
+                onClick={onEditClick}
+                size="sm"
+                data-testid="add-labels-button"
+              >
+                <Trans i18nKey="alerting.labels-field-in-form.add-labels">Add labels</Trans>
+              </Button>
+            </Stack>
+          )}
+        </Stack>
+      </Stack>
+    </Field>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/__snapshots__/PolicyTreeSelector.integration.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -115,7 +115,9 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -132,7 +134,7 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],
@@ -262,7 +264,7 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -280,7 +282,9 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -297,7 +301,7 @@ exports[`PolicyTreeSelector - feature toggle ON new rule - collapsed default pol
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.test.tsx
@@ -6,8 +6,9 @@ import { ClassicCondition, ExpressionQuery } from 'app/features/expressions/type
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { mockReduceExpression, mockThresholdExpression } from '../../../mocks';
+import { SimpleCondition } from '../../../types/rule-form';
 
-import { SimpleCondition, SimpleConditionEditor } from './SimpleCondition';
+import { SimpleConditionEditor } from './SimpleCondition';
 
 const defaultSimpleCondition: SimpleCondition = {
   whenField: ReducerID.last,

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SimpleCondition.tsx
@@ -13,17 +13,10 @@ import { getReducerType, isRangeEvaluator } from 'app/features/expressions/utils
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { ToLabel } from '../../../../../expressions/components/ToLabel';
+import { SimpleCondition } from '../../../types/rule-form';
 import { ExpressionResult } from '../../expressions/Expression';
 
 import { updateExpression } from './reducer';
-
-export interface SimpleCondition {
-  whenField?: string;
-  evaluator: {
-    params: number[];
-    type: EvalFunction;
-  };
-}
 
 /**
  * This is the simple condition editor if the user is in the simple mode in the query section

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/useAdvancedMode.ts
@@ -6,8 +6,9 @@ import { ExpressionQuery } from 'app/features/expressions/types';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { areQueriesTransformableToSimpleCondition } from '../../../rule-editor/formProcessing';
+import { SimpleCondition } from '../../../types/rule-form';
 
-import { SimpleCondition, getSimpleConditionFromExpressions } from './SimpleCondition';
+import { getSimpleConditionFromExpressions } from './SimpleCondition';
 
 function initializeSimpleCondition(
   isGrafanaAlertingType: boolean,

--- a/public/app/features/alerting/unified/group-details/validation.ts
+++ b/public/app/features/alerting/unified/group-details/validation.ts
@@ -3,8 +3,8 @@ import { FieldValues, RegisterOptions } from 'react-hook-form';
 import { t } from '@grafana/i18n';
 import { RulerRuleDTO } from 'app/types/unified-alerting-dto';
 
-import { MIN_TIME_RANGE_STEP_S } from '../components/rule-editor/GrafanaEvaluationBehavior';
 import { rulesInSameGroupHaveInvalidFor } from '../state/actions';
+import { MIN_TIME_RANGE_STEP_S } from '../utils/constants';
 import { getAlertInfo } from '../utils/rules';
 import { formatPrometheusDuration, parsePrometheusDuration, safeParsePrometheusDuration } from '../utils/time';
 

--- a/public/app/features/alerting/unified/rule-editor/__snapshots__/RuleEditorGrafanaRules.test.tsx.snap
+++ b/public/app/features/alerting/unified/rule-editor/__snapshots__/RuleEditorGrafanaRules.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`RuleEditor grafana managed rules can create new grafana managed alert 1
                   "refId": "B",
                   "type": "reduce",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "B",
               },
               {
@@ -117,7 +117,9 @@ exports[`RuleEditor grafana managed rules can create new grafana managed alert 1
                         "type": "and",
                       },
                       "query": {
-                        "params": [],
+                        "params": [
+                          "C",
+                        ],
                       },
                       "reducer": {
                         "params": [],
@@ -134,7 +136,7 @@ exports[`RuleEditor grafana managed rules can create new grafana managed alert 1
                   "refId": "C",
                   "type": "threshold",
                 },
-                "queryType": "",
+                "queryType": "expression",
                 "refId": "C",
               },
             ],

--- a/public/app/features/alerting/unified/rule-editor/formDefaults.ts
+++ b/public/app/features/alerting/unified/rule-editor/formDefaults.ts
@@ -251,10 +251,12 @@ export function formValuesFromPrefill(rule: Partial<RuleFormValues>): RuleFormVa
     parsedRule = alertingAlertRuleFormSchema.parse(rule);
   }
 
-  return revealHiddenQueries({
-    ...getDefaultFormValues(rule.type),
-    ...parsedRule,
-  });
+  return setQueryEditorSettings(
+    revealHiddenQueries({
+      ...getDefaultFormValues(rule.type),
+      ...parsedRule,
+    })
+  );
 }
 
 export function formValuesFromExistingRule(rule: RuleWithLocation<RulerRuleDTO>) {

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -1,12 +1,13 @@
 import { isEmpty, omit } from 'lodash';
 
+import { ReducerID, getNextRefId } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import { isExpressionQuery } from 'app/features/expressions/guards';
-import { ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionDatasourceUID, ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
 import { isStrictReducer } from 'app/features/expressions/utils/expressionTypes';
 import { AlertDataQuery, AlertQuery } from 'app/types/unified-alerting-dto';
 
-import { KVObject, RuleFormValues } from '../types/rule-form';
+import { KVObject, RuleFormValues, SimpleCondition } from '../types/rule-form';
 import { defaultAnnotations } from '../utils/constants';
 import { isSupportedExternalRulesSourceType } from '../utils/datasource';
 import { getInstantFromDataQuery } from '../utils/rule-form';
@@ -27,8 +28,33 @@ export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
   // data queries only
   const dataQueries = values.queries.filter((query) => !isExpressionQuery(query.model));
 
-  // expression queries only
-  const expressionQueries = values.queries.filter((query) => isExpressionQueryInAlert(query));
+  // expression queries only - but filter out invalid ones that don't have a type field
+  const expressionQueries = values.queries.filter((query): query is AlertQuery<ExpressionQuery> => {
+    if (!isExpressionQueryInAlert(query)) {
+      return false;
+    }
+    // Some sources (e.g. dashboard panel, API) can yield expression-like queries without a type field
+    return 'type' in query.model && query.model.type !== undefined;
+  });
+
+  // If we have data queries but no VALID expressions (e.g., coming from dashboard panel with malformed expressions),
+  // remove the invalid expressions and set condition to empty so simplified mode can regenerate them
+  const hasDataQueries = dataQueries.length > 0;
+  const hasValidExpressions = expressionQueries.length > 0;
+  const totalExpressions = values.queries.filter((query) => isExpressionQueryInAlert(query)).length;
+  const hasInvalidExpressions = totalExpressions > expressionQueries.length;
+
+  if (hasDataQueries && (!hasValidExpressions || hasInvalidExpressions)) {
+    return {
+      ...values,
+      queries: dataQueries, // Only keep data queries, remove invalid expressions
+      condition: '', // Clear condition so simplified editor can set it
+      editorSettings: {
+        simplifiedQueryEditor: true,
+        simplifiedNotificationEditor: true,
+      },
+    };
+  }
 
   const queryParamsAreTransformable = areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries);
   return {
@@ -122,6 +148,73 @@ export function areQueriesTransformableToSimpleCondition(
   }
 
   return false;
+}
+
+/**
+ * Creates expression queries (reduce + threshold) from a simple condition configuration.
+ * Shared by the main rule form and the alert rule drawer to keep expression building in one place.
+ */
+export function createSimpleConditionExpressions(
+  simpleCondition: SimpleCondition,
+  dataQueries: AlertQuery[]
+): { queries: AlertQuery[]; condition: string } {
+  if (dataQueries.length === 0) {
+    return { queries: [], condition: '' };
+  }
+
+  const whenField = simpleCondition.whenField ?? ReducerID.last;
+  const lastDataQueryRefId = dataQueries[dataQueries.length - 1].refId;
+
+  const reduceRefId = getNextRefId(dataQueries);
+  const tempQueries = [...dataQueries, { refId: reduceRefId, datasourceUid: '', queryType: '', model: {} }];
+  const thresholdRefId = getNextRefId(tempQueries);
+
+  const reduceExpression: ExpressionQuery = {
+    refId: reduceRefId,
+    type: ExpressionQueryType.reduce,
+    datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID },
+    reducer: whenField,
+    expression: lastDataQueryRefId,
+  };
+
+  const thresholdExpression: ExpressionQuery = {
+    refId: thresholdRefId,
+    type: ExpressionQueryType.threshold,
+    datasource: { uid: ExpressionDatasourceUID, type: ExpressionDatasourceUID },
+    conditions: [
+      {
+        type: 'query',
+        evaluator: {
+          params: simpleCondition.evaluator.params,
+          type: simpleCondition.evaluator.type,
+        },
+        operator: { type: 'and' },
+        query: { params: [thresholdRefId] },
+        reducer: { params: [], type: 'last' as const },
+      },
+    ],
+    expression: reduceRefId,
+  };
+
+  const expressionQueries: AlertQuery[] = [
+    {
+      refId: reduceRefId,
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: reduceExpression,
+    },
+    {
+      refId: thresholdRefId,
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: thresholdExpression,
+    },
+  ];
+
+  return {
+    queries: [...dataQueries, ...expressionQueries],
+    condition: thresholdRefId,
+  };
 }
 
 export function isExpressionQueryInAlert(

--- a/public/app/features/alerting/unified/rule-editor/formProcessing.ts
+++ b/public/app/features/alerting/unified/rule-editor/formProcessing.ts
@@ -44,11 +44,29 @@ export function setQueryEditorSettings(values: RuleFormValues): RuleFormValues {
   const totalExpressions = values.queries.filter((query) => isExpressionQueryInAlert(query)).length;
   const hasInvalidExpressions = totalExpressions > expressionQueries.length;
 
-  if (hasDataQueries && (!hasValidExpressions || hasInvalidExpressions)) {
+  if (hasDataQueries && hasInvalidExpressions) {
+    const validRefIds = new Set(expressionQueries.map((q) => q.refId));
+    const conditionRefStillValid = values.condition && validRefIds.has(values.condition);
+    const strippedQueries = [...dataQueries, ...expressionQueries];
+
     return {
       ...values,
-      queries: dataQueries, // Only keep data queries, remove invalid expressions
-      condition: '', // Clear condition so simplified editor can set it
+      queries: strippedQueries,
+      condition: conditionRefStillValid ? values.condition : (expressionQueries[0]?.refId ?? ''),
+      editorSettings: {
+        simplifiedQueryEditor: hasValidExpressions
+          ? areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries)
+          : true,
+        simplifiedNotificationEditor: true,
+      },
+    };
+  }
+
+  if (hasDataQueries && !hasValidExpressions) {
+    return {
+      ...values,
+      queries: dataQueries,
+      condition: '',
       editorSettings: {
         simplifiedQueryEditor: true,
         simplifiedNotificationEditor: true,

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -1,3 +1,4 @@
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { AlertQuery, GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 
 export enum RuleFormType {
@@ -69,3 +70,11 @@ export interface RuleFormValues {
 }
 
 export type Folder = { title: string; uid: string };
+
+export interface SimpleCondition {
+  whenField?: string;
+  evaluator: {
+    params: number[];
+    type: EvalFunction;
+  };
+}

--- a/public/app/features/alerting/unified/utils/constants.ts
+++ b/public/app/features/alerting/unified/utils/constants.ts
@@ -49,3 +49,9 @@ export const defaultAnnotations = [
 
 /** Special matcher name used to identify alert rules by UID */
 export const MATCHER_ALERT_RULE_UID = '__alert_rule_uid__';
+
+/** Minimum evaluation interval step in seconds (used for validation and UI) */
+export const MIN_TIME_RANGE_STEP_S = 10;
+
+/** Maximum number of rule groups to fetch for evaluation group selector */
+export const MAX_GROUP_RESULTS = 1000;

--- a/public/app/features/alerting/unified/utils/navigation.ts
+++ b/public/app/features/alerting/unified/utils/navigation.ts
@@ -1,7 +1,10 @@
+import { urlUtil } from '@grafana/data';
+import { locationService, logInfo } from '@grafana/runtime';
 import { ObjectMatcher } from 'app/plugins/datasource/alertmanager/types';
 import { RuleGroupIdentifierV2, RuleIdentifier } from 'app/types/unified-alerting';
 
 import { createReturnTo } from '../hooks/useReturnTo';
+import { RuleFormValues } from '../types/rule-form';
 
 import { ROOT_ROUTE_NAME } from './k8s/constants';
 import { stringifyIdentifier } from './rule-id';
@@ -160,4 +163,36 @@ export const notificationPolicies = {
       alertmanager: alertmanagerSourceName,
     });
   },
+};
+
+export const createPanelAlertRuleNavigation = (
+  getFormValues: () => Promise<Partial<RuleFormValues> | undefined>,
+  location: { pathname: string; search: string }
+) => {
+  const navigateToAlerting = async (currentValues?: RuleFormValues) => {
+    logInfo('creating alert rule from panel');
+
+    const updateToDateFormValues = currentValues ?? (await getFormValues());
+
+    const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
+      defaults: JSON.stringify(updateToDateFormValues),
+      returnTo: location.pathname + location.search,
+    });
+
+    locationService.push(ruleFormUrl);
+  };
+
+  const onContinueInAlertingFromDrawer = (values: RuleFormValues) => {
+    void navigateToAlerting(values);
+  };
+
+  const onButtonClick = () => {
+    void navigateToAlerting(undefined);
+  };
+
+  return {
+    navigateToAlerting,
+    onContinueInAlertingFromDrawer,
+    onButtonClick,
+  };
 };

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -1,6 +1,6 @@
 import { PromQuery } from '@grafana/prometheus';
 import { config } from '@grafana/runtime';
-import { ExpressionDatasourceUID, ExpressionQueryType } from 'app/features/expressions/types';
+import { ExpressionDatasourceUID, ExpressionQuery, ExpressionQueryType } from 'app/features/expressions/types';
 import { RuleWithLocation } from 'app/types/unified-alerting';
 import {
   AlertDataQuery,
@@ -51,6 +51,35 @@ describe('formValuesToRulerGrafanaRuleDTO', () => {
     };
 
     expect(formValuesToRulerGrafanaRuleDTO(formValues)).toMatchSnapshot();
+  });
+
+  it('sets notification_settings.receiver only when manualRouting is true', () => {
+    const base: RuleFormValues = {
+      ...getDefaultFormValues(),
+      type: RuleFormType.grafana,
+      condition: 'A',
+      contactPoints: {
+        grafana: {
+          selectedContactPoint: 'team-receiver',
+          muteTimeIntervals: [],
+          activeTimeIntervals: [],
+          overrideGrouping: false,
+          overrideTimings: false,
+          groupBy: [],
+          groupWaitValue: '',
+          groupIntervalValue: '',
+          repeatIntervalValue: '',
+        },
+      },
+    };
+
+    // manualRouting false → no notification_settings
+    const dtoNoManual = formValuesToRulerGrafanaRuleDTO({ ...base, manualRouting: false });
+    expect(dtoNoManual.grafana_alert.notification_settings).toBeUndefined();
+
+    // manualRouting true → notification_settings.receiver present
+    const dtoManual = formValuesToRulerGrafanaRuleDTO({ ...base, manualRouting: true });
+    expect(dtoManual.grafana_alert.notification_settings?.receiver).toBe('team-receiver');
   });
 
   it('should not save both instant and range type queries', () => {
@@ -587,15 +616,24 @@ describe('getInstantFromDataQuery', () => {
   });
 });
 
+function isExpressionQuery(model: unknown): model is ExpressionQuery {
+  return typeof model === 'object' && model !== null && 'type' in model;
+}
+
 describe('getDefaultExpressions', () => {
   it('should create a reduce expression as the first query', () => {
     const result = getDefaultExpressions('B', 'C');
     const reduceQuery = result[0];
-    const model = reduceQuery.model;
+    const { model } = reduceQuery;
 
     expect(reduceQuery.refId).toBe('B');
     expect(reduceQuery.datasourceUid).toBe(ExpressionDatasourceUID);
-    expect(reduceQuery.queryType).toBe('');
+    expect(reduceQuery.queryType).toBe('expression');
+
+    if (!isExpressionQuery(model)) {
+      throw new Error('Expected ExpressionQuery');
+    }
+
     expect(model.type).toBe(ExpressionQueryType.reduce);
     expect(model.datasource?.uid).toBe(ExpressionDatasourceUID);
     expect(model.reducer).toBe('last');
@@ -604,7 +642,11 @@ describe('getDefaultExpressions', () => {
   it('should create reduce expression with proper conditions structure', () => {
     const result = getDefaultExpressions('B', 'C');
     const reduceQuery = result[0];
-    const model = reduceQuery.model;
+    const { model } = reduceQuery;
+
+    if (!isExpressionQuery(model)) {
+      throw new Error('Expected ExpressionQuery');
+    }
 
     expect(model.conditions).toHaveLength(1);
     expect(model.expression).toBe('A');
@@ -630,11 +672,16 @@ describe('getDefaultExpressions', () => {
   it('should create a threshold expression as the second query', () => {
     const result = getDefaultExpressions('B', 'C');
     const thresholdQuery = result[1];
-    const model = thresholdQuery.model;
+    const { model } = thresholdQuery;
 
     expect(thresholdQuery.refId).toBe('C');
     expect(thresholdQuery.datasourceUid).toBe(ExpressionDatasourceUID);
-    expect(thresholdQuery.queryType).toBe('');
+    expect(thresholdQuery.queryType).toBe('expression');
+
+    if (!isExpressionQuery(model)) {
+      throw new Error('Expected ExpressionQuery');
+    }
+
     expect(model.type).toBe(ExpressionQueryType.threshold);
     expect(model.datasource?.uid).toBe(ExpressionDatasourceUID);
   });
@@ -642,7 +689,11 @@ describe('getDefaultExpressions', () => {
   it('should create threshold expression with proper conditions structure', () => {
     const result = getDefaultExpressions('B', 'C');
     const thresholdQuery = result[1];
-    const model = thresholdQuery.model;
+    const { model } = thresholdQuery;
+
+    if (!isExpressionQuery(model)) {
+      throw new Error('Expected ExpressionQuery');
+    }
 
     expect(model.conditions).toHaveLength(1);
     expect(model.conditions?.[0]).toEqual({
@@ -655,7 +706,7 @@ describe('getDefaultExpressions', () => {
         type: 'and',
       },
       query: {
-        params: [],
+        params: ['C'],
       },
       reducer: {
         params: [],
@@ -667,7 +718,11 @@ describe('getDefaultExpressions', () => {
   it('should reference the reduce expression in the threshold expression', () => {
     const result = getDefaultExpressions('B', 'C');
     const thresholdQuery = result[1];
-    const model = thresholdQuery.model;
+    const { model } = thresholdQuery;
+
+    if (!isExpressionQuery(model)) {
+      throw new Error('Expected ExpressionQuery');
+    }
 
     expect(model.expression).toBe('B');
   });
@@ -676,6 +731,10 @@ describe('getDefaultExpressions', () => {
     const result = getDefaultExpressions('X', 'Y');
     const reduceModel = result[0].model;
     const thresholdModel = result[1].model;
+
+    if (!isExpressionQuery(reduceModel) || !isExpressionQuery(thresholdModel)) {
+      throw new Error('Expected ExpressionQuery');
+    }
 
     expect(result[0].refId).toBe('X');
     expect(reduceModel.refId).toBe('X');

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -278,6 +278,44 @@ export function getContactPointsFromDTO(ruleDefinition: GrafanaRuleDefinition): 
   };
 }
 
+/**
+ * Normalizes contact point fields to ensure all properties have defined values.
+ * This is needed when passing RuleFormValues to the rule editor page, as the form
+ * expects all ContactPoint fields to be defined. The submit flow doesn't need this
+ * because getNotificationSettingsForDTO handles partial/missing fields when building
+ * the DTO for the backend.
+ */
+export function normalizeContactPoints(
+  contactPoints: AlertManagerManualRouting | undefined
+): AlertManagerManualRouting | undefined {
+  if (!contactPoints) {
+    return contactPoints;
+  }
+
+  const normalized: AlertManagerManualRouting = {};
+
+  for (const [alertManager, contactPoint] of Object.entries(contactPoints)) {
+    if (contactPoint.selectedContactPoint) {
+      const defaultContactPoint: ContactPoint = {
+        selectedContactPoint: contactPoint.selectedContactPoint,
+        overrideGrouping: contactPoint.overrideGrouping ?? false,
+        groupBy: contactPoint.groupBy ?? [],
+        overrideTimings: contactPoint.overrideTimings ?? false,
+        groupWaitValue: contactPoint.groupWaitValue ?? '',
+        groupIntervalValue: contactPoint.groupIntervalValue ?? '',
+        repeatIntervalValue: contactPoint.repeatIntervalValue ?? '',
+        muteTimeIntervals: contactPoint.muteTimeIntervals ?? [],
+        activeTimeIntervals: contactPoint.activeTimeIntervals ?? [],
+      };
+      normalized[alertManager] = defaultContactPoint;
+    } else {
+      normalized[alertManager] = contactPoint;
+    }
+  }
+
+  return normalized;
+}
+
 function getEditorSettingsFromDTO(ga: GrafanaRuleDefinition) {
   // we need to check if the feature toggle is enabled as it might be disabled after the rule was created with the feature enabled
   if (!config.featureToggles.alertingQueryAndExpressionsStepMode) {
@@ -588,14 +626,85 @@ export const getDefaultRecordingRulesQueries = (
   ];
 };
 
-export const getDefaultExpressions = (...refIds: [string, string]) => {
+export const getDefaultExpressions = (...refIds: [string, string] | [string, string, string]): AlertQuery[] => {
   const refOne = refIds[0];
   const refTwo = refIds[1];
+  // If a third parameter is provided, use it as the source query refId, otherwise default to 'A'
+  const sourceRefId = refIds.length === 3 ? refIds[2] : 'A';
 
-  const reduceQuery = getDefaultReduceExpression({ inputRefId: 'A', reduceRefId: refOne });
-  const thresholdQuery = getDefaultThresholdExpression({ inputRefId: refOne, thresholdRefId: refTwo });
+  const reduceExpression: ExpressionQuery = {
+    refId: refIds[0],
+    type: ExpressionQueryType.reduce,
+    datasource: {
+      uid: ExpressionDatasourceUID,
+      type: ExpressionDatasourceRef.type,
+    },
+    conditions: [
+      {
+        type: 'query',
+        evaluator: {
+          params: [],
+          type: EvalFunction.IsAbove,
+        },
+        operator: {
+          type: 'and',
+        },
+        query: {
+          params: [],
+        },
+        reducer: {
+          params: [],
+          type: 'last',
+        },
+      },
+    ],
+    reducer: 'last',
+    expression: sourceRefId,
+  };
 
-  return [reduceQuery, thresholdQuery] as const;
+  const thresholdExpression: ExpressionQuery = {
+    refId: refTwo,
+    type: ExpressionQueryType.threshold,
+    datasource: {
+      uid: ExpressionDatasourceUID,
+      type: ExpressionDatasourceRef.type,
+    },
+    conditions: [
+      {
+        type: 'query',
+        evaluator: {
+          params: [0],
+          type: EvalFunction.IsAbove,
+        },
+        operator: {
+          type: 'and',
+        },
+        query: {
+          params: [refTwo],
+        },
+        reducer: {
+          params: [],
+          type: 'last',
+        },
+      },
+    ],
+    expression: refOne,
+  };
+
+  return [
+    {
+      refId: refOne,
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: reduceExpression,
+    },
+    {
+      refId: refTwo,
+      datasourceUid: ExpressionDatasourceUID,
+      queryType: 'expression',
+      model: thresholdExpression,
+    },
+  ];
 };
 
 const getDefaultExpressionsForRecording = (refOne: string): Array<AlertQuery<ExpressionQuery>> => {
@@ -638,95 +747,6 @@ const getDefaultExpressionsForRecording = (refOne: string): Array<AlertQuery<Exp
     },
   ];
 };
-
-export function getDefaultReduceExpression({
-  inputRefId,
-  reduceRefId,
-}: {
-  inputRefId: string;
-  reduceRefId: string;
-}): AlertQuery<ExpressionQuery> {
-  const reduceExpression: ExpressionQuery = {
-    refId: reduceRefId,
-    type: ExpressionQueryType.reduce,
-    datasource: {
-      uid: ExpressionDatasourceUID,
-      type: ExpressionDatasourceRef.type,
-    },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: [],
-          type: EvalFunction.IsAbove,
-        },
-        operator: {
-          type: 'and',
-        },
-        query: {
-          params: [],
-        },
-        reducer: {
-          params: [],
-          type: 'last',
-        },
-      },
-    ],
-    reducer: 'last',
-    expression: inputRefId,
-  };
-
-  return {
-    refId: reduceRefId,
-    datasourceUid: ExpressionDatasourceUID,
-    queryType: '',
-    model: reduceExpression,
-  };
-}
-
-export function getDefaultThresholdExpression({
-  inputRefId,
-  thresholdRefId,
-}: {
-  inputRefId: string;
-  thresholdRefId: string;
-}): AlertQuery<ExpressionQuery> {
-  const thresholdExpression: ExpressionQuery = {
-    refId: thresholdRefId,
-    type: ExpressionQueryType.threshold,
-    datasource: {
-      uid: ExpressionDatasourceUID,
-      type: ExpressionDatasourceRef.type,
-    },
-    conditions: [
-      {
-        type: 'query',
-        evaluator: {
-          params: [0],
-          type: EvalFunction.IsAbove,
-        },
-        operator: {
-          type: 'and',
-        },
-        query: {
-          params: [],
-        },
-        reducer: {
-          params: [],
-          type: 'last',
-        },
-      },
-    ],
-    expression: inputRefId,
-  };
-
-  return {
-    refId: thresholdRefId,
-    datasourceUid: ExpressionDatasourceUID,
-    queryType: '',
-    model: thresholdExpression,
-  };
-}
 
 export const dataQueriesToGrafanaQueries = async (
   queries: DataQuery[],
@@ -812,24 +832,15 @@ export const panelToRuleFormValues = async (
     return undefined;
   }
 
-  const lastQuery = queries.at(-1);
-  if (!lastQuery) {
-    return undefined;
-  }
-
+  // Add default expression queries if they don't exist
   if (!queries.find((query) => query.datasourceUid === ExpressionDatasourceUID)) {
-    const reduceExpression = getDefaultReduceExpression({
-      inputRefId: lastQuery.refId,
-      reduceRefId: getNextRefId(queries),
-    });
-    queries.push(reduceExpression);
-
-    const thresholdExpression = getDefaultThresholdExpression({
-      inputRefId: reduceExpression.refId,
-      thresholdRefId: getNextRefId(queries),
-    });
-
-    queries.push(thresholdExpression);
+    // Get the last data query's refId to use as the source for the reduce expression
+    const lastDataQueryRefId = queries[queries.length - 1].refId;
+    const reduceRefId = getNextRefId(queries);
+    const queriesWithReduce = [...queries, { refId: reduceRefId, datasourceUid: '', queryType: '', model: {} }];
+    const thresholdRefId = getNextRefId(queriesWithReduce);
+    const expressions = getDefaultExpressions(reduceRefId, thresholdRefId, lastDataQueryRefId);
+    queries.push(...expressions);
   }
 
   const { folderTitle, folderUid } = dashboard.meta;
@@ -899,24 +910,15 @@ export const scenesPanelToRuleFormValues = async (vizPanel: VizPanel): Promise<P
     return undefined;
   }
 
-  const lastQuery = grafanaQueries.at(-1);
-  if (!lastQuery) {
-    return undefined;
-  }
-
+  // Add default expression queries if they don't exist
   if (!grafanaQueries.find((query) => query.datasourceUid === ExpressionDatasourceUID)) {
-    const reduceExpression = getDefaultReduceExpression({
-      inputRefId: lastQuery.refId,
-      reduceRefId: getNextRefId(grafanaQueries),
-    });
-    grafanaQueries.push(reduceExpression);
-
-    const thresholdExpression = getDefaultThresholdExpression({
-      inputRefId: reduceExpression.refId,
-      thresholdRefId: getNextRefId(grafanaQueries),
-    });
-
-    grafanaQueries.push(thresholdExpression);
+    // Get the last data query's refId to use as the source for the reduce expression
+    const lastDataQueryRefId = grafanaQueries[grafanaQueries.length - 1].refId;
+    const reduceRefId = getNextRefId(grafanaQueries);
+    const queriesWithReduce = [...grafanaQueries, { refId: reduceRefId, datasourceUid: '', queryType: '', model: {} }];
+    const thresholdRefId = getNextRefId(queriesWithReduce);
+    const expressions = getDefaultExpressions(reduceRefId, thresholdRefId, lastDataQueryRefId);
+    grafanaQueries.push(...expressions);
   }
 
   const { folderTitle, folderUid } = dashboard.state.meta;

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/NewAlertRuleButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/NewAlertRuleButton.tsx
@@ -1,13 +1,16 @@
 import { css } from '@emotion/css';
+import { useState } from 'react';
 import { useLocation } from 'react-router-dom-v5-compat';
 import { useAsync } from 'react-use';
 
-import { GrafanaTheme2, urlUtil } from '@grafana/data';
+import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { locationService, logInfo } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
 import { Alert, Button, ButtonVariant, Tooltip, useStyles2 } from '@grafana/ui';
-import { LogMessages } from 'app/features/alerting/unified/Analytics';
+import { LogMessages, logInfo, trackCreateRuleFromPanelDrawerOpened } from 'app/features/alerting/unified/Analytics';
+import { AlertRuleDrawerForm } from 'app/features/alerting/unified/components/AlertRuleDrawerForm';
+import { createPanelAlertRuleNavigation } from 'app/features/alerting/unified/utils/navigation';
 import { scenesPanelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 
 import { ButtonFill } from '../../../../../../packages/grafana-ui/src/components/Button/Button';
@@ -34,6 +37,7 @@ export const ScenesNewRuleFromPanelButton = ({
   const location = useLocation();
 
   const { loading, value: formValues } = useAsync(() => scenesPanelToRuleFormValues(panel), [panel]);
+  const [isOpen, setIsOpen] = useState(false);
 
   if (disabled) {
     return (
@@ -82,23 +86,45 @@ export const ScenesNewRuleFromPanelButton = ({
     );
   }
 
-  const onClick = async () => {
-    logInfo(LogMessages.alertRuleFromPanel);
+  const { onContinueInAlertingFromDrawer, onButtonClick } = createPanelAlertRuleNavigation(
+    () => scenesPanelToRuleFormValues(panel),
+    location
+  );
 
-    const updateToDateFormValues = await scenesPanelToRuleFormValues(panel);
+  const shouldUseDrawer = config.featureToggles.createAlertRuleFromPanel;
 
-    const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
-      defaults: JSON.stringify(updateToDateFormValues),
-      returnTo: location.pathname + location.search,
-    });
-
-    locationService.push(ruleFormUrl);
-  };
+  if (shouldUseDrawer) {
+    return (
+      <>
+        <Button
+          icon="bell"
+          variant={variant}
+          size={size}
+          fill={fill}
+          className={className}
+          data-testid="create-alert-rule-button-drawer"
+          onClick={() => {
+            logInfo(LogMessages.alertRuleFromPanel);
+            trackCreateRuleFromPanelDrawerOpened();
+            setIsOpen(true);
+          }}
+        >
+          <Trans i18nKey="dashboard-scene.scenes-new-rule-from-panel-button.new-alert-rule">New alert rule</Trans>
+        </Button>
+        <AlertRuleDrawerForm
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          onContinueInAlerting={onContinueInAlertingFromDrawer}
+          prefill={formValues ?? undefined}
+        />
+      </>
+    );
+  }
 
   return (
     <Button
       icon="bell"
-      onClick={onClick}
+      onClick={onButtonClick}
       className={className}
       variant={variant}
       fill={fill}

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataPane.tsx
@@ -26,12 +26,14 @@ import { PanelDataQueriesTab } from './PanelDataQueriesTab';
 import { PanelDataTransformationsTab } from './PanelDataTransformationsTab';
 import { PanelDataPaneTab, PanelEditorInterface, TabId } from './types';
 
-function isTabId(value: string): value is TabId {
-  return Object.values<string>(TabId).includes(value);
-}
-
 function isPanelEditor(obj: object): obj is PanelEditorInterface {
   return 'onToggleQueryEditorVersion' in obj && typeof obj.onToggleQueryEditorVersion === 'function';
+}
+
+const VALID_TAB_IDS: Set<string> = new Set(Object.values(TabId));
+
+function isValidTabId(value: string): value is TabId {
+  return VALID_TAB_IDS.has(value);
 }
 
 export interface PanelDataPaneState extends SceneObjectState {
@@ -92,7 +94,7 @@ export class PanelDataPane extends SceneObjectBase<PanelDataPaneState> {
     if (!values.tab) {
       return;
     }
-    if (typeof values.tab === 'string' && isTabId(values.tab)) {
+    if (typeof values.tab === 'string' && isValidTabId(values.tab)) {
       this.setState({ tab: values.tab });
     }
   }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/__snapshots__/PanelDataAlertingTab.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
         "refId": "B",
         "type": "reduce",
       },
-      "queryType": "",
+      "queryType": "expression",
       "refId": "B",
     },
     {
@@ -83,7 +83,9 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
               "type": "and",
             },
             "query": {
-              "params": [],
+              "params": [
+                "C",
+              ],
             },
             "reducer": {
               "params": [],
@@ -100,7 +102,7 @@ exports[`PanelAlertTabContent Will render alerts belonging to panel and a button
         "refId": "C",
         "type": "threshold",
       },
-      "queryType": "",
+      "queryType": "expression",
       "refId": "C",
     },
   ],

--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -51,6 +51,9 @@ jest.mock('@grafana/runtime', () => ({
     featureToggles: {
       newVariables: false,
     },
+    unifiedAlerting: {
+      minInterval: '10s',
+    },
   },
 }));
 

--- a/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
+++ b/public/app/features/dashboard/components/DashExportModal/DashboardExporter.test.ts
@@ -42,6 +42,9 @@ jest.mock('@grafana/runtime', () => ({
     featureToggles: {
       newVariables: false,
     },
+    unifiedAlerting: {
+      minInterval: '10s',
+    },
   },
 }));
 

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -42,6 +42,9 @@ jest.mock('@grafana/runtime', () => ({
         },
       },
     },
+    unifiedAlerting: {
+      minInterval: '10s',
+    },
   },
 }));
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -499,6 +499,15 @@
     "alert-rule": {
       "term": "Alert rule"
     },
+    "alert-rule-drawer": {
+      "error-title": "Failed to create alert rule",
+      "error-unexpected": "Received an unexpected response. Please try again.",
+      "error-unknown": "An unexpected error occurred.",
+      "success-message": "Your alert rule has been created successfully.",
+      "success-title": "Alert rule created",
+      "validation-error-message": "Please correct the errors in the form and try again.",
+      "validation-error-title": "Validation error"
+    },
     "alert-rule-form": {
       "action-buttons": {
         "edit-yaml": "Edit YAML",
@@ -881,6 +890,8 @@
       "export-all": "Export all",
       "learn-more": "Learn more",
       "loading": "Loading...",
+      "optional": "(optional)",
+      "refresh": "Refresh",
       "search-by-matchers": "Search by matchers",
       "titles": {
         "notification-templates": "Notification Templates"
@@ -2022,6 +2033,8 @@
     "manual-and-automatic-routing": {
       "routing-options": {
         "label": {
+          "contact-point": "Contact point",
+          "notification-policy": "Notification policy",
           "select-contact-point": "Select contact point",
           "use-notification-policy": "Use notification policy"
         }
@@ -3277,12 +3290,57 @@
       "title-the-selected-alertmanager-has-no-configuration": "The selected Alertmanager has no configuration"
     },
     "simple-condition-editor": {
+      "aria-label-reducer": "Select reducer function",
+      "aria-label-threshold": "Threshold value",
+      "aria-label-threshold-from": "Threshold from value",
+      "aria-label-threshold-to": "Threshold to value",
       "label-of-query": "OF QUERY",
       "label-when": "WHEN",
       "label-when-query": "WHEN QUERY"
     },
     "simpleCondition": {
       "alertCondition": "Alert condition"
+    },
+    "simplified": {
+      "condition": {
+        "title": "Condition"
+      },
+      "continue-in-alerting": "Continue in Alerting",
+      "create": "Create",
+      "evaluation": {
+        "immediate-warning": "Immediate firing might lead to unnecessary alerts being sent for temporary issues"
+      },
+      "notification": {
+        "contact-point-selected": "Notifications for firing alerts are routed to a selected contact point.",
+        "description": {
+          "aria-label": "Description",
+          "label": "Description (optional)",
+          "placeholder": "Enter a description of what the alert rule does…"
+        },
+        "manual-routing": {
+          "aria": "Toggle manual routing"
+        },
+        "policy-selected": "Notifications for firing alerts are routed to contact points based on matching labels and the notification policy tree.",
+        "recipient": {
+          "label": "Recipient"
+        },
+        "refresh-error": "Failed to refresh contact points",
+        "runbook-url": {
+          "aria-label": "Runbook URL",
+          "invalid-format": "Invalid URL format. Please enter a valid URL.",
+          "invalid-protocol": "Invalid URL protocol. Please use http or https.",
+          "label": "Runbook URL (optional)",
+          "placeholder": "Enter the webpage where you keep your runbook for the alert…"
+        },
+        "select-contact-point": "Select a contact point...",
+        "summary": {
+          "aria-label": "Summary",
+          "label": "Summary (optional)",
+          "placeholder": "Enter a summary of what happened and why…"
+        },
+        "title": "Notification"
+      },
+      "rule-definition": "Rule Definition"
     },
     "smart-alert-type-detector": {
       "data-source-managed": "Data source-managed",


### PR DESCRIPTION
This PR creates a new unified alerting flow to create a rule from a dashboard panel via a drawer UI.
This is behind a feature toggle `createAlertRuleFromPanel`.

[Figma designs here.](https://www.figma.com/proto/AYMboJsnYgSAAdYM9hoMLn/Alerting?page-id=0%3A1&node-id=8301-48366&viewport=-28211%2C-25813%2C0.47&t=0IISkf3HvFqGQv2N-1&scaling=min-zoom&content-scaling=fixed&starting-point-node-id=8301%3A48366)

<img width="1508" height="773" alt="image" src="https://github.com/user-attachments/assets/1706ee9a-24c3-4a9e-b004-de7121803660" />


Create Alert Rule from Panel Recording:
https://github.com/user-attachments/assets/4d7af39d-0eab-4697-baeb-e72f9cd5a62a

Create Alert Rule from panel but continue in Alerting Recording:
https://github.com/user-attachments/assets/cc14a273-fb4f-479b-a872-6172e1c0d3b1

