### PR TITLE
Scopes: Don't redirect on URL sync

### DIFF
--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -100,7 +100,7 @@ describe('ScopesService', () => {
 
       service = new ScopesService(selectorService, dashboardsService, locationService);
 
-      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], undefined, 'node1');
+      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], undefined, 'node1', false);
     });
 
     it('should read scope_parent for backward compatibility', () => {
@@ -111,7 +111,7 @@ describe('ScopesService', () => {
 
       service = new ScopesService(selectorService, dashboardsService, locationService);
 
-      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], 'parent1', undefined);
+      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], 'parent1', undefined, false);
     });
 
     it('should prefer scope_node when both scope_node and scope_parent exist', () => {
@@ -123,7 +123,7 @@ describe('ScopesService', () => {
       service = new ScopesService(selectorService, dashboardsService, locationService);
 
       // Should call with parent1 as parentNodeId and node1 as scopeNodeId
-      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], 'parent1', 'node1');
+      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1'], 'parent1', 'node1', false);
       // Should preload node1 (not parent1)
       expect(selectorService.resolvePathToRoot).toHaveBeenCalledWith('node1', expect.anything());
     });
@@ -158,7 +158,7 @@ describe('ScopesService', () => {
 
       service = new ScopesService(selectorService, dashboardsService, locationService);
 
-      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1', 'scope2'], undefined, 'node1');
+      expect(selectorService.changeScopes).toHaveBeenCalledWith(['scope1', 'scope2'], undefined, 'node1', false);
     });
   });
 

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -157,7 +157,8 @@ export class ScopesService implements ScopesContextValue {
   }
 
   public changeScopes = (scopeNames: string[], parentNodeId?: string, scopeNodeId?: string) =>
-    this.selectorService.changeScopes(scopeNames, parentNodeId, scopeNodeId);
+    // Don't redirect on apply for initial load from URL. We only want to redirect when selecting from the selector
+    this.selectorService.changeScopes(scopeNames, parentNodeId, scopeNodeId, false);
 
   public setReadOnly = (readOnly: boolean) => {
     if (this.state.readOnly !== readOnly) {

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -341,14 +341,15 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     return this.collapseNode(scopeNodeId);
   };
 
-  changeScopes = (scopeNames: string[], parentNodeId?: string, scopeNodeId?: string) => {
+  changeScopes = (scopeNames: string[], parentNodeId?: string, scopeNodeId?: string, redirectOnApply?: boolean) => {
     return this.applyScopes(
       scopeNames.map((id, index) => ({
         scopeId: id,
         // Only the first scope gets the scopeNodeId
         scopeNodeId: index === 0 ? scopeNodeId : undefined,
         parentNodeId,
-      }))
+      })),
+      redirectOnApply
     );
   };
 
@@ -356,7 +357,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
    * Apply the selected scopes. Apart from setting the scopes it also fetches the scope metadata and also loads the
    * related dashboards.
    */
-  private applyScopes = async (scopes: SelectedScope[]) => {
+  private applyScopes = async (scopes: SelectedScope[], redirectOnApply = true) => {
     // Skip if we are trying to apply the same scopes as are already applied.
     if (
       this.state.appliedScopes.length === scopes.length &&
@@ -372,7 +373,9 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     // We call this even if we have 0 scope because in that case it also closes the dashboard drawer.
     this.dashboardsService.fetchDashboards(scopes.map((s) => s.scopeId)).then(() => {
       const selectedScopeNode = scopes[0]?.scopeNodeId ? this.state.nodes[scopes[0]?.scopeNodeId] : undefined;
-      this.redirectAfterApply(selectedScopeNode);
+      if (redirectOnApply) {
+        this.redirectAfterApply(selectedScopeNode);
+      }
     });
 
     if (scopes.length > 0) {
@@ -428,7 +431,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
     }
   };
 
-  public removeAllScopes = () => this.applyScopes([]);
+  public removeAllScopes = () => this.applyScopes([], false);
 
   private addRecentScopes = (scopes: Scope[], parentNode?: ScopeNode) => {
     if (scopes.length === 0) {

--- a/public/app/features/scopes/tests/dashboardsList.test.ts
+++ b/public/app/features/scopes/tests/dashboardsList.test.ts
@@ -262,7 +262,7 @@ describe('Dashboards list', () => {
     expectDashboardLength('billing-usage', 1);
   });
 
-  it('redirects to the first scope navigation if your current dashboard is not a scope navigation', async () => {
+  it('does not redirect when scopes are set programmatically on dashboard not in scope navigation list', async () => {
     // Render another dashboard, which is not a scope navigation
     const mockNavigations: ScopeNavigation[] = [
       {
@@ -284,10 +284,10 @@ describe('Dashboards list', () => {
     await renderDashboard();
     expect(locationService.getLocation().pathname).toBe('/');
 
+    // When scopes are set programmatically (not through UI), redirects should not happen
     await updateScopes(scopesService, ['grafana']);
-    expect(locationService.getLocation().pathname).toBe('/d/dashboard1');
-    // renderDashboard defaults to home dashboard
-    expect(locationService.getLocation().pathname).not.toBe('/');
+    // Should stay on the current page, not redirect
+    expect(locationService.getLocation().pathname).toBe('/');
     expect(fetchDashboardsSpy).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Makes it so that you will only be redirected when selecting a scope in the selector.

**Why do we need this feature?**

There were unwanted redirects when:
1. Reloading the page on a non relevant dashboard
2. When you deselect a scope

**Who is this feature for?**

Scopes users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/hyperion-planning/issues/452

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
