### PR TITLE
Provisioning: Include ref field in DELETE endpoint response for branch operations

### DIFF
--- a/pkg/registry/apis/provisioning/resources/dualwriter.go
+++ b/pkg/registry/apis/provisioning/resources/dualwriter.go
@@ -100,7 +100,7 @@ func (r *DualReadWriter) Delete(ctx context.Context, opts DualWriteOptions) (*Pa
 	}
 
 	// HACK: manual set to the provided branch so that the parser can possible read the file
-	if r.shouldUpdateGrafanaDB(opts, nil) {
+	if !r.shouldUpdateGrafanaDB(opts, nil) {
 		file.Ref = opts.Ref
 	}
 


### PR DESCRIPTION
## What this PR does / why we need it

Fixes a bug where the DELETE endpoint `/repositories/{name}/files/{path}` does not include the `ref` field in its `ResourceWrapper` response when deleting files to a branch, even though the ref is sent as a required query parameter. This causes the branch workflow success handler to fail silently in the frontend.

## Steps to Reproduce

1. Open a git provisioned dashboard
2. Go to settings page → scroll to bottom → delete button
3. Push changes to a branch
4. Submit the changes
5. Observe the API response - ref field is missing

<img width="693" height="661" alt="Screenshot 2025-11-08 at 08 08 34" src="https://github.com/user-attachments/assets/d54448f8-91c4-4314-b827-8973ad0e027a" />
<img width="1041" height="464" alt="Screenshot 2025-11-08 at 08 08 49" src="https://github.com/user-attachments/assets/67cbcf66-e1d7-46b3-9ede-ba4dc86c8fc0" />


## Root Cause

The issue was an inverted boolean condition in the `Delete` method in `dualwriter.go`. The code was setting `file.Ref = opts.Ref` when `shouldUpdateGrafanaDB` returned true (main branch operations), but it should have been setting it when false (branch operations), since we read the file with an empty ref.

## The Fix

Changed line 103 from:
\`\`\`go
if r.shouldUpdateGrafanaDB(opts, nil) {
\`\`\`

to:
\`\`\`go
if !r.shouldUpdateGrafanaDB(opts, nil) {
\`\`\`

This ensures the ref field is properly included in the ResourceWrapper response for branch operations, matching the behavior of folder deletes and other operations.

## Which issue(s) this PR fixes

Fix https://github.com/grafana/git-ui-sync-project/issues/639