### PR TITLE
Toolbar: Move ExtensionSidebar next to toolbar

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -46,7 +46,8 @@ export function AppChrome({ children }: Props) {
 
   const headerLevels = useChromeHeaderLevels();
   const headerHeight = headerLevels * getChromeHeaderLevelHeight();
-  const styles = useStyles2(getStyles, headerHeight);
+  const sidebarTop = headerLevels === 2 ? getChromeHeaderLevelHeight() : headerHeight;
+  const styles = useStyles2(getStyles, headerHeight, sidebarTop);
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);
 
@@ -56,7 +57,7 @@ export function AppChrome({ children }: Props) {
   const contentClass = cx({
     [styles.content]: true,
     [styles.contentChromeless]: state.chromeless,
-    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless,
+    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless && headerLevels !== 2,
   });
 
   const handleMegaMenu = () => {
@@ -131,7 +132,7 @@ export function AppChrome({ children }: Props) {
             className={cx(styles.pageContainer, {
               [styles.pageContainerMenuDocked]: menuDockedAndOpen || isScopesDashboardsOpen,
               [styles.pageContainerMenuDockedScopes]: menuDockedAndOpen && isScopesDashboardsOpen,
-              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen,
+              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen && headerLevels !== 2,
               [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen,
             })}
             id="pageContent"
@@ -186,7 +187,7 @@ function useResponsiveDockedMegaMenu(chrome: AppChromeService) {
   }, [isLargeScreen, chrome, dockedMenuLocalStorageState]);
 }
 
-const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
+const getStyles = (theme: GrafanaTheme2, headerHeight: number, sidebarTop: number) => {
   return {
     content: css({
       label: 'page-content',
@@ -280,9 +281,10 @@ const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
       // the `Resizeable` component overrides the needed `position` and `height`
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       position: 'fixed !important' as 'fixed',
-      top: headerHeight,
+      // When two bars, position from first level (next to Share button); otherwise from full header
+      top: sidebarTop,
       bottom: 0,
-      zIndex: 2,
+      zIndex: theme.zIndex.navbarFixed + 1,
       right: 0,
     }),
   };

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -279,7 +279,6 @@ const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: num
       // the `Resizeable` component overrides the needed `position` and `height`
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       position: 'fixed !important' as 'fixed',
-      // When two bars, position from first level (next to Share button); otherwise from full header
       top: headerHeight,
       bottom: 0,
       zIndex: theme.zIndex.navbarFixed + 1,

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -46,7 +46,7 @@ export function AppChrome({ children }: Props) {
 
   const headerLevels = useChromeHeaderLevels();
   const useSidebarTop = headerLevels === 2;
-  const styles = useStyles2(getStyles, getChromeHeaderLevelHeight());
+  const styles = useStyles2(getStyles, headerLevels, getChromeHeaderLevelHeight());
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);
 
@@ -186,13 +186,13 @@ function useResponsiveDockedMegaMenu(chrome: AppChromeService) {
   }, [isLargeScreen, chrome, dockedMenuLocalStorageState]);
 }
 
-const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
+const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: number) => {
   return {
     content: css({
       label: 'page-content',
       display: 'flex',
       flexDirection: 'column',
-      paddingTop: headerHeight,
+      paddingTop: headerLevels * headerHeight,
       flexGrow: 1,
       height: 'auto',
     }),

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -45,9 +45,8 @@ export function AppChrome({ children }: Props) {
   );
 
   const headerLevels = useChromeHeaderLevels();
-  const headerHeight = headerLevels * getChromeHeaderLevelHeight();
-  const sidebarTop = headerLevels === 2 ? getChromeHeaderLevelHeight() : headerHeight;
-  const styles = useStyles2(getStyles, headerHeight, sidebarTop);
+  const useSidebarTop = headerLevels === 2;
+  const styles = useStyles2(getStyles, getChromeHeaderLevelHeight());
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);
 
@@ -57,7 +56,7 @@ export function AppChrome({ children }: Props) {
   const contentClass = cx({
     [styles.content]: true,
     [styles.contentChromeless]: state.chromeless,
-    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless && headerLevels !== 2,
+    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless && !useSidebarTop,
   });
 
   const handleMegaMenu = () => {
@@ -110,7 +109,7 @@ export function AppChrome({ children }: Props) {
               actions={state.actions}
               breadcrumbActions={state.breadcrumbActions}
               scopes={scopes}
-              showToolbarLevel={headerLevels === 2}
+              showToolbarLevel={useSidebarTop}
             />
           </header>
         </>
@@ -132,7 +131,7 @@ export function AppChrome({ children }: Props) {
             className={cx(styles.pageContainer, {
               [styles.pageContainerMenuDocked]: menuDockedAndOpen || isScopesDashboardsOpen,
               [styles.pageContainerMenuDockedScopes]: menuDockedAndOpen && isScopesDashboardsOpen,
-              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen && headerLevels !== 2,
+              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen && !useSidebarTop,
               [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen,
             })}
             id="pageContent"
@@ -187,7 +186,7 @@ function useResponsiveDockedMegaMenu(chrome: AppChromeService) {
   }, [isLargeScreen, chrome, dockedMenuLocalStorageState]);
 }
 
-const getStyles = (theme: GrafanaTheme2, headerHeight: number, sidebarTop: number) => {
+const getStyles = (theme: GrafanaTheme2, headerHeight: number) => {
   return {
     content: css({
       label: 'page-content',
@@ -282,7 +281,7 @@ const getStyles = (theme: GrafanaTheme2, headerHeight: number, sidebarTop: numbe
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       position: 'fixed !important' as 'fixed',
       // When two bars, position from first level (next to Share button); otherwise from full header
-      top: sidebarTop,
+      top: headerHeight,
       bottom: 0,
       zIndex: theme.zIndex.navbarFixed + 1,
       right: 0,

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -45,7 +45,6 @@ export function AppChrome({ children }: Props) {
   );
 
   const headerLevels = useChromeHeaderLevels();
-  const useSidebarTop = headerLevels === 2;
   const styles = useStyles2(getStyles, headerLevels, getChromeHeaderLevelHeight());
   const contentSizeStyles = useStyles2(getContentSizeStyles, extensionSidebarWidth);
   const dragStyles = useStyles2(getDragStyles);
@@ -56,7 +55,7 @@ export function AppChrome({ children }: Props) {
   const contentClass = cx({
     [styles.content]: true,
     [styles.contentChromeless]: state.chromeless,
-    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless && !useSidebarTop,
+    [styles.contentWithSidebar]: isExtensionSidebarOpen && !state.chromeless,
   });
 
   const handleMegaMenu = () => {
@@ -109,7 +108,7 @@ export function AppChrome({ children }: Props) {
               actions={state.actions}
               breadcrumbActions={state.breadcrumbActions}
               scopes={scopes}
-              showToolbarLevel={useSidebarTop}
+              showToolbarLevel={headerLevels === 2}
             />
           </header>
         </>
@@ -131,7 +130,7 @@ export function AppChrome({ children }: Props) {
             className={cx(styles.pageContainer, {
               [styles.pageContainerMenuDocked]: menuDockedAndOpen || isScopesDashboardsOpen,
               [styles.pageContainerMenuDockedScopes]: menuDockedAndOpen && isScopesDashboardsOpen,
-              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen && !useSidebarTop,
+              [styles.pageContainerWithSidebar]: !state.chromeless && isExtensionSidebarOpen,
               [contentSizeStyles.contentWidth]: !state.chromeless && isExtensionSidebarOpen,
             })}
             id="pageContent"

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBarActions.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBarActions.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
@@ -6,6 +6,7 @@ import { ScopesContextValue } from '@grafana/runtime';
 import { Stack, useStyles2 } from '@grafana/ui';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 
+import { useExtensionSidebarContext } from '../ExtensionSidebar/ExtensionSidebarProvider';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
@@ -17,10 +18,14 @@ export interface Props {
 }
 
 export function SingleTopBarActions({ actions, breadcrumbActions, scopes }: Props) {
-  const styles = useStyles2(getStyles);
+  const { isOpen: isExtensionSidebarOpen, extensionSidebarWidth } = useExtensionSidebarContext();
+  const styles = useStyles2(getStyles, extensionSidebarWidth);
 
   return (
-    <div data-testid={Components.NavToolbar.container} className={styles.actionsBar}>
+    <div
+      data-testid={Components.NavToolbar.container}
+      className={cx(styles.actionsBar, isExtensionSidebarOpen && styles.constrained)}
+    >
       <Stack alignItems="center" justifyContent="flex-start" flex={1} wrap="nowrap" minWidth={0}>
         {scopes?.state.enabled ? <ScopesSelector /> : undefined}
         <Stack alignItems="center" justifyContent={'flex-end'} flex={1} wrap="nowrap" minWidth={0}>
@@ -33,7 +38,7 @@ export function SingleTopBarActions({ actions, breadcrumbActions, scopes }: Prop
   );
 }
 
-const getStyles = (theme: GrafanaTheme2) => {
+const getStyles = (theme: GrafanaTheme2, extensionSidebarWidth = 0) => {
   return {
     actionsBar: css({
       alignItems: 'center',
@@ -42,6 +47,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       height: getChromeHeaderLevelHeight(),
       padding: theme.spacing(0, 1, 0, 2),
+    }),
+    constrained: css({
+      maxWidth: `calc(100% - ${extensionSidebarWidth}px)`,
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

Previously the ExtensionSidebar was rendering below the toolbars. Especially in Dashboards and Explore that created a bad UX where toolbar buttons where too far away from the content it belongs to:

<img width="1211" height="1001" alt="image" src="https://github.com/user-attachments/assets/6ce09e06-1c96-4862-ad6c-b4cb1fedfda0" />

This PR moves the ExtensionSidebar next to the toolbar, if it has two header levels:
<img width="1200" height="1000" alt="image" src="https://github.com/user-attachments/assets/9bab5cff-3b80-4934-bf57-ae9ab2ad03e3" />
