### PR TITLE
IAM: Refactor user org hooks to use MutateRequest API

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -58,5 +58,4 @@ import (
 
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
 	_ "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
-	_ "github.com/testcontainers/testcontainers-go"
 )

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -58,4 +58,5 @@ import (
 
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
 	_ "github.com/grafana/grafana/apps/scope/pkg/apis/scope/v0alpha1"
+	_ "github.com/testcontainers/testcontainers-go"
 )

--- a/pkg/registry/apis/iam/resource_permission_hooks_test.go
+++ b/pkg/registry/apis/iam/resource_permission_hooks_test.go
@@ -16,8 +16,9 @@ import (
 
 type FakeZanzanaClient struct {
 	zanzana.Client
-	writeCallback func(context.Context, *v1.WriteRequest) error
-	readCallback  func(context.Context, *v1.ReadRequest) (*v1.ReadResponse, error)
+	writeCallback  func(context.Context, *v1.WriteRequest) error
+	readCallback   func(context.Context, *v1.ReadRequest) (*v1.ReadResponse, error)
+	mutateCallback func(context.Context, *v1.MutateRequest) error
 }
 
 // Read implements zanzana.Client.
@@ -31,6 +32,14 @@ func (f *FakeZanzanaClient) Read(ctx context.Context, req *v1.ReadRequest) (*v1.
 // Write implements zanzana.Client.
 func (f *FakeZanzanaClient) Write(ctx context.Context, req *v1.WriteRequest) error {
 	return f.writeCallback(ctx, req)
+}
+
+// Mutate implements zanzana.Client.
+func (f *FakeZanzanaClient) Mutate(ctx context.Context, req *v1.MutateRequest) error {
+	if f.mutateCallback != nil {
+		return f.mutateCallback(ctx, req)
+	}
+	return nil
 }
 
 func requireTuplesMatch(t *testing.T, actual []*v1.TupleKey, expected []*v1.TupleKey, msgAndArgs ...interface{}) {

--- a/pkg/registry/apis/iam/user_org_hooks.go
+++ b/pkg/registry/apis/iam/user_org_hooks.go
@@ -144,6 +144,10 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 						Operation: &v1.MutateOperation_UpdateUserOrgRole{
 							UpdateUserOrgRole: &v1.UpdateUserOrgRoleOperation{User: subjectName, Role: newRole},
 						},
+					}, {
+						Operation: &v1.MutateOperation_DeleteUserOrgRole{
+							DeleteUserOrgRole: &v1.DeleteUserOrgRoleOperation{User: subjectName, Role: oldRole},
+						},
 					},
 				},
 			})
@@ -154,6 +158,7 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 					"namespace", namespace,
 					"name", subjectName,
 					"role", newRole,
+					"oldRole", oldRole,
 				)
 			}
 		}(oldUser.Namespace, oldUser.Name, oldUser.Spec.Role, newUser.Spec.Role)

--- a/pkg/registry/apis/iam/user_org_hooks.go
+++ b/pkg/registry/apis/iam/user_org_hooks.go
@@ -10,26 +10,7 @@ import (
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	v1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 )
-
-// createUserBasicRoleTuple creates a tuple for a user's basic role assignment
-func createUserBasicRoleTuple(userUID, orgRole string) *v1.TupleKey {
-	if orgRole == "" {
-		return nil
-	}
-
-	basicRole := zanzana.TranslateBasicRole(orgRole)
-	if basicRole == "" {
-		return nil
-	}
-
-	return &v1.TupleKey{
-		User:     zanzana.NewTupleEntry(zanzana.TypeUser, userUID, ""),
-		Relation: zanzana.RelationAssignee,
-		Object:   zanzana.NewTupleEntry(zanzana.TypeRole, basicRole, ""),
-	}
-}
 
 // AfterUserCreate is a post-create hook that writes the user's basic role assignment to Zanzana (openFGA)
 func (b *IdentityAccessManagementAPIBuilder) AfterUserCreate(obj runtime.Object, _ *metav1.CreateOptions) {
@@ -43,24 +24,24 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserCreate(obj runtime.Object,
 		return
 	}
 
-	resourceType := "user"
-	operation := "create"
-
 	// Skip if user has no role assigned
 	if user.Spec.Role == "" {
 		b.logger.Debug("user has no role assigned, skipping basic role sync",
 			"namespace", user.Namespace,
-			"userUID", user.Name,
+			"name", user.Name,
 		)
 		return
 	}
+
+	resourceType := "user"
+	operation := "create"
 
 	// Grab a ticket to write to Zanzana
 	wait := time.Now()
 	b.zTickets <- true
 	hooksWaitHistogram.WithLabelValues(resourceType, operation).Observe(time.Since(wait).Seconds())
 
-	go func(u *iamv0.User) {
+	go func(namespace, subjectName, role, resourceType, operation string) {
 		start := time.Now()
 		status := "success"
 
@@ -70,44 +51,38 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserCreate(obj runtime.Object,
 			hooksOperationCounter.WithLabelValues(resourceType, operation, status).Inc()
 		}()
 
-		tuple := createUserBasicRoleTuple(u.Name, u.Spec.Role)
-		if tuple == nil {
-			b.logger.Warn("failed to create user basic role tuple",
-				"namespace", u.Namespace,
-				"userUID", u.Name,
-				"role", u.Spec.Role,
-			)
-			status = "failure"
-			return
-		}
-
 		b.logger.Debug("writing user basic role to zanzana",
-			"namespace", u.Namespace,
-			"userUID", u.Name,
-			"role", u.Spec.Role,
+			"namespace", namespace,
+			"name", subjectName,
+			"role", role,
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
 		defer cancel()
 
-		err := b.zClient.Write(ctx, &v1.WriteRequest{
-			Namespace: u.Namespace,
-			Writes: &v1.WriteRequestWrites{
-				TupleKeys: []*v1.TupleKey{tuple},
+		err := b.zClient.Mutate(ctx, &v1.MutateRequest{
+			Namespace: namespace,
+			Operations: []*v1.MutateOperation{
+				{
+					Operation: &v1.MutateOperation_UpdateUserOrgRole{
+						UpdateUserOrgRole: &v1.UpdateUserOrgRoleOperation{User: subjectName, Role: role},
+					},
+				},
 			},
 		})
+
 		if err != nil {
 			status = "failure"
 			b.logger.Error("failed to write user basic role to zanzana",
 				"err", err,
-				"namespace", u.Namespace,
-				"userUID", u.Name,
-				"role", u.Spec.Role,
+				"namespace", namespace,
+				"name", subjectName,
+				"role", role,
 			)
 		} else {
 			hooksTuplesCounter.WithLabelValues(resourceType, operation, "write").Inc()
 		}
-	}(user.DeepCopy())
+	}(user.Namespace, user.Name, user.Spec.Role, resourceType, operation)
 }
 
 // BeginUserUpdate is a pre-update hook that gets called on user updates
@@ -142,7 +117,7 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 		b.zTickets <- true
 		hooksWaitHistogram.WithLabelValues("user", "update").Observe(time.Since(wait).Seconds())
 
-		go func(old, new *iamv0.User) {
+		go func(namespace, subjectName, oldRole, newRole string) {
 			start := time.Now()
 			status := "success"
 
@@ -153,72 +128,35 @@ func (b *IdentityAccessManagementAPIBuilder) BeginUserUpdate(ctx context.Context
 			}()
 
 			b.logger.Debug("updating user basic role in zanzana",
-				"namespace", new.Namespace,
-				"userUID", new.Name,
-				"oldRole", old.Spec.Role,
-				"newRole", new.Spec.Role,
+				"namespace", namespace,
+				"name", subjectName,
+				"oldRole", oldRole,
+				"newRole", newRole,
 			)
 
 			ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
 			defer cancel()
 
-			req := &v1.WriteRequest{
-				Namespace: new.Namespace,
+			err := b.zClient.Mutate(ctx, &v1.MutateRequest{
+				Namespace: namespace,
+				Operations: []*v1.MutateOperation{
+					{
+						Operation: &v1.MutateOperation_UpdateUserOrgRole{
+							UpdateUserOrgRole: &v1.UpdateUserOrgRoleOperation{User: subjectName, Role: newRole},
+						},
+					},
+				},
+			})
+			if err != nil {
+				status = "failure"
+				b.logger.Error("failed to update user basic role in zanzana",
+					"err", err,
+					"namespace", namespace,
+					"name", subjectName,
+					"role", newRole,
+				)
 			}
-
-			// Delete old role tuple if it existed
-			if old.Spec.Role != "" {
-				oldTuple := createUserBasicRoleTuple(old.Name, old.Spec.Role)
-				if oldTuple != nil {
-					deleteTuple := tupleToTupleKeyWithoutCondition(oldTuple)
-					req.Deletes = &v1.WriteRequestDeletes{
-						TupleKeys: []*v1.TupleKeyWithoutCondition{deleteTuple},
-					}
-					b.logger.Debug("deleting old user basic role from zanzana",
-						"namespace", new.Namespace,
-						"userUID", new.Name,
-						"role", old.Spec.Role,
-					)
-				}
-			}
-
-			// Write new role tuple if it exists
-			if new.Spec.Role != "" {
-				newTuple := createUserBasicRoleTuple(new.Name, new.Spec.Role)
-				if newTuple != nil {
-					req.Writes = &v1.WriteRequestWrites{
-						TupleKeys: []*v1.TupleKey{newTuple},
-					}
-					b.logger.Debug("writing new user basic role to zanzana",
-						"namespace", new.Namespace,
-						"userUID", new.Name,
-						"role", new.Spec.Role,
-					)
-				}
-			}
-
-			// Only make the request if there are deletes or writes
-			if (req.Deletes != nil && len(req.Deletes.TupleKeys) > 0) || (req.Writes != nil && len(req.Writes.TupleKeys) > 0) {
-				err := b.zClient.Write(ctx, req)
-				if err != nil {
-					status = "failure"
-					b.logger.Error("failed to update user basic role in zanzana",
-						"err", err,
-						"namespace", new.Namespace,
-						"userUID", new.Name,
-					)
-				} else {
-					if req.Deletes != nil && len(req.Deletes.TupleKeys) > 0 {
-						hooksTuplesCounter.WithLabelValues("user", "update", "delete").Inc()
-					}
-					if req.Writes != nil && len(req.Writes.TupleKeys) > 0 {
-						hooksTuplesCounter.WithLabelValues("user", "update", "write").Inc()
-					}
-				}
-			} else {
-				b.logger.Debug("no tuples to update in zanzana", "namespace", new.Namespace)
-			}
-		}(oldUser.DeepCopy(), newUser.DeepCopy())
+		}(oldUser.Namespace, oldUser.Name, oldUser.Spec.Role, newUser.Spec.Role)
 	}, nil
 }
 
@@ -241,7 +179,7 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserDelete(obj runtime.Object,
 	if user.Spec.Role == "" {
 		b.logger.Debug("user had no role assigned, skipping basic role sync",
 			"namespace", user.Namespace,
-			"userUID", user.Name,
+			"name", user.Name,
 		)
 		return
 	}
@@ -250,7 +188,7 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserDelete(obj runtime.Object,
 	b.zTickets <- true
 	hooksWaitHistogram.WithLabelValues(resourceType, operation).Observe(time.Since(wait).Seconds())
 
-	go func(u *iamv0.User) {
+	go func(namespace, subjectName, role string) {
 		start := time.Now()
 		status := "success"
 
@@ -260,44 +198,36 @@ func (b *IdentityAccessManagementAPIBuilder) AfterUserDelete(obj runtime.Object,
 			hooksOperationCounter.WithLabelValues(resourceType, operation, status).Inc()
 		}()
 
-		tuple := createUserBasicRoleTuple(u.Name, u.Spec.Role)
-		if tuple == nil {
-			b.logger.Warn("failed to create user basic role tuple for deletion",
-				"namespace", u.Namespace,
-				"userUID", u.Name,
-				"role", u.Spec.Role,
-			)
-			status = "failure"
-			return
-		}
-
-		deleteTuple := tupleToTupleKeyWithoutCondition(tuple)
-
 		b.logger.Debug("deleting user basic role from zanzana",
-			"namespace", u.Namespace,
-			"userUID", u.Name,
-			"role", u.Spec.Role,
+			"namespace", namespace,
+			"name", subjectName,
+			"role", role,
 		)
 
 		ctx, cancel := context.WithTimeout(context.Background(), defaultWriteTimeout)
 		defer cancel()
 
-		err := b.zClient.Write(ctx, &v1.WriteRequest{
-			Namespace: u.Namespace,
-			Deletes: &v1.WriteRequestDeletes{
-				TupleKeys: []*v1.TupleKeyWithoutCondition{deleteTuple},
+		err := b.zClient.Mutate(ctx, &v1.MutateRequest{
+			Namespace: namespace,
+			Operations: []*v1.MutateOperation{
+				{
+					Operation: &v1.MutateOperation_DeleteUserOrgRole{
+						DeleteUserOrgRole: &v1.DeleteUserOrgRoleOperation{User: subjectName, Role: role},
+					},
+				},
 			},
 		})
+
 		if err != nil {
 			status = "failure"
 			b.logger.Error("failed to delete user basic role from zanzana",
 				"err", err,
-				"namespace", u.Namespace,
-				"userUID", u.Name,
-				"role", u.Spec.Role,
+				"namespace", namespace,
+				"name", subjectName,
+				"role", role,
 			)
 		} else {
 			hooksTuplesCounter.WithLabelValues(resourceType, operation, "delete").Inc()
 		}
-	}(user.DeepCopy())
+	}(user.Namespace, user.Name, user.Spec.Role)
 }

--- a/pkg/registry/apis/iam/user_org_hooks_test.go
+++ b/pkg/registry/apis/iam/user_org_hooks_test.go
@@ -191,14 +191,19 @@ func TestBeginUserUpdate(t *testing.T) {
 			defer wg.Done()
 			require.NotNil(t, req)
 			require.Equal(t, "org-1", req.Namespace)
-			require.Len(t, req.Operations, 1)
+			require.Len(t, req.Operations, 2)
 
-			op := req.Operations[0]
-			require.NotNil(t, op)
-			updateOp := op.GetUpdateUserOrgRole()
+			// First operation should be UpdateUserOrgRole with new role
+			updateOp := req.Operations[0].GetUpdateUserOrgRole()
 			require.NotNil(t, updateOp)
 			require.Equal(t, "testuser", updateOp.User)
 			require.Equal(t, "Admin", updateOp.Role)
+
+			// Second operation should be DeleteUserOrgRole with old role
+			deleteOp := req.Operations[1].GetDeleteUserOrgRole()
+			require.NotNil(t, deleteOp)
+			require.Equal(t, "testuser", deleteOp.User)
+			require.Equal(t, "Viewer", deleteOp.Role)
 
 			return nil
 		}
@@ -239,14 +244,19 @@ func TestBeginUserUpdate(t *testing.T) {
 			defer wg.Done()
 			require.NotNil(t, req)
 			require.Equal(t, "org-2", req.Namespace)
-			require.Len(t, req.Operations, 1)
+			require.Len(t, req.Operations, 2)
 
-			op := req.Operations[0]
-			require.NotNil(t, op)
-			updateOp := op.GetUpdateUserOrgRole()
+			// First operation should be UpdateUserOrgRole with empty role
+			updateOp := req.Operations[0].GetUpdateUserOrgRole()
 			require.NotNil(t, updateOp)
 			require.Equal(t, "testuser2", updateOp.User)
 			require.Equal(t, "", updateOp.Role)
+
+			// Second operation should be DeleteUserOrgRole with old role
+			deleteOp := req.Operations[1].GetDeleteUserOrgRole()
+			require.NotNil(t, deleteOp)
+			require.Equal(t, "testuser2", deleteOp.User)
+			require.Equal(t, "Editor", deleteOp.Role)
 
 			return nil
 		}
@@ -287,14 +297,19 @@ func TestBeginUserUpdate(t *testing.T) {
 			defer wg.Done()
 			require.NotNil(t, req)
 			require.Equal(t, "org-3", req.Namespace)
-			require.Len(t, req.Operations, 1)
+			require.Len(t, req.Operations, 2)
 
-			op := req.Operations[0]
-			require.NotNil(t, op)
-			updateOp := op.GetUpdateUserOrgRole()
+			// First operation should be UpdateUserOrgRole with new role
+			updateOp := req.Operations[0].GetUpdateUserOrgRole()
 			require.NotNil(t, updateOp)
 			require.Equal(t, "testuser3", updateOp.User)
 			require.Equal(t, "Admin", updateOp.Role)
+
+			// Second operation should be DeleteUserOrgRole with empty old role
+			deleteOp := req.Operations[1].GetDeleteUserOrgRole()
+			require.NotNil(t, deleteOp)
+			require.Equal(t, "testuser3", deleteOp.User)
+			require.Equal(t, "", deleteOp.Role)
 
 			return nil
 		}


### PR DESCRIPTION
**What is this feature?**

This PR refactors the user organization hooks to use the new `MutateRequest` API with `UpdateUserOrgRole` and `DeleteUserOrgRole` operations instead of the legacy `WriteRequest` API with tuple keys. This simplifies the code and aligns with the newer Zanzana (openFGA) mutation operations.

**Why do we need this feature?**

The current implementation uses low-level tuple operations which require manual tuple construction and conversion logic. The new `MutateRequest` API provides higher-level operations (`UpdateUserOrgRole` and `DeleteUserOrgRole`) that are more semantic and easier to maintain. This change:

- Simplifies the code by removing tuple construction logic
- Reduces code complexity (~278 lines removed, ~161 lines added)
- Improves maintainability by using semantic operations
- Aligns with the modern Zanzana API patterns

**Who is this feature for?**

This is an internal refactoring that improves code maintainability for Grafana developers working on IAM hooks.

**Which issue(s) does this PR fix?**

N/A - Internal refactoring

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Changes:**

- Refactored `AfterUserCreate`, `BeginUserUpdate`, and `AfterUserDelete` hooks to use `MutateRequest` with `UpdateUserOrgRole`/`DeleteUserOrgRole` operations
- Removed `createUserBasicRoleTuple` helper function (no longer needed)
- Updated `FakeZanzanaClient` in tests to support `Mutate` method
- Updated all tests to validate `MutateRequest` operations instead of tuple keys
- Removed obsolete `TestCreateUserBasicRoleTuple` test

**Testing:**

All existing tests have been updated and pass successfully:
- `TestAfterUserCreate` - validates user creation hooks
- `TestBeginUserUpdate` - validates user update hooks  
- `TestAfterUserDelete` - validates user deletion hooks