### PR TITLE
Revert "OFREP: add ST builder for the authorizer, APIEnabled=false needs it"

### DIFF
--- a/pkg/registry/apis/ofrep/register.go
+++ b/pkg/registry/apis/ofrep/register.go
@@ -64,6 +64,10 @@ func NewAPIBuilder(providerType string, url *url.URL, insecure bool, caFile stri
 }
 
 func RegisterAPIService(apiregistration builder.APIRegistrar, cfg *setting.Cfg) (*APIBuilder, error) {
+	if !cfg.OpenFeature.APIEnabled {
+		return nil, nil
+	}
+
 	var staticEvaluator featuremgmt.StaticFlagEvaluator //  No static evaluator needed for non-static provider
 	var err error
 	if cfg.OpenFeature.ProviderType == setting.StaticProviderType {


### PR DESCRIPTION
Reverts grafana/grafana#113809

This _may_ be responsible for [some features not being evaluated correctly in some environments.](https://ops.grafana-ops.net/a/grafana-irm-app/incidents/4151)