### PR TITLE
docs: clarifying info on what's new lading page

### DIFF
--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -181,6 +181,8 @@ weight: 1
 
 For release highlights, deprecations, and breaking changes in self-managed Grafana releases, refer to these "What's new" pages for each version.
 
+For information on new Grafana Cloud highlights, refer to [What's new from Grafana Labs](https://grafana.com/whats-new).
+
 {{< admonition type="note" >}}
 For Grafana versions prior to v9.2, additional information might also be available in the archived release notes. To access archived release notes, use the documentation for the minor version you want to see.
 

--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -170,7 +170,6 @@ aliases:
 description: Learn about new and updated features in Grafana.
 labels:
   products:
-    - cloud
     - enterprise
     - oss
 menuTitle: What's new
@@ -180,7 +179,7 @@ weight: 1
 
 # What's new in Grafana
 
-For release highlights, deprecations, and breaking changes in Grafana releases, refer to these "What's new" pages for each version.
+For release highlights, deprecations, and breaking changes in self-managed Grafana releases, refer to these "What's new" pages for each version.
 
 {{< admonition type="note" >}}
 For Grafana versions prior to v9.2, additional information might also be available in the archived release notes. To access archived release notes, use the documentation for the minor version you want to see.


### PR DESCRIPTION

**What is this feature?**

Removes the cloud tag from `docs/sources/whatsnew/_index.md` and clarifies in the wording these docs are for self-managed Grafana releases
 
**Why do we need this feature?**

Some users got confused and thought these pages corresponded to Grafana Cloud release info

**Who is this feature for?**

All users of Grafana documentation

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
