### PR TITLE
Theme: Add breakpoint methods for container queries

### DIFF
--- a/packages/grafana-data/src/themes/breakpoints.ts
+++ b/packages/grafana-data/src/themes/breakpoints.ts
@@ -18,6 +18,10 @@ export interface ThemeBreakpoints {
   unit: string;
   up: (key: ThemeBreakpointsKey | number) => string;
   down: (key: ThemeBreakpointsKey | number) => string;
+  container: {
+    up: (key: ThemeBreakpointsKey | number, name?: string) => string;
+    down: (key: ThemeBreakpointsKey | number, name?: string) => string;
+  };
 }
 
 /** @internal */
@@ -44,6 +48,18 @@ export function createBreakpoints(): ThemeBreakpoints {
     return `@media (max-width:${value - step / 100}${unit})`;
   }
 
+  function containerUp(key: ThemeBreakpointsKey | number, name?: string) {
+    const value = typeof key === 'number' ? key : values[key];
+    const query = typeof name === 'string' ? `@container ${name}` : '@container';
+    return `${query} (width >= ${value}${unit})`;
+  }
+
+  function containerDown(key: ThemeBreakpointsKey | number, name?: string) {
+    const value = typeof key === 'number' ? key : values[key];
+    const query = typeof name === 'string' ? `@container ${name}` : '@container';
+    return `${query} (width < ${value}${unit})`;
+  }
+
   // TODO add functions for between and only
 
   return {
@@ -52,5 +68,9 @@ export function createBreakpoints(): ThemeBreakpoints {
     down,
     keys,
     unit,
+    container: {
+      up: containerUp,
+      down: containerDown,
+    },
   };
 }

--- a/public/app/core/components/Page/Page.tsx
+++ b/public/app/core/components/Page/Page.tsx
@@ -99,6 +99,7 @@ const getStyles = (theme: GrafanaTheme2) => {
       flex: '1 1 0',
       flexDirection: 'column',
       position: 'relative',
+      container: 'page / inline-size',
     }),
     pageContent: css({
       label: 'page-content',


### PR DESCRIPTION
**What is this feature?**

Adds new methods to the `theme.breakpoints` object for working with container queries, and makes the page wrapper a container that can be used with these queries: `theme.breakpoints.container.up` and `theme.breakpoints.container.down`, which accept the same first argument as the non-container versions for the breakpoint, and an optional second argument for a named container.

**Why do we need this feature?**

With the sidebar becoming a feature more prevalently used in Grafana, and [container queries being a baseline browser feature](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/At-rules/@container), it seems like this would be a good way for pages (and plugins) to improve their responsiveness to the available space changing if the sidebar is opened/resized, rather than just based on the entire viewport width.

**Who is this feature for?**

Developers.

Plugins can migrate from `theme.breakpoints.up/down` to `theme.breakpoints.container.up/down` to be responsive to the page size changing, rather than just the viewport size changing. As an example: https://github.com/grafana/grafana-setupguide-app/pull/618/files (🔐)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
