### PR TITLE
Chore: Add gitattributes config for generated files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto eol=lf
+*.gen.ts linguist-generated
+*_gen.ts linguist-generated
+*_gen.go linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,5 @@
 *.gen.ts linguist-generated
 *_gen.ts linguist-generated
 *_gen.go linguist-generated
+**/openapi_snapshots/*.json linguist-generated
+apps/**/pkg/apis/*_manifest.go linguist-generated


### PR DESCRIPTION
**What is this feature?**
Makes our generated files marked as such in the github diff

**Why do we need this feature?**
For clearer PR reviews/auto hiding of generated files