### PR TITLE
Alerting: Resize created_by and updated_by columns in alert rules tables

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -159,5 +159,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	ualert.CollateAlertRuleGroup(mg)
 
+	ualert.ExpandAlertRuleUpdatedByMigration(mg)
+
 	ualert.AddAlertRuleGroupIndexMigration(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/rule_creator_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/rule_creator_mig.go
@@ -18,3 +18,15 @@ func AddAlertRuleUpdatedByMigration(mg *migrator.Migrator) {
 		Nullable: true,
 	}))
 }
+
+func ExpandAlertRuleUpdatedByMigration(mg *migrator.Migrator) {
+	mg.AddMigration("expand created_by in alert_rule_version table", migrator.NewRawSQLMigration("").
+		SQLite("SELECT 1;"). // do nothing for sqlite because it's a TEXT column
+		Postgres("ALTER TABLE `alert_rule_version` ALTER COLUMN created_by TYPE VARCHAR(190);").
+		Mysql("ALTER TABLE `alert_rule_version` MODIFY created_by VARCHAR(190);"))
+
+	mg.AddMigration("expand updated_by in alert_rule table", migrator.NewRawSQLMigration("").
+		SQLite("SELECT 1;"). // do nothing for sqlite because it's a TEXT column
+		Postgres("ALTER TABLE `alert_rule` ALTER COLUMN updated_by TYPE VARCHAR(190);").
+		Mysql("ALTER TABLE `alert_rule` MODIFY updated_by VARCHAR(190);"))
+}


### PR DESCRIPTION
This is a follow up for https://github.com/grafana/grafana/pull/113500/files that resized the column uid in the table `user`. 

The maximum size of the columns `alert_rule.updated_by` and `alert_rule_version.created_by` is increased from 40 to 190 symbols.