### PR TITLE
OpenTSDB: Fix type mismatch with counterMax and counterResetValue

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -60,8 +60,8 @@ type QueryModel struct {
 	Tags                 map[string]interface{} `json:"tags"`
 	ShouldComputeRate    bool                   `json:"shouldComputeRate"`
 	IsCounter            bool                   `json:"isCounter"`
-	CounterMax           float64                `json:"counterMax"`
-	CounterResetValue    float64                `json:"counterResetValue"`
+	CounterMax           string                 `json:"counterMax"`
+	CounterResetValue    string                 `json:"counterResetValue"`
 }
 
 func newInstanceSettings(httpClientProvider *httpclient.Provider) datasource.InstanceFactoryFunc {
@@ -311,15 +311,27 @@ func (s *Service) buildMetric(query backend.DataQuery) map[string]any {
 		rateOptions := make(map[string]any)
 		rateOptions["counter"] = model.IsCounter
 
-		if model.CounterMax != 0 {
-			rateOptions["counterMax"] = model.CounterMax
+		var counterMax *float64
+		if model.CounterMax != "" {
+			if val, err := strconv.ParseFloat(model.CounterMax, 64); err == nil {
+				counterMax = &val
+			}
+		}
+		if counterMax != nil {
+			rateOptions["counterMax"] = *counterMax
 		}
 
-		if model.CounterResetValue != 0 {
-			rateOptions["resetValue"] = model.CounterResetValue
+		var counterResetValue *float64
+		if model.CounterResetValue != "" {
+			if val, err := strconv.ParseFloat(model.CounterResetValue, 64); err == nil {
+				counterResetValue = &val
+			}
+		}
+		if counterResetValue != nil {
+			rateOptions["resetValue"] = *counterResetValue
 		}
 
-		if model.CounterMax == 0 && (model.CounterResetValue == 0) {
+		if counterMax == nil && (counterResetValue == nil || *counterResetValue == 0) {
 			rateOptions["dropResets"] = true
 		}
 

--- a/pkg/tsdb/opentsdb/opentsdb_test.go
+++ b/pkg/tsdb/opentsdb/opentsdb_test.go
@@ -377,8 +377,8 @@ func TestOpenTsdbExecutor(t *testing.T) {
 						"disableDownsampling": true,
 						"shouldComputeRate": true,
 						"isCounter": true,
-						"counterMax": 45,
-						"counterResetValue": 60,
+						"counterMax": "45",
+						"counterResetValue": "60",
 						"tags": {
 							"env": "prod",
 							"app": "grafana"
@@ -388,6 +388,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		}
 
 		metric := service.buildMetric(query)
+		t.Log(metric)
 
 		require.Len(t, metric, 5)
 		require.Equal(t, "cpu.average.percent", metric["metric"])


### PR DESCRIPTION
as part of [decouple the opentsdb data source from core](https://github.com/grafana/grafana/pull/113588), we removed the `simplejson` package and switched to manually extracting query data. during this change, `counterMax` and `counterResetValue` were assumed to be integers, but they are actually passed as strings. this mismatch is causing queries using these options to break.

this pr fixes the type handling to ensure these fields are correctly parsed.

**before / after: (using couterMax, same applies to counterResetValue)**
<div>
<img width="49%" height="735" alt="Screenshot 2025-11-13 at 20 22 03" src="https://github.com/user-attachments/assets/f4e512ec-185a-4021-94ec-58043556eb61" />
<img width="49%" height="799" alt="Screenshot 2025-11-13 at 20 24 19" src="https://github.com/user-attachments/assets/8837ef70-d04c-4835-b9ae-c38dc97ee57f" />

</div>