### PR TITLE
fix: only validate allowed descendants for folder deletion

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -144,7 +144,7 @@ func validateOnDelete(ctx context.Context,
 		return fmt.Errorf("could not verify if folder is empty: %v", resp.Error)
 	}
 
-	allowedResourceTypes := []string{"alertrules", "dashboards", "library_elements"}
+	allowedResourceTypes := []string{"alertrules", "dashboards", "library_elements", "folders"}
 
 	for _, v := range resp.Stats {
 		if slices.Contains(allowedResourceTypes, v.Resource) && v.Count > 0 {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -144,9 +144,11 @@ func validateOnDelete(ctx context.Context,
 		return fmt.Errorf("could not verify if folder is empty: %v", resp.Error)
 	}
 
+	allowedResourceTypes := []string{"alertrules", "dashboards", "library_elements"}
+
 	for _, v := range resp.Stats {
-		if v.Count > 0 {
-			return folder.ErrFolderNotEmpty.Errorf("folder is not empty, contains %d %s.%s", v.Count, v.Group, v.Resource)
+		if slices.Contains(allowedResourceTypes, v.Resource) && v.Count > 0 {
+			return folder.ErrFolderNotEmpty.Errorf("folder is not empty, contains %d %s", v.Count, v.Resource)
 		}
 	}
 	return nil

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -357,7 +357,64 @@ func TestValidateDelete(t *testing.T) {
 		},
 		expectedErr: "could not verify if folder is empty",
 	}, {
-		name: "folder not empty",
+		name: "folder not empty - contains dashboards",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "dashboard.grafana.app",
+						Resource: "dashboards",
+						Count:    10, // not empty
+					},
+				},
+			},
+		},
+		expectedErr: "[folder.not-empty]",
+	}, {
+		name: "folder not empty - contains alertrules",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "alerting.grafana.app",
+						Resource: "alertrules",
+						Count:    5, // not empty
+					},
+				},
+			},
+		},
+		expectedErr: "[folder.not-empty]",
+	}, {
+		name: "folder not empty - contains library_elements",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "library.grafana.app",
+						Resource: "library_elements",
+						Count:    3, // not empty
+					},
+				},
+			},
+		},
+		expectedErr: "[folder.not-empty]",
+	}, {
+		name: "folder can be deleted when it only contains non-validated resource types",
 		folder: &folders.Folder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nnn",
@@ -369,7 +426,36 @@ func TestValidateDelete(t *testing.T) {
 					{
 						Group:    "folders.grafana.app",
 						Resource: "folders",
-						Count:    10, // not empty
+						Count:    10, // has content but not a validated resource type
+					},
+					{
+						Group:    "other.grafana.app",
+						Resource: "other",
+						Count:    5, // has content but not a validated resource type
+					},
+				},
+			},
+		},
+		// No error expected - these resource types are not validated
+	}, {
+		name: "folder not empty - mixed resources with validated types",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "folders.grafana.app",
+						Resource: "folders",
+						Count:    10, // not validated
+					},
+					{
+						Group:    "dashboard.grafana.app",
+						Resource: "dashboards",
+						Count:    2, // validated and has content
 					},
 				},
 			},

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -320,7 +320,7 @@ func TestValidateDelete(t *testing.T) {
 			},
 		},
 	}, {
-		name: "stats error",
+		name: "stats error - nil stats",
 		folder: &folders.Folder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nnn",
@@ -331,7 +331,7 @@ func TestValidateDelete(t *testing.T) {
 		},
 		expectedErr: "could not verify if folder is empty",
 	}, {
-		name: "stats error",
+		name: "stats error - search error",
 		folder: &folders.Folder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nnn",
@@ -342,7 +342,7 @@ func TestValidateDelete(t *testing.T) {
 		},
 		expectedErr: "error running stats",
 	}, {
-		name: "stats error",
+		name: "stats error - error result",
 		folder: &folders.Folder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nnn",
@@ -414,7 +414,7 @@ func TestValidateDelete(t *testing.T) {
 		},
 		expectedErr: "[folder.not-empty]",
 	}, {
-		name: "folder can be deleted when it only contains non-validated resource types",
+		name: "folder not empty - contains folders",
 		folder: &folders.Folder{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "nnn",
@@ -426,6 +426,25 @@ func TestValidateDelete(t *testing.T) {
 					{
 						Group:    "folders.grafana.app",
 						Resource: "folders",
+						Count:    2, // not empty
+					},
+				},
+			},
+		},
+		expectedErr: "[folder.not-empty]",
+	}, {
+		name: "folder can be deleted when it only contains non-validated resource types",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "playlist.grafana.app",
+						Resource: "playlists",
 						Count:    10, // has content but not a validated resource type
 					},
 					{
@@ -436,7 +455,6 @@ func TestValidateDelete(t *testing.T) {
 				},
 			},
 		},
-		// No error expected - these resource types are not validated
 	}, {
 		name: "folder not empty - mixed resources with validated types",
 		folder: &folders.Folder{
@@ -450,7 +468,7 @@ func TestValidateDelete(t *testing.T) {
 					{
 						Group:    "folders.grafana.app",
 						Resource: "folders",
-						Count:    10, // not validated
+						Count:    10, // now validated
 					},
 					{
 						Group:    "dashboard.grafana.app",


### PR DESCRIPTION
Limit the resources to check when deleting folders through k8s api (unified).