### PR TITLE
kvstore: add cluster-scoped resource support

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -77,8 +77,10 @@ func (k DataKey) Validate() error {
 	}
 
 	// Validate naming conventions for all required fields
-	if err := validation.IsValidNamespace(k.Namespace); err != nil {
-		return NewValidationError("namespace", k.Namespace, err[0])
+	if k.Namespace != clusterScopeNamespace {
+		if err := validation.IsValidNamespace(k.Namespace); err != nil {
+			return NewValidationError("namespace", k.Namespace, err[0])
+		}
 	}
 	if err := validation.IsValidGroup(k.Group); err != nil {
 		return NewValidationError("group", k.Group, err[0])
@@ -117,7 +119,7 @@ func (k ListRequestKey) Validate() error {
 	if k.Namespace == "" && k.Name != "" {
 		return errors.New(ErrNameMustBeEmptyWhenNamespaceEmpty)
 	}
-	if k.Namespace != "" {
+	if k.Namespace != "" && k.Namespace != clusterScopeNamespace {
 		if err := validation.IsValidNamespace(k.Namespace); err != nil {
 			return NewValidationError("namespace", k.Namespace, err[0])
 		}
@@ -155,8 +157,10 @@ func (k GetRequestKey) Validate() error {
 	if k.Namespace == "" {
 		return errors.New(ErrNamespaceRequired)
 	}
-	if err := validation.IsValidNamespace(k.Namespace); err != nil {
-		return NewValidationError("namespace", k.Namespace, err[0])
+	if k.Namespace != clusterScopeNamespace {
+		if err := validation.IsValidNamespace(k.Namespace); err != nil {
+			return NewValidationError("namespace", k.Namespace, err[0])
+		}
 	}
 	if err := validation.IsValidGroup(k.Group); err != nil {
 		return NewValidationError("group", k.Group, err[0])

--- a/pkg/storage/unified/resource/eventstore.go
+++ b/pkg/storage/unified/resource/eventstore.go
@@ -51,8 +51,10 @@ func (k EventKey) Validate() error {
 
 	// Validate each field against the naming rules
 	// Validate naming conventions for all required fields
-	if err := validation.IsValidNamespace(k.Namespace); err != nil {
-		return NewValidationError("namespace", k.Namespace, err[0])
+	if k.Namespace != clusterScopeNamespace {
+		if err := validation.IsValidNamespace(k.Namespace); err != nil {
+			return NewValidationError("namespace", k.Namespace, err[0])
+		}
 	}
 	if err := validation.IsValidGroup(k.Group); err != nil {
 		return NewValidationError("group", k.Group, err[0])

--- a/pkg/storage/unified/resource/keys.go
+++ b/pkg/storage/unified/resource/keys.go
@@ -35,8 +35,10 @@ func verifyRequestKeyNamespaceGroupResource(key *resourcepb.ResourceKey) *resour
 	if key.Resource == "" {
 		return NewBadRequestError("request key is missing resource")
 	}
-	if err := validation.IsValidNamespace(key.Namespace); err != nil {
-		return NewBadRequestError(err[0])
+	if key.Namespace != clusterScopeNamespace {
+		if err := validation.IsValidNamespace(key.Namespace); err != nil {
+			return NewBadRequestError(err[0])
+		}
 	}
 	if err := validation.IsValidGroup(key.Group); err != nil {
 		return NewBadRequestError(err[0])


### PR DESCRIPTION
This PR introduces experimental support for cluster-scoped resources (resources with empty namespace) in the unified  kv storage backend.

### Changes

- **Internal namespace handling**: Cluster-scoped resources (empty namespace) are internally stored using a special `__cluster__` namespace to avoid validation issues, while maintaining an empty namespace in the API layer
- **New backend option**: Added `WithExperimentalClusterScope` flag to `KVBackendOptions` to enable the feature
- **Conditional validation**: Updated namespace validation logic across `DataKey`, `ListRequestKey`, `GetRequestKey`, and `EventKey` to skip validation for cluster-scoped resources
- **Namespace conversion**: All read/write operations now properly convert between empty namespace (API) and `__cluster__` (storage):
  - `WriteEvent`, `ReadResource`, `ListIterator`, and `WatchWriteEvents` maintain empty namespace in responses
  - Internal storage operations use `__cluster__` for consistency
