### PR TITLE
Select: Fix width bug when `maxVisibleValues` is set

### DIFF
--- a/packages/grafana-ui/src/components/Select/ValueContainer.tsx
+++ b/packages/grafana-ui/src/components/Select/ValueContainer.tsx
@@ -26,6 +26,7 @@ class UnthemedValueContainer<Option, isMulti extends boolean, Group extends Grou
     if (
       this.ref.current &&
       this.props.selectProps.autoWidth &&
+      !this.props.selectProps.maxVisibleValues &&
       !isEqual(prevProps.selectProps.value, this.props.selectProps.value)
     ) {
       // Reset in order to measure the new width
@@ -76,3 +77,4 @@ class UnthemedValueContainer<Option, isMulti extends boolean, Group extends Grou
 }
 
 export const ValueContainer = withTheme2(UnthemedValueContainer);
+export { UnthemedValueContainer };

--- a/packages/grafana-ui/src/components/Select/ValueContainer.tsx
+++ b/packages/grafana-ui/src/components/Select/ValueContainer.tsx
@@ -77,4 +77,3 @@ class UnthemedValueContainer<Option, isMulti extends boolean, Group extends Grou
 }
 
 export const ValueContainer = withTheme2(UnthemedValueContainer);
-export { UnthemedValueContainer };


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes an issue where the width of the select would make it look weird when `maxVisibleValues` was set, showing pills stretched and with a bunch of whitespace.

I have managed to repro on storybook [here](https://developers.grafana.com/ui/canary/index.html?path=/story/inputs-deprecated-select--width-auto&args=isMulti:!true;showAllSelectedWhenOpen:!true;maxVisibleValues:5;menuPlacement:bottom;allowCustomValue:!true;noMultiValueWrap:!true;isClearable:!true;virtualized:!true;tabSelectsValue:!false;closeMenuOnSelect:!false)

It seems to be the result of multiple option combos -- it doesn't always happen, but when all these flags are set it does. Check the link and add >5 options, with each added option the whitespace increases.

Before:

https://github.com/user-attachments/assets/14143f95-3f07-45a5-8296-4836eb3ac130



After:

https://github.com/user-attachments/assets/a8ecbccc-1973-4295-9087-b17b2fbc8ddc




**Why do we need this feature?**

Fixes issues in the Select, which were reported around multi-value variables

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/111092

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
