### PR TITLE
datasources: apiserver: do not enable extra methods by default

### DIFF
--- a/pkg/registry/apis/datasource/sub_health.go
+++ b/pkg/registry/apis/datasource/sub_health.go
@@ -10,6 +10,8 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	datasource "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type subHealthREST struct {
@@ -44,7 +46,19 @@ func (r *subHealthREST) NewConnectOptions() (runtime.Object, bool, string) {
 	return nil, false, ""
 }
 
+// FIXME: this endpoint has not been tested yet, so it is not enabled by default.
+var healthEnabled = false
+
 func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	if !healthEnabled {
+		return nil, &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status: metav1.StatusFailure,
+				Code:   http.StatusNotImplemented,
+			},
+		}
+	}
+
 	pluginCtx, err := r.builder.getPluginContext(ctx, name)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
the extra non-crud apiserver methods (check-health, call-resource, datasource proxy) have not been tested yet, so we will not enable them by default.