### PR TITLE
SchemaV2: Set library panel repeat option on GridItem during v2alpha1 conversion.

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 )
 
-func RegisterConversions(s *runtime.Scheme, dsInfoProvider schemaversion.DataSourceInfoProvider) error {
+func RegisterConversions(s *runtime.Scheme, dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) error {
 	// v0 conversions
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
@@ -21,13 +21,13 @@ func RegisterConversions(s *runtime.Scheme, dsInfoProvider schemaversion.DataSou
 	}
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv2alpha1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv2alpha1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V0_to_V2alpha1(a.(*dashv0.Dashboard), b.(*dashv2alpha1.Dashboard), scope, dsInfoProvider)
+			return Convert_V0_to_V2alpha1(a.(*dashv0.Dashboard), b.(*dashv2alpha1.Dashboard), scope, dsInfoProvider, libPanelProvider)
 		})); err != nil {
 		return err
 	}
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv2beta1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv2beta1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V0_to_V2beta1(a.(*dashv0.Dashboard), b.(*dashv2beta1.Dashboard), scope, dsInfoProvider)
+			return Convert_V0_to_V2beta1(a.(*dashv0.Dashboard), b.(*dashv2beta1.Dashboard), scope, dsInfoProvider, libPanelProvider)
 		})); err != nil {
 		return err
 	}
@@ -41,13 +41,13 @@ func RegisterConversions(s *runtime.Scheme, dsInfoProvider schemaversion.DataSou
 	}
 	if err := s.AddConversionFunc((*dashv1.Dashboard)(nil), (*dashv2alpha1.Dashboard)(nil),
 		withConversionMetrics(dashv1.APIVERSION, dashv2alpha1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V1beta1_to_V2alpha1(a.(*dashv1.Dashboard), b.(*dashv2alpha1.Dashboard), scope, dsInfoProvider)
+			return Convert_V1beta1_to_V2alpha1(a.(*dashv1.Dashboard), b.(*dashv2alpha1.Dashboard), scope, dsInfoProvider, libPanelProvider)
 		})); err != nil {
 		return err
 	}
 	if err := s.AddConversionFunc((*dashv1.Dashboard)(nil), (*dashv2beta1.Dashboard)(nil),
 		withConversionMetrics(dashv1.APIVERSION, dashv2beta1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {
-			return Convert_V1beta1_to_V2beta1(a.(*dashv1.Dashboard), b.(*dashv2beta1.Dashboard), scope, dsInfoProvider)
+			return Convert_V1beta1_to_V2beta1(a.(*dashv1.Dashboard), b.(*dashv2beta1.Dashboard), scope, dsInfoProvider, libPanelProvider)
 		})); err != nil {
 		return err
 	}

--- a/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection_test.go
@@ -830,9 +830,12 @@ func TestDataLossDetectionOnAllInputFiles(t *testing.T) {
 	dsProvider := testutil.NewDataSourceProvider(testutil.StandardTestConfig)
 	migration.Initialize(dsProvider)
 
+	libPanelProvider := testutil.NewFakeLibraryPanelProvider()
+	migration.InitializeLibraryPanelProvider(libPanelProvider)
+
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	// Read all files from input directory

--- a/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection_test.go
@@ -828,10 +828,8 @@ func TestWithConversionValidation_DataLoss(t *testing.T) {
 func TestDataLossDetectionOnAllInputFiles(t *testing.T) {
 	// Initialize the migrator with a test data source provider
 	dsProvider := testutil.NewDataSourceProvider(testutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
-
 	libPanelProvider := testutil.NewFakeLibraryPanelProvider()
-	migration.InitializeLibraryPanelProvider(libPanelProvider)
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()

--- a/apps/dashboard/pkg/migration/conversion/conversion_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_test.go
@@ -42,8 +42,9 @@ func TestConversionMatrixExist(t *testing.T) {
 		&dashv2beta1.Dashboard{Spec: dashv2beta1.DashboardSpec{Title: "dashboardV2beta1"}},
 	}
 
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	for idx, in := range versions {
@@ -87,9 +88,13 @@ func TestDashboardConversionToAllVersions(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
 	migration.Initialize(dsProvider)
 
+	// Create a fake library panel provider for testing with standard test models
+	libPanelProvider := migrationtestutil.NewStandardLibraryPanelProvider()
+	migration.InitializeLibraryPanelProvider(libPanelProvider)
+
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	// Read all files from input directory
@@ -246,9 +251,13 @@ func TestMigratedDashboardsConversion(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
 	migration.Initialize(dsProvider)
 
+	// Create a fake library panel provider for testing
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
+	migration.InitializeLibraryPanelProvider(libPanelProvider)
+
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	// Read all files from migration package's latest_version directory
@@ -385,8 +394,9 @@ func TestConversionMetrics(t *testing.T) {
 	migration.RegisterMetrics(registry)
 
 	// Set up conversion scheme
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	tests := []struct {
@@ -724,8 +734,9 @@ func TestConversionLogging(t *testing.T) {
 	migration.RegisterMetrics(registry)
 
 	// Set up conversion scheme
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
-	err := RegisterConversions(scheme, dsProvider)
+	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
 
 	tests := []struct {

--- a/apps/dashboard/pkg/migration/conversion/conversion_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_test.go
@@ -31,9 +31,10 @@ import (
 )
 
 func TestConversionMatrixExist(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	versions := []metav1.Object{
 		&dashv0.Dashboard{Spec: common.Unstructured{Object: map[string]any{"title": "dashboardV0"}}},
@@ -42,7 +43,6 @@ func TestConversionMatrixExist(t *testing.T) {
 		&dashv2beta1.Dashboard{Spec: dashv2beta1.DashboardSpec{Title: "dashboardV2beta1"}},
 	}
 
-	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
 	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
@@ -84,13 +84,10 @@ func TestDeepCopyValid(t *testing.T) {
 }
 
 func TestDashboardConversionToAllVersions(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
-
-	// Create a fake library panel provider for testing with standard test models
 	libPanelProvider := migrationtestutil.NewStandardLibraryPanelProvider()
-	migration.InitializeLibraryPanelProvider(libPanelProvider)
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()
@@ -247,13 +244,10 @@ func TestDashboardConversionToAllVersions(t *testing.T) {
 // TestMigratedDashboardsConversion tests conversion of already-migrated dashboards
 // from the migration package's latest_version output directory
 func TestMigratedDashboardsConversion(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
-
-	// Create a fake library panel provider for testing
 	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
-	migration.InitializeLibraryPanelProvider(libPanelProvider)
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	// Set up conversion scheme
 	scheme := runtime.NewScheme()
@@ -387,14 +381,14 @@ func testConversion(t *testing.T, convertedDash metav1.Object, filename, outputD
 func TestConversionMetrics(t *testing.T) {
 	// Initialize migration with test providers
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	// Create a test registry for metrics
 	registry := prometheus.NewRegistry()
 	migration.RegisterMetrics(registry)
 
 	// Set up conversion scheme
-	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
 	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
@@ -515,7 +509,7 @@ func TestConversionMetrics(t *testing.T) {
 // TestConversionMetricsWrapper tests the withConversionMetrics wrapper function
 func TestConversionMetricsWrapper(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	// Create a test registry for metrics
 	registry := prometheus.NewRegistry()
@@ -683,7 +677,7 @@ func TestSchemaVersionExtraction(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Test the schema version extraction logic by creating a wrapper and checking the metrics labels
 			dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-			migration.Initialize(dsProvider)
+			migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 			// Create a test registry for metrics
 			registry := prometheus.NewRegistry()
@@ -727,14 +721,14 @@ func TestSchemaVersionExtraction(t *testing.T) {
 // TestConversionLogging tests that conversion-level logging works correctly
 func TestConversionLogging(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
+	migration.Initialize(dsProvider, libPanelProvider)
 
 	// Create a test registry for metrics
 	registry := prometheus.NewRegistry()
 	migration.RegisterMetrics(registry)
 
 	// Set up conversion scheme
-	libPanelProvider := migrationtestutil.NewFakeLibraryPanelProvider()
 	scheme := runtime.NewScheme()
 	err := RegisterConversions(scheme, dsProvider, libPanelProvider)
 	require.NoError(t, err)
@@ -819,7 +813,7 @@ func TestConversionLogging(t *testing.T) {
 // TestConversionLogLevels tests that appropriate log levels are used
 func TestConversionLogLevels(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("log levels and structured fields verification", func(t *testing.T) {
 		// Create test wrapper to verify logging behavior
@@ -890,7 +884,7 @@ func TestConversionLogLevels(t *testing.T) {
 // TestConversionLoggingFields tests that all expected fields are included in log messages
 func TestConversionLoggingFields(t *testing.T) {
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("verify all log fields are present", func(t *testing.T) {
 		// Test that the conversion wrapper includes all expected structured fields

--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.library-panel-repeat.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.library-panel-repeat.json
@@ -1,0 +1,99 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "metadata": {
+    "name": "library-panel-repeat-test",
+    "labels": {
+      "test": "library-panel-repeat"
+    }
+  },
+  "spec": {
+    "title": "Library Panel Repeat Options Test Dashboard",
+    "description": "Testing library panel repeat options extraction during conversion",
+    "tags": ["test", "library-panels", "repeat"],
+    "editable": true,
+    "preload": false,
+    "panels": [
+      {
+        "id": 1,
+        "title": "Library Panel Without Repeat",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "libraryPanel": {
+          "uid": "lib-panel-no-repeat",
+          "name": "Library Panel No Repeat"
+        },
+        "type": "timeseries"
+      },
+      {
+        "id": 2,
+        "title": "Library Panel With Repeat",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "libraryPanel": {
+          "uid": "lib-panel-with-repeat",
+          "name": "Library Panel With Repeat"
+        },
+        "type": "timeseries"
+      },
+      {
+        "id": 3,
+        "title": "Library Panel With Repeat and Direction",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "libraryPanel": {
+          "uid": "lib-panel-repeat-h",
+          "name": "Library Panel Repeat Horizontal"
+        },
+        "type": "timeseries"
+      },
+      {
+        "id": 4,
+        "title": "Library Panel With All Repeat Options",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "libraryPanel": {
+          "uid": "lib-panel-repeat-complete",
+          "name": "Library Panel Repeat Complete"
+        },
+        "type": "timeseries"
+      },
+      {
+        "id": 5,
+        "title": "Panel With Direct Repeat (should not be overridden)",
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 32
+        },
+        "libraryPanel": {
+          "uid": "lib-panel-with-repeat",
+          "name": "Library Panel With Repeat"
+        },
+        "repeat": "server",
+        "repeatDirection": "v",
+        "maxPerRow": 4,
+        "type": "timeseries"
+      }
+    ],
+    "schemaVersion": 38
+  }
+}
+

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v0alpha1.json
@@ -1,0 +1,108 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "metadata": {
+    "name": "library-panel-repeat-test",
+    "labels": {
+      "test": "library-panel-repeat"
+    }
+  },
+  "spec": {
+    "description": "Testing library panel repeat options extraction during conversion",
+    "editable": true,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "libraryPanel": {
+          "name": "Library Panel No Repeat",
+          "uid": "lib-panel-no-repeat"
+        },
+        "title": "Library Panel Without Repeat",
+        "type": "timeseries"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 2,
+        "libraryPanel": {
+          "name": "Library Panel With Repeat",
+          "uid": "lib-panel-with-repeat"
+        },
+        "title": "Library Panel With Repeat",
+        "type": "timeseries"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 16
+        },
+        "id": 3,
+        "libraryPanel": {
+          "name": "Library Panel Repeat Horizontal",
+          "uid": "lib-panel-repeat-h"
+        },
+        "title": "Library Panel With Repeat and Direction",
+        "type": "timeseries"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "id": 4,
+        "libraryPanel": {
+          "name": "Library Panel Repeat Complete",
+          "uid": "lib-panel-repeat-complete"
+        },
+        "title": "Library Panel With All Repeat Options",
+        "type": "timeseries"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 32
+        },
+        "id": 5,
+        "libraryPanel": {
+          "name": "Library Panel With Repeat",
+          "uid": "lib-panel-with-repeat"
+        },
+        "maxPerRow": 4,
+        "repeat": "server",
+        "repeatDirection": "v",
+        "title": "Panel With Direct Repeat (should not be overridden)",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 38,
+    "tags": [
+      "test",
+      "library-panels",
+      "repeat"
+    ],
+    "title": "Library Panel Repeat Options Test Dashboard"
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v1beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v2alpha1.json
@@ -1,0 +1,197 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v2alpha1",
+  "metadata": {
+    "name": "library-panel-repeat-test",
+    "labels": {
+      "test": "library-panel-repeat"
+    }
+  },
+  "spec": {
+    "annotations": [],
+    "cursorSync": "Off",
+    "description": "Testing library panel repeat options extraction during conversion",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 1,
+          "title": "Library Panel Without Repeat",
+          "libraryPanel": {
+            "name": "Library Panel No Repeat",
+            "uid": "lib-panel-no-repeat"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 2,
+          "title": "Library Panel With Repeat",
+          "libraryPanel": {
+            "name": "Library Panel With Repeat",
+            "uid": "lib-panel-with-repeat"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 3,
+          "title": "Library Panel With Repeat and Direction",
+          "libraryPanel": {
+            "name": "Library Panel Repeat Horizontal",
+            "uid": "lib-panel-repeat-h"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 4,
+          "title": "Library Panel With All Repeat Options",
+          "libraryPanel": {
+            "name": "Library Panel Repeat Complete",
+            "uid": "lib-panel-repeat-complete"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 5,
+          "title": "Panel With Direct Repeat (should not be overridden)",
+          "libraryPanel": {
+            "name": "Library Panel With Repeat",
+            "uid": "lib-panel-with-repeat"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "h"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "h",
+                "maxPerRow": 3
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 32,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "v",
+                "maxPerRow": 4
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "test",
+      "library-panels",
+      "repeat"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Library Panel Repeat Options Test Dashboard",
+    "variables": []
+  },
+  "status": {}
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.library-panel-repeat.v2beta1.json
@@ -1,0 +1,197 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "metadata": {
+    "name": "library-panel-repeat-test",
+    "labels": {
+      "test": "library-panel-repeat"
+    }
+  },
+  "spec": {
+    "annotations": [],
+    "cursorSync": "Off",
+    "description": "Testing library panel repeat options extraction during conversion",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 1,
+          "title": "Library Panel Without Repeat",
+          "libraryPanel": {
+            "name": "Library Panel No Repeat",
+            "uid": "lib-panel-no-repeat"
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 2,
+          "title": "Library Panel With Repeat",
+          "libraryPanel": {
+            "name": "Library Panel With Repeat",
+            "uid": "lib-panel-with-repeat"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 3,
+          "title": "Library Panel With Repeat and Direction",
+          "libraryPanel": {
+            "name": "Library Panel Repeat Horizontal",
+            "uid": "lib-panel-repeat-h"
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 4,
+          "title": "Library Panel With All Repeat Options",
+          "libraryPanel": {
+            "name": "Library Panel Repeat Complete",
+            "uid": "lib-panel-repeat-complete"
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "LibraryPanel",
+        "spec": {
+          "id": 5,
+          "title": "Panel With Direct Repeat (should not be overridden)",
+          "libraryPanel": {
+            "name": "Library Panel With Repeat",
+            "uid": "lib-panel-with-repeat"
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 16,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "h"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "h",
+                "maxPerRow": 3
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 32,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              },
+              "repeat": {
+                "mode": "variable",
+                "value": "server",
+                "direction": "v",
+                "maxPerRow": 4
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "test",
+      "library-panels",
+      "repeat"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Library Panel Repeat Options Test Dashboard",
+    "variables": []
+  },
+  "status": {}
+}

--- a/apps/dashboard/pkg/migration/conversion/v0.go
+++ b/apps/dashboard/pkg/migration/conversion/v0.go
@@ -25,7 +25,7 @@ func Convert_V0_to_V1beta1(in *dashv0.Dashboard, out *dashv1.Dashboard, scope co
 	return nil
 }
 
-func Convert_V0_to_V2alpha1(in *dashv0.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider) error {
+func Convert_V0_to_V2alpha1(in *dashv0.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) error {
 	v1beta1 := &dashv1.Dashboard{}
 	if err := ConvertDashboard_V0_to_V1beta1(in, v1beta1, scope); err != nil {
 		out.Status = dashv2alpha1.DashboardStatus{
@@ -48,7 +48,7 @@ func Convert_V0_to_V2alpha1(in *dashv0.Dashboard, out *dashv2alpha1.Dashboard, s
 		return nil
 	}
 
-	if err := ConvertDashboard_V1beta1_to_V2alpha1(v1beta1, out, scope, dsInfoProvider); err != nil {
+	if err := ConvertDashboard_V1beta1_to_V2alpha1(v1beta1, out, scope, dsInfoProvider, libPanelProvider); err != nil {
 		out.Status = dashv2alpha1.DashboardStatus{
 			Conversion: &dashv2alpha1.DashboardConversionStatus{
 				StoredVersion: ptr.To(dashv0.VERSION),
@@ -72,7 +72,7 @@ func Convert_V0_to_V2alpha1(in *dashv0.Dashboard, out *dashv2alpha1.Dashboard, s
 	return nil
 }
 
-func Convert_V0_to_V2beta1(in *dashv0.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider) error {
+func Convert_V0_to_V2beta1(in *dashv0.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) error {
 	v1beta1 := &dashv1.Dashboard{}
 	if err := ConvertDashboard_V0_to_V1beta1(in, v1beta1, scope); err != nil {
 		out.Status = dashv2beta1.DashboardStatus{
@@ -86,7 +86,7 @@ func Convert_V0_to_V2beta1(in *dashv0.Dashboard, out *dashv2beta1.Dashboard, sco
 	}
 
 	v2alpha1 := &dashv2alpha1.Dashboard{}
-	if err := ConvertDashboard_V1beta1_to_V2alpha1(v1beta1, v2alpha1, scope, dsInfoProvider); err != nil {
+	if err := ConvertDashboard_V1beta1_to_V2alpha1(v1beta1, v2alpha1, scope, dsInfoProvider, libPanelProvider); err != nil {
 		out.Status = dashv2beta1.DashboardStatus{
 			Conversion: &dashv2beta1.DashboardConversionStatus{
 				StoredVersion: ptr.To(dashv0.VERSION),

--- a/apps/dashboard/pkg/migration/conversion/v0_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v0_test.go
@@ -17,9 +17,9 @@ import (
 
 // TestV0ConversionErrorHandling tests that v0 conversion functions properly return errors and set status
 func TestV0ConversionErrorHandling(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	tests := []struct {
 		name            string
@@ -128,9 +128,9 @@ func TestV0ConversionErrorHandling(t *testing.T) {
 
 // TestV0ConversionErrorPropagation tests that errors from atomic functions are properly propagated
 func TestV0ConversionErrorPropagation(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("ConvertDashboard_V0_to_V1beta1 returns error on migration failure", func(t *testing.T) {
 		source := &dashv0.Dashboard{
@@ -201,9 +201,9 @@ func TestV0ConversionErrorPropagation(t *testing.T) {
 
 // TestV0ConversionSuccessPaths tests that successful conversion paths are covered
 func TestV0ConversionSuccessPaths(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("Convert_V0_to_V1beta1 success path returns nil", func(t *testing.T) {
 		source := &dashv0.Dashboard{
@@ -269,9 +269,9 @@ func TestV0ConversionSuccessPaths(t *testing.T) {
 
 // TestV0ConversionSecondStepErrors tests error handling in second step of multi-step conversions
 func TestV0ConversionSecondStepErrors(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("Convert_V0_to_V2alpha1 sets status on first step error", func(t *testing.T) {
 		// Create a dashboard that will fail v0->v1beta1 conversion

--- a/apps/dashboard/pkg/migration/conversion/v0_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v0_test.go
@@ -108,9 +108,9 @@ func TestV0ConversionErrorHandling(t *testing.T) {
 			case *dashv1.Dashboard:
 				err = Convert_V0_to_V1beta1(tt.source, target, nil)
 			case *dashv2alpha1.Dashboard:
-				err = Convert_V0_to_V2alpha1(tt.source, target, nil, dsProvider)
+				err = Convert_V0_to_V2alpha1(tt.source, target, nil, dsProvider, nil)
 			case *dashv2beta1.Dashboard:
-				err = Convert_V0_to_V2beta1(tt.source, target, nil, dsProvider)
+				err = Convert_V0_to_V2beta1(tt.source, target, nil, dsProvider, nil)
 			default:
 				t.Fatalf("unexpected target type: %T", target)
 			}
@@ -190,7 +190,7 @@ func TestV0ConversionErrorPropagation(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		require.Error(t, err, "expected error to be returned on first step failure")
 		require.NotNil(t, target.Status.Conversion)
@@ -240,7 +240,7 @@ func TestV0ConversionSuccessPaths(t *testing.T) {
 		}
 		target := &dashv2alpha1.Dashboard{}
 
-		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider, nil)
 
 		require.NoError(t, err, "expected successful conversion")
 		// Layout should be set even on success
@@ -261,7 +261,7 @@ func TestV0ConversionSuccessPaths(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		require.NoError(t, err, "expected successful conversion")
 	})
@@ -289,7 +289,7 @@ func TestV0ConversionSecondStepErrors(t *testing.T) {
 		}
 		target := &dashv2alpha1.Dashboard{}
 
-		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider, nil)
 
 		// Convert_V0_to_V2alpha1 doesn't return error, just sets status
 		require.NoError(t, err, "Convert_V0_to_V2alpha1 doesn't return error")
@@ -323,7 +323,7 @@ func TestV0ConversionSecondStepErrors(t *testing.T) {
 		}
 		target := &dashv2alpha1.Dashboard{}
 
-		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2alpha1(source, target, nil, dsProvider, nil)
 
 		// Convert_V0_to_V2alpha1 doesn't return error, just sets status
 		require.NoError(t, err, "Convert_V0_to_V2alpha1 doesn't return error")
@@ -353,7 +353,7 @@ func TestV0ConversionSecondStepErrors(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		// May or may not error depending on dashboard content
 		// But if it does error on second step, status should be set
@@ -379,7 +379,7 @@ func TestV0ConversionSecondStepErrors(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V0_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		// May or may not error depending on dashboard content
 		// But if it does error on third step, status should be set

--- a/apps/dashboard/pkg/migration/conversion/v1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1.go
@@ -25,8 +25,8 @@ func Convert_V1beta1_to_V0(in *dashv1.Dashboard, out *dashv0.Dashboard, scope co
 	return nil
 }
 
-func Convert_V1beta1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider) error {
-	if err := ConvertDashboard_V1beta1_to_V2alpha1(in, out, scope, dsInfoProvider); err != nil {
+func Convert_V1beta1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) error {
+	if err := ConvertDashboard_V1beta1_to_V2alpha1(in, out, scope, dsInfoProvider, libPanelProvider); err != nil {
 		out.Status = dashv2alpha1.DashboardStatus{
 			Conversion: &dashv2alpha1.DashboardConversionStatus{
 				StoredVersion: ptr.To(dashv1.VERSION),
@@ -60,9 +60,9 @@ func Convert_V1beta1_to_V2alpha1(in *dashv1.Dashboard, out *dashv2alpha1.Dashboa
 	return nil
 }
 
-func Convert_V1beta1_to_V2beta1(in *dashv1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider) error {
+func Convert_V1beta1_to_V2beta1(in *dashv1.Dashboard, out *dashv2beta1.Dashboard, scope conversion.Scope, dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) error {
 	v2alpha1 := &dashv2alpha1.Dashboard{}
-	if err := ConvertDashboard_V1beta1_to_V2alpha1(in, v2alpha1, scope, dsInfoProvider); err != nil {
+	if err := ConvertDashboard_V1beta1_to_V2alpha1(in, v2alpha1, scope, dsInfoProvider, libPanelProvider); err != nil {
 		out.Status = dashv2beta1.DashboardStatus{
 			Conversion: &dashv2beta1.DashboardConversionStatus{
 				StoredVersion: ptr.To(dashv1.VERSION),

--- a/apps/dashboard/pkg/migration/conversion/v1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_test.go
@@ -36,7 +36,7 @@ func TestV1ConversionErrorHandling(t *testing.T) {
 		}
 		target := &dashv2alpha1.Dashboard{}
 
-		err := Convert_V1beta1_to_V2alpha1(source, target, nil, dsProvider)
+		err := Convert_V1beta1_to_V2alpha1(source, target, nil, dsProvider, nil)
 
 		// Convert_V1beta1_to_V2alpha1 doesn't return error, just sets status
 		require.NoError(t, err, "Convert_V1beta1_to_V2alpha1 doesn't return error")
@@ -63,7 +63,7 @@ func TestV1ConversionErrorHandling(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		// May or may not error depending on dashboard content
 		// But if it does error on first step, status should be set with correct StoredVersion
@@ -90,7 +90,7 @@ func TestV1ConversionErrorHandling(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		// May or may not error depending on dashboard content
 		// But if it does error on second step, status should be set with correct StoredVersion
@@ -116,7 +116,7 @@ func TestV1ConversionErrorHandling(t *testing.T) {
 		}
 		target := &dashv2beta1.Dashboard{}
 
-		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider)
+		err := Convert_V1beta1_to_V2beta1(source, target, nil, dsProvider, nil)
 
 		// Should succeed if dashboard is valid
 		if err == nil {

--- a/apps/dashboard/pkg/migration/conversion/v1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1_test.go
@@ -16,9 +16,9 @@ import (
 
 // TestV1ConversionErrorHandling tests that v1 conversion functions properly handle errors
 func TestV1ConversionErrorHandling(t *testing.T) {
-	// Initialize the migrator with a test data source provider
+	// Initialize the migrator with a test data source provider and library panel provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
-	migration.Initialize(dsProvider)
+	migration.Initialize(dsProvider, migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("Convert_V1beta1_to_V2alpha1 sets status on conversion error", func(t *testing.T) {
 		// Create a dashboard that will cause conversion to fail

--- a/apps/dashboard/pkg/migration/migrate.go
+++ b/apps/dashboard/pkg/migration/migrate.go
@@ -9,14 +9,9 @@ import (
 )
 
 // Initialize provides the migrator singleton with required dependencies and builds the map of migrations.
-func Initialize(dsInfoProvider schemaversion.DataSourceInfoProvider) {
-	migratorInstance.init(dsInfoProvider)
-}
-
-// InitializeLibraryPanelProvider initializes the library panel info provider.
-// This can be called separately from Initialize to allow for optional library panel support.
-func InitializeLibraryPanelProvider(libPanelProvider schemaversion.LibraryPanelInfoProvider) {
-	migratorInstance.initLibraryPanelProvider(libPanelProvider)
+// The library panel provider is optional and can be nil if library panel support is not needed.
+func Initialize(dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) {
+	migratorInstance.init(dsInfoProvider, libPanelProvider)
 }
 
 // GetDataSourceInfoProvider returns the datasource info provider instance that was initialized.
@@ -65,20 +60,14 @@ type migrator struct {
 	migrations       map[int]schemaversion.SchemaVersionMigrationFunc
 	dsInfoProvider   schemaversion.DataSourceInfoProvider
 	libPanelProvider schemaversion.LibraryPanelInfoProvider
-	libPanelInitOnce sync.Once
 }
 
-func (m *migrator) init(dsInfoProvider schemaversion.DataSourceInfoProvider) {
+func (m *migrator) init(dsInfoProvider schemaversion.DataSourceInfoProvider, libPanelProvider schemaversion.LibraryPanelInfoProvider) {
 	initOnce.Do(func() {
 		m.dsInfoProvider = dsInfoProvider
+		m.libPanelProvider = libPanelProvider
 		m.migrations = schemaversion.GetMigrations(dsInfoProvider)
 		close(m.ready)
-	})
-}
-
-func (m *migrator) initLibraryPanelProvider(libPanelProvider schemaversion.LibraryPanelInfoProvider) {
-	m.libPanelInitOnce.Do(func() {
-		m.libPanelProvider = libPanelProvider
 	})
 }
 

--- a/apps/dashboard/pkg/migration/migrate_test.go
+++ b/apps/dashboard/pkg/migration/migrate_test.go
@@ -29,7 +29,7 @@ const DEV_DASHBOARDS_OUTPUT_DIR = "testdata/dev-dashboards-output"
 func TestMigrate(t *testing.T) {
 	// Reset the migration singleton and use the same datasource provider as the frontend test to ensure consistency
 	ResetForTesting()
-	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig))
+	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig), migrationtestutil.NewFakeLibraryPanelProvider())
 
 	t.Run("minimum version check", func(t *testing.T) {
 		err := Migrate(context.Background(), map[string]interface{}{
@@ -45,7 +45,7 @@ func TestMigrate(t *testing.T) {
 
 func TestMigrateSingleVersion(t *testing.T) {
 	// Use the same datasource provider as the frontend test to ensure consistency
-	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig))
+	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig), migrationtestutil.NewFakeLibraryPanelProvider())
 
 	runSingleVersionMigrationTests(t, SINGLE_VERSION_OUTPUT_DIR)
 }
@@ -212,7 +212,7 @@ func loadDashboard(t *testing.T, path string) map[string]interface{} {
 // TestSchemaMigrationMetrics tests that schema migration metrics are recorded correctly
 func TestSchemaMigrationMetrics(t *testing.T) {
 	// Initialize migration with test providers
-	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig))
+	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig), migrationtestutil.NewFakeLibraryPanelProvider())
 
 	// Create a test registry for metrics
 	registry := prometheus.NewRegistry()
@@ -296,7 +296,7 @@ func TestSchemaMigrationMetrics(t *testing.T) {
 
 // TestSchemaMigrationLogging tests that schema migration logging works correctly
 func TestSchemaMigrationLogging(t *testing.T) {
-	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig))
+	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig), migrationtestutil.NewFakeLibraryPanelProvider())
 
 	tests := []struct {
 		name           string
@@ -413,7 +413,7 @@ func TestMigrateDevDashboards(t *testing.T) {
 	// Reset the migration singleton and use the dev dashboard datasource provider
 	// to match the frontend devDashboardDataSources configuration
 	ResetForTesting()
-	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.DevDashboardConfig))
+	Initialize(migrationtestutil.NewDataSourceProvider(migrationtestutil.DevDashboardConfig), migrationtestutil.NewFakeLibraryPanelProvider())
 
 	runDevDashboardMigrationTests(t, schemaversion.LATEST_VERSION, DEV_DASHBOARDS_OUTPUT_DIR)
 }

--- a/apps/dashboard/pkg/migration/schemaversion/migrations.go
+++ b/apps/dashboard/pkg/migration/schemaversion/migrations.go
@@ -28,6 +28,14 @@ type DataSourceInfoProvider interface {
 	GetDataSourceInfo(ctx context.Context) []DataSourceInfo
 }
 
+// LibraryPanelInfoProvider provides access to library panel models
+type LibraryPanelInfoProvider interface {
+	// GetPanelModelByUID returns the panel model for a library panel by its UID
+	// The context must have the namespace in it
+	// Returns the panel model as a map[string]interface{} or nil if not found
+	GetPanelModelByUID(ctx context.Context, uid string) (map[string]interface{}, error)
+}
+
 type PanelPluginInfo struct {
 	ID      string
 	Version string

--- a/apps/dashboard/pkg/migration/testutil/mocks.go
+++ b/apps/dashboard/pkg/migration/testutil/mocks.go
@@ -168,3 +168,60 @@ func (p *ConfigurableDataSourceProvider) getDevDashboardDataSources() []schemave
 		},
 	}
 }
+
+// FakeLibraryPanelProvider provides a fake implementation of LibraryPanelInfoProvider for testing
+type FakeLibraryPanelProvider struct {
+	panels map[string]map[string]interface{}
+}
+
+// NewFakeLibraryPanelProvider creates a new fake library panel provider
+func NewFakeLibraryPanelProvider() *FakeLibraryPanelProvider {
+	return &FakeLibraryPanelProvider{
+		panels: make(map[string]map[string]interface{}),
+	}
+}
+
+// AddPanelModel adds a panel model for a given UID
+func (p *FakeLibraryPanelProvider) AddPanelModel(uid string, model map[string]interface{}) {
+	p.panels[uid] = model
+}
+
+// GetPanelModelByUID returns the panel model for a library panel by its UID
+func (p *FakeLibraryPanelProvider) GetPanelModelByUID(_ context.Context, uid string) (map[string]interface{}, error) {
+	if model, ok := p.panels[uid]; ok {
+		return model, nil
+	}
+	return nil, nil
+}
+
+// NewStandardLibraryPanelProvider creates a library panel provider with standard test library panel models
+// This includes library panels used in test fixtures for repeat options testing
+func NewStandardLibraryPanelProvider() *FakeLibraryPanelProvider {
+	provider := NewFakeLibraryPanelProvider()
+
+	// Add library panel models for the test fixture v1beta1.library-panel-repeat.json
+	provider.AddPanelModel("lib-panel-no-repeat", map[string]interface{}{
+		"type":  "timeseries",
+		"title": "Library Panel No Repeat",
+	})
+	provider.AddPanelModel("lib-panel-with-repeat", map[string]interface{}{
+		"type":   "timeseries",
+		"title":  "Library Panel With Repeat",
+		"repeat": "server",
+	})
+	provider.AddPanelModel("lib-panel-repeat-h", map[string]interface{}{
+		"type":            "timeseries",
+		"title":           "Library Panel Repeat Horizontal",
+		"repeat":          "server",
+		"repeatDirection": "h",
+	})
+	provider.AddPanelModel("lib-panel-repeat-complete", map[string]interface{}{
+		"type":            "timeseries",
+		"title":           "Library Panel Repeat Complete",
+		"repeat":          "server",
+		"repeatDirection": "h",
+		"maxPerRow":       3,
+	})
+
+	return provider
+}

--- a/pkg/registry/apis/dashboard/librarypanels.go
+++ b/pkg/registry/apis/dashboard/librarypanels.go
@@ -1,0 +1,53 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/libraryelements"
+	"github.com/grafana/grafana/pkg/services/libraryelements/model"
+)
+
+var _ schemaversion.LibraryPanelInfoProvider = (*libraryPanelInfoProvider)(nil)
+
+type libraryPanelInfoProvider struct {
+	libraryPanelService libraryelements.Service
+}
+
+func (l *libraryPanelInfoProvider) GetPanelModelByUID(ctx context.Context, uid string) (map[string]interface{}, error) {
+	// Extract namespace info from context to get OrgID
+	nsInfo, err := request.NamespaceInfoFrom(ctx, true)
+	if err != nil {
+		// If namespace info is not available, return nil
+		return nil, nil
+	}
+
+	// Get identity from context, or create a service identity if not available
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		// Use service identity for background operations
+		ctx, user = identity.WithServiceIdentity(ctx, nsInfo.OrgID)
+	}
+
+	// Get the library element by UID
+	cmd := model.GetLibraryElementCommand{
+		UID: uid,
+	}
+	element, err := l.libraryPanelService.GetElement(ctx, user, cmd)
+	if err != nil {
+		// If library panel not found or error, return nil
+		return nil, nil
+	}
+
+	// Parse the model JSON into a map
+	var panelModel map[string]interface{}
+	if err := json.Unmarshal(element.Model, &panelModel); err != nil {
+		// If parsing fails, return nil
+		return nil, nil
+	}
+
+	return panelModel, nil
+}

--- a/pkg/registry/apis/dashboard/mutation_test.go
+++ b/pkg/registry/apis/dashboard/mutation_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func TestDashboardAPIBuilder_Mutate(t *testing.T) {
-	migration.Initialize(testutil.NewDataSourceProvider(testutil.StandardTestConfig))
+	migration.Initialize(testutil.NewDataSourceProvider(testutil.StandardTestConfig), testutil.NewFakeLibraryPanelProvider())
 	tests := []struct {
 		name                string
 		inputObj            runtime.Object

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -175,18 +175,20 @@ func RegisterAPIService(
 	}
 
 	migration.RegisterMetrics(reg)
-	migration.Initialize(&datasourceInfoProvider{
-		datasourceService: datasourceService,
-	})
-	migration.InitializeLibraryPanelProvider(&libraryPanelInfoProvider{
-		libraryPanelService: libraryPanels,
-	})
+	migration.Initialize(
+		&datasourceInfoProvider{
+			datasourceService: datasourceService,
+		},
+		&libraryPanelInfoProvider{
+			libraryPanelService: libraryPanels,
+		},
+	)
 	apiregistration.RegisterAPI(builder)
 	return builder
 }
 
-func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceInfoProvider, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface) *DashboardsAPIBuilder {
-	migration.Initialize(datasourceProvider)
+func NewAPIService(ac authlib.AccessClient, features featuremgmt.FeatureToggles, folderClientProvider client.K8sHandlerProvider, datasourceProvider schemaversion.DataSourceInfoProvider, resourcePermissionsSvc *dynamic.NamespaceableResourceInterface, libPanelProvider schemaversion.LibraryPanelInfoProvider) *DashboardsAPIBuilder {
+	migration.Initialize(datasourceProvider, libPanelProvider)
 	return &DashboardsAPIBuilder{
 		minRefreshInterval:     "10s",
 		accessClient:           ac,

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -178,6 +178,9 @@ func RegisterAPIService(
 	migration.Initialize(&datasourceInfoProvider{
 		datasourceService: datasourceService,
 	})
+	migration.InitializeLibraryPanelProvider(&libraryPanelInfoProvider{
+		libraryPanelService: libraryPanels,
+	})
 	apiregistration.RegisterAPI(builder)
 	return builder
 }
@@ -231,7 +234,7 @@ func (b *DashboardsAPIBuilder) InstallSchema(scheme *runtime.Scheme) error {
 	}
 
 	// Register the explicit conversions
-	if err := conversion.RegisterConversions(scheme, migration.GetDataSourceInfoProvider()); err != nil {
+	if err := conversion.RegisterConversions(scheme, migration.GetDataSourceInfoProvider(), migration.GetLibraryPanelInfoProvider()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What is this feature?**

This replaces 
#109921

We're trying to remove repeat options from library panels, and instead have the repeat options for library panels on the dashboard level.

Because it was originally part of the panel definition, the repeat options were present in the library panel definition and retrieved async after the dashboard was loaded. With the repeat options now being part of the grid item that's created before the library panel is loaded we've run into unnecessary complexities.

What we're doing in this PR is to migrate the repeat options from the library panel definition to the dashboard definition. We do this in the conversion from V1 to V2 by retrieving the library panel from the library panel service when creating the grid item, then setting the repeat options from the library panel definition on the grid item.

Most of this is modeled after how the dsInfoProvider works.

Apart from the tests I've verified that this correctly sets the repeat options from the library panel in the backend conversion.
<img width="750" height="194" alt="image" src="https://github.com/user-attachments/assets/2042e940-123f-41b2-9612-5d7628cd1c42" />
