### PR TITLE
settin.Cfg: split into smaller parts

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -80,7 +80,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		}
 	}
 
-	if cfg.DataProxyLogging {
+	if cfg.DataProxy.Logging {
 		ctxLogger.Debug("Requesting", "url", req.URL.String())
 	}
 }

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -231,10 +231,10 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 		req.Header.Set("Authorization", dsAuth)
 	}
 
-	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
+	proxyutil.ApplyUserHeader(proxy.cfg.DataProxy.SendUserHeader, req, proxy.ctx.SignedInUser)
 
 	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.cfg.LoginCookieName})
-	req.Header.Set("User-Agent", proxy.cfg.DataProxyUserAgent)
+	req.Header.Set("User-Agent", proxy.cfg.DataProxy.UserAgent)
 
 	jsonData := make(map[string]any)
 	if proxy.ds.JsonData != nil {
@@ -356,7 +356,7 @@ func (proxy *DataSourceProxy) hasAccessToRoute(route *plugins.Route) bool {
 }
 
 func (proxy *DataSourceProxy) logRequest() {
-	if !proxy.cfg.DataProxyLogging {
+	if !proxy.cfg.DataProxy.Logging {
 		return
 	}
 

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -619,7 +619,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 					UserID:       1,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 		)
 		assert.Equal(t, "test_user", req.Header.Get("X-Grafana-User"))
 	})
@@ -632,7 +632,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 					Login: "test_user",
 				},
 			},
-			&setting.Cfg{SendUserHeader: false},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: false}},
 		)
 		// Get will return empty string even if header is not set
 		assert.Empty(t, req.Header.Get("X-Grafana-User"))
@@ -644,7 +644,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			&contextmodel.ReqContext{
 				SignedInUser: &user.SignedInUser{IsAnonymous: true},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 		)
 		// Get will return empty string even if header is not set
 		assert.Empty(t, req.Header.Get("X-Grafana-User"))

--- a/pkg/api/pluginproxy/pluginproxy.go
+++ b/pkg/api/pluginproxy/pluginproxy.go
@@ -183,7 +183,7 @@ func (proxy PluginProxy) director(req *http.Request) {
 
 	req.Header.Set("X-Grafana-Context", string(ctxJSON))
 
-	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
+	proxyutil.ApplyUserHeader(proxy.cfg.DataProxy.SendUserHeader, req, proxy.ctx.SignedInUser)
 	proxyutil.ApplyForwardIDHeader(req, proxy.ctx.SignedInUser)
 
 	if err := addHeaders(&req.Header, proxy.matchedRoute, data); err != nil {
@@ -197,7 +197,7 @@ func (proxy PluginProxy) director(req *http.Request) {
 }
 
 func (proxy PluginProxy) logRequest() {
-	if !proxy.cfg.DataProxyLogging {
+	if !proxy.cfg.DataProxy.Logging {
 		return
 	}
 

--- a/pkg/api/pluginproxy/pluginproxy_test.go
+++ b/pkg/api/pluginproxy/pluginproxy_test.go
@@ -61,7 +61,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			route,
 		)
 
@@ -86,7 +86,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			nil,
 		)
 
@@ -110,7 +110,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: false},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: false}},
 			nil,
 		)
 		// Get will return empty string even if header is not set
@@ -131,7 +131,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			nil,
 		)
 
@@ -164,7 +164,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			route,
 		)
 		assert.Equal(t, "https://dynamic.grafana.com", req.URL.String())
@@ -192,7 +192,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			route,
 		)
 		assert.Equal(t, "https://example.com", req.URL.String())
@@ -230,7 +230,7 @@ func TestPluginProxy(t *testing.T) {
 					Req: httpReq,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&setting.Cfg{DataProxy: setting.DataProxySettings{SendUserHeader: true}},
 			route,
 		)
 		content, err := io.ReadAll(req.Body)

--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
@@ -25,10 +25,10 @@ func New(cfg *setting.Cfg, validator validations.DataSourceRequestURLValidator, 
 		TracingMiddleware(logger, tracer),
 		DataSourceMetricsMiddleware(),
 		sdkhttpclient.ContextualMiddleware(),
-		SetUserAgentMiddleware(cfg.DataProxyUserAgent),
+		SetUserAgentMiddleware(cfg.DataProxy.UserAgent),
 		sdkhttpclient.BasicAuthenticationMiddleware(),
 		sdkhttpclient.CustomHeadersMiddleware(),
-		sdkhttpclient.ResponseLimitMiddleware(cfg.ResponseLimit),
+		sdkhttpclient.ResponseLimitMiddleware(cfg.DataProxy.ResponseLimit),
 		RedirectLimitMiddleware(validator),
 	}
 
@@ -81,14 +81,14 @@ func newConntrackRoundTripper(name string, transport *http.Transport) *http.Tran
 // Note: Not optimal changing global state, but hard to not do in this case.
 func setDefaultTimeoutOptions(cfg *setting.Cfg) {
 	sdkhttpclient.DefaultTimeoutOptions = sdkhttpclient.TimeoutOptions{
-		Timeout:               time.Duration(cfg.DataProxyTimeout) * time.Second,
-		DialTimeout:           time.Duration(cfg.DataProxyDialTimeout) * time.Second,
-		KeepAlive:             time.Duration(cfg.DataProxyKeepAlive) * time.Second,
-		TLSHandshakeTimeout:   time.Duration(cfg.DataProxyTLSHandshakeTimeout) * time.Second,
-		ExpectContinueTimeout: time.Duration(cfg.DataProxyExpectContinueTimeout) * time.Second,
-		MaxConnsPerHost:       cfg.DataProxyMaxConnsPerHost,
-		MaxIdleConns:          cfg.DataProxyMaxIdleConns,
-		MaxIdleConnsPerHost:   cfg.DataProxyMaxIdleConns,
-		IdleConnTimeout:       time.Duration(cfg.DataProxyIdleConnTimeout) * time.Second,
+		Timeout:               time.Duration(cfg.DataProxy.Timeout) * time.Second,
+		DialTimeout:           time.Duration(cfg.DataProxy.DialTimeout) * time.Second,
+		KeepAlive:             time.Duration(cfg.DataProxy.KeepAlive) * time.Second,
+		TLSHandshakeTimeout:   time.Duration(cfg.DataProxy.TLSHandshakeTimeout) * time.Second,
+		ExpectContinueTimeout: time.Duration(cfg.DataProxy.ExpectContinueTimeout) * time.Second,
+		MaxConnsPerHost:       cfg.DataProxy.MaxConnsPerHost,
+		MaxIdleConns:          cfg.DataProxy.MaxIdleConns,
+		MaxIdleConnsPerHost:   cfg.DataProxy.MaxIdleConns,
+		IdleConnTimeout:       time.Duration(cfg.DataProxy.IdleConnTimeout) * time.Second,
 	}
 }

--- a/pkg/services/pluginsintegration/pluginconfig/config.go
+++ b/pkg/services/pluginsintegration/pluginconfig/config.go
@@ -118,11 +118,11 @@ func ProvidePluginInstanceConfig(cfg *setting.Cfg, settingProvider setting.Provi
 		GrafanaVersion:                      cfg.BuildVersion,
 		ConcurrentQueryCount:                cfg.ConcurrentQueryCount,
 		UserFacingDefaultError:              cfg.UserFacingDefaultError,
-		DataProxyRowLimit:                   cfg.DataProxyRowLimit,
+		DataProxyRowLimit:                   cfg.DataProxy.RowLimit,
 		SQLDatasourceMaxOpenConnsDefault:    cfg.SqlDatasourceMaxOpenConnsDefault,
 		SQLDatasourceMaxIdleConnsDefault:    cfg.SqlDatasourceMaxIdleConnsDefault,
 		SQLDatasourceMaxConnLifetimeDefault: cfg.SqlDatasourceMaxConnLifetimeDefault,
-		ResponseLimit:                       cfg.ResponseLimit,
+		ResponseLimit:                       cfg.DataProxy.ResponseLimit,
 		SigV4AuthEnabled:                    cfg.SigV4AuthEnabled,
 		SigV4VerboseLogging:                 cfg.SigV4VerboseLogging,
 	}, nil

--- a/pkg/services/pluginsintegration/pluginconfig/request_test.go
+++ b/pkg/services/pluginsintegration/pluginconfig/request_test.go
@@ -191,7 +191,7 @@ func TestRequestConfigProvider_PluginRequestConfig_appURL(t *testing.T) {
 func TestRequestConfigProvider_PluginRequestConfig_SQL(t *testing.T) {
 	t.Run("Uses the configured values", func(t *testing.T) {
 		cfg := setting.NewCfg()
-		cfg.DataProxyRowLimit = 23
+		cfg.DataProxy = setting.DataProxySettings{RowLimit: 23}
 		cfg.SqlDatasourceMaxOpenConnsDefault = 24
 		cfg.SqlDatasourceMaxIdleConnsDefault = 25
 		cfg.SqlDatasourceMaxConnLifetimeDefault = 26

--- a/pkg/services/pluginsintegration/pluginsintegration.go
+++ b/pkg/services/pluginsintegration/pluginsintegration.go
@@ -208,7 +208,7 @@ func CreateMiddlewares(cfg *setting.Cfg, oAuthTokenService oauthtoken.OAuthToken
 		clientmiddleware.NewUseAlertHeadersMiddleware(),
 	)
 
-	if cfg.SendUserHeader {
+	if cfg.DataProxy.SendUserHeader {
 		middlewares = append(middlewares, clientmiddleware.NewUserHeaderMiddleware())
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -301,19 +301,7 @@ type Cfg struct {
 	SSOSettingsConfigurableProviders map[string]bool
 
 	// Dataproxy
-	SendUserHeader                 bool
-	DataProxyLogging               bool
-	DataProxyTimeout               int
-	DataProxyDialTimeout           int
-	DataProxyTLSHandshakeTimeout   int
-	DataProxyExpectContinueTimeout int
-	DataProxyMaxConnsPerHost       int
-	DataProxyMaxIdleConns          int
-	DataProxyKeepAlive             int
-	DataProxyIdleConnTimeout       int
-	ResponseLimit                  int64
-	DataProxyRowLimit              int64
-	DataProxyUserAgent             string
+	DataProxy DataProxySettings
 
 	// DistributedCache
 	RemoteCacheOptions *RemoteCacheSettings

--- a/pkg/setting/setting_data_proxy.go
+++ b/pkg/setting/setting_data_proxy.go
@@ -8,29 +8,55 @@ import (
 
 const defaultDataProxyRowLimit = int64(1000000)
 
-func readDataProxySettings(iniFile *ini.File, cfg *Cfg) error {
+type DataProxySettings struct {
+	SendUserHeader        bool
+	Logging               bool
+	Timeout               int
+	DialTimeout           int
+	TLSHandshakeTimeout   int
+	ExpectContinueTimeout int
+	MaxConnsPerHost       int
+	MaxIdleConns          int
+	KeepAlive             int
+	IdleConnTimeout       int
+	ResponseLimit         int64
+	RowLimit              int64
+	UserAgent             string
+}
+
+func DataProxyFromINI(iniFile *ini.File) DataProxySettings {
+	d := DataProxySettings{}
+
 	dataproxy := iniFile.Section("dataproxy")
-	cfg.SendUserHeader = dataproxy.Key("send_user_header").MustBool(false)
-	cfg.DataProxyLogging = dataproxy.Key("logging").MustBool(false)
-	cfg.DataProxyTimeout = dataproxy.Key("timeout").MustInt(30)
-	cfg.DataProxyDialTimeout = dataproxy.Key("dialTimeout").MustInt(10)
-	cfg.DataProxyKeepAlive = dataproxy.Key("keep_alive_seconds").MustInt(30)
-	cfg.DataProxyTLSHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
-	cfg.DataProxyExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)
-	cfg.DataProxyMaxConnsPerHost = dataproxy.Key("max_conns_per_host").MustInt(0)
-	cfg.DataProxyMaxIdleConns = dataproxy.Key("max_idle_connections").MustInt()
-	cfg.DataProxyIdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)
-	cfg.ResponseLimit = dataproxy.Key("response_limit").MustInt64(0)
-	cfg.DataProxyRowLimit = dataproxy.Key("row_limit").MustInt64(defaultDataProxyRowLimit)
-	cfg.DataProxyUserAgent = dataproxy.Key("user_agent").String()
+	d.SendUserHeader = dataproxy.Key("send_user_header").MustBool(false)
+	d.Logging = dataproxy.Key("logging").MustBool(false)
+	d.Timeout = dataproxy.Key("timeout").MustInt(30)
+	d.DialTimeout = dataproxy.Key("dialTimeout").MustInt(10)
+	d.KeepAlive = dataproxy.Key("keep_alive_seconds").MustInt(30)
+	d.TLSHandshakeTimeout = dataproxy.Key("tls_handshake_timeout_seconds").MustInt(10)
+	d.ExpectContinueTimeout = dataproxy.Key("expect_continue_timeout_seconds").MustInt(1)
+	d.MaxConnsPerHost = dataproxy.Key("max_conns_per_host").MustInt(0)
+	d.MaxIdleConns = dataproxy.Key("max_idle_connections").MustInt()
+	d.IdleConnTimeout = dataproxy.Key("idle_conn_timeout_seconds").MustInt(90)
+	d.ResponseLimit = dataproxy.Key("response_limit").MustInt64(0)
+	d.RowLimit = dataproxy.Key("row_limit").MustInt64(defaultDataProxyRowLimit)
+	d.UserAgent = dataproxy.Key("user_agent").String()
 
-	if cfg.DataProxyUserAgent == "" {
-		cfg.DataProxyUserAgent = fmt.Sprintf("Grafana/%s", BuildVersion)
+	if d.UserAgent == "" {
+		d.UserAgent = fmt.Sprintf("Grafana/%s", BuildVersion)
 	}
 
-	if cfg.DataProxyRowLimit <= 0 {
-		cfg.DataProxyRowLimit = defaultDataProxyRowLimit
+	if d.RowLimit <= 0 {
+		d.RowLimit = defaultDataProxyRowLimit
 	}
+
+	return d
+}
+
+func readDataProxySettings(iniFile *ini.File, cfg *Cfg) error {
+	dataProxySettings := DataProxyFromINI(iniFile)
+
+	cfg.DataProxy = dataProxySettings
 
 	return nil
 }


### PR DESCRIPTION
certain parts of [setting.Cfg](https://github.com/grafana/grafana/blob/main/pkg/setting/setting.go) are already in smaller structures, like [JWTAuth](https://github.com/grafana/grafana/blob/e4637810772088ea8bc7c85ebac5d60587eacec7/pkg/setting/setting.go#L294).

other parts, like the [dataproxy section](https://github.com/grafana/grafana/blob/e4637810772088ea8bc7c85ebac5d60587eacec7/pkg/setting/setting.go#L303-L316) are just fields in the `setting.Cfg` structure.

here we explore the idea, where each section is it's own go structure, by converting the `dataproxy section` to a separate structure.

the advantage would be to be able to only load a single section from the INI-file into the go structure, by directly calling `DataProxyFromINI`