### PR TITLE
Alerting: Add counts for firing and pending alert rules

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/SummaryStats.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/SummaryStats.test.ts
@@ -1,0 +1,234 @@
+import { DataFrameView } from '@grafana/data';
+
+import { countRules, parseAlertstateFilter } from './SummaryStats';
+
+type RuleFrame = {
+  alertstate: 'firing' | 'pending';
+  alertname: string;
+  grafana_folder: string;
+  grafana_rule_uid: string;
+  Value: number;
+};
+
+describe('parseAlertstateFilter', () => {
+  it('should return "firing" when filter contains alertstate="firing"', () => {
+    expect(parseAlertstateFilter('alertstate="firing"')).toBe('firing');
+  });
+
+  it('should return "pending" when filter contains alertstate="pending"', () => {
+    expect(parseAlertstateFilter('alertstate="pending"')).toBe('pending');
+  });
+
+  it('should return null when filter contains both firing and pending', () => {
+    expect(parseAlertstateFilter('alertstate=~"firing|pending"')).toBe(null);
+  });
+
+  it('should return null when no alertstate filter', () => {
+    expect(parseAlertstateFilter('')).toBe(null);
+    expect(parseAlertstateFilter('namespace="default"')).toBe(null);
+  });
+
+  it('should handle regex operator =~', () => {
+    expect(parseAlertstateFilter('alertstate=~"firing"')).toBe('firing');
+    expect(parseAlertstateFilter('alertstate=~"pending"')).toBe('pending');
+  });
+
+  it('should handle whitespace', () => {
+    expect(parseAlertstateFilter('alertstate = "firing"')).toBe('firing');
+    expect(parseAlertstateFilter('alertstate =~ "pending"')).toBe('pending');
+  });
+});
+
+describe('countRules', () => {
+  // Helper to create mock DataFrameView
+  function createMockRuleDfv(
+    data: Array<{ ruleUID: string; alertstate: 'firing' | 'pending' }>
+  ): DataFrameView<RuleFrame> {
+    return {
+      length: data.length,
+      fields: {
+        grafana_rule_uid: {
+          values: data.map((d) => d.ruleUID),
+        },
+        alertstate: {
+          values: data.map((d) => d.alertstate),
+        },
+      },
+    } as unknown as DataFrameView<RuleFrame>;
+  }
+
+  describe('when no alertstate filter applied', () => {
+    it('should count rules with ANY firing instances', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule2', alertstate: 'firing' },
+        { ruleUID: 'rule3', alertstate: 'pending' },
+      ]);
+
+      const result = countRules(ruleDfv, null);
+
+      expect(result.firing).toBe(2);
+      expect(result.pending).toBe(1);
+    });
+
+    it('should count rules with ONLY pending instances (no firing)', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'pending' },
+        { ruleUID: 'rule2', alertstate: 'pending' },
+        { ruleUID: 'rule3', alertstate: 'firing' },
+      ]);
+
+      const result = countRules(ruleDfv, null);
+
+      expect(result.firing).toBe(1);
+      expect(result.pending).toBe(2);
+    });
+
+    it('should count rules with BOTH firing and pending as firing (firing takes precedence)', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'pending' }, // Same rule, both states
+        { ruleUID: 'rule2', alertstate: 'firing' }, // Only firing
+        { ruleUID: 'rule3', alertstate: 'pending' }, // Only pending
+      ]);
+
+      const result = countRules(ruleDfv, null);
+
+      // rule1 should be counted as firing (firing takes precedence)
+      // rule2 should be counted as firing
+      // rule3 should be counted as pending
+      expect(result.firing).toBe(2); // rule1 and rule2
+      expect(result.pending).toBe(1); // only rule3
+    });
+
+    it('should handle multiple instances of the same rule with same state', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'firing' }, // Same rule, duplicate entry
+        { ruleUID: 'rule2', alertstate: 'pending' },
+        { ruleUID: 'rule2', alertstate: 'pending' }, // Same rule, duplicate entry
+      ]);
+
+      const result = countRules(ruleDfv, null);
+
+      // Each rule should only be counted once despite multiple entries
+      expect(result.firing).toBe(1);
+      expect(result.pending).toBe(1);
+    });
+
+    it('should return 0 for both counts when no rules', () => {
+      const ruleDfv = createMockRuleDfv([]);
+
+      const result = countRules(ruleDfv, null);
+
+      expect(result.firing).toBe(0);
+      expect(result.pending).toBe(0);
+    });
+  });
+
+  describe('when filtering by alertstate=pending', () => {
+    it('should count ALL rules with any pending instances', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'pending' }, // Has both
+        { ruleUID: 'rule2', alertstate: 'pending' }, // Only pending
+        { ruleUID: 'rule3', alertstate: 'firing' }, // Only firing
+      ]);
+
+      const result = countRules(ruleDfv, 'pending');
+
+      // Should count rule1 and rule2 (both have pending instances)
+      expect(result.pending).toBe(2);
+      expect(result.firing).toBe(0);
+    });
+
+    it('should count rules with BOTH states as pending', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'pending' },
+        { ruleUID: 'rule2', alertstate: 'firing' },
+        { ruleUID: 'rule2', alertstate: 'pending' },
+        { ruleUID: 'rule3', alertstate: 'pending' },
+      ]);
+
+      const result = countRules(ruleDfv, 'pending');
+
+      // Should count all three rules (all have pending instances)
+      expect(result.pending).toBe(3);
+      expect(result.firing).toBe(0);
+    });
+
+    it('should be >= pending count from no filter scenario', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'pending' },
+        { ruleUID: 'rule2', alertstate: 'pending' },
+      ]);
+
+      const noFilterResult = countRules(ruleDfv, null);
+      const pendingFilterResult = countRules(ruleDfv, 'pending');
+
+      // With pending filter: should count rule1 and rule2 = 2
+      // Without filter: should count only rule2 = 1 (rule1 is counted as firing, not pending)
+      expect(pendingFilterResult.pending).toBeGreaterThanOrEqual(noFilterResult.pending);
+      expect(pendingFilterResult.pending).toBe(2);
+      expect(noFilterResult.pending).toBe(1); // Only rule2 (rule1 is firing)
+      expect(noFilterResult.firing).toBe(1); // rule1
+    });
+  });
+
+  describe('when filtering by alertstate=firing', () => {
+    it('should count ALL rules with any firing instances', () => {
+      const ruleDfv = createMockRuleDfv([
+        { ruleUID: 'rule1', alertstate: 'firing' },
+        { ruleUID: 'rule1', alertstate: 'pending' }, // Has both
+        { ruleUID: 'rule2', alertstate: 'firing' }, // Only firing
+        { ruleUID: 'rule3', alertstate: 'pending' }, // Only pending
+      ]);
+
+      const result = countRules(ruleDfv, 'firing');
+
+      // Should count rule1 and rule2 (both have firing instances)
+      expect(result.firing).toBe(2);
+      expect(result.pending).toBe(0);
+    });
+  });
+
+  describe('real-world scenarios', () => {
+    it('should handle complex scenario with many rules', () => {
+      const ruleDfv = createMockRuleDfv([
+        // Rule A: Only firing (3 instances)
+        { ruleUID: 'ruleA', alertstate: 'firing' },
+        { ruleUID: 'ruleA', alertstate: 'firing' },
+        { ruleUID: 'ruleA', alertstate: 'firing' },
+        // Rule B: Only pending (2 instances)
+        { ruleUID: 'ruleB', alertstate: 'pending' },
+        { ruleUID: 'ruleB', alertstate: 'pending' },
+        // Rule C: Both firing and pending (4 instances)
+        { ruleUID: 'ruleC', alertstate: 'firing' },
+        { ruleUID: 'ruleC', alertstate: 'firing' },
+        { ruleUID: 'ruleC', alertstate: 'pending' },
+        { ruleUID: 'ruleC', alertstate: 'pending' },
+        // Rule D: Only firing (1 instance)
+        { ruleUID: 'ruleD', alertstate: 'firing' },
+        // Rule E: Only pending (1 instance)
+        { ruleUID: 'ruleE', alertstate: 'pending' },
+      ]);
+
+      // No filter: Firing takes precedence
+      const noFilter = countRules(ruleDfv, null);
+      expect(noFilter.firing).toBe(3); // Rule A, C, and D (C has firing so it's counted as firing)
+      expect(noFilter.pending).toBe(2); // Rule B and E (only those with NO firing)
+
+      // With pending filter: Count all rules with ANY pending instances
+      const pendingFilter = countRules(ruleDfv, 'pending');
+      expect(pendingFilter.pending).toBe(3); // Rule B, C, and E
+      expect(pendingFilter.firing).toBe(0);
+
+      // With firing filter: Count all rules with ANY firing instances
+      const firingFilter = countRules(ruleDfv, 'firing');
+      expect(firingFilter.firing).toBe(3); // Rule A, C, and D
+      expect(firingFilter.pending).toBe(0);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
+++ b/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
@@ -10,20 +10,20 @@ import { METRIC_NAME } from '../constants';
 
 import { getDataQuery, useQueryFilter } from './utils';
 
+type AlertState = PromAlertingRuleState.Firing | PromAlertingRuleState.Pending;
+
 interface Frame {
-  alertstate: PromAlertingRuleState.Firing | PromAlertingRuleState.Pending;
+  alertstate: AlertState;
   Value: number;
 }
 
 export interface RuleFrame {
-  alertstate: PromAlertingRuleState.Firing | PromAlertingRuleState.Pending;
+  alertstate: AlertState;
   alertname: string;
   grafana_folder: string;
   grafana_rule_uid: string;
   Value: number;
 }
-
-type AlertState = PromAlertingRuleState.Firing | PromAlertingRuleState.Pending;
 
 export function parseAlertstateFilter(filter: string): AlertState | null {
   const firingMatch = filter.match(/alertstate\s*=~?\s*"firing"/);

--- a/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
+++ b/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
@@ -14,47 +14,205 @@ interface Frame {
   Value: number;
 }
 
+interface RuleFrame {
+  alertstate: 'firing' | 'pending';
+  alertname: string;
+  grafana_folder: string;
+  grafana_rule_uid: string;
+  Value: number;
+}
+
+type AlertState = 'firing' | 'pending';
+
+export function parseAlertstateFilter(filter: string): AlertState | null {
+  const firingMatch = filter.match(/alertstate\s*=~?\s*"firing"/);
+  const pendingMatch = filter.match(/alertstate\s*=~?\s*"pending"/);
+
+  if (firingMatch && pendingMatch) {
+    return null;
+  }
+
+  if (firingMatch) {
+    return 'firing';
+  }
+
+  if (pendingMatch) {
+    return 'pending';
+  }
+
+  return null;
+}
+
+export function countRules(ruleDfv: DataFrameView<RuleFrame>, alertstateFilter: AlertState | null) {
+  const rulesWithFiring = new Set<string>();
+  const rulesWithPending = new Set<string>();
+
+  ruleDfv.fields.grafana_rule_uid.values.forEach((ruleUID, i) => {
+    const alertstate = ruleDfv.fields.alertstate.values[i];
+    if (alertstate === 'firing') {
+      rulesWithFiring.add(ruleUID);
+    }
+    if (alertstate === 'pending') {
+      rulesWithPending.add(ruleUID);
+    }
+  });
+
+  // When filtering by pending, count all rules with pending instances (may also have firing)
+  if (alertstateFilter === 'pending') {
+    return {
+      firing: 0,
+      pending: rulesWithPending.size,
+    };
+  }
+
+  // When filtering by firing, count all rules with firing instances (may also have pending)
+  if (alertstateFilter === 'firing') {
+    return {
+      firing: rulesWithFiring.size,
+      pending: 0,
+    };
+  }
+
+  // When no filter: firing takes precedence
+  // A rule is "firing" if it has ANY firing instances (even if it also has pending)
+  // A rule is "pending" ONLY if it has pending instances but NO firing instances
+  const onlyPending = new Set([...rulesWithPending].filter((uid) => !rulesWithFiring.has(uid)));
+
+  return {
+    firing: rulesWithFiring.size, // ALL rules with firing instances
+    pending: onlyPending.size, // ONLY rules with no firing instances
+  };
+}
+
+function countInstances(instanceDfv: DataFrameView<Frame>) {
+  const getValue = (state: AlertState) => {
+    const index = instanceDfv.fields.alertstate.values.findIndex((s) => s === state);
+    return instanceDfv.fields.Value.values[index] ?? 0;
+  };
+  return { firing: getValue('firing'), pending: getValue('pending') };
+}
+
 export function SummaryStatsReact() {
   const filter = useQueryFilter();
+  const alertstateFilter = parseAlertstateFilter(filter);
 
-  const dataProvider = useQueryRunner({
+  const instanceDataProvider = useQueryRunner({
+    queries: [getDataQuery(`count by (alertstate) (${METRIC_NAME}{${filter}})`, { instant: true, format: 'table' })],
+  });
+
+  // Always remove alertstate filter from rule query to get accurate counts across both states
+  // This ensures we can count rules that have instances in either state
+  const ruleFilter = filter
+    .replace(/alertstate\s*=~?\s*"(firing|pending)"[,\s]*/, '')
+    .replace(/,\s*$/, '')
+    .replace(/^\s*,/, '');
+  const ruleDataProvider = useQueryRunner({
     queries: [
-      getDataQuery(`count by (alertstate) (${METRIC_NAME}{${filter}})`, {
-        instant: true,
-        exemplar: false,
-        format: 'table',
-      }),
+      getDataQuery(
+        `count by (alertname, grafana_folder, grafana_rule_uid, alertstate) (${METRIC_NAME}{${ruleFilter}})`,
+        {
+          instant: true,
+          format: 'table',
+        }
+      ),
     ],
   });
 
-  const isLoading = !dataProvider.isDataReadyToDisplay;
-  const data = dataProvider.useState().data;
-  const firstFrame = data?.series?.at(0);
+  const instanceData = instanceDataProvider.useState().data;
+  const ruleData = ruleDataProvider.useState().data;
+  const instanceFrame = instanceData?.series?.at(0);
+  const ruleFrame = ruleData?.series?.at(0);
 
-  if (isLoading || !firstFrame) {
+  if (
+    !instanceDataProvider.isDataReadyToDisplay ||
+    !ruleDataProvider.isDataReadyToDisplay ||
+    !instanceFrame ||
+    !ruleFrame
+  ) {
     return <div />;
   }
 
-  const dfv = new DataFrameView<Frame>(firstFrame);
-  if (dfv.length === 0) {
+  const instanceDfv = new DataFrameView<Frame>(instanceFrame);
+  const ruleDfv = new DataFrameView<RuleFrame>(ruleFrame);
+
+  if (instanceDfv.length === 0 || ruleDfv.length === 0) {
     return <div />;
   }
 
-  const firingIndex = dfv.fields.alertstate.values.findIndex((state) => state === 'firing');
-  const firingCount = dfv.fields.Value.values[firingIndex] ?? 0;
+  const instances = countInstances(instanceDfv);
+  const rules = countRules(ruleDfv, alertstateFilter);
 
-  const pendingIndex = dfv.fields.alertstate.values.findIndex((state) => state === 'pending');
-  const pendingCount = dfv.fields.Value.values[pendingIndex] ?? 0;
+  const renderStat = (i18nKey: string, color: 'error' | 'warning', values: Record<string, number>, text: string) => (
+    <Text color={color}>
+      <Trans i18nKey={i18nKey} values={values}>
+        {text}
+      </Trans>
+    </Text>
+  );
 
   return (
     <Stack direction="column" alignItems="flex-end" gap={0}>
       <Spacer />
-      <Text color="error">
-        <Trans i18nKey="alerting.triage.firing-instances-count">{{ firingCount }} firing instances</Trans>
-      </Text>
-      <Text color="warning">
-        <Trans i18nKey="alerting.triage.pending-instances-count">{{ pendingCount }} pending instances</Trans>
-      </Text>
+      {alertstateFilter === 'firing' && (
+        <>
+          {renderStat(
+            'alerting.triage.firing-rules-count',
+            'error',
+            { count: rules.firing },
+            '{{count}} firing alert rules'
+          )}
+          {renderStat(
+            'alerting.triage.firing-instances-count',
+            'error',
+            { firingCount: instances.firing },
+            '{{firingCount}} firing instances'
+          )}
+        </>
+      )}
+      {alertstateFilter === 'pending' && (
+        <>
+          {renderStat(
+            'alerting.triage.rules-with-pending-instances',
+            'warning',
+            { count: rules.pending },
+            '{{count}} alert rules with pending instances'
+          )}
+          {renderStat(
+            'alerting.triage.pending-instances-count',
+            'warning',
+            { pendingCount: instances.pending },
+            '{{pendingCount}} pending instances'
+          )}
+        </>
+      )}
+      {!alertstateFilter && (
+        <>
+          {renderStat(
+            'alerting.triage.firing-rules-count',
+            'error',
+            { count: rules.firing },
+            '{{count}} firing alert rules'
+          )}
+          {renderStat(
+            'alerting.triage.firing-instances-count',
+            'error',
+            { firingCount: instances.firing },
+            '{{firingCount}} firing instances'
+          )}
+          {renderStat(
+            'alerting.triage.pending-rules-count',
+            'warning',
+            { count: rules.pending },
+            '{{count}} pending alert rules'
+          )}
+          {renderStat(
+            'alerting.triage.pending-instances-count',
+            'warning',
+            { pendingCount: instances.pending },
+            '{{pendingCount}} pending instances'
+          )}
+        </>
+      )}
     </Stack>
   );
 }

--- a/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
+++ b/public/app/features/alerting/unified/triage/scene/SummaryStats.tsx
@@ -92,6 +92,23 @@ function countInstances(instanceDfv: DataFrameView<Frame>) {
   return { firing: getValue('firing'), pending: getValue('pending') };
 }
 
+interface StatRowProps {
+  i18nKey: string;
+  color: 'error' | 'warning';
+  values: Record<string, number>;
+  children: React.ReactNode;
+}
+
+function StatRow({ i18nKey, color, values, children }: StatRowProps) {
+  return (
+    <Text color={color}>
+      <Trans i18nKey={i18nKey} values={values}>
+        {children}
+      </Trans>
+    </Text>
+  );
+}
+
 export function SummaryStatsReact() {
   const filter = useQueryFilter();
   const alertstateFilter = parseAlertstateFilter(filter);
@@ -118,14 +135,14 @@ export function SummaryStatsReact() {
     ],
   });
 
-  const instanceData = instanceDataProvider.useState().data;
-  const ruleData = ruleDataProvider.useState().data;
+  const { data: instanceData } = instanceDataProvider.useState();
+  const { data: ruleData } = ruleDataProvider.useState();
   const instanceFrame = instanceData?.series?.at(0);
   const ruleFrame = ruleData?.series?.at(0);
 
   if (
-    !instanceDataProvider.isDataReadyToDisplay ||
-    !ruleDataProvider.isDataReadyToDisplay ||
+    !instanceDataProvider.isDataReadyToDisplay() ||
+    !ruleDataProvider.isDataReadyToDisplay() ||
     !instanceFrame ||
     !ruleFrame
   ) {
@@ -135,82 +152,70 @@ export function SummaryStatsReact() {
   const instanceDfv = new DataFrameView<Frame>(instanceFrame);
   const ruleDfv = new DataFrameView<RuleFrame>(ruleFrame);
 
-  if (instanceDfv.length === 0 || ruleDfv.length === 0) {
+  if (instanceDfv.length === 0 && ruleDfv.length === 0) {
     return <div />;
   }
 
   const instances = countInstances(instanceDfv);
   const rules = countRules(ruleDfv, alertstateFilter);
 
-  const renderStat = (i18nKey: string, color: 'error' | 'warning', values: Record<string, number>, text: string) => (
-    <Text color={color}>
-      <Trans i18nKey={i18nKey} values={values}>
-        {text}
-      </Trans>
-    </Text>
-  );
-
   return (
     <Stack direction="column" alignItems="flex-end" gap={0}>
       <Spacer />
       {alertstateFilter === 'firing' && (
         <>
-          {renderStat(
-            'alerting.triage.firing-rules-count',
-            'error',
-            { count: rules.firing },
-            '{{count}} firing alert rules'
-          )}
-          {renderStat(
-            'alerting.triage.firing-instances-count',
-            'error',
-            { firingCount: instances.firing },
-            '{{firingCount}} firing instances'
-          )}
+          <StatRow i18nKey="alerting.triage.firing-rules-count" color="error" values={{ count: rules.firing }}>
+            {'{{count}} firing alert rules'}
+          </StatRow>
+          <StatRow
+            i18nKey="alerting.triage.firing-instances-count"
+            color="error"
+            values={{ firingCount: instances.firing }}
+          >
+            {'{{firingCount}} firing instances'}
+          </StatRow>
         </>
       )}
       {alertstateFilter === 'pending' && (
         <>
-          {renderStat(
-            'alerting.triage.rules-with-pending-instances',
-            'warning',
-            { count: rules.pending },
-            '{{count}} alert rules with pending instances'
-          )}
-          {renderStat(
-            'alerting.triage.pending-instances-count',
-            'warning',
-            { pendingCount: instances.pending },
-            '{{pendingCount}} pending instances'
-          )}
+          <StatRow
+            i18nKey="alerting.triage.rules-with-pending-instances"
+            color="warning"
+            values={{ count: rules.pending }}
+          >
+            {'{{count}} rules with pending instances'}
+          </StatRow>
+          <StatRow
+            i18nKey="alerting.triage.pending-instances-count"
+            color="warning"
+            values={{ pendingCount: instances.pending }}
+          >
+            {'{{pendingCount}} pending instances'}
+          </StatRow>
         </>
       )}
       {!alertstateFilter && (
         <>
-          {renderStat(
-            'alerting.triage.firing-rules-count',
-            'error',
-            { count: rules.firing },
-            '{{count}} firing alert rules'
-          )}
-          {renderStat(
-            'alerting.triage.firing-instances-count',
-            'error',
-            { firingCount: instances.firing },
-            '{{firingCount}} firing instances'
-          )}
-          {renderStat(
-            'alerting.triage.pending-rules-count',
-            'warning',
-            { count: rules.pending },
-            '{{count}} pending alert rules'
-          )}
-          {renderStat(
-            'alerting.triage.pending-instances-count',
-            'warning',
-            { pendingCount: instances.pending },
-            '{{pendingCount}} pending instances'
-          )}
+          <StatRow i18nKey="alerting.triage.firing-rules-count" color="error" values={{ count: rules.firing }}>
+            {'{{count}} firing alert rules'}
+          </StatRow>
+          <StatRow
+            i18nKey="alerting.triage.firing-instances-count"
+            color="error"
+            values={{ firingCount: instances.firing }}
+          >
+            {'{{firingCount}} firing instances'}
+          </StatRow>
+          <StatRow i18nKey="alerting.triage.pending-rules-count" color="warning" values={{ count: rules.pending }}>
+            {'{{count}} pending alert rules'}
+          </StatRow>
+          <StatRow
+            i18nKey="alerting.triage.pending-instances-count"
+            color="warning"
+            values={{ pendingCount: instances.pending }}
+          >
+            {'{{pendingCount}} pending instances'}
+          </StatRow>
         </>
       )}
     </Stack>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2943,7 +2943,6 @@
     "triage": {
       "alert-instances": "Alert instances",
       "error-loading-rule": "Error loading rule",
-      "firing-instances-count": "{{firingCount}} firing instances",
       "instance-details-drawer": {
         "instance-details": "Instance details"
       },
@@ -2951,7 +2950,6 @@
       "no-labels": "No labels",
       "open-in-sidebar": "Open in sidebar",
       "open-rule-details": "Open rule details",
-      "pending-instances-count": "{{pendingCount}} pending instances",
       "rule-details": {
         "subtitle": "Rule details and conditions",
         "title": "Rule Details"


### PR DESCRIPTION
This PR adds pending & firing alert rule counts to the stats section in Alerts page.

**No alertstate filter**
<img width="1198" height="725" alt="image" src="https://github.com/user-attachments/assets/6f7e5228-289e-4e0e-b971-d440a051a1ac" />

**Filter with alertstate=firing**
<img width="1189" height="705" alt="image" src="https://github.com/user-attachments/assets/8b985d0b-dca7-4268-ab1a-7fc45c56d3c7" />

**Filter with alertstate=pending**
<img width="1193" height="696" alt="image" src="https://github.com/user-attachments/assets/36b1bc22-ba8a-4788-8fe7-cb2c08f9f72a" />
