### PR TITLE
docs(alerting): add note about invalid numeric identifiers in templates

### DIFF
--- a/docs/sources/alerting/alerting-rules/templates/reference.md
+++ b/docs/sources/alerting/alerting-rules/templates/reference.md
@@ -141,6 +141,20 @@ Alternatively, you can use the `index()` function to retrieve the query value:
 {{ index $values "B" }} CPU usage for {{ index $labels "instance" }} over the last 5 minutes.
 ```
 
+{{< admonition type="note" >}}
+
+Variable names that start with a number (for example, `1B`) are not [valid identifiers in Go templates](https://go.dev/ref/spec#Identifiers).
+
+To access a value or label whose key starts with a number, use the `index` function:
+
+```
+{{ index $values "1B" }} CPU usage for {{ index $labels "1instance" }} over the last 5 minutes.
+```
+
+Using `{{ $values.1B.Value }}` is invalid and causes the template code to render as plain text.
+
+{{< /admonition  >}}
+
 #### $value
 
 The `$value` variable is a string containing the labels and values of all instant queries; threshold, reduce and math expressions, and classic conditions in the alert rule.


### PR DESCRIPTION
This PR adds a note to the alerting templates reference explaining that variable names starting with a number (for example, `1B`) are not valid identifiers in Go templates. The recommendation is to use the `index` function.


Closes https://github.com/grafana/grafana/issues/113189

⭐ [Preview](https://deploy-preview-grafana-113269-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/alerting-rules/templates/reference/#values)

<img width="793" height="251" alt="Screenshot 2025-10-31 at 10 04 36" src="https://github.com/user-attachments/assets/fe6de6b1-358f-428b-95a5-5e4c9913ae46" />


