### PR TITLE
Dashboard: Fix editor specific permissions in /api

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -676,11 +676,14 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	// Validate folder
 	if dash.FolderID != 0 || dash.FolderUID != "" { // nolint:staticcheck
-		folder, err := dr.folderService.Get(ctx, &folder.GetFolderQuery{
+		// use a background requester, because the user may have been granted edit access to that specific dashboard, but
+		// not have access to the parent folder. we should still allow editing in that case.
+		ctxIdentity, backgroundRequester := identity.WithServiceIdentity(ctx, dash.OrgID)
+		folder, err := dr.folderService.Get(ctxIdentity, &folder.GetFolderQuery{
 			OrgID:        dash.OrgID,
 			UID:          &dash.FolderUID,
 			ID:           &dash.FolderID, // nolint:staticcheck
-			SignedInUser: dto.User,
+			SignedInUser: backgroundRequester,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -1211,5 +1211,68 @@ func TestIntegrationDashboardServicePermissions(t *testing.T) {
 			assert.Contains(t, foundTitles, "dashboard in parent", "Should return dashboard in parent folder")
 			assert.NotContains(t, foundTitles, "dashboard in child", "Should not return dashboard in child folder")
 		})
+
+		t.Run("user with edit permissions on dashboard but not on parent folder should be able to edit the dashboard", func(t *testing.T) {
+			testFolder := createFolder(t, grafanaListedAddr, "restricted folder")
+			testDash := createDashboard(t, grafanaListedAddr, "dashboard with specific permissions", testFolder.ID, testFolder.UID) // nolint:staticcheck
+			restrictedUserID := tests.CreateUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+				DefaultOrgRole: string(org.RoleNone),
+				Login:          "restricteduser",
+				Password:       "restricteduser",
+				IsAdmin:        false,
+			})
+			setDashboardPermissions := func(t *testing.T, grafanaListedAddr string, dashboardUID string, permissions []map[string]interface{}) {
+				t.Helper()
+
+				permissionPayload := map[string]interface{}{
+					"items": permissions,
+				}
+
+				payloadBytes, err := json.Marshal(permissionPayload)
+				require.NoError(t, err)
+
+				u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/uid/%s/permissions", grafanaListedAddr, dashboardUID)
+				req, err := http.NewRequest(http.MethodPost, u, bytes.NewBuffer(payloadBytes))
+				require.NoError(t, err)
+				req.Header.Set("Content-Type", "application/json")
+
+				client := &http.Client{}
+				resp, err := client.Do(req)
+				require.NoError(t, err)
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				err = resp.Body.Close()
+				require.NoError(t, err)
+			}
+			editPermissions := []map[string]interface{}{
+				{
+					"permission": 2,
+					"userId":     restrictedUserID,
+				},
+			}
+			setDashboardPermissions(t, grafanaListedAddr, testDash.UID, editPermissions)
+
+			// user cannot access the folder
+			u := fmt.Sprintf("http://restricteduser:restricteduser@%s/api/folders/%s", grafanaListedAddr, testFolder.UID)
+			resp, err := http.Get(u) // nolint:gosec
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusForbidden, resp.StatusCode, "User should not have access to the folder")
+			err = resp.Body.Close()
+			require.NoError(t, err)
+
+			// but can edit the dashboard
+			dashboardPayload := map[string]interface{}{
+				"dashboard": map[string]interface{}{
+					"uid":   testDash.UID,
+					"title": "Updated title by restricted user",
+				},
+				"folderUid": testFolder.UID,
+				"overwrite": true,
+			}
+			resp, err = postDashboard(t, grafanaListedAddr, "restricteduser", "restricteduser", dashboardPayload)
+			require.NoError(t, err)
+			assert.Equal(t, http.StatusOK, resp.StatusCode, "User should be able to edit dashboard even without folder access")
+			err = resp.Body.Close()
+			require.NoError(t, err)
+		})
 	})
 }


### PR DESCRIPTION
thanks to @alexanderzobnin for finding this as the root cause of https://github.com/grafana/grafana/issues/113078

This PR fixes the api, by making the parent folder check with a background requester, because a user may have been given editor access to a dashboard, but not have access to the folder itself.

Note: there is still a bug in the UI that we will still see this when saving (though it will save, it is calling the folder api `http://localhost:3000/api/folders?parentUid=af2ppj3wrstmob&page=1&limit=50` in the frontend):
<img width="437" height="253" alt="Screenshot 2025-10-31 at 7 29 11 AM" src="https://github.com/user-attachments/assets/f0f22d11-a690-4ea6-9810-24acf2932257" />

Will add that to the issue and ask frontend to take a look :)