### PR TITLE
CloudWatch Logs: Limit CloudWatch logs queries to use logGroupIdentifiers only for monitoring accounts

### DIFF
--- a/pkg/tsdb/cloudwatch/log_actions.go
+++ b/pkg/tsdb/cloudwatch/log_actions.go
@@ -232,10 +232,8 @@ func (ds *DataSource) executeStartQuery(ctx context.Context, logsClient models.C
 						arn := strings.TrimSuffix(lg.Arn, "*")
 						logGroupIdentifiers = append(logGroupIdentifiers, arn)
 					}
-					if len(logGroupIdentifiers) > 0 {
-						startQueryInput.LogGroupIdentifiers = logGroupIdentifiers
-						useLogGroupIdentifiers = true
-					}
+					startQueryInput.LogGroupIdentifiers = logGroupIdentifiers
+					useLogGroupIdentifiers = true
 				}
 			}
 		}

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -263,8 +263,8 @@ describe('datasource', () => {
       expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject({
         queryString: 'fields templatedField',
         logGroups: [
-          { name: 'templatedGroup-arn-1', arn: 'templatedGroup-arn-1' },
-          { name: 'templatedGroup-arn-2', arn: 'templatedGroup-arn-2' },
+          { name: 'templatedGroup-1', arn: 'templatedGroup-arn-1' },
+          { name: 'templatedGroup-2', arn: 'templatedGroup-arn-2' },
         ],
         logGroupNames: ['/some/group'],
         region: 'templatedRegion',
@@ -394,8 +394,9 @@ describe('datasource', () => {
 
       expect(templateService.replace).toHaveBeenNthCalledWith(1, '$regionVar', {});
       expect(templateService.replace).toHaveBeenNthCalledWith(2, '$groups', {}, 'pipe');
-      expect(templateService.replace).toHaveBeenNthCalledWith(3, '$expressionVar', {}, undefined);
-      expect(templateService.replace).toHaveBeenCalledTimes(3);
+      expect(templateService.replace).toHaveBeenNthCalledWith(3, '$groups', {}, 'text');
+      expect(templateService.replace).toHaveBeenNthCalledWith(4, '$expressionVar', {}, undefined);
+      expect(templateService.replace).toHaveBeenCalledTimes(4);
     });
 
     it('should replace correct variables in CloudWatchMetricsQuery', () => {

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -9,7 +9,7 @@ import {
   MutableDataFrame,
 } from '@grafana/data';
 
-import { regionVariable } from '../mocks/CloudWatchDataSource';
+import { logGroupNamesVariable, regionVariable } from '../mocks/CloudWatchDataSource';
 import { setupMockedLogsQueryRunner } from '../mocks/LogsQueryRunner';
 import { LogsRequestMock } from '../mocks/Request';
 import { validLogsQuery } from '../mocks/queries';
@@ -20,6 +20,63 @@ import { LOGSTREAM_IDENTIFIER_INTERNAL, LOG_IDENTIFIER_INTERNAL } from './CloudW
 describe('CloudWatchLogsQueryRunner', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  describe('interpolateLogsQueryVariables', () => {
+    it('returns logGroups with arn and name values sourced from the log group template variable', () => {
+      const { runner } = setupMockedLogsQueryRunner({ variables: [logGroupNamesVariable] });
+
+      const query: CloudWatchLogsQuery = {
+        ...validLogsQuery,
+        logGroups: [{ arn: '$groups', name: '$groups' }],
+      };
+
+      const { logGroups } = runner.interpolateLogsQueryVariables(query, {});
+
+      expect(logGroups).toEqual([
+        { arn: 'templatedGroup-arn-1', name: 'templatedGroup-1' },
+        { arn: 'templatedGroup-arn-2', name: 'templatedGroup-2' },
+      ]);
+    });
+
+    it('filters out duplicate log group arns when query already includes an expanded value', () => {
+      const { runner } = setupMockedLogsQueryRunner({ variables: [logGroupNamesVariable] });
+
+      const query: CloudWatchLogsQuery = {
+        ...validLogsQuery,
+        logGroups: [
+          { arn: 'templatedGroup-arn-1', name: 'existing-group-name' },
+          { arn: '$groups', name: '$groups' },
+        ],
+      };
+
+      const { logGroups } = runner.interpolateLogsQueryVariables(query, {});
+
+      expect(logGroups).toEqual([
+        { arn: 'templatedGroup-arn-1', name: 'existing-group-name' },
+        { arn: 'templatedGroup-arn-2', name: 'templatedGroup-2' },
+      ]);
+    });
+
+    it('keeps log groups with duplicate names as long as arns are unique', () => {
+      const { runner } = setupMockedLogsQueryRunner({ variables: [logGroupNamesVariable] });
+
+      const query: CloudWatchLogsQuery = {
+        ...validLogsQuery,
+        logGroups: [
+          { arn: 'arn-1', name: 'templatedGroup-1' },
+          { arn: '$groups', name: '$groups' },
+        ],
+      };
+
+      const { logGroups } = runner.interpolateLogsQueryVariables(query, {});
+
+      expect(logGroups).toEqual([
+        { arn: 'arn-1', name: 'templatedGroup-1' },
+        { arn: 'templatedGroup-arn-1', name: 'templatedGroup-1' },
+        { arn: 'templatedGroup-arn-2', name: 'templatedGroup-2' },
+      ]);
+    });
   });
 
   describe('getLogRowContext', () => {

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -1,4 +1,4 @@
-import { set, uniq } from 'lodash';
+import { set, uniq, uniqBy } from 'lodash';
 import {
   concatMap,
   finalize,
@@ -189,9 +189,19 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
       (query.logGroups || this.instanceSettings.jsonData.logGroups || []).map((lg) => lg.arn),
       scopedVars
     );
+    const interpolatedLogGroupNames = interpolateStringArrayUsingSingleOrMultiValuedVariable(
+      this.templateSrv,
+      (query.logGroups || this.instanceSettings.jsonData.logGroups || []).map((lg) => lg.name),
+      scopedVars,
+      'text'
+    );
+    const interpolatedLogGroups = interpolatedLogGroupArns.map((arn, index) => ({
+      arn,
+      name: interpolatedLogGroupNames[index] ?? arn,
+    }));
 
     // need to support legacy format variables too
-    const interpolatedLogGroupNames = interpolateStringArrayUsingSingleOrMultiValuedVariable(
+    const interpolatedLegacyLogGroupNames = interpolateStringArrayUsingSingleOrMultiValuedVariable(
       this.templateSrv,
       query.logGroupNames || this.instanceSettings.jsonData.defaultLogGroups || [],
       scopedVars,
@@ -200,8 +210,8 @@ export class CloudWatchLogsQueryRunner extends CloudWatchRequest {
 
     // if a log group template variable expands to log group that has already been selected in the log group picker, we need to remove duplicates.
     // Otherwise the StartLogQuery API will return a permission error
-    const logGroups = uniq(interpolatedLogGroupArns).map((arn) => ({ arn, name: arn }));
-    const logGroupNames = uniq(interpolatedLogGroupNames);
+    const logGroups = uniqBy(interpolatedLogGroups, 'arn');
+    const logGroupNames = uniq(interpolatedLegacyLogGroupNames);
 
     const logsSQLCustomerFormatter = (value: unknown, model: Partial<CustomFormatterVariable>) => {
       if (


### PR DESCRIPTION
**What is this feature?**

This PR makes it so CloudWatch logs queries use the [logGroupIdentifiers](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html#CWL-StartQuery-request-logGroupIdentifiers) parameter only when the data source is configured as a monitoring account for the region of the query.

Otherwise, logs queries will use the [logGroupName](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_StartQuery.html#CWL-StartQuery-request-logGroupNames) parameter.

**Why do we need this feature?**

Previously, we always used the `logGroupName` parameter for logs queries. When Cross-Account Observability was introduced, we switched over to using `logGroupIdentifiers` for all newly created queries when cross account observability was enabled.

However, this caused issues for dashboards that were designed to work across different accounts. For example, a dashboard could be set to query a log group `my-apps-log-group`. This log group could exist in multiple different AWS accounts such as `dev-aws-account` and `prod-aws-account`. Users could create a dashboard using the `my-apps-log-group` with a data source for `dev-aws-account` and switch to using a data source for `prod-aws-accout` and it would work. But it would not work if they had cross account observability enabled on their instance because it would use the `logGroupIdentifiers` to query for logs. This would cause errors because `logGroupIdentifiers` uses the ARN of a log group, which includes the account number and region in it meaning the query can only work for the account the log group belongs to.

This PR makes it so only monitoring account data sources use the `logGroupIdentifiers` parameter for querying logs. That way previously created dashboards can continue using the previous behaviour, without needing to disable cross account observability for the entire instance.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #111504

**Special notes for your reviewer:**

You can test this by have 2 different CloudWatch data sources set up in different accounts. Create a new logs query (the default query is fine) and select the `RDSOSMetrics` log group (this log group was available for external dev and the "AWS CloudWatch" provisioned data source. When you switch between the two data sources, the query should continue to run fine while fetching data for the selected data source. You can either switch the data source from the panel, or use a data source variable to switch the data source.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
