### PR TITLE
Adding adaptive telemetry's own weight

### DIFF
--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -21,6 +21,7 @@ const (
 	WeightAlerting
 	WeightAlertsAndIncidents
 	WeightAIAndML
+	WeightAdaptiveTelemetry
 	WeightTestingAndSynthetics
 	WeightObservability
 	WeightCloudServiceProviders

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -344,7 +344,7 @@ func (s *ServiceImpl) addPluginToSection(c *contextmodel.ReqContext, treeRoot *n
 				Id:         navtree.NavIDAdaptiveTelemetry,
 				SubTitle:   "Reduce noise, cut costs, and accelerate troubleshooting by intelligently ingesting only the telemetry data that matters most.",
 				Icon:       "adaptive-telemetry",
-				SortWeight: navtree.WeightAIAndML + 1, // Place under "AI & Machine Learning"
+				SortWeight: navtree.WeightAdaptiveTelemetry,
 				Children:   sectionChildren,
 				Url:        "adaptive-telemetry",
 				// Use the icon URL from the first "Adaptive Telemetry" plugin in the list (they will all be the same)


### PR DESCRIPTION

**What is this feature?**

This PR add its own weight for adaptive telemetry. It ensures that the weights are the single source of ordering navigation items.

**Why do we need this feature?**

Whilst working on https://github.com/grafana/grafana/pull/111739 it surfaced that the new cost management and billing app should be under adaptive telemetry, but as the latter does not have weight we would need to start adding more and more offsets to have relative positions. I think it is better to have an absolute list.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
