### PR TITLE
Apps: call app.Runner().Run() in a goroutine in the post-start hook

### DIFF
--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -203,6 +203,14 @@ func createPostStartHook(
 			logger.Error("Failed to initialize app", "app", installer.ManifestData().AppName, "error", err)
 			return fmt.Errorf("failed to get app from installer %s: %w", installer.ManifestData().AppName, err)
 		}
-		return app.Runner().Run(hookContext.Context)
+		go func() {
+			err := app.Runner().Run(hookContext.Context)
+			if err != nil {
+				logger.Error("App runner exited with error", "app", installer.ManifestData().AppName, "error", err)
+			} else {
+				logger.Info("App runner exited without error", "app", installer.ManifestData().AppName)
+			}
+		}()
+		return nil
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Run the app runner in a goroutine in the post-start hook, rather than blocking the return until the app finishes running.

**Why do we need this feature?**

The `/readyz` endpoint for the API server waits for a non-nil error response from the post-start hook to mark it as ready. If we don't run the app runner in a goroutine, we get 
```
[-]poststarthook/example failed: reason withheld
```
In the `/readyz` response, as it is waiting for the post-start-hook to "complete." Since most app runners run indefinitely for the lifetime of the API server, we don't want to block the `/readyz` functionality.

**Who is this feature for?**

People using the `/readyz` endpoint to determine readiness.

**Which issue(s) does this PR fix?**:

N/A

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
