### PR TITLE
InviteUser: Remove experimental feature toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -903,10 +903,6 @@ export interface FeatureToggles {
   */
   infinityRunQueriesInParallel?: boolean;
   /**
-  * Renders invite user button along the app
-  */
-  inviteUserExperimental?: boolean;
-  /**
   * Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1565,15 +1565,6 @@ var (
 			Owner:        grafanaOSSBigTent,
 		},
 		{
-			Name:              "inviteUserExperimental",
-			Description:       "Renders invite user button along the app",
-			Stage:             FeatureStageExperimental,
-			Owner:             grafanaSharingSquad,
-			HideFromAdminPage: true,
-			HideFromDocs:      true,
-			FrontendOnly:      true,
-		},
-		{
 			Name:         "alertingMigrationUI",
 			Description:  "Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules",
 			FrontendOnly: true,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -203,7 +203,6 @@ rendererDisableAppPluginsPreload,experimental,@grafana/grafana-operator-experien
 assetSriChecks,experimental,@grafana/frontend-ops,false,false,true
 alertRuleRestore,preview,@grafana/alerting-squad,false,false,false
 infinityRunQueriesInParallel,privatePreview,@grafana/oss-big-tent,false,false,false
-inviteUserExperimental,experimental,@grafana/sharing-squad,false,false,true
 alertingMigrationUI,GA,@grafana/alerting-squad,false,false,true
 alertingImportYAMLUI,GA,@grafana/alerting-squad,false,false,true
 unifiedStorageHistoryPruner,GA,@grafana/search-and-storage,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -822,10 +822,6 @@ const (
 	// Enables running Infinity queries in parallel
 	FlagInfinityRunQueriesInParallel = "infinityRunQueriesInParallel"
 
-	// FlagInviteUserExperimental
-	// Renders invite user button along the app
-	FlagInviteUserExperimental = "inviteUserExperimental"
-
 	// FlagAlertingMigrationUI
 	// Enables the alerting migration UI, to migrate data source-managed rules to Grafana-managed rules
 	FlagAlertingMigrationUI = "alertingMigrationUI"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2120,7 +2120,8 @@
       "metadata": {
         "name": "inviteUserExperimental",
         "resourceVersion": "1753448760331",
-        "creationTimestamp": "2025-03-07T19:09:59Z"
+        "creationTimestamp": "2025-03-07T19:09:59Z",
+        "deletionTimestamp": "2025-11-14T10:29:28Z"
       },
       "spec": {
         "description": "Renders invite user button along the app",

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
@@ -11,9 +11,6 @@ import { InviteUserButton } from './InviteUserButton';
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   config: {
-    featureToggles: {
-      inviteUserExperimental: true,
-    },
     externalUserMngLinkUrl: 'https://example.com/invite',
   },
   reportInteraction: jest.fn(),

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.test.tsx
@@ -31,9 +31,6 @@ const mockConfig = jest.mocked(config);
 const mockContextSrv = jest.mocked(contextSrv);
 const mockGetExternalUserMngLinkUrl = jest.mocked(getExternalUserMngLinkUrl);
 
-// Type assertion to make mockConfig.featureToggles assignable
-const mockFeatureToggles = mockConfig.featureToggles as Partial<FeatureToggles>;
-
 // Mock window.open
 const mockWindowOpen = jest.fn();
 Object.defineProperty(window, 'open', {
@@ -46,7 +43,6 @@ describe('InviteUserButtonUtils', () => {
     jest.clearAllMocks();
 
     // Set up default mocks
-    mockFeatureToggles.inviteUserExperimental = true;
     mockConfig.externalUserMngLinkUrl = 'https://example.com/invite';
     mockContextSrv.hasPermission.mockReturnValue(true);
 
@@ -58,12 +54,6 @@ describe('InviteUserButtonUtils', () => {
     it('should return true when all conditions are met', () => {
       expect(shouldRenderInviteUserButton()).toBe(true);
       expect(mockContextSrv.hasPermission).toHaveBeenCalledWith(AccessControlAction.OrgUsersAdd);
-    });
-
-    it('should return false when feature toggle is disabled', () => {
-      mockFeatureToggles.inviteUserExperimental = false;
-
-      expect(shouldRenderInviteUserButton()).toBe(false);
     });
 
     it('should return false when URL is not configured', () => {

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
@@ -4,9 +4,7 @@ import { getExternalUserMngLinkUrl } from 'app/features/users/utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
 export const shouldRenderInviteUserButton = () =>
-  config.featureToggles.inviteUserExperimental &&
-  config.externalUserMngLinkUrl &&
-  contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
+  config.externalUserMngLinkUrl && contextSrv.hasPermission(AccessControlAction.OrgUsersAdd);
 
 export const performInviteUserClick = (placement: string, cnt: string) => {
   reportInteraction('invite_user_button_clicked', {


### PR DESCRIPTION
**What is this feature?**

Remove `inviteUserExperimental` feature toggle after deciding to keep the current implementation and being turned on by default since July.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
