### PR TITLE
PublicDashboards: Dont call API on dashboard page if public dashboards is disabled

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/PublicDashboardBadge.tsx
@@ -2,13 +2,14 @@ import { css } from '@emotion/css';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { Badge, useStyles2 } from '@grafana/ui';
 import { useGetPublicDashboardQuery } from 'app/features/dashboard/api/publicDashboardApi';
 
 import { ToolbarActionProps } from '../types';
 
 export const PublicDashboardBadge = ({ dashboard }: ToolbarActionProps) => {
-  if (!dashboard.state.uid) {
+  if (!dashboard.state.uid || !config.publicDashboardsEnabled) {
     return null;
   }
 


### PR DESCRIPTION
**What is this feature?**

Avoids making an API call to `/public-dashboards` when loading any dashboard page if the Public Dashboards feature is disabled.

**Why do we need this feature?**

If the Public Dashboards feature is disabled, it does not make sense to issue this API call as it will always return 404.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

Addresses #110736

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
