### PR TITLE
Dashboards: Fix bug with anon users with editor permissions creating dashboards

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1174,12 +1174,7 @@ func (dr *DashboardServiceImpl) SetDefaultPermissionsAfterCreate(ctx context.Con
 	if err != nil {
 		return err
 	}
-	uid, err := user.GetInternalID()
-	if err != nil {
-		return err
-	}
 	permissions := []accesscontrol.SetResourcePermissionCommand{}
-
 	isNested := obj.GetFolder() != ""
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if dr.features.IsEnabledGlobally(featuremgmt.FlagKubernetesDashboards) && isNested {
@@ -1187,6 +1182,10 @@ func (dr *DashboardServiceImpl) SetDefaultPermissionsAfterCreate(ctx context.Con
 		return nil
 	}
 	if user.IsIdentityType(claims.TypeUser, claims.TypeServiceAccount) {
+		uid, err := user.GetInternalID()
+		if err != nil {
+			return err
+		}
 		permissions = append(permissions, accesscontrol.SetResourcePermissionCommand{
 			UserID: uid, Permission: dashboardaccess.PERMISSION_ADMIN.String(),
 		})

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -2127,6 +2127,7 @@ func TestSetDefaultPermissionsAfterCreate(t *testing.T) {
 			name                        string
 			rootFolder                  bool
 			featureKubernetesDashboards bool
+			User                        *user.SignedInUser
 			expectedPermission          []accesscontrol.SetResourcePermissionCommand
 		}{
 			{
@@ -2145,6 +2146,19 @@ func TestSetDefaultPermissionsAfterCreate(t *testing.T) {
 				featureKubernetesDashboards: true,
 				expectedPermission: []accesscontrol.SetResourcePermissionCommand{
 					{UserID: 1, Permission: dashboardaccess.PERMISSION_ADMIN.String()},
+					{BuiltinRole: string(org.RoleEditor), Permission: dashboardaccess.PERMISSION_EDIT.String()},
+					{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_VIEW.String()},
+				},
+			},
+			{
+				name:                        "with kubernetesDashboards feature in root folder and user is anonymous",
+				rootFolder:                  true,
+				featureKubernetesDashboards: true,
+				User: &user.SignedInUser{
+					IsAnonymous: true,
+					UserID:      0,
+				},
+				expectedPermission: []accesscontrol.SetResourcePermissionCommand{
 					{BuiltinRole: string(org.RoleEditor), Permission: dashboardaccess.PERMISSION_EDIT.String()},
 					{BuiltinRole: string(org.RoleViewer), Permission: dashboardaccess.PERMISSION_VIEW.String()},
 				},
@@ -2171,6 +2185,9 @@ func TestSetDefaultPermissionsAfterCreate(t *testing.T) {
 					OrgID:   1,
 					OrgRole: "Admin",
 					UserID:  1,
+				}
+				if tc.User != nil {
+					user = tc.User
 				}
 				ctx := request.WithNamespace(context.Background(), "default")
 				ctx = identity.WithRequester(ctx, user)


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/110828

That issue was due to two things - the original report was hitting [this check that was removed](https://github.com/grafana/grafana/pull/112024). The next issue is fixed in this PR.

For anonymous access - `uid, err := user.GetInternalID()` will fail [here](https://github.com/grafana/grafana/blob/cf242def3aed19a4d125bd84303d9adf8941f402/pkg/apimachinery/identity/requester.go#L100) with this error

<img width="572" height="478" alt="Screenshot 2025-10-30 at 10 50 57 PM" src="https://github.com/user-attachments/assets/6e5f300e-98fd-4550-91dd-922de99adc8d" />

We only want to grant the user admin permissions if they are indeed a logged in user or service account, so we can skip getting the uid for anonymous users and just set the default editor can edit and viewer can view