### PR TITLE
test: improve folder integration test performance

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -68,7 +68,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N"$SHARD" -d-)"
-          go test -tags=sqlite -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
 
   sqlite_nocgo:
     needs: detect-changes
@@ -109,7 +109,7 @@ jobs:
           # Build regex pattern like: pkg1$|pkg2$|pkg3$
           SKIP_PATTERN=$(echo "$SKIP_PACKAGES" | sed '/^$/d' | sed 's|.*|&$|' | paste -sd '|' -)
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d - | grep -Ev "($SKIP_PATTERN)")"
-          go test -tags=sqlite -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=sqlite -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
       - name: Run profiled tests
         id: run-profiled-tests
         if: matrix.shard == 'profiled'
@@ -135,7 +135,7 @@ jobs:
             pkg_name=$(basename "$full_pkg" | tr '/' '_' | tr '.' '_')
             echo "📦 Running $full_pkg"
             set +e
-            go test -tags=sqlite -timeout=12m -run '^TestIntegration' \
+            go test -tags=sqlite -timeout=8m -run '^TestIntegration' \
               -outputdir=profiles \
               -cpuprofile="cpu_${pkg_name}.prof" \
               -memprofile="mem_${pkg_name}.prof" \

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -1246,8 +1246,6 @@ func TestIntegrationFoldersGetAPIEndpointK8S(t *testing.T) {
 		},
 	}
 
-	// PERFORMANCE: Create ONE helper per mode, not per test case
-	// This reduces helper creation from 20 (5 modes × 4 test cases) to just 5
 	for mode := 0; mode <= 4; mode++ {
 		t.Run(fmt.Sprintf("Mode_%d", mode), func(t *testing.T) {
 			modeDw := grafanarest.DualWriterMode(mode)


### PR DESCRIPTION
Optimize the initialization of the test server setup. Updated permissions tests so that they don't re-initialize another server for each test case - this operation is quite expensive. We now only initialize it in each mode!

**Improvements:**
`TestIntegrationFoldersGetAPIEndpointK8S`: 20 helpers → 5 helpers
`TestIntegrationFolderCreatePermissions`: 25 helpers → 5 helpers
`TestIntegrationFolderGetPermissions`: 15 helpers → 5 helpers
`TestIntegrationFoldersCreateAPIEndpointK8S`: 30 helpers → 5 helpers

**Example Test Result:**
```
ok  	github.com/grafana/grafana/pkg/tests/apis/folder	158.484s
```

⏭️ ~Next up is to do the same for dashboard integration tests...~ The dashboard tests already adopt this approach 🤞 