### PR TITLE
ShortURL: Support memoize when creating shorturl using k8s api

### DIFF
--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -44,6 +44,11 @@ beforeEach(() => {
   document.execCommand = jest.fn();
   config.featureToggles.useKubernetesShortURLsAPI = false;
 
+  // clear memoizeOne function
+  if ('clear' in createShortLink) {
+    (createShortLink as { clear: () => void }).clear();
+  }
+
   // Clear any caches between tests
   jest.clearAllMocks();
 });
@@ -68,7 +73,7 @@ describe('createShortLink using k8s API', () => {
     });
 
     config.featureToggles.useKubernetesShortURLsAPI = true;
-    const shortUrl = await createShortLink('d/edhmipji89b0ga2/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
+    const shortUrl = await createShortLink('d/edhmipji89b0gb/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
     expect(shortUrl).toBe('https://www.test.grafana.com/goto/bewyw48durgu8d?orgId=1');
   });
 });

--- a/public/app/core/utils/shortLinks.test.ts
+++ b/public/app/core/utils/shortLinks.test.ts
@@ -13,7 +13,7 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => {
     return {
       post: () => {
-        return Promise.resolve({ url: 'www.test.grafana.com/goto/bewyw48durgu8d?orgId=1' });
+        return Promise.resolve({ url: 'https://www.test.grafana.com/goto/bewyw48durgu8d?orgId=1' });
       },
     };
   },
@@ -51,7 +51,7 @@ beforeEach(() => {
 describe('createShortLink', () => {
   it('creates short link', async () => {
     const shortUrl = await createShortLink('d/edhmipji89b0gb/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
-    expect(shortUrl).toBe('www.test.grafana.com/goto/bewyw48durgu8d?orgId=1');
+    expect(shortUrl).toBe('https://www.test.grafana.com/goto/bewyw48durgu8d?orgId=1');
   });
 });
 
@@ -68,7 +68,7 @@ describe('createShortLink using k8s API', () => {
     });
 
     config.featureToggles.useKubernetesShortURLsAPI = true;
-    const shortUrl = await createShortLink('d/edhmipji89b0gb/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
+    const shortUrl = await createShortLink('d/edhmipji89b0ga2/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
     expect(shortUrl).toBe('https://www.test.grafana.com/goto/bewyw48durgu8d?orgId=1');
   });
 });
@@ -88,7 +88,9 @@ describe('createAndCopyShortLink', () => {
   it('copies short link to clipboard via navigator.clipboard.writeText when ClipboardItem is undefined', async () => {
     window.isSecureContext = true;
     await createAndCopyShortLink('d/edhmipji89b0gb/welcome?orgId=1&from=now-6h&to=now&timezone=browser');
-    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('www.test.grafana.com/goto/bewyw48durgu8d?orgId=1');
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'https://www.test.grafana.com/goto/bewyw48durgu8d?orgId=1'
+    );
   });
 
   it('copies short link to clipboard via navigator.clipboard.write and ClipboardItem when it is defined', async () => {

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -34,14 +34,14 @@ function getRelativeURLPath(url: string) {
 }
 
 // Memoized legacy API call - preserves original behavior
-const createShortLinkLegacy = memoizeOne(async (path: string): Promise<string> => {
+const createShortLinkLegacy = async (path: string): Promise<string> => {
   const shortLink = await getBackendSrv().post(`/api/short-urls`, {
     path: getRelativeURLPath(path),
   });
   return shortLink.url;
-});
+};
 
-export const createShortLink = async function (path: string) {
+export const createShortLink = memoizeOne(async (path: string): Promise<string> => {
   try {
     if (config.featureToggles.useKubernetesShortURLsAPI) {
       // Use RTK API - it handles caching/failures/retries automatically
@@ -77,7 +77,7 @@ export const createShortLink = async function (path: string) {
     dispatch(notifyApp(createErrorNotification('Error generating shortened link')));
     throw err; // Re-throw so callers know it failed
   }
-};
+});
 
 /**
  * Creates a ClipboardItem for the shortened link. This is used due to clipboard issues in Safari after making async calls.

--- a/public/app/core/utils/shortLinks.ts
+++ b/public/app/core/utils/shortLinks.ts
@@ -33,7 +33,6 @@ function getRelativeURLPath(url: string) {
   return path.startsWith('/') ? path.substring(1, path.length) : path;
 }
 
-// Memoized legacy API call - preserves original behavior
 const createShortLinkLegacy = async (path: string): Promise<string> => {
   const shortLink = await getBackendSrv().post(`/api/short-urls`, {
     path: getRelativeURLPath(path),
@@ -41,6 +40,8 @@ const createShortLinkLegacy = async (path: string): Promise<string> => {
   return shortLink.url;
 };
 
+// Memoized API call, to not re-execute the same request multiple times
+// this function creates a shortURL using the legacy or the new k8s api depending on the feature toggle
 export const createShortLink = memoizeOne(async (path: string): Promise<string> => {
   try {
     if (config.featureToggles.useKubernetesShortURLsAPI) {
@@ -69,7 +70,6 @@ export const createShortLink = memoizeOne(async (path: string): Promise<string> 
 
       throw new Error('Failed to create short URL');
     } else {
-      // Old API - use memoized function (preserves original behavior)
       return await createShortLinkLegacy(path);
     }
   } catch (err) {


### PR DESCRIPTION
**What is this feature?**

Add support to `memoize` the shortURL when using the new k8s API to not make a new request when the parameters of the original URL to be shared didn't change.

Fixes https://github.com/grafana/grafana/issues/113401

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
