### PR TITLE
Dashboard Save: Fix the issue of clicking Save button that wouldn't trigger save

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2115,11 +2115,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx": {
-    "no-restricted-syntax": {
-      "count": 4
-    }
-  },
   "public/app/features/dashboard-scene/saving/SaveDashboardForm.tsx": {
     "no-restricted-syntax": {
       "count": 1

--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -1,5 +1,4 @@
-import debounce from 'debounce-promise';
-import { ChangeEvent, useState, useEffect } from 'react';
+import { ChangeEvent, useCallback, useEffect, useRef, useState } from 'react';
 import { UseFormSetValue, useForm } from 'react-hook-form';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -43,19 +42,49 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
     },
   });
 
-  const { errors, isValid, validatingFields } = formState;
+  const { errors, isValid } = formState;
   const formValues = watch();
 
   const { state, onSaveDashboard } = useSaveDashboard(false);
 
   const [contentSent, setContentSent] = useState<{ title?: string; folderUid?: string }>({});
 
+  // Create a debounced validation function with useRef
+  const validationTimeoutRef = useRef<NodeJS.Timeout>();
+
   // Validate title on form mount to catch invalid default values
   useEffect(() => {
     trigger('title');
   }, [trigger]);
 
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      clearTimeout(validationTimeoutRef.current);
+    };
+  }, []);
+
+  const handleTitleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      setValue('title', e.target.value, { shouldDirty: true });
+      clearTimeout(validationTimeoutRef.current);
+      validationTimeoutRef.current = setTimeout(() => {
+        trigger('title');
+      }, 400);
+    },
+    [setValue, trigger]
+  );
+
   const onSave = async (overwrite: boolean) => {
+    clearTimeout(validationTimeoutRef.current);
+
+    const isTitleValid = await trigger('title');
+
+    // This prevents the race between the new input and old validation state
+    if (!isTitleValid) {
+      return;
+    }
+
     const data = getValues();
 
     const result = await onSaveDashboard(dashboard, {
@@ -88,16 +117,7 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
   );
 
   const saveButton = (overwrite: boolean) => {
-    const isTitleValidating = !!validatingFields.title;
-
-    return (
-      <SaveButton
-        isValid={isValid && !isTitleValidating}
-        isLoading={state.loading}
-        onSave={onSave}
-        overwrite={overwrite}
-      />
-    );
+    return <SaveButton isValid={isValid} isLoading={state.loading} onSave={onSave} overwrite={overwrite} />;
   };
   function renderFooter(error?: Error) {
     const formValuesMatchContentSent =
@@ -128,23 +148,27 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
 
   return (
     <form onSubmit={handleSubmit(() => onSave(false))}>
-      <Field label={<TitleFieldLabel onChange={setValue} />} invalid={!!errors.title} error={errors.title?.message}>
+      <Field
+        noMargin
+        label={<TitleFieldLabel onChange={setValue} />}
+        invalid={!!errors.title}
+        error={errors.title?.message}
+      >
         <Input
           {...register('title', {
             required: t('dashboard-scene.save-dashboard-as-form.required', 'Required'),
             validate: validateDashboardName,
+            onChange: handleTitleChange,
           })}
           aria-label={t(
             'dashboard-scene.save-dashboard-as-form.aria-label-save-dashboard-title-field',
             'Save dashboard title field'
           )}
           data-testid={selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput}
-          onChange={debounce(async (e: ChangeEvent<HTMLInputElement>) => {
-            setValue('title', e.target.value, { shouldValidate: true });
-          }, 400)}
         />
       </Field>
       <Field
+        noMargin
         label={<DescriptionLabel onChange={setValue} />}
         invalid={!!errors.description}
         error={errors.description?.message}
@@ -159,7 +183,7 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
         />
       </Field>
 
-      <Field label={t('dashboard-scene.save-dashboard-as-form.label-folder', 'Folder')}>
+      <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-folder', 'Folder')}>
         <FolderPicker
           onChange={async (uid: string | undefined, title: string | undefined) => {
             setValue('folder', { uid, title });
@@ -177,7 +201,7 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
         />
       </Field>
       {!changeInfo.isNew && (
-        <Field label={t('dashboard-scene.save-dashboard-as-form.label-copy-tags', 'Copy tags')}>
+        <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-copy-tags', 'Copy tags')}>
           <Switch {...register('copyTags')} />
         </Field>
       )}

--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -49,7 +49,6 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
 
   const [contentSent, setContentSent] = useState<{ title?: string; folderUid?: string }>({});
 
-  // Create a debounced validation function with useRef
   const validationTimeoutRef = useRef<NodeJS.Timeout>();
 
   // Validate title on form mount to catch invalid default values


### PR DESCRIPTION
### Problem

This PR fixes an issue that was happening with Save dashboard button. If user typed in a valid dashboard title and then clicked on Save button, the save was not triggered, and user would have to press tab to bring the save button in focus or click outside of the dashboard title first. 

This was not noticeable in the local environment, but it does occur currently in ops.

The way to reproduce this locally is to throttle the CPU to at least 6x.

### Root Cause

Debouncing the `setValue` call delayed form updates. Clicking Save before the debounce completed caused a race: validation finished after the click, leaving the button in an inconsistent state and leading to misclicks or ignored clicks.

### Solution

- Updated the input to commit values immediately.
- Kept validation debounced (400ms after typing).
- Added a validation guard in `onSave`: run validation first and return early if it fails.

### Testing

**With the fix:** 
Set CPU throttling at 6x:
1. Create a new dashboard
2. Click Save to open the save dashboard form
3. Enter a dashboard title.
4. Click Save immediately.
5. Expected: single-click save works.
6. Enter a duplicate name → validation blocks save as expected.

**To reproduce the issue:**
  In our ops instance:
  1. Create a new dashboard
  2. Click Save to open the save dashboard form
  3. Enter a dashboard title.
  4. Click Save immediately. Save won't be triggered

  On main:
  1. Set CPU throttling to 6x
  2. Enter a dashboard title.
  7. Click Save immediately. Save won't be triggered

Please check that:
- [ ] It works as expected from a user's perspective.
