### PR TITLE
Heatmap: Improve error messaging if no numeric fields were provided

### DIFF
--- a/public/app/features/transformers/calculateHeatmap/heatmap.test.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.test.ts
@@ -108,4 +108,17 @@ describe('Heatmap transformer', () => {
       ]
     `);
   });
+
+  it('throws error if no numeric fields are present', async () => {
+    expect(() =>
+      rowsToCellsHeatmap({
+        frame: toDataFrame({
+          fields: [
+            { name: 'time', type: FieldType.time, values: [1, 2, 3, 4] },
+            { name: 'label', type: FieldType.string, values: ['a', 'b', 'c', 'd'] },
+          ],
+        }),
+      })
+    ).toThrowErrorMatchingInlineSnapshot(`"No numeric fields found for heatmap"`);
+  });
 });

--- a/public/app/features/transformers/calculateHeatmap/heatmap.ts
+++ b/public/app/features/transformers/calculateHeatmap/heatmap.ts
@@ -125,6 +125,10 @@ export function rowsToCellsHeatmap(opts: RowsHeatmapOptions): DataFrame {
   const xValues = xField.values;
   const yFields = opts.frame.fields.filter((f, idx) => f.type === FieldType.number && idx > 0);
 
+  if (yFields.length === 0) {
+    throw new Error(t('heatmap.error.no-y-fields', 'No numeric fields found for heatmap'));
+  }
+
   // similar to initBins() below
   const len = xValues.length * yFields.length;
   const xs = new Array(len);

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.tsx
@@ -54,6 +54,7 @@ export const HeatmapPanel = (props: HeatmapPanelProps) => {
         timeRange,
       });
     } catch (ex) {
+      console.error(ex);
       return { warning: `${ex}` };
     }
   }, [data.series, data.annotations, options, palette, theme, replaceVariables, timeRange]);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9150,6 +9150,9 @@
     "category-legend": "Legend",
     "category-tooltip": "Tooltip",
     "category-y-axis": "Y Axis",
+    "error": {
+      "no-y-fields": "No numeric fields found for heatmap"
+    },
     "mode-options": {
       "label-opacity": "Opacity",
       "label-scheme": "Scheme"


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/19448

- if we're going to display raw thrown error messages in the UI (which we should not do, so we should address that later), then we at least also need to `console.error` those errors when we `catch` them so they can be easily traced back when debugging.
- the issue here was a user accidentally sending numeric strings in when they intended to send numbers, so this error would help someone catch that they have failed to send number fields into the heatmap, and ensures that the access to `yFields[0]` later in the method won't throw TypeErrors.