### PR TITLE
PreviewBannerViewPR: Display branch info in preview banner

### DIFF
--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -1,25 +1,32 @@
 import { textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Icon, Stack } from '@grafana/ui';
+import { Alert, Box, Icon, Stack, TextLink } from '@grafana/ui';
 import { RepoTypeDisplay, RepoType } from 'app/features/provisioning/Wizard/types';
 import { usePullRequestParam } from 'app/features/provisioning/hooks/usePullRequestParam';
 
 import { commonAlertProps } from '../Dashboards/DashboardPreviewBanner';
-
-// TODO: We have this https://github.com/grafana/git-ui-sync-project/issues/166 to add more details about the PR.
+import { getBranchUrl } from '../utils/url';
 
 interface Props {
   prParam?: string;
   isNewPr?: boolean;
   behindBranch?: boolean;
   repoUrl?: string;
+  branchInfo?: PreviewBranchInfo;
 }
+
+export type PreviewBranchInfo = {
+  targetBranch?: string;
+  configuredBranch?: string;
+  repoBaseUrl?: string;
+};
 
 /**
  * @description This component is used to display a banner when a provisioned dashboard/folder is created or loaded from a new branch in repo.
  */
-export function PreviewBannerViewPR({ prParam, isNewPr, behindBranch, repoUrl }: Props) {
+export function PreviewBannerViewPR({ prParam, isNewPr, behindBranch, repoUrl, branchInfo }: Props) {
   const { repoType } = usePullRequestParam();
+  const { targetBranch, configuredBranch, repoBaseUrl } = branchInfo || {};
 
   const capitalizedRepoType = isValidRepoType(repoType) ? RepoTypeDisplay[repoType] : 'repository';
 
@@ -96,6 +103,15 @@ export function PreviewBannerViewPR({ prParam, isNewPr, behindBranch, repoUrl }:
         The rest of Grafana users in your organization will still see the current version saved to configured default
         branch until this branch is merged
       </Trans>
+
+      {/* when repo type is not local, we show branch information */}
+      {showBranchInfo(repoType, branchInfo) && (
+        <Box marginTop={1}>
+          <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch: </Trans>
+          <TextLink href={getBranchUrl(repoBaseUrl!, targetBranch!, repoType)}>{targetBranch}</TextLink> {'\u2192'}{' '}
+          <TextLink href={getBranchUrl(repoBaseUrl!, configuredBranch!, repoType)}>{configuredBranch}</TextLink>
+        </Box>
+      )}
     </Alert>
   );
 }
@@ -105,4 +121,9 @@ export function isValidRepoType(repoType: string | undefined): repoType is RepoT
     return false;
   }
   return repoType in RepoTypeDisplay;
+}
+
+function showBranchInfo(repoType: string | undefined, branchInfo?: PreviewBranchInfo): boolean {
+  const { targetBranch, configuredBranch, repoBaseUrl } = branchInfo || {};
+  return repoType !== 'local' && !!targetBranch && !!configuredBranch && !!repoBaseUrl;
 }

--- a/public/app/features/provisioning/components/utils/url.ts
+++ b/public/app/features/provisioning/components/utils/url.ts
@@ -1,0 +1,17 @@
+// repoType = string because this repoType is coming from URL param
+export const getBranchUrl = (baseUrl: string, branch: string, repoType?: string): string => {
+  if (repoType === 'local') {
+    return '';
+  }
+
+  switch (repoType) {
+    case 'github':
+      return `${baseUrl}/tree/${branch}`;
+    case 'gitlab':
+      return `${baseUrl}/-/tree/${branch}`;
+    case 'bitbucket':
+      return `${baseUrl}/src/${branch}`;
+    default:
+      return '';
+  }
+};

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11370,6 +11370,7 @@
   "provisioned-resource-preview-banner": {
     "preview-banner": {
       "behind-branch-text": "This resource is behind the branch in {{repoType}}.",
+      "branch-text": "branch:",
       "not-saved": "The rest of Grafana users in your organization will still see the current version saved to configured default branch until this branch is merged",
       "open-in-repo-button": "Open in {{repoType}}",
       "open-pull-request-in-repo": "Open pull request in {{repoType}}",


### PR DESCRIPTION
**What is this feature?**

When Git provisioned dashboard pushed changes to non-configured branch, we add branch info to preview banner. 
<img width="1078" height="300" alt="image" src="https://github.com/user-attachments/assets/1b1274fd-056d-4faa-a341-d5d830a68e3b" />


**Why do we need this feature?**

Provide user more context 

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/166

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
