### PR TITLE
logParser: memoize getVisibleFieldIndices

### DIFF
--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -149,7 +149,7 @@ export function separateVisibleFields(
 
 // Memoization cache for getVisibleFieldIndices results to avoid re-processing the same DataFrame structure
 // WeakMap ensures automatic garbage collection when DataFrames are no longer referenced
-const visibleFieldIndicesCache = new WeakMap<DataFrame, Set<number> | null>();
+const visibleFieldIndicesCache = new WeakMap<DataFrame, Set<number>>();
 function getCachedVisibleFieldIndices(frame: DataFrame): Set<number> {
   if (!visibleFieldIndicesCache.has(frame)) {
     visibleFieldIndicesCache.set(frame, getVisibleFieldIndices(frame, {}));
@@ -158,9 +158,9 @@ function getCachedVisibleFieldIndices(frame: DataFrame): Set<number> {
 }
 
 // Optimized version of separateVisibleFields() to only return visible fields for getAllFields()
-function getNonEmptyVisibleFields(row: LogRowModel, opts?: VisOptions): FieldWithIndex[] {
+function getNonEmptyVisibleFields(row: LogRowModel): FieldWithIndex[] {
   const frame = row.dataFrame;
-  const visibleFieldIndices = opts === undefined ? getCachedVisibleFieldIndices(frame) : getVisibleFieldIndices(frame, opts ?? {});
+  const visibleFieldIndices = getCachedVisibleFieldIndices(frame);
   const visibleFields: FieldWithIndex[] = [];
   for (let index = 0; index < frame.fields.length; index++) {
     const field = frame.fields[index];

--- a/public/app/features/logs/components/logParser.ts
+++ b/public/app/features/logs/components/logParser.ts
@@ -147,10 +147,20 @@ export function separateVisibleFields(
   return { visible, hidden };
 }
 
+// Memoization cache for getVisibleFieldIndices results to avoid re-processing the same DataFrame structure
+// WeakMap ensures automatic garbage collection when DataFrames are no longer referenced
+const visibleFieldIndicesCache = new WeakMap<DataFrame, Set<number> | null>();
+function getCachedVisibleFieldIndices(frame: DataFrame): Set<number> {
+  if (!visibleFieldIndicesCache.has(frame)) {
+    visibleFieldIndicesCache.set(frame, getVisibleFieldIndices(frame, {}));
+  }
+  return visibleFieldIndicesCache.get(frame)!;
+}
+
 // Optimized version of separateVisibleFields() to only return visible fields for getAllFields()
 function getNonEmptyVisibleFields(row: LogRowModel, opts?: VisOptions): FieldWithIndex[] {
   const frame = row.dataFrame;
-  const visibleFieldIndices = getVisibleFieldIndices(frame, opts ?? {});
+  const visibleFieldIndices = opts === undefined ? getCachedVisibleFieldIndices(frame) : getVisibleFieldIndices(frame, opts ?? {});
   const visibleFields: FieldWithIndex[] = [];
   for (let index = 0; index < frame.fields.length; index++) {
     const field = frame.fields[index];


### PR DESCRIPTION
Fixes #104607

Instead of memoizing at the `parseLogsFrame` level, which is a function that is used in different places in the repo, we can apply memoization to `getVisibleFieldIndices`, which returns fixed information about a data frame that doesn't need to be computed on every successive call.

Finally, `getNonEmptyVisibleFields` can evaluate the data frame fields for the particular `rowIndex` that is being passed at a given call.

The execution path is getAllFields -> getDataframeFields -> getNonEmptyVisibleFields, which is unique for getAllFields, the function that the logs panel calls for each log line.

Using a WeakMap allows the data frame object to be garbage collected when it's no longer used.

B:

https://github.com/user-attachments/assets/7fb1054b-e0e3-4e27-bebf-84c5243fd4de

A:

https://github.com/user-attachments/assets/d29dc040-09dd-4f22-8632-e3169f63fc54


