### PR TITLE
Table: Fix JSON display for array and object

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -1388,6 +1388,14 @@ describe('TableNG utils', () => {
       expect(displayJsonValue(field)(42).text).toBe('**42**ms');
       expect(displayJsonValue(field)(42).numeric).toBe(42);
     });
+
+    it('should not mangle objects into [object Object]', () => {
+      expect(displayJsonValue(field)({ a: 1, b: 2 }).text).toBe('{\n "a": 1,\n "b": 2\n}');
+    });
+
+    it('should render arrays as JSON', () => {
+      expect(displayJsonValue(field)([1, 2, 3]).text).toBe('[\n 1,\n 2,\n 3\n]');
+    });
   });
 
   describe('applySort', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -970,17 +970,19 @@ export function canFieldBeColorized(
 export const displayJsonValue: (field: Field) => DisplayProcessor = (field: Field, decimals?: DecimalCount) => {
   const origDisplay = field.display!;
   return (value: unknown): DisplayValue => {
-    let jsonText: string;
-
     const displayValue = origDisplay(value, decimals);
-    const formattedValue = formattedValueToString(displayValue);
 
-    // Handle string values that might be JSON
-    try {
-      const parsed = JSON.parse(formattedValue);
-      jsonText = JSON.stringify(parsed, null, ' ');
-    } catch {
-      jsonText = formattedValue; // Keep original if not valid JSON
+    let jsonText: string;
+    if (!Array.isArray(value) && !isPlainObject(value)) {
+      const formattedValue = formattedValueToString(displayValue);
+      try {
+        const parsed = JSON.parse(formattedValue);
+        jsonText = JSON.stringify(parsed, null, ' ');
+      } catch {
+        jsonText = formattedValue; // Keep original if not valid JSON
+      }
+    } else {
+      jsonText = JSON.stringify(value, null, ' ');
     }
 
     return { ...displayValue, text: jsonText };


### PR DESCRIPTION
Fixes an issue discovered internally, introduced by https://github.com/grafana/grafana/pull/111951

When rendering a JSON field, we need to bypass arrays and objects when passing things into the main display processor to handle units.

<details>
    <summary>test JSON dashboard></summary>

```json
{
  "annotations": {
    "list": [
      {
        "builtIn": 1,
        "datasource": {
          "type": "grafana",
          "uid": "-- Grafana --"
        },
        "enable": true,
        "hide": true,
        "iconColor": "rgba(0, 211, 255, 1)",
        "name": "Annotations & Alerts",
        "type": "dashboard"
      }
    ]
  },
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": 0,
  "links": [],
  "panels": [
    {
      "datasource": {
        "type": "grafana-testdata-datasource"
      },
      "fieldConfig": {
        "defaults": {
          "custom": {
            "align": "auto",
            "cellOptions": {
              "type": "auto"
            },
            "footer": {
              "reducers": []
            },
            "inspect": false
          },
          "mappings": [],
          "thresholds": {
            "mode": "absolute",
            "steps": [
              {
                "color": "green",
                "value": 0
              },
              {
                "color": "red",
                "value": 80
              }
            ]
          }
        },
        "overrides": [
          {
            "matcher": {
              "id": "byName",
              "options": "arrays"
            },
            "properties": [
              {
                "id": "custom.width",
                "value": 667
              }
            ]
          }
        ]
      },
      "gridPos": {
        "h": 8,
        "w": 12,
        "x": 0,
        "y": 0
      },
      "id": 1,
      "options": {
        "cellHeight": "sm",
        "showHeader": true
      },
      "pluginVersion": "12.3.0-pre",
      "targets": [
        {
          "datasource": {
            "type": "grafana-testdata-datasource"
          },
          "rawFrameContent": "[{\n  \"fields\": [{\n    \"name\": \"objects\",\n    \"type\": \"other\",\n    \"values\": [{\"a\": 1, \"b\": 2}, { \"b\": 2, \"c\": 4 }, { \"b\": { \"c\": [1, 2, 3] } }]\n  },\n  {\n    \"name\": \"arrays\",\n    \"type\": \"other\",\n    \"values\": [[1,2,3], [\"foo\",\"bar\",\"baz\"], [{\"c\": 1}]]\n  }]\n}]",
          "refId": "A",
          "scenarioId": "raw_frame"
        }
      ],
      "title": "New panel",
      "type": "table"
    }
  ],
  "preload": false,
  "schemaVersion": 42,
  "tags": [],
  "templating": {
    "list": []
  },
  "time": {
    "from": "now-6h",
    "to": "now"
  },
  "timepicker": {},
  "timezone": "browser",
  "title": "Test: fix object and arrays in JSON cell",
  "uid": "ad6k7kh",
  "version": 2
}
```
</details>

### Before

<img width="1376" height="390" alt="Screenshot 2025-10-31 at 12 19 20 PM" src="https://github.com/user-attachments/assets/a2bc4e69-1bf9-4f3a-859b-5dce4bfe5e85" />

### After

<img width="1393" height="388" alt="Screenshot 2025-10-31 at 12 23 30 PM" src="https://github.com/user-attachments/assets/c6c1dd6a-84f7-4a23-9f3c-7e111ee29205" />
