### PR TITLE
ExternalPlugins: Restore backward compatability for util function

### DIFF
--- a/packages/grafana-ui/src/options/builder/text.tsx
+++ b/packages/grafana-ui/src/options/builder/text.tsx
@@ -13,7 +13,7 @@ export function addTextSizeOptions<T extends OptionsWithTextFormatting>(
 ) {
   // if called from old plugins when parameter was withTitle boolean
   if (typeof options === 'boolean') {
-    options = { withValue: options };
+    options = { withTitle: options };
   }
 
   const category = [t('grafana-ui.builder.text.category-text-size', 'Text size')];

--- a/packages/grafana-ui/src/options/builder/text.tsx
+++ b/packages/grafana-ui/src/options/builder/text.tsx
@@ -11,6 +11,11 @@ export function addTextSizeOptions<T extends OptionsWithTextFormatting>(
   builder: PanelOptionsEditorBuilder<T>,
   options: { withValue?: boolean; withTitle?: boolean; withPercentChange?: boolean } = { withTitle: true }
 ) {
+  // if called from old plugins when parameter was withTitle boolean
+  if (typeof options === 'boolean') {
+    options = { withValue: options };
+  }
+
   const category = [t('grafana-ui.builder.text.category-text-size', 'Text size')];
   if (options.withTitle) {
     builder.addNumberInput({

--- a/packages/grafana-ui/src/options/builder/text.tsx
+++ b/packages/grafana-ui/src/options/builder/text.tsx
@@ -9,7 +9,7 @@ import { OptionsWithTextFormatting } from '@grafana/schema';
  */
 export function addTextSizeOptions<T extends OptionsWithTextFormatting>(
   builder: PanelOptionsEditorBuilder<T>,
-  options: { withValue?: boolean; withTitle?: boolean; withPercentChange?: boolean }
+  options: { withValue?: boolean; withTitle?: boolean; withPercentChange?: boolean } = { withTitle: true }
 ) {
   const category = [t('grafana-ui.builder.text.category-text-size', 'Text size')];
   if (options.withTitle) {


### PR DESCRIPTION
https://github.com/grafana/grafana/pull/112278 changed this util function that for some reason is exposed to plugins 🤷 

restoring the optional nature of the first param and also handles if boolean passed it 