### PR TITLE
Chore: Add html_handler_requests metric

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -214,14 +214,15 @@ type HTTPServer struct {
 	oauthTokenService    oauthtoken.OAuthTokenService
 	statsService         stats.Service
 	authnService         authn.Service
-	starApi              *starApi.API
-	promRegister         prometheus.Registerer
-	promGatherer         prometheus.Gatherer
-	clientConfigProvider grafanaapiserver.DirectRestConfigProvider
-	namespacer           request.NamespaceMapper
-	anonService          anonymous.Service
-	userVerifier         user.Verifier
-	tlsCerts             TLSCerts
+	starApi                     *starApi.API
+	promRegister                prometheus.Registerer
+	promGatherer                prometheus.Gatherer
+	clientConfigProvider        grafanaapiserver.DirectRestConfigProvider
+	namespacer                  request.NamespaceMapper
+	anonService                 anonymous.Service
+	userVerifier                user.Verifier
+	tlsCerts                    TLSCerts
+	htmlHandlerRequestsCounter  *prometheus.CounterVec
 }
 
 type TLSCerts struct {
@@ -375,7 +376,15 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 		namespacer:                   request.GetNamespaceMapper(cfg),
 		anonService:                  anonService,
 		userVerifier:                 userVerifier,
+		htmlHandlerRequestsCounter: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Name:      "html_handler_requests_total",
+			Help:      "Number of requests handled by the index.go HTML handler",
+		}, []string{"handler"}),
 	}
+
+	promRegister.MustRegister(hs.htmlHandlerRequestsCounter)
+
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")
 	}

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -22,16 +22,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
-)
-
-var (
-	htmlHandlerRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name:      "html_handler_requests_total",
-		Help:      "Number of requests handled by the index.go HTML handler",
-		Namespace: "grafana",
-	}, []string{"handler"})
 )
 
 type URLPrefs struct {
@@ -281,7 +271,7 @@ func hashUserIdentifier(identifier string, secret string) string {
 func (hs *HTTPServer) Index(c *contextmodel.ReqContext) {
 	c, span := hs.injectSpan(c, "api.Index")
 	defer span.End()
-	htmlHandlerRequestsCounter.WithLabelValues("index").Inc()
+	hs.htmlHandlerRequestsCounter.WithLabelValues("index").Inc()
 
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
@@ -297,7 +287,7 @@ func (hs *HTTPServer) NotFoundHandler(c *contextmodel.ReqContext) {
 		return
 	}
 
-	htmlHandlerRequestsCounter.WithLabelValues("not_found").Inc()
+	hs.htmlHandlerRequestsCounter.WithLabelValues("not_found").Inc()
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -8,11 +8,13 @@ import (
 	"html/template"
 	"net/http"
 	"strings"
+	"time"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/api/webassets"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/grafana/grafana/pkg/middleware"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -271,7 +273,11 @@ func hashUserIdentifier(identifier string, secret string) string {
 func (hs *HTTPServer) Index(c *contextmodel.ReqContext) {
 	c, span := hs.injectSpan(c, "api.Index")
 	defer span.End()
-	hs.htmlHandlerRequestsCounter.WithLabelValues("index").Inc()
+
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.htmlHandlerRequestsDuration.WithLabelValues("index"), time.Since(start).Seconds())
+	}()
 
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
@@ -287,7 +293,11 @@ func (hs *HTTPServer) NotFoundHandler(c *contextmodel.ReqContext) {
 		return
 	}
 
-	hs.htmlHandlerRequestsCounter.WithLabelValues("not_found").Inc()
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.htmlHandlerRequestsDuration.WithLabelValues("not_found"), time.Since(start).Seconds())
+	}()
+
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -22,6 +22,16 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	pref "github.com/grafana/grafana/pkg/services/preference"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	htmlHandlerRequestsCounter = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name:      "html_handler_requests_total",
+		Help:      "Number of requests handled by the index.go HTML handler",
+		Namespace: "grafana",
+	}, []string{"handler"})
 )
 
 type URLPrefs struct {
@@ -271,6 +281,7 @@ func hashUserIdentifier(identifier string, secret string) string {
 func (hs *HTTPServer) Index(c *contextmodel.ReqContext) {
 	c, span := hs.injectSpan(c, "api.Index")
 	defer span.End()
+	htmlHandlerRequestsCounter.WithLabelValues("index").Inc()
 
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
@@ -286,6 +297,7 @@ func (hs *HTTPServer) NotFoundHandler(c *contextmodel.ReqContext) {
 		return
 	}
 
+	htmlHandlerRequestsCounter.WithLabelValues("not_found").Inc()
 	data, err := hs.setIndexViewData(c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -9,11 +9,13 @@ import (
 	"net/url"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/metrics"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/grafana/grafana/pkg/infra/network"
 	"github.com/grafana/grafana/pkg/middleware"
 	"github.com/grafana/grafana/pkg/middleware/cookies"
@@ -101,7 +103,10 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 		return
 	}
 
-	hs.htmlHandlerRequestsCounter.WithLabelValues("login").Inc()
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.htmlHandlerRequestsDuration.WithLabelValues("login"), time.Since(start).Seconds())
+	}()
 	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -101,6 +101,7 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 		return
 	}
 
+	htmlHandlerRequestsCounter.WithLabelValues("login").Inc()
 	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)

--- a/pkg/api/login.go
+++ b/pkg/api/login.go
@@ -101,7 +101,7 @@ func (hs *HTTPServer) LoginView(c *contextmodel.ReqContext) {
 		return
 	}
 
-	htmlHandlerRequestsCounter.WithLabelValues("login").Inc()
+	hs.htmlHandlerRequestsCounter.WithLabelValues("login").Inc()
 	viewData, err := setIndexViewData(hs, c)
 	if err != nil {
 		c.Handle(hs.Cfg, http.StatusInternalServerError, "Failed to get settings", err)


### PR DESCRIPTION
Adds a prom metric to track requests handled by the `index.go` handler that returns HTML. This will be used to help track traffic with the migration to the frontend service.

Part of https://github.com/grafana/grafana-frontend-platform/issues/30 