### PR TITLE
fix: plugin updatable condition should check isPublished

### DIFF
--- a/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginListItemBadges.test.tsx
@@ -85,6 +85,13 @@ describe('PluginListItemBadges', () => {
     expect(screen.queryByText(/update available/i)).toBeNull();
   });
 
+  it('does not render an upgrade badge (when plugin has an available update and is not published)', () => {
+    render(
+      <PluginListItemBadges plugin={{ ...plugin, hasUpdate: true, installedVersion: '0.0.9', isPublished: false }} />
+    );
+    expect(screen.queryByText(/update available/i)).toBeNull();
+  });
+
   it('does not render an upgrade badge (when plugin is preinstalled with a version)', () => {
     render(
       <PluginListItemBadges

--- a/public/app/features/plugins/admin/helpers.ts
+++ b/public/app/features/plugins/admin/helpers.ts
@@ -426,6 +426,10 @@ export function isPluginUpdatable(plugin: CatalogPlugin) {
     return false;
   }
 
+  if (!plugin.isPublished) {
+    return false;
+  }
+
   // If there is no update available, the plugin cannot be updated
   if (!plugin.hasUpdate) {
     return false;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updatable plugin filter

**Why do we need this feature?**

Plugins that are not published to catalog should not show Updatable badge
**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
