### PR TITLE
fix(dashboard): proper check uint32 size

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -1726,7 +1727,7 @@ func buildAnnotationFilter(filterMap map[string]interface{}) *dashv2alpha1.Dashb
 					uintIds = append(uintIds, uint32(v))
 				}
 			case int:
-				if v >= 0 && v <= int(^uint32(0)) {
+				if v >= 0 && v <= math.MaxUint32 {
 					uintIds = append(uintIds, uint32(v))
 				}
 			}


### PR DESCRIPTION
Currently the main build is broken, because we try to case numbers into ints that won't fit into ints on 32-bit systems. This PR fixes the check, so that it doesn't happen.

More context:
The expression `int(^uint32(0))` is trying to convert the maximum `uint32` value (`4294967295`) to an int:

- On 64-bit platforms (x86_64): int is 64 bits, so int can hold values up to ~9.2 quintillion. The value 4294967295 fits easily.
- On 32-bit ARM: int is only 32 bits (same as int32), so int can only hold values up to 2147483647 (2^31 - 1). The value 4294967295 is too large and causes an overflow.

The Go compiler detects this overflow at compile time on 32-bit ARM because it's a constant expression.
> github.com/grafana/grafana/apps/dashboard/pkg/migration/conversion\napps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go:1729:27: constant 4294967295 overflows int"