### PR TITLE
experiment with disabling only_full_group_by in sqlexpressions

### DIFF
--- a/pkg/expr/sql/db.go
+++ b/pkg/expr/sql/db.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	sqle "github.com/dolthub/go-mysql-server"
@@ -74,7 +75,17 @@ func (db *DB) QueryFrames(ctx context.Context, tracer tracing.Tracer, name strin
 	mCtx.SetCurrentDatabase(dbName)
 
 	// Empty dir does not disable secure_file_priv
-	//ctx.SetSessionVariable(ctx, "secure_file_priv", "")
+	// ctx.SetSessionVariable(ctx, "secure_file_priv", "")
+
+	// remove only_full_group_by from the sql mode
+	defaultSqlMode := strings.Join([]string{
+		mysql.NoEngineSubstitution,
+		mysql.StrictTransTables,
+	}, ",")
+	err := mCtx.SetSessionVariable(mCtx, mysql.SqlModeSessionVar, defaultSqlMode)
+	if err != nil {
+		return nil, err
+	}
 
 	// TODO: Check if it's wise to reuse the existing provider, rather than creating a new one
 	a := analyzer.NewDefault(pro)

--- a/pkg/expr/sql/db_test.go
+++ b/pkg/expr/sql/db_test.go
@@ -61,6 +61,28 @@ func TestQueryFrames(t *testing.T) {
 				data.NewField("OSS Projects with Typos", nil, []string{"Garfana"}),
 			).SetRefID("sqlExpressionRefId"),
 		},
+		{
+			name: "disabling only_full_group_by mode allows GROUP BY without aggregate functions (we are not sure if this is a good idea)",
+			query: `SELECT
+  g,
+  SUM(v) * 100 * t.total AS pct_of_total
+FROM A
+CROSS JOIN (SELECT SUM(v) AS total FROM A) t
+GROUP BY g;
+`,
+			input_frames: []*data.Frame{
+				data.NewFrame(
+					"",
+					data.NewField("g", nil, []int64{1}),
+					data.NewField("v", nil, []int64{1}),
+				).SetRefID("A"),
+			},
+			expected: data.NewFrame(
+				"sqlExpressionRefId",
+				data.NewField("g", nil, []int64{1}),
+				data.NewField("pct_of_total", nil, []*float64{p(100.0)}),
+			).SetRefID("sqlExpressionRefId"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


**What is this feature?**

Related to https://github.com/grafana/grafana/issues/113299


Answering the narrow question of "how would we disable `only_full_group_by` mode, if that's what we wanted to do?

We've added a test with a query that fails with the same error as seen in the referenced issue, unless we remove  `only_full_group_by` mode. 

Before going any further here, we will research the issue more to understand whether the error is one we want to uphold in our use case.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
