### PR TITLE
Zanzana: Add team binding hooks

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -219,6 +219,14 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 			return err
 		}
 
+		// Only teamBindingStore exposes the AfterCreate, AfterDelete, and BeginUpdate hooks
+		if enableZanzanaSync {
+			b.logger.Info("Enabling hooks for TeamBinding to sync to Zanzana")
+			teamBindingStore.AfterCreate = b.AfterTeamBindingCreate
+			teamBindingStore.AfterDelete = b.AfterTeamBindingDelete
+			teamBindingStore.BeginUpdate = b.BeginTeamBindingUpdate
+		}
+
 		storage[teamBindingResource.StoragePath()] = teamBindingDW
 	}
 

--- a/pkg/registry/apis/iam/team_binding_hooks.go
+++ b/pkg/registry/apis/iam/team_binding_hooks.go
@@ -1,0 +1,348 @@
+package iam
+
+import (
+	"context"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/generic/registry"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	v1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
+)
+
+// convertTeamBindingToTuple converts a TeamBinding to a v1 TupleKey format
+// TeamBinding represents a user's membership in a team with a specific permission level
+func convertTeamBindingToTuple(tb *iamv0.TeamBinding) (*v1.TupleKey, error) {
+	if tb.Spec.Subject.Name == "" {
+		return nil, errEmptyName
+	}
+
+	if tb.Spec.TeamRef.Name == "" {
+		return nil, errEmptyName
+	}
+
+	// Map permission to relation
+	var relation string
+	switch tb.Spec.Permission {
+	case iamv0.TeamBindingTeamPermissionAdmin:
+		relation = zanzana.RelationTeamAdmin
+	case iamv0.TeamBindingTeamPermissionMember:
+		relation = zanzana.RelationTeamMember
+	default:
+		// Default to member if unknown permission
+		relation = zanzana.RelationTeamMember
+	}
+
+	// Create tuple: user:{subjectUID} has {relation} relation to team:{teamUID}
+	tuple := &v1.TupleKey{
+		User:     zanzana.NewTupleEntry(zanzana.TypeUser, tb.Spec.Subject.Name, ""),
+		Relation: relation,
+		Object:   zanzana.NewTupleEntry(zanzana.TypeTeam, tb.Spec.TeamRef.Name, ""),
+	}
+
+	return tuple, nil
+}
+
+// AfterTeamBindingCreate is a post-create hook that writes the team binding to Zanzana (openFGA)
+func (b *IdentityAccessManagementAPIBuilder) AfterTeamBindingCreate(obj runtime.Object, _ *metav1.CreateOptions) {
+	if b.zClient == nil {
+		return
+	}
+
+	tb, ok := obj.(*iamv0.TeamBinding)
+	if !ok {
+		b.logger.Error("failed to convert object to TeamBinding type", "object", obj)
+		return
+	}
+
+	resourceType := "teambinding"
+	operation := "create"
+
+	// Grab a ticket to write to Zanzana
+	// This limits the amount of concurrent connections to Zanzana
+	wait := time.Now()
+	b.zTickets <- true
+	hooksWaitHistogram.WithLabelValues(resourceType, operation).Observe(time.Since(wait).Seconds())
+
+	go func(tb *iamv0.TeamBinding) {
+		start := time.Now()
+		status := "success"
+
+		defer func() {
+			// Release the ticket after write is done
+			<-b.zTickets
+			// Record operation duration and count
+			hooksDurationHistogram.WithLabelValues(resourceType, operation, status).Observe(time.Since(start).Seconds())
+			hooksOperationCounter.WithLabelValues(resourceType, operation, status).Inc()
+		}()
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		if err != nil {
+			b.logger.Error("failed to convert team binding to tuple",
+				"namespace", tb.Namespace,
+				"name", tb.Name,
+				"subject", tb.Spec.Subject.Name,
+				"teamRef", tb.Spec.TeamRef.Name,
+				"err", err,
+			)
+			status = "failure"
+			return
+		}
+
+		b.logger.Debug("writing team binding to zanzana",
+			"namespace", tb.Namespace,
+			"name", tb.Name,
+			"subject", tb.Spec.Subject.Name,
+			"teamRef", tb.Spec.TeamRef.Name,
+			"permission", tb.Spec.Permission,
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
+		defer cancel()
+
+		err = b.zClient.Write(ctx, &v1.WriteRequest{
+			Namespace: tb.Namespace,
+			Writes: &v1.WriteRequestWrites{
+				TupleKeys: []*v1.TupleKey{tuple},
+			},
+		})
+		if err != nil {
+			status = "failure"
+			b.logger.Error("failed to write team binding to zanzana",
+				"err", err,
+				"namespace", tb.Namespace,
+				"name", tb.Name,
+				"subject", tb.Spec.Subject.Name,
+				"teamRef", tb.Spec.TeamRef.Name,
+			)
+		} else {
+			// Record successful tuple write
+			hooksTuplesCounter.WithLabelValues(resourceType, operation, "write").Inc()
+		}
+	}(tb.DeepCopy()) // Pass a copy of the object
+}
+
+// BeginTeamBindingUpdate is a pre-update hook that prepares zanzana updates
+// It converts old and new team bindings to tuples and performs the zanzana write after K8s update succeeds
+func (b *IdentityAccessManagementAPIBuilder) BeginTeamBindingUpdate(ctx context.Context, obj, oldObj runtime.Object, options *metav1.UpdateOptions) (registry.FinishFunc, error) {
+	if b.zClient == nil {
+		return nil, nil
+	}
+
+	// Extract team bindings from both old and new objects
+	oldTB, ok := oldObj.(*iamv0.TeamBinding)
+	if !ok {
+		return nil, nil
+	}
+
+	newTB, ok := obj.(*iamv0.TeamBinding)
+	if !ok {
+		return nil, nil
+	}
+
+	// Convert old team binding to tuple for deletion
+	var oldTuple *v1.TupleKey
+	var oldErr error
+	if oldTB.Spec.Subject.Name != "" && oldTB.Spec.TeamRef.Name != "" {
+		oldTuple, oldErr = convertTeamBindingToTuple(oldTB)
+		if oldErr != nil {
+			b.logger.Error("failed to convert old team binding to tuple",
+				"namespace", oldTB.Namespace,
+				"name", oldTB.Name,
+				"err", oldErr,
+			)
+		}
+	}
+
+	// Convert new team binding to tuple for writing
+	var newTuple *v1.TupleKey
+	var newErr error
+	if newTB.Spec.Subject.Name != "" && newTB.Spec.TeamRef.Name != "" {
+		newTuple, newErr = convertTeamBindingToTuple(newTB)
+		if newErr != nil {
+			b.logger.Error("failed to convert new team binding to tuple",
+				"namespace", newTB.Namespace,
+				"name", newTB.Name,
+				"err", newErr,
+			)
+		}
+	}
+
+	// Return a finish function that performs the zanzana write only on success
+	return func(ctx context.Context, success bool) {
+		if !success {
+			// Update failed, don't write to zanzana
+			return
+		}
+
+		// Grab a ticket to write to Zanzana
+		// This limits the amount of concurrent connections to Zanzana
+		wait := time.Now()
+		b.zTickets <- true
+		hooksWaitHistogram.WithLabelValues("teambinding", "update").Observe(time.Since(wait).Seconds())
+
+		go func() {
+			start := time.Now()
+			status := "success"
+
+			defer func() {
+				<-b.zTickets
+				// Record operation duration and count
+				hooksDurationHistogram.WithLabelValues("teambinding", "update", status).Observe(time.Since(start).Seconds())
+				hooksOperationCounter.WithLabelValues("teambinding", "update", status).Inc()
+			}()
+
+			b.logger.Debug("updating team binding in zanzana",
+				"namespace", newTB.Namespace,
+				"name", newTB.Name,
+				"oldSubject", oldTB.Spec.Subject.Name,
+				"newSubject", newTB.Spec.Subject.Name,
+				"oldTeamRef", oldTB.Spec.TeamRef.Name,
+				"newTeamRef", newTB.Spec.TeamRef.Name,
+				"oldPermission", oldTB.Spec.Permission,
+				"newPermission", newTB.Spec.Permission,
+			)
+
+			ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
+			defer cancel()
+
+			// Prepare write request
+			req := &v1.WriteRequest{
+				Namespace: newTB.Namespace,
+			}
+
+			// Add delete for old tuple
+			if oldTuple != nil && oldErr == nil {
+				deleteTuple := toTupleKeysWithoutCondition([]*v1.TupleKey{oldTuple})
+				req.Deletes = &v1.WriteRequestDeletes{
+					TupleKeys: deleteTuple,
+				}
+				b.logger.Debug("deleting existing team binding from zanzana",
+					"namespace", newTB.Namespace,
+					"subject", oldTB.Spec.Subject.Name,
+					"teamRef", oldTB.Spec.TeamRef.Name,
+				)
+			}
+
+			// Add write for new tuple
+			if newTuple != nil && newErr == nil {
+				req.Writes = &v1.WriteRequestWrites{
+					TupleKeys: []*v1.TupleKey{newTuple},
+				}
+				b.logger.Debug("writing new team binding to zanzana",
+					"namespace", newTB.Namespace,
+					"subject", newTB.Spec.Subject.Name,
+					"teamRef", newTB.Spec.TeamRef.Name,
+				)
+			}
+
+			// Only make the request if there are deletes or writes
+			if (req.Deletes != nil && len(req.Deletes.TupleKeys) > 0) || (req.Writes != nil && len(req.Writes.TupleKeys) > 0) {
+				err := b.zClient.Write(ctx, req)
+				if err != nil {
+					status = "failure"
+					b.logger.Error("failed to update team binding in zanzana",
+						"err", err,
+						"namespace", newTB.Namespace,
+						"name", newTB.Name,
+					)
+				} else {
+					// Record successful tuple operations
+					if oldTuple != nil && oldErr == nil {
+						hooksTuplesCounter.WithLabelValues("teambinding", "update", "delete").Inc()
+					}
+					if newTuple != nil && newErr == nil {
+						hooksTuplesCounter.WithLabelValues("teambinding", "update", "write").Inc()
+					}
+				}
+			} else {
+				b.logger.Debug("no tuples to update in zanzana", "namespace", newTB.Namespace, "name", newTB.Name)
+			}
+		}()
+	}, nil
+}
+
+// AfterTeamBindingDelete is a post-delete hook that removes the team binding from Zanzana (openFGA)
+func (b *IdentityAccessManagementAPIBuilder) AfterTeamBindingDelete(obj runtime.Object, _ *metav1.DeleteOptions) {
+	if b.zClient == nil {
+		return
+	}
+
+	tb, ok := obj.(*iamv0.TeamBinding)
+	if !ok {
+		b.logger.Error("failed to convert object to TeamBinding type", "object", obj)
+		return
+	}
+
+	resourceType := "teambinding"
+	operation := "delete"
+
+	// Grab a ticket to write to Zanzana
+	// This limits the amount of concurrent connections to Zanzana
+	wait := time.Now()
+	b.zTickets <- true
+	hooksWaitHistogram.WithLabelValues(resourceType, operation).Observe(time.Since(wait).Seconds())
+
+	go func(tb *iamv0.TeamBinding) {
+		start := time.Now()
+		status := "success"
+
+		defer func() {
+			// Release the ticket after write is done
+			<-b.zTickets
+			// Record operation duration and count
+			hooksDurationHistogram.WithLabelValues(resourceType, operation, status).Observe(time.Since(start).Seconds())
+			hooksOperationCounter.WithLabelValues(resourceType, operation, status).Inc()
+		}()
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		if err != nil {
+			b.logger.Error("failed to convert team binding to tuple for deletion",
+				"namespace", tb.Namespace,
+				"name", tb.Name,
+				"subject", tb.Spec.Subject.Name,
+				"teamRef", tb.Spec.TeamRef.Name,
+				"err", err,
+			)
+			status = "failure"
+			return
+		}
+
+		// Convert tuple to TupleKeyWithoutCondition for deletion
+		deleteTuple := toTupleKeysWithoutCondition([]*v1.TupleKey{tuple})
+
+		b.logger.Debug("deleting team binding from zanzana",
+			"namespace", tb.Namespace,
+			"name", tb.Name,
+			"subject", tb.Spec.Subject.Name,
+			"teamRef", tb.Spec.TeamRef.Name,
+			"permission", tb.Spec.Permission,
+		)
+
+		ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
+		defer cancel()
+
+		err = b.zClient.Write(ctx, &v1.WriteRequest{
+			Namespace: tb.Namespace,
+			Deletes: &v1.WriteRequestDeletes{
+				TupleKeys: deleteTuple,
+			},
+		})
+		if err != nil {
+			status = "failure"
+			b.logger.Error("failed to delete team binding from zanzana",
+				"err", err,
+				"namespace", tb.Namespace,
+				"name", tb.Name,
+				"subject", tb.Spec.Subject.Name,
+				"teamRef", tb.Spec.TeamRef.Name,
+			)
+		} else {
+			// Record successful tuple deletion
+			hooksTuplesCounter.WithLabelValues(resourceType, operation, "delete").Inc()
+		}
+	}(tb.DeepCopy()) // Pass a copy of the object
+}

--- a/pkg/registry/apis/iam/team_binding_hooks_test.go
+++ b/pkg/registry/apis/iam/team_binding_hooks_test.go
@@ -1,0 +1,749 @@
+package iam
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	v1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAfterTeamBindingCreate(t *testing.T) {
+	var wg sync.WaitGroup
+	b := &IdentityAccessManagementAPIBuilder{
+		logger:   log.NewNopLogger(),
+		zTickets: make(chan bool, 1),
+	}
+
+	t.Run("should create zanzana entry for team binding with member permission", func(t *testing.T) {
+		wg.Add(1)
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-1",
+				Namespace: "org-1",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+				External:   false,
+			},
+		}
+
+		testMemberBinding := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.NotNil(t, req.Writes)
+			require.Len(t, req.Writes.TupleKeys, 1)
+			require.Equal(t, "org-1", req.Namespace)
+			require.Nil(t, req.Deletes)
+
+			expectedTuple := &v1.TupleKey{
+				User:     "user:user-1",
+				Relation: "member",
+				Object:   "team:team-1",
+			}
+
+			actualTuple := req.Writes.TupleKeys[0]
+			require.Equal(t, expectedTuple.User, actualTuple.User)
+			require.Equal(t, expectedTuple.Relation, actualTuple.Relation)
+			require.Equal(t, expectedTuple.Object, actualTuple.Object)
+			require.Nil(t, actualTuple.Condition)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testMemberBinding}
+		b.AfterTeamBindingCreate(&teamBinding, nil)
+		wg.Wait()
+	})
+
+	t.Run("should create zanzana entry for team binding with admin permission", func(t *testing.T) {
+		wg.Add(1)
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-2",
+				Namespace: "org-2",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-2",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+				External:   true,
+			},
+		}
+
+		testAdminBinding := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.NotNil(t, req.Writes)
+			require.Len(t, req.Writes.TupleKeys, 1)
+			require.Equal(t, "org-2", req.Namespace)
+			require.Nil(t, req.Deletes)
+
+			expectedTuple := &v1.TupleKey{
+				User:     "user:user-2",
+				Relation: "admin",
+				Object:   "team:team-2",
+			}
+
+			actualTuple := req.Writes.TupleKeys[0]
+			require.Equal(t, expectedTuple.User, actualTuple.User)
+			require.Equal(t, expectedTuple.Relation, actualTuple.Relation)
+			require.Equal(t, expectedTuple.Object, actualTuple.Object)
+			require.Nil(t, actualTuple.Condition)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testAdminBinding}
+		b.AfterTeamBindingCreate(&teamBinding, nil)
+		wg.Wait()
+	})
+
+	t.Run("should not write to zanzana when zClient is nil", func(t *testing.T) {
+		builder := &IdentityAccessManagementAPIBuilder{
+			logger:   log.NewNopLogger(),
+			zTickets: make(chan bool, 1),
+			zClient:  nil,
+		}
+
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-3",
+				Namespace: "org-3",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-3",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-3",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		// Should not panic or error when zClient is nil
+		builder.AfterTeamBindingCreate(&teamBinding, nil)
+	})
+
+	t.Run("should handle conversion error gracefully", func(t *testing.T) {
+		// TeamBinding with empty subject name should fail conversion
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-4",
+				Namespace: "org-4",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "", // Empty name should cause error
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-4",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		writeCalled := false
+		testErrorHandling := func(ctx context.Context, req *v1.WriteRequest) error {
+			writeCalled = true
+			// Should not be called due to conversion error
+			require.Fail(t, "Write should not be called when conversion fails")
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testErrorHandling}
+		b.AfterTeamBindingCreate(&teamBinding, nil)
+		// Wait a bit to ensure the goroutine has time to process
+		// The goroutine will complete but won't call the write callback
+		time.Sleep(100 * time.Millisecond)
+		require.False(t, writeCalled, "Write callback should not be called when conversion fails")
+	})
+}
+
+func TestBeginTeamBindingUpdate(t *testing.T) {
+	var wg sync.WaitGroup
+	b := &IdentityAccessManagementAPIBuilder{
+		logger:   log.NewNopLogger(),
+		zTickets: make(chan bool, 1),
+	}
+
+	t.Run("should update zanzana entry when permission changes from member to admin", func(t *testing.T) {
+		wg.Add(1)
+		oldBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-1",
+				Namespace: "org-1",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		newBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-1",
+				Namespace: "org-1",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+			},
+		}
+
+		testPermissionUpdate := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.Equal(t, "org-1", req.Namespace)
+
+			// Should delete old member permission
+			require.NotNil(t, req.Deletes)
+			require.Len(t, req.Deletes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Deletes.TupleKeys[0],
+				&v1.TupleKeyWithoutCondition{User: "user:user-1", Relation: "member", Object: "team:team-1"},
+			)
+
+			// Should write new admin permission
+			require.NotNil(t, req.Writes)
+			require.Len(t, req.Writes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Writes.TupleKeys[0],
+				&v1.TupleKey{User: "user:user-1", Relation: "admin", Object: "team:team-1"},
+			)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testPermissionUpdate}
+
+		finishFunc, err := b.BeginTeamBindingUpdate(context.Background(), &newBinding, &oldBinding, nil)
+		require.NoError(t, err)
+		require.NotNil(t, finishFunc)
+
+		finishFunc(context.Background(), true)
+		wg.Wait()
+	})
+
+	t.Run("should update zanzana entry when user changes", func(t *testing.T) {
+		wg.Add(1)
+		oldBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-2",
+				Namespace: "org-2",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		newBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-2",
+				Namespace: "org-2",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		testUserUpdate := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.Equal(t, "org-2", req.Namespace)
+
+			// Should delete old user binding
+			require.NotNil(t, req.Deletes)
+			require.Len(t, req.Deletes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Deletes.TupleKeys[0],
+				&v1.TupleKeyWithoutCondition{User: "user:user-1", Relation: "member", Object: "team:team-1"},
+			)
+
+			// Should write new user binding
+			require.NotNil(t, req.Writes)
+			require.Len(t, req.Writes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Writes.TupleKeys[0],
+				&v1.TupleKey{User: "user:user-2", Relation: "member", Object: "team:team-1"},
+			)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testUserUpdate}
+
+		finishFunc, err := b.BeginTeamBindingUpdate(context.Background(), &newBinding, &oldBinding, nil)
+		require.NoError(t, err)
+		require.NotNil(t, finishFunc)
+
+		finishFunc(context.Background(), true)
+		wg.Wait()
+	})
+
+	t.Run("should update zanzana entry when team changes", func(t *testing.T) {
+		wg.Add(1)
+		oldBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-3",
+				Namespace: "org-3",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+			},
+		}
+
+		newBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-3",
+				Namespace: "org-3",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-2",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+			},
+		}
+
+		testTeamUpdate := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.Equal(t, "org-3", req.Namespace)
+
+			// Should delete old team binding
+			require.NotNil(t, req.Deletes)
+			require.Len(t, req.Deletes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Deletes.TupleKeys[0],
+				&v1.TupleKeyWithoutCondition{User: "user:user-1", Relation: "admin", Object: "team:team-1"},
+			)
+
+			// Should write new team binding
+			require.NotNil(t, req.Writes)
+			require.Len(t, req.Writes.TupleKeys, 1)
+			require.Equal(
+				t,
+				req.Writes.TupleKeys[0],
+				&v1.TupleKey{User: "user:user-1", Relation: "admin", Object: "team:team-2"},
+			)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testTeamUpdate}
+
+		finishFunc, err := b.BeginTeamBindingUpdate(context.Background(), &newBinding, &oldBinding, nil)
+		require.NoError(t, err)
+		require.NotNil(t, finishFunc)
+
+		finishFunc(context.Background(), true)
+		wg.Wait()
+	})
+
+	t.Run("should not write to zanzana when update fails", func(t *testing.T) {
+		oldBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-4",
+				Namespace: "org-4",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		newBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-4",
+				Namespace: "org-4",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		testNoWriteOnFailure := func(ctx context.Context, req *v1.WriteRequest) error {
+			// Should not be called when success=false
+			require.Fail(t, "Write should not be called when update fails")
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testNoWriteOnFailure}
+
+		finishFunc, err := b.BeginTeamBindingUpdate(context.Background(), &newBinding, &oldBinding, nil)
+		require.NoError(t, err)
+		require.NotNil(t, finishFunc)
+
+		// Call finish function with success=false
+		finishFunc(context.Background(), false)
+		// No wait needed since write should not be called
+	})
+
+	t.Run("should not write to zanzana when zClient is nil", func(t *testing.T) {
+		builder := &IdentityAccessManagementAPIBuilder{
+			logger:   log.NewNopLogger(),
+			zTickets: make(chan bool, 1),
+			zClient:  nil,
+		}
+
+		oldBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-5",
+				Namespace: "org-5",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		newBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-5",
+				Namespace: "org-5",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		finishFunc, err := builder.BeginTeamBindingUpdate(context.Background(), &newBinding, &oldBinding, nil)
+		require.NoError(t, err)
+		require.Nil(t, finishFunc) // Should return nil when zClient is nil
+	})
+}
+
+func TestAfterTeamBindingDelete(t *testing.T) {
+	var wg sync.WaitGroup
+	b := &IdentityAccessManagementAPIBuilder{
+		logger:   log.NewNopLogger(),
+		zTickets: make(chan bool, 1),
+	}
+
+	t.Run("should delete zanzana entry for team binding with member permission", func(t *testing.T) {
+		wg.Add(1)
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-1",
+				Namespace: "org-1",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+				External:   false,
+			},
+		}
+
+		testMemberDelete := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.Equal(t, "org-1", req.Namespace)
+
+			// Should have deletes but no writes
+			require.NotNil(t, req.Deletes)
+			require.Len(t, req.Deletes.TupleKeys, 1)
+			require.Nil(t, req.Writes)
+
+			require.Equal(
+				t,
+				req.Deletes.TupleKeys[0],
+				&v1.TupleKeyWithoutCondition{User: "user:user-1", Relation: "member", Object: "team:team-1"},
+			)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testMemberDelete}
+		b.AfterTeamBindingDelete(&teamBinding, nil)
+		wg.Wait()
+	})
+
+	t.Run("should delete zanzana entry for team binding with admin permission", func(t *testing.T) {
+		wg.Add(1)
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-2",
+				Namespace: "org-2",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-2",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+				External:   true,
+			},
+		}
+
+		testAdminDelete := func(ctx context.Context, req *v1.WriteRequest) error {
+			defer wg.Done()
+			require.NotNil(t, req)
+			require.Equal(t, "org-2", req.Namespace)
+
+			// Should have deletes but no writes
+			require.NotNil(t, req.Deletes)
+			require.Len(t, req.Deletes.TupleKeys, 1)
+			require.Nil(t, req.Writes)
+
+			require.Equal(
+				t,
+				req.Deletes.TupleKeys[0],
+				&v1.TupleKeyWithoutCondition{User: "user:user-2", Relation: "admin", Object: "team:team-2"},
+			)
+
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testAdminDelete}
+		b.AfterTeamBindingDelete(&teamBinding, nil)
+		wg.Wait()
+	})
+
+	t.Run("should not delete from zanzana when zClient is nil", func(t *testing.T) {
+		builder := &IdentityAccessManagementAPIBuilder{
+			logger:   log.NewNopLogger(),
+			zTickets: make(chan bool, 1),
+			zClient:  nil,
+		}
+
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-3",
+				Namespace: "org-3",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-3",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-3",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		// Should not panic or error when zClient is nil
+		builder.AfterTeamBindingDelete(&teamBinding, nil)
+	})
+
+	t.Run("should handle conversion error gracefully", func(t *testing.T) {
+		// TeamBinding with empty team ref name should fail conversion
+		teamBinding := iamv0.TeamBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "binding-4",
+				Namespace: "org-4",
+			},
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-4",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "", // Empty name should cause error
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		writeCalled := false
+		testErrorHandling := func(ctx context.Context, req *v1.WriteRequest) error {
+			writeCalled = true
+			// Should not be called due to conversion error
+			require.Fail(t, "Write should not be called when conversion fails")
+			return nil
+		}
+
+		b.zClient = &FakeZanzanaClient{writeCallback: testErrorHandling}
+		b.AfterTeamBindingDelete(&teamBinding, nil)
+		// Wait a bit to ensure the goroutine has time to process
+		// The goroutine will complete but won't call the write callback
+		time.Sleep(100 * time.Millisecond)
+		require.False(t, writeCalled, "Write callback should not be called when conversion fails")
+	})
+}
+
+func TestConvertTeamBindingToTuple(t *testing.T) {
+	t.Run("should convert member permission correctly", func(t *testing.T) {
+		tb := &iamv0.TeamBinding{
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		require.NoError(t, err)
+		require.NotNil(t, tuple)
+		require.Equal(t, "user:user-1", tuple.User)
+		require.Equal(t, "member", tuple.Relation)
+		require.Equal(t, "team:team-1", tuple.Object)
+		require.Nil(t, tuple.Condition)
+	})
+
+	t.Run("should convert admin permission correctly", func(t *testing.T) {
+		tb := &iamv0.TeamBinding{
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-2",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-2",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionAdmin,
+			},
+		}
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		require.NoError(t, err)
+		require.NotNil(t, tuple)
+		require.Equal(t, "user:user-2", tuple.User)
+		require.Equal(t, "admin", tuple.Relation)
+		require.Equal(t, "team:team-2", tuple.Object)
+		require.Nil(t, tuple.Condition)
+	})
+
+	t.Run("should return error for empty subject name", func(t *testing.T) {
+		tb := &iamv0.TeamBinding{
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		require.Error(t, err)
+		require.Nil(t, tuple)
+		require.Equal(t, errEmptyName, err)
+	})
+
+	t.Run("should return error for empty team ref name", func(t *testing.T) {
+		tb := &iamv0.TeamBinding{
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "",
+				},
+				Permission: iamv0.TeamBindingTeamPermissionMember,
+			},
+		}
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		require.Error(t, err)
+		require.Nil(t, tuple)
+		require.Equal(t, errEmptyName, err)
+	})
+
+	t.Run("should default to member for unknown permission", func(t *testing.T) {
+		tb := &iamv0.TeamBinding{
+			Spec: iamv0.TeamBindingSpec{
+				Subject: iamv0.TeamBindingspecSubject{
+					Name: "user-1",
+				},
+				TeamRef: iamv0.TeamBindingTeamRef{
+					Name: "team-1",
+				},
+				Permission: "unknown", // Invalid permission
+			},
+		}
+
+		tuple, err := convertTeamBindingToTuple(tb)
+		require.NoError(t, err)
+		require.NotNil(t, tuple)
+		// Should default to member relation
+		require.Equal(t, "member", tuple.Relation)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

Adds post-create, post-delete, and pre-update hooks for TeamBinding resources to automatically sync team membership data to Zanzana (OpenFGA) authorization store. When a TeamBinding is created, updated, or deleted through the Kubernetes-style IAM API, the corresponding authorization tuples are automatically written to or removed from Zanzana.

**Why do we need this feature?**

Team bindings define user-team relationships and permissions, which need to be synchronized with the authorization system (Zanzana) to enable fine-grained access control checks. Without these hooks, team membership changes made through the IAM API would not be reflected in the authorization store, leading to inconsistencies and authorization failures.

**Who is this feature for?**

- Grafana administrators managing team memberships through the Kubernetes-style IAM API
- Developers using the unified storage system with Zanzana integration
- Operations teams requiring consistent authorization state across Grafana's storage systems

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Feature Toggle:** This feature requires `kubernetesAuthzZanzanaSync` to be enabled in `[feature_toggles]`.

---

## Testing Instructions

### Prerequisites

1. **Enable required feature toggles** in `conf/custom.ini`:
```ini
[feature_toggles]
kubernetesAuthzApis = true
kubernetesAuthzZanzanaSync = true
zanzana = true
unifiedStorage = true
kubernetesAuthnMutation = true
managedDualWriter = true
```

2. **Ensure Zanzana is running and accessible** - The hooks require a working Zanzana client connection.

3. **Enable dual writer** (if testing with unified storage):
```ini
[unified_storage.teambindings.iam.grafana.app]
dualWriterMode = 1
```

### Manual Testing Steps

#### 1. Create a TeamBinding

Create a TeamBinding resource that assigns a user as admin or member of a team:

```bash
curl -k -X POST https://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/teambindings \
  -u admin:admin \
  -H "Content-Type: application/json" \
  -d '{
    "apiVersion": "iam.grafana.app/v0alpha1",
    "kind": "TeamBinding",
    "metadata": {
      "name": "test-binding-admin"
    },
    "spec": {
      "subject": {
        "name": "<USER_UID>"
      },
      "teamRef": {
        "name": "<TEAM_NAME>"
      },
      "permission": "admin",
      "external": false
    }
  }'
```

**Verification:**
- Check Grafana logs for: `"writing team binding to zanzana"` with debug level
- Verify the tuple is written to Zanzana with:
  - User: `user:<USER_UID>`
  - Relation: `admin` (or `member` for member permission)
  - Object: `team:<TEAM_NAME>`
- Check Prometheus metrics for `iam_hooks_operation_counter` with labels `{resource_type="teambinding", operation="create", status="success"}`

#### 2. Update a TeamBinding

Update an existing TeamBinding to change permission or team:

```bash
curl -k -X PUT https://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/teambindings/test-binding-admin \
  -u admin:admin \
  -H "Content-Type: application/json" \
  -d '{
    "apiVersion": "iam.grafana.app/v0alpha1",
    "kind": "TeamBinding",
    "metadata": {
      "name": "test-binding-admin"
    },
    "spec": {
      "subject": {
        "name": "<USER_UID>"
      },
      "teamRef": {
        "name": "<TEAM_NAME>"
      },
      "permission": "member",
      "external": false
    }
  }'
```

**Verification:**
- Check logs for: `"updating team binding in zanzana"` with both old and new values
- Verify Zanzana has:
  - Deleted the old tuple (admin relation)
  - Written the new tuple (member relation)
- Check metrics for both `delete` and `write` operations in update metrics

#### 3. Delete a TeamBinding

Delete a TeamBinding:

```bash
curl -k -X DELETE https://localhost:3000/apis/iam.grafana.app/v0alpha1/namespaces/default/teambindings/test-binding-admin \
  -u admin:admin
```

**Verification:**
- Check logs for: `"deleting team binding from zanzana"`
- Verify the tuple is removed from Zanzana
- Check metrics for `{operation="delete", status="success"}`

### Testing Different Permission Types

Test both permission types:

1. **Admin permission:**
```json
"permission": "admin"
```
Expected relation in Zanzana: `admin`

2. **Member permission:**
```json
"permission": "member"
```
Expected relation in Zanzana: `member`

### Debugging

#### Check if hooks are enabled:
Look for log message on startup: `"Enabling hooks for TeamBinding to sync to Zanzana"`

#### Breakpoint locations for debugging:
- `pkg/registry/apis/iam/team_binding_hooks before:49` - AfterTeamBindingCreate entry
- `pkg/registry/apis/iam/team_binding_hooks before:106` - Zanzana write call
- `pkg/registry/apis/iam/team_binding_hooks before:128` - BeginTeamBindingUpdate entry
- `pkg/registry/apis/iam/team_binding_hooks before:268` - AfterTeamBindingDelete entry

#### Metrics to monitor:
- `iam_hooks_operation_counter` - Count of hook operations by type and status
- `iam_hooks_duration_histogram` - Duration of hook operations
- `iam_hooks_wait_histogram` - Wait time for Zanzana tickets
- `iam_hooks_tuples_counter` - Count of tuples written/deleted

#### Common issues:
- **Hooks not triggering:** Verify `kubernetesAuthzZanzanaSync` is enabled and dual writer is active
- **Zanzana write failures:** Check Zanzana connectivity and logs for errors
- **No metrics:** Ensure hooks are registered (check startup logs)

### Unit Tests

Run the unit tests to verify hook logic:

```bash
go test ./pkg/registry/apis/iam -run TestAfterTeamBindingCreate -v
go test ./pkg/registry/apis/iam -run TestBeginTeamBindingUpdate -v
go test ./pkg/registry/apis/iam -run TestAfterTeamBindingDelete -v
```

All tests should pass and verify:
- Correct tuple conversion (user, relation, object)
- Proper error handling
- Async operation handling
- Ticket channel management