### PR TITLE
SCIM: Update UIDs for provisioned users

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -149,7 +149,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 
 	scimUserNotAdminInitial := &user.User{
 		ID:            100,
-		UID:           "scim_uid_100",
+		UID:           "scim-uid-100",
 		Login:         "scim.user.notadmin",
 		Email:         "scim.notadmin@example.com",
 		Name:          "SCIM NotAdmin",
@@ -160,7 +160,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 
 	scimUserIsAdminInitial := &user.User{
 		ID:            101,
-		UID:           "scim_uid_101",
+		UID:           "scim-uid-101",
 		Login:         "scim.user.isadmin",
 		Email:         "scim.isadmin@example.com",
 		Name:          "SCIM IsAdmin",
@@ -171,7 +171,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 
 	nonScimUserInitial := &user.User{
 		ID:            102,
-		UID:           "nonscim_uid_102",
+		UID:           "nonscim-uid-102",
 		Login:         "nonscim.user",
 		Email:         "nonscim@example.com",
 		Name:          "NonSCIM User",

--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -181,6 +181,12 @@ func addUserMigrations(mg *Migrator) {
 	mg.AddMigration("Add index on user.is_service_account and user.last_seen_at", NewAddIndexMigration(userV2, &Index{
 		Cols: []string{"is_service_account", "last_seen_at"}, Type: IndexType,
 	}))
+
+	// Prefix SCIM UID for provisioned users to avoid numeric/existing-id collisions
+	mg.AddMigration("Prefix SCIM uid for provisioned users", NewRawSQLMigration("").
+		SQLite("UPDATE user SET uid = 'scim_' || uid WHERE is_provisioned = 1 AND uid NOT LIKE 'scim_%';").
+		Postgres("UPDATE `user` SET uid = 'scim_' || uid WHERE is_provisioned = TRUE AND uid NOT LIKE 'scim_%';").
+		Mysql("UPDATE user SET uid = CONCAT('scim_', uid) WHERE is_provisioned = 1 AND uid NOT LIKE 'scim_%';"))
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;

--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -184,9 +184,9 @@ func addUserMigrations(mg *Migrator) {
 
 	// Prefix SCIM UID for provisioned users to avoid numeric/existing-id collisions
 	mg.AddMigration("Prefix SCIM uid for provisioned users", NewRawSQLMigration("").
-		SQLite("UPDATE user SET uid = 'scim_' || uid WHERE is_provisioned = 1 AND uid NOT LIKE 'scim_%';").
-		Postgres("UPDATE `user` SET uid = 'scim_' || uid WHERE is_provisioned = TRUE AND uid NOT LIKE 'scim_%';").
-		Mysql("UPDATE user SET uid = CONCAT('scim_', uid) WHERE is_provisioned = 1 AND uid NOT LIKE 'scim_%';"))
+		SQLite("UPDATE user SET uid = 'scim-' || uid WHERE is_provisioned = 1 AND uid NOT LIKE 'scim-%';").
+		Postgres("UPDATE `user` SET uid = 'scim-' || uid WHERE is_provisioned = TRUE AND uid NOT LIKE 'scim-%';").
+		Mysql("UPDATE user SET uid = CONCAT('scim-', uid) WHERE is_provisioned = 1 AND uid NOT LIKE 'scim-%';"))
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;


### PR DESCRIPTION
**What is this feature?**

This feature migrates provisioend UIDs to a common format.

**Why do we need this feature?**

Part of the rework for provisioned External IDs.

**Who is this feature for?**

IAM
