### PR TITLE
log: added debug-log

### DIFF
--- a/pkg/api/ds_query.go
+++ b/pkg/api/ds_query.go
@@ -76,6 +76,8 @@ func (hs *HTTPServer) QueryMetricsV2(c *contextmodel.ReqContext) response.Respon
 
 	var resp *backend.QueryDataResponse
 	var err error
+
+	hs.log.Debug("QueryMetricsV2: request received", "time_in_query", handleTimeInQuery)
 	if handleTimeInQuery {
 		resp, err = hs.queryDataService.QueryDataNew(c.Req.Context(), c.SignedInUser, c.SkipDSCache, reqDTO)
 	} else {

--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
 	"github.com/grafana/grafana/pkg/infra/localcache"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/backendplugin"
 	pluginClient "github.com/grafana/grafana/pkg/plugins/manager/client"
@@ -86,6 +87,7 @@ func TestAPIEndpoint_Metrics_QueryMetricsV2(t *testing.T) {
 	server := SetupAPITestServer(t, func(hs *HTTPServer) {
 		hs.queryDataService = qds
 		hs.QuotaService = quotatest.New(false, nil)
+		hs.log = log.New("test-logger")
 	})
 
 	t.Run("Status code is 400 when data source response has an error", func(t *testing.T) {

--- a/pkg/api/ds_query_test.go
+++ b/pkg/api/ds_query_test.go
@@ -254,6 +254,7 @@ func TestDataSourceQueryError(t *testing.T) {
 				err := r.Add(context.Background(), p)
 				require.NoError(t, err)
 				ds := &fakeDatasources.FakeDataSourceService{}
+				hs.log = log.New("test-logger")
 				hs.queryDataService = query.ProvideService(
 					cfg,
 					&fakeDatasources.FakeCacheService{},


### PR DESCRIPTION
added a debug-log message connected to processing `/api/ds/query` requests. this will enable us to debug situations easier, where it is important whether we want local-time-range processing enabled or disabled.