### PR TITLE
Dashboard Provisioning: Add duplicate cleanup for modes 0-2

### DIFF
--- a/pkg/registry/apis/dashboard/legacysearcher/search_client.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client.go
@@ -312,7 +312,7 @@ func (c *DashboardSearchClient) Search(ctx context.Context, req *resourcepb.Reso
 		for _, dashboard := range provisioningData {
 			list.Results.Rows = append(list.Results.Rows, &resourcepb.ResourceTableRow{
 				Key: getResourceKey(&dashboards.DashboardSearchProjection{
-					UID: dashboard.Dashboard.UID,
+					UID: dashboard.UID,
 				}, req.Options.Key.Namespace),
 				Cells: c.createDetailedProvisioningCells(dashboard, query),
 			})
@@ -512,7 +512,7 @@ func (c *DashboardSearchClient) createProvisioningCells(dashboard *dashboards.Da
 }
 
 func (c *DashboardSearchClient) createDetailedProvisioningCells(dashboard *dashboards.DashboardProvisioningSearchResults, query *dashboards.FindPersistedDashboardsQuery) [][]byte {
-	cells := c.createCommonCells(dashboard.Dashboard.Title, dashboard.Dashboard.FolderUID, dashboard.Dashboard.ID, []byte("[]"))
+	cells := c.createCommonCells(dashboard.Title, dashboard.FolderUID, dashboard.ID, []byte("[]"))
 	return append(cells,
 		[]byte(query.ManagedBy),
 		[]byte(dashboard.Provisioner),

--- a/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
+++ b/pkg/registry/apis/dashboard/legacysearcher/search_client_test.go
@@ -454,7 +454,9 @@ func TestDashboardSearchClient_Search(t *testing.T) {
 	t.Run("Should retrieve dashboards by provisioner name through a different function", func(t *testing.T) {
 		mockStore.On("GetProvisionedDashboardsByName", mock.Anything, "test", mock.Anything).Return([]*dashboards.DashboardProvisioningSearchResults{
 			{
-				Dashboard:   dashboards.Dashboard{UID: "uid", Title: "Test Dashboard", FolderUID: "folder1"},
+				UID:         "uid",
+				Title:       "Test Dashboard",
+				FolderUID:   "folder1",
 				ExternalID:  "test",
 				Provisioner: string(utils.ManagerKindClassicFP), // nolint:staticcheck
 			},

--- a/pkg/services/dashboards/dashboard.go
+++ b/pkg/services/dashboards/dashboard.go
@@ -87,6 +87,7 @@ type Store interface {
 	GetProvisionedDataByDashboardUID(ctx context.Context, orgID int64, dashboardUID string) (*DashboardProvisioningSearchResults, error)
 	GetProvisionedDashboardsByName(ctx context.Context, name string, orgID int64) ([]*DashboardProvisioningSearchResults, error)
 	GetOrphanedProvisionedDashboards(ctx context.Context, notIn []string, orgID int64) ([]*Dashboard, error)
+	GetDuplicateProvisionedDashboards(ctx context.Context) ([]*DashboardProvisioningSearchResults, error)
 	SaveDashboard(ctx context.Context, cmd SaveDashboardCommand) (*Dashboard, error)
 	SaveProvisionedDashboard(ctx context.Context, cmd SaveDashboardCommand, provisioning *DashboardProvisioning) (*Dashboard, error)
 	UnprovisionDashboard(ctx context.Context, id int64) error

--- a/pkg/services/dashboards/database/database.go
+++ b/pkg/services/dashboards/database/database.go
@@ -307,8 +307,6 @@ func (d *dashboardStore) GetDuplicateProvisionedDashboards(ctx context.Context) 
 
 	dashes := []*dashboards.DashboardProvisioningSearchResults{}
 	err := d.store.WithDbSession(ctx, func(sess *db.Session) error {
-		// Find all provisioned dashboards that have duplicates based on name, external_id, and check_sum
-		// First, find the duplicate groups
 		type duplicateGroup struct {
 			Name       string `xorm:"name"`
 			ExternalID string `xorm:"external_id"`

--- a/pkg/services/dashboards/models.go
+++ b/pkg/services/dashboards/models.go
@@ -241,11 +241,15 @@ type DeleteOrphanedProvisionedDashboardsCommand struct {
 }
 
 type DashboardProvisioningSearchResults struct {
-	Dashboard       Dashboard `xorm:"extends"`
-	Provisioner     string    `xorm:"name"`
-	ExternalID      string    `xorm:"external_id"`
-	CheckSum        string    `xorm:"check_sum"`
-	ProvisionUpdate int64     `xorm:"provisioning_updated"`
+	ID              int64  `xorm:"id"`
+	UID             string `xorm:"uid"`
+	Title           string `xorm:"title"`
+	FolderUID       string `xorm:"folder_uid"`
+	OrgID           int64  `xorm:"org_id"`
+	Provisioner     string `xorm:"name"`
+	ExternalID      string `xorm:"external_id"`
+	CheckSum        string `xorm:"check_sum"`
+	ProvisionUpdate int64  `xorm:"provisioning_updated"`
 }
 
 //

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -938,8 +938,8 @@ func (dr *DashboardServiceImpl) DeleteDuplicateProvisionedDashboards(ctx context
 			externalID: dash.ExternalID,
 		}
 		if _, exists := groups[key]; exists {
-			if err = dr.deleteDashboard(ctx, dash.Dashboard.ID, dash.Dashboard.UID, dash.Dashboard.OrgID, false); err != nil {
-				dr.log.Error("Failed to delete duplicate provisioned dashboard", "error", err, "dashboardUID", dash.Dashboard.UID, "dashboardID", dash.Dashboard.ID)
+			if err = dr.deleteDashboard(ctx, dash.ID, dash.UID, dash.OrgID, false); err != nil {
+				dr.log.Error("Failed to delete duplicate provisioned dashboard", "error", err, "dashboardUID", dash.UID, "dashboardID", dash.ID)
 			}
 		}
 		groups[key] = append(groups[key], dash)

--- a/pkg/services/dashboards/store_mock.go
+++ b/pkg/services/dashboards/store_mock.go
@@ -305,6 +305,36 @@ func (_m *FakeDashboardStore) GetOrphanedProvisionedDashboards(ctx context.Conte
 	return r0, r1
 }
 
+// GetDuplicateProvisionedDashboards provides a mock function with given fields: ctx
+func (_m *FakeDashboardStore) GetDuplicateProvisionedDashboards(ctx context.Context) ([]*DashboardProvisioningSearchResults, error) {
+	ret := _m.Called(ctx)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDuplicateProvisionedDashboards")
+	}
+
+	var r0 []*DashboardProvisioningSearchResults
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) ([]*DashboardProvisioningSearchResults, error)); ok {
+		return rf(ctx)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context) []*DashboardProvisioningSearchResults); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*DashboardProvisioningSearchResults)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetProvisionedDashboardData provides a mock function with given fields: ctx, name
 func (_m *FakeDashboardStore) GetProvisionedDashboardData(ctx context.Context, name string) ([]*DashboardProvisioning, error) {
 	ret := _m.Called(ctx, name)


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/113139:

This bug https://github.com/grafana/grafana/pull/112619 caused duplicate provisioned dashboards for instances in modes 1-3. Although the bug is fixed, the duplicate provisioned dashboards remain. This PR adds a cleanup for duplicate provisioned dashboards _if_ the provisioner name and external id match, ie:

```
1	1	default	/dashboards/annotations/annotation-filtering.json	1760060767	1e2a6ea02b007f42b9b53fa3d1aa1fdb
2	2	default	/dashboards/annotations/test.json	1760899526	6f357b6e0db2fe30fb58ce8da7bdc734
3	3	default	/dashboards/annotations/test.json	1760899527	6f357b6e0db2fe30fb58ce8da7bdc734
```

dashboard 2 _or_ 3 would be cleaned up (it doesn't matter which as if the checksum is different, it will be overwritten by the most up to date json)

Fixes https://github.com/grafana/support-escalations/issues/19171


Note: The main benefit of this approach is it does not list all provisioned dashboards. Drawback is it does not work for modes 3+, which may be fine so long as we dont have anymore bugs that do this :)

It also makes all the provisioned dashboard search functions stop returning the dashboard body unnecessarily
