### PR TITLE
Chore: Run annotation data migration in batches

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -54,9 +54,16 @@ type xormRepositoryImpl struct {
 }
 
 func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Service, reg prometheus.Registerer) *xormRepositoryImpl {
+<<<<<<< HEAD
 	xormMigrationTrigger.Do(func() {
 		triggerAlwaysOnMigrations(cfg, l, db)
 	})
+=======
+	err := migrations.RunDashboardUIDMigrations(db.GetEngine().NewSession(), db.GetEngine().DriverName(), l)
+	if err != nil {
+		l.Error("failed to populate dashboard_uid for annotations", "error", err)
+	}
+>>>>>>> 7c791552d70 (run annotation data migration in batches)
 
 	repo := &xormRepositoryImpl{
 		cfg:        cfg,

--- a/pkg/services/annotations/annotationsimpl/xorm_store.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store.go
@@ -54,16 +54,9 @@ type xormRepositoryImpl struct {
 }
 
 func NewXormStore(cfg *setting.Cfg, l log.Logger, db db.DB, tagService tag.Service, reg prometheus.Registerer) *xormRepositoryImpl {
-<<<<<<< HEAD
 	xormMigrationTrigger.Do(func() {
 		triggerAlwaysOnMigrations(cfg, l, db)
 	})
-=======
-	err := migrations.RunDashboardUIDMigrations(db.GetEngine().NewSession(), db.GetEngine().DriverName(), l)
-	if err != nil {
-		l.Error("failed to populate dashboard_uid for annotations", "error", err)
-	}
->>>>>>> 7c791552d70 (run annotation data migration in batches)
 
 	repo := &xormRepositoryImpl{
 		cfg:        cfg,

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -768,24 +769,28 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 		require.NotNil(t, store)
 		assert.Equal(t, "sql", store.Type())
 
+		// Wait for the async migration to complete (runs in background goroutine)
 		var result struct {
 			DashboardUID *string `xorm:"dashboard_uid"`
 		}
-		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
-			has, err := sess.Table("annotation").
-				Where("id = ?", annotation.ID).
-				Get(&result)
+		require.Eventually(t, func() bool {
+			err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+				has, err := sess.Table("annotation").
+					Where("id = ?", annotation.ID).
+					Get(&result)
+				if err != nil {
+					return err
+				}
+				if !has {
+					return fmt.Errorf("annotation not found")
+				}
+				return nil
+			})
 			if err != nil {
-				return err
+				return false
 			}
-			if !has {
-				return fmt.Errorf("annotation not found")
-			}
-			return nil
-		})
-		require.NoError(t, err)
-		require.NotNil(t, result.DashboardUID, "dashboard_uid should not be NULL when migration runs")
-		assert.Equal(t, "test-run-uid", *result.DashboardUID, "dashboard_uid should be populated when migration runs")
+			return result.DashboardUID != nil && *result.DashboardUID == "test-run-uid"
+		}, 5*time.Second, 100*time.Millisecond, "dashboard_uid should be populated when migration runs")
 	})
 }
 

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -2,6 +2,8 @@ package migrations
 
 import (
 	"fmt"
+	"os"
+	"strconv"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util/xorm"
@@ -249,6 +251,13 @@ func (m *SetDashboardUIDMigration) Exec(sess *xorm.Session, mg *Migrator) error 
 
 func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log.Logger) error {
 	batchSize := 5000
+	if size := os.Getenv("ANNOTATION_DASHBOARD_UID_MIGRATION_BATCH_SIZE"); size != "" {
+		n, err := strconv.ParseInt(size, 10, 64)
+		if err == nil {
+			batchSize = int(n)
+		}
+	}
+
 	logger.Info("Starting batched dashboard_uid migration for annotations (newest first)", "batchSize", batchSize)
 	updateSQL := `UPDATE annotation
 		SET dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = annotation.dashboard_id)

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -249,7 +249,7 @@ func (m *SetDashboardUIDMigration) Exec(sess *xorm.Session, mg *Migrator) error 
 
 func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log.Logger) error {
 	batchSize := 5000
-	logger.Info("Starting batched dashboard_uid migration for annotations", "batchSize", batchSize)
+	logger.Info("Starting batched dashboard_uid migration for annotations (newest first)", "batchSize", batchSize)
 	updateSQL := `UPDATE annotation
 		SET dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = annotation.dashboard_id)
 		WHERE dashboard_uid IS NULL 
@@ -258,7 +258,7 @@ func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log
 		  AND annotation.id IN (
 			SELECT id FROM annotation
 			WHERE dashboard_uid IS NULL AND dashboard_id != 0
-			ORDER BY id
+			ORDER BY id DESC
 			LIMIT ?
 		  )`
 	switch driverName {
@@ -272,7 +272,7 @@ func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log
 		 AND annotation.id IN (
 			SELECT id FROM annotation
 			WHERE dashboard_uid IS NULL AND dashboard_id != 0
-			ORDER BY id
+			ORDER BY id DESC
 			LIMIT $1
 		 )`
 	case MySQL:
@@ -285,7 +285,7 @@ func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log
 			SELECT id FROM (
 				SELECT id FROM annotation
 				WHERE dashboard_uid IS NULL AND dashboard_id != 0
-				ORDER BY id
+				ORDER BY id DESC
 				LIMIT ?
 			) AS batch
 		  )`

--- a/pkg/services/sqlstore/migrations/annotation_mig.go
+++ b/pkg/services/sqlstore/migrations/annotation_mig.go
@@ -3,6 +3,7 @@ package migrations
 import (
 	"fmt"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/util/xorm"
 
 	. "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
@@ -243,30 +244,79 @@ func (m *SetDashboardUIDMigration) SQL(dialect Dialect) string {
 }
 
 func (m *SetDashboardUIDMigration) Exec(sess *xorm.Session, mg *Migrator) error {
-	return RunDashboardUIDMigrations(sess, mg.Dialect.DriverName())
+	return RunDashboardUIDMigrations(sess, mg.Dialect.DriverName(), mg.Logger)
 }
 
-func RunDashboardUIDMigrations(sess *xorm.Session, driverName string) error {
-	sql := `UPDATE annotation
-	SET dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = annotation.dashboard_id)
-	WHERE dashboard_uid IS NULL AND dashboard_id != 0 AND EXISTS (SELECT 1 FROM dashboard WHERE dashboard.id = annotation.dashboard_id);`
+func RunDashboardUIDMigrations(sess *xorm.Session, driverName string, logger log.Logger) error {
+	batchSize := 5000
+	logger.Info("Starting batched dashboard_uid migration for annotations", "batchSize", batchSize)
+	updateSQL := `UPDATE annotation
+		SET dashboard_uid = (SELECT uid FROM dashboard WHERE dashboard.id = annotation.dashboard_id)
+		WHERE dashboard_uid IS NULL 
+		  AND dashboard_id != 0 
+		  AND EXISTS (SELECT 1 FROM dashboard WHERE dashboard.id = annotation.dashboard_id)
+		  AND annotation.id IN (
+			SELECT id FROM annotation
+			WHERE dashboard_uid IS NULL AND dashboard_id != 0
+			ORDER BY id
+			LIMIT ?
+		  )`
 	switch driverName {
 	case Postgres:
-		sql = `UPDATE annotation
+		updateSQL = `UPDATE annotation
 		SET dashboard_uid = dashboard.uid
 		FROM dashboard
 		WHERE annotation.dashboard_id = dashboard.id
 		 AND annotation.dashboard_id != 0
-		 AND annotation.dashboard_uid IS NULL;`
+		 AND annotation.dashboard_uid IS NULL
+		 AND annotation.id IN (
+			SELECT id FROM annotation
+			WHERE dashboard_uid IS NULL AND dashboard_id != 0
+			ORDER BY id
+			LIMIT $1
+		 )`
 	case MySQL:
-		sql = `UPDATE annotation
-		LEFT JOIN dashboard ON annotation.dashboard_id = dashboard.id
+		updateSQL = `UPDATE annotation
+		INNER JOIN dashboard ON annotation.dashboard_id = dashboard.id
 		SET annotation.dashboard_uid = dashboard.uid
-		WHERE annotation.dashboard_uid IS NULL and annotation.dashboard_id != 0;`
-	}
-	if _, err := sess.Exec(sql); err != nil {
-		return fmt.Errorf("failed to set dashboard_uid for annotation: %w", err)
+		WHERE annotation.dashboard_uid IS NULL 
+		  AND annotation.dashboard_id != 0
+		  AND annotation.id IN (
+			SELECT id FROM (
+				SELECT id FROM annotation
+				WHERE dashboard_uid IS NULL AND dashboard_id != 0
+				ORDER BY id
+				LIMIT ?
+			) AS batch
+		  )`
 	}
 
+	updatedTotal := int64(0)
+	batchNum := 0
+	for {
+		batchNum++
+		result, err := sess.Exec(updateSQL, batchSize)
+		if err != nil {
+			return fmt.Errorf("failed to set dashboard_uid for annotation batch %d: %w", batchNum, err)
+		}
+
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("failed to get rows affected for batch %d: %w", batchNum, err)
+		}
+
+		if rowsAffected == 0 {
+			break
+		}
+
+		updatedTotal += rowsAffected
+		logger.Info("Updated annotation batch", "batch", batchNum, "rowsInBatch", rowsAffected, "totalUpdated", updatedTotal)
+
+		if rowsAffected < int64(batchSize) {
+			break
+		}
+	}
+
+	logger.Info("Completed dashboard_uid migration for annotations", "totalUpdated", updatedTotal)
 	return nil
 }


### PR DESCRIPTION
This PR modified annotation migration that updates dashboard UIDs, so that it would run in batches. Also it starts from the end of the table, i.e. newest annotations would be migrated first and users shouldn't notice the delay.

Confirmed it on manually upgrading grafana from v12.0.0 to this version with 1M annotations in the database, there is no blocking when the migration runs, latest annotations show up on dashboards immediately.