### PR TITLE
SaveProvisionedDashboardForm: When comment is edited, enable save button

### DIFF
--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.test.tsx
@@ -413,4 +413,36 @@ describe('SaveProvisionedDashboardForm', () => {
     // Branch field is not shown
     expect(screen.queryByRole('textbox', { name: /branch/i })).not.toBeInTheDocument();
   });
+
+  it('enables save button when only the comment changes', async () => {
+    const { user } = setup({
+      dashboard: {
+        useState: () => ({
+          meta: {
+            folderUid: 'folder-uid',
+            slug: 'test-dashboard',
+            k8s: { name: 'test-dashboard' },
+          },
+          title: 'Test Dashboard',
+          description: 'Test Description',
+          isDirty: false,
+        }),
+        setState: jest.fn(),
+        closeModal: jest.fn(),
+        getSaveAsModel: jest.fn().mockReturnValue({}),
+        setManager: jest.fn(),
+      } as unknown as DashboardScene,
+    });
+
+    const commentInput = screen.getByRole('textbox', { name: /comment/i });
+    const saveButton = screen.getByRole('button', { name: /save/i });
+
+    expect(saveButton).toBeDisabled();
+
+    await user.type(commentInput, 'Comment-only change');
+
+    await waitFor(() => {
+      expect(saveButton).toBeEnabled();
+    });
+  });
 });

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -55,7 +55,16 @@ export function SaveProvisionedDashboardForm({
   const [createOrUpdateFile, request] = useCreateOrUpdateRepositoryFile(isNew ? undefined : defaultValues.path);
 
   const methods = useForm<ProvisionedDashboardFormData>({ defaultValues });
-  const { handleSubmit, watch, control, reset, register } = methods;
+  const {
+    handleSubmit,
+    watch,
+    control,
+    reset,
+    register,
+    formState: { dirtyFields },
+  } = methods;
+  // button enabled if form comment is dirty or dashboard state is dirty
+  const isDirtyState = Boolean(dirtyFields.comment) || isDirty;
   const [workflow, ref, path] = watch(['workflow', 'ref', 'path']);
 
   // Update the form if default values change
@@ -282,7 +291,7 @@ export function SaveProvisionedDashboardForm({
             <Button variant="secondary" onClick={drawer.onClose} fill="outline">
               <Trans i18nKey="dashboard-scene.save-provisioned-dashboard-form.cancel">Cancel</Trans>
             </Button>
-            <Button variant="primary" type="submit" disabled={request.isLoading || !isDirty || readOnly}>
+            <Button variant="primary" type="submit" disabled={request.isLoading || readOnly || !isDirtyState}>
               {request.isLoading
                 ? t('dashboard-scene.save-provisioned-dashboard-form.saving', 'Saving...')
                 : t('dashboard-scene.save-provisioned-dashboard-form.save', 'Save')}


### PR DESCRIPTION
**What is this feature?**

`SaveProvisionedDashboardForm`: Enable save button when comment is edit

**Why do we need this feature?**

Allow user push dashboard changes when comment is edited. 

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/648

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
