### PR TITLE
Plugin links: Add buildPathAsync function 

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -30,6 +30,7 @@ export type PluginExtensionLink = PluginExtensionBase & {
   onClick?: (event?: React.MouseEvent) => void;
   icon?: IconName;
   category?: string;
+  buildPathAsync?: <Context extends object = object>(context: Context) => Promise<string | null>;
 };
 
 export type PluginExtensionComponentMeta = Omit<PluginExtensionComponent, 'component'>;
@@ -106,6 +107,7 @@ export type PluginAddedLinksConfigureFunc<Context extends object> = (context: Re
       onClick: (event: React.MouseEvent | undefined, helpers: PluginExtensionEventHelpers<Context>) => void;
       icon: IconName;
       category: string;
+      buildPathAsync: (context: Context) => Promise<string | null>;
     }>
   | undefined;
 
@@ -137,6 +139,9 @@ export type PluginExtensionAddedLinkConfig<Context extends object = object> = Pl
 
   // (Optional) A category to be used when grouping the options in the ui
   category?: string;
+
+  // (Optional) An async function that builds a dynamic path based on context
+  buildPathAsync?: (context: Context) => Promise<string | null>;
 };
 
 export type PluginExtensionExposedComponentConfig<Props = {}> = PluginExtensionConfigBase & {

--- a/public/app/features/plugins/extensions/getPluginExtensions.ts
+++ b/public/app/features/plugins/extensions/getPluginExtensions.ts
@@ -113,6 +113,7 @@ export const getPluginExtensions: GetExtensions = ({
         title: addedLink.title,
         description: addedLink.description ?? '',
         onClick: typeof addedLink.onClick,
+        buildPathAsync: typeof addedLink.buildPathAsync,
       });
       // Run the configure() function with the current context, and apply the ovverides
       const overrides = getLinkExtensionOverrides(pluginId, addedLink, linkLog, frozenContext);
@@ -135,6 +136,7 @@ export const getPluginExtensions: GetExtensions = ({
         description: overrides?.description || addedLink.description || '',
         path: isString(path) ? getLinkExtensionPathWithTracking(pluginId, path, extensionPointId) : undefined,
         category: overrides?.category || addedLink.category,
+        buildPathAsync: overrides?.buildPathAsync || addedLink.buildPathAsync,
       };
 
       extensions.push(extension);

--- a/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
+++ b/public/app/features/plugins/extensions/registry/AddedLinksRegistry.ts
@@ -21,6 +21,7 @@ export type AddedLinkRegistryItem<Context extends object = object> = {
   configure?: PluginAddedLinksConfigureFunc<Context>;
   icon?: IconName;
   category?: string;
+  buildPathAsync?: (context: Context) => Promise<string | null>;
 };
 
 export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], PluginExtensionAddedLinkConfig> {
@@ -40,13 +41,14 @@ export class AddedLinksRegistry extends Registry<AddedLinkRegistryItem[], Plugin
     const { pluginId, configs } = item;
 
     for (const config of configs) {
-      const { path, title, description, configure, onClick, targets } = config;
+      const { path, title, description, configure, onClick, targets, buildPathAsync } = config;
       const configLog = this.logger.child({
         path: path ?? '',
         description: description ?? '',
         title,
         pluginId,
         onClick: typeof onClick,
+        buildPathAsync: typeof buildPathAsync,
       });
 
       if (!title) {

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -478,6 +478,7 @@ export function getLinkExtensionOverrides(
       path = config.path,
       icon = config.icon,
       category = config.category,
+      buildPathAsync = config.buildPathAsync,
       ...rest
     } = overrides;
 
@@ -502,6 +503,7 @@ export function getLinkExtensionOverrides(
       path,
       icon,
       category,
+      buildPathAsync,
     };
   } catch (error) {
     if (error instanceof Error) {


### PR DESCRIPTION
**What is this feature?**

Add an async function to support dynamic async path generation in plugins, enabling lazy loading of heavy modules, like promql parser.

This allows the Metrics Drilldown app to dynamically load the lezer promql parser, saving ~50kb and getting the correct URL path in the Grafana Assistant navigation feature.

Companion PRs
[Metrics Drilldown PR](https://github.com/grafana/metrics-drilldown/pull/852)
[Grafana Assistant PR](https://github.com/grafana/grafana-assistant-app/pull/3073)

**Why do we need this feature?**

Metrics drilldown uses the PromQL parser to build a URL path using a plugin link extension. Importing this module synchronously increases the app bundle size ~50kb. [To solve for this, we first dynamically load the promql parser in the `onClick` function](https://github.com/grafana/metrics-drilldown/pull/665) and this works great, until it doesn't :(

It does not work in the Grafana Assistant, which uses plugin links to navigate to drilldown apps and does not use the onClick function.

Because of this, we are adding a link function to build the path async. This will allow for lazy loading of large modules and still be able to build a full and correct URL path given the context.

**Who is this feature for?**

This is for plugin developers, users of Grafana Assistant and users of the Drilldown apps

**Which issue(s) does this PR fix?**:

https://github.com/grafana/metrics-drilldown/issues/851

**Special notes for your reviewer:**
How to test: 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
