### PR TITLE
Switch flag from FlagGrafanaAPIServerWithExperimentalAPIs to FlagQueryyServiceWithConnections

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -14,7 +14,6 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	openapi "k8s.io/kube-openapi/pkg/common"
-	"k8s.io/utils/strings/slices"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -58,14 +57,9 @@ func RegisterAPIService(
 	reg prometheus.Registerer,
 	pluginSources sources.Registry,
 ) (*DataSourceAPIBuilder, error) {
-	// We want to expose just a limited set of plugins
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	explicitPluginList := features.IsEnabledGlobally(featuremgmt.FlagDatasourceAPIServers)
-
-	// This requires devmode!
-	//nolint:staticcheck // not yet migrated to OpenFeature
-	if !explicitPluginList && !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) {
-		return nil, nil // skip registration unless opting into experimental apis
+	if !features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections) && !features.IsEnabledGlobally(featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs) {
+		return nil, nil
 	}
 
 	var err error
@@ -76,31 +70,14 @@ func RegisterAPIService(
 		return nil, fmt.Errorf("error getting list of datasource plugins: %s", err)
 	}
 
-	ids := []string{
-		"grafana-testdata-datasource",
-		"prometheus",
-		"graphite",
-	}
-
 	for _, pluginJSON := range pluginJSONs {
-		if explicitPluginList && !slices.Contains(ids, pluginJSON.ID) {
-			continue // skip this one
-		}
-
-		if !pluginJSON.Backend {
-			continue // skip frontend only plugins
-		}
-
-		if pluginJSON.Type != plugins.TypeDataSource {
-			continue // skip non-datasource plugins
-		}
-
 		client, ok := pluginClient.(PluginClient)
 		if !ok {
 			return nil, fmt.Errorf("plugin client is not a PluginClient: %T", pluginClient)
 		}
 
-		builder, err = NewDataSourceAPIBuilder(pluginJSON,
+		builder, err = NewDataSourceAPIBuilder(
+			pluginJSON,
 			client,
 			datasources.GetDatasourceProvider(pluginJSON),
 			contextProvider,
@@ -305,14 +282,17 @@ func getDatasourcePlugins(pluginSources sources.Registry) ([]plugins.JSONData, e
 			return nil, err
 		}
 		for _, p := range res {
-			if p.Primary.JSONData.Type == plugins.TypeDataSource {
-				if _, found := uniquePlugins[p.Primary.JSONData.ID]; found {
-					backend.Logger.Info("Found duplicate plugin %s when registering API groups.", p.Primary.JSONData.ID)
-					continue
-				}
-				uniquePlugins[p.Primary.JSONData.ID] = true
-				pluginJSONs = append(pluginJSONs, p.Primary.JSONData)
+			if !p.Primary.JSONData.Backend || p.Primary.JSONData.Type != plugins.TypeDataSource {
+				continue
 			}
+
+			if _, found := uniquePlugins[p.Primary.JSONData.ID]; found {
+				backend.Logger.Info("Found duplicate plugin %s when registering API groups.", p.Primary.JSONData.ID)
+				continue
+			}
+
+			uniquePlugins[p.Primary.JSONData.ID] = true
+			pluginJSONs = append(pluginJSONs, p.Primary.JSONData)
 		}
 	}
 	return pluginJSONs, nil


### PR DESCRIPTION
The FlagGrafanaAPIServerWithExperimentalAPIs is only available when `app_mode=development`. We have a more specific flag that is usable in production, so use that.

Also, there was some old code constraining these APIs to a static list of datasources. We don't need that anymore, so this PR removes it.

Fixes https://github.com/grafana/grafana-enterprise/issues/10166
