### PR TITLE
datasources: ClearAuthHeadersMiddleware: refactor

### DIFF
--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -207,7 +207,7 @@ type AuthHTTPHeaderList struct {
 	Items []string
 }
 
-func GetAuthHTTPHeaders(cfg *setting.Cfg) []string {
+func GetAuthHTTPHeaders(jwtAuth *setting.AuthJWTSettings, authProxy *setting.AuthProxySettings) []string {
 	var items []string
 
 	// used by basic auth, api keys and potentially jwt auth
@@ -217,14 +217,14 @@ func GetAuthHTTPHeaders(cfg *setting.Cfg) []string {
 	items = append(items, "X-Grafana-Device-Id")
 
 	// if jwt is enabled we add it to the list. We can ignore in case it is set to Authorization
-	if cfg.JWTAuth.Enabled && cfg.JWTAuth.HeaderName != "" && cfg.JWTAuth.HeaderName != "Authorization" {
-		items = append(items, cfg.JWTAuth.HeaderName)
+	if jwtAuth.Enabled && jwtAuth.HeaderName != "" && jwtAuth.HeaderName != "Authorization" {
+		items = append(items, jwtAuth.HeaderName)
 	}
 
 	// if auth proxy is enabled add the main proxy header and all configured headers
-	if cfg.AuthProxy.Enabled {
-		items = append(items, cfg.AuthProxy.HeaderName)
-		for _, header := range cfg.AuthProxy.Headers {
+	if authProxy.Enabled {
+		items = append(items, authProxy.HeaderName)
+		for _, header := range authProxy.Headers {
 			if header != "" {
 				items = append(items, header)
 			}
@@ -244,7 +244,7 @@ func WithAuthHTTPHeaders(ctx context.Context, cfg *setting.Cfg) context.Context 
 		}
 	}
 
-	for _, item := range GetAuthHTTPHeaders(cfg) {
+	for _, item := range GetAuthHTTPHeaders(&cfg.JWTAuth, &cfg.AuthProxy) {
 		list.Items = append(list.Items, item)
 	}
 

--- a/pkg/services/contexthandler/contexthandler.go
+++ b/pkg/services/contexthandler/contexthandler.go
@@ -244,9 +244,7 @@ func WithAuthHTTPHeaders(ctx context.Context, cfg *setting.Cfg) context.Context 
 		}
 	}
 
-	for _, item := range GetAuthHTTPHeaders(&cfg.JWTAuth, &cfg.AuthProxy) {
-		list.Items = append(list.Items, item)
-	}
+	list.Items = append(list.Items, GetAuthHTTPHeaders(&cfg.JWTAuth, &cfg.AuthProxy)...)
 
 	return context.WithValue(ctx, authHTTPHeaderListKey, list)
 }

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go
@@ -12,18 +12,20 @@ import (
 // NewClearAuthHeadersMiddleware creates a new backend.HandlerMiddleware
 // that will clear any outgoing HTTP headers that was part of the incoming
 // HTTP request and used when authenticating to Grafana.
-func NewClearAuthHeadersMiddleware(cfg *setting.Cfg) backend.HandlerMiddleware {
+func NewClearAuthHeadersMiddleware(cfgJWTAuth *setting.AuthJWTSettings, cfgAuthProxy *setting.AuthProxySettings) backend.HandlerMiddleware {
 	return backend.HandlerMiddlewareFunc(func(next backend.Handler) backend.Handler {
 		return &ClearAuthHeadersMiddleware{
-			BaseHandler: backend.NewBaseHandler(next),
-			cfg:         cfg,
+			BaseHandler:  backend.NewBaseHandler(next),
+			cfgJWTAuth:   cfgJWTAuth,
+			cfgAuthProxy: cfgAuthProxy,
 		}
 	})
 }
 
 type ClearAuthHeadersMiddleware struct {
 	backend.BaseHandler
-	cfg *setting.Cfg
+	cfgJWTAuth   *setting.AuthJWTSettings
+	cfgAuthProxy *setting.AuthProxySettings
 }
 
 func (m *ClearAuthHeadersMiddleware) clearHeaders(ctx context.Context, h backend.ForwardHTTPHeaders) {
@@ -33,7 +35,7 @@ func (m *ClearAuthHeadersMiddleware) clearHeaders(ctx context.Context, h backend
 		return
 	}
 
-	items := contexthandler.GetAuthHTTPHeaders(m.cfg)
+	items := contexthandler.GetAuthHTTPHeaders(m.cfgJWTAuth, m.cfgAuthProxy)
 	for _, k := range items {
 		h.DeleteHTTPHeader(k)
 	}

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
@@ -19,9 +19,10 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("When requests are for a datasource", func(t *testing.T) {
+		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(setting.NewCfg())),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
 		)
 
 		pluginCtx := backend.PluginContext{
@@ -126,9 +127,10 @@ func TestClearAuthHeadersMiddleware(t *testing.T) {
 	})
 
 	t.Run("When requests are for an app", func(t *testing.T) {
+		cfg := setting.NewCfg()
 		cdt := handlertest.NewHandlerMiddlewareTest(t,
 			WithReqContext(req, &user.SignedInUser{}),
-			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(setting.NewCfg())),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy)),
 		)
 
 		req.Header.Set("Authorization", "val")

--- a/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/handlertest"
-	"github.com/grafana/grafana/pkg/services/contexthandler"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -16,397 +15,225 @@ import (
 func TestClearAuthHeadersMiddleware(t *testing.T) {
 	const otherHeader = "test"
 
-	t.Run("When no auth headers in reqContext", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
-		require.NoError(t, err)
+	req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
+	require.NoError(t, err)
 
-		req.Header.Set(otherHeader, "test")
+	t.Run("When requests are for a datasource", func(t *testing.T) {
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(setting.NewCfg())),
+		)
 
-		t.Run("And requests are for a datasource", func(t *testing.T) {
-			cdt := handlertest.NewHandlerMiddlewareTest(t,
-				WithReqContext(req, &user.SignedInUser{}),
-				handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
-			)
+		pluginCtx := backend.PluginContext{
+			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+		}
 
-			pluginCtx := backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
-			}
-
-			t.Run("No auth headers to clear when calling QueryData", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.QueryDataReq)
-				require.Len(t, cdt.QueryDataReq.Headers, 1)
-				require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling QueryData", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
-
-			t.Run("No auth headers to clear when calling CallResource", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string][]string{otherHeader: {"test"}},
-				}, nopCallResourceSender)
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CallResourceReq)
-				require.Len(t, cdt.CallResourceReq.Headers, 1)
-				require.Equal(t, http.Header{http.CanonicalHeaderKey(otherHeader): {"test"}}, cdt.CallResourceReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling CheckHealth", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CheckHealthReq)
-				require.Len(t, cdt.CheckHealthReq.Headers, 1)
-				require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling SubscribeStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.SubscribeStreamReq)
-				require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
-				require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling PublishStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.PublishStreamReq)
-				require.Len(t, cdt.PublishStreamReq.Headers, 1)
-				require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling RunStream", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				}, &backend.StreamSender{})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.RunStreamReq)
-				require.Len(t, cdt.RunStreamReq.Headers, 1)
-				require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
-			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.QueryDataReq)
+			require.Len(t, cdt.QueryDataReq.Headers, 1)
+			require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+			require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
 		})
 
-		t.Run("And requests are for an app", func(t *testing.T) {
-			cdt := handlertest.NewHandlerMiddlewareTest(t,
-				WithReqContext(req, &user.SignedInUser{}),
-				handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
-			)
+		t.Run("Should clear auth headers when calling CallResource", func(t *testing.T) {
+			err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string][]string{
+					otherHeader:           {"test"},
+					"Authorization":       {"secret"},
+					"X-Grafana-Device-Id": {"secret"},
+				},
+			}, nopCallResourceSender)
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CallResourceReq)
+			require.Len(t, cdt.CallResourceReq.Headers, 1)
+			require.Equal(t, []string{"test"}, cdt.CallResourceReq.Headers[otherHeader])
+			require.Equal(t, "test", cdt.CallResourceReq.GetHTTPHeader(otherHeader))
+		})
 
-			pluginCtx := backend.PluginContext{
-				AppInstanceSettings: &backend.AppInstanceSettings{},
-			}
-
-			t.Run("No auth headers to clear when calling QueryData", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.QueryDataReq)
-				require.Len(t, cdt.QueryDataReq.Headers, 1)
-				require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
-				require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling CheckHealth", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CheckHealthReq)
+			require.Len(t, cdt.CheckHealthReq.Headers, 1)
+			require.Equal(t, "test", cdt.CheckHealthReq.Headers[otherHeader])
+			require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
+		})
 
-			t.Run("No auth headers to clear when calling CallResource", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string][]string{otherHeader: {"test"}},
-				}, nopCallResourceSender)
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CallResourceReq)
-				require.Len(t, cdt.CallResourceReq.Headers, 1)
-				require.Equal(t, []string{"test"}, cdt.CallResourceReq.Headers[otherHeader])
-				require.Equal(t, http.Header{http.CanonicalHeaderKey(otherHeader): {"test"}}, cdt.CallResourceReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling SubscribeStream", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.SubscribeStreamReq)
+			require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.SubscribeStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
+		})
 
-			t.Run("No auth headers to clear when calling CheckHealth", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CheckHealthReq)
-				require.Len(t, cdt.CheckHealthReq.Headers, 1)
-				require.Equal(t, "test", cdt.CheckHealthReq.Headers[otherHeader])
-				require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling PublishStream", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.PublishStreamReq)
+			require.Len(t, cdt.PublishStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.PublishStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
+		})
 
-			t.Run("No auth headers to clear when calling SubscribeStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.SubscribeStreamReq)
-				require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.SubscribeStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling PublishStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.PublishStreamReq)
-				require.Len(t, cdt.PublishStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.PublishStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("No auth headers to clear when calling RunStream", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
-					PluginContext: pluginCtx,
-					Headers:       map[string]string{otherHeader: "test"},
-				}, &backend.StreamSender{})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.RunStreamReq)
-				require.Len(t, cdt.RunStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
-			})
+		t.Run("Should clear auth headers when calling RunStream", func(t *testing.T) {
+			err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
+			}, &backend.StreamSender{})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.RunStreamReq)
+			require.Len(t, cdt.RunStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
 		})
 	})
 
-	t.Run("When auth headers in reqContext", func(t *testing.T) {
-		req, err := http.NewRequest(http.MethodGet, "/some/thing", nil)
-		require.NoError(t, err)
+	t.Run("When requests are for an app", func(t *testing.T) {
+		cdt := handlertest.NewHandlerMiddlewareTest(t,
+			WithReqContext(req, &user.SignedInUser{}),
+			handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware(setting.NewCfg())),
+		)
 
-		t.Run("And requests are for a datasource", func(t *testing.T) {
-			cdt := handlertest.NewHandlerMiddlewareTest(t,
-				WithReqContext(req, &user.SignedInUser{}),
-				handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
-			)
+		req.Header.Set("Authorization", "val")
 
-			req := req.WithContext(contexthandler.WithAuthHTTPHeaders(req.Context(), setting.NewCfg()))
+		const otherHeader = "x-Other"
+		req.Header.Set(otherHeader, "test")
 
-			pluginCtx := backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
-			}
+		pluginCtx := backend.PluginContext{
+			AppInstanceSettings: &backend.AppInstanceSettings{},
+		}
 
-			t.Run("Should clear auth headers when calling QueryData", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.QueryDataReq)
-				require.Len(t, cdt.QueryDataReq.Headers, 1)
-				require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
-				require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling QueryData", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
-
-			t.Run("Should clear auth headers when calling CallResource", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string][]string{
-						otherHeader:           {"test"},
-						"Authorization":       {"secret"},
-						"X-Grafana-Device-Id": {"secret"},
-					},
-				}, nopCallResourceSender)
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CallResourceReq)
-				require.Len(t, cdt.CallResourceReq.Headers, 1)
-				require.Equal(t, []string{"test"}, cdt.CallResourceReq.Headers[otherHeader])
-				require.Equal(t, "test", cdt.CallResourceReq.GetHTTPHeader(otherHeader))
-			})
-
-			t.Run("Should clear auth headers when calling CheckHealth", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CheckHealthReq)
-				require.Len(t, cdt.CheckHealthReq.Headers, 1)
-				require.Equal(t, "test", cdt.CheckHealthReq.Headers[otherHeader])
-				require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
-			})
-
-			t.Run("Should clear auth headers when calling SubscribeStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.SubscribeStreamReq)
-				require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.SubscribeStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("Should clear auth headers when calling PublishStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.PublishStreamReq)
-				require.Len(t, cdt.PublishStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.PublishStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("Should clear auth headers when calling RunStream", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				}, &backend.StreamSender{})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.RunStreamReq)
-				require.Len(t, cdt.RunStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
-			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.QueryDataReq)
+			require.Len(t, cdt.QueryDataReq.Headers, 1)
+			require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
+			require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
 		})
 
-		t.Run("And requests are for an app", func(t *testing.T) {
-			cdt := handlertest.NewHandlerMiddlewareTest(t,
-				WithReqContext(req, &user.SignedInUser{}),
-				handlertest.WithMiddlewares(NewClearAuthHeadersMiddleware()),
-			)
+		t.Run("Should clear auth headers when calling CallResource", func(t *testing.T) {
+			err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string][]string{
+					otherHeader:           {"test"},
+					"Authorization":       {"secret"},
+					"X-Grafana-Device-Id": {"secret"},
+				},
+			}, nopCallResourceSender)
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CallResourceReq)
+			require.Len(t, cdt.CallResourceReq.Headers, 1)
+			require.Equal(t, []string{"test"}, cdt.CallResourceReq.Headers[otherHeader])
+			require.Equal(t, "test", cdt.CallResourceReq.GetHTTPHeader(otherHeader))
+		})
 
-			req := req.WithContext(contexthandler.WithAuthHTTPHeaders(req.Context(), setting.NewCfg()))
-			req.Header.Set("Authorization", "val")
-
-			const otherHeader = "x-Other"
-			req.Header.Set(otherHeader, "test")
-
-			pluginCtx := backend.PluginContext{
-				AppInstanceSettings: &backend.AppInstanceSettings{},
-			}
-
-			t.Run("Should clear auth headers when calling QueryData", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.QueryData(req.Context(), &backend.QueryDataRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.QueryDataReq)
-				require.Len(t, cdt.QueryDataReq.Headers, 1)
-				require.Equal(t, "test", cdt.QueryDataReq.Headers[otherHeader])
-				require.Empty(t, cdt.QueryDataReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling CheckHealth", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.CheckHealthReq)
+			require.Len(t, cdt.CheckHealthReq.Headers, 1)
+			require.Equal(t, "test", cdt.CheckHealthReq.Headers[otherHeader])
+			require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
+		})
 
-			t.Run("Should clear auth headers when calling CallResource", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.CallResource(req.Context(), &backend.CallResourceRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string][]string{
-						otherHeader:           {"test"},
-						"Authorization":       {"secret"},
-						"X-Grafana-Device-Id": {"secret"},
-					},
-				}, nopCallResourceSender)
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CallResourceReq)
-				require.Len(t, cdt.CallResourceReq.Headers, 1)
-				require.Equal(t, []string{"test"}, cdt.CallResourceReq.Headers[otherHeader])
-				require.Equal(t, "test", cdt.CallResourceReq.GetHTTPHeader(otherHeader))
+		t.Run("Should clear auth headers when calling SubscribeStream", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.SubscribeStreamReq)
+			require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.SubscribeStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
+		})
 
-			t.Run("Should clear auth headers when calling CheckHealth", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.CheckHealth(req.Context(), &backend.CheckHealthRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.CheckHealthReq)
-				require.Len(t, cdt.CheckHealthReq.Headers, 1)
-				require.Equal(t, "test", cdt.CheckHealthReq.Headers[otherHeader])
-				require.Empty(t, cdt.CheckHealthReq.GetHTTPHeaders())
+		t.Run("Should clear auth headers when calling PublishStream", func(t *testing.T) {
+			_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
 			})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.PublishStreamReq)
+			require.Len(t, cdt.PublishStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.PublishStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
+		})
 
-			t.Run("Should clear auth headers when calling SubscribeStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.SubscribeStream(req.Context(), &backend.SubscribeStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.SubscribeStreamReq)
-				require.Len(t, cdt.SubscribeStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.SubscribeStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.SubscribeStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("Should clear auth headers when calling PublishStream", func(t *testing.T) {
-				_, err = cdt.MiddlewareHandler.PublishStream(req.Context(), &backend.PublishStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.PublishStreamReq)
-				require.Len(t, cdt.PublishStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.PublishStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.PublishStreamReq.GetHTTPHeaders())
-			})
-
-			t.Run("Should clear auth headers when calling RunStream", func(t *testing.T) {
-				err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
-					PluginContext: pluginCtx,
-					Headers: map[string]string{
-						otherHeader:           "test",
-						"Authorization":       "secret",
-						"X-Grafana-Device-Id": "secret",
-					},
-				}, &backend.StreamSender{})
-				require.NoError(t, err)
-				require.NotNil(t, cdt.RunStreamReq)
-				require.Len(t, cdt.RunStreamReq.Headers, 1)
-				require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
-				require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
-			})
+		t.Run("Should clear auth headers when calling RunStream", func(t *testing.T) {
+			err = cdt.MiddlewareHandler.RunStream(req.Context(), &backend.RunStreamRequest{
+				PluginContext: pluginCtx,
+				Headers: map[string]string{
+					otherHeader:           "test",
+					"Authorization":       "secret",
+					"X-Grafana-Device-Id": "secret",
+				},
+			}, &backend.StreamSender{})
+			require.NoError(t, err)
+			require.NotNil(t, cdt.RunStreamReq)
+			require.Len(t, cdt.RunStreamReq.Headers, 1)
+			require.Equal(t, "test", cdt.RunStreamReq.Headers[otherHeader])
+			require.Empty(t, cdt.RunStreamReq.GetHTTPHeaders())
 		})
 	})
 }

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -200,7 +200,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 
 	middlewares = append(middlewares,
 		clientmiddleware.NewTracingHeaderMiddleware(),
-		clientmiddleware.NewClearAuthHeadersMiddleware(),
+		clientmiddleware.NewClearAuthHeadersMiddleware(cfg),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
 		clientmiddleware.NewCachingMiddleware(cachingServiceClient),

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -200,7 +200,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 
 	middlewares = append(middlewares,
 		clientmiddleware.NewTracingHeaderMiddleware(),
-		clientmiddleware.NewClearAuthHeadersMiddleware(cfg),
+		clientmiddleware.NewClearAuthHeadersMiddleware(&cfg.JWTAuth, &cfg.AuthProxy),
 		clientmiddleware.NewOAuthTokenMiddleware(oAuthTokenService),
 		clientmiddleware.NewCookiesMiddleware(skipCookiesNames),
 		clientmiddleware.NewCachingMiddleware(cachingServiceClient),


### PR DESCRIPTION
The [clear auth headers middleware](https://github.com/grafana/grafana/blob/main/pkg/services/pluginsintegration/clientmiddleware/clear_auth_headers_middleware.go) is built in an unusual way.

it's job is to delete auth-related headers.

when it is invoked, first it needs to know which headers should it delete. usually, the middleware would consult the config (`setting.Cfg`), but here it is done in an indirect way:

- somewhere, before the middleware was invoked, something calls [WithAuthHTTPHeaders](https://github.com/grafana/grafana/blob/4ae1774e1f14ea6185a9e9a7149f0547a3995dda/pkg/services/contexthandler/contexthandler.go#L212C6-L212C25). this checks the `setting.Cfg`, calculates the list of headers, and stores the list of in the context
- then, when the middleware is invoked, it simply pulls out the list from the context

i do not know why it was done this way, one reason might be that there are other consumers of that list too, not just the middleware. it is also used by [reverse_proxy.go](https://github.com/grafana/grafana/blob/main/pkg/util/proxyutil/reverse_proxy.go), it is also using this list to delete headers.

this pull request tries to make the middleware more regular. it is made of two commits:

1. first commit extract the logic that calculates the header-names based on `setting.Cfg` into it's own function
2. the second commit makes the middleware call the function directly, this way it does not need to rely on reading things from the context.

this should be functionally equal to the old behavior, with one exception:
- technically, in the old approach, it was possible to have a situation where nobody calls `WithAuthHTTPHeaders`, so nothing is put in the context, so the middleware does not delete anything.
- in the new approach, this cannot happen, we always calculate the headers

i think this change is acceptable (also, my guess is that this scenario never happens in the current codebase, but i cannot be sure). also, for this reason we need to delete a couple unit-test, because they test for a scenario that now cannot happen.

WDYT?