### PR TITLE
Dashboard Provisioning: Add duplicate cleanup

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -319,7 +319,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 		for _, dashboard := range provisioningData {
 			list.Results.Rows = append(list.Results.Rows, &resourcepb.ResourceTableRow{
 				Key: getResourceKey(&dashboards.DashboardSearchProjection{
-					UID: dashboard.Dashboard.UID,
+					UID: dashboard.UID,
 				}, req.Options.Key.Namespace),
 				Cells: c.createDetailedProvisioningCells(dashboard, query),
 			})
@@ -519,7 +519,7 @@ func (c *DashboardSearchClient) createProvisioningCells(dashboard *dashboards.Da
 }
 
 func (c *DashboardSearchClient) createDetailedProvisioningCells(dashboard *dashboards.DashboardProvisioningSearchResults, query *dashboards.FindPersistedDashboardsQuery) [][]byte {
-	cells := c.createCommonCells(dashboard.Dashboard.Title, dashboard.Dashboard.FolderUID, dashboard.Dashboard.ID, []byte("[]"))
+	cells := c.createCommonCells(dashboard.Title, dashboard.FolderUID, dashboard.ID, []byte("[]"))
 	return append(cells,
 		[]byte(query.ManagedBy),
 		[]byte(dashboard.Provisioner),

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -290,17 +290,24 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 		// for classic FP, we will return the regular search response alongside all the data in the dashboard_provisioning table
 		provisioningData := []*dashboards.DashboardProvisioningSearchResults{}
 		if query.ManagerIdentity == "" {
-			var data *dashboards.DashboardProvisioningSearchResults
-			if len(query.DashboardIds) > 0 {
-				data, err = c.dashboardStore.GetProvisionedDataByDashboardID(ctx, query.DashboardIds[0])
-			} else if len(query.DashboardUIDs) > 0 {
-				data, err = c.dashboardStore.GetProvisionedDataByDashboardUID(ctx, user.GetOrgID(), query.DashboardUIDs[0])
-			}
-			if err != nil {
-				return nil, err
-			}
-			if data != nil {
-				provisioningData = append(provisioningData, data)
+			if len(query.DashboardIds) > 0 || len(query.DashboardUIDs) > 0 {
+				var data *dashboards.DashboardProvisioningSearchResults
+				if len(query.DashboardIds) > 0 {
+					data, err = c.dashboardStore.GetProvisionedDataByDashboardID(ctx, query.DashboardIds[0])
+				} else if len(query.DashboardUIDs) > 0 {
+					data, err = c.dashboardStore.GetProvisionedDataByDashboardUID(ctx, user.GetOrgID(), query.DashboardUIDs[0])
+				}
+				if err != nil {
+					return nil, err
+				}
+				if data != nil {
+					provisioningData = append(provisioningData, data)
+				}
+			} else {
+				provisioningData, err = c.dashboardStore.GetAllProvisionedDashboards(ctx, user.GetOrgID())
+				if err != nil {
+					return nil, err
+				}
 			}
 		} else {
 			provisioningData, err = c.dashboardStore.GetProvisionedDashboardsByName(ctx, query.ManagerIdentity, user.GetOrgID())

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -454,7 +454,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 	t.Run("Should retrieve dashboards by provisioner name through a different function", func(t *testing.T) {
 		mockStore.On("GetProvisionedDashboardsByName", mock.Anything, "test", mock.Anything).Return([]*dashboards.DashboardProvisioningSearchResults{
 			{
-				Dashboard:   dashboards.Dashboard{UID: "uid", Title: "Test Dashboard", FolderUID: "folder1"},
+				UID:         "uid",
+				Title:       "Test Dashboard",
+				FolderUID:   "folder1",
 				ExternalID:  "test",
 				Provisioner: string(utils.ManagerKindClassicFP), // nolint:staticcheck
 			},

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -86,6 +86,7 @@ type Store interface {
 	GetProvisionedDataByDashboardID(ctx context.Context, dashboardID int64) (*DashboardProvisioningSearchResults, error)
 	GetProvisionedDataByDashboardUID(ctx context.Context, orgID int64, dashboardUID string) (*DashboardProvisioningSearchResults, error)
 	GetProvisionedDashboardsByName(ctx context.Context, name string, orgID int64) ([]*DashboardProvisioningSearchResults, error)
+	GetAllProvisionedDashboards(ctx context.Context, orgID int64) ([]*DashboardProvisioningSearchResults, error)
 	GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string, orgID int64) ([]*Dashboard, error)
 	SaveDashboard(ctx context.Context, cmd SaveDashboardCommand) (*Dashboard, error)
 	SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error)

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -209,7 +209,9 @@ func (d *dashboardStore) GetProvisionedDataByDashboardID(ctx context.Context, da
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
 			Where(`dashboard_provisioning.dashboard_id = ?`, dashboardID).
-			Select("dashboard.*, dashboard_provisioning.name, dashboard_provisioning.external_id, dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum").
+			Select(`dashboard.id, dashboard.uid, dashboard.title, dashboard.folder_uid, 
+				dashboard_provisioning.name, dashboard_provisioning.external_id, 
+				dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum`).
 			Find(&data)
 	})
 	if err != nil {
@@ -241,7 +243,9 @@ func (d *dashboardStore) GetProvisionedDataByDashboardUID(ctx context.Context, o
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
 			Where(`dashboard_provisioning.dashboard_id = ?`, dashboard.ID).
-			Select("dashboard.*, dashboard_provisioning.name, dashboard_provisioning.external_id, dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum").
+			Select(`dashboard.id, dashboard.uid, dashboard.title, dashboard.folder_uid, 
+				dashboard_provisioning.name, dashboard_provisioning.external_id, 
+				dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum`).
 			Find(&provisionedDashboard)
 	})
 	if err != nil {
@@ -275,7 +279,9 @@ func (d *dashboardStore) GetProvisionedDashboardsByName(ctx context.Context, nam
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
 			Where(`dashboard_provisioning.name = ? AND dashboard.org_id = ?`, name, orgID).
-			Select("dashboard.*, dashboard_provisioning.name, dashboard_provisioning.external_id, dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum").
+			Select(`dashboard.id, dashboard.uid, dashboard.title, dashboard.folder_uid, 
+				dashboard_provisioning.name, dashboard_provisioning.external_id, 
+				dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum`).
 			Find(&dashes)
 	})
 	if err != nil {
@@ -290,10 +296,13 @@ func (d *dashboardStore) GetAllProvisionedDashboards(ctx context.Context, orgID 
 
 	dashes := []*dashboards.DashboardProvisioningSearchResults{}
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
+		// Select only the minimal fields needed for search/provisioning operations (no dashboard body)
 		return sess.Table(`dashboard`).
 			Join(`INNER`, `dashboard_provisioning`, `dashboard.id = dashboard_provisioning.dashboard_id`).
 			Where(`dashboard.org_id = ?`, orgID).
-			Select("dashboard.*, dashboard_provisioning.name, dashboard_provisioning.external_id, dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum").
+			Select(`dashboard.id, dashboard.uid, dashboard.title, dashboard.folder_uid, 
+				dashboard_provisioning.name, dashboard_provisioning.external_id, 
+				dashboard_provisioning.updated as provisioning_updated, dashboard_provisioning.check_sum`).
 			Find(&dashes)
 	})
 	if err != nil {

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -241,11 +241,14 @@ type DeleteOrphanedProvisionedDashboardsCommand struct {
 }
 
 type DashboardProvisioningSearchResults struct {
-	Dashboard       Dashboard `xorm:"extends"`
-	Provisioner     string    `xorm:"name"`
-	ExternalID      string    `xorm:"external_id"`
-	CheckSum        string    `xorm:"check_sum"`
-	ProvisionUpdate int64     `xorm:"provisioning_updated"`
+	ID              int64  `xorm:"id"`
+	UID             string `xorm:"uid"`
+	Title           string `xorm:"title"`
+	FolderUID       string `xorm:"folder_uid"`
+	Provisioner     string `xorm:"name"`
+	ExternalID      string `xorm:"external_id"`
+	CheckSum        string `xorm:"check_sum"`
+	ProvisionUpdate int64  `xorm:"provisioning_updated"`
 }
 
 //

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -365,6 +365,36 @@ func (_m *FakeDashboardStore) GetProvisionedDashboardsByName(ctx context.Context
 	return r0, r1
 }
 
+// GetAllProvisionedDashboards provides a mock function with given fields: ctx, orgID
+func (_m *FakeDashboardStore) GetAllProvisionedDashboards(ctx context.Context, orgID int64) ([]*DashboardProvisioningSearchResults, error) {
+	ret := _m.Called(ctx, orgID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllProvisionedDashboards")
+	}
+
+	var r0 []*DashboardProvisioningSearchResults
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, int64) ([]*DashboardProvisioningSearchResults, error)); ok {
+		return rf(ctx, orgID)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int64) []*DashboardProvisioningSearchResults); ok {
+		r0 = rf(ctx, orgID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*DashboardProvisioningSearchResults)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int64) error); ok {
+		r1 = rf(ctx, orgID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetProvisionedDataByDashboardID provides a mock function with given fields: ctx, dashboardID
 func (_m *FakeDashboardStore) GetProvisionedDataByDashboardID(ctx context.Context, dashboardID int64) (*DashboardProvisioningSearchResults, error) {
 	ret := _m.Called(ctx, dashboardID)


### PR DESCRIPTION
This bug https://github.com/grafana/grafana/pull/112619 caused duplicate provisioned dashboards for instances in modes 1-3. Although the bug is fixed, the duplicate provisioned dashboards remain. This PR adds a cleanup for duplicate provisioned dashboards _if_ the provisioner name and external id match, ie:

```
1	1	default	/dashboards/annotations/annotation-filtering.json	1760060767	1e2a6ea02b007f42b9b53fa3d1aa1fdb
2	2	default	/dashboards/annotations/test.json	1760899526	6f357b6e0db2fe30fb58ce8da7bdc734
3	3	default	/dashboards/annotations/test.json	1760899527	6f357b6e0db2fe30fb58ce8da7bdc734
```

dashboard 2 _or_ 3 would be cleaned up (it doesn't matter which as if the checksum is different, it will be overwritten by the most up to date json)