### PR TITLE
Test: Fix array element removal in adhoc filter e2e test

### DIFF
--- a/e2e-playwright/dashboards-suite/adhoc-filter-from-panel.spec.ts
+++ b/e2e-playwright/dashboards-suite/adhoc-filter-from-panel.spec.ts
@@ -52,7 +52,7 @@ test.describe(
         // during the test, we select the "inner_eval" slice to filter; this simulates the behavior
         // of prometheus applying that filter and removing dataframes from the response.
         if (route.request().postData()?.includes('{slice=\\\"inner_eval\\\"}')) {
-          delete fixture.results.A.frames[1];
+          fixture.results.A.frames.splice(1, 1);
         }
 
         await route.fulfill({


### PR DESCRIPTION
Replace incorrect delete operator with splice() method to properly remove array elements in the test fixture. Using delete creates sparse arrays with undefined values instead of actually removing elements, which can cause unexpected test behavior.