### PR TITLE
BackendSrv: Remove extra `console.logs` in `chunked`

### DIFF
--- a/public/app/core/services/backend_srv.ts
+++ b/public/app/core/services/backend_srv.ts
@@ -173,7 +173,6 @@ export class BackendSrv implements BackendService {
         .subscribe(this.getChunkedResponseObserver({ controller, observer, options, requestId }));
 
       return function unsubscribe() {
-        console.log(requestId, 'unsubscribe');
         controller.abort('unsubscribe');
         sub.unsubscribe();
       };
@@ -218,7 +217,6 @@ export class BackendSrv implements BackendService {
         // Setup onabort callback so that we can cancel the reader properly
         controller.signal.onabort = () => {
           reader.cancel(controller.signal.reason);
-          console.log(requestId, 'signal.aborted');
         };
 
         async function process() {
@@ -230,13 +228,11 @@ export class BackendSrv implements BackendService {
             });
             if (chunk.done) {
               done = true;
-              console.log(requestId, 'done');
             }
           }
         }
         process()
           .then(() => {
-            console.log(requestId, 'complete');
             observer.complete();
           }) // runs in background
           .catch((e) => {


### PR DESCRIPTION

**What is this feature?**
`BackendSrv` had a bunch of extra `console.log` statements that do not seem interesting. I left one in:
https://github.com/grafana/grafana/compare/svennergr/remove-extra-logs?expand=1#diff-a59fe074f33f72d2359deef1d8321eeef3bcfb19d2471f25cc0025817dcbce0eL243

```ts
          .catch((e) => {
            console.log(requestId, 'catch', e);
            observer.error(e);
          }); // from abort
```