### PR TITLE
[v12.2.x] Docs: Clarify difference between "Add" and "Replace" for saved queries

### DIFF
--- a/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
+++ b/docs/sources/dashboards/build-dashboards/create-dashboard/index.md
@@ -122,18 +122,18 @@ Dashboards and panels allow you to show your data in visual form. Each panel nee
 
    For more information about data sources, refer to [Data sources](ref:data-sources) for specific guidelines.
 
-1. To add a query, do one of the following:
+1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** to add a previously saved query.
-   - If you've already written a query, you can click the **Replace with saved query** icon to use a previously saved query instead.
+   - Click **Replace with saved query** to reuse a [saved query](ref:saved-queries).
 
-1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** icon.
+1. (Optional) To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+1. Click **Refresh** to query the data source.
+1. (Optional) To add subsequent queries, click **+ Add query** or **+ Add from saved queries**, and refresh the data source as many times as needed.
 
    {{< admonition type="note" >}}
-   [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+   [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
    {{< /admonition >}}
 
-1. Click **Refresh** to query the data source.
 1. In the visualization list, select a visualization type.
 
    ![Visualization selector](/media/docs/grafana/dashboards/screenshot-select-visualization-11-2.png)

--- a/docs/sources/explore/get-started-with-explore.md
+++ b/docs/sources/explore/get-started-with-explore.md
@@ -71,12 +71,13 @@ Explore consists of a toolbar, outline, query editor, the ability to add multipl
   - **Run query** - Click to run your query.
 
 - **Query editor** - Interface where you construct the query for a specific data source. Query editor elements differ based on data source. In order to run queries across multiple data sources you need to select **Mixed** from the data source picker.
-
-- **+ Add query** - Add additional queries.
-- **+ Add from saved queries** - Add a saved query. If you've already written a query, you can click the **Replace with saved query** icon to use a previously saved query instead. To [save the query](ref:save-query) for reuse, click the **Save query** icon.
+  - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+  - **Replace with saved query** - Reuse a saved query.
+  - **+ Add query** - Add an additional query.
+  - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+  [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
   {{< /admonition >}}
 
 - **Query history** - Query history contains the list of queries that you created in Explore. You can also add queries from the history to your saved queries. Refer to [Query history](/docs/grafana/<GRAFANA_VERSION>/explore/query-management/#query-history) for detailed information on working with your query history.

--- a/docs/sources/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/panels-visualizations/panel-editor-overview/index.md
@@ -87,10 +87,13 @@ The data section contains tabs where you enter queries, transform your data, and
 
 - **Queries**
   - Select your data source. You can also set or update the data source in existing dashboards using the drop-down menu in the **Queries** tab.
-  - [Add queries](ref:add-a-query). Write or construct a query in the query language of your data source or click **+ Add from saved queries** to add a previously saved query. If you've already written a query, you can click the **Replace with saved query** icon to use a previously saved query instead. To [save the query](ref:save-query) for reuse, click the **Save query** icon.
+  - **Save query** - To [save the query](ref:save-query) for reuse, click the **Save query** button (or icon).
+  - **Replace with saved query** - Reuse a saved query.
+  - **+ Add query** - Add an additional query.
+  - **+ Add from saved queries** - Add an additional query by reusing a saved query.
 
   {{< admonition type="note" >}}
-  [Saved queries](ref:saved-queries) is in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Cloud only.
+  [Saved queries](ref:saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/) in Grafana Enterprise and Grafana Cloud only.
   {{< /admonition >}}
 
 - **Transformations** - Apply data transformations. For more information, refer to [Transform data](ref:transform-data).

--- a/docs/sources/panels-visualizations/query-transform-data/_index.md
+++ b/docs/sources/panels-visualizations/query-transform-data/_index.md
@@ -153,11 +153,9 @@ Access the duplicate, lock, unlock, and delete query options through the menu in
 
 To access your saved queries, click **+ Add from saved queries** in the query editor:
 
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-add-from-saved-2-v12.2.png" max-width="750px" alt="Add a saved query" >}}
+{{< figure src="/media/docs/grafana/dashboards/screenshot-use-saved-queries-v12.3.png" max-width="750px" alt="Access saved queries" >}}
 
-If you've already entered a query, you also have the option to replace it with a saved one:
-
-{{< figure src="/media/docs/grafana/panels-visualizations/screenshot-replace-w-saved-v12.2.png" max-width="750px" alt="Replace a query with a saved one" >}}
+Clicking **+ Add from saved queries** adds an additional query, while clicking **Replace with saved query** updates your existing query.
 
 #### Save a query
 
@@ -216,18 +214,18 @@ To add a query, follow these steps:
 
    For more information about query options, refer to [Query options](#query-options).
 
-1. To add a query, do one of the following:
+1. To create a query, do one of the following:
    - Write or construct a query in the query language of your data source.
-   - Click **+ Add from saved queries** to add a previously saved query.
-   - If you've already written a query, you can click the **Replace with saved query** icon to use a previously saved query instead.
-
-1. (Optional) To save the query for reuse, click the **Save query** icon.
+   - Click **Replace with saved query** to reuse a saved query.
 
    {{< admonition type="note" >}}
    [Saved queries](#saved-queries) is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available.
 
    This feature is only available on Grafana Enterprise and Grafana Cloud.
    {{< /admonition >}}
+
+1. (Optional) To [save the query](#save-a-query) for reuse, click the **Save query** button (or icon).
+1. (Optional) Click **+ Add query** or **Add from saved queries** to add more queries as needed.
 
 1. Click **Run queries**.
 


### PR DESCRIPTION
(cherry picked from commit 16a0f6c86e560120e62c479925f8b4e2a0fc9984)

***********

This PR clarifies the uses of the following saved queries UI elements:

- Add from saved queries - Adds an additional query/query editor and reuses a saved query.
- Replace with saved query - Updates the existing query with a saved query.

This wasn't clear in the documentation previously.
As part of this update, the query creation flow in affected areas has been updated to prioritize the Replace button with the Add button being mentioned later in the context of adding additional queries.
This also entailed an update to a screenshot where this difference is pointed out.

