### PR TITLE
BootstrapStep: Display disabled option and add reason

### DIFF
--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -99,20 +99,22 @@ describe('BootstrapStep', () => {
       shouldSkipSync: true,
     });
 
-    (useModeOptions as jest.Mock).mockReturnValue([
-      {
-        target: 'instance',
-        label: 'Sync all resources with external storage',
-        description: 'Resources will be synced with external storage',
-        subtitle: 'Use this option if you want to sync your entire instance',
-      },
-      {
-        target: 'folder',
-        label: 'Sync external storage to a new Grafana folder',
-        description: 'A new Grafana folder will be created',
-        subtitle: 'Use this option to sync into a new folder',
-      },
-    ]);
+    (useModeOptions as jest.Mock).mockReturnValue({
+      enabledOptions: [
+        {
+          target: 'instance',
+          label: 'Sync all resources with external storage',
+          description: 'Resources will be synced with external storage',
+          subtitle: 'Use this option if you want to sync your entire instance',
+        },
+        {
+          target: 'folder',
+          label: 'Sync external storage to a new Grafana folder',
+          description: 'A new Grafana folder will be created',
+          subtitle: 'Use this option to sync into a new folder',
+        },
+      ],
+    });
   });
 
   describe('rendering', () => {
@@ -232,14 +234,24 @@ describe('BootstrapStep', () => {
     });
 
     it('should only display instance option when legacy storage exists', async () => {
-      (useModeOptions as jest.Mock).mockReturnValue([
-        {
-          target: 'instance',
-          label: 'Sync all resources with external storage',
-          description: 'Resources will be synced with external storage',
-          subtitle: 'Use this option if you want to sync your entire instance',
-        },
-      ]);
+      (useModeOptions as jest.Mock).mockReturnValue({
+        enabledOptions: [
+          {
+            target: 'instance',
+            label: 'Sync all resources with external storage',
+            description: 'Resources will be synced with external storage',
+            subtitle: 'Use this option if you want to sync your entire instance',
+          },
+        ],
+        disabledOptions: [
+          {
+            target: 'folder',
+            label: 'Sync external storage to a new Grafana folder',
+            description: 'A new Grafana folder will be created',
+            subtitle: 'Use this option to sync into a new folder',
+          },
+        ],
+      });
 
       setup({
         settingsData: {
@@ -251,7 +263,7 @@ describe('BootstrapStep', () => {
       });
 
       expect(await screen.findByText('Sync all resources with external storage')).toBeInTheDocument();
-      expect(screen.queryByText('Sync external storage to a new Grafana folder')).not.toBeInTheDocument();
+      expect(await screen.findByText('Sync external storage to a new Grafana folder')).not.toBeChecked();
     });
 
     it('should allow selecting different sync targets', async () => {

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -34,7 +34,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
   const selectedTarget = watch('repository.sync.target');
   const repositoryType = watch('repository.type');
   const { enabledOptions, disabledOptions } = useModeOptions(repoName, settingsData);
-  const { target } = enabledOptions[0];
+  const { target } = enabledOptions?.[0];
   const { resourceCountString, fileCountString, isLoading } = useResourceStats(repoName, settingsData?.legacyStorage);
   const styles = useStyles2(getStyles);
 
@@ -134,12 +134,12 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
                 'My repository connection'
               )}
               // Autofocus the title field if it's the only available option
-              autoFocus={enabledOptions.length === 1 && enabledOptions[0].target === 'folder'}
+              autoFocus={enabledOptions?.length === 1 && enabledOptions[0]?.target === 'folder'}
             />
           </Field>
         )}
 
-        {disabledOptions.length > 0 && (
+        {disabledOptions?.length > 0 && (
           <>
             {/* Unavailable options */}
             <Box marginTop={3}>

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -33,10 +33,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
 
   const selectedTarget = watch('repository.sync.target');
   const repositoryType = watch('repository.type');
-  const options = useModeOptions(repoName, settingsData);
-  // Filtering 2 mode options on each render; trivial cost, so no need for useMemo here.
-  const enabledOptions = options.filter((option) => !option.disabled);
-  const disabledOptions = options.filter((option) => option.disabled);
+  const { enabledOptions, disabledOptions } = useModeOptions(repoName, settingsData);
   const { target } = enabledOptions[0];
   const { resourceCountString, fileCountString, isLoading } = useResourceStats(repoName, settingsData?.legacyStorage);
   const styles = useStyles2(getStyles);
@@ -137,7 +134,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
                 'My repository connection'
               )}
               // Autofocus the title field if it's the only available option
-              autoFocus={options.length === 1 && options[0].target === 'folder'}
+              autoFocus={enabledOptions.length === 1 && enabledOptions[0].target === 'folder'}
             />
           </Field>
         )}

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -178,6 +178,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   infoIcon: css({
     color: theme.colors.primary.main,
-    marginRight: theme.spacing(0.5),
+    marginRight: theme.spacing(0.25),
+    marginBottom: theme.spacing(0.25),
   }),
 });

--- a/public/app/features/provisioning/Wizard/BootstrapStep.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.tsx
@@ -34,6 +34,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
   const selectedTarget = watch('repository.sync.target');
   const repositoryType = watch('repository.type');
   const options = useModeOptions(repoName, settingsData);
+  // Filtering 2 mode options on each render; trivial cost, so no need for useMemo here.
   const enabledOptions = options.filter((option) => !option.disabled);
   const disabledOptions = options.filter((option) => option.disabled);
   const { target } = enabledOptions[0];
@@ -73,7 +74,7 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
           control={control}
           render={({ field: { ref, onChange, ...field } }) => (
             <>
-              {enabledOptions.map((action) => (
+              {enabledOptions?.map((action) => (
                 <Card
                   key={action.target}
                   isSelected={action.target === selectedTarget}
@@ -141,21 +142,27 @@ export const BootstrapStep = memo(function BootstrapStep({ settingsData, repoNam
           </Field>
         )}
 
-        {/* Unavailable options */}
-        <Box marginTop={3}>
-          <Text variant="h4">{t('provisioning.bootstrap-step.unavailable-options.title', 'Unavailable options')}</Text>
-        </Box>
-        {disabledOptions.map((action) => (
-          <Card key={action.target} noMargin disabled={action.disabled}>
-            <Card.Heading>
-              <Text variant="h5">{action.label}</Text>
-            </Card.Heading>
-            <Card.Description>
-              <div className={styles.divider} />
-              <Icon name="info-circle" className={styles.infoIcon} /> {action.disabledReason}
-            </Card.Description>
-          </Card>
-        ))}
+        {disabledOptions.length > 0 && (
+          <>
+            {/* Unavailable options */}
+            <Box marginTop={3}>
+              <Text variant="h4">
+                {t('provisioning.bootstrap-step.unavailable-options.title', 'Unavailable options')}
+              </Text>
+            </Box>
+            {disabledOptions?.map((action) => (
+              <Card key={action.target} noMargin disabled={action.disabled}>
+                <Card.Heading>
+                  <Text variant="h5">{action.label}</Text>
+                </Card.Heading>
+                <Card.Description>
+                  <div className={styles.divider} />
+                  <Icon name="info-circle" className={styles.infoIcon} /> {action.disabledReason}
+                </Card.Description>
+              </Card>
+            ))}
+          </>
+        )}
       </Stack>
     </Stack>
   );

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -103,6 +103,14 @@ export function useModeOptions(repoName: string, settings?: RepositoryViewList) 
       },
     ];
 
-    return filterModeOptions(modeOptions, repoName, settings);
+    const options = filterModeOptions(modeOptions, repoName, settings);
+    // Filtering 2 mode options on each render; trivial cost, so no need for useMemo here.
+    const enabledOptions = options.filter((option) => !option.disabled);
+    const disabledOptions = options.filter((option) => option.disabled);
+
+    return {
+      enabledOptions,
+      disabledOptions,
+    };
   }, [repoName, settings]);
 }

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -11,26 +11,61 @@ import { ModeOption } from '../types';
 function filterModeOptions(modeOptions: ModeOption[], repoName: string, settings?: RepositoryViewList): ModeOption[] {
   const folderConnected = settings?.items?.some((item) => item.target === 'folder' && item.name !== repoName);
   const allowedTargets = settings?.allowedTargets || ['instance', 'folder'];
+  const legacyStorageEnabled = settings?.legacyStorage;
 
-  return modeOptions.filter((option) => {
-    if (!allowedTargets.includes(option.target)) {
-      return false;
+  return modeOptions.map((option) => {
+    if (option.disabled) {
+      return option;
     }
 
-    if (settings?.legacyStorage) {
-      return option.target === 'instance';
+    const disabledReason = resolveDisabledReason(option, { allowedTargets, folderConnected, legacyStorageEnabled });
+
+    if (!disabledReason) {
+      return option;
     }
 
-    if (option.target === 'folder') {
-      return true;
-    }
-
-    if (option.target === 'instance') {
-      return !folderConnected;
-    }
-
-    return false;
+    return {
+      ...option,
+      disabled: true,
+      disabledReason,
+    };
   });
+}
+
+type DisableContext = {
+  allowedTargets: string[];
+  folderConnected?: boolean;
+  legacyStorageEnabled?: boolean;
+};
+
+// Returns a translated reason why the given mode option should be disabled.
+function resolveDisabledReason(option: ModeOption, context: DisableContext) {
+  if (!context.allowedTargets.includes(option.target)) {
+    return t(
+      'provisioning.mode-options.disabled.not-allowed',
+      'Provisioning settings for this repository restrict syncing to specific targets. Update the repository configuration to enable this option.'
+    );
+  }
+
+  if (context.legacyStorageEnabled && option.target !== 'instance') {
+    return t(
+      'provisioning.mode-options.disabled.legacy-storage',
+      'Legacy storage mode only supports syncing the entire Grafana instance.'
+    );
+  }
+
+  if (option.target === 'instance' && context.folderConnected) {
+    return t(
+      'provisioning.mode-options.disabled.folder-connected',
+      'Full instance synchronization is disabled because another folder is already synced with a repository.'
+    );
+  }
+
+  if (option.target !== 'instance' && option.target !== 'folder') {
+    return t('provisioning.mode-options.disabled.not-supported', 'This option is not supported yet.');
+  }
+
+  return undefined;
 }
 
 /**
@@ -51,6 +86,7 @@ export function useModeOptions(repoName: string, settings?: RepositoryViewList) 
           'provisioning.mode-options.instance.subtitle',
           'Use this option if you want to sync and manage your entire Grafana instance through external storage.'
         ),
+        disabled: false,
       },
       {
         target: 'folder',
@@ -63,6 +99,7 @@ export function useModeOptions(repoName: string, settings?: RepositoryViewList) 
           'provisioning.mode-options.folder.subtitle',
           'Use this option to sync external resources into a new folder without affecting the rest of your instance. You can repeat this process for up to 10 folders.'
         ),
+        disabled: false,
       },
     ];
 

--- a/public/app/features/provisioning/Wizard/types.ts
+++ b/public/app/features/provisioning/Wizard/types.ts
@@ -24,6 +24,8 @@ export interface ModeOption {
   label: string;
   description: string;
   subtitle: string;
+  disabled: boolean;
+  disabledReason?: string;
 }
 
 export const RepoTypeDisplay: { [key in RepoType]: string } = {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11491,6 +11491,9 @@
       "label-display-name": "Display name",
       "placeholder-my-repository-connection": "My repository connection",
       "text-loading-resource-information": "Loading resource information...",
+      "unavailable-options": {
+        "title": "Unavailable options"
+      },
       "unmanaged-resources-label": "Unmanaged resources"
     },
     "check-repository": {
@@ -11766,6 +11769,12 @@
       "truncated": "Message truncated"
     },
     "mode-options": {
+      "disabled": {
+        "folder-connected": "Full instance synchronization is disabled because another folder is already synced with a repository.",
+        "legacy-storage": "Legacy storage mode only supports syncing the entire Grafana instance.",
+        "not-allowed": "Provisioning settings for this repository restrict syncing to specific targets. Update the repository configuration to enable this option.",
+        "not-supported": "This option is not supported yet."
+      },
       "folder": {
         "description": "After setup, a new Grafana folder will be created and synced with external storage. If any resources are present in external storage, they will be provisioned to this new folder. All new resources created in this folder will be stored and versioned in external storage.",
         "label": "Sync external storage to a new Grafana folder",


### PR DESCRIPTION
**What is this feature?**

When configuring a repo, on sync folder/instance step, display all options with reason why an option is disabled. 
<img width="990" height="771" alt="image" src="https://github.com/user-attachments/assets/a74bce7d-75e6-4f79-b62b-95abfb5d0290" />


**Why do we need this feature?**

Prevent user confusion

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/678

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
