### PR TITLE
[release-11.6.8] Annotations: Honor dashboardUID on dashboardsWithVisibleAnnotations

### DIFF
--- a/pkg/services/annotations/accesscontrol/accesscontrol.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol.go
@@ -131,7 +131,9 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 		searchstore.OrgFilter{OrgId: query.OrgID},
 	}
 
+	var dashboardUIDs []string
 	if query.DashboardUID != "" {
+		dashboardUIDs = append(dashboardUIDs, query.DashboardUID)
 		filters = append(filters, searchstore.DashboardFilter{
 			UIDs: []string{query.DashboardUID},
 		})
@@ -143,12 +145,13 @@ func (authz *AuthService) dashboardsWithVisibleAnnotations(ctx context.Context, 
 	}
 
 	dashs, err := authz.dashSvc.SearchDashboards(ctx, &dashboards.FindPersistedDashboardsQuery{
-		OrgId:        query.SignedInUser.GetOrgID(),
-		Filters:      filters,
-		SignedInUser: query.SignedInUser,
-		Page:         query.Page,
-		Type:         filterType,
-		Limit:        authz.searchDashboardsPageLimit,
+		DashboardUIDs: dashboardUIDs,
+		OrgId:         query.SignedInUser.GetOrgID(),
+		Filters:       filters,
+		SignedInUser:  query.SignedInUser,
+		Page:          query.Page,
+		Type:          filterType,
+		Limit:         authz.searchDashboardsPageLimit,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/annotations/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/annotations/accesscontrol/accesscontrol_test.go
@@ -18,18 +18,24 @@ import (
 	"github.com/grafana/grafana/pkg/services/annotations/testutil"
 	"github.com/grafana/grafana/pkg/services/apiserver/client"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/dashboards/database"
 	dashboardsservice "github.com/grafana/grafana/pkg/services/dashboards/service"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder/folderimpl"
 	"github.com/grafana/grafana/pkg/services/guardian"
 	"github.com/grafana/grafana/pkg/services/quota/quotatest"
+	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/services/search/sort"
+	"github.com/grafana/grafana/pkg/services/sqlstore/permissions"
+	"github.com/grafana/grafana/pkg/services/sqlstore/searchstore"
 	"github.com/grafana/grafana/pkg/services/supportbundles/supportbundlestest"
 	"github.com/grafana/grafana/pkg/services/tag/tagimpl"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestMain(m *testing.M) {
@@ -224,4 +230,91 @@ func TestIntegrationAuthorize(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDashboardsWithVisibleAnnotations(t *testing.T) {
+	store := db.InitTestDB(t)
+
+	user := &user.SignedInUser{
+		OrgID: 1,
+	}
+
+	// Create permission filters
+	p1 := permissions.NewAccessControlDashboardPermissionFilter(user, dashboardaccess.PERMISSION_VIEW, searchstore.TypeDashboard, featuremgmt.WithFeatures(), true, store.GetDialect())
+	p2 := searchstore.OrgFilter{OrgId: 1}
+
+	// If DashboardUID is provided, it should be added as a filter
+	p3 := searchstore.DashboardFilter{UIDs: []string{"uid1"}}
+
+	dashSvc := &dashboards.FakeDashboardService{}
+
+	// First call, without DashboardUID
+	queryNoDashboardUID := &dashboards.FindPersistedDashboardsQuery{
+		OrgId:        1,
+		SignedInUser: user,
+		Type:         "dash-db",
+		Limit:        int64(100),
+		Page:         int64(1),
+		Filters: []any{
+			p1,
+			p2,
+		},
+	}
+	dashSvc.On("SearchDashboards", mock.Anything, queryNoDashboardUID).Return(model.HitList{
+		&model.Hit{UID: "uid1", ID: 101},
+		&model.Hit{UID: "uid2", ID: 102},
+	}, nil)
+
+	// Second call, with DashboardUID filter
+	queryWithDashboardUID := &dashboards.FindPersistedDashboardsQuery{
+		OrgId:        1,
+		SignedInUser: user,
+		Type:         "dash-db",
+		Limit:        int64(100),
+		Page:         int64(1),
+		Filters: []any{
+			p1,
+			p2,
+			// This filter should be added on second call
+			p3,
+		},
+		DashboardUIDs: []string{"uid1"},
+	}
+
+	dashSvc.On("SearchDashboards", mock.Anything, queryWithDashboardUID).Return(model.HitList{
+		&model.Hit{UID: "uid1", ID: 101},
+	}, nil)
+
+	// Create auth service
+	authz := &AuthService{
+		db:                        store,
+		features:                  featuremgmt.WithFeatures(),
+		dashSvc:                   dashSvc,
+		searchDashboardsPageLimit: 100,
+	}
+
+	// First call without DashboardUID
+	result, err := authz.dashboardsWithVisibleAnnotations(context.Background(), annotations.ItemQuery{
+		SignedInUser: user,
+		OrgID:        1,
+		Page:         1,
+	})
+	assert.NoError(t, err)
+	// Should return two dashboards
+	assert.Equal(t, map[string]int64{"uid1": 101, "uid2": 102}, result)
+	// Ensure SearchDashboards was called with correct query
+	dashSvc.AssertCalled(t, "SearchDashboards", mock.Anything, queryNoDashboardUID)
+
+	// Second call with DashboardUID
+	result, err = authz.dashboardsWithVisibleAnnotations(context.Background(), annotations.ItemQuery{
+		SignedInUser: user,
+		OrgID:        1,
+		Page:         1,
+		DashboardUID: "uid1",
+	})
+	assert.NoError(t, err)
+	// Should only return one dashboard
+	assert.Equal(t, map[string]int64{"uid1": 101}, result)
+	// Ensure SearchDashboards was called with correct query (including DashboardUID filter)
+	dashSvc.AssertCalled(t, "SearchDashboards", mock.Anything, queryWithDashboardUID)
 }


### PR DESCRIPTION
Backport 75a1846344ec598d38ad7421ff636c69d1162df6 from #112350

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fix `dashboardsWithVisibleAnnotations`: the call to `dashboards.SearchDashboards` must include the DashboardUID if the caller has provided one.

**Why do we need this feature?**

Current implementation is not filtering by DashboardUID (when caller passes one), this causes `dashboardsWithVisibleAnnotations` to return all visible dashboards, which is super innefficient.
 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/support-escalations/issues/18184

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
