### PR TITLE
Timeseries: Change mouse cursors to indicate active x-axis and y-axis zoom interactions

### DIFF
--- a/e2e-playwright/panels-suite/timeseries-mouse-zoom-interaction.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries-mouse-zoom-interaction.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'TkZXxlNG3';
+
+test.describe('Panels test: Timeseries zoom interaction', { tag: ['@panels', '@timeseries'] }, () => {
+  test('shows zoom cursor during x-axis drag-to-zoom interaction', async ({ gotoDashboardPage, page }) => {
+    await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+    });
+
+    const uplotOverlay = page.locator('.u-over').first();
+    await expect(uplotOverlay, 'uplot overlay is visible').toBeVisible();
+
+    const bbox = await uplotOverlay.boundingBox();
+    expect(bbox, 'uplot overlay has dimensions').toBeDefined();
+
+    await expect(uplotOverlay, 'no zoom cursor initially').not.toHaveClass(/zoom-drag/);
+
+    await page.mouse.move(bbox!.x + 100, bbox!.y + 50);
+    await page.mouse.down();
+
+    await expect(uplotOverlay, 'zoom cursor appears on mousedown').toHaveClass(/zoom-drag/);
+
+    await page.mouse.move(bbox!.x + 300, bbox!.y + 50);
+
+    await expect(uplotOverlay, 'zoom cursor persists during drag').toHaveClass(/zoom-drag/);
+
+    await page.mouse.up();
+
+    await expect(uplotOverlay, 'zoom cursor removed after mouseup').not.toHaveClass(/zoom-drag/);
+  });
+
+  test('shows zoom cursor during y-axis drag-to-zoom interaction with Shift key', async ({
+    gotoDashboardPage,
+    page,
+  }) => {
+    await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+    });
+
+    const uplotOverlay = page.locator('.u-over').first();
+    await expect(uplotOverlay, 'uplot overlay is visible').toBeVisible();
+
+    const bbox = await uplotOverlay.boundingBox();
+    expect(bbox, 'uplot overlay has dimensions').toBeDefined();
+
+    await expect(uplotOverlay, 'no zoom cursor initially').not.toHaveClass(/zoom-drag/);
+
+    await page.keyboard.down('Shift');
+    await page.mouse.move(bbox!.x + 100, bbox!.y + 50);
+    await page.mouse.down();
+
+    await expect(uplotOverlay, 'zoom cursor appears on mousedown with Shift').toHaveClass(/zoom-drag/);
+
+    await page.mouse.move(bbox!.x + 100, bbox!.y + 150);
+
+    await expect(uplotOverlay, 'zoom cursor persists during drag with Shift').toHaveClass(/zoom-drag/);
+
+    await page.mouse.up();
+    await page.keyboard.up('Shift');
+
+    await expect(uplotOverlay, 'zoom cursor removed after mouseup').not.toHaveClass(/zoom-drag/);
+  });
+
+  test('does not show zoom cursor when modifier keys are pressed', async ({ gotoDashboardPage, page }) => {
+    await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+    });
+
+    const uplotOverlay = page.locator('.u-over').first();
+    await expect(uplotOverlay, 'uplot overlay is visible').toBeVisible();
+
+    const bbox = await uplotOverlay.boundingBox();
+
+    await page.keyboard.down('Control');
+    await page.mouse.move(bbox!.x + 100, bbox!.y + 50);
+    await page.mouse.down();
+
+    await expect(uplotOverlay, 'no zoom cursor with Ctrl key').not.toHaveClass(/zoom-drag/);
+
+    await page.mouse.up();
+    await page.keyboard.up('Control');
+
+    await page.keyboard.down('Meta');
+    await page.mouse.move(bbox!.x + 100, bbox!.y + 50);
+    await page.mouse.down();
+
+    await expect(uplotOverlay, 'no zoom cursor with Meta key').not.toHaveClass(/zoom-drag/);
+
+    await page.mouse.up();
+    await page.keyboard.up('Meta');
+  });
+});

--- a/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/TooltipPlugin2.tsx
@@ -340,6 +340,30 @@ export const TooltipPlugin2 = ({
         );
       }
 
+      // add zoom-in cursor during drag-to-zoom interaction
+      if (queryZoom != null || clientZoom) {
+        u.over.addEventListener(
+          'mousedown',
+          (e) => {
+            if (!maybeZoomAction(e)) {
+              return;
+            }
+
+            if (e.button === 0) {
+              u.over.classList.add('zoom-drag');
+
+              let onUp = () => {
+                u.over.classList.remove('zoom-drag');
+                document.removeEventListener('mouseup', onUp, true);
+              };
+
+              document.addEventListener('mouseup', onUp, true);
+            }
+          },
+          true
+        );
+      }
+
       // this handles pinning, 0-width range selection, and one-click
       u.over.addEventListener('click', (e) => {
         if (e.target === u.over) {

--- a/packages/grafana-ui/src/themes/GlobalStyles/uPlot.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/uPlot.ts
@@ -12,6 +12,10 @@ export function getUplotStyles(theme: GrafanaTheme2) {
       background: 'rgba(120, 120, 130, 0.2)',
     },
 
+    '.u-over.zoom-drag': {
+      cursor: 'zoom-in !important',
+    },
+
     '.u-hz .u-cursor-x, .u-vt .u-cursor-y': {
       borderRight: '1px dashed rgba(120, 120, 130, 0.5)',
     },

--- a/packages/grafana-ui/src/themes/GlobalStyles/uPlot.ts
+++ b/packages/grafana-ui/src/themes/GlobalStyles/uPlot.ts
@@ -13,7 +13,7 @@ export function getUplotStyles(theme: GrafanaTheme2) {
     },
 
     '.u-over.zoom-drag': {
-      cursor: 'zoom-in !important',
+      cursor: 'zoom-in',
     },
 
     '.u-hz .u-cursor-x, .u-vt .u-cursor-y': {


### PR DESCRIPTION
**What is this feature?**

This change adds mouse cursors to existing x-axis and y-axis zoom mouse interactions at the panel level.

https://github.com/user-attachments/assets/57e5feca-bc38-41ab-8bde-74e8dcea542c


**Why do we need this feature?**

Currently, the lack of visual cues during panel level mouse zoom on the x-axis and y-axis make the interaction less intuitive than we would like, this will help people understand the significance of the interaction without docs.


**Who is this feature for?**

All users of Grafana.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113114


Special notes for your reviewer:

- 🖱️ Click-and-drag to test x-axis zoom
- ⌨️ + 🖱️ Press and hold the `Shift` modifier key during click-and-drag to test y-axis zoom
- 🧪 You can run the test suites with `yarn e2e:playwright --ui` then search for `"timeseries zoom"`
- 📄 I excluded docs, because we're handling them separately in https://github.com/grafana/grafana/issues/113115

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
