### PR TITLE
Canvas: Fix Field image source when non-string field is used

### DIFF
--- a/public/app/features/dimensions/resource.test.ts
+++ b/public/app/features/dimensions/resource.test.ts
@@ -1,7 +1,7 @@
 import { createDataFrame } from '@grafana/data';
 import { ResourceDimensionMode } from '@grafana/schema';
 
-import { getResourceDimension } from './resource';
+import { getPublicOrAbsoluteUrl, getResourceDimension } from './resource';
 
 describe('getResourceDimension', () => {
   const publicPath = 'https://grafana.fake/public/';
@@ -104,4 +104,25 @@ describe('getResourceDimension', () => {
   });
 
   // TODO: write tests for mapping modes
+});
+
+describe('getPublicOrAbsoluteUrl', () => {
+  const publicPath = 'https://grafana.fake/public/';
+  beforeAll(() => {
+    window.__grafana_public_path__ = publicPath;
+  });
+
+  it('should handle string paths correctly', () => {
+    expect(getPublicOrAbsoluteUrl('icon.png')).toEqual(`${publicPath}build/icon.png`);
+    expect(getPublicOrAbsoluteUrl('https://example.com/icon.png')).toEqual('https://example.com/icon.png');
+  });
+
+  it('should return empty string for non-string values', () => {
+    expect(getPublicOrAbsoluteUrl(true)).toEqual('');
+    expect(getPublicOrAbsoluteUrl(123)).toEqual('');
+    expect(getPublicOrAbsoluteUrl(null)).toEqual('');
+    expect(getPublicOrAbsoluteUrl(undefined)).toEqual('');
+    expect(getPublicOrAbsoluteUrl({ path: 'icon.png' })).toEqual('');
+    expect(getPublicOrAbsoluteUrl(['icon.png'])).toEqual('');
+  });
 });

--- a/public/app/features/dimensions/resource.test.ts
+++ b/public/app/features/dimensions/resource.test.ts
@@ -63,5 +63,45 @@ describe('getResourceDimension', () => {
     expect(getResourceDimension(frame, config).value()).toEqual('https://3rdparty.fake/field.png');
   });
 
+  it('should return empty string for boolean field values', () => {
+    const frame = createDataFrame({
+      fields: [
+        {
+          name: 'image_field',
+          values: [true],
+          display: (v) => ({
+            text: String(v),
+            numeric: NaN,
+            icon: undefined,
+          }),
+        },
+      ],
+    });
+    const config = { mode: ResourceDimensionMode.Field, field: 'image_field', fixed: '' };
+
+    expect(getResourceDimension(frame, config).get(0)).toEqual('');
+    expect(getResourceDimension(frame, config).value()).toEqual('');
+  });
+
+  it('should return empty string for numeric field values', () => {
+    const frame = createDataFrame({
+      fields: [
+        {
+          name: 'image_field',
+          values: [123],
+          display: (v) => ({
+            text: String(v),
+            numeric: Number(v),
+            icon: undefined,
+          }),
+        },
+      ],
+    });
+    const config = { mode: ResourceDimensionMode.Field, field: 'image_field', fixed: '' };
+
+    expect(getResourceDimension(frame, config).get(0)).toEqual('');
+    expect(getResourceDimension(frame, config).value()).toEqual('');
+  });
+
   // TODO: write tests for mapping modes
 });

--- a/public/app/features/dimensions/resource.ts
+++ b/public/app/features/dimensions/resource.ts
@@ -55,7 +55,11 @@ export function getResourceDimension(
   }
 
   // mode === ResourceDimensionMode.Field case
-  const getImageOrIcon = (value: string): string => {
+  const getImageOrIcon = (value: unknown): string => {
+    if (typeof value !== 'string') {
+      return '';
+    }
+
     let url = value;
     if (field && field.display) {
       const displayValue = field.display(value);

--- a/public/app/features/dimensions/resource.ts
+++ b/public/app/features/dimensions/resource.ts
@@ -7,8 +7,8 @@ import { findField, getLastNotNullFieldValue } from './utils';
 //---------------------------------------------------------
 // Resource dimension
 //---------------------------------------------------------
-export function getPublicOrAbsoluteUrl(path: string): string {
-  if (!path) {
+export function getPublicOrAbsoluteUrl(path: unknown): string {
+  if (!path || typeof path !== 'string') {
     return '';
   }
 


### PR DESCRIPTION
Added type check for `getImageOrIcon` and `getPublicOrAbsoluteUrl` 
Field-source images were introduced in #112308.


Fixes https://github.com/grafana/support-escalations/issues/19297
Fixes https://github.com/grafana/support-escalations/issues/19344


This should be back-ported to v12.3.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
