### PR TITLE
datasources: querier: forward ip-address-related headers

### DIFF
--- a/pkg/registry/apis/query/header_utils.go
+++ b/pkg/registry/apis/query/header_utils.go
@@ -40,6 +40,8 @@ var expectedHeaders = map[string]string{
 	strings.ToLower(queryService.HeaderPanelPluginId):  queryService.HeaderPanelPluginId,
 	strings.ToLower(queryService.HeaderDashboardTitle): queryService.HeaderDashboardTitle,
 	strings.ToLower(queryService.HeaderPanelTitle):     queryService.HeaderPanelTitle,
+	strings.ToLower("X-Real-IP"):                       "X-Real-IP",
+	strings.ToLower("X-Forwarded-For"):                 "X-Forwarded-For",
 }
 
 func ExtractKnownHeaders(header http.Header) map[string]string {


### PR DESCRIPTION
a [middleware we need to support](https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/grafana_request_id_header_middleware.go#L30) will ask for the "remote ip address" of the current request.

it does so by calling into this function: https://github.com/grafana/grafana/blob/f3eabbf588b227d26e00f7eb919d174254a54edb/pkg/web/context.go#L71

that function checks two http headers: `X-Real-IP` and `X-Forwarded-For`.

so we have to make sure these headers are available.
