### PR TITLE
Provisioning: detect stale sync status and trigger resync

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -291,7 +291,9 @@ func (rc *RepositoryController) shouldResync(ctx context.Context, obj *provision
 
 	// Check for stale sync status - if sync status indicates a job is running but the job no longer exists
 	// Only check if Finished is set (meaning a sync has completed before) to avoid interfering with initial syncs
+	// Only trigger resync if sync is enabled to avoid unnecessary operations
 	if obj.Status.Sync.Finished > 0 &&
+		obj.Spec.Sync.Enabled &&
 		(obj.Status.Sync.State == provisioning.JobStatePending || obj.Status.Sync.State == provisioning.JobStateWorking) &&
 		obj.Status.Sync.JobID != "" {
 		_, err := rc.jobs.Get(ctx, obj.Namespace, obj.Status.Sync.JobID)

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -3,18 +3,25 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/labels"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	provisioningv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
@@ -337,4 +344,263 @@ func TestShouldUseIncrementalSync(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, got)
 	})
+}
+
+// mockJobsQueueStore implements both jobs.Queue and jobs.Store for testing
+type mockJobsQueueStore struct {
+	*jobs.MockQueue
+	*jobs.MockStore
+}
+
+// mockRepositoryLister implements listers.RepositoryLister for testing
+type mockRepositoryLister struct {
+	repositoriesFunc func(namespace string) listers.RepositoryNamespaceLister
+}
+
+func (m *mockRepositoryLister) Repositories(namespace string) listers.RepositoryNamespaceLister {
+	if m.repositoriesFunc != nil {
+		return m.repositoriesFunc(namespace)
+	}
+	return nil
+}
+
+func (m *mockRepositoryLister) List(selector labels.Selector) ([]*provisioning.Repository, error) {
+	panic("not needed for testing")
+}
+
+// mockRepositoryNamespaceLister implements listers.RepositoryNamespaceLister for testing
+type mockRepositoryNamespaceLister struct {
+	getFunc func(name string) (*provisioning.Repository, error)
+}
+
+func (m *mockRepositoryNamespaceLister) Get(name string) (*provisioning.Repository, error) {
+	if m.getFunc != nil {
+		return m.getFunc(name)
+	}
+	return nil, nil
+}
+
+func (m *mockRepositoryNamespaceLister) List(selector labels.Selector) ([]*provisioning.Repository, error) {
+	panic("not needed for testing")
+}
+
+func TestRepositoryController_shouldResync_StaleSyncStatus(t *testing.T) {
+	testCases := []struct {
+		name           string
+		repo           *provisioning.Repository
+		jobGetError    error
+		expectedResync bool
+		description    string
+	}{
+		{
+			name: "stale sync status with Pending state - job not found",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-123",
+						Started:  time.Now().Add(-10 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-123"),
+			expectedResync: true,
+			description:    "should return true to trigger resync when job is not found",
+		},
+		{
+			name: "stale sync status with Working state - job not found",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStateWorking,
+						JobID:    "test-job-456",
+						Started:  time.Now().Add(-5 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-5 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-456"),
+			expectedResync: true,
+			description:    "should return true to trigger resync when working job is not found",
+		},
+		{
+			name: "non-stale sync status - job exists",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-789",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,   // Job exists
+			expectedResync: false, // Should continue with normal logic
+			description:    "should continue with normal logic when job exists",
+		},
+		{
+			name: "non-stale sync status - no JobID",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,
+			expectedResync: false,
+			description:    "should not check when JobID is empty",
+		},
+		{
+			name: "non-stale sync status - already finished",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStateSuccess,
+						JobID:    "test-job-999",
+						Finished: time.Now().Add(-1 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,
+			expectedResync: false,
+			description:    "should not check when sync status is already finished",
+		},
+		{
+			name: "stale sync status - job lookup error (non-NotFound)",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-error",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    assert.AnError, // Non-NotFound error
+			expectedResync: false,          // Should continue with normal logic
+			description:    "should handle non-NotFound errors gracefully and continue with normal logic",
+		},
+		{
+			name: "stale sync status but sync disabled",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         false,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-disabled",
+						Started:  time.Now().Add(-10 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-disabled"),
+			expectedResync: false, // Should return false when sync is disabled
+			description:    "should return false when sync is disabled even if job is stale",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mocks
+			mockQueue := jobs.NewMockQueue(t)
+			mockStore := jobs.NewMockStore(t)
+			mockJobs := &mockJobsQueueStore{
+				MockQueue: mockQueue,
+				MockStore: mockStore,
+			}
+
+			// Set up job Get mock
+			if tc.repo.Status.Sync.JobID != "" && (tc.repo.Status.Sync.State == provisioning.JobStatePending || tc.repo.Status.Sync.State == provisioning.JobStateWorking) {
+				mockStore.On("Get", mock.Anything, tc.repo.Namespace, tc.repo.Status.Sync.JobID).Return(nil, tc.jobGetError).Once()
+			}
+
+			// Create controller
+			rc := &RepositoryController{
+				jobs: mockJobs,
+			}
+
+			// Test shouldResync
+			ctx := context.Background()
+			result := rc.shouldResync(ctx, tc.repo)
+
+			// Verify
+			assert.Equal(t, tc.expectedResync, result, tc.description)
+		})
+	}
 }


### PR DESCRIPTION
## Problem

When sync jobs expire and are cleaned up by the expired job cleanup controller, the Repository sync status remains stuck in `Pending` or `Working` state. This prevents new sync jobs from being queued because `shouldResync()` blocks on these states, causing repositories to stop syncing indefinitely.

<img width="1884" height="662" alt="Screenshot 2025-11-13 at 11 53 05" src="https://github.com/user-attachments/assets/093ecc69-7481-4809-9f29-4c1c06859975" />

## Solution

This change adds detection logic in `shouldResync()` to check if a sync job referenced in the sync status still exists. If the job doesn't exist (NotFound error), we trigger a resync to reconcile the stale state through the normal reconciliation flow.

## Changes

- Updated `shouldResync()` to accept `context.Context` parameter to enable job existence checks
- Added stale sync status detection: when sync status is `Pending` or `Working` with a `JobID`, checks if the job still exists using `jobs.Get()`
- If job doesn't exist, returns `true` to trigger resync/reconciliation
- Updated `RepositoryController` jobs field type to support both `Queue` and `Store` interfaces
- Added comprehensive tests covering various scenarios

## Testing

- Added unit tests for stale sync status detection
- Tests cover: stale status with Pending/Working states, non-stale status (job exists), empty JobID, already finished status, error handling
- Tested also manually stopping a long-running job, and restarting Grafana. 

Fixes grafana/git-ui-sync-project#626


## Screenshots

Before restart / resync: 
<img width="1884" height="662" alt="Screenshot 2025-11-13 at 11 53 05" src="https://github.com/user-attachments/assets/093ecc69-7481-4809-9f29-4c1c06859975" />

After restart / resync with this fix: 
<img width="1877" height="730" alt="image" src="https://github.com/user-attachments/assets/576b1a03-de7d-4130-98e8-a61cf6ca3b81" />
