### PR TITLE
datasource: allow mTLS certificate rotation without restarting grafana

### DIFF
--- a/docs/sources/administration/provisioning/index.md
+++ b/docs/sources/administration/provisioning/index.md
@@ -206,6 +206,8 @@ Common settings in the [built-in core data sources](../../datasources/#built-in-
 | ------------------------------- | ------- | ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `tlsAuth`                       | boolean | _HTTP\*_, MySQL                                                  | Enable TLS authentication using client cert configured in secure JSON data                                                                                                                                                                                                                    |
 | `tlsAuthWithCACert`             | boolean | _HTTP\*_, MySQL, PostgreSQL                                      | Enable TLS authentication using CA cert                                                                                                                                                                                                                                                       |
+| `tlsClientCertFile`             | string  | _HTTP\*_ , MySQL, PostgreSQL, MSSQL                               | Path to a client certificate file. When set together with `tlsClientKeyFile`, Grafana reloads the certificate for every request to allow mTLS certificate rotation without restarting Grafana.                                                                                               |
+| `tlsClientKeyFile`              | string  | _HTTP\*_ , MySQL, PostgreSQL, MSSQL                               | Path to a client key file. Use with `tlsClientCertFile`; Grafana reloads both on each request enabling seamless mTLS client cert/key rotation.                                                                                                                                                |
 | `tlsSkipVerify`                 | boolean | _HTTP\*_, MySQL, PostgreSQL, MSSQL                               | Controls whether a client verifies the server's certificate chain and host name.                                                                                                                                                                                                              |
 | `serverName`                    | string  | _HTTP\*_, MSSQL                                                  | Optional. Controls the server name used for certificate common name/subject alternative name verification. Defaults to using the data source URL.                                                                                                                                             |
 | `timeout`                       | string  | _HTTP\*_                                                         | Request timeout in seconds. Overrides `dataproxy.timeout` option                                                                                                                                                                                                                              |
@@ -262,6 +264,10 @@ Data sources tagged with _HTTP\*_ communicate using the HTTP protocol, which inc
 {{< /admonition >}}
 
 For examples of specific data sources' JSON data, refer to that [data source's documentation](../../datasources/).
+
+{{< admonition type="note" >}}
+To enable dynamic mTLS client certificate rotation (for example with cert-manager on Kubernetes), set both `tlsClientCertFile` and `tlsClientKeyFile` in `jsonData`. Grafana then reloads the client certificate and key on every request, so you don't need to restart Grafana when certificates rotate.
+{{< /admonition >}}
 
 #### Secure JSON data
 


### PR DESCRIPTION
**What is this feature?**

When tlsClientCertFile and tlsClientKeyFile are set, configure GetClientCertificate to reload the certificate and key on each request. This enables mTLS deployments to rotate certificates without requiring an application restart.

**Why do we need this feature?**

mTLS datasources typically use client certificates that are rotated regularly, often with short lifetimes (e.g., a few months or less). Relying on application restarts to pick up new certificates is operationally fragile and doesn’t scale, especially when the restart must be coordinated before expiry.

With this feature, environments such as Kubernetes, where cert-manager handles certificate rotation, can update client certificates. Grafana will load the certificate dynamically.

**Who is this feature for?**

Whoever uses datasources with mTLS.

**Which issue(s) does this PR fix?**:

ref. https://github.com/grafana/grafana/discussions/44296

**Special notes for your reviewer:**

Requires: https://github.com/grafana/grafana-plugin-sdk-go/pull/1429

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
