### PR TITLE
Logs in Explore: Hide "show original line" when using the table

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -979,6 +979,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             displayedFields={displayedFields}
             clearDisplayedFields={clearDisplayedFields}
             defaultDisplayedFields={defaultDisplayedFields}
+            visualisationType={visualisationType}
           />
         </div>
         <div className={cx(styles.logsSection, visualisationType === 'table' ? styles.logsTable : undefined)}>

--- a/public/app/features/explore/Logs/LogsMetaRow.test.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.test.tsx
@@ -28,9 +28,10 @@ const defaultProps: LogsMetaRowProps = {
   logRows: [],
   clearDisplayedFields: jest.fn(),
   defaultDisplayedFields: [],
+  visualisationType: 'logs',
 };
 
-const setup = (propOverrides?: object, disableDownload = false) => {
+const setup = (propOverrides?: Partial<LogsMetaRowProps>, disableDownload = false) => {
   const props = {
     ...defaultProps,
     ...propOverrides,
@@ -53,6 +54,15 @@ describe('LogsMetaRow', () => {
         name: 'Show original line',
       })
     ).toBeInTheDocument();
+  });
+
+  it('does not render the show original line button if the current viz is the table', () => {
+    setup({ displayedFields: ['test'], visualisationType: 'table' });
+    expect(
+      screen.queryByRole('button', {
+        name: 'Show original line',
+      })
+    ).not.toBeInTheDocument();
   });
 
   it('renders the displayed fields', async () => {

--- a/public/app/features/explore/Logs/LogsMetaRow.tsx
+++ b/public/app/features/explore/Logs/LogsMetaRow.tsx
@@ -19,6 +19,7 @@ import { LogLabels, LogLabelsList, Props as LogLabelsProps } from '../../logs/co
 import { DownloadFormat, downloadLogs } from '../../logs/utils';
 import { MetaInfoText, MetaItemProps } from '../MetaInfoText';
 
+import { LogsVisualisationType } from './Logs';
 import { SETTINGS_KEYS } from './utils/logs';
 
 const getStyles = () => ({
@@ -41,6 +42,7 @@ export type Props = {
   logRows: LogRowModel[];
   clearDisplayedFields: () => void;
   defaultDisplayedFields: string[];
+  visualisationType: LogsVisualisationType;
 };
 
 export const LogsMetaRow = memo(
@@ -52,6 +54,7 @@ export const LogsMetaRow = memo(
     clearDisplayedFields,
     logRows,
     defaultDisplayedFields,
+    visualisationType,
   }: Props) => {
     const style = useStyles2(getStyles);
 
@@ -67,7 +70,11 @@ export const LogsMetaRow = memo(
     }
 
     // Add detected fields info
-    if (displayedFields?.length > 0 && shallowCompare(displayedFields, defaultDisplayedFields) === false) {
+    if (
+      visualisationType === 'logs' &&
+      displayedFields?.length > 0 &&
+      shallowCompare(displayedFields, defaultDisplayedFields) === false
+    ) {
       logsMetaItem.push(
         {
           label: t('explore.logs-meta-row.label.showing-only-selected-fields', 'Showing only selected fields'),


### PR DESCRIPTION
Showing this button when the current visualization is the table was a noop. Now only showing it when using the Logs viz.

<img width="664" height="109" alt="imagen" src="https://github.com/user-attachments/assets/19410d64-94c4-4a9d-9a6c-a85963e3f1b7" />
