### PR TITLE
Nav: Render menu items as `p` tags so truncation logic can work

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -107,7 +107,9 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
               })}
             >
               {level === 0 && iconElement && <FeatureHighlightWrapper>{iconElement}</FeatureHighlightWrapper>}
-              <Text truncate>{link.text}</Text>
+              <Text truncate element="p">
+                {link.text}
+              </Text>
               {link.isNew && <FeatureBadge featureState={FeatureState.new} />}
             </div>
           </MegaMenuItemText>


### PR DESCRIPTION
**What is this feature?**
Makes the mega menu render items in a way that means text truncation is handled properly.

**Why do we need this feature?**
Some nav items have long names, and with the prevalence of `New!` badges, they can often be truncated. This means you sometimes have no way of reading the whole name of an item unless you visit the page 😱 

This is a before and after (I added some buffer text, and refreshed the page with the fix half way through)
https://github.com/user-attachments/assets/64ad75c5-5261-4bd1-a95c-47bf4c8be8b5
