### PR TITLE
FS: Preserve buildInfo.edition from backend

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -288,16 +288,21 @@
             user: [[.DefaultUser]],
           }
 
-          // tenant-specific config
-          // TODO split this into separate API calls
+          // Preserve a mix of values from the initial boot data, and from the backend
+          // - nav tree and user info come from the backend
+          // - merge settings from both. FS settings contains less values
+          // - build info edition comes from the backend
           const { navTree, settings, user } = await loadBootData();
 
           window.grafanaBootData.settings = {
             ...settings,
-            ...window.grafanaBootData.settings, // preserve frontend-service settings
+            ...window.grafanaBootData.settings,
           }
           window.grafanaBootData.navTree = navTree;
           window.grafanaBootData.user = user;
+          if (settings?.buildInfo?.edition) {
+            window.grafanaBootData.settings.buildInfo.edition = settings.buildInfo.edition;
+          }
 
           // The per-theme CSS still contains some global styles needed
           // to render the page correctly.


### PR DESCRIPTION
The new FS index.html prefers to use the buildInfo from the frontend service itself to maintain the version and version_string, but we would prefer the licensed 'Edition' comes from the backend.

This changes the HTML to preserve the edition from the backend build info.