### PR TITLE
Storybook: Ensure panels have unique titles

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -770,11 +770,6 @@
       "count": 1
     }
   },
-  "packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/PanelChrome/PanelContext.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 2

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.story.tsx
@@ -32,8 +32,6 @@ const meta: Meta<typeof PanelChrome> = {
     docs: {
       page: mdx,
     },
-    // TODO fix a11y issue in story and remove this
-    a11y: { test: 'off' },
   },
 };
 
@@ -46,7 +44,7 @@ function getContentStyle(): CSSProperties {
   };
 }
 
-function renderPanel(name: string, overrides?: Partial<PanelChromeProps>) {
+function renderPanel(content: string, overrides?: Partial<PanelChromeProps>) {
   const props: PanelChromeProps = {
     width: PANEL_WIDTH,
     height: PANEL_HEIGHT,
@@ -60,7 +58,7 @@ function renderPanel(name: string, overrides?: Partial<PanelChromeProps>) {
   return (
     <PanelChrome {...props}>
       {(innerWidth: number, innerHeight: number) => {
-        return <div style={{ width: innerWidth, height: innerHeight, ...contentStyle }}>{name}</div>;
+        return <div style={{ width: innerWidth, height: innerHeight, ...contentStyle }}>{content}</div>;
       }}
     </PanelChrome>
   );
@@ -133,70 +131,74 @@ export const Examples = () => {
     <DashboardStoryCanvas>
       <div>
         <Stack gap={2} alignItems="flex-start" wrap="wrap">
-          {renderPanel('Has statusMessage', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'Panel with statusMessage',
             statusMessage: 'Error text',
             statusMessageOnClick: action('ErrorIndicator: onClick fired'),
           })}
-          {renderPanel('No padding, has statusMessage', {
+          {renderPanel('Content', {
             padding: 'none',
-            title: 'Default title',
+            title: 'Panel with statusMessage and no padding',
             statusMessage: 'Error text',
             statusMessageOnClick: action('ErrorIndicator: onClick fired'),
           })}
-          {renderPanel('No title, loadingState is Error, no statusMessage', {
+          {renderPanel('Content', {
             loadingState: LoadingState.Error,
+            title: 'No title, loadingState is Error, no statusMessage',
           })}
-          {renderPanel('loadingState is Streaming', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'loadingState is Streaming',
             loadingState: LoadingState.Streaming,
           })}
 
-          {renderPanel('loadingState is Loading', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'loadingState is Loading',
             loadingState: LoadingState.Loading,
           })}
 
           {renderPanel('Default panel: no non-required props')}
-          {renderPanel('No padding', {
+          {renderPanel('Content', {
             padding: 'none',
+            title: 'No padding',
           })}
-          {renderPanel('Very long title', {
+          {renderPanel('Content', {
             title: 'Very long title that should get ellipsis when there is no more space',
           })}
-          {renderPanel('No title, streaming loadingState', {
+          {renderPanel('Content', {
+            title: 'No title, streaming loadingState',
             loadingState: LoadingState.Streaming,
           })}
-          {renderPanel('Error status, menu', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'Error status, menu',
             menu,
             statusMessage: 'Error text',
             statusMessageOnClick: action('ErrorIndicator: onClick fired'),
           })}
-          {renderPanel('No padding; has statusMessage, menu', {
+          {renderPanel('Content', {
             padding: 'none',
-            title: 'Default title',
+            title: 'No padding; has statusMessage, menu',
             menu,
             statusMessage: 'Error text',
             statusMessageOnClick: action('ErrorIndicator: onClick fired'),
           })}
-          {renderPanel('No title, loadingState is Error, no statusMessage, menu', {
+          {renderPanel('Content', {
+            title: 'No title, loadingState is Error, no statusMessage, menu',
             menu,
             loadingState: LoadingState.Error,
           })}
-          {renderPanel('loadingState is Streaming, menu', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'loadingState is Streaming, menu',
             menu,
             loadingState: LoadingState.Streaming,
           })}
-          {renderPanel('loadingState is Loading, menu', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'loadingState is Loading, menu',
             menu,
             loadingState: LoadingState.Loading,
           })}
-          {renderPanel('No padding, deprecated loading indicator', {
+          {renderPanel('Content', {
             padding: 'none',
-            title: 'Default title',
+            title: 'No padding, deprecated loading indicator',
             leftItems: [
               <PanelChrome.LoadingIndicator
                 loading={loading}
@@ -205,12 +207,12 @@ export const Examples = () => {
               />,
             ],
           })}
-          {renderPanel('Display mode = transparent', {
-            title: 'Default title',
+          {renderPanel('Content', {
+            title: 'Display mode = transparent',
             displayMode: 'transparent',
             menu,
           })}
-          {renderPanel('Actions with button no menu', {
+          {renderPanel('Content', {
             title: 'Actions with button no menu',
             actions: (
               <Button size="sm" variant="secondary" key="A">
@@ -218,8 +220,8 @@ export const Examples = () => {
               </Button>
             ),
           })}
-          {renderPanel('Panel with two actions', {
-            title: 'I have two buttons',
+          {renderPanel('Content', {
+            title: 'Panel with two actions',
             actions: [
               <Button size="sm" variant="secondary" key="A">
                 Breakdown
@@ -227,8 +229,8 @@ export const Examples = () => {
               <Button aria-label="Close" size="sm" variant="secondary" icon="times" key="B" />,
             ],
           })}
-          {renderPanel('With radio button', {
-            title: 'I have a radio button',
+          {renderPanel('Content', {
+            title: 'With radio button',
             actions: [
               <RadioButtonGroup
                 key="radio-button-group"
@@ -241,16 +243,16 @@ export const Examples = () => {
               />,
             ],
           })}
-          {renderCollapsiblePanel('Collapsible panel', {
-            title: 'Default title',
+          {renderCollapsiblePanel('Content', {
+            title: 'Collapsible panel',
             collapsible: true,
           })}
-          {renderPanel('Menu always visible', {
+          {renderPanel('Content', {
             title: 'Menu always visible',
             showMenuAlways: true,
             menu,
           })}
-          {renderPanel('Panel with action link', {
+          {renderPanel('Content', {
             title: 'Panel with action link',
             actions: (
               <TextLink external href="http://www.example.com/some/page">
@@ -258,8 +260,8 @@ export const Examples = () => {
               </TextLink>
             ),
           })}
-          {renderPanel('Action and menu (should be rare)', {
-            title: 'Action and menu',
+          {renderPanel('Content', {
+            title: 'Action and menu (should be rare)',
             menu,
             actions: (
               <Button size="sm" variant="secondary">
@@ -279,7 +281,7 @@ export const ExamplesHoverHeader = () => {
       <div>
         <Stack gap={2} alignItems="flex-start" wrap="wrap">
           {renderPanel('Title items, menu, hover header', {
-            title: 'Default title',
+            title: 'Default title with description',
             description: 'This is a description',
             menu,
             hoverHeader: true,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- ensures every panel in the `PanelChrome` story has a unique title
- reenables a11y tests for `PanelChrome`
- discussion:
  - having sections with the same name is an a11y problem
  - panels with the same title is also confusing for a sighted user
  - we don't enforce uniqueness of panel title in dashboards
  - i'm not sure if the effort/payoff is worth trying to ensure panel title uniqueness... there's all sorts of things we'd have to consider:
    - validation in the editor
    - json validation of imported/hand-edited dashboards
    - how to migrate old dashboards
  - so this PR just fixes the problem in storybook and leaves it up to users to not create confusing dashboards 😄 

**Why do we need this feature?**

- so we can reenable a11y tests for `PanelChrome`

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/109450

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
