### PR TITLE
fix: detect circular references in GetDescendants

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -439,8 +439,7 @@ func (ss *FolderUnifiedStoreImpl) GetDescendants(ctx context.Context, orgID int6
 	}
 
 	descendantsMap := map[string]*folder.Folder{}
-	seen := map[string]struct{}{}
-	err = getDescendants(nodes, tree, ancestor_uid, descendantsMap, seen)
+	err = getDescendants(nodes, tree, ancestor_uid, descendantsMap, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -458,12 +457,15 @@ func getDescendants(
 	tree map[string]map[string]*folder.Folder,
 	ancestorUID string,
 	descendantsMap map[string]*folder.Folder,
-	seen map[string]struct{},
+	seen map[string]bool,
 ) error {
-	if _, exists := seen[ancestorUID]; exists {
+	if seen == nil {
+		seen = map[string]bool{}
+	}
+	if seen[ancestorUID] {
 		return folder.ErrCircularReference.Errorf("circular reference detected at folder uid: %s", ancestorUID)
 	}
-	seen[ancestorUID] = struct{}{}
+	seen[ancestorUID] = true
 	for uid := range tree[ancestorUID] {
 		descendantsMap[uid] = nodes[uid]
 		if err := getDescendants(nodes, tree, uid, descendantsMap, seen); err != nil {


### PR DESCRIPTION
```
runtime: goroutine stack exceeds 1000000000-byte limit
runtime: sp=0xc048416340 stack=[0xc048416000, 0xc068416000]
fatal error: stack overflow

runtime stack:
runtime.throw({0x23cc9c6?, 0x1abef96e7899?})
	runtime/panic.go:1094 +0x48 fp=0x7feb52d3f8f0 sp=0x7feb52d3f8c0 pc=0xa79fd88
runtime.newstack()
	runtime/stack.go:1159 +0x5bd fp=0x7feb52d3fa20 sp=0x7feb52d3f8f0 pc=0xa782b5d
runtime.morestack()
	runtime/asm_amd64.s:620 +0x7d fp=0x7feb52d3fa28 sp=0x7feb52d3fa20 pc=0xa7a6f9d

goroutine 51136 gp=0xc00a4fee00 m=18 mp=0xc000e54008 [running]:
runtime.mapaccess1_faststr(0x116d9e0, 0xc068413718, {0xc019e03b30, 0x6})
	internal/runtime/maps/runtime_faststr_swiss.go:103 +0x277 fp=0xc048416350 sp=0xc048416348 pc=0xa72bab7
github.com/grafana/grafana/pkg/services/folder/folderimpl.getDescendants(0xc068413810, 0xc068413718, {0xc019e03b30?, 0x6?}, 0xc068413620)
	github.com/grafana/grafana/pkg/services/folder/folderimpl/unifiedstore.go:451 +0x49 fp=0xc048416470 sp=0xc048416350 pc=0x1096ada9
github.com/grafana/grafana/pkg/services/folder/folderimpl.getDescendants(...)
```