### PR TITLE
Alerting: Fix width of the code editor for Alertmanager configurations

### DIFF
--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
@@ -165,11 +165,11 @@ export default function AlertmanagerConfig({ alertmanagerName, onDismiss, onSave
 
       {isLoadingSuccessful && (
         <div className={styles.content}>
-          <AutoSizer>
-            {({ height, width }) => (
+          <AutoSizer disableWidth>
+            {({ height }) => (
               <CodeEditor
                 language="json"
-                width={width}
+                width="100%"
                 height={height}
                 showLineNumbers={true}
                 monacoOptions={{


### PR DESCRIPTION
**What is this feature?**

This PR fixes an odd bug where the code editor(s) for Alertmanager configurations weren't properly initialized.