### PR TITLE
FrontendService: Add support for swagger in the local dev env

### DIFF
--- a/devenv/frontend-service/README.md
+++ b/devenv/frontend-service/README.md
@@ -13,9 +13,9 @@ On top of the main Grafana development dependencies, you will need installed:
 - [Docker](https://docs.docker.com/get-started/get-docker/)
 - [Tilt](https://docs.tilt.dev/install.html). At the moment we're not using Kubernetes locally, so you shouldn't need to follow the instructions to install kubectl or kind.
 
-To start the stack, from the root of the Grafana project run `make frontend-service-up`. Tilt will orchestrate the webpack and docker builds, and then run the services with Docker compose. You can monitor it's progress and see logs with the URL to the Tilt console. Once done, you can access Grafana at `http://localhost:3000`.
+To start the stack, from the root of the Grafana project run `make frontend-service`. Tilt will orchestrate the webpack and docker builds, and then run the services with Docker compose. You can monitor it's progress and see logs with the URL to the Tilt console. Once done, you can access Grafana at `http://localhost:3000`.
 
-Quitting the process will not stop the service from running. Run `make frontend-service-down` when done to shut down the docker containers.
+Quitting the process will stop the service from running.
 
 ### Grafana config
 

--- a/devenv/frontend-service/configs/nginx.conf
+++ b/devenv/frontend-service/configs/nginx.conf
@@ -73,7 +73,7 @@ server {
   }
 
   # API calls go to the backend
-  location ~ ^/(api|apis|avatar|bootdata|render|logout|public\/plugins|goto) {
+  location ~ ^/(api|apis|avatar|bootdata|render|logout|public/plugins|public/openapi3|public/api-merged|goto|swagger|openapi/v3) {
     # Add debug headers to the response
     add_header Nginx-Trace-Id $otel_trace_id always;
     add_header Nginx-Route "backend" always;

--- a/devenv/frontend-service/docker-compose.yaml
+++ b/devenv/frontend-service/docker-compose.yaml
@@ -31,6 +31,8 @@ services:
       - ./provisioning/dashboards:/grafana/conf/provisioning/dashboards
       - ../dev-dashboards:/grafana/conf/dev-dashboards
       - ./configs/grafana-api.local.ini:/grafana/conf/custom.ini
+      - ../../public/openapi3.json:/grafana/public/openapi3.json
+      - ../../public/api-merged.json:/grafana/public/api-merged.json
     environment:
       OTEL_BSP_SCHEDULE_DELAY: 500
       GF_DEFAULT_APP_MODE: development


### PR DESCRIPTION
**What is this feature?**

Add support for swagger in the local dev env when using `make frontend-service`


**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
