### PR TITLE
Dashboard: Add uid to dashboard saved tracking events

### DIFF
--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -83,6 +83,7 @@ export function useSaveDashboard(isCopy = false) {
           trackDashboardSceneCreatedOrSaved(!!options.isNew, scene, {
             name: saveModel.title || '',
             url: resultData.url || '',
+            uid: resultData.uid,
             expression_types: scene.getExpressionTypes(saveModel),
           });
         }

--- a/public/app/features/dashboard-scene/utils/tracking.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.ts
@@ -51,7 +51,7 @@ export const trackDashboardSceneEditButtonClicked = (dashboardUid?: string) => {
 export function trackDashboardSceneCreatedOrSaved(
   isNew: boolean,
   dashboard: DashboardScene,
-  initialProperties: { name: string; url: string; expression_types?: string[] }
+  initialProperties: { name: string; url: string;uid?: string; expression_types?: string[] }
 ) {
   // url values for dashboard library experiment
   const urlParams = new URLSearchParams(window.location.search);

--- a/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
+++ b/public/app/features/dashboard/components/SaveDashboard/useDashboardSave.tsx
@@ -65,7 +65,7 @@ export const useDashboardSave = (isCopy = false) => {
         if (isCopy) {
           DashboardInteractions.dashboardCopied({ name: dashboard.title || '', url: result.url });
         } else {
-          trackDashboardCreatedOrSaved(!!dashboard.id, { name: dashboard.title, url: result.url });
+          trackDashboardCreatedOrSaved(!!dashboard.id, { name: dashboard.title, url: result.url, uid: result.uid });
         }
 
         const currentPath = locationService.getLocation().pathname;

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -26,7 +26,7 @@ export function trackDashboardLoaded(dashboard: DashboardModel, duration?: numbe
   });
 }
 
-export function trackDashboardCreatedOrSaved(isNew: boolean | undefined, trackingProps: { name: string; url: string }) {
+export function trackDashboardCreatedOrSaved(isNew: boolean | undefined, trackingProps: { name: string; url: string;uid?: string }) {
   DashboardInteractions.dashboardCreatedOrSaved(isNew, trackingProps);
 }
 


### PR DESCRIPTION
**## What this PR does / why we need it**

This PR adds the `uid` property to `grafana_dashboard_saved` tracking events for both Scene-based and legacy dashboard systems.

**## Which issue(s) this PR fixes**

Relates to https://github.com/grafana/grafana/issues/112563

**## Special notes for your reviewer**

- Changes are minimal and focused on adding a single property to existing tracking events
- Type definitions updated to maintain TypeScript type safety
- Both Scene-based (new) and legacy (old) dashboard systems updated for consistency
