### PR TITLE
[release-12.3.0] docs: clarifying info on what's new lading page

### DIFF
--- a/docs/sources/whatsnew/_index.md
+++ b/docs/sources/whatsnew/_index.md
@@ -170,7 +170,6 @@ aliases:
 description: Learn about new and updated features in Grafana.
 labels:
   products:
-    - cloud
     - enterprise
     - oss
 menuTitle: What's new
@@ -180,7 +179,9 @@ weight: 1
 
 # What's new in Grafana
 
-For release highlights, deprecations, and breaking changes in Grafana releases, refer to these "What's new" pages for each version.
+For release highlights, deprecations, and breaking changes in self-managed Grafana releases, refer to these "What's new" pages for each version.
+
+For information on new Grafana Cloud highlights, refer to [What's new from Grafana Labs](https://grafana.com/whats-new).
 
 {{< admonition type="note" >}}
 For Grafana versions prior to v9.2, additional information might also be available in the archived release notes. To access archived release notes, use the documentation for the minor version you want to see.


### PR DESCRIPTION

backports https://github.com/grafana/grafana/pull/113562 to `release-12.3.0` to ensure we have the information available on release day instead of waiting for patching