### PR TITLE
Tempo: Fix "undefined is not object (evaluating 'super.query')" error

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -629,7 +629,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     );
   }
 
-  handleTraceQlQuery = (options: DataQueryRequest<TempoQuery>, targets: { [type: string]: TempoQuery[] }) => {
+  handleTraceQlQuery(options: DataQueryRequest<TempoQuery>, targets: { [type: string]: TempoQuery[] }) {
     const startTime = performance.now();
     const traceqlSearchTargets = targets.traceqlSearch || targets.traceql;
     const appliedQuery = this.applyVariables(traceqlSearchTargets[0], options.scopedVars);
@@ -707,7 +707,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
         return of({ error: { message: getErrorMessage(err?.data?.message) }, data: [] });
       })
     );
-  };
+  }
 
   // this is just a short term function, we will remove once we have rolled
   // out the backend migration and are happy with the stability of the feature


### PR DESCRIPTION
**What is this feature?**

While executing a traceql query we got errors only on Safari. It's a special case for Safari (I don't know why exactly but since it's javascript engine is different than other major browsers it handles the scope differently.)
We recently migrated tempo to backend: https://github.com/grafana/grafana/pull/109800
So to be able to reproduce this on locally `tempoSearchBackendMigration` feature toggle must be enabled. 
And alongside with usual `yarn start` in another terminal `yarn workspace @grafana-plugins/tempo dev` has to be run. 

TLDR; there was a scope issue and I converted the arrow function to a normal function. 


**Why do we need this feature?**

To be able to execute queries on Safari

**Who is this feature for?**

Tempo users who use Safari as browser

