### PR TITLE
Plugins: Datasource breadcrumb link should link to settings tab

### DIFF
--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -78,6 +78,7 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
     active: true,
     text: datasource.name || '',
     subTitle: dataSourceMeta.name ? `Type: ${dataSourceMeta.name}` : '',
+    url: `/connections/datasources/edit/${uid}/`,
     children: (pageNav.main.children || []).map((navModelItem) => ({
       ...navModelItem,
       url: navModelItem.url?.replace('datasources/edit/', '/connections/datasources/edit/'),

--- a/public/app/features/connections/hooks/useDataSourceTabNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceTabNav.ts
@@ -79,6 +79,7 @@ export function useDataSourceTabNav(pageName: string, pageIdParam?: string) {
     active: true,
     text: datasource.name || '',
     subTitle: dataSourceMeta.name ? `Type: ${dataSourceMeta.name}` : '',
+    url: `/connections/datasources/edit/${uid}/`,
     children: (pageNav.main.children || []).map((navModelItem) => ({
       ...navModelItem,
       url: navModelItem.url?.replace('datasources/edit/', '/connections/datasources/edit/'),


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where the datasource link would redirect to the homepage instead of the default connection tab.

Before:

https://github.com/user-attachments/assets/f29f8d16-4288-4897-9a85-443cd5c7c562


After:

https://github.com/user-attachments/assets/c3420d69-36fc-44a6-8a8d-e1f35d840100


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/support-escalations/issues/19437

