### PR TITLE
Provisioning: Add sync job & phase metrics

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/sync/full.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full.go
@@ -29,11 +29,16 @@ func FullSync(
 	progress jobs.JobProgressRecorder,
 	tracer tracing.Tracer,
 	maxSyncWorkers int,
+	metrics jobs.JobMetrics,
 ) error {
+	syncStart := time.Now()
 	cfg := repo.Config()
 
 	ctx, span := tracer.Start(ctx, "provisioning.sync.full")
 	defer span.End()
+	defer func() {
+		metrics.RecordSyncDuration(jobs.SyncTypeFull, time.Since(syncStart))
+	}()
 
 	ensureFolderCtx, ensureFolderSpan := tracer.Start(ctx, "provisioning.sync.full.ensure_folder_exists")
 	// Ensure the configured folder exists and is managed by the repository
@@ -50,6 +55,7 @@ func FullSync(
 	}
 	ensureFolderSpan.End()
 
+	compareStart := time.Now()
 	compareCtx, compareSpan := tracer.Start(ctx, "provisioning.sync.full.compare")
 	changes, err := compare(compareCtx, repo, repositoryResources, currentRef)
 	if err != nil {
@@ -57,13 +63,14 @@ func FullSync(
 		return tracing.Error(span, fmt.Errorf("compare changes: %w", err))
 	}
 	compareSpan.End()
+	metrics.RecordFullSyncPhase(jobs.FullSyncPhaseCompare, time.Since(compareStart))
 
 	if len(changes) == 0 {
 		progress.SetFinalMessage(ctx, "no changes to sync")
 		return nil
 	}
 
-	return applyChanges(ctx, changes, clients, repositoryResources, progress, tracer, maxSyncWorkers)
+	return applyChanges(ctx, changes, clients, repositoryResources, progress, tracer, maxSyncWorkers, metrics)
 }
 
 func applyChange(ctx context.Context, change ResourceFileChange, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer) {
@@ -156,7 +163,7 @@ func applyChange(ctx context.Context, change ResourceFileChange, clients resourc
 	writeSpan.End()
 }
 
-func applyChanges(ctx context.Context, changes []ResourceFileChange, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int) error {
+func applyChanges(ctx context.Context, changes []ResourceFileChange, clients resources.ResourceClients, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics) error {
 	progress.SetTotal(ctx, len(changes))
 
 	_, applyChangesSpan := tracer.Start(ctx, "provisioning.sync.full.apply_changes",
@@ -200,26 +207,44 @@ func applyChanges(ctx context.Context, changes []ResourceFileChange, clients res
 		attribute.Int("file_creations", len(fileCreations)),
 	)
 
+	// instrument a function with a phase and metrics
+	instrumented := func(phase jobs.FullSyncPhase, fn func() error) error {
+		phaseStart := time.Now()
+		err := fn()
+		metrics.RecordFullSyncPhase(phase, time.Since(phaseStart))
+		return err
+	}
+
 	if len(fileDeletions) > 0 {
-		if err := applyResourcesInParallel(ctx, fileDeletions, clients, repositoryResources, progress, tracer, maxSyncWorkers); err != nil {
+		if err := instrumented(jobs.FullSyncPhaseFileDeletions, func() error {
+			return applyResourcesInParallel(ctx, fileDeletions, clients, repositoryResources, progress, tracer, maxSyncWorkers)
+		}); err != nil {
 			return err
 		}
 	}
 
 	if len(folderDeletions) > 0 {
-		if err := applyFoldersSerially(ctx, folderDeletions, clients, repositoryResources, progress, tracer); err != nil {
+		if err := instrumented(jobs.FullSyncPhaseFolderDeletions, func() error {
+			return applyFoldersSerially(ctx, folderDeletions, clients, repositoryResources, progress, tracer)
+		}); err != nil {
 			return err
 		}
 	}
 
 	if len(folderCreations) > 0 {
-		if err := applyFoldersSerially(ctx, folderCreations, clients, repositoryResources, progress, tracer); err != nil {
+		if err := instrumented(jobs.FullSyncPhaseFolderCreations, func() error {
+			return applyFoldersSerially(ctx, folderCreations, clients, repositoryResources, progress, tracer)
+		}); err != nil {
 			return err
 		}
 	}
 
 	if len(fileCreations) > 0 {
-		return applyResourcesInParallel(ctx, fileCreations, clients, repositoryResources, progress, tracer, maxSyncWorkers)
+		if err := instrumented(jobs.FullSyncPhaseFileCreations, func() error {
+			return applyResourcesInParallel(ctx, fileCreations, clients, repositoryResources, progress, tracer, maxSyncWorkers)
+		}); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_sync_fn_mock.go
@@ -28,17 +28,17 @@ func (_m *MockFullSyncFn) EXPECT() *MockFullSyncFn_Expecter {
 	return &MockFullSyncFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer
-func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int) error {
-	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer)
+// Execute provides a mock function with given fields: ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics
+func (_m *MockFullSyncFn) Execute(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics) error {
+	ret := _m.Called(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer) error); ok {
-		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics) error); ok {
+		r0 = rf(ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -60,13 +60,15 @@ type MockFullSyncFn_Execute_Call struct {
 //   - repositoryResources resources.RepositoryResources
 //   - progress jobs.JobProgressRecorder
 //   - tracer tracing.Tracer
-func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}) *MockFullSyncFn_Execute_Call {
-	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer)}
+//   - maxSyncWorkers int
+//   - metrics jobs.JobMetrics
+func (_e *MockFullSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, compare interface{}, clients interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, maxSyncWorkers interface{}, metrics interface{}) *MockFullSyncFn_Execute_Call {
+	return &MockFullSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, compare, clients, currentRef, repositoryResources, progress, tracer, maxSyncWorkers, metrics)}
 }
 
-func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer)) *MockFullSyncFn_Execute_Call {
+func (_c *MockFullSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics)) *MockFullSyncFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(CompareFn), args[3].(resources.ResourceClients), args[4].(string), args[5].(resources.RepositoryResources), args[6].(jobs.JobProgressRecorder), args[7].(tracing.Tracer))
+		run(args[0].(context.Context), args[1].(repository.Reader), args[2].(CompareFn), args[3].(resources.ResourceClients), args[4].(string), args[5].(resources.RepositoryResources), args[6].(jobs.JobProgressRecorder), args[7].(tracing.Tracer), args[8].(int), args[9].(jobs.JobMetrics))
 	})
 	return _c
 }
@@ -76,7 +78,7 @@ func (_c *MockFullSyncFn_Execute_Call) Return(_a0 error) *MockFullSyncFn_Execute
 	return _c
 }
 
-func (_c *MockFullSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer) error) *MockFullSyncFn_Execute_Call {
+func (_c *MockFullSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Reader, CompareFn, resources.ResourceClients, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, int, jobs.JobMetrics) error) *MockFullSyncFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/full_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/full_test.go
@@ -744,9 +744,9 @@ func TestFullSync_ApplyChanges(t *testing.T) { //nolint:gocyclo
 				},
 			})
 
-		progress.On("SetTotal", mock.Anything, len(tt.changes)).Return()
-		err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
-		if tt.expectedError != "" {
+			progress.On("SetTotal", mock.Anything, len(tt.changes)).Return()
+			err := FullSync(context.Background(), repo, compareFn.Execute, clients, "current-ref", repoResources, progress, tracing.NewNoopTracerService(), 10, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError, tt.description)
 			} else {
 				require.NoError(t, err, tt.description)

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_sync_fn_mock.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_sync_fn_mock.go
@@ -28,17 +28,17 @@ func (_m *MockIncrementalSyncFn) EXPECT() *MockIncrementalSyncFn_Expecter {
 	return &MockIncrementalSyncFn_Expecter{mock: &_m.Mock}
 }
 
-// Execute provides a mock function with given fields: ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer
-func (_m *MockIncrementalSyncFn) Execute(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer) error {
-	ret := _m.Called(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer)
+// Execute provides a mock function with given fields: ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics
+func (_m *MockIncrementalSyncFn) Execute(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics) error {
+	ret := _m.Called(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Execute")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer) error); ok {
-		r0 = rf(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer)
+	if rf, ok := ret.Get(0).(func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics) error); ok {
+		r0 = rf(ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -59,13 +59,14 @@ type MockIncrementalSyncFn_Execute_Call struct {
 //   - repositoryResources resources.RepositoryResources
 //   - progress jobs.JobProgressRecorder
 //   - tracer tracing.Tracer
-func (_e *MockIncrementalSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, previousRef interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}) *MockIncrementalSyncFn_Execute_Call {
-	return &MockIncrementalSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer)}
+//   - metrics jobs.JobMetrics
+func (_e *MockIncrementalSyncFn_Expecter) Execute(ctx interface{}, repo interface{}, previousRef interface{}, currentRef interface{}, repositoryResources interface{}, progress interface{}, tracer interface{}, metrics interface{}) *MockIncrementalSyncFn_Execute_Call {
+	return &MockIncrementalSyncFn_Execute_Call{Call: _e.mock.On("Execute", ctx, repo, previousRef, currentRef, repositoryResources, progress, tracer, metrics)}
 }
 
-func (_c *MockIncrementalSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer)) *MockIncrementalSyncFn_Execute_Call {
+func (_c *MockIncrementalSyncFn_Execute_Call) Run(run func(ctx context.Context, repo repository.Versioned, previousRef string, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics)) *MockIncrementalSyncFn_Execute_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(repository.Versioned), args[2].(string), args[3].(string), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder), args[6].(tracing.Tracer))
+		run(args[0].(context.Context), args[1].(repository.Versioned), args[2].(string), args[3].(string), args[4].(resources.RepositoryResources), args[5].(jobs.JobProgressRecorder), args[6].(tracing.Tracer), args[7].(jobs.JobMetrics))
 	})
 	return _c
 }
@@ -75,7 +76,7 @@ func (_c *MockIncrementalSyncFn_Execute_Call) Return(_a0 error) *MockIncremental
 	return _c
 }
 
-func (_c *MockIncrementalSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer) error) *MockIncrementalSyncFn_Execute_Call {
+func (_c *MockIncrementalSyncFn_Execute_Call) RunAndReturn(run func(context.Context, repository.Versioned, string, string, resources.RepositoryResources, jobs.JobProgressRecorder, tracing.Tracer, jobs.JobMetrics) error) *MockIncrementalSyncFn_Execute_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -387,9 +387,9 @@ func TestIncrementalSync(t *testing.T) {
 			repoResources := resources.NewMockRepositoryResources(t)
 			progress := jobs.NewMockJobProgressRecorder(t)
 
-		tt.setupMocks(repo, repoResources, progress)
+			tt.setupMocks(repo, repoResources, progress)
 
-		err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+			err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)
@@ -510,9 +510,9 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 			repoResources := resources.NewMockRepositoryResources(t)
 			progress := jobs.NewMockJobProgressRecorder(t)
 
-		tt.setupMocks(repo, repoResources, progress)
+			tt.setupMocks(repo, repoResources, progress)
 
-		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+			err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)

--- a/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/incremental_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -31,7 +32,7 @@ func TestIncrementalSync_ContextCancelled(t *testing.T) {
 	progress.On("SetTotal", mock.Anything, 1).Return()
 	progress.On("SetMessage", mock.Anything, "replicating versioned changes").Return()
 
-	err := IncrementalSync(ctx, repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService())
+	err := IncrementalSync(ctx, repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 	require.EqualError(t, err, "context canceled")
 }
 
@@ -386,9 +387,9 @@ func TestIncrementalSync(t *testing.T) {
 			repoResources := resources.NewMockRepositoryResources(t)
 			progress := jobs.NewMockJobProgressRecorder(t)
 
-			tt.setupMocks(repo, repoResources, progress)
+		tt.setupMocks(repo, repoResources, progress)
 
-			err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService())
+		err := IncrementalSync(context.Background(), repo, tt.previousRef, tt.currentRef, repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)
@@ -509,9 +510,9 @@ func TestIncrementalSync_CleanupOrphanedFolders(t *testing.T) {
 			repoResources := resources.NewMockRepositoryResources(t)
 			progress := jobs.NewMockJobProgressRecorder(t)
 
-			tt.setupMocks(repo, repoResources, progress)
+		tt.setupMocks(repo, repoResources, progress)
 
-			err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService())
+		err := IncrementalSync(context.Background(), repo, "old-ref", "new-ref", repoResources, progress, tracing.NewNoopTracerService(), jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
 
 			if tt.expectedError != "" {
 				require.EqualError(t, err, tt.expectedError)

--- a/pkg/registry/apis/provisioning/jobs/sync/sync.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync.go
@@ -12,13 +12,13 @@ import (
 )
 
 //go:generate mockery --name FullSyncFn --structname MockFullSyncFn --inpackage --filename full_sync_fn_mock.go --with-expecter
-type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int) error
+type FullSyncFn func(ctx context.Context, repo repository.Reader, compare CompareFn, clients resources.ResourceClients, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics) error
 
 //go:generate mockery --name CompareFn --structname MockCompareFn --inpackage --filename compare_fn_mock.go --with-expecter
 type CompareFn func(ctx context.Context, repo repository.Reader, repositoryResources resources.RepositoryResources, ref string) ([]ResourceFileChange, error)
 
 //go:generate mockery --name IncrementalSyncFn --structname MockIncrementalSyncFn --inpackage --filename incremental_sync_fn_mock.go --with-expecter
-type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer) error
+type IncrementalSyncFn func(ctx context.Context, repo repository.Versioned, previousRef, currentRef string, repositoryResources resources.RepositoryResources, progress jobs.JobProgressRecorder, tracer tracing.Tracer, metrics jobs.JobMetrics) error
 
 //go:generate mockery --name Syncer --structname MockSyncer --inpackage --filename syncer_mock.go --with-expecter
 type Syncer interface {
@@ -30,15 +30,17 @@ type syncer struct {
 	fullSync        FullSyncFn
 	incrementalSync IncrementalSyncFn
 	tracer          tracing.Tracer
+	metrics         jobs.JobMetrics
 	maxSyncWorkers  int
 }
 
-func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int) Syncer {
+func NewSyncer(compare CompareFn, fullSync FullSyncFn, incrementalSync IncrementalSyncFn, tracer tracing.Tracer, maxSyncWorkers int, metrics jobs.JobMetrics) Syncer {
 	return &syncer{
 		compare:         compare,
 		fullSync:        fullSync,
 		incrementalSync: incrementalSync,
 		tracer:          tracer,
+		metrics:         metrics,
 		maxSyncWorkers:  maxSyncWorkers,
 	}
 }
@@ -57,11 +59,11 @@ func (r *syncer) Sync(ctx context.Context, repo repository.ReaderWriter, options
 
 		if cfg.Status.Sync.LastRef != "" && options.Incremental {
 			progress.SetMessage(ctx, "incremental sync")
-			return currentRef, r.incrementalSync(ctx, versionedRepo, cfg.Status.Sync.LastRef, currentRef, repositoryResources, progress, r.tracer)
+			return currentRef, r.incrementalSync(ctx, versionedRepo, cfg.Status.Sync.LastRef, currentRef, repositoryResources, progress, r.tracer, r.metrics)
 		}
 	}
 
 	progress.SetMessage(ctx, "full sync")
 
-	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers)
+	return currentRef, r.fullSync(ctx, repo, r.compare, clients, currentRef, repositoryResources, progress, r.tracer, r.maxSyncWorkers, r.metrics)
 }

--- a/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
+++ b/pkg/registry/apis/provisioning/jobs/sync/sync_test.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/prometheus/client_golang/prometheus"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
+	"github.com/prometheus/client_golang/prometheus"
 	mock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -66,8 +66,8 @@ func TestSyncer_Sync(t *testing.T) {
 				})
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
 
-			progress.On("SetMessage", mock.Anything, "full sync").Return()
-			fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				progress.On("SetMessage", mock.Anything, "full sync").Return()
+				fullSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, mock.Anything, mock.Anything, "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedMessages: []string{"full sync"},
 		},
@@ -88,8 +88,8 @@ func TestSyncer_Sync(t *testing.T) {
 					},
 				})
 				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
-			progress.On("SetMessage", mock.Anything, "incremental sync").Return()
-			incrementalSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				progress.On("SetMessage", mock.Anything, "incremental sync").Return()
+				incrementalSyncFn.EXPECT().Execute(mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			expectedRef:      "new-ref",
 			expectedMessages: []string{"incremental sync"},
@@ -130,9 +130,9 @@ func TestSyncer_Sync(t *testing.T) {
 						},
 					},
 				})
-			repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
-			progress.On("SetMessage", mock.Anything, "incremental sync").Return()
-			incrementalSyncFn.On("Execute", mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("incremental sync failed"))
+				repo.MockVersioned.On("LatestRef", mock.Anything).Return("new-ref", nil)
+				progress.On("SetMessage", mock.Anything, "incremental sync").Return()
+				incrementalSyncFn.On("Execute", mock.Anything, mock.Anything, "old-ref", "new-ref", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(fmt.Errorf("incremental sync failed"))
 			},
 			expectedRef:      "new-ref",
 			expectedMessages: []string{"incremental sync"},
@@ -154,16 +154,16 @@ func TestSyncer_Sync(t *testing.T) {
 				MockVersioned:  repository.NewMockVersioned(t),
 			}
 
-		tt.setupMocks(repo, repoResources, clients, progress, compareFn, fullSyncFn, incrementalSyncFn)
+			tt.setupMocks(repo, repoResources, clients, progress, compareFn, fullSyncFn, incrementalSyncFn)
 
-		syncer := NewSyncer(
-			compareFn.Execute,
-			fullSyncFn.Execute,
-			incrementalSyncFn.Execute,
-			tracing.NewNoopTracerService(),
-			10,
-			jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()),
-		)
+			syncer := NewSyncer(
+				compareFn.Execute,
+				fullSyncFn.Execute,
+				incrementalSyncFn.Execute,
+				tracing.NewNoopTracerService(),
+				10,
+				jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()),
+			)
 
 			ref, err := syncer.Sync(context.Background(), repo, tt.options, repoResources, clients, progress)
 			if tt.expectedError != "" {

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -696,7 +696,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				metrics,
 			)
 
-			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10)
+			syncer := sync.NewSyncer(sync.Compare, sync.FullSync, sync.IncrementalSync, b.tracer, 10, metrics)
 			syncWorker := sync.NewSyncWorker(
 				b.clients,
 				b.repositoryResources,


### PR DESCRIPTION
This adds new metric instrumentation to Git-Sync jobs, notably duration histograms for individual phases as well as complete jobs.

It exposes the following metrics: 
```go
	durationHist := prometheus.NewHistogramVec(
		prometheus.HistogramOpts{
			Name:    "grafana_provisioning_jobs_duration_seconds",
			Help:    "Duration of job",
			Buckets: []float64{5.0, 10.0, 30.0, 60.0, 120.0, 300.0},
		},
		[]string{"action", "resources_changed_bucket"},
	)

	incrementalSyncPhaseDurationHist := prometheus.NewHistogramVec(
		prometheus.HistogramOpts{
			Name:    "grafana_provisioning_jobs_incremental_sync_phase_duration_seconds",
			Help:    "Duration of job phases for incremental sync",
			Buckets: prometheus.ExponentialBucketsRange(0.01, 10*60, 8), // 1ms -> 10m
		},
		[]string{"phase"},
	)
	registry.MustRegister(incrementalSyncPhaseDurationHist)

	fullSyncPhaseDurationHist := prometheus.NewHistogramVec(
		prometheus.HistogramOpts{
			Name:    "grafana_provisioning_jobs_full_sync_phase_duration_seconds",
			Help:    "Duration of job phases for full sync",
			Buckets: prometheus.ExponentialBucketsRange(0.01, 10*60, 8), // 1ms -> 10m
		},
		[]string{"phase"},
	)
```

Originally, I intended to unify the phase metrics such that we could partition on another label "sync_type=incremental|full", however the implementations of the variants are different enough that this appeared more trouble than it was worth. Therefore, I added duration histograms for phases within each job type and a unifying duration histogram for complete jobs of _both_ types, partitioned on a `type` label.

**Notes for Reviewer**: 
* In order to avoid handling metric recording in every return case (notably early return in the event of error), I did some refactoring around how we execute phases. This allows us to use `defer record()` easily from subroutines rather than the tedious, verbose, and error-prone alternative of recording metrics on every err check.
* I chose to extend the Sync function types with metrics arguments -- there are other ways to do this if there's a strong need for keeping these isolated from each other.
* Image below is a local example showing some of these metrics once an initial sync has completed.

<img width="1420" height="792" alt="image" src="https://github.com/user-attachments/assets/39af454d-fd25-47b5-8baa-cf611854e5fa" />

