### PR TITLE
ElasticSearch: Fixed `Log Volumes` panel by adding the label `level` to the valueField.

### DIFF
--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -644,7 +644,19 @@ function defaultExtractLevel(dataFrame: DataFrame): LogLevel {
   try {
     valueField = new FieldCache(dataFrame).getFirstFieldOfType(FieldType.number);
   } catch {}
-  return valueField?.labels ? getLogLevelFromLabels(valueField.labels) : LogLevel.unknown;
+
+  // Attempt to get log level from labels first.
+  if (valueField?.labels) {
+    return getLogLevelFromLabels(valueField.labels);
+  }
+
+  // If the dataframe has a name, attempt to use it as log level.
+  if (dataFrame.name) {
+    return getLogLevelFromKey(dataFrame.name);
+  }
+
+  // No log level could be extracted.
+  return LogLevel.unknown;
 }
 
 function getLogLevelFromLabels(labels: Labels): LogLevel {

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -691,9 +691,6 @@ export class ElasticDatasource
           enhanceDataFrameWithDataLinks(dataFrame, this.dataLinks);
         });
 
-        if (request.targets.some((t) => t.refId?.startsWith(REF_ID_STARTER_LOG_VOLUME))) {
-          response.data = attachLogLevelLabelsToDataFrames(response.data);
-        }
         return response;
       })
     );
@@ -1319,21 +1316,4 @@ function createContextTimeRange(rowTimeEpochMs: number, direction: string, inter
       };
     }
   }
-}
-
-// Attach log level as label. This is used to determine the log level in future operations.
-function attachLogLevelLabelsToDataFrames(dataFrames: DataFrame[]): DataFrame[] {
-  return dataFrames.map((frame) => {
-    // Log level is returned properly in the frame.name.
-    const level = frame.name;
-
-    // Add the label to the numeric value field
-    const valueField = frame.fields.find((f) => f.type === 'number');
-    if (valueField) {
-      valueField.labels = valueField.labels || {};
-      valueField.labels['level'] = String(level);
-    }
-
-    return frame;
-  });
 }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -690,6 +690,10 @@ export class ElasticDatasource
         response.data.forEach((dataFrame) => {
           enhanceDataFrameWithDataLinks(dataFrame, this.dataLinks);
         });
+
+        if (request.targets.some((t) => t.refId?.startsWith(REF_ID_STARTER_LOG_VOLUME))) {
+          response.data = attachLogLevelLabelsToDataFrames(response.data);
+        }
         return response;
       })
     );
@@ -1315,4 +1319,24 @@ function createContextTimeRange(rowTimeEpochMs: number, direction: string, inter
       };
     }
   }
+}
+
+// Attach log level as label. This is used to determine the log level in future operations.
+function attachLogLevelLabelsToDataFrames(
+  dataFrames: DataFrame[]
+): DataFrame[] {
+
+  return dataFrames.map((frame) => {
+    // Log level is returned properly in the frame.name.
+    const level = frame.name;
+
+    // Add the label to the numeric value field
+    const valueField = frame.fields.find((f) => f.type === 'number');
+    if (valueField) {
+      valueField.labels = valueField.labels || {};
+      valueField.labels['level'] = String(level);
+    }
+
+    return frame;
+  });
 }

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -690,7 +690,6 @@ export class ElasticDatasource
         response.data.forEach((dataFrame) => {
           enhanceDataFrameWithDataLinks(dataFrame, this.dataLinks);
         });
-
         return response;
       })
     );

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -1322,10 +1322,7 @@ function createContextTimeRange(rowTimeEpochMs: number, direction: string, inter
 }
 
 // Attach log level as label. This is used to determine the log level in future operations.
-function attachLogLevelLabelsToDataFrames(
-  dataFrames: DataFrame[]
-): DataFrame[] {
-
+function attachLogLevelLabelsToDataFrames(dataFrames: DataFrame[]): DataFrame[] {
   return dataFrames.map((frame) => {
     // Log level is returned properly in the frame.name.
     const level = frame.name;


### PR DESCRIPTION
**What is this bugfix?**
The logs volume panel is currently broken for the `Elasticsearch` datasource.
After applying the fix it's working again:

<img width="1418" height="652" alt="afbeelding" src="https://github.com/user-attachments/assets/f2320fce-6695-47c7-8c2a-b65fea45b8fd" />

 

**Which issue(s) does this PR fix?**:
Fixes grafana/grafana#113153 
Fixes grafana/grafana#90436


**Special notes for your reviewer:**
I first fixed it in the elastic query but it seems like the fix in the caller `logsModel.ts` was more efficient so you can ignore the first commits.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
