### PR TITLE
OFREP: add ST builder for the authorizer, APIEnabled=false needs it

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -61,10 +61,6 @@ func NewAPIBuilder(providerType string, url *url.URL, insecure bool, caFile stri
 }
 
 func RegisterAPIService(apiregistration builder.APIRegistrar, cfg *setting.Cfg) (*APIBuilder, error) {
-	if !cfg.OpenFeature.APIEnabled {
-		return nil, nil
-	}
-
 	var staticEvaluator featuremgmt.StaticFlagEvaluator //  No static evaluator needed for non-static provider
 	var err error
 	if cfg.OpenFeature.ProviderType == setting.StaticProviderType {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Earlier, I had asked the MTFF team to not register the ST API running local to the instance. This concern was to allow aggregation to proceed unhindered. Since `12.3.0-18574877265` however, the ST API and aggregated versions can co-exist as far as registration and there is tie-breaker logic (still driven by `cfg.OpenFeature.APIEnabled`) in kube-aggregator code which opts into the aggregated MTFF in cloud.

As such, the ST API doesn't need to be disabled anymore just for the purpose of selecting the MTFF. 

The main reason for this PR is that the authorizer, when not configured for an API Group (e.g. `features.grafana.app`) within the Single Tenant instance, the authorizer that has the final say is the [Role Authorizer](https://github.com/grafana/grafana/blob/main/pkg/services/apiserver/auth/authorizer/role.go). As one can determine from that authorizer's implementation, it denies Viewer roles `create` access to `ofrep/evaluate` subresource.

Although the builder registration isn't inherently useful to us in single-tenant since the final API serving the request is MT, having its authorizer is useful here. Not every service has this luxury and even though this is cryptic, it serves the use-case for now, until we have something better.

**Why do we need this feature?**

To give viewers access to FF evals in the new MTFF in cloud.

**Who is this feature for?**

MTFF Team, Frontend

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Tangential to https://github.com/grafana/grafana-org/issues/712

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
