### PR TITLE
Docs: Fix grpc server key file param in config ini

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -113,7 +113,7 @@ network = "tcp"
 address = "127.0.0.1:10000"
 use_tls = false
 cert_file =
-key_file =
+cert_key =
 # this will log the request and response for each unary gRPC call
 enable_logging = false
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -114,7 +114,7 @@
 ;address = "127.0.0.1:10000"
 ;use_tls = false
 ;cert_file =
-;key_file =
+;cert_key =
 ;max_recv_msg_size =
 ;max_send_msg_size =
 # this will log the request and response for each unary gRPC call


### PR DESCRIPTION
This pull request renames the `key_file` option to `cert_key` in `conf/defaults.ini` and `conf/sample.ini` to match the expected field name:

https://github.com/grafana/grafana/blob/3e31f7b7138c0e8f683cfa19f9efd05de68d35d3/pkg/setting/setting_grpc.go#L117