### PR TITLE
docs(alerting): clarify notification group deletion after group interval elapses

### DIFF
--- a/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
+++ b/docs/sources/alerting/fundamentals/notifications/group-alert-notifications.md
@@ -159,7 +159,9 @@ Once the first notification has been sent for a new group of alerts, the group i
 
 When the group interval timer elapses, the system resets the group interval timer and sends a notification only if there were group changes. This process repeats until there are no more alerts.
 
-It's important to note that an alert instance exits the group after being resolved and notified of its state change. When no alerts remain, the group is deleted, and then the group wait timer handles the first notification for the next incoming alert once again.
+It's important to note that an alert instance exits the group after being resolved and notified of its state change.
+
+When the group interval timer elapses and no alerts remain, the group is deleted. The [group wait timer](#group-wait) will then start again the next time a new alert arrives.
 
 ### Repeat interval
 


### PR DESCRIPTION
This PR specifies how notification groups are deleted once the group interval elapses and no alerts remain. The previous version did not mention the group interval elapsing.

Related internal support escalation issue: https://github.com/grafana/support-escalations/issues/19186


⭐ [Content Preview](https://deploy-preview-grafana-113160-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/fundamentals/notifications/group-alert-notifications/#group-interval)
