### PR TITLE
Alerting: Hide metadata if grouping by folder

### DIFF
--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -36,7 +36,7 @@ function renderWorkbenchRow(
   leftColumnWidth: number,
   domain: Domain,
   key: React.Key,
-  groupBy: string[] | undefined,
+  enableFolderMeta: boolean,
   depth = 0
 ): React.ReactElement {
   if (row.type === 'alertRule') {
@@ -47,7 +47,7 @@ function renderWorkbenchRow(
         leftColumnWidth={leftColumnWidth}
         rowKey={key}
         depth={depth}
-        groupBy={groupBy}
+        enableFolderMeta={enableFolderMeta}
       />
     );
   } else {
@@ -57,7 +57,7 @@ function renderWorkbenchRow(
         leftColumnWidth,
         domain,
         `${key}-${generateRowKey(childRow, childIndex)}`,
-        groupBy,
+        enableFolderMeta,
         depth + 1
       )
     );
@@ -121,6 +121,9 @@ export function Workbench({ domain, data, queryRunner, groupBy }: WorkbenchProps
 
   const isLoading = !queryRunner.isDataReadyToDisplay();
   const [pageIndex, setPageIndex] = useState<number>(1);
+
+  // Calculate once: show folder metadata only if not grouping by grafana_folder
+  const enableFolderMeta = !groupBy?.includes('grafana_folder');
   // splitter for template and payload editor
   const splitter = useSplitter({
     direction: 'row',
@@ -168,7 +171,7 @@ export function Workbench({ domain, data, queryRunner, groupBy }: WorkbenchProps
               ) : (
                 dataSlice.map((row, index) => {
                   const rowKey = generateRowKey(row, index);
-                  return renderWorkbenchRow(row, leftColumnWidth, domain, rowKey, groupBy);
+                  return renderWorkbenchRow(row, leftColumnWidth, domain, rowKey, enableFolderMeta);
                 })
               )}
               {hasMore && <LoadMoreHelper handleLoad={() => setPageIndex((prevIndex) => prevIndex + 1)} />}

--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -23,7 +23,7 @@ import { Domain, Filter, WorkbenchRow } from './types';
 type WorkbenchProps = {
   domain: Domain;
   data: WorkbenchRow[];
-  groupBy?: string[]; // @TODO proper type
+  groupBy?: string[];
   filterBy?: Filter[];
   queryRunner: SceneQueryRunner;
 };
@@ -36,13 +36,30 @@ function renderWorkbenchRow(
   leftColumnWidth: number,
   domain: Domain,
   key: React.Key,
+  groupBy: string[] | undefined,
   depth = 0
 ): React.ReactElement {
   if (row.type === 'alertRule') {
-    return <AlertRuleRow key={key} row={row} leftColumnWidth={leftColumnWidth} rowKey={key} depth={depth} />;
+    return (
+      <AlertRuleRow
+        key={key}
+        row={row}
+        leftColumnWidth={leftColumnWidth}
+        rowKey={key}
+        depth={depth}
+        groupBy={groupBy}
+      />
+    );
   } else {
     const children = row.rows.map((childRow, childIndex) =>
-      renderWorkbenchRow(childRow, leftColumnWidth, domain, `${key}-${generateRowKey(childRow, childIndex)}`, depth + 1)
+      renderWorkbenchRow(
+        childRow,
+        leftColumnWidth,
+        domain,
+        `${key}-${generateRowKey(childRow, childIndex)}`,
+        groupBy,
+        depth + 1
+      )
     );
 
     // Check if this is a grafana_folder group and use FolderGroupRow
@@ -99,7 +116,7 @@ function renderWorkbenchRow(
  │                         │ │                                   │
  └─────────────────────────┘ └───────────────────────────────────┘
  */
-export function Workbench({ domain, data, queryRunner }: WorkbenchProps) {
+export function Workbench({ domain, data, queryRunner, groupBy }: WorkbenchProps) {
   const styles = useStyles2(getStyles);
 
   const isLoading = !queryRunner.isDataReadyToDisplay();
@@ -151,7 +168,7 @@ export function Workbench({ domain, data, queryRunner }: WorkbenchProps) {
               ) : (
                 dataSlice.map((row, index) => {
                   const rowKey = generateRowKey(row, index);
-                  return renderWorkbenchRow(row, leftColumnWidth, domain, rowKey);
+                  return renderWorkbenchRow(row, leftColumnWidth, domain, rowKey, groupBy);
                 })
               )}
               {hasMore && <LoadMoreHelper handleLoad={() => setPageIndex((prevIndex) => prevIndex + 1)} />}

--- a/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
@@ -16,9 +16,10 @@ interface AlertRuleRowProps {
   leftColumnWidth: number;
   rowKey: React.Key;
   depth?: number;
+  groupBy?: string[];
 }
 
-export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0 }: AlertRuleRowProps) => {
+export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy }: AlertRuleRowProps) => {
   const { ruleUID, folder, title } = row.metadata;
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -29,6 +30,9 @@ export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0 }: AlertR
   const handleDrawerClose = () => {
     setIsDrawerOpen(false);
   };
+
+  // Hide folder metadata if grafana_folder is in the groupBy array
+  const shouldShowFolderMetadata = !groupBy?.includes('grafana_folder');
 
   return (
     <>
@@ -45,12 +49,14 @@ export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0 }: AlertR
           />
         }
         metadata={
-          <Stack direction="row" gap={0.5} alignItems="center">
-            <MetaText icon="folder" />
-            <Text variant="bodySmall" color="secondary">
-              {folder}
-            </Text>
-          </Stack>
+          shouldShowFolderMetadata ? (
+            <Stack direction="row" gap={0.5} alignItems="center">
+              <MetaText icon="folder" />
+              <Text variant="bodySmall" color="secondary">
+                {folder}
+              </Text>
+            </Stack>
+          ) : undefined
         }
         content={<AlertRuleSummary ruleUID={ruleUID} />}
         depth={depth}

--- a/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
@@ -16,10 +16,16 @@ interface AlertRuleRowProps {
   leftColumnWidth: number;
   rowKey: React.Key;
   depth?: number;
-  groupBy?: string[];
+  enableFolderMeta?: boolean;
 }
 
-export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy = [] }: AlertRuleRowProps) => {
+export const AlertRuleRow = ({
+  row,
+  leftColumnWidth,
+  rowKey,
+  depth = 0,
+  enableFolderMeta = true,
+}: AlertRuleRowProps) => {
   const { ruleUID, folder, title } = row.metadata;
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -30,9 +36,6 @@ export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy 
   const handleDrawerClose = () => {
     setIsDrawerOpen(false);
   };
-
-  // Hide folder metadata if grafana_folder is in the groupBy array
-  const shouldShowFolderMetadata = !groupBy.includes('grafana_folder');
 
   return (
     <>
@@ -49,7 +52,7 @@ export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy 
           />
         }
         metadata={
-          shouldShowFolderMetadata ? (
+          enableFolderMeta ? (
             <Stack direction="row" gap={0.5} alignItems="center">
               <MetaText icon="folder" />
               <Text variant="bodySmall" color="secondary">

--- a/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
+++ b/public/app/features/alerting/unified/triage/rows/AlertRuleRow.tsx
@@ -19,7 +19,7 @@ interface AlertRuleRowProps {
   groupBy?: string[];
 }
 
-export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy }: AlertRuleRowProps) => {
+export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy = [] }: AlertRuleRowProps) => {
   const { ruleUID, folder, title } = row.metadata;
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
@@ -32,7 +32,7 @@ export const AlertRuleRow = ({ row, leftColumnWidth, rowKey, depth = 0, groupBy 
   };
 
   // Hide folder metadata if grafana_folder is in the groupBy array
-  const shouldShowFolderMetadata = !groupBy?.includes('grafana_folder');
+  const shouldShowFolderMetadata = !groupBy.includes('grafana_folder');
 
   return (
     <>

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -34,7 +34,7 @@ export function WorkbenchRenderer() {
   const { data } = runner.useState();
   const rows = data ? convertToWorkbenchRows(data, groupByKeys) : [];
 
-  return <Workbench data={rows} domain={domain} queryRunner={runner} />;
+  return <Workbench data={rows} domain={domain} queryRunner={runner} groupBy={groupByKeys} />;
 }
 
 type DataPoint = Record<ArrayValues<typeof DEFAULT_FIELDS>, string> & Record<string, string | undefined>;


### PR DESCRIPTION
Issue: https://github.com/grafana/alerting-squad/issues/1091?issue=grafana%7Calerting-squad%7C1251 

Before
<img width="1512" height="767" alt="Screenshot 2025-10-30 at 10 46 52" src="https://github.com/user-attachments/assets/06ad0ea0-fc31-45ba-aef2-21df3ba2828a" />

After
<img width="1484" height="759" alt="image" src="https://github.com/user-attachments/assets/cb681142-42e3-49cd-95ee-9030c2034192" />
