### PR TITLE
External Alertmanagers: Assume Mimir AM when jsonData.implementation is missing

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -289,7 +289,7 @@ func (d *AlertsRouter) buildExternalURL(ds *datasources.DataSource) (string, err
 	if ds.JsonData != nil {
 		impl := ds.JsonData.Get("implementation").MustString("")
 		switch impl {
-		case "mimir", "cortex":
+		case "mimir", "cortex", "":
 			if parsed.Path == "" {
 				parsed.Path = "/"
 			}


### PR DESCRIPTION
When sending alerts to external Alertmanagers, we add the `/alertmanager` path prefix if the `jsonData.implementation` field is set to `"mimir"` or `"cortex"`.
This PR makes Grafana add the path prefix also when the field is missing.