### PR TITLE
Chore: Remove Chance.js dependency from runtime code

### DIFF
--- a/public/app/features/provisioning/components/utils/timestamp.test.ts
+++ b/public/app/features/provisioning/components/utils/timestamp.test.ts
@@ -8,8 +8,8 @@ describe('generateTimestamp', () => {
     expect(typeof timestamp).toBe('string');
 
     // Check that the timestamp follows the format YYYY-MM-DD-xxxxx
-    // where xxxxx is a random string of 5 alphabetic characters
-    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}-[a-zA-Z]{5}$/);
+    // where xxxxx is a random string of 5 alpha-num characters
+    expect(timestamp).toMatch(/^\d{4}-\d{2}-\d{2}-[a-z\d]{5}$/i);
   });
 
   it('should generate unique timestamps', () => {

--- a/public/app/features/provisioning/components/utils/timestamp.ts
+++ b/public/app/features/provisioning/components/utils/timestamp.ts
@@ -1,11 +1,9 @@
-import { Chance } from 'chance';
-
 import { dateTime } from '@grafana/data';
 
 /**
  * Generates a timestamp string in the format YYYY-MM-DD-xxxxx where xxxxx is a random string
  */
 export function generateTimestamp(): string {
-  const random = new Chance();
-  return `${dateTime().format('YYYY-MM-DD')}-${random.string({ length: 5, alpha: true })}`;
+  const randStr = Math.random().toString(36).substring(2, 7);
+  return `${dateTime().format('YYYY-MM-DD')}-${randStr}`;
 }


### PR DESCRIPTION
before/after: **-250KB**

<img width="3511" height="1382" alt="Screenshot_20251105_120617" src="https://github.com/user-attachments/assets/7e997c50-e3ad-44c3-bc50-0cd4ace23804" />
<img width="3511" height="1332" alt="Screenshot_20251105_120316" src="https://github.com/user-attachments/assets/db4ff894-98b3-4f3b-9eaf-a93df51768a9" />

---

both "total" _and_ "used" code drops by 0.2MB, even though the changed line that executes the Chance code never ran during empty dashboard load. this means that the "used" coverage stats are quite misleading:

<img width="3840" height="1200" alt="Screenshot_20251105_121530" src="https://github.com/user-attachments/assets/9112d18a-1eb4-4e87-9837-def631b3e397" />
<img width="3840" height="1200" alt="Screenshot_20251105_121716" src="https://github.com/user-attachments/assets/8f6424d6-1f52-4f71-a036-8b8137ddee79" />
