### PR TITLE
Alerting: Prevent routing preview from auto-triggering on mount

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -32,6 +32,7 @@ const getAlertManagerDataSourcesByPermissionAndConfigMock =
   >;
 
 const ui = {
+  previewButton: byRole('button', { name: /preview routing/i }),
   contactPointGroup: byRole('list'),
   grafanaAlertManagerLabel: byText(/alertmanager:grafana/i),
   otherAlertManagerLabel: byText(/alertmanager:other_am/i),
@@ -118,7 +119,12 @@ describe('NotificationPreview', () => {
       }),
     ]);
 
-    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
+    const { user } = render(
+      <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
+    );
+
+    // Click the preview button to trigger the preview
+    await user.click(await ui.previewButton.find());
 
     // wait for loading to finish
     await waitFor(async () => {
@@ -144,7 +150,12 @@ describe('NotificationPreview', () => {
       }),
     ]);
 
-    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
+    const { user } = render(
+      <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
+    );
+
+    // Click the preview button to trigger the preview
+    await user.click(await ui.previewButton.find());
 
     // wait for loading to finish
     await waitFor(async () => {
@@ -178,6 +189,10 @@ describe('NotificationPreview', () => {
     const { user } = render(
       <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
     );
+
+    // Click the preview button to trigger the preview
+    await user.click(await ui.previewButton.find());
+
     // wait for loading to finish
     await waitFor(async () => {
       const matchingContactPoint = await ui.contactPointGroup.findAll();

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -32,7 +32,6 @@ const getAlertManagerDataSourcesByPermissionAndConfigMock =
   >;
 
 const ui = {
-  previewButton: byRole('button', { name: /preview routing/i }),
   contactPointGroup: byRole('list'),
   grafanaAlertManagerLabel: byText(/alertmanager:grafana/i),
   otherAlertManagerLabel: byText(/alertmanager:other_am/i),
@@ -119,12 +118,7 @@ describe('NotificationPreview', () => {
       }),
     ]);
 
-    const { user } = render(
-      <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
-    );
-
-    // Click the preview button to trigger the preview
-    await user.click(await ui.previewButton.find());
+    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
 
     // wait for loading to finish
     await waitFor(async () => {
@@ -150,12 +144,7 @@ describe('NotificationPreview', () => {
       }),
     ]);
 
-    const { user } = render(
-      <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
-    );
-
-    // Click the preview button to trigger the preview
-    await user.click(await ui.previewButton.find());
+    render(<NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />);
 
     // wait for loading to finish
     await waitFor(async () => {
@@ -189,10 +178,6 @@ describe('NotificationPreview', () => {
     const { user } = render(
       <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
     );
-
-    // Click the preview button to trigger the preview
-    await user.click(await ui.previewButton.find());
-
     // wait for loading to finish
     await waitFor(async () => {
       const matchingContactPoint = await ui.contactPointGroup.findAll();

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/css';
 import { Fragment, Suspense, lazy } from 'react';
+import { useEffectOnce } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, LoadingPlaceholder, Stack, Text, useEffectOnce, useStyles2 } from '@grafana/ui';
+import { Button, LoadingPlaceholder, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { AlertQuery, Labels } from 'app/types/unified-alerting-dto';
 
@@ -103,9 +104,21 @@ export const NotificationPreview = ({
             </Text>
           )}
         </Stack>
-        <Button icon="sync" variant="secondary" type="button" onClick={onPreview} disabled={disabled}>
-          <Trans i18nKey="alerting.notification-preview.preview-routing">Preview routing</Trans>
-        </Button>
+        <Tooltip
+          content={
+            disabled ? (
+              <Trans i18nKey="alerting.notification-preview.disabled-tooltip">
+                You don&apos;t have sufficient permissions to preview
+              </Trans>
+            ) : (
+              ''
+            )
+          }
+        >
+          <Button icon="sync" variant="secondary" type="button" onClick={onPreview} disabled={disabled}>
+            <Trans i18nKey="alerting.notification-preview.preview-routing">Preview routing</Trans>
+          </Button>
+        </Tooltip>
       </Stack>
       {potentialInstances.length > 0 && (
         <Suspense

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -3,7 +3,7 @@ import { Fragment, Suspense, lazy } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, LoadingPlaceholder, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Button, LoadingPlaceholder, Stack, Text, useEffectOnce, useStyles2 } from '@grafana/ui';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
 import { AlertQuery, Labels } from 'app/types/unified-alerting-dto';
 
@@ -64,6 +64,12 @@ export const NotificationPreview = ({
       alertUid: alertUid,
     });
   };
+
+  useEffectOnce(() => {
+    if (!disabled) {
+      onPreview();
+    }
+  });
 
   //  Get alert managers's data source information
   const alertManagerDataSources = useGetAlertManagerDataSourcesByPermissionAndConfig('notification');

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { Fragment, Suspense, lazy } from 'react';
-import { useEffectOnce } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -65,10 +64,6 @@ export const NotificationPreview = ({
       alertUid: alertUid,
     });
   };
-
-  useEffectOnce(() => {
-    onPreview();
-  });
 
   //  Get alert managers's data source information
   const alertManagerDataSources = useGetAlertManagerDataSourcesByPermissionAndConfig('notification');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1982,6 +1982,7 @@
     },
     "notification-preview": {
       "alertmanager": "Alertmanager:",
+      "disabled-tooltip": "You don't have sufficient permissions to preview",
       "error": "Could not load routing preview for {{alertmanager}}",
       "initialized": "Based on the labels added, alert instances are routed to the following notification policies. Expand each notification policy below to view more details.",
       "preview-routing": "Preview routing",


### PR DESCRIPTION
Issue: Users with Basic Editor role see permission errors immediately when opening the alert rule creation page, even before attempting to preview routing.
Support Escalation: https://github.com/grafana/support-escalations/issues/19394

**Can't reproduce on local instance:** The issue only occurs in GrafanaCloud environments where notification policies are stored as Kubernetes RoutingTree resources and the K8s API server enforces RBAC permissions.

**Root cause:** The NotificationPreview component is automatically triggering the routing preview on mount using useEffectOnce(), causing immediate API calls to fetch routing trees (/apis/notifications.alerting.grafana.app/v0alpha1/namespaces/{namespace}/routingtrees), which Basic Editors don't have permission to list, resulting in 403 errors appearing before users even requested a preview.

**Fix:** Only call onPreview when user doesn't have permissions to preview routing. Add info message on-hover of the disbaled Preview Routing button.
<img width="1512" height="760" alt="image" src="https://github.com/user-attachments/assets/8f385404-bf71-49c6-8856-61e736252695" />


