### PR TITLE
Transforms: Extract Fields: Remove Deduplication feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -363,10 +363,6 @@ export interface FeatureToggles {
   */
   annotationPermissionUpdate?: boolean;
   /**
-  * Make sure extracted field names are unique in the dataframe
-  */
-  extractFieldsNameDeduplication?: boolean;
-  /**
   * Enables dashboard rendering using Scenes for viewer roles
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -605,13 +605,6 @@ var (
 			Owner:           identityAccessTeam,
 		},
 		{
-			Name:         "extractFieldsNameDeduplication",
-			Description:  "Make sure extracted field names are unique in the dataframe",
-			Stage:        FeatureStageExperimental,
-			FrontendOnly: true,
-			Owner:        grafanaDataProSquad,
-		},
-		{
 			Name:         "dashboardSceneForViewers",
 			Description:  "Enables dashboard rendering using Scenes for viewer roles",
 			Stage:        FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -80,7 +80,6 @@ alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,fal
 alertingProvenanceLockWrites,experimental,@grafana/alerting-squad,false,false,false
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
-extractFieldsNameDeduplication,experimental,@grafana/datapro,false,false,true
 dashboardSceneForViewers,GA,@grafana/dashboards-squad,false,false,true
 dashboardSceneSolo,GA,@grafana/dashboards-squad,false,false,true
 dashboardScene,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -331,10 +331,6 @@ const (
 	// Change the way annotation permissions work by scoping them to folders and dashboards.
 	FlagAnnotationPermissionUpdate = "annotationPermissionUpdate"
 
-	// FlagExtractFieldsNameDeduplication
-	// Make sure extracted field names are unique in the dataframe
-	FlagExtractFieldsNameDeduplication = "extractFieldsNameDeduplication"
-
 	// FlagDashboardSceneForViewers
 	// Enables dashboard rendering using Scenes for viewer roles
 	FlagDashboardSceneForViewers = "dashboardSceneForViewers"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1622,6 +1622,7 @@
         "name": "extractFieldsNameDeduplication",
         "resourceVersion": "1762442825881",
         "creationTimestamp": "2023-11-02T15:47:42Z",
+        "deletionTimestamp": "2025-11-11T16:00:57Z",
         "annotations": {
           "grafana.app/updatedTimestamp": "2025-11-06 15:27:05.88172 +0000 UTC"
         }

--- a/public/app/features/transformers/extractFields/extractFields.ts
+++ b/public/app/features/transformers/extractFields/extractFields.ts
@@ -10,7 +10,6 @@ import {
   getUniqueFieldName,
   SynchronousDataTransformerInfo,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { findField } from 'app/features/dimensions/utils';
 
 import { fieldExtractors } from './fieldExtractors';
@@ -109,9 +108,7 @@ export function addExtractedFields(frame: DataFrame, options: ExtractFieldsOptio
       type: buffer ? getFieldTypeFromValue(buffer.find((v) => v != null)) : FieldType.other,
       config: {},
     };
-    if (config.featureToggles.extractFieldsNameDeduplication) {
-      field.name = getUniqueFieldName(field, frame);
-    }
+    field.name = getUniqueFieldName(field, frame);
     return field;
   });
 

--- a/public/app/features/transformers/extractFields/fieldExtractor.test.ts
+++ b/public/app/features/transformers/extractFields/fieldExtractor.test.ts
@@ -1,5 +1,4 @@
 import { FieldType, toDataFrame } from '@grafana/data';
-import { config } from '@grafana/runtime';
 
 import { addExtractedFields } from './extractFields';
 import { fieldExtractors } from './fieldExtractors';
@@ -120,9 +119,7 @@ describe('Extract fields from text', () => {
     const frame = toDataFrame({
       fields: [{ name: 'foo', type: FieldType.string, values: ['{"foo":"extracedValue1"}'] }],
     });
-    config.featureToggles.extractFieldsNameDeduplication = true;
     const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'foo' });
-    config.featureToggles.extractFieldsNameDeduplication = false;
     expect(newFrame.fields.length).toBe(2);
     expect(newFrame.fields[1].name).toBe('foo 1');
   });
@@ -131,9 +128,7 @@ describe('Extract fields from text', () => {
     const frame = toDataFrame({
       fields: [{ name: 'foo', type: FieldType.string, values: ['{"bar":"extracedValue1"}'] }],
     });
-    config.featureToggles.extractFieldsNameDeduplication = true;
     const newFrame = addExtractedFields(frame, { format: FieldExtractorID.JSON, source: 'foo' });
-    config.featureToggles.extractFieldsNameDeduplication = false;
     expect(newFrame.fields.length).toBe(2);
     expect(newFrame.fields[1].name).toBe('bar');
   });


### PR DESCRIPTION
## What is this feature?

Removes the `extractFieldsNameDeduplication` feature toggle now that it has reached GA (General Availability).

## What problem does this feature solve?

The feature toggle is no longer needed since the name deduplication behavior is now permanent and fully rolled out.

## Which issue(s) does this PR fix?

Relates to feature toggle cleanup for GA features.

## Notes to the Reviewer

The feature toggle was at the Experimental stage and has now reached GA, so it can be safely removed. The name deduplication behavior in the extract fields transformer is now permanently enabled.

## Changes:
- Removed feature toggle definition from `registry.go`
- Removed feature toggle check in `extractFields.ts` (always deduplicate field names now)
- Updated tests to remove feature toggle manipulation
- Regenerated feature toggle files using `make gen-feature-toggles`