### PR TITLE
feat(dashboards): add ttl based caching for datasources

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -12,6 +12,11 @@ import (
 )
 
 func RegisterConversions(s *runtime.Scheme, dsIndexProvider schemaversion.DataSourceIndexProvider) error {
+	// Wrap the provider once with 10s caching for all conversions.
+	// This prevents repeated DB queries across multiple conversion calls while allowing
+	// the cache to refresh periodically, making it suitable for long-lived singleton usage.
+	dsIndexProvider = schemaversion.WrapIndexProviderWithOnce(dsIndexProvider)
+
 	// v0 conversions
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {

--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -15,7 +15,7 @@ func RegisterConversions(s *runtime.Scheme, dsIndexProvider schemaversion.DataSo
 	// Wrap the provider once with 10s caching for all conversions.
 	// This prevents repeated DB queries across multiple conversion calls while allowing
 	// the cache to refresh periodically, making it suitable for long-lived singleton usage.
-	dsIndexProvider = schemaversion.WrapIndexProviderWithOnce(dsIndexProvider)
+	dsIndexProvider = schemaversion.WrapIndexProviderWithCache(dsIndexProvider)
 
 	// v0 conversions
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv1.Dashboard)(nil),


### PR DESCRIPTION
This PR is adding a TTL based cache for datasources (10s) instead of a per dashboard conversion one. A request can have up to 100+ dashboards, so we would build a cache for each of them. As the conversion functions a registered once and provided by a registry, we don't have an easy way to provide an index per request. So we use a TTL based cache with-in the registry that caches the index for at most 10s and is provided for all the dashboards in that time window.

Follow up to #113911 