### PR TITLE
Alerting: Add rule_type filter to the rules endpoint

### DIFF
--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -481,6 +481,16 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 	receiverName := opts.Query.Get("receiver_name")
 	title := opts.Query.Get("search.rule_name")
 
+	var ruleType ngmodels.RuleTypeFilter
+	switch ngmodels.RuleType(opts.Query.Get("rule_type")) {
+	case ngmodels.RuleTypeAlerting:
+		ruleType = ngmodels.RuleTypeFilterAlerting
+	case ngmodels.RuleTypeRecording:
+		ruleType = ngmodels.RuleTypeFilterRecording
+	default:
+		ruleType = ngmodels.RuleTypeFilterAll
+	}
+
 	maxGroups := getInt64WithDefault(opts.Query, "group_limit", -1)
 	nextToken := opts.Query.Get("group_next_token")
 
@@ -498,6 +508,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 			ReceiverName:  receiverName,
 			SearchTitle:   title,
 		},
+		RuleType:      ruleType,
 		Limit:         maxGroups,
 		ContinueToken: nextToken,
 	}

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -43,6 +43,7 @@ type GrafanaPromRulesOptions = Omit<PromRulesOptions, 'ruleSource' | 'namespace'
   health?: RuleHealth[];
   state?: PromAlertingRuleState[];
   title?: string;
+  type?: 'alerting' | 'recording';
 };
 
 export const prometheusApi = alertingApi.injectEndpoints({
@@ -89,6 +90,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
         contactPoint,
         health,
         state,
+        type,
         groupLimit,
         limitAlerts,
         groupNextToken,
@@ -102,6 +104,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           receiver_name: contactPoint,
           health: health,
           state: state,
+          rule_type: type,
           limit_alerts: limitAlerts,
           group_limit: groupLimit?.toFixed(0),
           group_next_token: groupNextToken,

--- a/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
@@ -47,6 +47,7 @@ interface GrafanaPromApiFilter {
   health?: RuleHealth[];
   contactPoint?: string;
   title?: string;
+  type?: 'alerting' | 'recording';
 }
 
 interface GrafanaFetchGroupsOptions extends FetchGroupsOptions {

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
@@ -1,4 +1,5 @@
 import { config } from '@grafana/runtime';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
 
 import { RuleSource } from '../../search/rulesSearchParser';
 import { getFilter } from '../../utils/search';
@@ -21,9 +22,10 @@ describe('hasClientSideFilters', () => {
       config.featureToggles.alertingUIUseBackendFilters = true;
     });
 
-    it('should return false for title search filters (backend-supported)', () => {
+    it('should return false for backend-supported filters (title and type)', () => {
       expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(false);
       expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(false);
+      expect(hasClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(false);
     });
 
     it('should return true for client-side only filters', () => {
@@ -44,9 +46,10 @@ describe('hasClientSideFilters', () => {
       config.featureToggles.alertingUIUseBackendFilters = false;
     });
 
-    it('should return true for title search filters (client-side fallback)', () => {
+    it('should return true for title and type filters (client-side fallback)', () => {
       expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
       expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(true);
     });
 
     it('should return true for client-side only filters', () => {
@@ -67,10 +70,11 @@ describe('hasClientSideFilters', () => {
       config.featureToggles.alertingUIUseBackendFilters = undefined;
     });
 
-    it('should return true for title search filters (backward compatibility)', () => {
+    it('should return true for title and type filters (backward compatibility)', () => {
       // Default behavior should be client-side filtering
       expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
       expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(true);
     });
   });
 });

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
@@ -83,6 +83,7 @@ export function useFilteredRulesIteratorProvider() {
     const useBackendFilters = shouldUseBackendFilters();
 
     const titleSearch = useBackendFilters ? buildTitleSearch(filterState) : undefined;
+    const ruleType = useBackendFilters ? filterState.ruleType : undefined;
 
     const grafanaRulesGenerator: AsyncIterableX<RuleWithOrigin> = from(
       grafanaGroupsGenerator(groupLimit, {
@@ -90,6 +91,7 @@ export function useFilteredRulesIteratorProvider() {
         health: filterState.ruleHealth ? [filterState.ruleHealth] : [],
         state: filterState.ruleState ? [filterState.ruleState] : [],
         title: titleSearch,
+        type: ruleType,
       })
     ).pipe(
       withAbort(abortController.signal),
@@ -158,8 +160,9 @@ export function hasClientSideFilters(filterState: RulesFilter): boolean {
   const useBackendFilters = shouldUseBackendFilters();
 
   return (
-    // When backend filters are disabled, title search needs client-side filtering
-    (!useBackendFilters && (filterState.freeFormWords.length > 0 || Boolean(filterState.ruleName))) ||
+    // When backend filters are disabled, title search and type filter need client-side filtering
+    (!useBackendFilters &&
+      (filterState.freeFormWords.length > 0 || Boolean(filterState.ruleName) || Boolean(filterState.ruleType))) ||
     // Client-side only filters:
     Boolean(filterState.namespace) ||
     filterState.dataSourceNames.length > 0 ||


### PR DESCRIPTION
**What is this feature?**

Adds `rule_type` filter support to the API and the frontend. Example: https://ephemeral15111821113701alexan.grafana-dev.net/alerting/list?search=type:recording. Used only if `alertingUIUseBackendFilters` is enabled.

The `type` parameter is already supported at the database level, so this PR wires it up through the API layer and frontend to enable filtering by rule type (alerting vs recording rules). It also optimizes pagination by requesting only 40 rule groups (instead of 2000) when all active filters are backend-supported.

Part of https://github.com/grafana/alerting-squad/issues/1270

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.