### PR TITLE
SaveProvisionedDashboardForm: Bug fix repo type incorrectly showing in preview banner

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -86,7 +86,7 @@ export function SaveProvisionedDashboardForm({
   );
 
   const navigateToPreview = useCallback(
-    (ref: string, path: string, repoType: string) => {
+    (ref: string, path: string, repoType?: string) => {
       const url = buildResourceBranchRedirectUrl({
         baseUrl: `${PROVISIONING_URL}/${defaultValues.repo}/dashboard/preview/${path}`,
         paramName: 'ref',
@@ -110,7 +110,7 @@ export function SaveProvisionedDashboardForm({
   }, [dashboard, defaultValues.folder?.uid, drawer, panelEditor, request?.data?.resource]);
 
   const onWriteSuccess = useCallback(
-    ({ repoType }: ProvisionedOperationInfo, upsert: Resource<Dashboard>) => {
+    (upsert: Resource<Dashboard>) => {
       handleDismiss();
       if (isNew && upsert?.metadata.name) {
         handleNewDashboard(upsert);
@@ -118,7 +118,7 @@ export function SaveProvisionedDashboardForm({
 
       // if pushed to an existing but non-configured branch, navigate to preview page
       if (ref !== repository?.branch && ref) {
-        navigateToPreview(ref, path, repoType);
+        navigateToPreview(ref, path, repository?.type);
         return;
       }
 
@@ -127,7 +127,7 @@ export function SaveProvisionedDashboardForm({
         editPanel: null,
       });
     },
-    [isNew, path, ref, repository?.branch, handleDismiss, handleNewDashboard, navigateToPreview]
+    [isNew, path, ref, repository?.branch, repository?.type, handleDismiss, handleNewDashboard, navigateToPreview]
   );
 
   const onBranchSuccess = useCallback(
@@ -147,6 +147,7 @@ export function SaveProvisionedDashboardForm({
     request,
     workflow,
     resourceType: 'dashboard',
+    repository,
     handlers: {
       onBranchSuccess: ({ ref, path }, info, resource) => onBranchSuccess(ref, path, info, resource),
       onWriteSuccess,

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -92,7 +92,7 @@ function FormContent({ initialValues, repository, workflowOptions, folder, onDis
     handlers: {
       onDismiss,
       onBranchSuccess,
-      onWriteSuccess: (_, resource) => onWriteSuccess(resource),
+      onWriteSuccess,
       onError,
     },
   });

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
@@ -153,12 +153,7 @@ describe('useProvisionedRequestHandler', () => {
       );
 
       expect(handlers.onWriteSuccess).toHaveBeenCalledWith(
-        expect.objectContaining({
-          resourceType: 'dashboard',
-          repoType: 'git',
-          workflow: 'write',
-        }),
-        expect.any(Object)
+        expect.objectContaining({ kind: 'Dashboard', metadata: expect.objectContaining({ name: 'test-dashboard' }) })
       );
       expect(handlers.onDismiss).toHaveBeenCalled();
     });

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -29,7 +29,7 @@ interface RequestHandlers<T> {
     info: ProvisionedOperationInfo,
     resource: Resource<T>
   ) => void;
-  onWriteSuccess?: (info: ProvisionedOperationInfo, resource: Resource<T>) => void;
+  onWriteSuccess?: (resource: Resource<T>) => void;
   onError?: (error: unknown, info: ProvisionedOperationInfo) => void;
   onDismiss?: () => void;
 }
@@ -116,7 +116,7 @@ export function useProvisionedRequestHandler<T>({
           // refetch folder items after success if folderUID is passed in
           dispatch(refetchChildren({ parentUID: folderUID || repository?.name, pageSize: PAGE_SIZE }));
         }
-        handlers.onWriteSuccess(info, resourceData);
+        handlers.onWriteSuccess(resourceData);
       }
 
       handlers.onDismiss?.();


### PR DESCRIPTION
**What is this feature?**

Bug fix when saving dashboard changes to branch, preview banner action button is showing wrong git type. 

**Why do we need this feature?**

Better user experience

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/638

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
