### PR TITLE
CSV Export: FieldType.other objects will be stringified

### DIFF
--- a/packages/grafana-data/src/utils/csv.test.ts
+++ b/packages/grafana-data/src/utils/csv.test.ts
@@ -181,6 +181,26 @@ describe('DataFrame to CSV', () => {
     `);
   });
 
+  it('should handle field type other', () => {
+    const dataFrame = new MutableDataFrame({
+      fields: [
+        { name: 'Time', values: [1589455688623, 1589455692345] },
+        {
+          name: 'Value',
+          type: FieldType.other,
+          values: [{ text: 'value1' }, { text: 'value2' }],
+        },
+      ],
+    });
+
+    const csv = toCSV([dataFrame]);
+    expect(csv).toMatchInlineSnapshot(`
+      ""Time","Value"
+      1589455688623,"{""text"":""value1""}"
+      1589455692345,"{""text"":""value2""}""
+    `);
+  });
+
   it('should handle null values', () => {
     const dataFrame = new MutableDataFrame({
       fields: [

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -1,5 +1,5 @@
 // Libraries
-import { defaults } from 'lodash';
+import { defaults, isObject } from 'lodash';
 import Papa, { ParseConfig, Parser, ParseResult } from 'papaparse';
 
 // Types
@@ -315,6 +315,10 @@ export function toCSV(data: DataFrame[], config?: CSVConfig): string {
             // For FieldType frame, use value if it exists to prevent exporting [object object]
             if (fields[j].type === FieldType.frame && 'value' in v) {
               v = v.value;
+            }
+
+            if (fields[j].type === FieldType.other && isObject(v)) {
+              v = JSON.stringify(v);
             }
 
             csv += writers[j](v);


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue where fields of type `other` that are json objects will get printed on csv exports as `[object Object]`.

**Why do we need this feature?**

So that CSV exports with fields like that get proper values exported.

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
