### PR TITLE
Zanzana: Log token namespace in case of error

### DIFF
--- a/pkg/services/authz/zanzana/server/auth.go
+++ b/pkg/services/authz/zanzana/server/auth.go
@@ -26,7 +26,7 @@ func authorize(ctx context.Context, namespace string, ss setting.ZanzanaServerSe
 		return status.Errorf(codes.Unauthenticated, "unauthenticated")
 	}
 	if !claims.NamespaceMatches(c.GetNamespace(), namespace) {
-		return status.Errorf(codes.PermissionDenied, "namespace does not match")
+		return status.Errorf(codes.PermissionDenied, "token namespace %s does not match request namespace", c.GetNamespace())
 	}
 	return nil
 }


### PR DESCRIPTION
**What is this feature?**

Log token namespace on the server side in case of error. This would help with debugging. Namespace is not leaked to the client since we return generic error and not the original one.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
