### PR TITLE
Docs: Clarify difference between "Add" and "Replace" for saved queries

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -31,12 +31,12 @@ refs:
       destination: /docs/grafana-cloud/developer-resources/api-reference/http-api/annotations/
   saved-queries:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#saved-queries
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
   save-query:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#save-a-query
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 ---
@@ -160,18 +160,16 @@ To add a new annotation query to a dashboard, follow these steps:
 
 1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.  The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
-   - Click **Replace with saved query** to reuse a saved query.
-
-   {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-
-   This feature is only available on Grafana Enterprise and Grafana Cloud.
-   {{< /admonition >}}
+   - Click **Replace with saved query** to reuse a [saved query](ref:saved-queries).
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 1. (Optional) Click **Test annotation query** to ensure that the query is working properly.
-1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
-1. (Optional) Test added queries as needed.
+1. (Optional) To add subsequent queries, click **+ Add query** or **+ Add from saved queries**, and test them as many times as needed.
+
+   {{< admonition type="note" >}}
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
+   {{< /admonition >}}
+
 1. Click **Save dashboard**.
 1. Click **Back to dashboard** and **Exit edit**.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -150,8 +150,7 @@ To add a new annotation query to a dashboard, follow these steps:
 
 1. To add a query, do one of the following:
    - Write or construct a query in the query language of your data source. The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
-   - Click **+ Add from saved queries** to reuse a saved query.
-   - Click the **Replace with saved query** button (or icon) to reuse a saved query.
+   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -159,7 +159,7 @@ To add a new annotation query to a dashboard, follow these steps:
    {{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-filtering-10-v2.png" max-width="600px" caption="Annotation filtering" >}}
 
 1. To create a query, do one of the following:
-   - Write or construct a query in the query language of your data source.  The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
+   - Write or construct a query in the query language of your data source. The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
    - Click **Replace with saved query** to reuse a [saved query](ref:saved-queries).
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -29,6 +29,16 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/developers/http_api/annotations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/developer-resources/api-reference/http-api/annotations/
+  saved-queries:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#saved-queries
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
+  save-query:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#save-a-query
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 ---
 
 # Annotate visualizations
@@ -148,17 +158,20 @@ To add a new annotation query to a dashboard, follow these steps:
 
    {{< figure src="/media/docs/grafana/dashboards/screenshot-annotation-filtering-10-v2.png" max-width="600px" caption="Annotation filtering" >}}
 
-1. To add a query, do one of the following:
-   - Write or construct a query in the query language of your data source. The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
-   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
-
-1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+1. To create a query, do one of the following:
+   - Write or construct a query in the query language of your data source.  The annotation query options are different for each data source. For information about annotations in a specific data source, refer to the specific [data source](ref:data-source) topic.
+   - Click **Replace with saved query** to reuse a saved query.
 
    {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+
+   This feature is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
 
+1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 1. (Optional) Click **Test annotation query** to ensure that the query is working properly.
+1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
+1. (Optional) Test added queries as needed.
 1. Click **Save dashboard**.
 1. Click **Back to dashboard** and **Exit edit**.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -23,27 +23,27 @@ refs:
       destination: /docs/grafana-cloud/connect-externally-hosted/data-sources/#special-data-sources
   visualization-specific-options:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/visualizations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/
   configure-standard-options:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-standard-options/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-standard-options/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-standard-options/
   configure-value-mappings:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-value-mappings/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-value-mappings/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-value-mappings/
   generative-ai-features:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/manage-dashboards/#set-up-generative-ai-features-for-dashboards
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/manage-dashboards/#set-up-generative-ai-features-for-dashboards
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/dashboards/manage-dashboards/#set-up-generative-ai-features-for-dashboards
   configure-thresholds:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-thresholds/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-thresholds/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-thresholds/
   data-sources:
@@ -63,27 +63,27 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/
   visualizations-options:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/visualizations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/
   configure-repeating-panels:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-panel-options/#configure-repeating-panels
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-panel-options/#configure-repeating-panels
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-panel-options/#configure-repeating-panels
   override-field-values:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/configure-overrides/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/configure-overrides/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/configure-overrides/
   saved-queries:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#saved-queries
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
   save-query:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#save-a-query
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 ---
@@ -125,7 +125,12 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
 1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **Replace with saved query** to reuse a saved query.
+   - Click **Replace with saved query** to reuse a [saved query](ref:saved-queries).
+
+1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+
+1. Click **Refresh** to query the data source.
+1. (Optional) To add subsequent queries, click **+ Add query** or **+ Add from saved queries**, and refresh the data source as many times as needed.
 
    {{< admonition type="note" >}}
    [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
@@ -133,10 +138,6 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
    This feature is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
 
-1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
-
-1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
-1. Click **Refresh** to query the data source.
 1. In the visualization list, select a visualization type.
 
    ![Visualization selector](/media/docs/grafana/dashboards/screenshot-select-visualization-11-2.png)

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -125,8 +125,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
 1. To add a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** to reuse a saved query.
-   - Click the **Replace with saved query** button (or icon) to reuse a saved query.
+   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -128,12 +128,11 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
    - Click **Replace with saved query** to reuse a [saved query](ref:saved-queries).
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
-
 1. Click **Refresh** to query the data source.
 1. (Optional) To add subsequent queries, click **+ Add query** or **+ Add from saved queries**, and refresh the data source as many times as needed.
 
    {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
    {{< /admonition >}}
 
 1. In the visualization list, select a visualization type.

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -123,16 +123,19 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    For more information about data sources, refer to [Data sources](ref:data-sources) for specific guidelines.
 
-1. To add a query, do one of the following:
+1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
+   - Click **Replace with saved query** to reuse a saved query.
+
+   {{< admonition type="note" >}}
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
+
+   This feature is only available on Grafana Enterprise and Grafana Cloud.
+   {{< /admonition >}}
 
 1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 
-   {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
-   {{< /admonition >}}
-
+1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
 1. Click **Refresh** to query the data source.
 1. In the visualization list, select a visualization type.
 

--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/index.md
@@ -133,9 +133,7 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 1. (Optional) To add subsequent queries, click **+ Add query** or **+ Add from saved queries**, and refresh the data source as many times as needed.
 
    {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
-
-   This feature is only available on Grafana Enterprise and Grafana Cloud.
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only. Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
    {{< /admonition >}}
 
 1. In the visualization list, select a visualization type.

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -14,12 +14,12 @@ title: Get started with Explore
 refs:
   saved-queries:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#saved-queries
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
   save-query:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#save-a-query
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 weight: 5

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -72,7 +72,7 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
 
 - **Query editor** - Interface where you construct the query for a specific data source. Query editor elements differ based on data source. In order to run queries across multiple data sources you need to select **Mixed** from the data source picker.
   - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
-  - **Replace with saved query** - Reuse a saved query.  
+  - **Replace with saved query** - Reuse a saved query.
   - **+ Add query** - Add an additional query.
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -73,7 +73,7 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
 - **Query editor** - Interface where you construct the query for a specific data source. Query editor elements differ based on data source. In order to run queries across multiple data sources you need to select **Mixed** from the data source picker.
 
 - **+ Add query** - Add additional queries.
-- **+ Add from saved queries** - Add a saved query. Click the **Replace with saved query** button (or icon) to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+- **+ Add from saved queries** and **Replace with saved query** - Add a saved query. **+ Add from saved queries** or **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
 
   {{< admonition type="note" >}}
   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -71,9 +71,10 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
   - **Run query** - Click to run your query.
 
 - **Query editor** - Interface where you construct the query for a specific data source. Query editor elements differ based on data source. In order to run queries across multiple data sources you need to select **Mixed** from the data source picker.
-
-- **+ Add query** - Add additional queries.
-- **+ Add from saved queries** and **Replace with saved query** - Add a saved query. **+ Add from saved queries** or **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+  - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+  - **Replace with saved query** - Reuse a saved query.  
+  - **+ Add query** - Add an additional query.
+  - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.

--- a/docs/sources/visualizations/explore/get-started-with-explore.md
+++ b/docs/sources/visualizations/explore/get-started-with-explore.md
@@ -77,7 +77,7 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+  [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
   {{< /admonition >}}
 
 - **Query history** - Query history contains the list of queries that you created in Explore. You can also add queries from the history to your saved queries. Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-management/#query-history) for detailed information on working with your query history.

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -88,7 +88,7 @@ The data section contains tabs where you enter queries, transform your data, and
 
 - **Queries**
   - Select your data source. You can also set or update the data source in existing dashboards using the drop-down menu in the **Queries** tab.
-  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source, or click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** icon.
+  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source, or click **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** icon. To add subsequent queries, click **+ Add query** or **+Add from saved queries**.
 
   {{< admonition type="note" >}}
   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -88,7 +88,7 @@ The data section contains tabs where you enter queries, transform your data, and
 
 - **Queries**
   - Select your data source. You can also set or update the data source in existing dashboards using the drop-down menu in the **Queries** tab.
-  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source or click **+ Add from saved queries** to add a previously saved query. If you've already written a query, you can click the **Replace with saved query** icon to use a previously saved query instead. To [save the query](ref:save-query) for reuse, click the **Save query** icon.
+  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source, or click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** icon.
 
   {{< admonition type="note" >}}
   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -89,7 +89,7 @@ The data section contains tabs where you enter queries, transform your data, and
 - **Queries**
   - Select your data source. You can also set or update the data source in existing dashboards using the drop-down menu in the **Queries** tab.
   - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
-  - **Replace with saved query** - Reuse a saved query.  
+  - **Replace with saved query** - Reuse a saved query.
   - **+ Add query** - Add an additional query.
   - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -28,7 +28,7 @@ weight: 20
 refs:
   transform-data:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/transform-data/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/transform-data/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/transform-data/
   the-overview-of-grafana-alerting:
@@ -38,22 +38,22 @@ refs:
       destination: /docs/grafana-cloud/alerting-and-irm/alerting/
   table:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/visualizations/table/
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/visualizations/table/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/visualizations/table/
   add-a-query:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#add-a-query
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#add-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#add-a-query
   saved-queries:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#saved-queries
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#saved-queries
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#saved-queries
   save-query:
     - pattern: /docs/grafana/
-      destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/query-transform-data/#save-a-query
+      destination: /docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/query-transform-data/#save-a-query
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/visualizations/panels-visualizations/query-transform-data/#save-a-query
 ---
@@ -88,10 +88,13 @@ The data section contains tabs where you enter queries, transform your data, and
 
 - **Queries**
   - Select your data source. You can also set or update the data source in existing dashboards using the drop-down menu in the **Queries** tab.
-  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source, or click **Replace with saved query** to reuse a saved query. To [save the query](ref:save-query) for reuse, click the **Save query** icon. To add subsequent queries, click **+ Add query** or **+Add from saved queries**.
+  - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+  - **Replace with saved query** - Reuse a saved query.  
+  - **+ Add query** - Add an additional query.
+  - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+  [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
   {{< /admonition >}}
 
 - **Transformations** - Apply data transformations. For more information, refer to [Transform data](ref:transform-data).

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -137,7 +137,7 @@ Saved queries are available in:
 
 You can see a list of these queries in the **Saved queries** drawer:
 
-{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v12.3.png" max-width="550px" alt="List of saved queries and the edit query form" caption="The Saved queries drawer accessed from Dashboards" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-saved-queries-v12.3.png" max-width="550px" alt="List of saved queries and the edit query form" caption="The **Saved queries** drawer accessed from Dashboards" >}}
 
 When you first open the drawer, the list of queries in the **All** tab is filtered by the data source of the panel.
 However, you can clear that filter to display all saved queries.
@@ -156,13 +156,11 @@ In the **Saved queries** drawer, you can:
 - Edit a query title, description, tags, or the availability of the query to other users in your organization. By default, saved queries are locked for editing.
 - When you access the **Saved queries** drawer from Explore, you can use the **Edit in Explore** option to edit the body of a query.
 
-To access your saved queries, click **+ Add from saved queries** in the query editor:
+To access your saved queries, click **+ Add from saved queries** or **Replace with saved query** in the query editor:
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-from-saved-2-v12.2.png" max-width="750px" alt="Add a saved query" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-use-saved-queries-v12.3.png" max-width="750px" alt="Access saved queries" >}}
 
-If you've already entered a query, you also have the option to replace it with a saved one:
-
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-replace-w-saved-v12.2.png" max-width="750px" alt="Replace a query with a saved one" >}}
+Clicking **+ Add from saved queries** adds an additional query, while clicking **Replace with saved query** updates your existing query.
 
 #### Save a query
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -221,17 +221,18 @@ To add a query, follow these steps:
 
    For more information about query options, refer to [Query options](#query-options).
 
-1. To add a query, do one of the following:
+1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
-
-1. (Optional) To save the query for reuse, click the **Save query** button (or icon).
+   - Click **Replace with saved query** to reuse a saved query.
 
    {{< admonition type="note" >}}
    [Saved queries](#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
    This feature is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
+
+1. (Optional) To [save the query](#save-a-query) for reuse, click the **Save query** button (or icon).
+1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
 
 1. Click **Run queries**.
 

--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/_index.md
@@ -223,8 +223,7 @@ To add a query, follow these steps:
 
 1. To add a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** to reuse a saved query.
-   - Click the **Replace with saved query** button (or icon) to reuse a saved query.
+   - Click **+ Add from saved queries** or **Replace with saved query** to reuse a saved query.
 
 1. (Optional) To save the query for reuse, click the **Save query** button (or icon).
 


### PR DESCRIPTION
This PR clarifies the uses of the following saved queries UI elements:
- **+ Add from saved queries** - Adds an additional query/query editor and reuses a saved query.
- **Replace with saved query** - Updates the existing query with a saved query.

This wasn't clear in the documentation previously. 
As part of this update, the query creation flow in affected areas has been updated to prioritize the **Replace** button with the **Add** button being mentioned later in the context of adding additional queries.
This also entailed an update to a screenshot where this difference is pointed out.