### PR TITLE
datasources: querier: forward the cookie-header to the datasources

### DIFF
--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -42,6 +42,7 @@ var expectedHeaders = map[string]string{
 	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
 	strings.ToLower("X-Real-IP"):                       "X-Real-IP",
 	strings.ToLower("X-Forwarded-For"):                 "X-Forwarded-For",
+	strings.ToLower("Cookie"):                          "Cookie",
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {


### PR DESCRIPTION
we need to support the functionality, where the user can configure a datasource so that certain cookies coming from the browser should be sent out to the database.

the final decision is on the datasource, but the query-service also needs to handle the Cookie header to keep this working.