### PR TITLE
Secrets: Fix MariaDB syntax error due to unsupported CTE syntax (#111610)

### DIFF
--- a/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
@@ -1,20 +1,19 @@
-WITH to_update AS (
+UPDATE
+  {{ .Ident "secret_secure_value" }}
+SET
+  {{ .Ident "lease_token" }} = {{ .Arg .LeaseToken }},
+  {{ .Ident "lease_created" }} = {{ .Arg .Now }}
+WHERE guid IN (
   SELECT guid FROM (
-    SELECT 
+    SELECT
       guid,
       ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
-    FROM {{ .Ident "secret_secure_value" }} 
-    WHERE 
+    FROM {{ .Ident "secret_secure_value" }}
+    WHERE
       {{ .Ident "active" }} = FALSE AND
       {{ .Arg .Now }} - {{ .Ident "created" }} > {{ .Arg .MinAge }} AND
       {{ .Arg .Now }} - {{ .Ident "lease_created" }} > {{ .Arg .LeaseTTL }}
   ) AS sub
   WHERE rn <= {{ .Arg .MaxBatchSize }}
 )
-UPDATE
-  {{ .Ident "secret_secure_value" }}
-SET
-  {{ .Ident "lease_token" }} = {{ .Arg .LeaseToken }},
-  {{ .Ident "lease_created" }} = {{ .Arg .Now }}
-WHERE guid IN (SELECT guid FROM to_update)
 ;

--- a/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
+++ b/pkg/storage/secret/metadata/data/secure_value_lease_inactive.sql
@@ -3,11 +3,11 @@ UPDATE
 SET
   {{ .Ident "lease_token" }} = {{ .Arg .LeaseToken }},
   {{ .Ident "lease_created" }} = {{ .Arg .Now }}
-WHERE guid IN (
-  SELECT guid FROM (
+WHERE {{ .Ident "guid" }} IN (
+  SELECT {{ .Ident "guid" }} FROM (
     SELECT
-      guid,
-      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+      {{ .Ident "guid" }},
+      ROW_NUMBER() OVER (ORDER BY {{ .Ident "created" }} ASC) AS rn
     FROM {{ .Ident "secret_secure_value" }}
     WHERE
       {{ .Ident "active" }} = FALSE AND

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
@@ -3,16 +3,16 @@ UPDATE
 SET
   `lease_token` = 'token',
   `lease_created` = 10
-WHERE guid IN (
-  SELECT guid FROM (
+WHERE `guid` IN (
+  SELECT `guid` FROM (
     SELECT
-     guid,
-     ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+      `guid`,
+      ROW_NUMBER() OVER (ORDER BY `created` ASC) AS rn
     FROM `secret_secure_value`
     WHERE
-     `active` = FALSE AND
-     10 - `created` > 300 AND
-     10 - `lease_created` > 30
+      `active` = FALSE AND
+      10 - `created` > 300 AND
+      10 - `lease_created` > 30
   ) AS sub
   WHERE rn <= 10
 )

--- a/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/mysql--secure_value_lease_inactive-lease inactive.sql
@@ -1,20 +1,19 @@
-WITH to_update AS (
-  SELECT guid FROM (
-    SELECT 
-      guid,
-      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
-    FROM `secret_secure_value` 
-    WHERE 
-      `active` = FALSE AND
-      10 - `created` > 300 AND
-      10 - `lease_created` > 30
-  ) AS sub
-  WHERE rn <= 10
-)
 UPDATE
   `secret_secure_value`
 SET
   `lease_token` = 'token',
   `lease_created` = 10
-WHERE guid IN (SELECT guid FROM to_update)
+WHERE guid IN (
+  SELECT guid FROM (
+    SELECT
+     guid,
+     ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+    FROM `secret_secure_value`
+    WHERE
+     `active` = FALSE AND
+     10 - `created` > 300 AND
+     10 - `lease_created` > 30
+  ) AS sub
+  WHERE rn <= 10
+)
 ;

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
@@ -3,11 +3,11 @@ UPDATE
 SET
   "lease_token" = 'token',
   "lease_created" = 10
-WHERE guid IN (
-  SELECT guid FROM (
+WHERE "guid" IN (
+  SELECT "guid" FROM (
     SELECT
-      guid,
-      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+      "guid",
+      ROW_NUMBER() OVER (ORDER BY "created" ASC) AS rn
     FROM "secret_secure_value"
     WHERE
       "active" = FALSE AND

--- a/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/postgres--secure_value_lease_inactive-lease inactive.sql
@@ -1,20 +1,19 @@
-WITH to_update AS (
+UPDATE
+  "secret_secure_value"
+SET
+  "lease_token" = 'token',
+  "lease_created" = 10
+WHERE guid IN (
   SELECT guid FROM (
-    SELECT 
+    SELECT
       guid,
       ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
-    FROM "secret_secure_value" 
-    WHERE 
+    FROM "secret_secure_value"
+    WHERE
       "active" = FALSE AND
       10 - "created" > 300 AND
       10 - "lease_created" > 30
   ) AS sub
   WHERE rn <= 10
 )
-UPDATE
-  "secret_secure_value"
-SET
-  "lease_token" = 'token',
-  "lease_created" = 10
-WHERE guid IN (SELECT guid FROM to_update)
 ;

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
@@ -3,11 +3,11 @@ UPDATE
 SET
   "lease_token" = 'token',
   "lease_created" = 10
-WHERE guid IN (
-  SELECT guid FROM (
+WHERE "guid" IN (
+  SELECT "guid" FROM (
     SELECT
-      guid,
-      ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
+      "guid",
+      ROW_NUMBER() OVER (ORDER BY "created" ASC) AS rn
     FROM "secret_secure_value"
     WHERE
       "active" = FALSE AND

--- a/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
+++ b/pkg/storage/secret/metadata/testdata/sqlite--secure_value_lease_inactive-lease inactive.sql
@@ -1,20 +1,19 @@
-WITH to_update AS (
+UPDATE
+  "secret_secure_value"
+SET
+  "lease_token" = 'token',
+  "lease_created" = 10
+WHERE guid IN (
   SELECT guid FROM (
-    SELECT 
+    SELECT
       guid,
       ROW_NUMBER() OVER (ORDER BY created ASC) AS rn
-    FROM "secret_secure_value" 
-    WHERE 
+    FROM "secret_secure_value"
+    WHERE
       "active" = FALSE AND
       10 - "created" > 300 AND
       10 - "lease_created" > 30
   ) AS sub
   WHERE rn <= 10
 )
-UPDATE
-  "secret_secure_value"
-SET
-  "lease_token" = 'token',
-  "lease_created" = 10
-WHERE guid IN (SELECT guid FROM to_update)
 ;


### PR DESCRIPTION
**What is this feature?**

Since Grafana 12.2.0, a SQL syntax error is logged every minute when using MariaDB. It also causes secrets garbage collection not to work. This is caused by the CTE introduced in 6b5cacfa, which (apparently, according to the docs for both) works in MySQL but not in MariaDB.

I realize MariaDB is _not_ a supported database but Grafana has been working flawlessly with MariaDB LTS for me for years, so I figured I'd do my small part to help keep it that way.

**Why do we need this feature?**

To keep Grafana running on a wider number of unsupported platforms (TL;DR you really don't :smiley:)

**Who is this feature for?**

Anyone who is running Grafana with MariaDB.

**Which issue(s) does this PR fix?**:

Fixes #111610.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
