### PR TITLE
PanelEdit: Remove double border when viz picker is open

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -138,10 +138,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     padding: theme.spacing(2, 1),
     height: '100%',
     gap: theme.spacing(2),
-    border: `1px solid ${theme.colors.border.weak}`,
-    borderRight: 'none',
-    borderBottom: 'none',
-    borderTopLeftRadius: theme.shape.radius.default,
   }),
   searchRow: css({
     display: 'flex',


### PR DESCRIPTION

Removes the double border present around right side pane when viz picker is open 