### PR TITLE
Provisioning: concurrent deletes in finalizers and 404 handling

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
@@ -1,0 +1,29 @@
+package cuevalidator
+
+import (
+	"sync"
+
+	"cuelang.org/go/cue"
+	cuejson "cuelang.org/go/encoding/json"
+)
+
+// Validator provides thread-safe CUE schema validation.
+//
+// CUE is not safe for concurrent use: https://github.com/cue-lang/cue/discussions/1205#discussioncomment-1189238
+// This validator uses a mutex to protect concurrent access to the underlying CUE validation.
+type Validator struct {
+	schema cue.Value
+	mu     sync.Mutex
+}
+
+func NewValidator(schema cue.Value) *Validator {
+	return &Validator{
+		schema: schema,
+	}
+}
+
+func (v *Validator) Validate(data []byte) error {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	return cuejson.Validate(data, v.schema)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
@@ -12,8 +12,8 @@ import (
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
-	cuejson "cuelang.org/go/encoding/json"
 
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 )
 
@@ -34,7 +34,7 @@ func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorLis
 		}, schemaVersionError
 	}
 
-	if err := cuejson.Validate(data, getCueSchema()); err != nil {
+	if err := getValidator().Validate(data); err != nil {
 		errs := field.ErrorList{}
 
 		for _, e := range errors.Errors(err) {
@@ -72,20 +72,21 @@ func formatErrorPath(path []string) string {
 }
 
 var (
-	compiledSchema cue.Value
-	getSchemaOnce  sync.Once
+	validator     *cuevalidator.Validator
+	getSchemaOnce sync.Once
 )
 
 //go:embed dashboard_kind.cue
 var schemaSource string
 
-func getCueSchema() cue.Value {
+func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
 		cueCtx := cuecontext.New()
-		compiledSchema = cueCtx.CompileString(schemaSource).LookupPath(
+		compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(
 			cue.ParsePath("lineage.schemas[0].schema.spec"),
 		)
+		validator = cuevalidator.NewValidator(compiledSchema)
 	})
 
-	return compiledSchema
+	return validator
 }

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -41,6 +41,7 @@ type provisioningControllerConfig struct {
 	clients             resources.ClientFactory
 	tokenExchangeClient *authn.TokenExchangeClient
 	tlsConfig           rest.TLSClientConfig
+	maxSyncWorkers      int
 }
 
 // expects:
@@ -201,6 +202,7 @@ func setupFromConfig(cfg *setting.Cfg, registry prometheus.Registerer) (controll
 		resyncInterval:      operatorSec.Key("resync_interval").MustDuration(60 * time.Second),
 		tokenExchangeClient: tokenExchangeClient,
 		tlsConfig:           tlsConfig,
+		maxSyncWorkers:      operatorSec.Key("max_sync_workers").MustInt(10),
 	}, nil
 }
 

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -41,7 +41,6 @@ type provisioningControllerConfig struct {
 	clients             resources.ClientFactory
 	tokenExchangeClient *authn.TokenExchangeClient
 	tlsConfig           rest.TLSClientConfig
-	maxSyncWorkers      int
 }
 
 // expects:
@@ -202,7 +201,6 @@ func setupFromConfig(cfg *setting.Cfg, registry prometheus.Registerer) (controll
 		resyncInterval:      operatorSec.Key("resync_interval").MustDuration(60 * time.Second),
 		tokenExchangeClient: tokenExchangeClient,
 		tlsConfig:           tlsConfig,
-		maxSyncWorkers:      operatorSec.Key("max_sync_workers").MustInt(10),
 	}, nil
 }
 

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -90,6 +90,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		statusPatcher,
 		deps.Registerer,
 		tracer,
+		controllerCfg.maxSyncWorkers,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create repository controller: %w", err)
@@ -110,6 +111,7 @@ type repoControllerConfig struct {
 	allowedTargets      []string
 	allowImageRendering bool
 	minSyncInterval     time.Duration
+	maxSyncWorkers      int
 }
 
 func getRepoControllerConfig(cfg *setting.Cfg, registry prometheus.Registerer) (*repoControllerConfig, error) {
@@ -130,5 +132,6 @@ func getRepoControllerConfig(cfg *setting.Cfg, registry prometheus.Registerer) (
 		workerCount:                  cfg.SectionWithEnvOverrides("operator").Key("worker_count").MustInt(1),
 		allowImageRendering:          cfg.SectionWithEnvOverrides("provisioning").Key("allow_image_rendering").MustBool(false),
 		minSyncInterval:              cfg.SectionWithEnvOverrides("provisioning").Key("min_sync_interval").MustDuration(1 * time.Minute),
+		maxSyncWorkers:               controllerCfg.maxSyncWorkers,
 	}, nil
 }

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -90,7 +90,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		statusPatcher,
 		deps.Registerer,
 		tracer,
-		controllerCfg.maxSyncWorkers,
+		controllerCfg.parallelOperations,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create repository controller: %w", err)
@@ -108,10 +108,10 @@ func RunRepoController(deps server.OperatorDependencies) error {
 type repoControllerConfig struct {
 	provisioningControllerConfig
 	workerCount         int
+	parallelOperations  int
 	allowedTargets      []string
 	allowImageRendering bool
 	minSyncInterval     time.Duration
-	maxSyncWorkers      int
 }
 
 func getRepoControllerConfig(cfg *setting.Cfg, registry prometheus.Registerer) (*repoControllerConfig, error) {
@@ -130,8 +130,8 @@ func getRepoControllerConfig(cfg *setting.Cfg, registry prometheus.Registerer) (
 		provisioningControllerConfig: *controllerCfg,
 		allowedTargets:               allowedTargets,
 		workerCount:                  cfg.SectionWithEnvOverrides("operator").Key("worker_count").MustInt(1),
+		parallelOperations:           cfg.SectionWithEnvOverrides("operator").Key("parallel_operations").MustInt(10),
 		allowImageRendering:          cfg.SectionWithEnvOverrides("provisioning").Key("allow_image_rendering").MustBool(false),
 		minSyncInterval:              cfg.SectionWithEnvOverrides("provisioning").Key("min_sync_interval").MustDuration(1 * time.Minute),
-		maxSyncWorkers:               controllerCfg.maxSyncWorkers,
 	}, nil
 }

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -147,7 +147,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(&provisioning.ResourceList{
 						Items: []provisioning.ResourceListItem{
@@ -171,12 +171,12 @@ func TestFinalizer_process(t *testing.T) {
 				}
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
 				clients.
-					On("ForResource", context.Background(), schema.GroupVersionResource{
+					On("ForResource", mock.Anything, schema.GroupVersionResource{
 						Group:    "dashboard.grafana.app",
 						Resource: "dashboards",
 					}).
@@ -203,7 +203,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(&provisioning.ResourceList{
 						Items: []provisioning.ResourceListItem{
@@ -227,12 +227,12 @@ func TestFinalizer_process(t *testing.T) {
 				}
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
 				clients.
-					On("ForResource", context.Background(), schema.GroupVersionResource{
+					On("ForResource", mock.Anything, schema.GroupVersionResource{
 						Group:    "dashboard.grafana.app",
 						Resource: "dashboards",
 					}).
@@ -260,7 +260,7 @@ func TestFinalizer_process(t *testing.T) {
 				clientFactory := resources.NewMockClientFactory(t)
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(nil, assert.AnError)
 
@@ -282,7 +282,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(nil, assert.AnError)
 
@@ -293,7 +293,7 @@ func TestFinalizer_process(t *testing.T) {
 				clients := resources.NewMockResourceClients(t)
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
@@ -315,7 +315,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(&provisioning.ResourceList{
 						Items: []provisioning.ResourceListItem{
@@ -334,12 +334,12 @@ func TestFinalizer_process(t *testing.T) {
 				clients := resources.NewMockResourceClients(t)
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
 				clients.
-					On("ForResource", context.Background(), schema.GroupVersionResource{
+					On("ForResource", mock.Anything, schema.GroupVersionResource{
 						Group:    "dashboard.grafana.app",
 						Resource: "dashboards",
 					}).
@@ -364,7 +364,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(&provisioning.ResourceList{
 						Items: []provisioning.ResourceListItem{
@@ -388,12 +388,12 @@ func TestFinalizer_process(t *testing.T) {
 				}
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
 				clients.
-					On("ForResource", context.Background(), schema.GroupVersionResource{
+					On("ForResource", mock.Anything, schema.GroupVersionResource{
 						Group:    "dashboard.grafana.app",
 						Resource: "dashboards",
 					}).
@@ -421,7 +421,7 @@ func TestFinalizer_process(t *testing.T) {
 				resourceLister := resources.NewMockResourceLister(t)
 
 				resourceLister.
-					On("List", context.Background(), "default", "my-repo").
+					On("List", mock.Anything, "default", "my-repo").
 					Once().
 					Return(&provisioning.ResourceList{
 						Items: []provisioning.ResourceListItem{
@@ -445,12 +445,12 @@ func TestFinalizer_process(t *testing.T) {
 				}
 
 				clientFactory.
-					On("Clients", context.Background(), "default").
+					On("Clients", mock.Anything, "default").
 					Once().
 					Return(clients, nil)
 
 				clients.
-					On("ForResource", context.Background(), schema.GroupVersionResource{
+					On("ForResource", mock.Anything, schema.GroupVersionResource{
 						Group:    "dashboard.grafana.app",
 						Resource: "dashboards",
 					}).

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -84,6 +84,7 @@ func NewRepositoryController(
 	statusPatcher StatusPatcher,
 	registry prometheus.Registerer,
 	tracer tracing.Tracer,
+	maxSyncWorkers int,
 ) (*RepositoryController, error) {
 	finalizerMetrics := registerFinalizerMetrics(registry)
 
@@ -104,6 +105,7 @@ func NewRepositoryController(
 			lister:        resourceLister,
 			clientFactory: clients,
 			metrics:       &finalizerMetrics,
+			maxWorkers:    maxSyncWorkers,
 		},
 		jobs:      jobs,
 		logger:    logging.DefaultLogger.With("logger", loggerName),

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -84,7 +84,7 @@ func NewRepositoryController(
 	statusPatcher StatusPatcher,
 	registry prometheus.Registerer,
 	tracer tracing.Tracer,
-	maxSyncWorkers int,
+	parallelOperations int,
 ) (*RepositoryController, error) {
 	finalizerMetrics := registerFinalizerMetrics(registry)
 
@@ -105,7 +105,7 @@ func NewRepositoryController(
 			lister:        resourceLister,
 			clientFactory: clients,
 			metrics:       &finalizerMetrics,
-			maxWorkers:    maxSyncWorkers,
+			maxWorkers:    parallelOperations,
 		},
 		jobs:      jobs,
 		logger:    logging.DefaultLogger.With("logger", loggerName),

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -798,6 +798,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.statusPatcher,
 				b.registry,
 				b.tracer,
+				10,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
This PR tackles the following:
- Handle 404s in finalizers
- Parallel deletion when executing repo finalizers
- Fix Dashboard thread safe validation for cue

Closes:
https://github.com/grafana/git-ui-sync-project/issues/640
https://github.com/grafana/git-ui-sync-project/issues/624
https://github.com/grafana/git-ui-sync-project/issues/627

From ~5req/s capped, not it executes in parallel (only for dashboards as in repo creation)
<img width="1210" height="1110" alt="CleanShot 2025-10-29 at 11 44 05@2x" src="https://github.com/user-attachments/assets/df79fd32-e900-4e9d-a78b-5ceb9fe1252e" />