### PR TITLE
DashboardEmpty: Disable import dashboard function when a new dashboard is git provisioned

### DIFF
--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyHooks.ts
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyHooks.ts
@@ -73,8 +73,9 @@ export const useOnAddLibraryPanel = ({ dashboard, canCreate, isReadOnlyRepo }: H
 };
 
 export const useOnImportDashboard = ({ dashboard, canCreate, isReadOnlyRepo }: HookProps) => {
+  const isProvisioned = dashboard instanceof DashboardScene && dashboard.isManagedRepository();
   return useMemo(() => {
-    if (!canCreate || isReadOnlyRepo) {
+    if (!canCreate || isProvisioned || isReadOnlyRepo) {
       return undefined;
     }
 
@@ -82,5 +83,5 @@ export const useOnImportDashboard = ({ dashboard, canCreate, isReadOnlyRepo }: H
       DashboardInteractions.emptyDashboardButtonClicked({ item: 'import_dashboard' });
       onImportDashboardImpl();
     };
-  }, [canCreate, isReadOnlyRepo]);
+  }, [canCreate, isReadOnlyRepo, isProvisioned]);
 };


### PR DESCRIPTION
**What is this feature?**

When a new dashboard is git provisioned, **disable** **add panel** and **import dashboard** functionality. 
<img width="1080" height="762" alt="image" src="https://github.com/user-attachments/assets/f779863a-5444-44a6-8a14-1e05282e7445" />


**Why do we need this feature?**

Prevent error flow

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/637

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
