### PR TITLE
Alerting: Fix for fetching evaluation group in new filter

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -25,6 +25,11 @@ export function useNamespaceAndGroupOptions(): {
   const [fetchGrafanaGroups] = prometheusApi.useLazyGetGrafanaGroupsQuery();
   const [fetchExternalGroups] = prometheusApi.useLazyGetGroupsQuery();
 
+  const { data: grafanaData, isLoading: isLoadingGrafana } = prometheusApi.useGetGrafanaGroupsQuery({
+    limitAlerts: 0,
+    groupLimit: 1000,
+  });
+
   // Formats a raw namespace string into a user-friendly combobox option.
   const formatNamespaceOption = useCallback((namespaceName: string): ComboboxOption<string> => {
     if (namespaceName.includes('/') && (namespaceName.endsWith('.yml') || namespaceName.endsWith('.yaml'))) {
@@ -89,8 +94,14 @@ export function useNamespaceAndGroupOptions(): {
     [fetchGrafanaGroups, fetchExternalGroups, formatNamespaceOption]
   );
 
-  const allGroupNames: string[] = [];
-  const isLoadingNamespaces = false;
+  // Extract all unique group names from Grafana data
+  const allGroupNames: string[] = grafanaData?.data.groups
+    ? Array.from(new Set(grafanaData.data.groups.map((g: GrafanaPromRuleGroupDTO) => g.name))).sort((a, b) =>
+        collator.compare(a, b)
+      )
+    : [];
+
+  const isLoadingNamespaces = isLoadingGrafana;
   const namespacePlaceholder = t('alerting.rules-filter.filter-options.placeholder-namespace', 'Select namespace');
   const groupPlaceholder = t('grafana.select-group', 'Select group');
 

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -15,6 +15,16 @@ function getExternalRuleDataSources() {
   return getRulesDataSources().filter((ds: DataSourceInstanceSettings) => !!ds?.url);
 }
 
+const THRESHOLD_LIMIT = 500;
+
+function createInfoOption(message: string): ComboboxOption<string> {
+  return {
+    label: message,
+    value: '__GRAFANA_INFO_OPTION__',
+    infoOption: true,
+  };
+}
+
 export function useNamespaceAndGroupOptions(): {
   namespaceOptions: (inputValue: string) => Promise<Array<ComboboxOption<string>>>;
   groupOptions: (inputValue: string) => Promise<Array<ComboboxOption<string>>>;
@@ -49,17 +59,11 @@ export function useNamespaceAndGroupOptions(): {
 
   const namespaceOptions = useCallback(
     async (inputValue: string) => {
-      // Grafana namespaces
-      const grafanaResponse = await fetchGrafanaGroups({ limitAlerts: 0, groupLimit: 1000 }).unwrap();
-      const grafanaFolders: Array<ComboboxOption<string>> = Array.from(
+      // Grafana namespaces - fetch with limit to check threshold
+      const grafanaResponse = await fetchGrafanaGroups({ limitAlerts: 0, groupLimit: THRESHOLD_LIMIT + 1 }).unwrap();
+      const grafanaFolderNames = Array.from(
         new Set(grafanaResponse.data.groups.map((g: GrafanaPromRuleGroupDTO) => g.file || 'default'))
-      )
-        .map((name) => ({
-          label: name,
-          value: name,
-          description: t('alerting.rules-filter.grafana-folder', 'Grafana folder'),
-        }))
-        .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
+      );
 
       // External namespaces
       const namespaceNameSet = new Set<string>();
@@ -67,7 +71,7 @@ export function useNamespaceAndGroupOptions(): {
         fetchExternalGroups({
           ruleSource: { uid: ds.uid },
           excludeAlerts: true,
-          groupLimit: 500,
+          groupLimit: THRESHOLD_LIMIT + 1,
           notificationOptions: { showErrorAlert: false },
         }).unwrap()
       );
@@ -77,6 +81,29 @@ export function useNamespaceAndGroupOptions(): {
           res.value.data.groups.forEach((group: { file?: string }) => namespaceNameSet.add(group.file || 'default'));
         }
       }
+
+      const totalNamespaces = grafanaFolderNames.length + namespaceNameSet.size;
+
+      // If we have more than THRESHOLD_LIMIT unique namespaces, show info message
+      if (totalNamespaces > THRESHOLD_LIMIT) {
+        return [
+          createInfoOption(
+            t(
+              'alerting.rules-filter.namespace-autocomplete-unavailable',
+              'Due to large number of folders, autocomplete is not available'
+            )
+          ),
+        ];
+      }
+
+      const grafanaFolders: Array<ComboboxOption<string>> = grafanaFolderNames
+        .map((name) => ({
+          label: name,
+          value: name,
+          description: t('alerting.rules-filter.grafana-folder', 'Grafana folder'),
+        }))
+        .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
+
       const externalNamespaces = Array.from(namespaceNameSet)
         .map(formatNamespaceOption)
         .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
@@ -90,9 +117,20 @@ export function useNamespaceAndGroupOptions(): {
 
   const groupOptions = useCallback(
     async (inputValue: string) => {
-      // Limit to 500 groups for performance - users with more groups can use the search input with group: syntax
-      const grafanaResponse = await fetchGrafanaGroups({ limitAlerts: 0, groupLimit: 500 }).unwrap();
+      const grafanaResponse = await fetchGrafanaGroups({ limitAlerts: 0, groupLimit: THRESHOLD_LIMIT + 1 }).unwrap();
       const groupNames = Array.from(new Set(grafanaResponse.data.groups.map((g: GrafanaPromRuleGroupDTO) => g.name)));
+
+      // If we have more than THRESHOLD_LIMIT unique groups, show info message
+      if (groupNames.length > THRESHOLD_LIMIT) {
+        return [
+          createInfoOption(
+            t(
+              'alerting.rules-filter.group-autocomplete-unavailable',
+              'Due to large number of groups, autocomplete is not available'
+            )
+          ),
+        ];
+      }
 
       const options: Array<ComboboxOption<string>> = groupNames
         .map((name) => ({ label: name, value: name }))

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -104,31 +104,7 @@ export default function RulesFilter({ viewMode, onViewModeChange }: RulesFilterP
   };
 
   const handleAdvancedFilters: SubmitHandler<AdvancedFilters> = (values) => {
-    // Build search query parts for namespace and group when they contain free-form text
-    const searchParts: string[] = [];
-
-    if (values.namespace) {
-      searchParts.push(`namespace:${values.namespace}`);
-    }
-    if (values.groupName) {
-      searchParts.push(`group:${values.groupName}`);
-    }
-
-    // Apply filters based on whether we have search parts
-    if (searchParts.length > 0) {
-      const newQuery = [searchQuery, ...searchParts].filter(Boolean).join(' ');
-      const parsedFilter = getSearchFilterFromQuery(newQuery);
-
-      // Clear namespace and groupName from form values since they're now in the search query
-      const modifiedValues = { ...values, namespace: null, groupName: null };
-      const combinedFilter = { ...formAdvancedFiltersToRuleFilter(modifiedValues), ...parsedFilter };
-
-      updateFilters(combinedFilter);
-      setSearchQuery(newQuery);
-    } else {
-      updateFilters(formAdvancedFiltersToRuleFilter(values));
-    }
-
+    updateFilters(formAdvancedFiltersToRuleFilter(values));
     trackFilterButtonApplyClick(values, pluginsFilterEnabled);
     setIsPopupOpen(false);
   };

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -248,8 +248,7 @@ const FilterOptions = ({ onSubmit, onClear, pluginsFilterEnabled }: FilterOption
   const defaultValues = searchQueryToDefaultValues(filterState);
 
   // Fetch namespace and group data from all sources (optimized for filter UI)
-  const { namespaceOptions, allGroupNames, isLoadingNamespaces, namespacePlaceholder, groupPlaceholder } =
-    useNamespaceAndGroupOptions();
+  const { namespaceOptions, groupOptions, namespacePlaceholder, groupPlaceholder } = useNamespaceAndGroupOptions();
 
   const { labelOptions } = useLabelOptions();
 
@@ -294,13 +293,11 @@ const FilterOptions = ({ onSubmit, onClear, pluginsFilterEnabled }: FilterOption
             <NamespaceField
               namespaceOptions={namespaceOptions}
               namespacePlaceholder={namespacePlaceholder}
-              isLoadingNamespaces={isLoadingNamespaces}
               portalContainer={portalContainer}
             />
             <GroupField
-              allGroupNames={allGroupNames}
+              groupOptions={groupOptions}
               groupPlaceholder={groupPlaceholder}
-              isLoadingNamespaces={isLoadingNamespaces}
               portalContainer={portalContainer}
             />
             <DataSourceNamesField dataSourceOptions={dataSourceOptions} portalContainer={portalContainer} />
@@ -373,12 +370,10 @@ function LabelsField({
 function NamespaceField({
   namespaceOptions,
   namespacePlaceholder,
-  isLoadingNamespaces,
   portalContainer,
 }: {
   namespaceOptions: (inputValue: string) => Promise<Array<{ label?: string; value: string; description?: string }>>;
   namespacePlaceholder: string;
-  isLoadingNamespaces: boolean;
   portalContainer?: HTMLElement;
 }) {
   const { control } = useFormContext<AdvancedFilters>();
@@ -397,7 +392,6 @@ function NamespaceField({
               options={namespaceOptions}
               onChange={(option) => field.onChange(option?.value || null)}
               value={field.value}
-              loading={isLoadingNamespaces}
               isClearable
               portalContainer={portalContainer}
             />
@@ -409,21 +403,37 @@ function NamespaceField({
 }
 
 function GroupField({
-  allGroupNames,
+  groupOptions,
   groupPlaceholder,
-  isLoadingNamespaces,
   portalContainer,
 }: {
-  allGroupNames: string[];
+  groupOptions: (inputValue: string) => Promise<Array<{ label?: string; value: string }>>;
   groupPlaceholder: string;
-  isLoadingNamespaces: boolean;
   portalContainer?: HTMLElement;
 }) {
   const { control } = useFormContext<AdvancedFilters>();
   return (
     <>
       <Label>
-        <Trans i18nKey="alerting.search.property.evaluation-group">Evaluation group</Trans>
+        <Stack gap={0.5} alignItems="center">
+          <span>
+            <Trans i18nKey="alerting.search.property.evaluation-group">Evaluation group</Trans>
+          </span>
+          <Tooltip
+            content={
+              <Trans i18nKey="alerting.rules-filter.evaluation-group-tooltip">
+                Showing the first 500 evaluation groups. If you have more groups or can&apos;t find yours, use the
+                search input above with group: syntax (e.g., group:cpu-usage).
+              </Trans>
+            }
+          >
+            <Icon
+              name="info-circle"
+              size="sm"
+              title={t('alerting.rules-filter.evaluation-group-tooltip-title', 'Evaluation group filter help')}
+            />
+          </Tooltip>
+        </Stack>
       </Label>
       <Controller
         name="groupName"
@@ -432,10 +442,9 @@ function GroupField({
           return (
             <Combobox<string>
               placeholder={groupPlaceholder}
-              options={allGroupNames.map((name) => ({ label: name, value: name }))}
+              options={groupOptions}
               onChange={(option) => field.onChange(option?.value || null)}
               value={field.value}
-              loading={isLoadingNamespaces}
               isClearable
               portalContainer={portalContainer}
             />

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -474,25 +474,7 @@ function GroupField({
   return (
     <>
       <Label>
-        <Stack gap={0.5} alignItems="center">
-          <span>
-            <Trans i18nKey="alerting.search.property.evaluation-group">Evaluation group</Trans>
-          </span>
-          <Tooltip
-            content={
-              <Trans i18nKey="alerting.rules-filter.evaluation-group-tooltip">
-                Showing the first 500 evaluation groups. If you have more groups or can&apos;t find yours, use the
-                search input above with group: syntax (e.g., group:cpu-usage).
-              </Trans>
-            }
-          >
-            <Icon
-              name="info-circle"
-              size="sm"
-              title={t('alerting.rules-filter.evaluation-group-tooltip-title', 'Evaluation group filter help')}
-            />
-          </Tooltip>
-        </Stack>
+        <Trans i18nKey="alerting.search.property.evaluation-group">Evaluation group</Trans>
       </Label>
       <Controller
         name="groupName"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2623,12 +2623,14 @@
         "placeholder-search-input": "Search by name or enter filter query..."
       },
       "grafana-folder": "Grafana folder",
+      "group-autocomplete-unavailable": "Due to large number of groups, autocomplete is not available",
       "health": "Health",
       "label": {
         "hide": "Hide",
         "show": "Show"
       },
       "manage-alerts": "In these data sources, you can select Manage alerts via Alerting UI to be able to manage these alert rules in the Grafana UI as well as in the data source where they were configured.",
+      "namespace-autocomplete-unavailable": "Due to large number of folders, autocomplete is not available",
       "placeholder-all-data-sources": "All data sources",
       "placeholder-contact-point": "Select contact point",
       "placeholder-data-sources": "Select data sources",


### PR DESCRIPTION
This PR fixes the fetching of Evaluation Group in the new filter on Alert Rule List page.

**Before:**
"No options found"
<img width="601" height="537" alt="image" src="https://github.com/user-attachments/assets/3d040981-3f69-454f-bb43-411c14bb9a77" />

**After:**
<img width="735" height="724" alt="image" src="https://github.com/user-attachments/assets/37e4615d-21ea-44c4-8901-ec9ed6bff37e" />

Recording:

![Kapture 2025-11-13 at 11 06 43](https://github.com/user-attachments/assets/18eb526b-9278-43c7-be98-2d46af010956)
