### PR TITLE
TimeSeries: Improve e2e for time range pan

### DIFF
--- a/e2e-playwright/panels-suite/timeseries.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries.spec.ts
@@ -9,8 +9,13 @@ test.use({
 });
 
 test.describe('Panels test: TimeSeries X-axis panning', { tag: ['@panels', '@timeseries'] }, () => {
-  test('cursor changes to grab hand over x-axis', async ({ gotoDashboardPage, page }) => {
-    await test.step('Load dashboard and verify cursor changes to grab', async () => {
+  test('x-axis panning functionality', async ({ gotoDashboardPage, page, selectors }) => {
+    let centerX: number;
+    let centerY: number;
+    let initialFromTime: number;
+    let initialToTime: number;
+
+    const dashboardPage = await test.step('Load dashboard and verify cursor changes to grab', async () => {
       const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
 
       const timeseriesPanel = page.locator('.uplot').first();
@@ -23,23 +28,13 @@ test.describe('Panels test: TimeSeries X-axis panning', { tag: ['@panels', '@tim
 
       const cursorStyle = await xAxis.evaluate((el: HTMLElement) => window.getComputedStyle(el).cursor);
       expect(cursorStyle, 'cursor is grab').toBe('grab');
+
+      return dashboardPage;
     });
-  });
 
-  test('drag right pans backward in time, drag left pans forward', async ({ gotoDashboardPage, page, selectors }) => {
-    let centerX: number;
-    let centerY: number;
-    let initialFromTime: number;
-    let initialToTime: number;
-
-    const dashboardPage = await test.step('Load dashboard and capture initial time range', async () => {
-      const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
-
+    await test.step('Capture initial time range', async () => {
       const timeseriesPanel = page.locator('.uplot').first();
-      await expect(timeseriesPanel, 'panel rendered').toBeVisible();
-
       const xAxis = timeseriesPanel.locator('.u-axis').first();
-      await expect(xAxis, 'x-axis rendered').toBeVisible();
 
       const timePickerButton = dashboardPage.getByGrafanaSelector(selectors.components.TimePicker.openButton);
       await timePickerButton.click();
@@ -61,8 +56,6 @@ test.describe('Panels test: TimeSeries X-axis panning', { tag: ['@panels', '@tim
 
       centerX = axisBox.x + axisBox.width / 2;
       centerY = axisBox.y + axisBox.height / 2;
-
-      return dashboardPage;
     });
 
     await test.step('Drag right pans backward in time', async () => {


### PR DESCRIPTION
The existing playwright tests for `timeRangePan` were calling `gotoDashboardPage` twice. This PR consolidates the test into one call to help reduce overhead.