### PR TITLE
Prometheus: Filter label values based on the search in metrics browser

### DIFF
--- a/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
+++ b/packages/grafana-prometheus/src/components/metrics-browser/ValueSelector.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { FixedSizeList } from 'react-window';
 
 import { selectors } from '@grafana/e2e-selectors';
@@ -17,6 +17,16 @@ export function ValueSelector() {
   const [valueSearchTerm, setValueSearchTerm] = useState('');
   const { labelValues, selectedLabelValues, isLoadingLabelValues, onLabelValueClick, onLabelKeyClick } =
     useMetricsBrowser();
+  const [filteredLabelValues, setFilteredLabelValues] = useState<Record<string, string[]>>({ ...labelValues });
+
+  useEffect(() => {
+    const filtered: Record<string, string[]> = {};
+    for (const labelKey in labelValues) {
+      const values = labelValues[labelKey];
+      filtered[labelKey] = values.filter((value) => value.includes(valueSearchTerm));
+    }
+    setFilteredLabelValues(filtered);
+  }, [labelValues, valueSearchTerm]);
 
   return (
     <div className={styles.section}>
@@ -47,7 +57,7 @@ export function ValueSelector() {
         </div>
       ) : (
         <div className={styles.valueListArea}>
-          {Object.entries(labelValues).map(([lk, lv]) => {
+          {Object.entries(filteredLabelValues).map(([lk, lv]) => {
             if (!lk || !lv) {
               console.error('label values are empty:', { lk, lv });
               return null;


### PR DESCRIPTION
**What is this feature?**

When we have a long list of values, typing something is just highlighting the matches but not filtering them down. In this PR we have such quality of life improvement. 

**Who is this feature for?**

Prometheus users who use Metrics Browser

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113755

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
