### PR TITLE
ShortURL: Set same generateName for old and new API endpoints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -181,7 +181,7 @@
 /pkg/services/search/ @grafana/grafana-search-and-storage
 /pkg/services/searchusers/ @grafana/grafana-search-and-storage
 /pkg/services/secrets/ @grafana/grafana-operator-experience-squad
-/pkg/services/shorturls/ @grafana/grafana-backend-group
+/pkg/services/shorturls/ @grafana/sharing-squad
 /pkg/services/sqlstore/ @grafana/grafana-search-and-storage
 /pkg/services/ssosettings/ @grafana/identity-squad
 /pkg/services/star/ @grafana/grafana-search-and-storage
@@ -199,6 +199,7 @@
 /pkg/tests/apis/features @grafana/grafana-backend-services-squad
 /pkg/tests/apis/folder @grafana/grafana-search-and-storage
 /pkg/tests/apis/iam @grafana/identity-access-team
+/pkg/tests/apis/shorturl @grafana/sharing-squad
 /pkg/tests/api/correlations/ @grafana/datapro
 /pkg/tsdb/grafanads/ @grafana/grafana-backend-group
 /pkg/tsdb/opentsdb/ @grafana/partner-datasources

--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -212,7 +212,7 @@ func (sk8s *shortURLK8sHandler) createKubernetesShortURLsHandler(c *contextmodel
 
 	c.Logger.Debug("Creating short URL", "path", cmd.Path)
 	obj := shorturl.LegacyCreateCommandToUnstructured(cmd)
-	obj.SetGenerateName("u") // becomes a prefix
+	obj.SetGenerateName("s") // becomes a prefix
 
 	out, err := client.Create(c.Req.Context(), &obj, v1.CreateOptions{})
 	if err != nil {

--- a/public/app/api/clients/shorturl/v1alpha1/index.ts
+++ b/public/app/api/clients/shorturl/v1alpha1/index.ts
@@ -17,8 +17,7 @@ export const shortURLAPIv1alpha1 = generatedAPI.enhanceEndpoints({
         const metadata = requestOptions.shortUrl.metadata;
         if (!metadata.name && !metadata.generateName) {
           // GenerateName lets the apiserver create a new uid for the name
-          // This wont be used, the backend will generate a random uid but cannot be blank or will fail.
-          metadata.generateName = 's-';
+          metadata.generateName = 's'; // becomes a prefix
         }
         return originalQuery(requestOptions);
       };


### PR DESCRIPTION
**What is this feature?**

The short url uid is the name and it will be randomly generated in the backend.
The `name` or `generateName` are required so this PR set the same `generateName` prefix `s` when using the new API and also when re-routing from legacy endpoint to the new API.

Also changes codeowner


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
