### PR TITLE
CloudWatch: Make match exact toggle false by default

### DIFF
--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -460,7 +460,7 @@ describe('datasource', () => {
       expect((datasource.getDefaultQuery(CoreApp.PanelEditor) as CloudWatchDefaultQuery).metricEditorMode).toEqual(
         MetricEditorMode.Builder
       );
-      expect((datasource.getDefaultQuery(CoreApp.PanelEditor) as CloudWatchDefaultQuery).matchExact).toEqual(true);
+      expect((datasource.getDefaultQuery(CoreApp.PanelEditor) as CloudWatchDefaultQuery).matchExact).toEqual(false);
     });
     it('should set default values from logs query', () => {
       const defaultLogGroups = [{ name: 'logName', arn: 'logARN' }];

--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -24,7 +24,7 @@ export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   metricEditorMode: MetricEditorMode.Builder,
   sql: undefined,
   sqlExpression: '',
-  matchExact: true,
+  matchExact: false,
 };
 
 export const DEFAULT_ANNOTATIONS_QUERY: Omit<CloudWatchAnnotationQuery, 'refId'> = {


### PR DESCRIPTION
We discussed this in the daily, so following up. I couldn't identify that it was different before, but I think it makes more sense to make it false, since `matchExact=true` is an additional layer of filtering the user most likely doesn't want by default