### PR TITLE
Improve log messages.

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -863,7 +863,7 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 				doc, err := builder.BuildDocument(ctx, key, iter.ResourceVersion(), iter.Value())
 				if err != nil {
 					span.RecordError(err)
-					logger.Error("error building search document", "key", SearchID(key), "err", err)
+					logger.Error("error building search document", "key", SearchID(key), "rv", iter.ResourceVersion(), "err", err)
 					continue
 				}
 
@@ -933,7 +933,7 @@ func (s *searchSupport) build(ctx context.Context, nsr NamespacedResource, size 
 				doc, err := builder.BuildDocument(ctx, key, res.ResourceVersion, res.Value)
 				if err != nil {
 					span.RecordError(err)
-					logger.Error("error building search document", "key", SearchID(key), "err", err)
+					logger.Error("error building search document", "key", SearchID(key), "rv", res.ResourceVersion, "err", err)
 					continue
 				}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1854,6 +1854,7 @@ func (q *permissionScopedQuery) Searcher(ctx context.Context, i index.IndexReade
 			return false
 		}
 		ns := parts[0]
+		group := parts[1]
 		resource := parts[2]
 		name := parts[3]
 		folder := ""
@@ -1863,16 +1864,16 @@ func (q *permissionScopedQuery) Searcher(ctx context.Context, i index.IndexReade
 			}
 		})
 		if err != nil {
-			logger.Debug("Error reading doc values", "error", err)
+			logger.Debug("Error reading doc values", "namespace", ns, "group", group, "resource", resource, "name", name, "folder", folder, "error", err)
 			return false
 		}
 		if _, ok := q.checkers[resource]; !ok {
-			logger.Debug("No resource checker found", "resource", resource)
+			logger.Debug("No resource checker found", "namespace", ns, "group", group, "resource", resource, "name", name, "folder", folder)
 			return false
 		}
 		allowed := q.checkers[resource](name, folder)
 		if !allowed {
-			logger.Debug("Denying access", "ns", ns, "name", name, "folder", folder)
+			logger.Debug("Denying access", "namespace", ns, "group", group, "resource", resource, "name", name, "folder", folder)
 		}
 		return allowed
 	})


### PR DESCRIPTION
Log RV when building of search document fails. Log details about denied access to the resource.