### PR TITLE
feature: Support reqFeatureFlag in page includes

### DIFF
--- a/apps/plugins/kinds/plugin.cue
+++ b/apps/plugins/kinds/plugin.cue
@@ -141,6 +141,7 @@ pluginV0Alpha1: {
 	component?: string
 	role?: "Admin" | "Editor" | "Viewer"
 	action?: string
+	reqFeatureToggle?: string
 	path?: string
 	addToNav?: bool
 	defaultNav?: bool

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -301,6 +301,10 @@
             "type": "string",
             "description": "The RBAC action a user must have to see this page in the navigation menu. **Warning**: unless the action targets the plugin, only the action is verified, not what it applies to."
           },
+          "reqFeatureToggle": {
+            "type": "string",
+            "description": "The feature toggle that must be enabled for this page to appear in the navigation menu."
+          },
           "path": {
             "type": "string",
             "description": "Used for app plugins."

--- a/packages/grafana-data/src/types/plugin.ts
+++ b/packages/grafana-data/src/types/plugin.ts
@@ -177,6 +177,9 @@ export interface PluginInclude {
   // Adds the "page" or "dashboard" type includes to the navigation if set to `true`.
   addToNav?: boolean;
 
+  // if reqFeatureToggle is set then the include will only show up in the navigation if the feature toggle is enabled.
+  reqFeatureToggle?: string;
+
   // Angular app pages
   component?: string;
 }

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -148,17 +148,18 @@ type ExtensionsDependencies struct {
 }
 
 type Includes struct {
-	Name       string       `json:"name"`
-	Path       string       `json:"path"`
-	Type       string       `json:"type"`
-	Component  string       `json:"component"`
-	Role       org.RoleType `json:"role"`
-	Action     string       `json:"action,omitempty"`
-	AddToNav   bool         `json:"addToNav"`
-	DefaultNav bool         `json:"defaultNav"`
-	Slug       string       `json:"slug"`
-	Icon       string       `json:"icon"`
-	UID        string       `json:"uid"`
+	Name             string       `json:"name"`
+	Path             string       `json:"path"`
+	Type             string       `json:"type"`
+	Component        string       `json:"component"`
+	Role             org.RoleType `json:"role"`
+	Action           string       `json:"action,omitempty"`
+	AddToNav         bool         `json:"addToNav"`
+	DefaultNav       bool         `json:"defaultNav"`
+	Slug             string       `json:"slug"`
+	Icon             string       `json:"icon"`
+	UID              string       `json:"uid"`
+	ReqFeatureToggle string       `json:"reqFeatureToggle,omitempty"`
 
 	ID string `json:"-"`
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature adds a new property reqFeatureFlag to plugin.json > includes, so that we can control which includes are visible based on feature flags. 

**Why do we need this feature?**

We often develop new features that are accessible via the left navigation menu, but we can't control rollouts as flexibly as other UI features. 

**Who is this feature for?**

Mostly for plugin developers to control rollout of new features 

**Which issue(s) does this PR fix?**:

fixes: https://github.com/grafana/grafana/issues/86346

Screenshots: 
With the feature flag: 
<img width="291" height="386" alt="image" src="https://github.com/user-attachments/assets/7ba6aa16-6031-4c36-aabf-393c90535817" />

Without the feature flag: 
<img width="248" height="172" alt="image" src="https://github.com/user-attachments/assets/d3616f4d-26e1-4bef-9295-6d47680182ca" />

plugin.json example: 
<img width="618" height="266" alt="image" src="https://github.com/user-attachments/assets/63fa1dd0-8f58-4320-879f-ebffb130b1ea" />


<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
