### PR TITLE
ShortURL: Use RTK api for creation

### DIFF
--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -1,10 +1,10 @@
 import memoizeOne from 'memoize-one';
 
-import { generatedAPI } from '@grafana/api-clients/rtkq/shorturl/v1alpha1';
 import { AbsoluteTimeRange, LogRowModel, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getBackendSrv, config, locationService } from '@grafana/runtime';
 import { sceneGraph, SceneTimeRangeLike, VizPanel } from '@grafana/scenes';
+import { shortURLAPIv1alpha1 } from 'app/api/clients/shorturl/v1alpha1';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification, createSuccessNotification } from 'app/core/copy/appNotification';
 import { DashboardScene } from 'app/features/dashboard-scene/scene/DashboardScene';
@@ -46,7 +46,7 @@ export const createShortLink = async function (path: string) {
     if (config.featureToggles.useKubernetesShortURLsAPI) {
       // Use RTK API - it handles caching/failures/retries automatically
       const result = await dispatch(
-        generatedAPI.endpoints.createShortUrl.initiate({
+        shortURLAPIv1alpha1.endpoints.createShortUrl.initiate({
           shortUrl: {
             apiVersion: 'shorturl.grafana.app/v1alpha1',
             kind: 'ShortURL',


### PR DESCRIPTION
**What is this feature?**

Use the populated `generateName` endpoint when creating a short URL with RTK.
`name` or `generateName` are required by the API.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
