### PR TITLE
Table: Clearer feedback for mismatched field and cell types

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -964,9 +964,7 @@ export enum TableCellHeight {
  * Table cell options. Each cell has a display mode
  * and other potential options for that display.
  */
-export type TableCellOptions = (TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TablePillCellOptions | TableDataLinksCellOptions | TableActionsCellOptions | TableJsonViewCellOptions | TableMarkdownCellOptions | {
-    type: TableCellDisplayMode.Geo
-  });
+export type TableCellOptions = (TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TablePillCellOptions | TableDataLinksCellOptions | TableActionsCellOptions | TableJsonViewCellOptions | TableMarkdownCellOptions);
 
 export enum TableCellTooltipPlacement {
   Auto = 'auto',

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -94,7 +94,7 @@ TableCellHeight: "sm" | "md" | "lg" | "auto" @cuetsy(kind="enum")
 
 // Table cell options. Each cell has a display mode
 // and other potential options for that display.
-TableCellOptions: TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TablePillCellOptions | TableDataLinksCellOptions | TableActionsCellOptions | TableJsonViewCellOptions | TableMarkdownCellOptions | TableGeoCellOptions @cuetsy(kind="type")
+TableCellOptions: TableAutoCellOptions | TableSparklineCellOptions | TableBarGaugeCellOptions | TableColoredBackgroundCellOptions | TableColorTextCellOptions | TableImageCellOptions | TablePillCellOptions | TableDataLinksCellOptions | TableActionsCellOptions | TableJsonViewCellOptions | TableMarkdownCellOptions @cuetsy(kind="type")
 
 TableCellTooltipPlacement: "top" | "bottom" | "left" | "right" | "auto" @cuetsy(kind="enum")
 

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/InvalidCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/InvalidCell.tsx
@@ -1,0 +1,23 @@
+import { Trans } from '@grafana/i18n';
+import { TableCellDisplayMode } from '@grafana/schema';
+
+import { Badge } from '../../../Badge/Badge';
+import { InvalidCellProps } from '../types';
+
+import { getLocalizedDisplayModeName } from './i18n';
+import { getAutoRendererDisplayMode } from './renderers';
+
+export function InvalidCell({ field, cellOptions }: InvalidCellProps) {
+  const cellType = cellOptions?.type ?? TableCellDisplayMode.Auto;
+  const displayMode = getLocalizedDisplayModeName(
+    cellType === TableCellDisplayMode.Auto ? getAutoRendererDisplayMode(field) : cellType
+  );
+
+  return (
+    <Badge
+      color="red"
+      icon="ban"
+      text={<Trans i18nKey="grafana-ui.table.invalid-field">Invalid data for {{ displayMode }} cell</Trans>}
+    />
+  );
+}

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/i18n.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/i18n.ts
@@ -1,0 +1,24 @@
+import { t } from '@grafana/i18n';
+import { TableCellDisplayMode } from '@grafana/schema';
+
+import { RenderableCellTypes } from '../types';
+
+export const getTableCellLocalizedDisplayModes = (): Record<RenderableCellTypes, string> => ({
+  [TableCellDisplayMode.Actions]: t('table.cell-types.actions', 'Actions'),
+  [TableCellDisplayMode.Auto]: t('table.cell-types.auto', 'Auto'),
+  [TableCellDisplayMode.ColorBackground]: t('table.cell-types.color-background', 'Colored background'),
+  [TableCellDisplayMode.ColorText]: t('table.cell-types.color-text', 'Colored text'),
+  [TableCellDisplayMode.Custom]: t('table.cell-types.color-text', 'Custom'),
+  [TableCellDisplayMode.DataLinks]: t('table.cell-types.data-links', 'Data links'),
+  [TableCellDisplayMode.Gauge]: t('table.cell-types.gauge', 'Gauge'),
+  [TableCellDisplayMode.Geo]: t('table.cell-types.gauge', 'Geo'),
+  [TableCellDisplayMode.Image]: t('table.cell-types.image', 'Image'),
+  [TableCellDisplayMode.JSONView]: t('table.cell-types.json', 'JSON View'),
+  [TableCellDisplayMode.Markdown]: t('table.cell-types.markdown', 'Markdown + HTML'),
+  [TableCellDisplayMode.Pill]: t('table.cell-types.pill', 'Pill'),
+  [TableCellDisplayMode.Sparkline]: t('table.cell-types.sparkline', 'Sparkline'),
+});
+
+export const getLocalizedDisplayModeName = (mode: RenderableCellTypes): string => {
+  return getTableCellLocalizedDisplayModes()[mode] ?? mode;
+};

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/renderers.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { screen, render } from '@testing-library/react';
 
 import { createDataFrame, createTheme, Field, FieldType } from '@grafana/data';
 
@@ -292,7 +292,7 @@ describe('TableNG Cells renderers', () => {
         expect(container.childNodes).toHaveLength(1);
       });
 
-      it('should use AutoCell when attempting to render a field with an unsupported type', () => {
+      it('should use InvalidCell when attempting to render a field with an unsupported type', () => {
         // confirm that a real pill cell has spans.
         const stringField = createField(FieldType.string, ['42']);
         const { container: stringFieldContainer } = renderCell(stringField, { type: TableCellDisplayMode.Pill });
@@ -301,11 +301,12 @@ describe('TableNG Cells renderers', () => {
         expect(stringFieldContainer.querySelector('span')).toBeInTheDocument();
 
         // confirm that number pill cell doesn't actually render a pill cell.
-        const numberField = createField(FieldType.number, [42]);
-        const { container: numberFieldContainer } = renderCell(numberField, { type: TableCellDisplayMode.Pill });
-        expect(numberFieldContainer).toBeInTheDocument();
-        expect(numberFieldContainer.childNodes).toHaveLength(1);
-        expect(numberFieldContainer.querySelector('span')).toBeNull();
+        const objectField = createField(FieldType.other, [{ some: 'object' }]);
+        const { container: objectFieldContainer } = renderCell(objectField, { type: TableCellDisplayMode.Pill });
+        expect(objectFieldContainer).toBeInTheDocument();
+        expect(objectFieldContainer.childNodes).toHaveLength(1);
+        expect(objectFieldContainer.querySelector('span')).toBeNull();
+        expect(screen.getByText('Invalid data for Pill cell')).toBeInTheDocument();
       });
     });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -14,7 +14,7 @@ import {
   SelectableValue,
   FieldState,
 } from '@grafana/data';
-import { TableCellHeight, TableFieldOptions } from '@grafana/schema';
+import { TableCellDisplayMode, TableCellHeight, TableFieldOptions } from '@grafana/schema';
 
 import { TableCellInspectorMode } from '../TableCellInspector';
 import { TableCellOptions } from '../types';
@@ -240,6 +240,11 @@ export interface ActionCellProps {
   getActions: GetActionsFunctionLocal;
 }
 
+export interface InvalidCellProps {
+  cellOptions: TableCellOptions;
+  field: Field;
+}
+
 export interface PillCellProps {
   theme: GrafanaTheme2;
   field: Field;
@@ -303,6 +308,7 @@ export interface MeasureCellHeightEntry {
   fieldIdxs: number[];
 }
 
+export type RenderableCellTypes = TableCellOptions['type'] | TableCellDisplayMode.Geo;
 export type CellRootRenderer = (key: React.Key, props: CellRendererProps<TableRow, TableSummaryRow>) => React.ReactNode;
 
 export interface FromFieldsResult {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -532,6 +532,12 @@ describe('TableNG utils', () => {
       });
     });
 
+    it('should migrate non-selectable display modes to Auto', () => {
+      expect(migrateTableDisplayModeToCellOptions(TableCellDisplayMode.Geo)).toEqual({
+        type: TableCellDisplayMode.Auto,
+      });
+    });
+
     it('should handle other display modes', () => {
       const result = migrateTableDisplayModeToCellOptions(TableCellDisplayMode.ColorText);
       expect(result).toEqual({ type: TableCellDisplayMode.ColorText });

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -30,6 +30,7 @@ import {
 } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../../utils/colors';
+import { Table } from '../Table';
 import { TableCellInspectorMode } from '../TableCellInspector';
 import { TableCellOptions } from '../types';
 
@@ -792,6 +793,10 @@ export function migrateTableDisplayModeToCellOptions(displayMode: TableCellDispl
     // catching a nonsense case: `displayMode`: 'custom' should pre-date the CustomCell.
     // if it doesn't, we need to just nope out and return an auto cell.
     case TableCellDisplayMode.Custom:
+      return {
+        type: TableCellDisplayMode.Auto,
+      };
+    case TableCellDisplayMode.Geo:
       return {
         type: TableCellDisplayMode.Auto,
       };

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -30,7 +30,6 @@ import {
 } from '@grafana/schema';
 
 import { getTextColorForAlphaBackground } from '../../../utils/colors';
-import { Table } from '../Table';
 import { TableCellInspectorMode } from '../TableCellInspector';
 import { TableCellOptions } from '../types';
 

--- a/packages/grafana-ui/src/internal/index.ts
+++ b/packages/grafana-ui/src/internal/index.ts
@@ -105,3 +105,4 @@ export { closePopover } from '../utils/closePopover';
 
 export { flattenTokens } from '../slate-plugins/slate-prism';
 export { RadialGauge } from '../components/RadialGauge/RadialGauge';
+export { getTableCellLocalizedDisplayModes } from '../components/Table/TableNG/Cells/i18n';

--- a/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/ConvertFieldTypeTransformerEditor.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback } from 'react';
+import { ChangeEvent, useCallback, useId } from 'react';
 
 import {
   DataTransformerID,
@@ -36,6 +36,7 @@ export const ConvertFieldTypeTransformerEditor = ({
 }: TransformerUIProps<ConvertFieldTypeTransformerOptions>) => {
   const allTypes = getAllFieldTypeIconOptions().filter((v) => v.value !== FieldType.trace);
   const timeZoneOptions: Array<SelectableValue<string>> = getTimezoneOptions(true);
+  const id = useId();
 
   // Format timezone options
   const tzs = getTimeZones();
@@ -145,24 +146,35 @@ export const ConvertFieldTypeTransformerEditor = ({
         const shouldRenderJoinWith =
           c.joinWith?.length || (targetField?.type && [FieldType.other, FieldType.string].includes(targetField.type));
 
+        const fieldId = `${id}-${idx}-field`;
+        const asId = `${id}-${idx}-as`;
+
         return (
           <div key={`${c.targetField}-${idx}`}>
             <InlineFieldRow>
-              <InlineField label={t('transformers.convert-field-type-transformer-editor.label-field', 'Field')}>
+              <InlineField
+                htmlFor={fieldId}
+                label={t('transformers.convert-field-type-transformer-editor.label-field', 'Field')}
+              >
                 <FieldNamePicker
                   context={{ data: input }}
                   value={c.targetField ?? ''}
                   onChange={onSelectField(idx)}
                   item={fieldNamePickerSettings}
+                  id={fieldId}
                 />
               </InlineField>
-              <InlineField label={t('transformers.convert-field-type-transformer-editor.label-as', 'as')}>
+              <InlineField
+                htmlFor={asId}
+                label={t('transformers.convert-field-type-transformer-editor.label-as', 'as')}
+              >
                 <Select
                   options={allTypes}
                   value={c.destinationType}
                   placeholder={t('transformers.convert-field-type-transformer-editor.placeholder-type', 'Type')}
                   onChange={onSelectDestinationType(idx)}
                   width={18}
+                  inputId={asId}
                 />
               </InlineField>
               {c.destinationType === FieldType.time && (

--- a/public/app/plugins/panel/table/TableCellOptionEditor.tsx
+++ b/public/app/plugins/panel/table/TableCellOptionEditor.tsx
@@ -3,9 +3,9 @@ import { merge } from 'lodash';
 import { useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { t } from '@grafana/i18n';
 import { TableCellOptions } from '@grafana/schema';
 import { Combobox, ComboboxOption, Field, TableCellDisplayMode, useStyles2 } from '@grafana/ui';
+import { getTableCellLocalizedDisplayModes } from '@grafana/ui/internal';
 
 import { BarGaugeCellOptionsEditor } from './cells/BarGaugeCellOptionsEditor';
 import { ColorBackgroundCellOptionsEditor } from './cells/ColorBackgroundCellOptionsEditor';
@@ -27,26 +27,27 @@ interface Props {
   id?: string;
 }
 
+const LOCALIZED_CELL_TYPES = getTableCellLocalizedDisplayModes();
+const CELL_TYPE_OPTIONS: Array<ComboboxOption<TableCellOptions['type']>> = (
+  [
+    TableCellDisplayMode.Auto,
+    TableCellDisplayMode.ColorText,
+    TableCellDisplayMode.ColorBackground,
+    TableCellDisplayMode.DataLinks,
+    TableCellDisplayMode.Gauge,
+    TableCellDisplayMode.Sparkline,
+    TableCellDisplayMode.JSONView,
+    TableCellDisplayMode.Pill,
+    TableCellDisplayMode.Markdown,
+    TableCellDisplayMode.Image,
+    TableCellDisplayMode.Actions,
+  ] as const
+).map((value) => ({ label: LOCALIZED_CELL_TYPES[value], value }));
+
 export const TableCellOptionEditor = ({ value, onChange, id }: Props) => {
   const cellType = value.type;
   const styles = useStyles2(getStyles);
-  const cellDisplayModeOptions: Array<ComboboxOption<TableCellOptions['type']>> = [
-    { value: TableCellDisplayMode.Auto, label: t('table.cell-types.auto', 'Auto') },
-    { value: TableCellDisplayMode.ColorText, label: t('table.cell-types.color-text', 'Colored text') },
-    {
-      value: TableCellDisplayMode.ColorBackground,
-      label: t('table.cell-types.color-background', 'Colored background'),
-    },
-    { value: TableCellDisplayMode.DataLinks, label: t('table.cell-types.data-links', 'Data links') },
-    { value: TableCellDisplayMode.Gauge, label: t('table.cell-types.gauge', 'Gauge') },
-    { value: TableCellDisplayMode.Sparkline, label: t('table.cell-types.sparkline', 'Sparkline') },
-    { value: TableCellDisplayMode.JSONView, label: t('table.cell-types.json', 'JSON View') },
-    { value: TableCellDisplayMode.Pill, label: t('table.cell-types.pill', 'Pill') },
-    { value: TableCellDisplayMode.Markdown, label: t('table.cell-types.markdown', 'Markdown + HTML') },
-    { value: TableCellDisplayMode.Image, label: t('table.cell-types.image', 'Image') },
-    { value: TableCellDisplayMode.Actions, label: t('table.cell-types.actions', 'Actions') },
-  ];
-  const currentMode = cellDisplayModeOptions.find((o) => o.value === cellType)!;
+  const currentMode = CELL_TYPE_OPTIONS.find((o) => o.value === cellType)!;
 
   let [settingCache, setSettingCache] = useState<Record<string, TableCellOptions>>({});
 
@@ -79,7 +80,7 @@ export const TableCellOptionEditor = ({ value, onChange, id }: Props) => {
   return (
     <div className={styles.fixBottomMargin}>
       <Field>
-        <Combobox id={id} options={cellDisplayModeOptions} value={currentMode} onChange={onCellTypeChange} />
+        <Combobox id={id} options={CELL_TYPE_OPTIONS} value={currentMode} onChange={onCellTypeChange} />
       </Field>
       {cellType === TableCellDisplayMode.Gauge && (
         <BarGaugeCellOptionsEditor cellOptions={value} onChange={onCellOptionsChange} />

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8952,6 +8952,7 @@
         }
       },
       "inspect-drawer-title": "Inspect value",
+      "invalid-field": "Invalid data for {{displayMode}} cell",
       "nested-table": {
         "no-data": "No data"
       },


### PR DESCRIPTION
Today, we try to fall back to AutoCell if you've selected a cell type but you have invalid data flowing into that cell. This can be confusing for the end user. Worse yet, in some cases we don't actually stop rendering of a cell when there's invalid data flowing into a given cell type (for example, if you send bad data into the Gauge cell type - see #113321).

This PR introduces a UI element which will appear if you have a mismatched FieldType or values for a given field type that you're attempting to render in the table. Here's an example where the Gauge will yell if you send it strings:

https://github.com/user-attachments/assets/fc2b35be-3b8a-41a9-a4af-2cd74392c23a

This should also help users understand if their Sparkline data is malformed. In a future iteration, I'd like to find a way to populate the tooltip of the badge with some contextual help, but I think this is a good change to start with.