### PR TITLE
Zanzana: Fix namespace in remote client

### DIFF
--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -110,7 +110,7 @@ func ProvideStandaloneZanzanaClient(cfg *setting.Cfg, features featuremgmt.Featu
 		ServerCertFile:   cfg.ZanzanaClient.ServerCertFile,
 	}
 
-	return NewRemoteZanzanaClient(fmt.Sprintf("stacks-%s", cfg.StackID), zanzanaConfig)
+	return NewRemoteZanzanaClient(cfg.ZanzanaClient.TokenNamespace, zanzanaConfig)
 }
 
 type ZanzanaClientConfig struct {

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -27,6 +27,8 @@ type ZanzanaClientSettings struct {
 	// URL called to perform exchange request.
 	// Only used when mode is set to client.
 	TokenExchangeURL string
+	// Namespace to use for the token.
+	TokenNamespace string
 }
 
 type ZanzanaServerSettings struct {
@@ -112,6 +114,10 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zc.TokenExchangeURL = clientSec.Key("token_exchange_url").MustString("")
 	zc.Addr = clientSec.Key("address").MustString("")
 	zc.ServerCertFile = clientSec.Key("tls_cert").MustString("")
+
+	// TODO: read Token and TokenExchangeURL from grpc_client_authentication section
+	grpcClientAuthSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	zc.TokenNamespace = grpcClientAuthSection.Key("token_namespace").MustString("stacks-" + cfg.StackID)
 
 	cfg.ZanzanaClient = zc
 


### PR DESCRIPTION
**What is this feature?**

When remote zanzana client is used anywhere outside grafana, we need to configure namespace properly.
It's better to read everything from `grpc_client_authentication` section, but I will do it in next PR, because it potentially can break folder operator.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
