### PR TITLE
RBAC: Correctly display the new roles after updating user, service account and team roles

### DIFF
--- a/public/app/core/components/RolePicker/UserRolePicker.tsx
+++ b/public/app/core/components/RolePicker/UserRolePicker.tsx
@@ -54,24 +54,25 @@ export const UserRolePicker = ({
   width,
   isLoading,
 }: Props) => {
-  const [{ loading, value: appliedRoles = roles || [] }, getUserRoles] = useAsyncFn(async () => {
-    try {
-      if (roles) {
-        return roles;
+  const [{ loading, value: appliedRoles = roles || [] }, getUserRoles] = useAsyncFn(
+    async (force = false) => {
+      try {
+        if (!force && roles) {
+          return roles;
+        }
+        if (!force && apply && Boolean(pendingRoles?.length)) {
+          return pendingRoles;
+        }
+        if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList) && userId > 0) {
+          return await fetchUserRoles(userId, orgId);
+        }
+      } catch (e) {
+        console.error('Error fetching user roles');
       }
-      if (apply && Boolean(pendingRoles?.length)) {
-        return pendingRoles;
-      }
-
-      if (contextSrv.hasPermission(AccessControlAction.ActionUserRolesList) && userId > 0) {
-        return await fetchUserRoles(userId, orgId);
-      }
-    } catch (e) {
-      // TODO handle error
-      console.error('Error loading options');
-    }
-    return [];
-  }, [orgId, userId, pendingRoles, roles]);
+      return [];
+    },
+    [orgId, userId, pendingRoles, roles]
+  );
 
   useEffect(() => {
     // only load roles when there is an Org selected
@@ -83,7 +84,7 @@ export const UserRolePicker = ({
   const onRolesChange = async (roles: Role[]) => {
     if (!apply) {
       await updateUserRoles(roles, userId, orgId);
-      await getUserRoles();
+      await getUserRoles(true); // Force fetch from backend after update
     } else if (onApplyRoles) {
       onApplyRoles(roles, userId, orgId);
     }


### PR DESCRIPTION
**What is this feature?**

Force the fetching of team, user, or service account roles after the they have been updated.

**Why do we need this feature?**

So that the role picker UI always displays the correct state of roles.

Before:

https://github.com/user-attachments/assets/10aa8aee-7e57-4f0e-be1b-32cb17b613b0

After:

https://github.com/user-attachments/assets/8e97b34d-05cf-4a78-a003-4670b8d69983

**Who is this feature for?**

Users updating roles through the UI.
