### PR TITLE
Card: apply grid fractional unit to description instead of heading

### DIFF
--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -93,7 +93,7 @@ export const getCardContainerStyles = (
       display: 'grid',
       position: 'relative',
       gridTemplateColumns: 'auto 1fr auto',
-      gridTemplateRows: '1fr auto auto auto',
+      gridTemplateRows: 'auto auto 1fr auto',
       gridAutoColumns: '1fr',
       gridAutoFlow: 'row',
       gridTemplateAreas: `


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Slight change to `<Card>` css so that the `<Card.Description>` content expands in height to fill the card instead of the `<Card.Heading>` content. This improves how multiple `<Card>` components look when it is placed within a `<Stack>` component.

# Before this change:
<img width="630" height="316" alt="image" src="https://github.com/user-attachments/assets/83f5e134-b2c5-4497-8a0e-bc929021d18f" />

# After this change:
<img width="637" height="315" alt="image" src="https://github.com/user-attachments/assets/272d86c6-589e-4c07-a349-66a32b570d39" />

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
  - All examples in Storybook still look good :+1: 
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [ ] ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
