### PR TITLE
Prom/Loki: Query editor padding fix

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryBuilderOptions.tsx
@@ -6,8 +6,8 @@ import * as React from 'react';
 import { CoreApp, SelectableValue } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { EditorField, EditorRow, EditorSwitch } from '@grafana/plugin-ui';
-import { AutoSizeInput, RadioButtonGroup, Select } from '@grafana/ui';
+import { EditorField, EditorSwitch } from '@grafana/plugin-ui';
+import { AutoSizeInput, Box, RadioButtonGroup, Select } from '@grafana/ui';
 
 import { getQueryTypeChangeHandler, getQueryTypeOptions } from '../../components/PromExploreExtraField';
 import { PromQueryFormat } from '../../dataquery';
@@ -80,7 +80,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
     const queryTypeLabel = queryTypeOptions.find((x) => x.value === queryTypeValue)!.label;
 
     return (
-      <EditorRow>
+      <Box backgroundColor={'secondary'}>
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.options}>
           <QueryOptionGroup
             title={t('grafana-prometheus.querybuilder.prom-query-builder-options.title-options', 'Options')}
@@ -181,7 +181,7 @@ export const PromQueryBuilderOptions = React.memo<PromQueryBuilderOptionsProps>(
             )}
           </QueryOptionGroup>
         </div>
-      </EditorRow>
+      </Box>
     );
   }
 );

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilderOptions.tsx
@@ -3,9 +3,9 @@ import { useCallback, useEffect, useMemo } from 'react';
 import * as React from 'react';
 
 import { CoreApp, isValidGrafanaDuration, LogSortOrderChangeEvent, LogsSortOrder, store } from '@grafana/data';
-import { EditorField, EditorRow, QueryOptionGroup } from '@grafana/plugin-ui';
+import { EditorField, QueryOptionGroup } from '@grafana/plugin-ui';
 import { getAppEvents } from '@grafana/runtime';
-import { AutoSizeInput, RadioButtonGroup } from '@grafana/ui';
+import { AutoSizeInput, Box, RadioButtonGroup } from '@grafana/ui';
 
 import {
   getQueryDirectionLabel,
@@ -133,7 +133,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
     }, [query.step, datasource]);
 
     return (
-      <EditorRow>
+      <Box backgroundColor={'secondary'}>
         <QueryOptionGroup
           title="Options"
           collapsedInfo={getCollapsedInfo(query, queryType, maxLines, isLogQuery, isValidStep, query.direction)}
@@ -196,7 +196,7 @@ export const LokiQueryBuilderOptions = React.memo<Props>(
             </>
           )}
         </QueryOptionGroup>
-      </EditorRow>
+      </Box>
     );
   }
 );


### PR DESCRIPTION
The last options row in both loki and prometheus query editors have recently received double padding compared to what they had originally (And other editor rows have). This is due to the usage of the Collapse component, that component gives no control over padding (and messy to add). So the easiest change was to skip using EditorRow here and just a Box with background color 

Before: 

<img width="1046" height="533" alt="Screenshot 2025-11-12 at 08 57 40" src="https://github.com/user-attachments/assets/0602495e-1f5e-4d42-ade7-e6c9dcb0da25" />

After:

<img width="1049" height="236" alt="Screenshot 2025-11-12 at 08 56 12" src="https://github.com/user-attachments/assets/aaeb58e4-5ae0-4298-af56-28639917fba7" />
