### PR TITLE
datasources: querier: do not forward these headers

### DIFF
--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -40,8 +40,6 @@ var expectedHeaders = map[string]string{
 	strings.ToLower(queryService.HeaderPanelPluginId):  queryService.HeaderPanelPluginId,
 	strings.ToLower(queryService.HeaderDashboardTitle): queryService.HeaderDashboardTitle,
 	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
-	strings.ToLower("X-Real-IP"):                       "X-Real-IP",
-	strings.ToLower("X-Forwarded-For"):                 "X-Forwarded-For",
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {


### PR DESCRIPTION
we remove two header-names from a list.

the list defined in this file is used in two places:
- [query.go](https://github.com/grafana/grafana/blob/ddeb970b4ddd1639499abe476cb1541ab9a09ed3/pkg/registry/apis/query/query.go#L292)
- [sub_query.go](https://github.com/grafana/grafana/blob/ddeb970b4ddd1639499abe476cb1541ab9a09ed3/pkg/registry/apis/datasource/sub_query.go#L94)

we want the `x-real-ip` and `x-forwarded-for` headers to be used in `query_go`, but we do not want them to be used in `sub_query.go`. if i have them in the list, they will be used in both places.

for this reason i am removing them, and will find another way to add them only to `query.go`.