### PR TITLE
Alerting: Fix to prevent regex escape on search input query

### DIFF
--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -162,6 +162,7 @@ export default function RulesFilter({ viewMode, onViewModeChange }: RulesFilterP
                     'Search by name or enter filter query...'
                   )}
                   name="searchQuery"
+                  escapeRegex={false}
                   onChange={(next) => {
                     trackRulesSearchInputCleared(field.value, next);
                     field.onChange(next);


### PR DESCRIPTION
This PR sets escapeRegex as false in FilterInput component for the search input. 
Fixes this issue: https://raintank-corp.slack.com/archives/C04LG9N6R4J/p1762938126516189