### PR TITLE
APIs: Include enterprise spec check

### DIFF
--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -79,7 +79,7 @@ jobs:
           make swagger-clean && make openapi3-gen
 
           # Check if the generated specs differ from what's in the repository
-          for f in public/api-merged.json public/openapi3.json; do git add $f; done
+          for f in public/api-merged.json public/openapi3.json public/api-enterprise-spec.json; do git add $f; done
           if [ -z "$(git diff --name-only --cached)" ]; then
             echo "OpenAPI specs are up to date!"
           else

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -2975,6 +2975,10 @@
           "description": "Name of annotation.",
           "type": "string"
         },
+        "placement": {
+          "description": "Placement can be used to display the annotation query somewhere else on the dashboard other than the default location.",
+          "type": "string"
+        },
         "target": {
           "$ref": "#/definitions/AnnotationTarget"
         },
@@ -4320,6 +4324,20 @@
         "version": {
           "type": "integer",
           "format": "int64"
+        }
+      }
+    },
+    "DashboardVersionResponseMeta": {
+      "type": "object",
+      "properties": {
+        "continueToken": {
+          "type": "string"
+        },
+        "versions": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/DashboardVersionMeta"
+          }
         }
       }
     },
@@ -7979,6 +7997,9 @@
         "teamUID": {
           "type": "string"
         },
+        "uid": {
+          "type": "string"
+        },
         "userId": {
           "type": "integer",
           "format": "int64"
@@ -9420,10 +9441,7 @@
     "dashboardVersionsResponse": {
       "description": "",
       "schema": {
-        "type": "array",
-        "items": {
-          "$ref": "#/definitions/DashboardVersionMeta"
-        }
+        "$ref": "#/definitions/DashboardVersionResponseMeta"
       }
     },
     "deleteCorrelationResponse": {


### PR DESCRIPTION
**What is this feature?**
Includes the enterprise spec file when checking for out of date OpenAPI specs. It's currently out of date so I included the updates as well. We're already performing the enterprise check and setup in internal PRs anyway, so it makes sense to also check the enterprise file for diffs