### PR TITLE
Field Selector: Show scroll and add "suggested" section for fields

### DIFF
--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -53,7 +53,7 @@ export const ActiveFields = ({ activeFields, clear, fields, reorder, suggestedFi
     [activeFields, suggestedFields]
   );
 
-  if (active.length) {
+  if (active.length || suggested.length) {
     return (
       <>
         <div className={styles.columnHeader}>

--- a/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/ActiveFields.tsx
@@ -44,9 +44,13 @@ export const ActiveFields = ({ activeFields, clear, fields, reorder, suggestedFi
           (name) => fields.find((field) => field.name === name) ?? suggestedFields.find((field) => field.name === name)
         )
         .filter((field) => field !== undefined),
-      ...suggestedFields.filter((suggestedField) => !activeFields.includes(suggestedField.name)),
     ],
     [activeFields, fields, suggestedFields]
+  );
+
+  const suggested = useMemo(
+    () => suggestedFields.filter((suggestedField) => !activeFields.includes(suggestedField.name)),
+    [activeFields, suggestedFields]
   );
 
   if (active.length) {
@@ -96,6 +100,20 @@ export const ActiveFields = ({ activeFields, clear, fields, reorder, suggestedFi
             )}
           </Droppable>
         </DragDropContext>
+        {suggested.length > 0 && (
+          <>
+            <div className={styles.columnSubHeader}>
+              <Trans i18nKey="explore.logs-table-multi-select.suggested-fields">Suggested</Trans>
+            </div>
+            <div className={styles.columnWrapper}>
+              {suggested.map((field) => (
+                <div className={styles.wrap} key={field.name}>
+                  <Field field={field} toggle={toggle} />
+                </div>
+              ))}
+            </div>
+          </>
+        )}
       </>
     );
   }
@@ -128,6 +146,10 @@ export function getLogsFieldsStyles(theme: GrafanaTheme2) {
       paddingLeft: theme.spacing(1.5),
       zIndex: 3,
       marginBottom: theme.spacing(2),
+    }),
+    columnSubHeader: css({
+      padding: theme.spacing(0, 0, 0.75, 0.5),
+      color: theme.colors.text.secondary,
     }),
     columnHeaderButton: css({
       appearance: 'none',

--- a/public/app/features/logs/components/fieldSelector/FieldList.tsx
+++ b/public/app/features/logs/components/fieldSelector/FieldList.tsx
@@ -48,12 +48,7 @@ function getStyles(theme: GrafanaTheme2) {
     sidebarWrap: css({
       overflowY: 'scroll',
       flex: 1,
-      /* Hide scrollbar for Chrome, Safari, and Opera */
-      '&::-webkit-scrollbar': {
-        display: 'none',
-      },
-      /* Hide scrollbar for Firefox */
-      scrollbarWidth: 'none',
+      scrollbarWidth: 'thin',
     }),
     columnHeader: css({
       display: 'flex',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7189,7 +7189,8 @@
     "logs-table-multi-select": {
       "fields": "Fields",
       "reset": "Reset",
-      "selected-fields": "Selected fields"
+      "selected-fields": "Selected fields",
+      "suggested-fields": "Suggested"
     },
     "logs-table-wrap": {
       "aria-label-select-query-by-name": "Select query by name",


### PR DESCRIPTION
- Make scrollbars visible
- If available, move suggested fields under a new section.

<img width="245" height="312" alt="imagen" src="https://github.com/user-attachments/assets/6d33f7ca-bdd1-4094-be44-9377373fa45a" />

Part of https://github.com/grafana/grafana/issues/101083