### PR TITLE
fix: delete subfolder dangling panels

### DIFF
--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -654,8 +654,9 @@ func (s *Service) deleteFromApiServer(ctx context.Context, cmd *folder.DeleteFol
 		//	and remove "user" from the signature of DeleteInFolder in the folder RegistryService.
 		//	Context: https://github.com/grafana/grafana/pull/69149#discussion_r1235057903
 		//	*/
+		// Obs: DeleteInFolders only deletes dangling library panels (not linked to any dashboard) and throws errors if there are connections
 		if err := libraryPanelSrv.DeleteInFolders(ctx, cmd.OrgID, folders, cmd.SignedInUser); err != nil {
-			s.log.Error("failed to delete dangling library panels in folder", "error", err)
+			s.log.Error("failed to delete dangling library panels in folders", "error", err, "folders", strings.Join(folders, ","))
 			return err
 		}
 		// We need a list of dashboard uids inside the folder to delete related dashboards & public dashboards -

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -17,6 +17,7 @@ import (
 	clientrest "k8s.io/client-go/rest"
 
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/bus"
@@ -33,6 +34,9 @@ import (
 	dashboardsearch "github.com/grafana/grafana/pkg/services/dashboards/service/search"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/folder/foldertest"
+	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/librarypanels"
 	ngstore "github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/publicdashboards"
 	"github.com/grafana/grafana/pkg/services/search/model"
@@ -209,6 +213,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 				{Action: dashboards.ActionFoldersDelete, Scope: dashboards.ScopeFoldersAll},
 				{Action: dashboards.ActionFoldersRead, Scope: dashboards.ScopeFoldersAll},
 				{Action: accesscontrol.ActionAlertingRuleDelete, Scope: dashboards.ScopeFoldersAll},
+				{Action: accesscontrol.ActionLibraryPanelsDelete, Scope: dashboards.ScopeFoldersAll},
 			}),
 	}}
 
@@ -217,6 +222,16 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		Cfg:           cfg.UnifiedAlerting,
 		Logger:        log.New("test-alerting-store"),
 		AccessControl: actest.FakeAccessControl{ExpectedEvaluate: true},
+	}
+
+	mockDashboardService := dashboards.NewFakeDashboardService(t)
+	mockFolderService := foldertest.NewFakeService()
+	elementService := libraryelements.ProvideService(cfg, db, routing.NewRouteRegister(), mockFolderService, featuremgmt.WithFeatures(), actest.FakeAccessControl{ExpectedEvaluate: true}, mockDashboardService, nil, nil)
+	lps := librarypanels.LibraryPanelService{
+		Cfg:                   cfg,
+		SQLStore:              db,
+		LibraryElementService: elementService,
+		FolderService:         mockFolderService,
 	}
 
 	publicDashboardService := publicdashboards.NewFakePublicDashboardServiceWrapper(t)
@@ -237,6 +252,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	}
 
 	require.NoError(t, folderService.RegisterService(alertingStore))
+	require.NoError(t, folderService.RegisterService(lps))
 
 	t.Run("Folder service tests", func(t *testing.T) {
 		t.Run("Given user has no permissions", func(t *testing.T) {
@@ -876,6 +892,17 @@ func TestIntegrationDeleteFoldersFromApiServer(t *testing.T) {
 		AccessControl: actest.FakeAccessControl{ExpectedEvaluate: true},
 	}
 	require.NoError(t, service.RegisterService(alertingStore))
+
+	mockDashboardService := dashboards.NewFakeDashboardService(t)
+	mockFolderService := foldertest.NewFakeService()
+	elementService := libraryelements.ProvideService(cfg, db, routing.NewRouteRegister(), mockFolderService, featuremgmt.WithFeatures(), actest.FakeAccessControl{ExpectedEvaluate: true}, mockDashboardService, nil, nil)
+	lps := librarypanels.LibraryPanelService{
+		Cfg:                   cfg,
+		SQLStore:              db,
+		LibraryElementService: elementService,
+		FolderService:         mockFolderService,
+	}
+	require.NoError(t, service.RegisterService(lps))
 
 	t.Run("Should delete folder", func(t *testing.T) {
 		publicDashboardFakeService.On("DeleteByDashboardUIDs", mock.Anything, int64(1), []string{}).Return(nil).Once()


### PR DESCRIPTION
**What is this feature?**  

This PR fixes prevents dangling dashboard panels in subfolders and ensure it errors if they are used. It also trigger the call failure earlier, so dashboards are not deleted if the call fails due to used library panels. 

**Why do we need this feature?**  

When deleting folders with subfolders in the unified storage backend, only library elements in the first folder were checked and only their dangling panels were removed. The folder deletion would fail later in the call stack but the dashboards would already be gone.

**Who is this feature for?**  

This fix is for all Grafana users who use nested folders and library panels.

**Which issue(s) does this PR fix?**:  

Fixes: https://github.com/grafana/search-and-storage-team/issues/571

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
