### PR TITLE
Playwright: fix timezone test to work at all times

### DIFF
--- a/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
@@ -213,10 +213,7 @@ const isTimeCorrect = (inUtc: string, inTz: string, offset: number): boolean => 
   }
 
   const utcDate = toDate(parseISO(inUtc));
-  const utcDateWithOffset = addHours(toDate(parseISO(inUtc)), offset);
-  const dayDifference = differenceInCalendarDays(utcDate, utcDateWithOffset); // if the utcDate +/- offset is the day before/after then we need to adjust reference
-  const dayOffset = isBefore(utcDateWithOffset, utcDate) ? dayDifference * -1 : dayDifference;
-  const tzDate = addDays(toDate(parseISO(inTz)), dayOffset); // adjust tzDate with any dayOffset
+  const tzDate = toDate(parseISO(inTz));
   const diff = Math.abs(differenceInMinutes(utcDate, tzDate)); // use Math.abs if tzDate is in future
 
   return diff <= Math.abs(offset * 60);

--- a/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
+++ b/e2e-playwright/dashboards-suite/dashboard-time-zone.spec.ts
@@ -1,4 +1,4 @@
-import { addDays, addHours, differenceInCalendarDays, differenceInMinutes, isBefore, parseISO, toDate } from 'date-fns';
+import { differenceInMinutes, parseISO, toDate } from 'date-fns';
 import { Page } from 'playwright-core';
 
 import { test, expect, DashboardPage, E2ESelectorGroups } from '@grafana/plugin-e2e';


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- fixes the `dashboard-time-zone` test to work at all times of day
- the `isTimeCorrect` function was attempting to adjust for times spanning across different days
- this isn't necessary! `differenceInMinutes` already gives the correct difference in minutes across the day boundary 
- as the test looks at the first timestamp when using `Last 3 hours` in the UTC and `America/Chicago` (UTC-6) timezones, this meant the test would **consistently** fail between 03:00 and 09:00 UTC 😅 
  - these are the times where the first row would give a timestamp showing a different day value in UTC/chicago time
- you can repro the failure even later in the day by using a timezone with a more extreme offset, e.g. `Pacific/Honolulu`
  - this is a UTC-10 timezone, so changing the test to use that will mean it would fail between 03:00 and 13:00

**Why do we need this feature?**

- so our e2e tests work consistently at all times of day

**Who is this feature for?**

- grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
