### PR TITLE
feat(unified-storage): add tracing to dual writer and legacy storage

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -40,8 +40,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
-const tracePrefix = "legacy."
-
 var (
 	_      DashboardAccess = (*dashboardSqlAccess)(nil)
 	tracer                 = otel.Tracer("github.com/grafana/grafana/pkg/registry/apis/dashboard/legacy")
@@ -109,7 +107,7 @@ func NewDashboardAccess(sql legacysql.LegacyDatabaseProvider,
 }
 
 func (a *dashboardSqlAccess) getRows(ctx context.Context, sql *legacysql.LegacyDatabaseHelper, query *DashboardQuery) (*rowsWrapper, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.getRows")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.getRows")
 	defer span.End()
 
 	if len(query.Labels) > 0 {
@@ -423,7 +421,7 @@ func getUserID(v sql.NullString, id sql.NullInt64) string {
 
 // DeleteDashboard implements DashboardAccess.
 func (a *dashboardSqlAccess) DeleteDashboard(ctx context.Context, orgId int64, uid string) (*dashboardV1.Dashboard, bool, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.DeleteDashboard")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.DeleteDashboard")
 	defer span.End()
 
 	dash, _, err := a.GetDashboard(ctx, orgId, uid, 0)
@@ -442,7 +440,7 @@ func (a *dashboardSqlAccess) DeleteDashboard(ctx context.Context, orgId int64, u
 }
 
 func (a *dashboardSqlAccess) buildSaveDashboardCommand(ctx context.Context, orgId int64, dash *dashboardV1.Dashboard) (*dashboards.SaveDashboardCommand, bool, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.buildSaveDashboardCommand")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.buildSaveDashboardCommand")
 	defer span.End()
 
 	created := false
@@ -508,7 +506,7 @@ func (a *dashboardSqlAccess) buildSaveDashboardCommand(ctx context.Context, orgI
 }
 
 func (a *dashboardSqlAccess) SaveDashboard(ctx context.Context, orgId int64, dash *dashboardV1.Dashboard, failOnExisting bool) (*dashboardV1.Dashboard, bool, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.SaveDashboard")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.SaveDashboard")
 	defer span.End()
 
 	user, ok := claims.AuthInfoFrom(ctx)
@@ -581,7 +579,7 @@ type panel struct {
 }
 
 func (a *dashboardSqlAccess) GetLibraryPanels(ctx context.Context, query LibraryPanelQuery) (*dashboardV0.LibraryPanelList, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetLibraryPanels")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.GetLibraryPanels")
 	defer span.End()
 
 	limit := int(query.Limit)

--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -40,7 +40,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 )
 
-const tracePrefix = "legacy"
+const tracePrefix = "legacy."
 
 var (
 	_      DashboardAccess = (*dashboardSqlAccess)(nil)

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -254,7 +254,7 @@ func (a *dashboardSqlAccess) ListHistory(ctx context.Context, req *resourcepb.Li
 }
 
 func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListModifiedSince")
+	_, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListModifiedSince")
 	defer span.End()
 
 	return 0, func(yield func(*resource.ModifiedResource, error) bool) {
@@ -263,7 +263,7 @@ func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource
 }
 
 func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetResourceLastImportTimes")
+	_, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetResourceLastImportTimes")
 	defer span.End()
 
 	return func(yield func(resource.ResourceLastImportTime, error) bool) {

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -78,7 +78,7 @@ func isDashboardKey(key *resourcepb.ResourceKey, requireName bool) error {
 }
 
 func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.WriteEvent) (rv int64, err error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.WriteEvent")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.WriteEvent")
 	defer span.End()
 
 	info, err := claims.ParseNamespace(event.Key.Namespace)
@@ -173,7 +173,7 @@ func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.Writ
 }
 
 func (a *dashboardSqlAccess) GetDashboard(ctx context.Context, orgId int64, uid string, v int64) (*dashboard.Dashboard, int64, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetDashboard")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.GetDashboard")
 	defer span.End()
 
 	sql, err := a.sql(ctx)
@@ -203,7 +203,7 @@ func (a *dashboardSqlAccess) GetDashboard(ctx context.Context, orgId int64, uid 
 
 // Read implements ResourceStoreServer.
 func (a *dashboardSqlAccess) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *resource.BackendReadResponse {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ReadResource")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.ReadResource")
 	defer span.End()
 
 	rsp := &resource.BackendReadResponse{}
@@ -247,14 +247,14 @@ func (a *dashboardSqlAccess) ReadResource(ctx context.Context, req *resourcepb.R
 
 // ListHistory implements StorageBackend.
 func (a *dashboardSqlAccess) ListHistory(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListHistory")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.ListHistory")
 	defer span.End()
 
 	return a.ListIterator(ctx, req, cb)
 }
 
 func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
-	_, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListModifiedSince")
+	_, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.ListModifiedSince")
 	defer span.End()
 
 	return 0, func(yield func(*resource.ModifiedResource, error) bool) {
@@ -263,7 +263,7 @@ func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource
 }
 
 func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
-	_, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetResourceLastImportTimes")
+	_, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.GetResourceLastImportTimes")
 	defer span.End()
 
 	return func(yield func(resource.ResourceLastImportTime, error) bool) {
@@ -273,7 +273,7 @@ func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) ite
 
 // List implements StorageBackend.
 func (a *dashboardSqlAccess) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListIterator")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.ListIterator")
 	defer span.End()
 
 	if req.ResourceVersion != 0 {
@@ -369,14 +369,14 @@ func (a *dashboardSqlAccess) WatchWriteEvents(ctx context.Context) (<-chan *reso
 
 // Simple wrapper for index implementation
 func (a *dashboardSqlAccess) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resource.BackendReadResponse, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.Read")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.Read")
 	defer span.End()
 
 	return a.ReadResource(ctx, req), nil
 }
 
 func (a *dashboardSqlAccess) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.Search")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.Search")
 	defer span.End()
 
 	return a.dashboardSearchClient.Search(ctx, req)
@@ -392,7 +392,7 @@ func (a *dashboardSqlAccess) CountManagedObjects(context.Context, *resourcepb.Co
 
 // GetStats implements ResourceServer.
 func (a *dashboardSqlAccess) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetStats")
+	ctx, span := tracer.Start(ctx, "legacy.dashboardSqlAccess.GetStats")
 	defer span.End()
 
 	return a.dashboardSearchClient.GetStats(ctx, req)

--- a/pkg/registry/apis/dashboard/legacy/storage.go
+++ b/pkg/registry/apis/dashboard/legacy/storage.go
@@ -78,6 +78,9 @@ func isDashboardKey(key *resourcepb.ResourceKey, requireName bool) error {
 }
 
 func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.WriteEvent) (rv int64, err error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.WriteEvent")
+	defer span.End()
+
 	info, err := claims.ParseNamespace(event.Key.Namespace)
 	if err == nil {
 		err = isDashboardKey(event.Key, true)
@@ -170,6 +173,9 @@ func (a *dashboardSqlAccess) WriteEvent(ctx context.Context, event resource.Writ
 }
 
 func (a *dashboardSqlAccess) GetDashboard(ctx context.Context, orgId int64, uid string, v int64) (*dashboard.Dashboard, int64, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetDashboard")
+	defer span.End()
+
 	sql, err := a.sql(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -197,6 +203,9 @@ func (a *dashboardSqlAccess) GetDashboard(ctx context.Context, orgId int64, uid 
 
 // Read implements ResourceStoreServer.
 func (a *dashboardSqlAccess) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *resource.BackendReadResponse {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ReadResource")
+	defer span.End()
+
 	rsp := &resource.BackendReadResponse{}
 	info, err := claims.ParseNamespace(req.Key.Namespace)
 	if err == nil {
@@ -238,16 +247,25 @@ func (a *dashboardSqlAccess) ReadResource(ctx context.Context, req *resourcepb.R
 
 // ListHistory implements StorageBackend.
 func (a *dashboardSqlAccess) ListHistory(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListHistory")
+	defer span.End()
+
 	return a.ListIterator(ctx, req, cb)
 }
 
 func (a *dashboardSqlAccess) ListModifiedSince(ctx context.Context, key resource.NamespacedResource, sinceRv int64) (int64, iter.Seq2[*resource.ModifiedResource, error]) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListModifiedSince")
+	defer span.End()
+
 	return 0, func(yield func(*resource.ModifiedResource, error) bool) {
 		yield(nil, errors.New("not implemented"))
 	}
 }
 
 func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[resource.ResourceLastImportTime, error] {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetResourceLastImportTimes")
+	defer span.End()
+
 	return func(yield func(resource.ResourceLastImportTime, error) bool) {
 		yield(resource.ResourceLastImportTime{}, errors.New("not implemented"))
 	}
@@ -255,6 +273,9 @@ func (a *dashboardSqlAccess) GetResourceLastImportTimes(ctx context.Context) ite
 
 // List implements StorageBackend.
 func (a *dashboardSqlAccess) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(resource.ListIterator) error) (int64, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.ListIterator")
+	defer span.End()
+
 	if req.ResourceVersion != 0 {
 		return 0, apierrors.NewBadRequest("List with explicit resourceVersion is not supported with this storage backend")
 	}
@@ -348,10 +369,16 @@ func (a *dashboardSqlAccess) WatchWriteEvents(ctx context.Context) (<-chan *reso
 
 // Simple wrapper for index implementation
 func (a *dashboardSqlAccess) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resource.BackendReadResponse, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.Read")
+	defer span.End()
+
 	return a.ReadResource(ctx, req), nil
 }
 
 func (a *dashboardSqlAccess) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.Search")
+	defer span.End()
+
 	return a.dashboardSearchClient.Search(ctx, req)
 }
 
@@ -365,5 +392,8 @@ func (a *dashboardSqlAccess) CountManagedObjects(context.Context, *resourcepb.Co
 
 // GetStats implements ResourceServer.
 func (a *dashboardSqlAccess) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dashboardSqlAccess.GetStats")
+	defer span.End()
+
 	return a.dashboardSearchClient.GetStats(ctx, req)
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -32,7 +32,6 @@ const (
 	// to complete. Those run in the background and won't impact the
 	// user experience in any way.
 	backgroundReqTimeout = time.Minute
-	tracePrefix          = "dualwrite."
 )
 
 // dualWriter will write first to legacy, then to unified keeping the same internal ID
@@ -44,7 +43,7 @@ type dualWriter struct {
 }
 
 func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Get",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.Get",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
@@ -82,7 +81,7 @@ func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 func (d *dualWriter) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.List",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.List",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
@@ -196,7 +195,7 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 
 // Create overrides the behavior of the generic DualWriter and writes to LegacyStorage and Storage.
 func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Create",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.Create",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
@@ -314,7 +313,7 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	// By setting RemovePermissions to false in the context, we will skip the deletion of permissions
 	// in the legacy store. This is needed as otherwise the permissions would be missing when executing
 	// the delete operation in the unified storage store.
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Delete",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.Delete",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
@@ -360,7 +359,7 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 
 // Update overrides the behavior of the generic DualWriter and writes first to Storage and then to LegacyStorage.
 func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Update",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.Update",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
@@ -427,7 +426,7 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 
 // DeleteCollection overrides the behavior of the generic DualWriter and deletes from both LegacyStorage and Storage.
 func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
-	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.DeleteCollection",
+	ctx, span := tracer.Start(ctx, "dualwrite.dualWriter.DeleteCollection",
 		trace.WithAttributes(
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metainternalversion "k8s.io/apimachinery/pkg/apis/meta/internalversion"
@@ -19,41 +22,18 @@ import (
 )
 
 var (
-	_ grafanarest.Storage = (*dualWriter)(nil)
+	_      grafanarest.Storage = (*dualWriter)(nil)
+	tracer                     = otel.Tracer("github.com/grafana/grafana/pkg/storage/legacysql/dualwrite")
 )
 
-func objectInfo(obj runtime.Object) map[string]interface{} {
-	if obj == nil {
-		return map[string]interface{}{"object": "nil"}
-	}
-
-	acc, err := meta.Accessor(obj)
-	if err != nil {
-		return map[string]interface{}{"object": fmt.Sprintf("%T", obj), "error": err.Error()}
-	}
-
-	info := map[string]interface{}{
-		"name": acc.GetName(),
-	}
-
-	if ns := acc.GetNamespace(); ns != "" {
-		info["namespace"] = ns
-	}
-	if uid := acc.GetUID(); uid != "" {
-		info["uid"] = string(uid)
-	}
-	if rv := acc.GetResourceVersion(); rv != "" {
-		info["resourceVersion"] = rv
-	}
-
-	return info
-}
-
-// Let's give the background queries a bit more time to complete
-// as we also run them as part of load tests that might need longer
-// to complete. Those run in the background and won't impact the
-// user experience in any way.
-const backgroundReqTimeout = time.Minute
+const (
+	// Let's give the background queries a bit more time to complete
+	// as we also run them as part of load tests that might need longer
+	// to complete. Those run in the background and won't impact the
+	// user experience in any way.
+	backgroundReqTimeout = time.Minute
+	tracePrefix          = "dualwrite."
+)
 
 // dualWriter will write first to legacy, then to unified keeping the same internal ID
 type dualWriter struct {
@@ -64,6 +44,12 @@ type dualWriter struct {
 }
 
 func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Get",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
+
 	log := logging.FromContext(ctx).With("method", "Get", "name", name)
 	// If we read from unified, we can just do that and return.
 	if d.readUnified {
@@ -96,6 +82,12 @@ func (d *dualWriter) Get(ctx context.Context, name string, options *metav1.GetOp
 }
 
 func (d *dualWriter) List(ctx context.Context, options *metainternalversion.ListOptions) (runtime.Object, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.List",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
+
 	// Always work on *copies* so we never mutate the caller's ListOptions.
 	var (
 		legacyOptions  = options.DeepCopy()
@@ -204,6 +196,12 @@ func (d *dualWriter) List(ctx context.Context, options *metainternalversion.List
 
 // Create overrides the behavior of the generic DualWriter and writes to LegacyStorage and Storage.
 func (d *dualWriter) Create(ctx context.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Create",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
+
 	log := logging.FromContext(ctx).With("method", "Create")
 
 	accIn, err := meta.Accessor(in)
@@ -316,6 +314,11 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 	// By setting RemovePermissions to false in the context, we will skip the deletion of permissions
 	// in the legacy store. This is needed as otherwise the permissions would be missing when executing
 	// the delete operation in the unified storage store.
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Delete",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
 	log := logging.FromContext(ctx).With("method", "Delete", "name", name)
 	ctx = utils.SetFolderRemovePermissions(ctx, false)
 
@@ -357,8 +360,12 @@ func (d *dualWriter) Delete(ctx context.Context, name string, deleteValidation r
 
 // Update overrides the behavior of the generic DualWriter and writes first to Storage and then to LegacyStorage.
 func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {
-	log := logging.FromContext(ctx).With("method", "Update", "name", name)
-
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.Update",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
+	log := logging.FromContext(ctx).With("method", "Update", "name", name, "objInfo", objInfo)
 	// update in legacy first, and then unistore. Will return a failure if either fails.
 	//
 	// we want to update in legacy first, otherwise if the update from unistore was successful,
@@ -420,6 +427,12 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 
 // DeleteCollection overrides the behavior of the generic DualWriter and deletes from both LegacyStorage and Storage.
 func (d *dualWriter) DeleteCollection(ctx context.Context, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions, listOptions *metainternalversion.ListOptions) (runtime.Object, error) {
+	ctx, span := tracer.Start(ctx, tracePrefix+"dualWriter.DeleteCollection",
+		trace.WithAttributes(
+			attribute.Bool("errorIsOK", d.errorIsOK),
+			attribute.Bool("readUnified", d.readUnified)))
+	defer span.End()
+
 	log := logging.FromContext(ctx).With("method", "DeleteCollection", "resourceVersion", listOptions.ResourceVersion)
 
 	// delete from legacy first, and anything that is successful can be deleted in unistore too.
@@ -527,4 +540,31 @@ func (w *wrappedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime.Ob
 	meta.SetResourceVersion("")
 	meta.SetUID("")
 	return obj, err
+}
+
+func objectInfo(obj runtime.Object) map[string]interface{} {
+	if obj == nil {
+		return map[string]interface{}{"object": "nil"}
+	}
+
+	acc, err := meta.Accessor(obj)
+	if err != nil {
+		return map[string]interface{}{"object": fmt.Sprintf("%T", obj), "error": err.Error()}
+	}
+
+	info := map[string]interface{}{
+		"name": acc.GetName(),
+	}
+
+	if ns := acc.GetNamespace(); ns != "" {
+		info["namespace"] = ns
+	}
+	if uid := acc.GetUID(); uid != "" {
+		info["uid"] = string(uid)
+	}
+	if rv := acc.GetResourceVersion(); rv != "" {
+		info["resourceVersion"] = rv
+	}
+
+	return info
 }

--- a/pkg/storage/legacysql/dualwrite/dualwriter.go
+++ b/pkg/storage/legacysql/dualwrite/dualwriter.go
@@ -365,7 +365,7 @@ func (d *dualWriter) Update(ctx context.Context, name string, objInfo rest.Updat
 			attribute.Bool("errorIsOK", d.errorIsOK),
 			attribute.Bool("readUnified", d.readUnified)))
 	defer span.End()
-	log := logging.FromContext(ctx).With("method", "Update", "name", name, "objInfo", objInfo)
+	log := logging.FromContext(ctx).With("method", "Update", "name", name)
 	// update in legacy first, and then unistore. Will return a failure if either fails.
 	//
 	// we want to update in legacy first, otherwise if the update from unistore was successful,


### PR DESCRIPTION
This PR adds some tracing to the dual writer and the legacy storage for dashboards. It uses the [current](https://github.com/grafana/grafana/blob/main/contribute/backend/instrumentation.md) best practices.