### PR TITLE
Prometheus: Hide 'Kick start your query' button for existing queries

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -1,6 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
 import { isEqual } from 'lodash';
-import { memo, SyntheticEvent, useCallback, useEffect, useState } from 'react';
+import { memo, SyntheticEvent, useCallback, useEffect, useState, useMemo} from 'react';
 
 import { CoreApp, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -89,6 +89,16 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
     setQueryPatternsModalOpen(true);
   }, [app]);
 
+  const hasPreviousQuery = useMemo(() => {
+    const visualQuery = buildVisualQueryFromString(query.expr ?? '');
+    const hasOperations = visualQuery.query.operations.length > 0,
+      hasMetric = visualQuery.query.metric,
+      hasLabels = visualQuery.query.labels.length > 0,
+      hasBinaryQueries = visualQuery.query.binaryQueries ? visualQuery.query.binaryQueries.length > 0 : false;
+  
+    return hasOperations || hasMetric || hasLabels || hasBinaryQueries;
+  }, [query.expr]);
+
   return (
     <>
       <ConfirmModal
@@ -118,16 +128,18 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         onAddQuery={onAddQuery}
       />
       <EditorHeader>
-        <Button
-          data-testid={selectors.components.QueryBuilder.queryPatterns}
-          variant="secondary"
-          size="sm"
-          onClick={handleOpenQueryPatternsModal}
-        >
+        {!hasPreviousQuery && (
+          <Button
+            data-testid={selectors.components.QueryBuilder.queryPatterns}
+            variant="secondary"
+            size="sm"
+            onClick={handleOpenQueryPatternsModal}
+          >
           <Trans i18nKey="grafana-prometheus.querybuilder.prom-query-editor-selector.kick-start-your-query">
             Kick start your query
           </Trans>
         </Button>
+        )}
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.explain}>
           <QueryHeaderSwitch
             label={t('grafana-prometheus.querybuilder.prom-query-editor-selector.label-explain', 'Explain')}

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -1,6 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
 import { isEqual } from 'lodash';
-import { memo, SyntheticEvent, useCallback, useEffect, useState, useMemo} from 'react';
+import { memo, SyntheticEvent, useCallback, useEffect, useState} from 'react';
 
 import { CoreApp, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -89,16 +89,6 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
     setQueryPatternsModalOpen(true);
   }, [app]);
 
-  const hasPreviousQuery = useMemo(() => {
-    const visualQuery = buildVisualQueryFromString(query.expr ?? '');
-    const hasOperations = visualQuery.query.operations.length > 0,
-      hasMetric = visualQuery.query.metric,
-      hasLabels = visualQuery.query.labels.length > 0,
-      hasBinaryQueries = visualQuery.query.binaryQueries ? visualQuery.query.binaryQueries.length > 0 : false;
-  
-    return hasOperations || hasMetric || hasLabels || hasBinaryQueries;
-  }, [query.expr]);
-
   return (
     <>
       <ConfirmModal
@@ -128,7 +118,7 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
         onAddQuery={onAddQuery}
       />
       <EditorHeader>
-        {!hasPreviousQuery && (
+        {!query.expr && (
           <Button
             data-testid={selectors.components.QueryBuilder.queryPatterns}
             variant="secondary"

--- a/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/PromQueryEditorSelector.tsx
@@ -1,6 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx
 import { isEqual } from 'lodash';
-import { memo, SyntheticEvent, useCallback, useEffect, useState} from 'react';
+import { memo, SyntheticEvent, useCallback, useEffect, useState } from 'react';
 
 import { CoreApp, LoadingState } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -125,10 +125,10 @@ export const PromQueryEditorSelector = memo<Props>((props) => {
             size="sm"
             onClick={handleOpenQueryPatternsModal}
           >
-          <Trans i18nKey="grafana-prometheus.querybuilder.prom-query-editor-selector.kick-start-your-query">
-            Kick start your query
-          </Trans>
-        </Button>
+            <Trans i18nKey="grafana-prometheus.querybuilder.prom-query-editor-selector.kick-start-your-query">
+              Kick start your query
+            </Trans>
+          </Button>
         )}
         <div data-testid={selectors.components.DataSource.Prometheus.queryEditor.explain}>
           <QueryHeaderSwitch


### PR DESCRIPTION
**What this PR does**

Fixes #113762

This PR improves the Prometheus query builder UX by conditionally showing the "Kick start your query" button only for new, empty queries. 

**Changes made:**
1 Modified file:`public/app/plugins/datasource/prometheus/querybuilder/components/PromQueryEditorSelector.tsx`
2. Conditionally render the "Kick start your query" button only when `!query.expr`


