### PR TITLE
Card: Adjust grid styles conditionally based on the presence of description

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -69,10 +69,22 @@ export const Card: CardInterface = ({
     () => React.Children.toArray(children).some((c) => React.isValidElement(c) && c.type === Heading),
     [children]
   );
+  const hasDescriptionComponent = useMemo(
+    () => React.Children.toArray(children).some((c) => React.isValidElement(c) && c.type === Description),
+    [children]
+  );
 
   const disableHover = disabled || (!onClick && !href);
   const onCardClick = onClick && !disabled ? onClick : undefined;
-  const styles = useStyles2(getCardContainerStyles, disabled, disableHover, isSelected, isCompact, noMargin);
+  const styles = useStyles2(
+    getCardContainerStyles,
+    disabled,
+    disableHover,
+    hasDescriptionComponent,
+    isSelected,
+    isCompact,
+    noMargin
+  );
 
   return (
     <CardContainer
@@ -81,6 +93,7 @@ export const Card: CardInterface = ({
       isSelected={isSelected}
       className={cx(styles.container, className)}
       noMargin={noMargin}
+      hasDescriptionComponent={hasDescriptionComponent}
       {...htmlProps}
     >
       <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected }}>

--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -96,15 +96,20 @@ export const getCardContainerStyles = (
     container: css({
       display: 'grid',
       position: 'relative',
-      gridTemplateColumns: 'auto 1fr auto',
-      gridTemplateRows: hasDescriptionComponent ? 'auto auto 1fr auto' : '1fr auto auto auto',
-      gridAutoColumns: '1fr',
-      gridAutoFlow: 'row',
-      gridTemplateAreas: `
+      gridTemplate: hasDescriptionComponent
+        ? `
         "Figure Heading Tags"
         "Figure Meta Tags"
-        "Figure Description Tags"
-        "Figure Actions Secondary"`,
+        "Figure Description Tags" 1fr
+        "Figure Actions Secondary" / auto 1fr auto
+      `
+        : `
+        "Figure Heading Tags" 1fr
+        "Figure Meta Tags"
+        "Figure Actions Secondary" / auto 1fr auto
+      `,
+      gridAutoColumns: '1fr',
+      gridAutoFlow: 'row',
       width: '100%',
       padding: theme.spacing(isCompact ? 1 : 2),
       background: theme.colors.background.secondary,

--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -49,6 +49,7 @@ export interface CardContainerProps extends HTMLAttributes<HTMLOrSVGElement>, Ca
   className?: string;
   /** Remove the bottom margin */
   noMargin?: boolean;
+  hasDescriptionComponent?: boolean;
 }
 
 /** @deprecated Using `CardContainer` directly is discouraged and should be replaced with `Card` */
@@ -60,12 +61,14 @@ export const CardContainer = ({
   className,
   href,
   noMargin,
+  hasDescriptionComponent = false,
   ...props
 }: CardContainerProps) => {
   const { oldContainer } = useStyles2(
     getCardContainerStyles,
     disableEvents,
     disableHover,
+    hasDescriptionComponent,
     isSelected,
     undefined,
     noMargin
@@ -82,6 +85,7 @@ export const getCardContainerStyles = (
   theme: GrafanaTheme2,
   disabled = false,
   disableHover = false,
+  hasDescriptionComponent: boolean,
   isSelected?: boolean,
   isCompact?: boolean,
   noMargin = false
@@ -93,7 +97,7 @@ export const getCardContainerStyles = (
       display: 'grid',
       position: 'relative',
       gridTemplateColumns: 'auto 1fr auto',
-      gridTemplateRows: 'auto auto 1fr auto',
+      gridTemplateRows: hasDescriptionComponent ? 'auto auto 1fr auto' : '1fr auto auto auto',
       gridAutoColumns: '1fr',
       gridAutoFlow: 'row',
       gridTemplateAreas: `


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adjusts the `Card` styles based on the presence of description
- https://github.com/grafana/grafana/pull/113424 caused a regression in the `DataSourcePicker`, which actually uses a `Card` element without a description
- open to better suggestions for how to fix this 🙏 

| before | after |
| --- | --- |
| <img width="582" height="354" alt="image" src="https://github.com/user-attachments/assets/0d300c7c-dbc5-4f76-a271-988502e6553a" /> | <img width="567" height="349" alt="image" src="https://github.com/user-attachments/assets/aafaca0e-9e0e-4f97-b386-40683ac3ea78" /> |
| <img width="880" height="790" alt="image" src="https://github.com/user-attachments/assets/2481fe34-e4d3-4431-8207-79a7316c12a2" /> | <img width="893" height="806" alt="image" src="https://github.com/user-attachments/assets/7a0800ca-7ca0-4ad3-b22c-1c1555d03ad0" /> |

**Why do we need this feature?**

- fix `DataSourcePicker` appearance

**Who is this feature for?**

- everyone!

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Follow up to https://github.com/grafana/grafana/pull/113424

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
