### PR TITLE
[release-12.0.7] SCIM: Upgrade the User.UID field to allow for the new scim- prefix

### DIFF
--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -173,10 +173,6 @@ func addUserMigrations(mg *Migrator) {
 	// Users login and email should be in lower case - 2, fix for creating users not lowering login and email
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail+"2", &usermig.UsersLowerCaseLoginAndEmail{})
 
-	mg.AddMigration("Add index on user.is_service_account and user.last_seen_at", NewAddIndexMigration(userV2, &Index{
-		Cols: []string{"is_service_account", "last_seen_at"}, Type: IndexType,
-	}))
-
 	// Expand uid column to safely accommodate 'scim-' prefix without truncation/collisions
 	mg.AddMigration("Expand user.uid length to 190", NewRawSQLMigration("").
 		SQLite("SELECT 1;").

--- a/pkg/services/sqlstore/migrations/user_mig.go
+++ b/pkg/services/sqlstore/migrations/user_mig.go
@@ -172,6 +172,22 @@ func addUserMigrations(mg *Migrator) {
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail, &usermig.UsersLowerCaseLoginAndEmail{})
 	// Users login and email should be in lower case - 2, fix for creating users not lowering login and email
 	mg.AddMigration(usermig.LowerCaseUserLoginAndEmail+"2", &usermig.UsersLowerCaseLoginAndEmail{})
+
+	mg.AddMigration("Add index on user.is_service_account and user.last_seen_at", NewAddIndexMigration(userV2, &Index{
+		Cols: []string{"is_service_account", "last_seen_at"}, Type: IndexType,
+	}))
+
+	// Expand uid column to safely accommodate 'scim-' prefix without truncation/collisions
+	mg.AddMigration("Expand user.uid length to 190", NewRawSQLMigration("").
+		SQLite("SELECT 1;").
+		Postgres("ALTER TABLE `user` ALTER COLUMN uid TYPE VARCHAR(190);").
+		Mysql("ALTER TABLE user MODIFY uid VARCHAR(190);"))
+
+	// Prefix SCIM UID for provisioned users to avoid numeric/existing-id collisions
+	mg.AddMigration("Prefix SCIM uid for provisioned users", NewRawSQLMigration("").
+		SQLite("UPDATE user SET uid = 'scim-' || uid WHERE is_provisioned = 1 AND uid NOT LIKE 'scim-%';").
+		Postgres("UPDATE `user` SET uid = 'scim-' || uid WHERE is_provisioned = TRUE AND uid NOT LIKE 'scim-%';").
+		Mysql("UPDATE user SET uid = CONCAT('scim-', uid) WHERE is_provisioned = 1 AND uid NOT LIKE 'scim-%';"))
 }
 
 const migSQLITEisServiceAccountNullable = `ALTER TABLE user ADD COLUMN tmp_service_account BOOLEAN DEFAULT 0;


### PR DESCRIPTION
Backport ca5d89812015ef2db3acc62826f73650450b331e from #113500

---

**What is this feature?**

This PR will upgrade the `User.UID` field to 190 chars, allowing the new `scim-` prefix to be appended to the `User.UID` field.

The new `scim-` prefix will be appended to the `User.UID` only if the user was provisioned.

**Why do we need this feature?**

Part of the rework for provisioned External IDs when using SCIM.

**Who is this feature for?**

IAM
