### PR TITLE
[release-11.6.8] CI: Make notify-pr workflow optional

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -317,7 +317,10 @@ jobs:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
           REPO: ${{ github.repository }}
-        run: echo "ISSUE_NUMBER=$(gh api "/repos/grafana/${REPO}/commits/${GRAFANA_COMMIT}/pulls" | jq -r '.[0].number')" >> "$GITHUB_ENV"
+        run:
+          set -eo pipefail
+          gh api "/repos/${REPO}/commits/${GRAFANA_COMMIT}/pulls" | jq -r '.[0].number' | tee issue_number.txt
+          echo "ISSUE_NUMBER=$(cat issue_number.txt)" >> "$GITHUB_ENV"
       - name: Find Comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         if: ${{ steps.find-pr.outcome == 'success' }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -322,6 +322,7 @@ jobs:
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
         if: ${{ steps.find-pr.outcome == 'success' }}
         id: fc
+        continue-on-error: true
         with:
           issue-number: ${{ env.ISSUE_NUMBER }}
           comment-author: 'grafana-delivery-bot[bot]'
@@ -329,7 +330,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
       - name: Create or update comment
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v4
-        if: ${{ steps.find-pr.outcome == 'success' }}
+        if: ${{ steps.find-pr.outcome == 'success' }} # Run even if comment wasn't found
         with:
           token: ${{ steps.generate_token.outputs.token }}
           comment-id: ${{ steps.fc.outputs.comment-id }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -311,12 +311,16 @@ jobs:
           repositories: '["grafana"]'
           permissions: '{"issues": "write", "pull_requests": "write", "contents": "read"}'
       - name: Find PR
+        continue-on-error: true
+        id: find-pr
         env:
           GITHUB_TOKEN: ${{ steps.generate_token.outputs.token }}
           GRAFANA_COMMIT: ${{ needs.setup.outputs.grafana-commit }}
-        run: echo "ISSUE_NUMBER=$(gh api "/repos/grafana/grafana/commits/${GRAFANA_COMMIT}/pulls" | jq -r '.[0].number')" >> "$GITHUB_ENV"
+          REPO: ${{ github.repository }}
+        run: echo "ISSUE_NUMBER=$(gh api "/repos/grafana/${REPO}/commits/${GRAFANA_COMMIT}/pulls" | jq -r '.[0].number')" >> "$GITHUB_ENV"
       - name: Find Comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e # v3
+        if: ${{ steps.find-pr.outcome == 'success' }}
         id: fc
         with:
           issue-number: ${{ env.ISSUE_NUMBER }}
@@ -324,7 +328,8 @@ jobs:
           body-includes: GitHub Actions Build
           token: ${{ steps.generate_token.outputs.token }}
       - name: Create or update comment
-        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v4
+        if: ${{ steps.find-pr.outcome == 'success' }}
         with:
           token: ${{ steps.generate_token.outputs.token }}
           comment-id: ${{ steps.fc.outputs.comment-id }}


### PR DESCRIPTION
Backport d92cb9f7a6dde75c75cf8d49af52747ba5b160c7 from #113896

---

If the workflow fails to find a PR (Like in a manual push), the workflow should not fail.
