### PR TITLE
Alerting: Support rule title search on the backend

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -350,6 +350,10 @@ export interface FeatureToggles {
   */
   alertingProvenanceLockWrites?: boolean;
   /**
+  * Enables the UI to use certain backend-side filters
+  */
+  alertingUIUseBackendFilters?: boolean;
+  /**
   * Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
   */
   alertmanagerRemotePrimary?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -584,6 +584,14 @@ var (
 			HideFromDocs:      true,
 		},
 		{
+			Name:              "alertingUIUseBackendFilters",
+			Description:       "Enables the UI to use certain backend-side filters",
+			Stage:             FeatureStageExperimental,
+			Owner:             grafanaAlertingSquad,
+			HideFromAdminPage: true,
+			HideFromDocs:      true,
+		},
+		{
 			Name:        "alertmanagerRemotePrimary",
 			Description: "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -77,6 +77,7 @@ cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-e
 addFieldFromCalculationStatFunctions,GA,@grafana/datapro,false,false,true
 alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false
 alertingProvenanceLockWrites,experimental,@grafana/alerting-squad,false,false,false
+alertingUIUseBackendFilters,experimental,@grafana/alerting-squad,false,false,false
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 dashboardSceneForViewers,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -319,6 +319,10 @@ const (
 	// Enables a feature to avoid issues with concurrent writes to the alerting provenance table in MySQL
 	FlagAlertingProvenanceLockWrites = "alertingProvenanceLockWrites"
 
+	// FlagAlertingUIUseBackendFilters
+	// Enables the UI to use certain backend-side filters
+	FlagAlertingUIUseBackendFilters = "alertingUIUseBackendFilters"
+
 	// FlagAlertmanagerRemotePrimary
 	// Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
 	FlagAlertmanagerRemotePrimary = "alertmanagerRemotePrimary"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -616,6 +616,20 @@
     },
     {
       "metadata": {
+        "name": "alertingUIUseBackendFilters",
+        "resourceVersion": "1762966218072",
+        "creationTimestamp": "2025-11-12T16:50:18Z"
+      },
+      "spec": {
+        "description": "Enables the UI to use certain backend-side filters",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingUseNewSimplifiedRoutingHashAlgorithm",
         "resourceVersion": "1759339813575",
         "creationTimestamp": "2025-10-01T17:28:42Z",

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -479,7 +479,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
-	title := opts.Query.Get("title")
+	title := opts.Query.Get("search.title")
 
 	maxGroups := getInt64WithDefault(opts.Query, "group_limit", -1)
 	nextToken := opts.Query.Get("group_next_token")
@@ -626,7 +626,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
-	title := opts.Query.Get("title")
+	title := opts.Query.Get("search.title")
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
 		OrgID:         opts.OrgID,

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -479,6 +479,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
+	title := opts.Query.Get("title")
 
 	maxGroups := getInt64WithDefault(opts.Query, "group_limit", -1)
 	nextToken := opts.Query.Get("group_next_token")
@@ -495,6 +496,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 			PanelID:       panelID,
 			RuleGroups:    ruleGroups,
 			ReceiverName:  receiverName,
+			TitleSearch:   title,
 		},
 		Limit:         maxGroups,
 		ContinueToken: nextToken,
@@ -624,6 +626,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
+	title := opts.Query.Get("title")
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
 		OrgID:         opts.OrgID,
@@ -632,6 +635,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 		PanelID:       panelID,
 		RuleGroups:    ruleGroups,
 		ReceiverName:  receiverName,
+		TitleSearch:   title,
 	}
 	ruleList, err := store.ListAlertRules(opts.Ctx, &alertRuleQuery)
 	if err != nil {

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -479,7 +479,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
-	title := opts.Query.Get("search.title")
+	title := opts.Query.Get("search.rule_name")
 
 	maxGroups := getInt64WithDefault(opts.Query, "group_limit", -1)
 	nextToken := opts.Query.Get("group_next_token")
@@ -626,7 +626,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 	ruleGroups := opts.Query["rule_group"]
 
 	receiverName := opts.Query.Get("receiver_name")
-	title := opts.Query.Get("search.title")
+	title := opts.Query.Get("search.rule_name")
 
 	alertRuleQuery := ngmodels.ListAlertRulesQuery{
 		OrgID:         opts.OrgID,

--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -496,7 +496,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 			PanelID:       panelID,
 			RuleGroups:    ruleGroups,
 			ReceiverName:  receiverName,
-			TitleSearch:   title,
+			SearchTitle:   title,
 		},
 		Limit:         maxGroups,
 		ContinueToken: nextToken,
@@ -635,7 +635,7 @@ func PrepareRuleGroupStatuses(log log.Logger, store ListAlertRulesStore, opts Ru
 		PanelID:       panelID,
 		RuleGroups:    ruleGroups,
 		ReceiverName:  receiverName,
-		TitleSearch:   title,
+		SearchTitle:   title,
 	}
 	ruleList, err := store.ListAlertRules(opts.Ctx, &alertRuleQuery)
 	if err != nil {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -978,9 +978,9 @@ type ListAlertRulesQuery struct {
 
 	ReceiverName     string
 	TimeIntervalName string
-	// TitleSearch allows searching for alert rules that contain
+	// SearchTitle allows searching for alert rules that contain
 	// the given string in their title (case insensitive)
-	TitleSearch string
+	SearchTitle string
 
 	HasPrometheusRuleDefinition *bool
 }

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -978,6 +978,9 @@ type ListAlertRulesQuery struct {
 
 	ReceiverName     string
 	TimeIntervalName string
+	// TitleSearch allows searching for alert rules that contain
+	// the given string in their title (case insensitive)
+	TitleSearch string
 
 	HasPrometheusRuleDefinition *bool
 }

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -855,8 +855,8 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 		}
 	}
 
-	if query.TitleSearch != "" {
-		words := strings.Fields(query.TitleSearch)
+	if query.SearchTitle != "" {
+		words := strings.Fields(query.SearchTitle)
 		if len(words) > 0 {
 			// Build sequential pattern: %word1%word2%word3%
 			pattern := strings.Join(words, "%")

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -856,8 +856,13 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 	}
 
 	if query.TitleSearch != "" {
-		sql, param := st.SQLStore.GetDialect().LikeOperator("title", true, query.TitleSearch, true)
-		q = q.And(sql, param)
+		words := strings.Fields(query.TitleSearch)
+		if len(words) > 0 {
+			// Build sequential pattern: %word1%word2%word3%
+			pattern := strings.Join(words, "%")
+			sql, param := st.SQLStore.GetDialect().LikeOperator("title", true, pattern, true)
+			q = q.And(sql, param)
+		}
 	}
 
 	if query.HasPrometheusRuleDefinition != nil {

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -855,6 +855,11 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 		}
 	}
 
+	if query.TitleSearch != "" {
+		sql, param := st.SQLStore.GetDialect().LikeOperator("title", true, query.TitleSearch, true)
+		q = q.And(sql, param)
+	}
+
 	if query.HasPrometheusRuleDefinition != nil {
 		q, err = st.filterWithPrometheusRuleDefinition(*query.HasPrometheusRuleDefinition, q)
 		if err != nil {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2020,12 +2020,10 @@ func Benchmark_ListAlertRules(b *testing.B) {
 func TestIntegration_ListAlertRules(t *testing.T) {
 	tutil.SkipIntegrationTestInShortMode(t)
 
-	sqlStore := db.InitTestDB(t)
 	cfg := setting.NewCfg()
 	cfg.UnifiedAlerting = setting.UnifiedAlertingSettings{
 		BaseInterval: time.Duration(rand.Int64N(100)) * time.Second,
 	}
-	folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 	b := &fakeBus{}
 	orgID := int64(1)
 	ruleGen := models.RuleGen
@@ -2034,6 +2032,8 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 		ruleGen.WithOrgID(orgID),
 	)
 	t.Run("filter by HasPrometheusRuleDefinition", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
 		regularRule := createRule(t, store, ruleGen)
 		importedRule := createRule(t, store, ruleGen.With(
@@ -2065,6 +2065,55 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 				query := &models.ListAlertRulesQuery{
 					OrgID:                       orgID,
 					HasPrometheusRuleDefinition: tt.importedPrometheusRule,
+				}
+				result, err := store.ListAlertRules(context.Background(), query)
+				require.NoError(t, err)
+				require.ElementsMatch(t, tt.expectedRules, result)
+			})
+		}
+	})
+
+	t.Run("filter by TitleSearch", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+		rule1 := createRule(t, store, ruleGen.With(models.RuleMuts.WithTitle("CPU Usage Alert")))
+		rule2 := createRule(t, store, ruleGen.With(models.RuleMuts.WithTitle("Memory Usage Alert")))
+		rule3 := createRule(t, store, ruleGen.With(models.RuleMuts.WithTitle("Disk Space Alert")))
+		rule4 := createRule(t, store, ruleGen.With(models.RuleMuts.WithTitle("Application Error Rate")))
+
+		tc := []struct {
+			name          string
+			titleSearch   string
+			expectedRules []*models.AlertRule
+		}{
+			{
+				name:          "should find rules",
+				titleSearch:   "alert",
+				expectedRules: []*models.AlertRule{rule1, rule2, rule3},
+			},
+			{
+				name:          "should find rule with partial match",
+				titleSearch:   "aPpl",
+				expectedRules: []*models.AlertRule{rule4},
+			},
+			{
+				name:          "should return no rules when no match",
+				titleSearch:   "nonexistent",
+				expectedRules: []*models.AlertRule{},
+			},
+			{
+				name:          "should return all rules when empty",
+				titleSearch:   "",
+				expectedRules: []*models.AlertRule{rule1, rule2, rule3, rule4},
+			},
+		}
+
+		for _, tt := range tc {
+			t.Run(tt.name, func(t *testing.T) {
+				query := &models.ListAlertRulesQuery{
+					OrgID:       orgID,
+					TitleSearch: tt.titleSearch,
 				}
 				result, err := store.ListAlertRules(context.Background(), query)
 				require.NoError(t, err)

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2107,6 +2107,26 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 				titleSearch:   "",
 				expectedRules: []*models.AlertRule{rule1, rule2, rule3, rule4},
 			},
+			{
+				name:          "should not find rules when word order is reversed",
+				titleSearch:   "usage cpu",
+				expectedRules: []*models.AlertRule{},
+			},
+			{
+				name:          "should find multiple rules matching sequential words",
+				titleSearch:   "usage alert",
+				expectedRules: []*models.AlertRule{rule1, rule2},
+			},
+			{
+				name:          "should handle extra whitespace between words",
+				titleSearch:   "  cpu   usage  ",
+				expectedRules: []*models.AlertRule{rule1},
+			},
+			{
+				name:          "should handle multiple words with partial matches",
+				titleSearch:   "aPp erR",
+				expectedRules: []*models.AlertRule{rule4},
+			},
 		}
 
 		for _, tt := range tc {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2073,7 +2073,7 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 		}
 	})
 
-	t.Run("filter by TitleSearch", func(t *testing.T) {
+	t.Run("filter by SearchTitle", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
 		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
@@ -2133,7 +2133,7 @@ func TestIntegration_ListAlertRules(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				query := &models.ListAlertRulesQuery{
 					OrgID:       orgID,
-					TitleSearch: tt.titleSearch,
+					SearchTitle: tt.titleSearch,
 				}
 				result, err := store.ListAlertRules(context.Background(), query)
 				require.NoError(t, err)

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -105,7 +105,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           limit_alerts: limitAlerts,
           group_limit: groupLimit?.toFixed(0),
           group_next_token: groupNextToken,
-          title: title,
+          'search.title': title,
         },
       }),
       providesTags: (_result, _error, { folderUid, groupName, ruleName }) => {

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -42,6 +42,7 @@ type GrafanaPromRulesOptions = Omit<PromRulesOptions, 'ruleSource' | 'namespace'
   contactPoint?: string;
   health?: RuleHealth[];
   state?: PromAlertingRuleState[];
+  title?: string;
 };
 
 export const prometheusApi = alertingApi.injectEndpoints({
@@ -91,6 +92,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
         groupLimit,
         limitAlerts,
         groupNextToken,
+        title,
       }) => ({
         url: `api/prometheus/grafana/api/v1/rules`,
         params: {
@@ -103,6 +105,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           limit_alerts: limitAlerts,
           group_limit: groupLimit?.toFixed(0),
           group_next_token: groupNextToken,
+          title: title,
         },
       }),
       providesTags: (_result, _error, { folderUid, groupName, ruleName }) => {

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -105,7 +105,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           limit_alerts: limitAlerts,
           group_limit: groupLimit?.toFixed(0),
           group_next_token: groupNextToken,
-          'search.title': title,
+          'search.rule_name': title,
         },
       }),
       providesTags: (_result, _error, { folderUid, groupName, ruleName }) => {

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -21,3 +21,5 @@ export const shouldAllowRecoveringDeletedRules = () =>
 
 export const shouldAllowPermanentlyDeletingRules = () =>
   (shouldAllowRecoveringDeletedRules() && config.featureToggles.alertingRulePermanentlyDelete) ?? false;
+
+export const shouldUseBackendFilters = () => config.featureToggles.alertingUIUseBackendFilters ?? false;

--- a/public/app/features/alerting/unified/rule-list/FilterView.tsx
+++ b/public/app/features/alerting/unified/rule-list/FilterView.tsx
@@ -23,7 +23,7 @@ import {
   hasClientSideFilters,
   useFilteredRulesIteratorProvider,
 } from './hooks/useFilteredRulesIterator';
-import { FRONTEND_LIST_PAGE_SIZE, getApiGroupPageSize } from './paginationLimits';
+import { FRONTEND_LIST_PAGE_SIZE, getSearchApiGroupPageSize } from './paginationLimits';
 
 interface FilterViewProps {
   filterState: RulesFilter;
@@ -80,7 +80,7 @@ function FilterViewResults({ filterState }: FilterViewProps) {
        */
       const { iterable, abortController } = getFilteredRulesIterator(
         filterState,
-        getApiGroupPageSize(hasClientSideFilters(filterState))
+        getSearchApiGroupPageSize(hasClientSideFilters(filterState))
       );
       const rulesBatchIterator = iterable
         .pipe(

--- a/public/app/features/alerting/unified/rule-list/FilterView.tsx
+++ b/public/app/features/alerting/unified/rule-list/FilterView.tsx
@@ -20,6 +20,7 @@ import {
   GrafanaRuleWithOrigin,
   PromRuleWithOrigin,
   RuleWithOrigin,
+  hasClientSideFilters,
   useFilteredRulesIteratorProvider,
 } from './hooks/useFilteredRulesIterator';
 import { FRONTEND_LIST_PAGE_SIZE, getApiGroupPageSize } from './paginationLimits';
@@ -77,7 +78,10 @@ function FilterViewResults({ filterState }: FilterViewProps) {
        * ⚠️ Make sure we are returning / using a "iterator" and not an "iterable" since the iterable is only a blueprint
        * and the iterator will allow us to exhaust the iterable in a stateful way
        */
-      const { iterable, abortController } = getFilteredRulesIterator(filterState, getApiGroupPageSize(true));
+      const { iterable, abortController } = getFilteredRulesIterator(
+        filterState,
+        getApiGroupPageSize(hasClientSideFilters(filterState))
+      );
       const rulesBatchIterator = iterable
         .pipe(
           bufferCountOrTime(FRONTEND_LIST_PAGE_SIZE, 1000),

--- a/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/filters.test.ts
@@ -60,6 +60,34 @@ describe('ruleFilter', () => {
     expect(ruleFilter(rule, getFilter({ ruleName: 'memory' }))).toBe(false);
   });
 
+  describe('backendFiltered parameter for backend filtering', () => {
+    it('should skip title filtering when backendFiltered is true', () => {
+      const rule = mockPromAlertingRule({ name: 'High CPU Usage' });
+
+      // When backendFiltered is true, title search should be skipped (already filtered by backend)
+      expect(ruleFilter(rule, getFilter({ freeFormWords: ['memory'] }), true)).toBe(true);
+      expect(ruleFilter(rule, getFilter({ ruleName: 'memory' }), true)).toBe(true);
+    });
+
+    it('should perform title filtering when backendFiltered is false', () => {
+      const rule = mockPromAlertingRule({ name: 'High CPU Usage' });
+
+      // When backendFiltered is false, title search should be performed client-side
+      expect(ruleFilter(rule, getFilter({ freeFormWords: ['cpu'] }), false)).toBe(true);
+      expect(ruleFilter(rule, getFilter({ freeFormWords: ['memory'] }), false)).toBe(false);
+      expect(ruleFilter(rule, getFilter({ ruleName: 'cpu' }), false)).toBe(true);
+      expect(ruleFilter(rule, getFilter({ ruleName: 'memory' }), false)).toBe(false);
+    });
+
+    it('should perform title filtering when backendFiltered is not specified (backward compatibility)', () => {
+      const rule = mockPromAlertingRule({ name: 'High CPU Usage' });
+
+      // When backendFiltered is not provided, should perform client-side filtering (default behavior)
+      expect(ruleFilter(rule, getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
+      expect(ruleFilter(rule, getFilter({ freeFormWords: ['memory'] }))).toBe(false);
+    });
+  });
+
   it('should filter by labels', () => {
     const rule = mockPromAlertingRule({
       labels: { severity: 'critical', team: 'ops' },

--- a/public/app/features/alerting/unified/rule-list/hooks/filters.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/filters.ts
@@ -36,18 +36,20 @@ export function groupFilter(
 
 /**
  * @returns True if the rule matches the filter, false otherwise
+ * @param backendFiltered - If true, title search is skipped (already filtered by backend)
  */
-export function ruleFilter(rule: PromRuleDTO, filterState: RulesFilter) {
+export function ruleFilter(rule: PromRuleDTO, filterState: RulesFilter, backendFiltered?: boolean) {
   const { name, labels = {}, health, type } = rule;
 
-  if (filterState.freeFormWords.length > 0) {
+  if (filterState.freeFormWords.length > 0 && !backendFiltered) {
     const nameMatches = fuzzyMatches(name, filterState.freeFormWords.join(' '));
     if (!nameMatches) {
       return false;
     }
   }
 
-  if (filterState.ruleName && !fuzzyMatches(name, filterState.ruleName)) {
+  // Rule name search: Backend-supported for backend-filtered rules, client-side otherwise
+  if (filterState.ruleName && !backendFiltered && !fuzzyMatches(name, filterState.ruleName)) {
     return false;
   }
 

--- a/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/prometheusGroupsGenerator.ts
@@ -46,6 +46,7 @@ interface GrafanaPromApiFilter {
   state?: PromAlertingRuleState[];
   health?: RuleHealth[];
   contactPoint?: string;
+  title?: string;
 }
 
 interface GrafanaFetchGroupsOptions extends FetchGroupsOptions {

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
@@ -3,7 +3,7 @@ import { config } from '@grafana/runtime';
 import { RuleSource } from '../../search/rulesSearchParser';
 import { getFilter } from '../../utils/search';
 
-import { hasClientSideFilters } from './useFilteredRulesIterator';
+import { buildTitleSearch, hasClientSideFilters } from './useFilteredRulesIterator';
 
 describe('hasClientSideFilters', () => {
   const originalFeatureToggles = config.featureToggles;
@@ -72,5 +72,25 @@ describe('hasClientSideFilters', () => {
       expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
       expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(true);
     });
+  });
+});
+
+describe('buildTitleSearch', () => {
+  it('returns undefined when no search terms are provided', () => {
+    expect(buildTitleSearch(getFilter({}))).toBeUndefined();
+  });
+
+  it('returns the rule name when only a rule search is provided', () => {
+    expect(buildTitleSearch(getFilter({ ruleName: 'cpu' }))).toBe('cpu');
+  });
+
+  it('returns joined free-form words when only text search is provided', () => {
+    expect(buildTitleSearch(getFilter({ freeFormWords: ['cpu', 'memory'] }))).toBe('cpu memory');
+  });
+
+  it('concatenates rule search and free-form text when both are provided', () => {
+    expect(buildTitleSearch(getFilter({ ruleName: 'cpu', freeFormWords: ['memory', 'latency'] }))).toBe(
+      'cpu memory latency'
+    );
   });
 });

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.test.ts
@@ -1,0 +1,76 @@
+import { config } from '@grafana/runtime';
+
+import { RuleSource } from '../../search/rulesSearchParser';
+import { getFilter } from '../../utils/search';
+
+import { hasClientSideFilters } from './useFilteredRulesIterator';
+
+describe('hasClientSideFilters', () => {
+  const originalFeatureToggles = config.featureToggles;
+
+  beforeEach(() => {
+    config.featureToggles = { ...originalFeatureToggles };
+  });
+
+  afterEach(() => {
+    config.featureToggles = originalFeatureToggles;
+  });
+
+  describe('when alertingUIUseBackendFilters is enabled', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingUIUseBackendFilters = true;
+    });
+
+    it('should return false for title search filters (backend-supported)', () => {
+      expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(false);
+      expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(false);
+    });
+
+    it('should return true for client-side only filters', () => {
+      expect(hasClientSideFilters(getFilter({ namespace: 'test' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleSource: RuleSource.DataSource }))).toBe(true);
+    });
+
+    it('should return false when no filters are applied', () => {
+      expect(hasClientSideFilters(getFilter({}))).toBe(false);
+    });
+  });
+
+  describe('when alertingUIUseBackendFilters is disabled', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingUIUseBackendFilters = false;
+    });
+
+    it('should return true for title search filters (client-side fallback)', () => {
+      expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(true);
+    });
+
+    it('should return true for client-side only filters', () => {
+      expect(hasClientSideFilters(getFilter({ namespace: 'test' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleSource: RuleSource.DataSource }))).toBe(true);
+    });
+
+    it('should return false when no filters are applied', () => {
+      expect(hasClientSideFilters(getFilter({}))).toBe(false);
+    });
+  });
+
+  describe('when alertingUIUseBackendFilters is undefined (default)', () => {
+    beforeEach(() => {
+      config.featureToggles.alertingUIUseBackendFilters = undefined;
+    });
+
+    it('should return true for title search filters (backward compatibility)', () => {
+      // Default behavior should be client-side filtering
+      expect(hasClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
+      expect(hasClientSideFilters(getFilter({ ruleName: 'test' }))).toBe(true);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFilteredRulesIterator.ts
@@ -82,9 +82,7 @@ export function useFilteredRulesIteratorProvider() {
     const hasDataSourceFilterActive = Boolean(filterState.dataSourceNames.length);
     const useBackendFilters = shouldUseBackendFilters();
 
-    const titleSearch = useBackendFilters
-      ? filterState.ruleName || (filterState.freeFormWords.length > 0 ? filterState.freeFormWords.join(' ') : undefined)
-      : undefined;
+    const titleSearch = useBackendFilters ? buildTitleSearch(filterState) : undefined;
 
     const grafanaRulesGenerator: AsyncIterableX<RuleWithOrigin> = from(
       grafanaGroupsGenerator(groupLimit, {
@@ -169,6 +167,30 @@ export function hasClientSideFilters(filterState: RulesFilter): boolean {
     Boolean(filterState.dashboardUid) ||
     filterState.ruleSource === RuleSource.DataSource
   );
+}
+
+export function buildTitleSearch(filterState: RulesFilter): string | undefined {
+  const titleParts: string[] = [];
+
+  const ruleName = filterState.ruleName?.trim();
+  if (ruleName) {
+    titleParts.push(ruleName);
+  }
+
+  const freeFormSegment = filterState.freeFormWords
+    .map((word) => word.trim())
+    .filter(Boolean)
+    .join(' ');
+
+  if (freeFormSegment) {
+    titleParts.push(freeFormSegment);
+  }
+
+  if (titleParts.length === 0) {
+    return undefined;
+  }
+
+  return titleParts.join(' ');
 }
 
 function mergeIterables(iterables: Array<AsyncIterableX<RuleWithOrigin>>): AsyncIterableX<RuleWithOrigin> {

--- a/public/app/features/alerting/unified/rule-list/paginationLimits.ts
+++ b/public/app/features/alerting/unified/rule-list/paginationLimits.ts
@@ -1,9 +1,15 @@
 export const FRONTEND_LIST_PAGE_SIZE = 100;
 
-export const FILTERED_GROUPS_API_PAGE_SIZE = 2000;
+export const FILTERED_GROUPS_LARGE_API_PAGE_SIZE = 2000;
+export const FILTERED_GROUPS_SMALL_API_PAGE_SIZE = 100;
+
 export const DEFAULT_GROUPS_API_PAGE_SIZE = 40;
 export const FRONTED_GROUPED_PAGE_SIZE = DEFAULT_GROUPS_API_PAGE_SIZE;
 
 export function getApiGroupPageSize(hasFilters: boolean) {
-  return hasFilters ? FILTERED_GROUPS_API_PAGE_SIZE : DEFAULT_GROUPS_API_PAGE_SIZE;
+  return hasFilters ? FILTERED_GROUPS_LARGE_API_PAGE_SIZE : DEFAULT_GROUPS_API_PAGE_SIZE;
+}
+
+export function getSearchApiGroupPageSize(hasFrontendFilters: boolean) {
+  return hasFrontendFilters ? FILTERED_GROUPS_LARGE_API_PAGE_SIZE : FILTERED_GROUPS_SMALL_API_PAGE_SIZE;
 }


### PR DESCRIPTION
**What is this feature?**


Adds `search.rule_name` filter support to the API and the frontend. It also optimizes pagination by requesting only 40 rule groups (instead of 2000) when all active filters are backend-supported. 

A new feature toggle `alertingUIUseBackendFilters` makes the UI use the new filter.

Example: https://ephemeral15111821113738alexan.grafana-dev.net/alerting/list?search=BouNcy%20AlpA

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
