### PR TITLE
Docs: Update search default information

### DIFF
--- a/docs/sources/developers/http_api/folder_dashboard_search.md
+++ b/docs/sources/developers/http_api/folder_dashboard_search.md
@@ -36,7 +36,7 @@ Query parameters:
 - **dashboardUIDs** – List of dashboard uid's to search for
 - **folderUIDs** – List of folder UIDs to search in
 - **starred** – Flag indicating if only starred Dashboards should be returned
-- **limit** – Limit the number of returned results (max is 5000; default is 1000)
+- **limit** – Limit the number of returned results (max is 5000; default is 1000). If an invalid value is provided (for example, strings or special characters), the parameter defaults to 1000.
 - **page** – Use this parameter to access hits beyond limit. Numbering starts at 1. limit param acts as page size.
 
 **Example request for retrieving folders and dashboards at the root level**:


### PR DESCRIPTION
This PR documents how we handle invalid  limit query parameters (we use the default of 1000 items)

Fixes https://github.com/grafana/grafana/issues/109463