### PR TITLE
Alerting: Fix data source recording rules editor

### DIFF
--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -366,11 +366,27 @@ export function rulerRuleToFormValues(ruleWithLocation: RuleWithLocation): RuleF
         group: group.name,
       };
     } else if (rulerRuleType.dataSource.recordingRule(rule)) {
+      const datasourceUid = getDataSourceSrv().getInstanceSettings(ruleSourceName)?.uid ?? '';
+
+      const defaultQuery = {
+        refId: 'A',
+        datasourceUid,
+        queryType: '',
+        relativeTimeRange: getDefaultRelativeTimeRange(),
+        expr: rule.expr,
+        model: {
+          refId: 'A',
+          hide: false,
+          expr: rule.expr,
+        },
+      };
+
       const recordingRuleValues = recordingRulerRuleToRuleForm(rule);
 
       return {
         ...defaultFormValues,
         ...recordingRuleValues,
+        queries: [defaultQuery],
         type: RuleFormType.cloudRecording,
         dataSourceName: ruleSourceName,
         namespace,


### PR DESCRIPTION
**What is this feature?**

This PR fixes the query editor for data source recording rules. Users cannot edit query in data source recording rule.
When editing a cloud recording rule, the queries array was not populated correctly. Similar to this [fix](https://github.com/grafana/grafana/pull/72927) that was only applied for cloud rules.

**Why do we need this feature?**

It's fixing a bug.

**Who is this feature for?**

Alerting users.

**Which issue(s) does this PR fix?**:

related to this [escalation](https://github.com/grafana/support-escalations/issues/19256)

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
