### PR TITLE
Alerting: Improve ASH Loki query efficiency by including folderUID

### DIFF
--- a/pkg/services/ngalert/state/historian/annotation.go
+++ b/pkg/services/ngalert/state/historian/annotation.go
@@ -44,6 +44,7 @@ type AnnotationBackend struct {
 type RuleStore interface {
 	GetAlertRuleByUID(ctx context.Context, query *ngmodels.GetAlertRuleByUIDQuery) (*ngmodels.AlertRule, error)
 	GetUserVisibleNamespaces(ctx context.Context, orgID int64, user identity.Requester) (map[string]*folder.Folder, error)
+	GetAlertRuleVersionFolders(ctx context.Context, orgID int64, guid string) ([]string, error)
 }
 
 type AnnotationStore interface {

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -1002,13 +1002,13 @@ func TestGetFolderUIDsForFilter(t *testing.T) {
 
 func TestGetFolderUIDsForFilterWithHistoricalFolders(t *testing.T) {
 	// Simple history generator to avoid repetitive code in test cases.
-	simpleHistory := func(guid string) map[string][]*models.AlertRule {
-		return map[string][]*models.AlertRule{
+	simpleHistory := func(guid string) map[string][]*models.AlertRuleVersion {
+		return map[string][]*models.AlertRuleVersion{
 			guid: {
-				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
-				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-1")).GenerateRef(),
-				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-2")).GenerateRef(),
-				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-3")).GenerateRef(),
+				&models.AlertRuleVersion{AlertRule: models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-current")).Generate()},
+				&models.AlertRuleVersion{AlertRule: models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-1")).Generate()},
+				&models.AlertRuleVersion{AlertRule: models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-2")).Generate()},
+				&models.AlertRuleVersion{AlertRule: models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-3")).Generate()},
 			},
 		}
 	}
@@ -1040,7 +1040,7 @@ func TestGetFolderUIDsForFilterWithHistoricalFolders(t *testing.T) {
 	cases := []struct {
 		name string
 		// Setup.
-		existingHistory map[string][]*models.AlertRule
+		existingHistory map[string][]*models.AlertRuleVersion
 		canReadAllRules bool
 		rule            *models.AlertRule
 

--- a/pkg/services/ngalert/state/historian/loki_test.go
+++ b/pkg/services/ngalert/state/historian/loki_test.go
@@ -22,6 +22,7 @@ import (
 
 	alertingInstrument "github.com/grafana/alerting/http/instrument"
 	"github.com/grafana/alerting/http/instrument/instrumenttest"
+
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -868,7 +869,8 @@ func TestGetFolderUIDsForFilter(t *testing.T) {
 			}
 			result, err := createLoki(ac).getFolderUIDsForFilter(context.Background(), models.HistoryQuery{OrgID: orgID, RuleUID: rule.UID, SignedInUser: usr})
 			assert.NoError(t, err)
-			assert.Empty(t, result)
+			assert.Len(t, result, 1)
+			assert.Contains(t, result, rule.GetNamespaceUID())
 
 			assert.Len(t, ac.Calls, 1)
 			assert.Equal(t, "CanReadAllRules", ac.Calls[0].MethodName)
@@ -893,7 +895,8 @@ func TestGetFolderUIDsForFilter(t *testing.T) {
 
 			result, err := loki.getFolderUIDsForFilter(context.Background(), models.HistoryQuery{OrgID: orgID, RuleUID: rule.UID, SignedInUser: usr})
 			assert.NoError(t, err)
-			assert.Empty(t, result)
+			assert.Len(t, result, 1)
+			assert.Contains(t, result, rule.GetNamespaceUID())
 
 			assert.Len(t, ac.Calls, 2)
 			assert.Equal(t, "CanReadAllRules", ac.Calls[0].MethodName)
@@ -915,6 +918,21 @@ func TestGetFolderUIDsForFilter(t *testing.T) {
 				result, err = loki.getFolderUIDsForFilter(context.Background(), models.HistoryQuery{OrgID: orgID, RuleUID: "not-found", SignedInUser: usr})
 				require.ErrorIs(t, err, models.ErrAlertRuleNotFound)
 			})
+		})
+
+		t.Run("should return folderUID", func(t *testing.T) {
+			for _, authBypass := range []bool{true, false} {
+				t.Run(fmt.Sprintf("authBypass=%v", authBypass), func(t *testing.T) {
+					ac := &acfakes.FakeRuleService{}
+					ac.CanReadAllRulesFunc = func(ctx context.Context, requester identity.Requester) (bool, error) {
+						return authBypass, nil
+					}
+					result, err := createLoki(ac).getFolderUIDsForFilter(context.Background(), models.HistoryQuery{OrgID: orgID, RuleUID: rule.UID, SignedInUser: usr})
+					assert.NoError(t, err)
+					assert.Len(t, result, 1)
+					assert.Contains(t, result, rule.GetNamespaceUID())
+				})
+			}
 		})
 	})
 
@@ -980,6 +998,161 @@ func TestGetFolderUIDsForFilter(t *testing.T) {
 			})
 		})
 	})
+}
+
+func TestGetFolderUIDsForFilterWithHistoricalFolders(t *testing.T) {
+	// Simple history generator to avoid repetitive code in test cases.
+	simpleHistory := func(guid string) map[string][]*models.AlertRule {
+		return map[string][]*models.AlertRule{
+			guid: {
+				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-1")).GenerateRef(),
+				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-2")).GenerateRef(),
+				models.RuleGen.With(models.RuleMuts.WithGUID(guid), models.RuleMuts.WithNamespaceUID("folder-historical-3")).GenerateRef(),
+			},
+		}
+	}
+
+	// Helper to create simple folder access override functions.
+	canReadRulesInFolders := func(folderUids ...string) func(folderUID string) (bool, error) {
+		return func(folderUID string) (bool, error) {
+			for _, f := range folderUids {
+				if folderUID == f {
+					return true, nil
+				}
+			}
+			return false, nil
+		}
+	}
+
+	// Helper to fail historical folders query.
+	failHistoryQueryHook := func(cmd any) error {
+		q, ok := cmd.(fakes.GenericRecordedQuery)
+		if !ok {
+			return nil
+		}
+		if q.Name == "GetAlertRuleVersionFolders" {
+			return errors.New("generic error")
+		}
+		return nil
+	}
+
+	cases := []struct {
+		name string
+		// Setup.
+		existingHistory map[string][]*models.AlertRule
+		canReadAllRules bool
+		rule            *models.AlertRule
+
+		// Error overrides.
+		ruleStoreHook        func(cmd any) error
+		folderAccessOverride func(folderUID string) (bool, error)
+
+		// Expected.
+		expectedFolders []string
+	}{
+		{
+			name:            "should include historical folders when user can read all rules",
+			existingHistory: simpleHistory("guid-1"),
+			canReadAllRules: true,
+			rule:            models.RuleGen.With(models.RuleMuts.WithGUID("guid-1"), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+			expectedFolders: []string{"folder-current", "folder-historical-1", "folder-historical-2", "folder-historical-3"},
+		},
+		{
+			name:                 "should include only authorized historical folders",
+			existingHistory:      simpleHistory("guid-1"),
+			folderAccessOverride: canReadRulesInFolders("folder-current", "folder-historical-2"),
+			rule:                 models.RuleGen.With(models.RuleMuts.WithGUID("guid-1"), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+			expectedFolders:      []string{"folder-current", "folder-historical-2"},
+		},
+		{
+			name:            "if historical folders query fails, should return current folder",
+			existingHistory: simpleHistory("guid-1"),
+			canReadAllRules: true,
+			rule:            models.RuleGen.With(models.RuleMuts.WithGUID("guid-1"), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+			ruleStoreHook:   failHistoryQueryHook,
+			expectedFolders: []string{"folder-current"},
+		},
+		{
+			name:                 "if historical folders query fails, should return current folder",
+			existingHistory:      simpleHistory("guid-1"),
+			folderAccessOverride: canReadRulesInFolders("folder-current", "folder-historical-2"),
+			rule:                 models.RuleGen.With(models.RuleMuts.WithGUID("guid-1"), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+			ruleStoreHook:        failHistoryQueryHook,
+			expectedFolders:      []string{"folder-current"},
+		},
+		{
+			name:            "if access check for historical folders fails, should ignore",
+			existingHistory: simpleHistory("guid-1"),
+			rule:            models.RuleGen.With(models.RuleMuts.WithGUID("guid-1"), models.RuleMuts.WithNamespaceUID("folder-current")).GenerateRef(),
+			folderAccessOverride: func(folderUID string) (bool, error) {
+				switch folderUID {
+				case "folder-current", "folder-historical-3":
+					return true, nil
+				case "folder-historical-2":
+					return false, nil
+				case "folder-historical-1":
+					return false, errors.New("generic error")
+				}
+				return false, nil
+			},
+			expectedFolders: []string{"folder-current", "folder-historical-3"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Setup.
+			orgID := int64(1)
+			usr := accesscontrol.BackgroundUser("test", 1, org.RoleNone, nil)
+
+			ac := &acfakes.FakeRuleService{}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, requester identity.Requester) (bool, error) {
+				return tc.canReadAllRules, nil
+			}
+			ac.AuthorizeAccessInFolderFunc = func(ctx context.Context, requester identity.Requester, namespaced models.Namespaced) error {
+				if tc.canReadAllRules {
+					return nil
+				}
+				hasAccess, err := tc.folderAccessOverride(namespaced.GetNamespaceUID())
+				if err != nil {
+					return err
+				}
+				if !hasAccess {
+					return rulesAuthz.ErrAuthorizationBase.Errorf("%w", err)
+				}
+				return nil
+			}
+			ac.HasAccessInFolderFunc = func(ctx context.Context, requester identity.Requester, namespaced models.Namespaced) (bool, error) {
+				if tc.canReadAllRules {
+					return true, nil
+				}
+				return tc.folderAccessOverride(namespaced.GetNamespaceUID())
+			}
+
+			rulesStore := fakes.NewRuleStore(t)
+			rulesStore.Rules = map[int64][]*models.AlertRule{
+				orgID: {
+					tc.rule,
+					// Add some irrelevant rules to ensure they are ignored.
+					models.RuleGen.With(models.RuleMuts.WithNamespaceUID(tc.rule.GetNamespaceUID())).GenerateRef(),
+					models.RuleGen.With(models.RuleMuts.WithNamespaceUID("irrelevant-folder")).GenerateRef(),
+				},
+			}
+			rulesStore.History = tc.existingHistory
+			if tc.ruleStoreHook != nil {
+				rulesStore.Hook = tc.ruleStoreHook
+			}
+
+			loki := createTestLokiBackend(t, instrumenttest.NewFakeRequester(), metrics.NewHistorianMetrics(prometheus.NewRegistry(), metrics.Subsystem))
+			loki.ruleStore = rulesStore
+			loki.ac = ac
+
+			// Test conditions.
+			result, err := loki.getFolderUIDsForFilter(context.Background(), models.HistoryQuery{OrgID: orgID, RuleUID: tc.rule.UID, SignedInUser: usr})
+			assert.NoError(t, err)
+			assert.ElementsMatch(t, tc.expectedFolders, result)
+		})
+	}
 }
 
 func createTestLokiBackend(t *testing.T, req alertingInstrument.Requester, met *metrics.Historian) *RemoteLokiBackend {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1740,7 +1740,7 @@ func TestIntegrationGetAlertRuleVersionFolders(t *testing.T) {
 	gen := models.RuleGen
 	gen = gen.With(gen.WithIntervalMatching(store.Cfg.BaseInterval), gen.WithOrgID(orgID), gen.WithVersion(1))
 
-	inserted, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, []models.AlertRule{gen.Generate()})
+	inserted, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, []models.InsertRule{{AlertRule: gen.Generate()}})
 	require.NoError(t, err)
 	ruleV1, err := store.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{UID: inserted[0].UID})
 	require.NoError(t, err)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1726,6 +1726,55 @@ func TestIntegrationGetRuleVersions(t *testing.T) {
 	})
 }
 
+func TestIntegrationGetAlertRuleVersionFolders(t *testing.T) {
+	tutil.SkipIntegrationTestInShortMode(t)
+
+	// Setup.
+	cfg := setting.NewCfg()
+	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{BaseInterval: time.Duration(rand.Int64N(100)+1) * time.Second}
+	sqlStore := db.InitTestDB(t)
+	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+	b := &fakeBus{}
+	store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+	orgID := int64(1)
+	gen := models.RuleGen
+	gen = gen.With(gen.WithIntervalMatching(store.Cfg.BaseInterval), gen.WithOrgID(orgID), gen.WithVersion(1))
+
+	inserted, err := store.InsertAlertRules(context.Background(), &models.AlertingUserUID, []models.AlertRule{gen.Generate()})
+	require.NoError(t, err)
+	ruleV1, err := store.GetAlertRuleByUID(context.Background(), &models.GetAlertRuleByUIDQuery{UID: inserted[0].UID})
+	require.NoError(t, err)
+
+	oldRule := ruleV1
+	updatedRule := ruleV1
+	updateRule := func(title string, folderUID string) {
+		oldRule = updatedRule
+		updatedRule = models.CopyRule(oldRule, gen.WithTitle(title), gen.WithNamespaceUID(folderUID))
+		require.NoError(t, store.UpdateAlertRules(context.Background(), &models.AlertingUserUID, []models.UpdateRule{{Existing: oldRule, New: *updatedRule}}))
+		updatedRule.Version++ // Simulate version increment after update to avoid conflict errors.
+	}
+
+	// Update rule a couple of times to create versions.
+	originalFolder := oldRule.NamespaceUID
+	updateRule(util.GenerateShortUID(), originalFolder)
+	updateRule(util.GenerateShortUID(), "newfolder-1")
+	updateRule(util.GenerateShortUID(), "newfolder-2")
+	updateRule(util.GenerateShortUID(), "newfolder-2")
+	updateRule(util.GenerateShortUID(), originalFolder)
+	updateRule(util.GenerateShortUID(), "current-folder")
+
+	t.Run("should return rule versions folders sorted in decreasing order", func(t *testing.T) {
+		historicalFolders, err := store.GetAlertRuleVersionFolders(context.Background(), updatedRule.OrgID, updatedRule.GUID)
+		require.NoError(t, err)
+		assert.Equal(t, []string{ // Return folders with more recent first.
+			"current-folder",
+			originalFolder,
+			"newfolder-2",
+			"newfolder-1",
+		}, historicalFolders)
+	})
+}
+
 // createAlertRule creates an alert rule in the database and returns it.
 // If a generator is not specified, uniqueness of primary key is not guaranteed.
 func createRule(tb testing.TB, store *DBstore, generator *models.AlertRuleGenerator) *models.AlertRule {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -2,6 +2,7 @@ package fakes
 
 import (
 	"context"
+	"maps"
 	"math/rand"
 	"slices"
 	"strings"
@@ -595,6 +596,30 @@ func (f *RuleStore) GetAlertRuleVersions(_ context.Context, orgID int64, guid st
 	}
 
 	return f.History[guid], nil
+}
+
+func (f *RuleStore) GetAlertRuleVersionFolders(_ context.Context, orgID int64, guid string) ([]string, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	q := GenericRecordedQuery{
+		Name:   "GetAlertRuleVersionFolders",
+		Params: []any{orgID, guid},
+	}
+	defer func() {
+		f.RecordedOps = append(f.RecordedOps, q)
+	}()
+
+	if err := f.Hook(q); err != nil {
+		return nil, err
+	}
+
+	folderSet := make(map[string]struct{})
+	for _, rule := range f.History[guid] {
+		folderSet[rule.NamespaceUID] = struct{}{}
+	}
+
+	return slices.Collect(maps.Keys(folderSet)), nil
 }
 
 func (f *RuleStore) ListDeletedRules(_ context.Context, orgID int64) ([]*models.AlertRule, error) {


### PR DESCRIPTION
Previously, the `folderUID` label was only included in ASH Loki queries when:
- `ruleUID` was not specified, and
- the user did not have full alert rule read permissions.

This PR improves query efficiency by always including the `folderUID` in ASH Loki queries when a `ruleUID` is specified, even for users with full alert rule read permissions.

### Background and Considerations

A few subtle issues needed to be addressed:

- Folder movement and history loss:  
  A naive approach of including only the current folder UID would cause rule history to disappear if a rule was moved to a new folder.

- Previous behavior trade-off:
  The old implementation only checked RBAC for the current folder but allowed history from old folders to be included (if available).

So, to preserve history and maintain correct RBAC enforcement, the PR:
- Makes an additional database query to fetch the folders of previous versions of the alert rule.  
- Includes all (current and old) `folderUID`s in the ASH Loki query to ensure history continuity across folder moves.  
- Applies RBAC checks for each relevant folder.

**NOTE**: I chose to make the extra history from old folders non-blocking on error. If fetching or checking old folder data fails, the issue is logged but does not block access to the current folder’s history.
