### PR TITLE
Zanzana: Respect action sets for dashboards and folders during reconciliation

### DIFF
--- a/pkg/services/authz/zanzana/common/translations.go
+++ b/pkg/services/authz/zanzana/common/translations.go
@@ -67,6 +67,13 @@ var resourceTranslations = map[string]resourceTranslation{
 			"dashboards:write":  newScopedMapping(RelationUpdate, dashboardGroup, dashboardResource, ""),
 			"dashboards:create": newScopedMapping(RelationCreate, dashboardGroup, dashboardResource, ""),
 			"dashboards:delete": newScopedMapping(RelationDelete, dashboardGroup, dashboardResource, ""),
+			// Action sets
+			"folders:view":     newMapping(RelationSetView, ""),
+			"folders:edit":     newMapping(RelationSetEdit, ""),
+			"folders:admin":    newMapping(RelationSetAdmin, ""),
+			"dashboards:view":  newScopedMapping(RelationSetView, dashboardGroup, dashboardResource, ""),
+			"dashboards:edit":  newScopedMapping(RelationSetEdit, dashboardGroup, dashboardResource, ""),
+			"dashboards:admin": newScopedMapping(RelationSetAdmin, dashboardGroup, dashboardResource, ""),
 		},
 	},
 	KindDashboards: {
@@ -78,6 +85,10 @@ var resourceTranslations = map[string]resourceTranslation{
 			"dashboards:write":  newMapping(RelationUpdate, ""),
 			"dashboards:create": newMapping(RelationCreate, ""),
 			"dashboards:delete": newMapping(RelationDelete, ""),
+			// Action sets
+			"dashboards:view":  newMapping(RelationSetView, ""),
+			"dashboards:edit":  newMapping(RelationSetEdit, ""),
+			"dashboards:admin": newMapping(RelationSetAdmin, ""),
 		},
 	},
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes legacy reconciler after migrating to action sets in legacy RBAC database.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/identity-access-team/issues/1805

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
