### PR TITLE
kvstore: Fix missing Folder field in listModifiedSinceEventStore data lookup

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -778,14 +778,7 @@ func (k *kvStorageBackend) listModifiedSinceEventStore(ctx context.Context, key 
 			}
 			seen[evtKey.Name] = struct{}{}
 
-			value, err := k.getValueFromDataStore(ctx, DataKey{
-				Group:           evtKey.Group,
-				Resource:        evtKey.Resource,
-				Namespace:       evtKey.Namespace,
-				Name:            evtKey.Name,
-				ResourceVersion: evtKey.ResourceVersion,
-				Action:          evtKey.Action,
-			})
+			value, err := k.getValueFromDataStore(ctx, DataKey(evtKey))
 			if err != nil {
 				yield(&ModifiedResource{}, err)
 				return

--- a/pkg/storage/unified/resource/storage_backend_test.go
+++ b/pkg/storage/unified/resource/storage_backend_test.go
@@ -815,6 +815,123 @@ func seedBackend(t *testing.T, backend *kvStorageBackend, ctx context.Context, n
 	return expectations
 }
 
+func TestKvStorageBackend_ListModifiedSince_WithFolder(t *testing.T) {
+	backend := setupTestStorageBackend(t)
+	ctx := context.Background()
+
+	// Use a unique resource type to avoid conflicts with other tests
+	ns := NamespacedResource{
+		Namespace: "test-folder-ns",
+		Group:     "test.folder.app",
+		Resource:  "test-resources",
+	}
+
+	// Create test objects with folder field set
+	testObj1, err := createTestObjectWithName("dashboard-1", ns, "data-1")
+	require.NoError(t, err)
+	metaAccessor1, err := utils.MetaAccessor(testObj1)
+	require.NoError(t, err)
+	metaAccessor1.SetFolder("folder-abc")
+
+	testObj2, err := createTestObjectWithName("dashboard-2", ns, "data-2")
+	require.NoError(t, err)
+	metaAccessor2, err := utils.MetaAccessor(testObj2)
+	require.NoError(t, err)
+	metaAccessor2.SetFolder("folder-xyz")
+
+	// Write first dashboard
+	writeEvent1 := WriteEvent{
+		Type: resourcepb.WatchEvent_ADDED,
+		Key: &resourcepb.ResourceKey{
+			Namespace: ns.Namespace,
+			Group:     ns.Group,
+			Resource:  ns.Resource,
+			Name:      "dashboard-1",
+		},
+		Value:      objectToJSONBytes(t, testObj1),
+		Object:     metaAccessor1,
+		PreviousRV: 0,
+	}
+	rv1, err := backend.WriteEvent(ctx, writeEvent1)
+	require.NoError(t, err)
+
+	// Write second dashboard
+	writeEvent2 := WriteEvent{
+		Type: resourcepb.WatchEvent_ADDED,
+		Key: &resourcepb.ResourceKey{
+			Namespace: ns.Namespace,
+			Group:     ns.Group,
+			Resource:  ns.Resource,
+			Name:      "dashboard-2",
+		},
+		Value:      objectToJSONBytes(t, testObj2),
+		Object:     metaAccessor2,
+		PreviousRV: 0,
+	}
+	rv2, err := backend.WriteEvent(ctx, writeEvent2)
+	require.NoError(t, err)
+
+	t.Run("via event store (recent RV < 1 hour)", func(t *testing.T) {
+		// Use recent RV to trigger event store path
+		recentRV := rv1 - 1
+
+		// List resources via event store
+		rv, seq := backend.ListModifiedSince(ctx, ns, recentRV)
+
+		changes := make(map[string]*ModifiedResource)
+		for mr, err := range seq {
+			require.NoError(t, err, "Should not get error when Folder field is included")
+			require.Equal(t, ns.Group, mr.Key.Group)
+			require.Equal(t, ns.Namespace, mr.Key.Namespace)
+			require.Equal(t, ns.Resource, mr.Key.Resource)
+			changes[mr.Key.Name] = mr
+		}
+
+		require.Greater(t, rv, recentRV)
+		require.Len(t, changes, 2, "Should return 2 resources")
+
+		// Verify dashboard-1
+		require.Contains(t, changes, "dashboard-1")
+		require.Equal(t, rv1, changes["dashboard-1"].ResourceVersion)
+		require.Equal(t, objectToJSONBytes(t, testObj1), changes["dashboard-1"].Value)
+
+		// Verify dashboard-2
+		require.Contains(t, changes, "dashboard-2")
+		require.Equal(t, rv2, changes["dashboard-2"].ResourceVersion)
+		require.Equal(t, objectToJSONBytes(t, testObj2), changes["dashboard-2"].Value)
+	})
+
+	t.Run("via data store (old RV > 1 hour)", func(t *testing.T) {
+		// Use old RV (2 hours) to trigger data store path
+		oldRV := generateOldSnowflake(t)
+
+		// List resources via data store
+		rv, seq := backend.ListModifiedSince(ctx, ns, oldRV)
+
+		changes := make(map[string]*ModifiedResource)
+		for mr, err := range seq {
+			require.NoError(t, err, "Should not get error when Folder field is included")
+			require.Equal(t, ns.Group, mr.Key.Group)
+			require.Equal(t, ns.Namespace, mr.Key.Namespace)
+			require.Equal(t, ns.Resource, mr.Key.Resource)
+			changes[mr.Key.Name] = mr
+		}
+
+		require.Greater(t, rv, oldRV)
+		require.GreaterOrEqual(t, len(changes), 2, "Should return at least 2 resources")
+
+		// Verify dashboard-1
+		require.Contains(t, changes, "dashboard-1")
+		require.Equal(t, rv1, changes["dashboard-1"].ResourceVersion)
+		require.Equal(t, objectToJSONBytes(t, testObj1), changes["dashboard-1"].Value)
+
+		// Verify dashboard-2
+		require.Contains(t, changes, "dashboard-2")
+		require.Equal(t, rv2, changes["dashboard-2"].ResourceVersion)
+		require.Equal(t, objectToJSONBytes(t, testObj2), changes["dashboard-2"].Value)
+	})
+}
+
 func createAndSaveTestObject(t *testing.T, backend *kvStorageBackend, ctx context.Context, ns NamespacedResource, uniqueStringGen func() string, updates int, deleted bool) *ModifiedResource {
 	name := uniqueStringGen()
 	action := resourcepb.WatchEvent_ADDED


### PR DESCRIPTION
Fixes a bug in `listModifiedSinceEventStore` where the `Folder` field was missing when constructing the `DataKey` for data store lookups. This caused resources within folders to fail retrieval with "key not found" errors when using the event store path (for changes < 1 hour old).

### Changes
- **storage_backend.go**: Changed `DataKey` construction in `listModifiedSinceEventStore` from a struct literal (which omitted the `Folder` field) to a type conversion `DataKey(evtKey)` that properly includes all fields
- **storage_backend_test.go**: Added comprehensive test coverage for `ListModifiedSince` with resources in folders, testing both code paths:
  - Event store path (recent RV < 1 hour)
  - Data store path (old RV > 1 hour)

### Why this matters
The `Folder` field is part of the storage key. When it was missing from the lookup key, any resources with a non-empty folder would fail to be retrieved via `listModifiedSinceEventStore`, breaking change synchronization for dashboards and other resources organized in folders.