### PR TITLE
Chore: Mark more files as generated in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 *.gen.ts linguist-generated
 *_gen.ts linguist-generated
 *_gen.go linguist-generated
+*_gen.csv linguist-generated
+*_gen.json linguist-generated
 **/openapi_snapshots/*.json linguist-generated
 apps/**/pkg/apis/*_manifest.go linguist-generated
 public/openapi3.json linguist-generated


### PR DESCRIPTION
**What is this feature?**
Marks more files as generated (noticed this as some other files generated by the feature toggle code weren't captured)

**Why do we need this feature?**
Cleaner PR diffs/clearer indication of generated files