### PR TITLE
FilesView: .keep file should not be clickable and no actions available

### DIFF
--- a/public/app/features/provisioning/File/FilesView.test.tsx
+++ b/public/app/features/provisioning/File/FilesView.test.tsx
@@ -146,4 +146,21 @@ describe('FilesView', () => {
     expect(screen.getByRole('link', { name: 'View' })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: 'History' })).not.toBeInTheDocument();
   });
+
+  it('renders plain text and hides actions for .keep files', () => {
+    mockRepositoryFilesQuery({
+      isSuccess: true,
+      status: 'fulfilled',
+      data: {
+        items: [{ path: 'dashboards/.keep', hash: 'abc', size: '0' }],
+      },
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('dashboards/.keep')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'dashboards/.keep' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'View' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'History' })).not.toBeInTheDocument();
+  });
 });

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -31,6 +31,10 @@ export function FilesView({ repo }: FilesViewProps) {
       sortType: 'string',
       cell: ({ row: { original } }: FileCell<'path'>) => {
         const { path } = original;
+        const isDotKeepFile = isGenerateDotKeepFile(path);
+        if (isDotKeepFile) {
+          return path;
+        }
         return <a href={`${PROVISIONING_URL}/${name}/file/${path}`}>{path}</a>;
       },
     },
@@ -44,6 +48,10 @@ export function FilesView({ repo }: FilesViewProps) {
       header: '',
       cell: ({ row: { original } }: FileCell<'path'>) => {
         const { path } = original;
+        const isDotKeepFile = isGenerateDotKeepFile(path);
+        if (isDotKeepFile) {
+          return null;
+        }
         return (
           <Stack>
             {(path.endsWith('.json') || path.endsWith('.yaml') || path.endsWith('.yml')) && (
@@ -83,4 +91,9 @@ export function FilesView({ repo }: FilesViewProps) {
       <InteractiveTable columns={columns} data={data} pageSize={25} getRowId={(f: FileDetails) => String(f.path)} />
     </Stack>
   );
+}
+
+function isGenerateDotKeepFile(path: string): boolean {
+  // e.g. 'dashboards/.keep' → true, 'dashboards/example.keep.json' → false
+  return path.split('/').pop() === '.keep';
 }

--- a/public/app/features/provisioning/File/FilesView.tsx
+++ b/public/app/features/provisioning/File/FilesView.tsx
@@ -31,7 +31,7 @@ export function FilesView({ repo }: FilesViewProps) {
       sortType: 'string',
       cell: ({ row: { original } }: FileCell<'path'>) => {
         const { path } = original;
-        const isDotKeepFile = isGenerateDotKeepFile(path);
+        const isDotKeepFile = getIsDotKeepFile(path);
         if (isDotKeepFile) {
           return path;
         }
@@ -48,7 +48,7 @@ export function FilesView({ repo }: FilesViewProps) {
       header: '',
       cell: ({ row: { original } }: FileCell<'path'>) => {
         const { path } = original;
-        const isDotKeepFile = isGenerateDotKeepFile(path);
+        const isDotKeepFile = getIsDotKeepFile(path);
         if (isDotKeepFile) {
           return null;
         }
@@ -93,7 +93,7 @@ export function FilesView({ repo }: FilesViewProps) {
   );
 }
 
-function isGenerateDotKeepFile(path: string): boolean {
+function getIsDotKeepFile(path: string): boolean {
   // e.g. 'dashboards/.keep' → true, 'dashboards/example.keep.json' → false
   return path.split('/').pop() === '.keep';
 }


### PR DESCRIPTION
**What is this feature?**

`FilesView`: `.keep` file row should not be clickable, and no action buttons should be available. 
<img width="1027" height="642" alt="image" src="https://github.com/user-attachments/assets/5767ab5d-554e-450c-9278-43809c73d4b6" />


**Why do we need this feature?**

Prevent error

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/653

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
