### PR TITLE
Alerting: Improve test notification visualization

### DIFF
--- a/public/app/features/alerting/unified/api/receiversApi.ts
+++ b/public/app/features/alerting/unified/api/receiversApi.ts
@@ -1,8 +1,10 @@
 /** @deprecated To be deleted - use alertingApiServer API instead */
 
 import { ContactPointsState } from 'app/features/alerting/unified/types/alerting';
+import { Receiver, TestReceiversAlert, TestReceiversResult } from 'app/plugins/datasource/alertmanager/types';
 
 import { CONTACT_POINTS_STATE_INTERVAL_MS } from '../utils/constants';
+import { getDatasourceAPIUid } from '../utils/datasource';
 
 import { alertingApi } from './alertingApi';
 import { fetchContactPointsState } from './grafana';
@@ -19,8 +21,33 @@ export const receiversApi = alertingApi.injectEndpoints({
         }
       },
     }),
+    testIntegration: build.mutation<TestReceiversResult, TestReceiversOptions>({
+      query: ({ alertManagerSourceName, receivers, alert }) => ({
+        method: 'POST',
+        data: {
+          receivers,
+          alert,
+        },
+        url: `/api/alertmanager/${getDatasourceAPIUid(alertManagerSourceName)}/config/api/v1/receivers/test`,
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      }),
+      transformResponse: (response: TestReceiversResult) => {
+        // Check if the response contains errors even though the HTTP status was 200
+        if (receiversResponseContainsErrors(response)) {
+          throw new Error(getReceiverResultError(response));
+        }
+        return response;
+      },
+    }),
   }),
 });
+
+interface TestReceiversOptions {
+  alertManagerSourceName: string;
+  receivers: Receiver[];
+  alert?: TestReceiversAlert;
+}
 
 export const useGetContactPointsState = (alertManagerSourceName: string) => {
   const contactPointsStateEmpty: ContactPointsState = { receivers: {}, errorCount: 0 };
@@ -33,3 +60,22 @@ export const useGetContactPointsState = (alertManagerSourceName: string) => {
   );
   return contactPointsState ?? contactPointsStateEmpty;
 };
+
+export const { useTestIntegrationMutation } = receiversApi;
+
+// Helper functions for checking receiver test results
+function receiversResponseContainsErrors(result: TestReceiversResult): boolean {
+  return result.receivers.some((receiver) =>
+    receiver.grafana_managed_receiver_configs.some((config) => config.status === 'failed')
+  );
+}
+
+function getReceiverResultError(receiversResult: TestReceiversResult): string {
+  return receiversResult.receivers
+    .flatMap((receiver) =>
+      receiver.grafana_managed_receiver_configs
+        .filter((config) => config.status === 'failed')
+        .map((config) => config.error ?? 'Unknown error.')
+    )
+    .join('; ');
+}

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -9,7 +9,6 @@ import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, Field, Select, Stack, Text, useStyles2 } from '@grafana/ui';
 import { NotificationChannelOption } from 'app/features/alerting/unified/types/alerting';
 
-import { useUnifiedAlertingSelector } from '../../../hooks/useUnifiedAlertingSelector';
 import {
   ChannelValues,
   CloudChannelValues,
@@ -66,7 +65,6 @@ export function ChannelSubForm<R extends ChannelValues>({
 
   const selectedType = watch(typeFieldPath) ?? defaultValues.type;
   const parse_mode = watch(`${settingsFieldPath}.parse_mode`);
-  const { loading: testingReceiver } = useUnifiedAlertingSelector((state) => state.testReceivers);
 
   // TODO I don't like integration specific code here but other ways require a bigger refactoring
   const onCallIntegrationType = watch(`${settingsFieldPath}.integration_type`);
@@ -232,14 +230,7 @@ export function ChannelSubForm<R extends ChannelValues>({
         </div>
         <div className={styles.buttons}>
           {isTestable && onTest && isTestAvailable && (
-            <Button
-              disabled={testingReceiver}
-              size="xs"
-              variant="secondary"
-              type="button"
-              onClick={() => handleTest()}
-              icon={testingReceiver ? 'spinner' : 'message'}
-            >
+            <Button size="xs" variant="secondary" type="button" onClick={() => handleTest()} icon="message">
               <Trans i18nKey="alerting.channel-sub-form.test">Test</Trans>
             </Button>
           )}

--- a/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
@@ -1,6 +1,4 @@
 import { css } from '@emotion/css';
-import { SerializedError } from '@reduxjs/toolkit';
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
@@ -49,7 +47,7 @@ export const TestContactPointModal = ({ isOpen, onDismiss, alertManagerSourceNam
   const [notificationType, setNotificationType] = useState<NotificationType>(NotificationType.predefined);
   const styles = useStyles2(getStyles);
   const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
-  const [testIntegration, { isLoading, error }] = useTestIntegrationMutation();
+  const [testIntegration, { isLoading, error, isSuccess }] = useTestIntegrationMutation();
 
   const onSubmit = async (data: FormFields) => {
     let alert: TestReceiversAlert | undefined;
@@ -86,6 +84,13 @@ export const TestContactPointModal = ({ isOpen, onDismiss, alertManagerSourceNam
         <Alert title={t('alerting.test-contact-point-modal.test-failed', 'Test notification failed')} severity="error">
           {stringifyErrorLike(error)}
         </Alert>
+      )}
+
+      {isSuccess && (
+        <Alert
+          title={t('alerting.test-contact-point-modal.test-successful', 'Test notification sent successfully')}
+          severity="success"
+        />
       )}
 
       <div className={styles.section}>

--- a/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/TestContactPointModal.tsx
@@ -1,21 +1,26 @@
 import { css } from '@emotion/css';
+import { SerializedError } from '@reduxjs/toolkit';
+import { FetchBaseQueryError } from '@reduxjs/toolkit/query';
 import { useState } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, Label, Modal, RadioButtonGroup, useStyles2 } from '@grafana/ui';
-import { TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
+import { Alert, Button, Label, Modal, RadioButtonGroup, useStyles2 } from '@grafana/ui';
+import { Receiver, TestReceiversAlert } from 'app/plugins/datasource/alertmanager/types';
 import { Annotations, Labels } from 'app/types/unified-alerting-dto';
 
+import { useTestIntegrationMutation } from '../../../api/receiversApi';
 import { defaultAnnotations } from '../../../utils/constants';
+import { stringifyErrorLike } from '../../../utils/misc';
 import AnnotationsStep from '../../rule-editor/AnnotationsStep';
 import LabelsField from '../../rule-editor/labels/LabelsField';
 
 interface Props {
   isOpen: boolean;
   onDismiss: () => void;
-  onTest: (alert?: TestReceiversAlert) => void;
+  alertManagerSourceName: string;
+  receivers: Receiver[];
 }
 
 type AnnoField = {
@@ -40,14 +45,17 @@ const defaultValues: FormFields = {
   labels: [{ key: '', value: '' }],
 };
 
-export const TestContactPointModal = ({ isOpen, onDismiss, onTest }: Props) => {
+export const TestContactPointModal = ({ isOpen, onDismiss, alertManagerSourceName, receivers }: Props) => {
   const [notificationType, setNotificationType] = useState<NotificationType>(NotificationType.predefined);
   const styles = useStyles2(getStyles);
   const formMethods = useForm<FormFields>({ defaultValues, mode: 'onBlur' });
+  const [testIntegration, { isLoading, error }] = useTestIntegrationMutation();
 
-  const onSubmit = (data: FormFields) => {
+  const onSubmit = async (data: FormFields) => {
+    let alert: TestReceiversAlert | undefined;
+
     if (notificationType === NotificationType.custom) {
-      const alert = {
+      alert = {
         annotations: data.annotations
           .filter(({ key, value }) => !!key && !!value)
           .reduce<Annotations>((acc, { key, value }) => {
@@ -59,10 +67,13 @@ export const TestContactPointModal = ({ isOpen, onDismiss, onTest }: Props) => {
             return { ...acc, [key]: value };
           }, {}),
       };
-      onTest(alert);
-    } else {
-      onTest();
     }
+
+    await testIntegration({
+      alertManagerSourceName,
+      receivers,
+      alert,
+    }).unwrap();
   };
 
   return (
@@ -71,6 +82,12 @@ export const TestContactPointModal = ({ isOpen, onDismiss, onTest }: Props) => {
       isOpen={isOpen}
       title={t('alerting.test-contact-point-modal.title-test-contact-point', 'Test contact point')}
     >
+      {Boolean(error) && (
+        <Alert title={t('alerting.test-contact-point-modal.test-failed', 'Test notification failed')} severity="error">
+          {stringifyErrorLike(error)}
+        </Alert>
+      )}
+
       <div className={styles.section}>
         <Label>
           <Trans i18nKey="alerting.test-contact-point-modal.notification-message">Notification message</Trans>
@@ -110,7 +127,7 @@ export const TestContactPointModal = ({ isOpen, onDismiss, onTest }: Props) => {
           )}
 
           <Modal.ButtonRow>
-            <Button type="submit">
+            <Button type="submit" disabled={isLoading}>
               <Trans i18nKey="alerting.test-contact-point-modal.send-test-notification">Send test notification</Trans>
             </Button>
           </Modal.ButtonRow>

--- a/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
@@ -160,9 +160,24 @@ const getReceiversHandler = () =>
   });
 
 const testReceiversHandler = () =>
-  http.post('/api/alertmanager/grafana/config/api/v1/receivers/test', () => {
-    // TODO: scaffold out response as needed by tests
-    return HttpResponse.json({});
+  http.post('/api/alertmanager/grafana/config/api/v1/receivers/test', async ({ request }) => {
+    const body = await request.clone().json();
+    const { receivers = [] } = body;
+
+    // Build response with successful test results for each receiver
+    const testResults = receivers.map((receiver: any) => ({
+      name: receiver.name,
+      grafana_managed_receiver_configs: (receiver.grafana_managed_receiver_configs || []).map((config: any) => ({
+        name: config.name || config.type,
+        uid: config.uid,
+        status: 'ok' as const,
+      })),
+    }));
+
+    return HttpResponse.json({
+      notified_at: new Date().toISOString(),
+      receivers: testResults,
+    });
   });
 
 const getGroupsHandler = () =>

--- a/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
@@ -11,7 +11,7 @@ import {
 } from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
 import { MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER } from 'app/features/alerting/unified/mocks/server/handlers/datasources';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
-import { AlertManagerCortexConfig, AlertState, TestReceiversResult } from 'app/plugins/datasource/alertmanager/types';
+import { AlertManagerCortexConfig, AlertState, TestReceiversPayload } from 'app/plugins/datasource/alertmanager/types';
 
 export const grafanaAlertingConfigurationStatusHandler = (
   response = defaultGrafanaAlertingConfigurationStatusResponse
@@ -161,14 +161,14 @@ const getReceiversHandler = () =>
 
 const testReceiversHandler = () =>
   http.post('/api/alertmanager/grafana/config/api/v1/receivers/test', async ({ request }) => {
-    const body: TestReceiversResult = await request.clone().json();
+    const body: TestReceiversPayload = await request.clone().json();
     const { receivers = [] } = body;
 
     // Build response with successful test results for each receiver
     const testResults = receivers.map((receiver) => ({
       name: receiver.name,
       grafana_managed_receiver_configs: (receiver.grafana_managed_receiver_configs || []).map((config) => ({
-        name: config.name,
+        name: config.name || config.type,
         uid: config.uid,
         status: 'ok' as const,
       })),

--- a/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/alertmanagers.ts
@@ -11,7 +11,7 @@ import {
 } from 'app/features/alerting/unified/mocks/server/entities/alertmanagers';
 import { MOCK_DATASOURCE_UID_BROKEN_ALERTMANAGER } from 'app/features/alerting/unified/mocks/server/handlers/datasources';
 import { GRAFANA_RULES_SOURCE_NAME } from 'app/features/alerting/unified/utils/datasource';
-import { AlertManagerCortexConfig, AlertState } from 'app/plugins/datasource/alertmanager/types';
+import { AlertManagerCortexConfig, AlertState, TestReceiversResult } from 'app/plugins/datasource/alertmanager/types';
 
 export const grafanaAlertingConfigurationStatusHandler = (
   response = defaultGrafanaAlertingConfigurationStatusResponse
@@ -161,14 +161,14 @@ const getReceiversHandler = () =>
 
 const testReceiversHandler = () =>
   http.post('/api/alertmanager/grafana/config/api/v1/receivers/test', async ({ request }) => {
-    const body = await request.clone().json();
+    const body: TestReceiversResult = await request.clone().json();
     const { receivers = [] } = body;
 
     // Build response with successful test results for each receiver
-    const testResults = receivers.map((receiver: any) => ({
+    const testResults = receivers.map((receiver) => ({
       name: receiver.name,
-      grafana_managed_receiver_configs: (receiver.grafana_managed_receiver_configs || []).map((config: any) => ({
-        name: config.name || config.type,
+      grafana_managed_receiver_configs: (receiver.grafana_managed_receiver_configs || []).map((config) => ({
+        name: config.name,
         uid: config.uid,
         status: 'ok' as const,
       })),

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -14,12 +14,7 @@ import { RuleIdentifier, RuleNamespace, StateHistoryItem } from 'app/types/unifi
 import { RulerRuleDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
 import { withPromRulesMetadataLogging, withRulerRulesMetadataLogging } from '../Analytics';
-import {
-  deleteAlertManagerConfig,
-  fetchAlertGroups,
-  testReceivers,
-  updateAlertManagerConfig,
-} from '../api/alertmanager';
+import { deleteAlertManagerConfig, fetchAlertGroups, updateAlertManagerConfig } from '../api/alertmanager';
 import { alertmanagerApi } from '../api/alertmanagerApi';
 import { fetchAnnotations } from '../api/annotations';
 import { featureDiscoveryApi } from '../api/featureDiscoveryApi';
@@ -261,22 +256,6 @@ export const deleteAlertManagerConfigAction = createAsyncThunk(
         successMessage: 'Alertmanager configuration reset.',
       }
     );
-  }
-);
-
-interface TestReceiversOptions {
-  alertManagerSourceName: string;
-  receivers: Receiver[];
-  alert?: TestReceiversAlert;
-}
-
-export const testReceiversAction = createAsyncThunk(
-  'unifiedalerting/testReceivers',
-  ({ alertManagerSourceName, receivers, alert }: TestReceiversOptions): Promise<void> => {
-    return withAppEvents(withSerializedError(testReceivers(alertManagerSourceName, receivers, alert)), {
-      errorMessage: 'Failed to send test alert.',
-      successMessage: 'Test alert sent.',
-    });
   }
 );
 

--- a/public/app/features/alerting/unified/state/actions.ts
+++ b/public/app/features/alerting/unified/state/actions.ts
@@ -2,13 +2,7 @@ import { createAsyncThunk } from '@reduxjs/toolkit';
 import { isEmpty } from 'lodash';
 
 import { locationService, logMeasurement } from '@grafana/runtime';
-import {
-  AlertManagerCortexConfig,
-  AlertmanagerGroup,
-  Matcher,
-  Receiver,
-  TestReceiversAlert,
-} from 'app/plugins/datasource/alertmanager/types';
+import { AlertManagerCortexConfig, AlertmanagerGroup, Matcher } from 'app/plugins/datasource/alertmanager/types';
 import { ThunkResult } from 'app/types/store';
 import { RuleIdentifier, RuleNamespace, StateHistoryItem } from 'app/types/unified-alerting';
 import { RulerRuleDTO, RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';

--- a/public/app/features/alerting/unified/state/reducers.ts
+++ b/public/app/features/alerting/unified/state/reducers.ts
@@ -8,7 +8,6 @@ import {
   fetchGrafanaAnnotationsAction,
   fetchPromRulesAction,
   fetchRulerRulesAction,
-  testReceiversAction,
   updateAlertManagerConfigAction,
 } from './actions';
 
@@ -23,7 +22,6 @@ export const reducer = combineReducers({
     fetchAlertGroupsAction,
     (alertManagerSourceName) => alertManagerSourceName
   ).reducer,
-  testReceivers: createAsyncSlice('testReceivers', testReceiversAction).reducer,
   managedAlertStateHistory: createAsyncSlice('managedAlertStateHistory', fetchGrafanaAnnotationsAction).reducer,
 });
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2885,6 +2885,8 @@
       "notification-message": "Notification message",
       "predefined-notification-message": "You will send a test notification that uses a predefined alert. If you have defined a custom template or message, for better results switch to <strong>custom</strong> notification message, from above.",
       "send-test-notification": "Send test notification",
+      "test-failed": "Test notification failed",
+      "test-successful": "Test notification sent successfully",
       "title-test-contact-point": "Test contact point"
     },
     "threshold": {


### PR DESCRIPTION
**What is this feature?**

This PR refactors the test contact points functionality to use RTK Query (RTKQ) instead of Redux thunks, and improves error and success message visibility in the test notification modal.

<img width="895" height="465" alt="image" src="https://github.com/user-attachments/assets/eacfed36-b208-447e-bf44-53b8d77ac2d6" />

<img width="810" height="417" alt="image" src="https://github.com/user-attachments/assets/a5f21d6e-1210-4d8f-bbe3-4c16a6798bea" />


**Why do we need this feature?**

The previous implementation used Redux thunks (`testReceiversAction`) which required manual state management and coordination between components. This led to less clear error handling and success feedback. By migrating to RTK Query:
- Error and success states are automatically managed by the mutation hook
- Loading states are handled more cleanly without global Redux state
- Error messages are displayed directly in the modal where users perform the action
- Success messages are now visible (previously missing), providing better user feedback

**Who is this feature for?**

This feature is for Grafana users who configure and test alerting contact points. It improves the user experience when testing notification channels by providing clearer feedback about test results.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**
