### PR TITLE
Dashboards: Fix timeseries off-by N time shift bug after mouse x-axis zoom in panel

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -113,6 +113,30 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
     );
   }
 
+  public onTimeRangeChange(timeRange: TimeRange): void {
+    const { timeShift } = this.state;
+
+    if (timeShift) {
+      const timeShiftInterpolated = sceneGraph.interpolate(this, timeShift);
+      const reverseShift = '+' + timeShiftInterpolated;
+
+      const from = dateMath.parseDateMath(reverseShift, timeRange.from, false);
+      const to = dateMath.parseDateMath(reverseShift, timeRange.to, true);
+
+      if (from && to) {
+        this.getAncestorTimeRange().onTimeRangeChange({
+          ...timeRange,
+          from,
+          to,
+          raw: { from, to },
+        });
+        return;
+      }
+    }
+
+    this.getAncestorTimeRange().onTimeRangeChange(timeRange);
+  }
+
   private getTimeOverride(parentTimeRange: TimeRange): TimeOverrideResult {
     const { timeFrom, timeShift, compareWith } = this.state;
     const infoBlocks = [];


### PR DESCRIPTION
**What is this feature?**

This change fixes a bug with time shifted queries when zooming into a time range at the panel level, where zoom was incorrectly offset back in time, by an extra N amount as the configured time shift period, doubling the offset in panel/dashboard.

Before fix (note panel and dashboard time ranges):

https://github.com/user-attachments/assets/d76ae4cf-4fc8-45b7-9692-2a07aa5fa9f2

After fix  (note panel and dashboard time ranges):

https://github.com/user-attachments/assets/96a69625-729e-4436-b1f3-84d5c3391de6


**Why do we need this feature?**

We need click and drag time range zoom interactions to be accurate, instead of zooming into an inaccurate range.

**Who is this feature for?**

All users of Grafana for any timeseries panel visualizations where time range zoom is employed.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113820

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
