### PR TITLE
datasources: querier: add mode-info

### DIFF
--- a/pkg/registry/apis/query/client/instance_provider.go
+++ b/pkg/registry/apis/query/client/instance_provider.go
@@ -52,6 +52,10 @@ func (s *singleTenantInstanceProvider) GetInstance(_ context.Context, logger log
 	}, nil
 }
 
+func (s *singleTenantInstanceProvider) GetMode() string {
+	return "st"
+}
+
 func (s *singleTenantInstance) GetSettings() clientapi.InstanceConfigurationSettings {
 	return s.instanceConf
 }

--- a/pkg/registry/apis/query/clientapi/clientapi.go
+++ b/pkg/registry/apis/query/clientapi/clientapi.go
@@ -39,4 +39,5 @@ type Instance interface {
 
 type InstanceProvider interface {
 	GetInstance(ctx context.Context, logger log.Logger, headers map[string]string) (Instance, error)
+	GetMode() string
 }

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -122,6 +122,8 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 	b := r.builder
 
 	return http.HandlerFunc(func(w http.ResponseWriter, httpreq *http.Request) {
+		w.Header().Set("X-Ds-Querier", b.instanceProvider.GetMode())
+
 		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
 		defer span.End()
 		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -274,6 +274,10 @@ func (m mockClient) GetInstance(ctx context.Context, logger log.Logger, headers 
 	return mclient, nil
 }
 
+func (m mockClient) GetMode() string {
+	return "testing"
+}
+
 func (m mockClient) ReportMetrics() {
 }
 


### PR DESCRIPTION
provides a http-response-header that explains in what mode the query-service was running when it produced the response.