### PR TITLE
Alerting: Update tooltip message when routing preview is disabled

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -36,7 +36,7 @@ export const NotificationPreview = ({
   alertUid,
 }: NotificationPreviewProps) => {
   const styles = useStyles2(getStyles);
-  const disabled = !condition || !folder;
+  const previewRoutingDisabled = !condition || !folder;
 
   const [trigger, { data = [], isLoading, isUninitialized: previewUninitialized }] = preview.useMutation();
 
@@ -51,7 +51,7 @@ export const NotificationPreview = ({
   }, []);
 
   const onPreview = () => {
-    if (!folder || !condition) {
+    if (previewRoutingDisabled) {
       return;
     }
 
@@ -67,7 +67,7 @@ export const NotificationPreview = ({
   };
 
   useEffectOnce(() => {
-    if (!disabled) {
+    if (!previewRoutingDisabled) {
       onPreview();
     }
   });
@@ -75,6 +75,20 @@ export const NotificationPreview = ({
   //  Get alert managers's data source information
   const alertManagerDataSources = useGetAlertManagerDataSourcesByPermissionAndConfig('notification');
   const singleAlertManagerConfigured = alertManagerDataSources.length === 1;
+
+  const getTooltipContent = () => {
+    if (!folder) {
+      return <Trans i18nKey="alerting.notification-preview.disabled-tooltip">Select a folder to preview routing</Trans>;
+    }
+    if (previewRoutingDisabled) {
+      return (
+        <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">
+          You don&apos;t have sufficient permissions to preview
+        </Trans>
+      );
+    }
+    return '';
+  };
 
   return (
     <Stack direction="column">
@@ -104,18 +118,8 @@ export const NotificationPreview = ({
             </Text>
           )}
         </Stack>
-        <Tooltip
-          content={
-            disabled ? (
-              <Trans i18nKey="alerting.notification-preview.disabled-tooltip">
-                You don&apos;t have sufficient permissions to preview
-              </Trans>
-            ) : (
-              ''
-            )
-          }
-        >
-          <Button icon="sync" variant="secondary" type="button" onClick={onPreview} disabled={disabled}>
+        <Tooltip content={getTooltipContent()}>
+          <Button icon="sync" variant="secondary" type="button" onClick={onPreview} disabled={previewRoutingDisabled}>
             <Trans i18nKey="alerting.notification-preview.preview-routing">Preview routing</Trans>
           </Button>
         </Tooltip>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -78,11 +78,13 @@ export const NotificationPreview = ({
 
   const getTooltipContent = () => {
     if (!folder) {
-      return <Trans i18nKey="alerting.notification-preview.disabled-tooltip">Select a folder to preview routing</Trans>;
+      return (
+        <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">Select a folder to preview routing</Trans>
+      );
     }
     if (previewRoutingDisabled) {
       return (
-        <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">
+        <Trans i18nKey="alerting.notification-preview.disabled-tooltip">
           You don&apos;t have sufficient permissions to preview
         </Trans>
       );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1982,10 +1982,11 @@
     },
     "notification-preview": {
       "alertmanager": "Alertmanager:",
-      "disabled-tooltip": "You don't have sufficient permissions to preview",
+      "disabled-tooltip": "Select a folder to preview routing",
       "error": "Could not load routing preview for {{alertmanager}}",
       "initialized": "Based on the labels added, alert instances are routed to the following notification policies. Expand each notification policy below to view more details.",
       "preview-routing": "Preview routing",
+      "select-folder-tooltip": "You don't have sufficient permissions to preview",
       "text-loading-preview": "Loading preview...",
       "title": "Alert instance routing preview",
       "uninitialized": "When you have your folder selected and your query and labels are configured, click \"Preview routing\" to see the results here."

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1982,11 +1982,11 @@
     },
     "notification-preview": {
       "alertmanager": "Alertmanager:",
-      "disabled-tooltip": "Select a folder to preview routing",
+      "disabled-tooltip": "You don't have sufficient permissions to preview",
       "error": "Could not load routing preview for {{alertmanager}}",
       "initialized": "Based on the labels added, alert instances are routed to the following notification policies. Expand each notification policy below to view more details.",
       "preview-routing": "Preview routing",
-      "select-folder-tooltip": "You don't have sufficient permissions to preview",
+      "select-folder-tooltip": "Select a folder to preview routing",
       "text-loading-preview": "Loading preview...",
       "title": "Alert instance routing preview",
       "uninitialized": "When you have your folder selected and your query and labels are configured, click \"Preview routing\" to see the results here."


### PR DESCRIPTION
Relates to this PR: https://github.com/grafana/grafana/pull/113749

When a user has permissions to preview routing but hasn't selected a folder, they should see a different info message when hovering over the disabled Preview Routing button.
<img width="279" height="142" alt="image" src="https://github.com/user-attachments/assets/388a8896-0ad5-4276-8b51-1043a097f8e4" />
