### PR TITLE
Zanzana: Fix shadow client metric

### DIFF
--- a/pkg/services/authz/zanzana/client/metrics.go
+++ b/pkg/services/authz/zanzana/client/metrics.go
@@ -33,7 +33,7 @@ func newShadowClientMetrics(reg prometheus.Registerer) *metrics {
 		),
 		compileSeconds: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
-				Name:      "compile_seconds",
+				Name:      "engine_compile_seconds",
 				Help:      "Histogram for item checker compilation time for the specific access control engine (RBAC and zanzana).",
 				Namespace: metricsNamespace,
 				Subsystem: metricsSubSystem,

--- a/pkg/services/authz/zanzana/client/shadow_client.go
+++ b/pkg/services/authz/zanzana/client/shadow_client.go
@@ -40,13 +40,12 @@ func (c *ShadowClient) Check(ctx context.Context, id authlib.AuthInfo, req authl
 		}
 
 		timer := prometheus.NewTimer(c.metrics.evaluationsSeconds.WithLabelValues("zanzana"))
-		defer timer.ObserveDuration()
-
 		zanzanaCtx := context.WithoutCancel(ctx)
 		res, err := c.zanzanaClient.Check(zanzanaCtx, id, req, folder)
 		if err != nil {
 			c.logger.Error("Failed to run zanzana check", "error", err)
 		}
+		timer.ObserveDuration()
 
 		acRes := <-acResChan
 		acErr := <-acErrChan


### PR DESCRIPTION
**What is this feature?**

`grafana_iam_authz_zanzana_engine_evaluations_seconds_bucket` metric is not collected correctly in case of Zanzana. RBAC vs Zanzana are almost equal all the time.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
