### PR TITLE
Stars: Update star toolbar button to include name only in the label

### DIFF
--- a/public/app/features/stars/StarToolbarButton.tsx
+++ b/public/app/features/stars/StarToolbarButton.tsx
@@ -7,12 +7,10 @@ import { Icon, ToolbarButton } from '@grafana/ui';
 import { useStarItem, useStarredItems } from './hooks';
 
 const getStarTooltips = (title: string) => ({
-  star: t('stars.mark-as-starred', 'Mark "{{title}}" as favorite', {
-    title,
-  }),
-  unstar: t('stars.unmark-as-starred', 'Unmark "{{title}}" as favorite', {
-    title,
-  }),
+  star: t('stars.mark-as-starred', 'Mark as favorite'),
+  starWithTitle: t('stars.mark-as-starred-with-title', 'Mark "{{title}}" as favorite', { title }),
+  unstar: t('stars.unmark-as-starred', 'Unmark as favorite'),
+  unstarWithTitle: t('stars.unmark-as-starred-with-title', 'Unmark "{{title}}" as favorite', { title }),
 });
 
 type Props = {
@@ -51,18 +49,21 @@ export function StarToolbarButton({ title, group, kind, id, onStarChange }: Prop
     return { name: 'star', type: 'default' } as const;
   })();
 
-  const tooltip = (() => {
+  const tooltipAndLabel = (() => {
     if (isLoading) {
-      return undefined;
+      return {};
     }
-    return isStarred ? tooltips.unstar : tooltips.star;
+    return isStarred
+      ? { tooltip: tooltips.unstar, label: tooltips.unstarWithTitle }
+      : { tooltip: tooltips.star, label: tooltips.starWithTitle };
   })();
 
   const icon = <Icon {...iconProps} size="lg" />;
   return (
     <ToolbarButton
       disabled={isLoading}
-      tooltip={tooltip}
+      tooltip={tooltipAndLabel.tooltip}
+      aria-label={tooltipAndLabel.label}
       icon={icon}
       data-testid={selectors.components.NavToolbar.markAsFavorite}
       onClick={handleStarToggle}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12823,8 +12823,10 @@
     "view-explanation": "View explanation"
   },
   "stars": {
-    "mark-as-starred": "Mark \"{{title}}\" as favorite",
-    "unmark-as-starred": "Unmark \"{{title}}\" as favorite"
+    "mark-as-starred": "Mark as favorite",
+    "mark-as-starred-with-title": "Mark \"{{title}}\" as favorite",
+    "unmark-as-starred": "Unmark as favorite",
+    "unmark-as-starred-with-title": "Unmark \"{{title}}\" as favorite"
   },
   "stat": {
     "add-orientation-option": {


### PR DESCRIPTION
**What is this feature?**
Changes the tooltip for marking/unmarking a dashboard as favourite so it doesn't include the title.

**Why do we need this feature?**
Having the title in the tooltip can make it a little unwieldy. However, we should still distinguish the button with the dashboard's name, for accessibility purposes (so we aren't reliant on the surrounding context too much - this was the original intent of the change). 

This is particularly relevant in the DashList panel

**Who is this feature for?**
Dashboard users