### PR TITLE
Restore Canvas element key simplification to prevent blinking icons

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -1109,7 +1109,7 @@ export class ElementState implements LayerElement {
           style={{ userSelect: 'none' }}
         >
           <item.display
-            key={`${this.UID}/${this.revId}`}
+            key={this.UID}
             config={this.options.config}
             data={this.data}
             isSelected={isSelected}

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -1108,12 +1108,7 @@ export class ElementState implements LayerElement {
           tabIndex={0}
           style={{ userSelect: 'none' }}
         >
-          <item.display
-            key={this.UID}
-            config={this.options.config}
-            data={this.data}
-            isSelected={isSelected}
-          />
+          <item.display key={this.UID} config={this.options.config} data={this.data} isSelected={isSelected} />
         </div>
         {this.showActionConfirmation && this.renderActionsConfirmModal(this.getPrimaryAction())}
         {this.showActionVarsModal && this.renderVariablesInputModal(this.getPrimaryAction())}


### PR DESCRIPTION
**Description:**

This PR restores a fix that was previously merged in #110128 but reverted by #111200.

**Issue**
Canvas elements were experiencing visual blinking when using streaming data sources due to unnecessary re-renders caused by complex key references.

**Solution**
Simplify the item.display component key from a complex template literal (${this.UID}/${this.revId}) to a simple this.UID reference. This prevents unnecessary re-renders and eliminates the blinking icon issue.

**Changes**
Changed key={${this.UID}/${this.revId}} to key={this.UID} in the Canvas element render method

**Related Issues**
Fixes regression introduced in #111200
Restores fix from #110128