### PR TITLE
Dashboard: Hide add variable button in edit views

### DIFF
--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -27,11 +27,7 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
         .map((variable) => (
           <VariableValueSelectWrapper key={variable.state.key} variable={variable} />
         ))}
-      {config.featureToggles.dashboardNewLayouts ? (
-        <div className="dashboard-canvas-add-button">
-          <AddVariableButton dashboard={dashboard} />
-        </div>
-      ) : null}
+      {config.featureToggles.dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
     </>
   );
 }

--- a/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControlsAddButton.tsx
@@ -9,7 +9,7 @@ import { DashboardInteractions } from '../utils/interactions';
 import { DashboardScene } from './DashboardScene';
 
 export function AddVariableButton({ dashboard }: { dashboard: DashboardScene }) {
-  const { isEditing } = dashboard.useState();
+  const { editview, editPanel, isEditing, viewPanel } = dashboard.useState();
 
   const handlePointerDown: PointerEventHandler = useCallback(
     (evt) => {
@@ -20,13 +20,20 @@ export function AddVariableButton({ dashboard }: { dashboard: DashboardScene }) 
     [dashboard]
   );
 
-  if (!isEditing) {
+  // Hide the button if:
+  // - the dashboard is not in edit mode
+  // - the dashboard is in an edit view mode
+  // - the dashboard is in a view panel mode
+  // - the dashboard is in an edit panel mode
+  if (!isEditing || !!editview || !!viewPanel || !!editPanel) {
     return null;
   }
 
   return (
-    <Button icon="plus" variant="primary" fill="text" onPointerDown={handlePointerDown}>
-      <Trans i18nKey="dashboard-scene.variable-controls.add-variable">Add variable</Trans>
-    </Button>
+    <div className="dashboard-canvas-add-button">
+      <Button icon="plus" variant="primary" fill="text" onPointerDown={handlePointerDown}>
+        <Trans i18nKey="dashboard-scene.variable-controls.add-variable">Add variable</Trans>
+      </Button>
+    </div>
   );
 }


### PR DESCRIPTION
**What is this feature?**

Hide the "add variable" button when the viewing / editing a panel.

**Why do we need this feature?**

-

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
