### PR TITLE
Secrets: Remove unused register_api_server setting

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2211,8 +2211,6 @@ encryption_provider = secret_key.v1
 
 # These flags are required in on-prem installations for GitSync to work
 #
-# Whether to register the MT CRUD API
-register_api_server = true
 # Whether to create the MT secrets management database
 run_secrets_db_migrations = true
 # Whether to run the data key id migration. Requires that RunSecretsDBMigrations is also true.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -2109,8 +2109,6 @@ default_datasource_uid =
 
 # These flags are required in on-prem installations for GitSync to work
 #
-# Whether to register the MT CRUD API
-;register_api_server = true
 # Whether to create the MT secrets management database
 ;run_secrets_db_migrations = true
 # Whether to run the data key id migration. Requires that RunSecretsDBMigrations is also true.

--- a/pkg/setting/setting_secrets_manager.go
+++ b/pkg/setting/setting_secrets_manager.go
@@ -36,8 +36,6 @@ type SecretsManagerSettings struct {
 	// How long to wait for the process to clean up a secure value to complete.
 	GCWorkerPerSecureValueCleanupTimeout time.Duration
 
-	// Whether to register the MT CRUD API
-	RegisterAPIServer bool
 	// Whether to create the MT secrets management database
 	RunSecretsDBMigrations bool
 	// Whether to run the data key id migration. Requires that RunSecretsDBMigrations is also true.
@@ -62,7 +60,6 @@ func (cfg *Cfg) readSecretsManagerSettings() {
 	cfg.SecretsManagement.GCWorkerPollInterval = secretsMgmt.Key("gc_worker_poll_interval").MustDuration(1 * time.Minute)
 	cfg.SecretsManagement.GCWorkerPerSecureValueCleanupTimeout = secretsMgmt.Key("gc_worker_per_request_timeout").MustDuration(5 * time.Second)
 
-	cfg.SecretsManagement.RegisterAPIServer = secretsMgmt.Key("register_api_server").MustBool(true)
 	cfg.SecretsManagement.RunSecretsDBMigrations = secretsMgmt.Key("run_secrets_db_migrations").MustBool(true)
 	cfg.SecretsManagement.RunDataKeyMigration = secretsMgmt.Key("run_data_key_migration").MustBool(true)
 

--- a/pkg/setting/setting_secrets_manager_test.go
+++ b/pkg/setting/setting_secrets_manager_test.go
@@ -171,28 +171,6 @@ domain = example.com
 		assert.Empty(t, cfg.SecretsManagement.ConfiguredKMSProviders)
 	})
 
-	t.Run("should handle configuration with register_api_server disabled", func(t *testing.T) {
-		iniContent := `
-[secrets_manager]
-register_api_server = false
-`
-		cfg, err := NewCfgFromBytes([]byte(iniContent))
-		require.NoError(t, err)
-
-		assert.False(t, cfg.SecretsManagement.RegisterAPIServer)
-	})
-
-	t.Run("should handle configuration without register_api_server set", func(t *testing.T) {
-		iniContent := `
-[secrets_manager]
-encryption_provider = aws_kms
-`
-		cfg, err := NewCfgFromBytes([]byte(iniContent))
-		require.NoError(t, err)
-
-		assert.True(t, cfg.SecretsManagement.RegisterAPIServer)
-	})
-
 	t.Run("should handle configuration with run_secrets_db_migrations disabled", func(t *testing.T) {
 		iniContent := `
 [secrets_manager]

--- a/scripts/grafana-server/custom.ini
+++ b/scripts/grafana-server/custom.ini
@@ -40,6 +40,5 @@ host = localhost:7777
 developer_mode = true ; Enable developer mode to use in-memory implementations of 3rdparty services needed.
 
 [secrets_manager]
-register_api_server = true
 run_secrets_db_migrations = true
 run_data_key_migration = true


### PR DESCRIPTION
We can always register the API unconditionally, so we don't need this flag anymore.

Related to https://github.com/grafana/grafana/pull/113809