### PR TITLE
Sidepane: Remove padding

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebar.tsx
@@ -61,10 +61,13 @@ const getStyles = (theme: GrafanaTheme2) => {
       display: 'flex',
       flexDirection: 'column',
       gap: theme.spacing(1),
-      padding: theme.spacing(1),
       width: '100%',
       height: '100%',
       overflow: 'auto',
+      // Temp fix for AI assistant, remove in a 1-2 months
+      ' > div > div': {
+        margin: 0,
+      },
     }),
     content: css({
       flex: 1,


### PR DESCRIPTION
Noticed this awkward padding in the path finder app which is missing in the AI assistant. 

The AI assistant has a negative -8px margin on an inner div. Figured it be better to remove this padding in the main app so the panes can have a header that is flush with the borders. 

Added a temporary nested margin override so that the AI assistant does not look temporarily broken before they remove it. 

<img width="418" height="1512" alt="Screenshot 2025-11-13 at 10 36 56" src="https://github.com/user-attachments/assets/e4deedc9-3015-41fd-9930-b144a24cf70f" />
