### PR TITLE
SaveDashboardAsForm: Adjust form field spacing

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveDashboardAsForm.tsx
@@ -147,64 +147,66 @@ export function SaveDashboardAsForm({ dashboard, changeInfo }: Props) {
 
   return (
     <form onSubmit={handleSubmit(() => onSave(false))}>
-      <Field
-        noMargin
-        label={<TitleFieldLabel onChange={setValue} />}
-        invalid={!!errors.title}
-        error={errors.title?.message}
-      >
-        <Input
-          {...register('title', {
-            required: t('dashboard-scene.save-dashboard-as-form.required', 'Required'),
-            validate: validateDashboardName,
-            onChange: handleTitleChange,
-          })}
-          aria-label={t(
-            'dashboard-scene.save-dashboard-as-form.aria-label-save-dashboard-title-field',
-            'Save dashboard title field'
-          )}
-          data-testid={selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput}
-        />
-      </Field>
-      <Field
-        noMargin
-        label={<DescriptionLabel onChange={setValue} />}
-        invalid={!!errors.description}
-        error={errors.description?.message}
-      >
-        <TextArea
-          {...register('description', { required: false })}
-          aria-label={t(
-            'dashboard-scene.save-dashboard-as-form.aria-label-save-dashboard-description-field',
-            'Save dashboard description field'
-          )}
-          autoFocus
-        />
-      </Field>
-
-      <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-folder', 'Folder')}>
-        <FolderPicker
-          onChange={async (uid: string | undefined, title: string | undefined) => {
-            setValue('folder', { uid, title });
-            const meta = await getProvisionedMeta(uid);
-            dashboard.setState({
-              meta: {
-                ...meta,
-                folderUid: uid,
-              },
-            });
-            // Re-validate title when folder changes to check for duplicates in new folder
-            trigger('title');
-          }}
-          value={formValues.folder?.uid}
-        />
-      </Field>
-      {!changeInfo.isNew && (
-        <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-copy-tags', 'Copy tags')}>
-          <Switch {...register('copyTags')} />
+      <Stack direction="column" gap={2}>
+        <Field
+          noMargin
+          label={<TitleFieldLabel onChange={setValue} />}
+          invalid={!!errors.title}
+          error={errors.title?.message}
+        >
+          <Input
+            {...register('title', {
+              required: t('dashboard-scene.save-dashboard-as-form.required', 'Required'),
+              validate: validateDashboardName,
+              onChange: handleTitleChange,
+            })}
+            aria-label={t(
+              'dashboard-scene.save-dashboard-as-form.aria-label-save-dashboard-title-field',
+              'Save dashboard title field'
+            )}
+            data-testid={selectors.components.Drawer.DashboardSaveDrawer.saveAsTitleInput}
+          />
         </Field>
-      )}
-      <Box paddingTop={2}>{renderFooter(state.error)}</Box>
+        <Field
+          noMargin
+          label={<DescriptionLabel onChange={setValue} />}
+          invalid={!!errors.description}
+          error={errors.description?.message}
+        >
+          <TextArea
+            {...register('description', { required: false })}
+            aria-label={t(
+              'dashboard-scene.save-dashboard-as-form.aria-label-save-dashboard-description-field',
+              'Save dashboard description field'
+            )}
+            autoFocus
+          />
+        </Field>
+
+        <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-folder', 'Folder')}>
+          <FolderPicker
+            onChange={async (uid: string | undefined, title: string | undefined) => {
+              setValue('folder', { uid, title });
+              const meta = await getProvisionedMeta(uid);
+              dashboard.setState({
+                meta: {
+                  ...meta,
+                  folderUid: uid,
+                },
+              });
+              // Re-validate title when folder changes to check for duplicates in new folder
+              trigger('title');
+            }}
+            value={formValues.folder?.uid}
+          />
+        </Field>
+        {!changeInfo.isNew && (
+          <Field noMargin label={t('dashboard-scene.save-dashboard-as-form.label-copy-tags', 'Copy tags')}>
+            <Switch {...register('copyTags')} />
+          </Field>
+        )}
+        <Box paddingTop={2}>{renderFooter(state.error)}</Box>
+      </Stack>
     </form>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Wrap SaveDashboardAsForm form in `Stack` to increase spacing between each field. 

**After:**  
<img width="868" height="522" alt="image" src="https://github.com/user-attachments/assets/7c0f7abe-967b-4a75-a010-2ea6e3794bdd" />

**Before:**  
<img width="888" height="399" alt="image" src="https://github.com/user-attachments/assets/9e4095dd-aaf2-4c69-b5a3-9f300c0a1416" />


**Why do we need this feature?**

Increase readability for our form

**Who is this feature for?**

Users who create dashboard

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
