### PR TITLE
Provisioning: Remove image renderer note from PR comment template

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -3,18 +3,25 @@ package controller
 import (
 	"context"
 	"testing"
+	"time"
 
-	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
+	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"k8s.io/apimachinery/pkg/labels"
+
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	provisioningv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+	listers "github.com/grafana/grafana/apps/provisioning/pkg/generated/listers/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 )
 
@@ -337,4 +344,263 @@ func TestShouldUseIncrementalSync(t *testing.T) {
 		assert.NoError(t, err)
 		assert.False(t, got)
 	})
+}
+
+// mockJobsQueueStore implements both jobs.Queue and jobs.Store for testing
+type mockJobsQueueStore struct {
+	*jobs.MockQueue
+	*jobs.MockStore
+}
+
+// mockRepositoryLister implements listers.RepositoryLister for testing
+type mockRepositoryLister struct {
+	repositoriesFunc func(namespace string) listers.RepositoryNamespaceLister
+}
+
+func (m *mockRepositoryLister) Repositories(namespace string) listers.RepositoryNamespaceLister {
+	if m.repositoriesFunc != nil {
+		return m.repositoriesFunc(namespace)
+	}
+	return nil
+}
+
+func (m *mockRepositoryLister) List(selector labels.Selector) ([]*provisioning.Repository, error) {
+	panic("not needed for testing")
+}
+
+// mockRepositoryNamespaceLister implements listers.RepositoryNamespaceLister for testing
+type mockRepositoryNamespaceLister struct {
+	getFunc func(name string) (*provisioning.Repository, error)
+}
+
+func (m *mockRepositoryNamespaceLister) Get(name string) (*provisioning.Repository, error) {
+	if m.getFunc != nil {
+		return m.getFunc(name)
+	}
+	return nil, nil
+}
+
+func (m *mockRepositoryNamespaceLister) List(selector labels.Selector) ([]*provisioning.Repository, error) {
+	panic("not needed for testing")
+}
+
+func TestRepositoryController_shouldResync_StaleSyncStatus(t *testing.T) {
+	testCases := []struct {
+		name           string
+		repo           *provisioning.Repository
+		jobGetError    error
+		expectedResync bool
+		description    string
+	}{
+		{
+			name: "stale sync status with Pending state - job not found",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-123",
+						Started:  time.Now().Add(-10 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-123"),
+			expectedResync: true,
+			description:    "should return true to trigger resync when job is not found",
+		},
+		{
+			name: "stale sync status with Working state - job not found",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStateWorking,
+						JobID:    "test-job-456",
+						Started:  time.Now().Add(-5 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-5 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-456"),
+			expectedResync: true,
+			description:    "should return true to trigger resync when working job is not found",
+		},
+		{
+			name: "non-stale sync status - job exists",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-789",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,   // Job exists
+			expectedResync: false, // Should continue with normal logic
+			description:    "should continue with normal logic when job exists",
+		},
+		{
+			name: "non-stale sync status - no JobID",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,
+			expectedResync: false,
+			description:    "should not check when JobID is empty",
+		},
+		{
+			name: "non-stale sync status - already finished",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStateSuccess,
+						JobID:    "test-job-999",
+						Finished: time.Now().Add(-1 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    nil,
+			expectedResync: false,
+			description:    "should not check when sync status is already finished",
+		},
+		{
+			name: "stale sync status - job lookup error (non-NotFound)",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         true,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-error",
+						Started:  time.Now().Add(-2 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-2 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    assert.AnError, // Non-NotFound error
+			expectedResync: false,          // Should continue with normal logic
+			description:    "should handle non-NotFound errors gracefully and continue with normal logic",
+		},
+		{
+			name: "stale sync status but sync disabled",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Sync: provisioning.SyncOptions{
+						Enabled:         false,
+						IntervalSeconds: 300,
+					},
+				},
+				Status: provisioning.RepositoryStatus{
+					Sync: provisioning.SyncStatus{
+						State:    provisioning.JobStatePending,
+						JobID:    "test-job-disabled",
+						Started:  time.Now().Add(-10 * time.Minute).UnixMilli(),
+						Finished: time.Now().Add(-10 * time.Minute).UnixMilli(),
+					},
+				},
+			},
+			jobGetError:    apierrors.NewNotFound(schema.GroupResource{Resource: "jobs"}, "test-job-disabled"),
+			expectedResync: false, // Should return false when sync is disabled
+			description:    "should return false when sync is disabled even if job is stale",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create mocks
+			mockQueue := jobs.NewMockQueue(t)
+			mockStore := jobs.NewMockStore(t)
+			mockJobs := &mockJobsQueueStore{
+				MockQueue: mockQueue,
+				MockStore: mockStore,
+			}
+
+			// Set up job Get mock
+			if tc.repo.Status.Sync.JobID != "" && (tc.repo.Status.Sync.State == provisioning.JobStatePending || tc.repo.Status.Sync.State == provisioning.JobStateWorking) {
+				mockStore.On("Get", mock.Anything, tc.repo.Namespace, tc.repo.Status.Sync.JobID).Return(nil, tc.jobGetError).Once()
+			}
+
+			// Create controller
+			rc := &RepositoryController{
+				jobs: mockJobs,
+			}
+
+			// Test shouldResync
+			ctx := context.Background()
+			result := rc.shouldResync(ctx, tc.repo)
+
+			// Verify
+			assert.Equal(t, tc.expectedResync, result, tc.description)
+		})
+	}
 }

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/comment.go
@@ -102,9 +102,7 @@ and {{ .SkippedFiles }} more files.
 `
 
 // TODO: this should expand and show links to setup docs
-const commentTemplateMissingImageRenderer = `
-NOTE: The image renderer is not configured
-`
+const commentTemplateMissingImageRenderer = ``
 
 // TODO: does this have some value?
 func (f *fileChangeInfo) Kind() string {

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/testdata/update-dashboard-missing-renderer.md
@@ -3,5 +3,3 @@ Grafana spotted some changes to your dashboard.
 
 
 See the [original](http://grafana/d/uid) and [preview](http://grafana/admin/preview) of file.json.
-
-NOTE: The image renderer is not configured


### PR DESCRIPTION
**What is this feature?**

This PR removes the "NOTE: The image renderer is not configured" message from pull request comments generated by the provisioning webhook when the image renderer is unavailable.

**Why do we need this feature?**

This addresses issue #656 in git-ui-sync-project. The note was unnecessary and cluttering the PR comments. When the image renderer is not configured, it's better to simply omit the note rather than displaying a message that doesn't provide actionable information.

**Who is this feature for?**

This change affects users of the provisioning webhook feature who receive automated PR comments. The comments will now be cleaner without the unnecessary note.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/656

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

**Changes made:**
- Removed the note text from `commentTemplateMissingImageRenderer` template (now empty string)
- Updated testdata file `update-dashboard-missing-renderer.md` to reflect the change
- All unit tests pass successfully