### PR TITLE
AuthZ: Instantiate needed clients for IAM hooks

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -99,21 +99,26 @@ func RegisterAPIService(
 	return builder, nil
 }
 
-// TODO zClient, zTickets, reg
 func NewAPIService(
 	accessClient types.AccessClient,
 	dbProvider legacysql.LegacyDatabaseProvider,
 	features featuremgmt.FeatureToggles,
+	zClient zanzana.Client,
+	reg prometheus.Registerer,
 ) *IdentityAccessManagementAPIBuilder {
 	store := legacy.NewLegacySQLStores(dbProvider)
 	resourcePermissionsStorage := resourcepermission.ProvideStorageBackend(dbProvider)
 	resourceAuthorizer := gfauthorizer.NewResourceAuthorizer(accessClient)
+	registerMetrics(reg)
 	return &IdentityAccessManagementAPIBuilder{
 		store:                      store,
 		display:                    user.NewLegacyDisplayREST(store),
 		resourcePermissionsStorage: resourcePermissionsStorage,
 		logger:                     log.New("iam.apis"),
 		features:                   features,
+		zClient:                    zClient,
+		zTickets:                   make(chan bool, MaxConcurrentZanzanaWrites),
+		reg:                        reg,
 		authorizer: authorizer.AuthorizerFunc(
 			func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				// For now only authorize resourcepermissions resource


### PR DESCRIPTION
**What is this feature?**

Enables IAM hooks to populate openFGA after resource creation/update/deletion by adding zanzana client, zTickets channel, and prometheus registerer to `NewAPIService` initialization.

**Why do we need this feature?**

IAM hooks require these clients to sync ResourcePermission resources to Zanzana (openFGA) for multi-tenant authorization.

**Who is this feature for?**

Multi-tenant Grafana deployments using openFGA for authorization.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/identity-access-team/issues/1783

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.