### PR TITLE
Dynamic dashboards: Fix empty space under time controls when dashboard has many variables

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -205,10 +205,6 @@ function renderHiddenVariables(dashboard: DashboardScene) {
 function getStyles(theme: GrafanaTheme2) {
   return {
     controls: css({
-      /*display: 'flex',
-      alignItems: 'flex-start',
-      flex: '100%',
-      */
       gap: theme.spacing(1),
       padding: theme.spacing(2),
       flexDirection: 'row',

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -206,7 +206,7 @@ function getStyles(theme: GrafanaTheme2) {
   return {
     controls: css({
       gap: theme.spacing(1),
-      padding: theme.spacing(2),
+      padding: theme.spacing(2, 2, 1, 2),
       flexDirection: 'row',
       flexWrap: 'nowrap',
       position: 'relative',
@@ -234,7 +234,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       justifyContent: 'flex-end',
       gap: theme.spacing(1),
-      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(1),
       float: 'right',
     }),
     timeControlsWrap: css({

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -163,23 +163,20 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       data-testid={selectors.pages.Dashboard.Controls}
       className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
     >
-      <Stack grow={1} wrap={'wrap'}>
-        {!hideVariableControls && (
-          <>
-            <VariableControls dashboard={dashboard} />
-            <DashboardDataLayerControls dashboard={dashboard} />
-          </>
-        )}
-        <Box grow={1} />
-        {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
-        {editPanel && <PanelEditControls panelEditor={editPanel} />}
-      </Stack>
       {!hideTimeControls && (
         <div className={cx(styles.timeControls, editPanel && styles.timeControlsWrap)}>
           <timePicker.Component model={timePicker} />
           <refreshPicker.Component model={refreshPicker} />
         </div>
       )}
+      {!hideVariableControls && (
+        <>
+          <VariableControls dashboard={dashboard} />
+          <DashboardDataLayerControls dashboard={dashboard} />
+        </>
+      )}
+      {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
+      {editPanel && <PanelEditControls panelEditor={editPanel} />}
       {!hideDashboardControls && model.hasDashboardControls() && (
         <Stack>
           <DashboardControlsButton dashboard={dashboard} />
@@ -208,9 +205,10 @@ function renderHiddenVariables(dashboard: DashboardScene) {
 function getStyles(theme: GrafanaTheme2) {
   return {
     controls: css({
-      display: 'flex',
+      /*display: 'flex',
       alignItems: 'flex-start',
       flex: '100%',
+      */
       gap: theme.spacing(1),
       padding: theme.spacing(2),
       flexDirection: 'row',
@@ -240,6 +238,8 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       justifyContent: 'flex-end',
       gap: theme.spacing(1),
+      marginTop: theme.spacing(1),
+      float: 'right',
     }),
     timeControlsWrap: css({
       flexWrap: 'wrap',

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -105,7 +105,7 @@ export function VariableValueSelectWrapper({ variable, inMenu }: VariableSelectP
       onPointerDown={onPointerDown}
       data-testid={selectors.pages.Dashboard.SubMenu.submenuItem}
     >
-      <VariableLabel variable={variable} className={cx(isSelectable && styles.labelSelectable)} />
+      <VariableLabel variable={variable} className={cx(isSelectable && styles.labelSelectable, styles.label)} />
       <variable.Component model={variable} />
     </div>
   );
@@ -145,12 +145,16 @@ function VariableLabel({
 
 const getStyles = (theme: GrafanaTheme2) => ({
   container: css({
-    display: 'flex',
+    display: 'inline-flex',
+    alignItems: 'center',
+    verticalAlign: 'middle',
     // No border for second element (inputs) as label and input border is shared
     '> :nth-child(2)': css({
       borderTopLeftRadius: 'unset',
       borderBottomLeftRadius: 'unset',
     }),
+    marginTop: theme.spacing(1),
+    marginRight: theme.spacing(1),
   }),
   verticalContainer: css({
     display: 'flex',
@@ -175,5 +179,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   labelSelectable: css({
     cursor: 'pointer',
+  }),
+  label: css({
+    display: 'flex',
+    alignItems: 'center',
   }),
 });

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -19,6 +19,7 @@ import { AddVariableButton } from './VariableControlsAddButton';
 
 export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
   const { variables } = sceneGraph.getVariables(dashboard)!.useState();
+  const styles = useStyles2(getStyles);
 
   return (
     <>
@@ -27,7 +28,11 @@ export function VariableControls({ dashboard }: { dashboard: DashboardScene }) {
         .map((variable) => (
           <VariableValueSelectWrapper key={variable.state.key} variable={variable} />
         ))}
-      {config.featureToggles.dashboardNewLayouts ? <AddVariableButton dashboard={dashboard} /> : null}
+      {config.featureToggles.dashboardNewLayouts ? (
+        <div className={styles.addButton}>
+          <AddVariableButton dashboard={dashboard} />
+        </div>
+      ) : null}
     </>
   );
 }
@@ -183,5 +188,12 @@ const getStyles = (theme: GrafanaTheme2) => ({
   label: css({
     display: 'flex',
     alignItems: 'center',
+  }),
+  addButton: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    verticalAlign: 'middle',
+    marginBottom: theme.spacing(1),
+    marginRight: theme.spacing(1),
   }),
 });

--- a/public/app/features/dashboard-scene/scene/VariableControls.tsx
+++ b/public/app/features/dashboard-scene/scene/VariableControls.tsx
@@ -153,7 +153,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
       borderTopLeftRadius: 'unset',
       borderBottomLeftRadius: 'unset',
     }),
-    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(1),
     marginRight: theme.spacing(1),
   }),
   verticalContainer: css({


### PR DESCRIPTION
Fixes excessive empty space under time controls when dashboards have many variables or large adhoc filters. Variables now wrap underneath the time controls instead of creating empty space.

<img width="820" height="738" alt="image" src="https://github.com/user-attachments/assets/3345b7ab-4c36-48b3-b379-b11ad87a429d" />



Implemented float-based layout for time controls: Switched from flexbox to CSS floats. Time controls use `float: 'right'` so variables flow around them and wrap underneath when needed, eliminating the empty space.

This should keep the existing visual appearance while fixing the layout issue.

Fixes #103516