### PR TITLE
fix(TopBar): consistent ToolbarButton styling for sidebar buttons

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -1,9 +1,7 @@
-import { css } from '@emotion/css';
 import React from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { ToolbarButton, useStyles2 } from '@grafana/ui';
+import { ToolbarButton } from '@grafana/ui';
 
 interface ToolbarItemButtonProps {
   isOpen: boolean;
@@ -30,7 +28,6 @@ function ExtensionToolbarItemButtonComponent(
   { isOpen, title, onClick, pluginId }: ToolbarItemButtonProps,
   ref: React.ForwardedRef<HTMLButtonElement>
 ) {
-  const styles = useStyles2(getStyles);
   const icon = getPluginIcon(pluginId);
 
   if (isOpen) {
@@ -38,11 +35,10 @@ function ExtensionToolbarItemButtonComponent(
     return (
       <ToolbarButton
         ref={ref}
-        className={styles.buttonActive}
         icon={icon}
         iconOnly
         data-testid="extension-toolbar-button-close"
-        variant="default"
+        variant="active"
         onClick={onClick}
         tooltip={t('navigation.extension-sidebar.button-tooltip.close', 'Close {{title}}', { title })}
       />
@@ -71,14 +67,3 @@ function ExtensionToolbarItemButtonComponent(
 export const ExtensionToolbarItemButton = React.forwardRef<HTMLButtonElement, ToolbarItemButtonProps>(
   ExtensionToolbarItemButtonComponent
 );
-
-function getStyles(theme: GrafanaTheme2) {
-  return {
-    buttonActive: css({
-      borderRadius: theme.shape.radius.circle,
-      backgroundColor: theme.colors.primary.transparent,
-      border: `1px solid ${theme.colors.primary.borderTransparent}`,
-      color: theme.colors.text.primary,
-    }),
-  };
-}

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -29,11 +29,15 @@ function ExtensionToolbarItemButtonComponent(
   ref: React.ForwardedRef<HTMLButtonElement>
 ) {
   const icon = getPluginIcon(pluginId);
-  const tooltip = isOpen
-    ? t('navigation.extension-sidebar.button-tooltip.close', 'Close {{title}}', { title })
-    : title
-      ? t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title })
-      : t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
+  const tooltip = (() => {
+    if (isOpen) {
+      return t('navigation.extension-sidebar.button-tooltip.close', 'Close {{title}}', { title });
+    }
+    if (title) {
+      return t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title });
+    }
+    return t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
+  })();
 
   return (
     <ToolbarButton

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -1,4 +1,4 @@
-import { css, cx } from '@emotion/css';
+import { css } from '@emotion/css';
 import React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
@@ -38,8 +38,9 @@ function ExtensionToolbarItemButtonComponent(
     return (
       <ToolbarButton
         ref={ref}
-        className={cx(styles.button, styles.buttonActive)}
+        className={styles.buttonActive}
         icon={icon}
+        iconOnly
         data-testid="extension-toolbar-button-close"
         variant="default"
         onClick={onClick}
@@ -55,8 +56,8 @@ function ExtensionToolbarItemButtonComponent(
   return (
     <ToolbarButton
       ref={ref}
-      className={cx(styles.button)}
       icon={icon}
+      iconOnly
       data-testid="extension-toolbar-button-open"
       variant="default"
       onClick={onClick}
@@ -73,17 +74,6 @@ export const ExtensionToolbarItemButton = React.forwardRef<HTMLButtonElement, To
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    button: css({
-      // this is needed because with certain breakpoints the button will get `width: auto`
-      // and the icon will stretch
-      aspectRatio: '1 / 1 !important',
-      width: '28px',
-      height: '28px',
-      padding: 0,
-      justifyContent: 'center',
-      borderRadius: theme.shape.radius.circle,
-      margin: theme.spacing(0, 0.25),
-    }),
     buttonActive: css({
       borderRadius: theme.shape.radius.circle,
       backgroundColor: theme.colors.primary.transparent,

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -29,33 +29,19 @@ function ExtensionToolbarItemButtonComponent(
   ref: React.ForwardedRef<HTMLButtonElement>
 ) {
   const icon = getPluginIcon(pluginId);
+  const tooltip = isOpen
+    ? t('navigation.extension-sidebar.button-tooltip.close', 'Close {{title}}', { title })
+    : title
+      ? t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title })
+      : t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
 
-  if (isOpen) {
-    // render button to close the sidebar
-    return (
-      <ToolbarButton
-        ref={ref}
-        icon={icon}
-        iconOnly
-        data-testid="extension-toolbar-button-close"
-        variant="active"
-        onClick={onClick}
-        tooltip={t('navigation.extension-sidebar.button-tooltip.close', 'Close {{title}}', { title })}
-      />
-    );
-  }
-  // if a title is provided, use it in the tooltip
-  let tooltip = t('navigation.extension-sidebar.button-tooltip.open-all', 'Open AI assistants and sidebar apps');
-  if (title) {
-    tooltip = t('navigation.extension-sidebar.button-tooltip.open', 'Open {{title}}', { title });
-  }
   return (
     <ToolbarButton
       ref={ref}
       icon={icon}
       iconOnly
-      data-testid="extension-toolbar-button-open"
-      variant="default"
+      data-testid={`extension-toolbar-button-${isOpen ? 'close' : 'open'}`}
+      variant={isOpen ? 'active' : 'default'}
       onClick={onClick}
       tooltip={tooltip}
     />

--- a/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
@@ -1,10 +1,8 @@
-import { css } from '@emotion/css';
 import { memo } from 'react';
 
-import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getAppEvents } from '@grafana/runtime';
-import { Dropdown, ToolbarButton, useStyles2 } from '@grafana/ui';
+import { Dropdown, ToolbarButton } from '@grafana/ui';
 import { OpenExtensionSidebarEvent } from 'app/types/events';
 
 import {
@@ -23,7 +21,6 @@ interface Props {
 export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }: Props) {
   const enrichedHelpNode = useHelpNode();
   const { setDockedComponentId, dockedComponentId, availableComponents } = useExtensionSidebarContext();
-  const styles = useStyles2(getStyles);
 
   if (!enrichedHelpNode) {
     return null;
@@ -52,7 +49,7 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
       iconOnly
       icon="question-circle"
       aria-label={t('navigation.help.aria-label', 'Help')}
-      className={isOpen ? styles.helpButtonActive : undefined}
+      variant={isOpen ? 'active' : 'default'}
       tooltip={
         isOpen
           ? t(
@@ -76,13 +73,4 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
       }}
     />
   );
-});
-
-const getStyles = (theme: GrafanaTheme2) => ({
-  helpButtonActive: css({
-    borderRadius: theme.shape.radius.circle,
-    backgroundColor: theme.colors.primary.transparent,
-    border: `1px solid ${theme.colors.primary.borderTransparent}`,
-    color: theme.colors.text.primary,
-  }),
 });


### PR DESCRIPTION
**What is this feature?**

Updates the toolbar buttons shown for help (when pathfinder is present), and all other extension buttons (assistant) to be consistently styled, so that they match each other and all use the standard ToolbarButton styling for an icon-only button, including the standard active state.

**Why do we need this feature?**

Consistency in the UI.

| Before | After |
|-|-|
| Help hover | _(no change)_ |
| <img width="425" height="58" alt="image" src="https://github.com/user-attachments/assets/00fd6f90-5178-4ddb-9c69-8ab14f1f6ee1" /> | <img width="435" height="61" alt="image" src="https://github.com/user-attachments/assets/686117c5-02d6-4357-a889-cab8fd14433e" /> |
| Help active | |
| <img width="423" height="58" alt="image" src="https://github.com/user-attachments/assets/551782b4-12ca-4ad6-b79a-8a621e599a99" /> | <img width="430" height="60" alt="image" src="https://github.com/user-attachments/assets/8221250e-2e15-48e1-90e5-584f61f15431" /> |
| Assistant hover | |
| <img width="426" height="61" alt="image" src="https://github.com/user-attachments/assets/e870e55a-7508-45e6-917d-22146f8d51f6" /> | <img width="433" height="59" alt="image" src="https://github.com/user-attachments/assets/1937b1ea-9f12-4f00-924e-4ce05f2ab7dd" /> |
| Assistant active | |
| <img width="424" height="56" alt="image" src="https://github.com/user-attachments/assets/02c9c2c3-ede1-4e6b-be13-c80094a40103" /> | <img width="431" height="60" alt="image" src="https://github.com/user-attachments/assets/a5f2df28-26ac-4369-882f-6b3e410b2365" /> |

**Who is this feature for?**

Cloud.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
