### PR TITLE
Dashboard Export: Don't pass already templateized ds var to ds service

### DIFF
--- a/public/app/features/dashboard-scene/scene/export/exporters.test.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.test.ts
@@ -293,6 +293,65 @@ describe('dashboard exporter v1', () => {
     expect(exported.panels[0].targets[0].datasource).toEqual({ uid: '${DS_OTHER}', type: 'other' });
   });
 
+  it('should not attempt to templateize datasource variable ref if they have already been templateized', async () => {
+    const dashboard: Dashboard = {
+      title: 'My dashboard',
+      revision: 1,
+      editable: false,
+      graphTooltip: DashboardCursorSync.Off,
+      schemaVersion: 1,
+      timepicker: { hidden: true },
+      timezone: '',
+      panels: [
+        {
+          id: 1,
+          type: 'timeseries',
+          title: 'My panel title',
+          gridPos: { x: 0, y: 0, w: 1, h: 1 },
+          datasource: {
+            type: 'prometheus',
+            uid: '${ds_var}',
+          },
+        },
+      ],
+      templating: {
+        list: [
+          {
+            current: {
+              selected: false,
+              text: 'my-prometheus-datasource',
+              value: 'my-prometheus-datasource-uid',
+            },
+            hide: 0,
+            includeAll: false,
+            multi: false,
+            name: 'ds_var',
+            options: [],
+            query: 'prometheus',
+            refresh: 1,
+            regex: '',
+            skipUrlSync: false,
+            type: 'datasource',
+          },
+          // query variable here uses the datasource variable that has already been templateized
+          {
+            name: 'query_var',
+            datasource: { uid: '${ds_var}', type: 'prometheus' },
+            type: 'query',
+          },
+        ],
+      },
+    };
+    const dashboardModel = new DashboardModel(dashboard, undefined, {
+      getVariablesFromState: () => dashboard.templating!.list! as TypedVariableModel[],
+    });
+    const exported = (await makeExportableV1(dashboardModel)) as DashboardJson;
+
+    // @ts-ignore
+    const queryVarDatasource = exported.templating?.list[1].datasource;
+    expect(queryVarDatasource).toEqual({ uid: '${ds_var}', type: 'prometheus' });
+  });
+
   describe('given dashboard with repeated panels', () => {
     let dash: any, exported: any;
 

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -128,6 +128,12 @@ export async function makeExportableV1(dashboard: DashboardModel) {
     if (match) {
       varName = match[1] || match[2] || match[4];
       datasourceVariable = variableLookup[varName];
+
+      // if datasource variable is already templated, skip it
+      if (datasourceVariableRefNameMap[varName]) {
+        return;
+      }
+
       if (datasourceVariable && datasourceVariable.current) {
         datasource = datasourceVariable.current.value;
       }
@@ -172,7 +178,7 @@ export async function makeExportableV1(dashboard: DashboardModel) {
           };
         }
 
-        // if it panel or query is relying on a datasource variable
+        // if panel or query is relying on a datasource variable
         // skip templating datasource uid but save the reference so we can set datasource variable's current prop
         if (datasourceVariable && varName) {
           datasourceVariableRefNameMap[varName] = '${' + refName + '}';


### PR DESCRIPTION
This PR fixes a bug where, when trying to export externally, an already templateized datasource variable was being passed to the datasource service, which was resulting in an error. 

Since exporter first processes panels and then template variables, this was only happening for dashboards that have query variables relying on a datasource variable, and that datasource came before the query variable. 

The bug was introduced here https://github.com/grafana/grafana/pull/109764, as a part of improving export/import experience, where I didn't account that once we process a ds variable, its `current.value` will be set to a templateized value, and then any other variable that relies on that ds variable would have that templateized value as datasource, because of this logic:

```ts
 if (datasourceVariable && datasourceVariable.current) {
        datasource = datasourceVariable.current.value;
      }
```

Fixes https://github.com/grafana/support-escalations/issues/19232

Please check that:
- [ ] It works as expected from a user's perspective.

