### PR TITLE
Linter: Rollback suppressed errors

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3328,6 +3328,23 @@
       "count": 2
     }
   },
+  "public/app/features/query/components/QueryEditorRow.tsx": {
+    "@grafana/no-aria-label-selectors": {
+      "count": 1
+    },
+    "@typescript-eslint/consistent-type-assertions": {
+      "count": 3
+    },
+    "no-restricted-syntax": {
+      "count": 1
+    },
+    "react-hooks/rules-of-hooks": {
+      "count": 1
+    },
+    "react-prefer-function-component/react-prefer-function-component": {
+      "count": 1
+    }
+  },
   "public/app/features/query/components/QueryEditorRowHeader.tsx": {
     "@grafana/no-aria-label-selectors": {
       "count": 1

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -85,7 +85,6 @@ interface State<TQuery extends DataQuery> {
   showingHelp: boolean;
 }
 
-// eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
 export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Props<TQuery>, State<TQuery>> {
   dataSourceSrv = getDataSourceSrv();
   id = '';
@@ -136,7 +135,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     }
 
     this.setState({
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       datasource: datasource as unknown as DataSourceApi<TQuery>,
       queriedDataSourceIdentifier: interpolatedUID,
     });
@@ -378,7 +376,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
           query,
           queries,
           timeRange: data.timeRange,
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
           onAddQuery: onAddQuery as (query: DataQuery) => void,
           dataSource,
           key: index,
@@ -497,7 +494,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
       data?.error && data.error.refId === query.refId ? data.error : data?.errors?.find((e) => e.refId === query.refId);
     const rowClasses = classNames('query-editor-row', {
       'query-editor-row--disabled': isHidden,
-      // eslint-disable-next-line no-restricted-syntax
       'gf-form-disabled': isHidden,
     });
 
@@ -539,7 +535,6 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
     );
 
     return (
-      // eslint-disable-next-line @grafana/no-aria-label-selectors
       <div data-testid="query-editor-row" aria-label={selectors.components.QueryEditorRows.rows}>
         {queryLibraryRef && (
           <MaybeQueryLibraryEditingHeader
@@ -636,7 +631,6 @@ function MaybeQueryLibraryEditingHeader(props: {
 
 function AdaptiveTelemetryQueryActions({ query }: { query: DataQuery }) {
   try {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const { isLoading, components } = usePluginComponents<PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context>({
       extensionPointId: PluginExtensionPoints.QueryEditorRowAdaptiveTelemetryV1,
     });


### PR DESCRIPTION
Rolling back some eslint suppresed errors.

Please, see this PR's conversation to get more context: https://github.com/grafana/grafana/pull/113113#issuecomment-3485006332