### PR TITLE
ShortURL: Increase redirect functionality test timeout from 15s to 30s to address flakiness in actions

### DIFF
--- a/pkg/tests/apis/shorturl/shorturl_test.go
+++ b/pkg/tests/apis/shorturl/shorturl_test.go
@@ -290,7 +290,7 @@ func doDualWriteTests(t *testing.T, helper *apis.K8sTestHelper, mode grafanarest
 			require.True(t, exists)
 
 			require.Greater(t, lastSeenAt, int64(1), "lastSeenAt should be greater than 1 after redirect")
-		}, time.Second*15, time.Millisecond*150, "lastSeenAt not changed after 15s")
+		}, time.Second*30, time.Millisecond*150, "lastSeenAt not changed after 15s")
 
 		// Clean up
 		err := client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{})


### PR DESCRIPTION
Bump of the timeout change in [this PR](https://github.com/grafana/grafana/pull/113294) from 15 seconds to 30 seconds to see if that addresses the flakiness better.
