### PR TITLE
Zanzana: Inject client into standalone AuthZ client

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -95,6 +95,24 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, fea
 	}
 }
 
+// ProvideStandaloneZanzanaClient provides a standalone Zanzana client, without registering the Zanzana service.
+// Client connects to a remote Zanzana server specified in the configuration.
+func ProvideStandaloneZanzanaClient(cfg *setting.Cfg, features featuremgmt.FeatureToggles) (zanzana.Client, error) {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	if !features.IsEnabledGlobally(featuremgmt.FlagZanzana) {
+		return zClient.NewNoopClient(), nil
+	}
+
+	zanzanaConfig := ZanzanaClientConfig{
+		URL:              cfg.ZanzanaClient.Addr,
+		Token:            cfg.ZanzanaClient.Token,
+		TokenExchangeURL: cfg.ZanzanaClient.TokenExchangeURL,
+		ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
+	}
+
+	return NewRemoteZanzanaClient(fmt.Sprintf("stacks-%s", cfg.StackID), zanzanaConfig)
+}
+
 type ZanzanaClientConfig struct {
 	URL              string
 	Token            string


### PR DESCRIPTION
**What is this feature?**

We need to inject zanzana client into standalone AuthZ client the same way we do it for embedded one.

**Why do we need this feature?**

Otherwise, we're not really shadowing requests to zanzana in modes that use unistore.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
