### PR TITLE
Alerting: Add message field to alert_rule_version table.

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -63,6 +63,9 @@ const (
 	// configIdentifierHeader is the header that specifies the identifier for imported Alertmanager config.
 	configIdentifierHeader  = "X-Grafana-Alerting-Config-Identifier"
 	defaultConfigIdentifier = "default"
+
+	// versionMessageHeader is the header that specifies an optional message for rule versions.
+	versionMessageHeader = "X-Grafana-Alerting-Version-Message"
 )
 
 var (
@@ -407,6 +410,12 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 		return errorToResponse(err)
 	}
 
+	versionMessage, err := parseVersionMessageHeader(c)
+	if err != nil {
+		logger.Error("Failed to parse version message header", "error", err)
+		return errorToResponse(err)
+	}
+
 	// 2. Convert Prometheus Rules to GMA
 	grafanaGroups := make([]*models.AlertRuleGroup, 0, len(promNamespaces))
 	for ns, rgs := range promNamespaces {
@@ -444,6 +453,12 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostRuleGroups(c *context
 				logger.Error("Failed to convert Prometheus rules to Grafana rules", "error", err)
 				return errorToResponse(err)
 			}
+
+			// Inject version message, if given.
+			for i := range grafanaGroup.Rules {
+				grafanaGroup.Rules[i].Message = versionMessage
+			}
+
 			grafanaGroups = append(grafanaGroups, grafanaGroup)
 		}
 	}
@@ -854,6 +869,16 @@ func parseMergeMatchersHeader(c *contextmodel.ReqContext) (amconfig.Matchers, er
 func parseExtraLabelsHeader(c *contextmodel.ReqContext) (map[string]string, error) {
 	labelsStr := strings.TrimSpace(c.Req.Header.Get(extraLabelsHeader))
 	return parseKeyValuePairs(labelsStr, extraLabelsHeader)
+}
+
+// parseVersionMessageHeader obtains and validates the message header value.
+func parseVersionMessageHeader(c *contextmodel.ReqContext) (string, error) {
+	str := strings.TrimSpace(c.Req.Header.Get(versionMessageHeader))
+	// Limit message to the same as the dashboards message.
+	if len(str) > 500 {
+		return "", errInvalidHeaderValue(versionMessageHeader, errors.New("must be less than 500 characters"))
+	}
+	return str, nil
 }
 
 func formatMergeMatchers(matchers amconfig.Matchers) string {

--- a/pkg/services/ngalert/api/api_ruler.go
+++ b/pkg/services/ngalert/api/api_ruler.go
@@ -662,6 +662,7 @@ func toGettableExtendedRuleNode(r ngmodels.AlertRule, provenanceRecords map[stri
 			UpdatedBy:                   getUserFromMapping(userUIDmapping, r.UpdatedBy),
 			IntervalSeconds:             r.IntervalSeconds,
 			Version:                     r.Version,
+			Message:                     r.Message,
 			UID:                         r.UID,
 			NamespaceUID:                r.NamespaceUID,
 			RuleGroup:                   r.RuleGroup,

--- a/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
+++ b/pkg/services/ngalert/api/tooling/definitions/cortex-ruler.go
@@ -605,6 +605,7 @@ type GettableGrafanaRule struct {
 	UpdatedBy                   *UserInfo                      `json:"updated_by" yaml:"updated_by"`
 	IntervalSeconds             int64                          `json:"intervalSeconds" yaml:"intervalSeconds"`
 	Version                     int64                          `json:"version" yaml:"version"`
+	Message                     string                         `json:"message,omitempty" yaml:"message,omitempty"`
 	UID                         string                         `json:"uid" yaml:"uid"`
 	NamespaceUID                string                         `json:"namespace_uid" yaml:"namespace_uid"`
 	RuleGroup                   string                         `json:"rule_group" yaml:"rule_group"`

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -344,15 +344,18 @@ type AlertRule struct {
 	UpdatedBy       *UserUID
 	IntervalSeconds int64
 	Version         int64
-	UID             string
-	NamespaceUID    string
-	DashboardUID    *string
-	PanelID         *int64
-	RuleGroup       string
-	RuleGroupIndex  int
-	Record          *Record
-	NoDataState     NoDataState
-	ExecErrState    ExecutionErrorState
+	// Message is version history metadata, only populated when reading version history
+	// and only used when creating or updating rules.
+	Message        string
+	UID            string
+	NamespaceUID   string
+	DashboardUID   *string
+	PanelID        *int64
+	RuleGroup      string
+	RuleGroupIndex int
+	Record         *Record
+	NoDataState    NoDataState
+	ExecErrState   ExecutionErrorState
 	// ideally this field should have been apimodels.ApiDuration
 	// but this is currently not possible because of circular dependencies
 	For                  time.Duration

--- a/pkg/services/ngalert/store/compat.go
+++ b/pkg/services/ngalert/store/compat.go
@@ -210,6 +210,7 @@ func alertRuleToAlertRuleVersion(rule alertRule) alertRuleVersion {
 		Version:                     rule.Version,
 		Created:                     rule.Updated, // assuming the Updated time as the creation time
 		CreatedBy:                   rule.UpdatedBy,
+		Message:                     "", // Message is set by caller when creating versions
 		Title:                       rule.Title,
 		Condition:                   rule.Condition,
 		Data:                        rule.Data,
@@ -228,8 +229,8 @@ func alertRuleToAlertRuleVersion(rule alertRule) alertRuleVersion {
 	}
 }
 
-func alertRuleVersionToAlertRule(version alertRuleVersion) alertRule {
-	return alertRule{
+func alertRuleVersionToModelsAlertRule(version alertRuleVersion, l log.Logger) (models.AlertRule, error) {
+	rule := alertRule{
 		ID:              version.ID,
 		GUID:            version.RuleGUID,
 		OrgID:           version.RuleOrgID,
@@ -260,4 +261,12 @@ func alertRuleVersionToAlertRule(version alertRuleVersion) alertRule {
 		Metadata:                    version.Metadata,
 		MissingSeriesEvalsToResolve: version.MissingSeriesEvalsToResolve,
 	}
+
+	result, err := alertRuleToModelsAlertRule(rule, l)
+	if err != nil {
+		return result, err
+	}
+
+	result.Message = version.Message
+	return result, nil
 }

--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -69,10 +69,11 @@ type alertRuleVersion struct {
 	NotificationSettings        string `xorm:"notification_settings"`
 	Metadata                    string `xorm:"metadata"`
 	MissingSeriesEvalsToResolve *int64 `xorm:"missing_series_evals_to_resolve"`
+	Message                     string
 }
 
 // EqualSpec compares two alertRuleVersion objects for equality based on their specifications and returns true if they match.
-// The comparison is very basic and can produce false-negative. Fields excluded: ID, ParentVersion, RestoredFrom, Version, Created, RuleGroupIndex and CreatedBy
+// The comparison is very basic and can produce false-negative. Fields excluded: ID, ParentVersion, RestoredFrom, Version, Created, RuleGroupIndex, CreatedBy and Message
 func (a alertRuleVersion) EqualSpec(b alertRuleVersion) bool {
 	return a.RuleOrgID == b.RuleOrgID &&
 		a.RuleGUID == b.RuleGUID &&

--- a/pkg/services/sqlstore/migrations/ualert/tables.go
+++ b/pkg/services/sqlstore/migrations/ualert/tables.go
@@ -24,6 +24,9 @@ func AddTablesMigrations(mg *migrator.Migrator) {
 	mg.AddMigration("add last_applied column to alert_configuration_history", migrator.NewAddColumnMigration(migrator.Table{Name: "alert_configuration_history"}, &migrator.Column{
 		Name: "last_applied", Type: migrator.DB_Int, Nullable: false, Default: "0",
 	}))
+	mg.AddMigration("add message column to alert_rule_version", migrator.NewAddColumnMigration(migrator.Table{Name: "alert_rule_version"}, &migrator.Column{
+		Name: "message", Type: migrator.DB_Text, Nullable: true,
+	}))
 	// End of migration log, add new migrations above this line.
 }
 


### PR DESCRIPTION
Adds a message column to the alert_rule_version table to support commit-style
messages when updating alert rules, similar to dashboard_version. The messages
are limited to 500 characters (matching dashboards).

Initially, message support is only exposed through the Prometheus convert API,
by setting a header value. This functionality can be exposed in the frontend
and/or other provisioning APIs at a later date.

One slightly unsavoury aspect of this change is the addition of Message to
models.AlertRule; it's only needed to pass the message down when changes are
made, and up again when listing versions. It might be cleaner, but much more
invasive, to define AlertRuleVersion types instead and pass them around.
