### PR TITLE
CloudMigrations: Check contact point permissions before fetching it

### DIFF
--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
@@ -13,7 +12,6 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -127,10 +125,7 @@ func TestGetContactPoints(t *testing.T) {
 
 		contactPoints, err := s.getContactPoints(ctx, user)
 		require.Nil(t, contactPoints)
-
-		gfErr := errutil.Error{}
-		require.ErrorAs(t, err, &gfErr)
-		require.Equal(t, http.StatusForbidden, gfErr.Reason.Status().HTTPStatus())
+		require.Contains(t, err.Error(), "alert.notifications.receivers.secrets:read")
 	})
 }
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/xorm_store_test.go
@@ -822,7 +822,7 @@ func TestEncodeDecode(t *testing.T) {
 		Private: grafanaPrivateKey[:],
 	},
 		crypto.NewNacl(),
-		"",
+		t.TempDir(),
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
**What is this feature?**

Checks before trying to fetch contact points if the user has permission to do so.

**Why do we need this feature?**

A non-Admin that can access the Migration Assistant would not be able to migrate Contact Points without the "Alerting > Full admin access" role.

**Who is this feature for?**

Migration Assistant users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-operator-experience-squad/issues/1140

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
