### PR TITLE
Dynamic Dashboards: Change dragging to using grid items instead of viz panels.

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -1,5 +1,6 @@
 import { PointerEvent as ReactPointerEvent } from 'react';
 
+import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
   SceneObjectBase,
@@ -70,7 +71,9 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
           this._sourceDropTarget?.draggedGridItemOutside?.(gridItem);
           this._lastDropTarget?.draggedGridItemInside?.(gridItem);
         } else {
-          console.warn('No grid item to drag');
+          const warningMessage = 'No grid item to drag';
+          console.warn(warningMessage);
+          logWarning(warningMessage);
         }
       });
     }

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -39,11 +39,11 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     };
   }
 
-  public startDraggingSync(evt: ReactPointerEvent, panel: VizPanel): void {
+  public startDraggingSync(evt: ReactPointerEvent, gridItem: SceneGridItemLike): void {
     this._pointerDistance.set(evt);
     this._isSelectedObject = false;
 
-    const dropTarget = sceneGraph.findObject(panel, isDashboardDropTarget);
+    const dropTarget = sceneGraph.findObject(gridItem, isDashboardDropTarget);
 
     if (!dropTarget || !isDashboardDropTarget(dropTarget)) {
       return;
@@ -55,15 +55,7 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
     document.body.addEventListener('pointermove', this._onPointerMove);
     document.body.addEventListener('pointerup', this._stopDraggingSync);
 
-    // Get the grid item if the panel is inside one (could be DashboardGridItem or AutoGridItem)
-    const gridItem = panel.parent;
-    if (gridItem && 'isDashboardLayoutItem' in gridItem) {
-      this.setState({ draggingGridItem: gridItem.getRef() });
-    } else {
-      // If no grid item, we can't drag it properly
-      console.warn('Panel is not inside a grid item, cannot drag');
-      return;
-    }
+    this.setState({ draggingGridItem: gridItem.getRef() });
   }
 
   private _stopDraggingSync(_evt: PointerEvent) {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -1,6 +1,13 @@
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { SceneComponentProps, SceneObject, SceneObjectBase, SceneObjectState, VizPanel } from '@grafana/scenes';
+import {
+  SceneComponentProps,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectState,
+  VizPanel,
+  SceneGridItemLike,
+} from '@grafana/scenes';
 import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -324,6 +331,33 @@ export class AutoGridLayoutManager extends SceneObjectBase<AutoGridLayoutManager
     });
 
     return layoutManager;
+  }
+
+  public addGridItem(gridItem: SceneGridItemLike): void {
+    if (!(gridItem instanceof AutoGridItem)) {
+      // If it's a DashboardGridItem, convert it to AutoGridItem
+      if (gridItem instanceof DashboardGridItem) {
+        if (!(gridItem.state.body instanceof VizPanel)) {
+          throw new Error('DashboardGridItem body is not a VizPanel');
+        }
+        const panel = gridItem.state.body;
+        panel.clearParent();
+
+        const newGridItem = new AutoGridItem({
+          body: panel,
+          variableName: gridItem.state.variableName,
+        });
+
+        this.state.layout.setState({ children: [...this.state.layout.state.children, newGridItem] });
+        return;
+      }
+      throw new Error('Grid item must be an AutoGridItem or DashboardGridItem');
+    }
+
+    // Clear parent before moving
+    gridItem.clearParent();
+
+    this.state.layout.setState({ children: [...this.state.layout.state.children, gridItem] });
   }
 }
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -125,9 +125,12 @@ export class DefaultGridLayoutManager
   private _activationHandler() {
     if (config.featureToggles.dashboardNewLayouts) {
       this._subs.add(
-        this.subscribeToEvent(SceneGridLayoutDragStartEvent, ({ payload: { evt, panel } }) =>
-          getLayoutOrchestratorFor(this)?.startDraggingSync(evt, panel)
-        )
+        this.subscribeToEvent(SceneGridLayoutDragStartEvent, ({ payload: { evt, panel } }) => {
+          const gridItem = panel.parent;
+          if (gridItem instanceof DashboardGridItem) {
+            getLayoutOrchestratorFor(this)?.startDraggingSync(evt, gridItem);
+          }
+        })
       );
     }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { t } from '@grafana/i18n';
+import { logWarning } from '@grafana/runtime';
 import {
   sceneGraph,
   SceneObject,
@@ -184,7 +185,9 @@ export class RowItem
         const newChildren = layout.state.children.filter((child) => child !== gridItem);
         layout.setState({ children: newChildren });
       } else {
-        throw new Error('Grid item has unexpected parent type');
+        const warningMessage = 'Grid item has unexpected parent type';
+        console.warn(warningMessage);
+        logWarning(warningMessage);
       }
     }
     this.setIsDropTarget(false);
@@ -196,7 +199,9 @@ export class RowItem
     if (isDashboardLayoutGrid(layout)) {
       layout.addGridItem(gridItem);
     } else {
-      throw new Error('Layout manager does not support addGridItem');
+      const warningMessage = 'Layout manager does not support addGridItem';
+      console.warn(warningMessage);
+      logWarning(warningMessage);
     }
     this.setIsDropTarget(false);
   }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -7,7 +7,8 @@ import {
   SceneObjectBase,
   SceneObjectState,
   VariableDependencyConfig,
-  VizPanel,
+  SceneGridItemLike,
+  SceneGridLayout,
 } from '@grafana/scenes';
 import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import appEvents from 'app/core/app_events';
@@ -20,11 +21,15 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { getDashboardSceneFor } from '../../utils/utils';
+import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
+import { AutoGridLayout } from '../layout-auto-grid/AutoGridLayout';
 import { AutoGridLayoutManager } from '../layout-auto-grid/AutoGridLayoutManager';
+import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { clearClipboard } from '../layouts-shared/paste';
 import { scrollCanvasElementIntoView } from '../layouts-shared/scrollCanvasElementIntoView';
 import { BulkActionElement } from '../types/BulkActionElement';
 import { DashboardDropTarget } from '../types/DashboardDropTarget';
+import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { EditableDashboardElement, EditableDashboardElementInfo } from '../types/EditableDashboardElement';
 import { LayoutParent } from '../types/LayoutParent';
@@ -168,14 +173,31 @@ export class RowItem
     }
   }
 
-  public draggedPanelOutside(panel: VizPanel) {
-    this.getLayout().removePanel?.(panel);
+  public draggedGridItemOutside?(gridItem: SceneGridItemLike): void {
+    // Remove from source layout
+    if (gridItem instanceof DashboardGridItem || gridItem instanceof AutoGridItem) {
+      const layout = gridItem.parent;
+      if (gridItem instanceof DashboardGridItem && layout instanceof SceneGridLayout) {
+        const newChildren = layout.state.children.filter((child) => child !== gridItem);
+        layout.setState({ children: newChildren });
+      } else if (gridItem instanceof AutoGridItem && layout instanceof AutoGridLayout) {
+        const newChildren = layout.state.children.filter((child) => child !== gridItem);
+        layout.setState({ children: newChildren });
+      } else {
+        throw new Error('Grid item has unexpected parent type');
+      }
+    }
     this.setIsDropTarget(false);
   }
 
-  public draggedPanelInside(panel: VizPanel) {
-    panel.clearParent();
-    this.getLayout().addPanel(panel);
+  public draggedGridItemInside(gridItem: SceneGridItemLike): void {
+    const layout = this.getLayout();
+
+    if (isDashboardLayoutGrid(layout)) {
+      layout.addGridItem(gridItem);
+    } else {
+      throw new Error('Layout manager does not support addGridItem');
+    }
     this.setIsDropTarget(false);
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { t } from '@grafana/i18n';
+import { logWarning } from '@grafana/runtime';
 import {
   SceneObjectState,
   SceneObjectBase,
@@ -202,7 +203,9 @@ export class TabItem
         const newChildren = layout.state.children.filter((child) => child !== gridItem);
         layout.setState({ children: newChildren });
       } else {
-        throw new Error('Grid item has unexpected parent type');
+        const warningMessage = 'Grid item has unexpected parent type';
+        console.warn(warningMessage);
+        logWarning(warningMessage);
       }
     }
     this.setIsDropTarget(false);
@@ -214,7 +217,9 @@ export class TabItem
     if (isDashboardLayoutGrid(layout)) {
       layout.addGridItem(gridItem);
     } else {
-      throw new Error('Layout manager does not support addGridItem');
+      const warningMessage = 'Layout manager does not support addGridItem';
+      console.warn(warningMessage);
+      logWarning(warningMessage);
     }
     this.setIsDropTarget(false);
 

--- a/public/app/features/dashboard-scene/scene/types/DashboardDropTarget.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardDropTarget.ts
@@ -1,10 +1,10 @@
-import { SceneObject, VizPanel } from '@grafana/scenes';
+import { SceneObject, SceneGridItemLike } from '@grafana/scenes';
 
 export interface DashboardDropTarget extends SceneObject {
   isDashboardDropTarget: Readonly<true>;
   setIsDropTarget?(isDropTarget: boolean): void;
-  draggedPanelOutside?(panel: VizPanel): void;
-  draggedPanelInside?(panel: VizPanel): void;
+  draggedGridItemOutside?(gridItem: SceneGridItemLike): void;
+  draggedGridItemInside?(gridItem: SceneGridItemLike): void;
 }
 
 export function isDashboardDropTarget(scene: SceneObject): scene is DashboardDropTarget {

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutGrid.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutGrid.ts
@@ -1,3 +1,5 @@
+import { SceneGridItemLike } from '@grafana/scenes';
+
 import { DashboardLayoutManager } from './DashboardLayoutManager';
 
 export interface DashboardLayoutGrid extends DashboardLayoutManager {
@@ -5,8 +7,12 @@ export interface DashboardLayoutGrid extends DashboardLayoutManager {
    * Merge the layout with another layout
    */
   mergeGrid(other: DashboardLayoutGrid): void;
+  /**
+   * Add a grid item to the layout
+   */
+  addGridItem(gridItem: SceneGridItemLike): void;
 }
 
 export function isDashboardLayoutGrid(obj: DashboardLayoutManager): obj is DashboardLayoutGrid {
-  return 'mergeGrid' in obj;
+  return 'mergeGrid' in obj && 'addGridItem' in obj;
 }


### PR DESCRIPTION
**What is this feature?**
This tries to drag grid items instead of VizPanel as far as possible (events originate from scenes where it would be a breaking change to use a different item type)

**Why do we need this feature?**

This makes it a lot easier to keep the size and repeat options for a panel.

Fixes #111797