### PR TITLE
Dashboard provisioning: Add support for v2 schema

### DIFF
--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -376,6 +376,7 @@ providers:
 
 When Grafana starts, it updates or creates all dashboards found in the configured path.
 These files can define the dashboard using the dashboard JSON:
+
 ```json
 {
   "dashboard": {
@@ -424,7 +425,7 @@ Or using a Kubernetes format, for example `kubernetes-dashboard.json`:
 }
 ```
 
-You *must* use the Kubernetes resource format to provision dashboards v2 / dynamic dashboards.
+You _must_ use the Kubernetes resource format to provision dashboards v2 / dynamic dashboards.
 
 It later polls that path every `updateIntervalSeconds` for updates to the dashboard files and updates its database.
 

--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -375,6 +375,57 @@ providers:
 ```
 
 When Grafana starts, it updates or creates all dashboards found in the configured path.
+These files can define the dashboard using the dashboard JSON:
+```json
+{
+  "dashboard": {
+    "id": null,
+    "uid": "example-dashboard",
+    "title": "Production Overview",
+    "tags": ["production", "monitoring"],
+    "timezone": "browser",
+    "schemaVersion": 16,
+    "version": 0,
+    "refresh": "30s"
+  },
+  "folderUid": "monitoring-folder",
+  "overwrite": true
+}
+```
+
+Or using a Kubernetes format, for example `kubernetes-dashboard.json`:
+
+```json
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "metadata": {
+    "name": "dashboard-uid"
+  },
+  "spec": {
+    "title": "Dashboard title",
+    "panels": [
+      {
+        "gridPos": {
+          "h": 13,
+          "w": 24,
+          "x": 0,
+          "y": 0
+        },
+        "options": {
+          "content": "<div><h1>Example panel</h1></div>",
+          "mode": "html"
+        },
+        "transparent": true,
+        "type": "text"
+      }
+    ]
+  }
+}
+```
+
+You *must* use the Kubernetes resource format to provision dashboards v2 / dynamic dashboards.
+
 It later polls that path every `updateIntervalSeconds` for updates to the dashboard files and updates its database.
 
 {{< admonition type="note" >}}

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -745,15 +745,16 @@ func (dr *DashboardServiceImpl) BuildSaveDashboardCommand(ctx context.Context, d
 
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Dashboard).Inc()
 	cmd := &dashboards.SaveDashboardCommand{
-		Dashboard: dash.Data,
-		Message:   dto.Message,
-		OrgID:     dto.OrgID,
-		Overwrite: dto.Overwrite,
-		UserID:    userID,
-		FolderID:  dash.FolderID, // nolint:staticcheck
-		FolderUID: dash.FolderUID,
-		IsFolder:  dash.IsFolder,
-		PluginID:  dash.PluginID,
+		Dashboard:  dash.Data,
+		Message:    dto.Message,
+		OrgID:      dto.OrgID,
+		Overwrite:  dto.Overwrite,
+		UserID:     userID,
+		FolderID:   dash.FolderID, // nolint:staticcheck
+		FolderUID:  dash.FolderUID,
+		IsFolder:   dash.IsFolder,
+		PluginID:   dash.PluginID,
+		APIVersion: dash.APIVersion,
 	}
 
 	if !dto.UpdatedAt.IsZero() {
@@ -2286,6 +2287,10 @@ func LegacySaveCommandToUnstructured(cmd *dashboards.SaveDashboardCommand, names
 
 	if cmd.Message != "" {
 		meta.SetMessage(cmd.Message)
+	}
+
+	if cmd.APIVersion != "" {
+		finalObj.SetAPIVersion(cmd.APIVersion)
 	}
 
 	return finalObj, nil

--- a/pkg/services/provisioning/dashboards/types.go
+++ b/pkg/services/provisioning/dashboards/types.go
@@ -69,11 +69,17 @@ func createDashboardJSON(data *simplejson.Json, lastModified time.Time, cfg *con
 	dash.Dashboard = dashboards.NewDashboardFromJson(data)
 	dash.UpdatedAt = lastModified
 	dash.Overwrite = true
+	if dash.Dashboard.OrgID > 0 && dash.Dashboard.OrgID != cfg.OrgID {
+		return nil, fmt.Errorf("dashboard orgID (%d) does not match provisioning provider orgID (%d)", dash.Dashboard.OrgID, cfg.OrgID)
+	}
 	dash.OrgID = cfg.OrgID
 	dash.Dashboard.OrgID = cfg.OrgID
 	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Provisioning).Inc()
 	// nolint:staticcheck
 	dash.Dashboard.FolderID = folderID
+	if dash.Dashboard.FolderUID != "" && folderUID != dash.Dashboard.FolderUID {
+		return nil, fmt.Errorf("dashboard folderUID (%q) does not match provisioning provider folderUID (%q)", dash.Dashboard.FolderUID, folderUID)
+	}
 	dash.Dashboard.FolderUID = folderUID
 
 	if dash.Dashboard.Title == "" {

--- a/pkg/services/provisioning/dashboards/types_test.go
+++ b/pkg/services/provisioning/dashboards/types_test.go
@@ -40,7 +40,7 @@ func TestCreateDashboardJSON(t *testing.T) {
 			assert.Equal(t, "Test Dashboard", result.Dashboard.Title)
 			assert.Equal(t, int64(1), result.OrgID)
 			assert.Equal(t, int64(1), result.Dashboard.OrgID)
-			assert.Equal(t, folderID, result.Dashboard.FolderID)
+			assert.Equal(t, folderID, result.Dashboard.FolderID) // nolint:staticcheck
 			assert.Equal(t, folderUID, result.Dashboard.FolderUID)
 			assert.True(t, result.Overwrite)
 			assert.Equal(t, lastModified, result.UpdatedAt)
@@ -93,7 +93,6 @@ func TestCreateDashboardJSON(t *testing.T) {
 			assert.Nil(t, result)
 			assert.Contains(t, err.Error(), "dashboard orgID")
 		})
-
 	})
 
 	t.Run("folderUID check", func(t *testing.T) {

--- a/pkg/services/provisioning/dashboards/types_test.go
+++ b/pkg/services/provisioning/dashboards/types_test.go
@@ -1,0 +1,194 @@
+package dashboards
+
+import (
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateDashboardJSON(t *testing.T) {
+	lastModified := time.Now()
+	folderID := int64(123)
+	folderUID := "folder-uid-123"
+
+	t.Run("orgID check", func(t *testing.T) {
+		t.Run("matching is OK", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":      "test-dashboard-uid",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, "Test Dashboard", result.Dashboard.Title)
+			assert.Equal(t, int64(1), result.OrgID)
+			assert.Equal(t, int64(1), result.Dashboard.OrgID)
+			assert.Equal(t, folderID, result.Dashboard.FolderID)
+			assert.Equal(t, folderUID, result.Dashboard.FolderUID)
+			assert.True(t, result.Overwrite)
+			assert.Equal(t, lastModified, result.UpdatedAt)
+		})
+
+		t.Run("not set is OK", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name": "test-dashboard-uid",
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, int64(1), result.OrgID)
+			assert.Equal(t, int64(1), result.Dashboard.OrgID)
+		})
+
+		t.Run("not matching is an error", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":      "test-dashboard-uid",
+					"namespace": "org-123",
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "dashboard orgID")
+		})
+
+	})
+
+	t.Run("folderUID check", func(t *testing.T) {
+		t.Run("matching is OK", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":      "test-dashboard-uid",
+					"namespace": "default",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder": folderUID,
+					},
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, folderUID, result.Dashboard.FolderUID)
+		})
+
+		t.Run("not matching is an error", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":      "test-dashboard-uid",
+					"namespace": "default",
+					"annotations": map[string]interface{}{
+						"grafana.app/folder": "different-folder-uid",
+					},
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "dashboard folderUID")
+		})
+
+		t.Run("not set is OK", func(t *testing.T) {
+			cfg := &config{
+				OrgID: 1,
+			}
+
+			dashboardJSON := simplejson.NewFromAny(map[string]interface{}{
+				"apiVersion": "dashboard.grafana.app/v2alpha1",
+				"kind":       "Dashboard",
+				"metadata": map[string]interface{}{
+					"name":      "test-dashboard-uid",
+					"namespace": "default",
+				},
+				"spec": map[string]interface{}{
+					"title": "Test Dashboard",
+				},
+			})
+
+			result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+			require.NoError(t, err)
+			assert.NotNil(t, result)
+			assert.Equal(t, folderUID, result.Dashboard.FolderUID)
+		})
+	})
+
+	t.Run("empty title is an error", func(t *testing.T) {
+		cfg := &config{
+			OrgID: 1,
+		}
+
+		dashboardJSON := simplejson.NewFromAny(map[string]any{
+			"title": "",
+		})
+
+		result, err := createDashboardJSON(dashboardJSON, lastModified, cfg, folderID, folderUID)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, dashboards.ErrDashboardTitleEmpty, err)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

This PR adds support for dashboard v2 in file based provisioning. It has to be defined in k8s object format (not just as the dashboard spec). This is documented.


**Why do we need this feature?**

Once dashboard v2 is GA, we want to support provisioning in this way.

**Testing**

Tested with:
```
{
  "apiVersion": "dashboard.grafana.app/v2alpha1",
  "kind": "Dashboard",
  "metadata": {
    "name": "test-v2alpha1-complete",
    "labels": {
      "category": "test"
    },
    "annotations": {
      "description": "Complete example of v2alpha1 dashboard features"
    }
  },
  "spec": {
    "title": "Test: Complete V2alpha1 Dashboard Example",
    "description": "This dashboard demonstrates all features that need to be converted from v2alpha1 to v2beta1",
    "editable": true,
    "liveNow": true,
    "preload": true,
    "cursorSync": "Tooltip",
    "tags": ["test", "example", "migration"],
    "annotations": [
      {
        "kind": "AnnotationQuery",
        "spec": {
          "builtIn": true,
          "datasource": {
            "type": "grafana",
            "uid": "-- Grafana --"
          },
          "enable": true,
          "hide": false,
          "iconColor": "rgba(0, 211, 255, 1)",
          "name": "Annotations & Alerts",
          "query": {
            "kind": "grafana",
            "spec": {
              "limit": 100,
              "matchAny": false,
              "tags": [],
              "type": "dashboard"
            }
          }
        }
      },
      {
        "kind": "AnnotationQuery",
        "spec": {
          "builtIn": false,
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "enable": true,
          "hide": false,
          "iconColor": "yellow",
          "name": "Prometheus Annotations",
          "query": {
            "kind": "prometheus",
            "spec": {
              "expr": "changes(process_start_time_seconds[1m])",
              "refId": "Anno"
            }
          }
        }
      }
    ],
    "variables": [
      {
        "kind": "QueryVariable",
        "spec": {
          "name": "prometheus_query",
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "query": {
            "kind": "prometheus",
            "spec": {
              "expr": "up"
            }
          },
          "refresh": "time",
          "regex": "",
          "sort": "alphabetical",
          "multi": true,
          "includeAll": true,
          "current": {
            "text": "All",
            "value": ["$__all"]
          },
          "hide": "dontHide",
          "label": "Prometheus Query",
          "description": "Shows all up metrics",
          "skipUrlSync": false,
          "definition": "up"
        }
      },
      {
        "kind": "TextVariable",
        "spec": {
          "name": "text_var",
          "label": "Text Variable",
          "description": "A simple text variable",
          "query": "server1,server2,server3",
          "current": {
            "selected": true,
            "text": "server1",
            "value": "server1"
          },
          "hide": "dontHide",
          "skipUrlSync": false
        }
      },
      {
        "kind": "ConstantVariable",
        "spec": {
          "name": "constant_var",
          "label": "Constant",
          "description": "A constant value",
          "query": "production",
          "current": {
            "selected": true,
            "text": "production",
            "value": "production"
          },
          "hide": "dontHide",
          "skipUrlSync": true
        }
      },
      {
        "kind": "DatasourceVariable",
        "spec": {
          "name": "ds_var",
          "label": "Datasource",
          "description": "Select a datasource",
          "pluginId": "prometheus",
          "refresh": "load",
          "regex": "/^gdev-/",
          "current": {
            "text": "gdev-prometheus",
            "value": "gdev-prometheus"
          },
          "options": [
            {
              "text": "gdev-prometheus",
              "value": "gdev-prometheus"
            }
          ],
          "multi": false,
          "includeAll": false,
          "hide": "dontHide",
          "skipUrlSync": false
        }
      },
      {
        "kind": "IntervalVariable",
        "spec": {
          "name": "interval",
          "label": "Interval",
          "description": "Time interval selection",
          "query": "1m,5m,10m,30m,1h,6h,12h,1d",
          "current": {
            "selected": true,
            "text": "5m",
            "value": "5m"
          },
          "options": [
            {
              "text": "1m",
              "value": "1m"
            },
            {
              "text": "5m",
              "value": "5m"
            },
            {
              "text": "10m",
              "value": "10m"
            },
            {
              "text": "30m",
              "value": "30m"
            },
            {
              "text": "1h",
              "value": "1h"
            },
            {
              "text": "6h",
              "value": "6h"
            },
            {
              "text": "12h",
              "value": "12h"
            },
            {
              "text": "1d",
              "value": "1d"
            }
          ],
          "auto": true,
          "auto_min": "10s",
          "auto_count": 30,
          "refresh": "load",
          "hide": "dontHide",
          "skipUrlSync": false
        }
      },
      {
        "kind": "CustomVariable",
        "spec": {
          "name": "custom_var",
          "label": "Custom Options",
          "description": "Custom multi-value variable",
          "query": "prod : Production, staging : Staging, dev : Development",
          "current": {
            "text": ["Production"],
            "value": ["prod"]
          },
          "options": [
            {
              "text": "Production",
              "value": "prod"
            },
            {
              "text": "Staging",
              "value": "staging"
            },
            {
              "text": "Development",
              "value": "dev"
            }
          ],
          "multi": true,
          "includeAll": true,
          "allValue": "*",
          "hide": "dontHide",
          "skipUrlSync": false,
          "allowCustomValue": true
        }
      },
      {
        "kind": "GroupByVariable",
        "spec": {
          "name": "group_by",
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "current": {
            "text": "instance",
            "value": "instance"
          },
          "description": "Group metrics by label",
          "hide": "dontHide",
          "label": "Group By"
        }
      },
      {
        "kind": "AdhocVariable",
        "spec": {
          "name": "filters",
          "datasource": {
            "type": "prometheus",
            "uid": "gdev-prometheus"
          },
          "baseFilters": [
            {
              "key": "job",
              "operator": "=",
              "value": "grafana",
              "condition": "AND"
            }
          ],
          "filters": [],
          "hide": "dontHide",
          "label": "Filters",
          "defaultKeys": [
            {
              "text": "job",
              "value": "job",
              "expandable": true
            },
            {
              "text": "instance",
              "value": "instance",
              "expandable": true
            }
          ]
        }
      }
    ],
    "elements": {
      "panel-1": {
        "kind": "Panel",
        "spec": {
          "id": 1,
          "title": "Panel with Conditional Rendering",
          "description": "This panel demonstrates conditional rendering features",
          "data": {
            "kind": "QueryGroup",
            "spec": {
              "queries": [
                {
                  "kind": "PanelQuery",
                  "spec": {
                    "refId": "A",
                    "datasource": {
                      "uid": "gdev-prometheus"
                    },
                    "query": {
                      "kind": "prometheus",
                      "spec": {
                        "expr": "up{job=\"grafana\"}"
                      }
                    }
                  }
                }
              ],
              "transformations": [
                {
                  "kind": "reduce",
                  "spec": {
                    "id": "reduce",
                    "options": {
                      "mode": "reduceFields",
                      "includeTimeField": false,
                      "reducers": ["mean"]
                    }
                  }
                }
              ]
            }
          },
          "vizConfig": {
            "kind": "stat",
            "spec": {
              "pluginVersion": "12.1.0-pre",
              "options": {
                "colorMode": "value",
                "graphMode": "area",
                "justifyMode": "auto",
                "textMode": "auto"
              },
              "fieldConfig": {
                "defaults": {
                  "color": {
                    "mode": "thresholds"
                  },
                  "thresholds": {
                    "mode": "absolute",
                    "steps": [
                      {
                        "color": "red",
                        "value": 0
                      },
                      {
                        "color": "green",
                        "value": 1
                      }
                    ]
                  },
                  "mappings": [
                    {
                      "type": "value",
                      "options": {
                        "0": {
                          "text": "Down",
                          "color": "red"
                        },
                        "1": {
                          "text": "Up",
                          "color": "green"
                        }
                      }
                    }
                  ]
                },
                "overrides": []
              }
            }
          }
        }
      }
    },
    "layout": {
      "kind": "RowsLayout",
      "spec": {
        "rows": [
          {
            "kind": "Row",
            "spec": {
              "title": "Conditional Row",
              "collapse": false,
              "hideHeader": false,
              "fillScreen": false,
              "conditionalRendering": {
                "kind": "ConditionalRenderingGroup",
                "spec": {
                  "visibility": "show",
                  "condition": "and",
                  "items": [
                    {
                      "kind": "ConditionalRenderingVariable",
                      "spec": {
                        "variable": "group_by",
                        "operator": "includes",
                        "value": "instance"
                      }
                    },
                    {
                      "kind": "ConditionalRenderingData",
                      "spec": {
                        "value": true
                      }
                    },
                    {
                      "kind": "ConditionalRenderingTimeRangeSize",
                      "spec": {
                        "value": "1h"
                      }
                    }
                  ]
                }
              },
              "layout": {
                "kind": "GridLayout",
                "spec": {
                  "items": [
                    {
                      "kind": "GridLayoutItem",
                      "spec": {
                        "x": 0,
                        "y": 0,
                        "width": 24,
                        "height": 8,
                        "element": {
                          "kind": "ElementReference",
                          "name": "panel-1"
                        }
                      }
                    }
                  ]
                }
              }
            }
          }
        ]
      }
    },
    "timeSettings": {
      "timezone": "browser",
      "weekStart": "monday",
      "fiscalYearStartMonth": 0,
      "autoRefresh": "10s",
      "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
      "from": "now-6h",
      "to": "now",
      "hideTimepicker": false
    }
  }
}
```