### PR TITLE
Docs: Update documentation on PDF/Email generation with logo

### DIFF
--- a/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
+++ b/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
@@ -46,7 +46,7 @@ The options in this section control the branding and theming of the report attac
 - **Company logo** - Company logo displayed in the report PDF.
   Configure it by specifying a URL or uploading a file.
   The maximum file size is 16 MB.
-  Defaults to the Grafana logo.
+  If not set, defaults to the Grafana logo. If the URL specified is not correct, the logo will appear as broken link logo.
 
 - **Theme** - Theme of the PDF attached to the report.
   The selected theme is also applied to the PDFs generated when you click **Preview PDF** during report creation or select the **Export as PDF** option on a dashboard.
@@ -66,7 +66,7 @@ The options in this section control the branding and theming of the report attac
 
 <!-- vale Grafana.WordList = YES -->
 
-- **Company logo** - Company logo displayed in the report email. Configure it by specifying a URL or uploading a file. The maximum file size is 16 MB. Defaults to the Grafana logo.
+- **Company logo** - Company logo displayed in the report email. Configure it by specifying a URL or uploading a file. The maximum file size is 16 MB. If not set, defaults to the Grafana logo. If the URL specified is not correct, the logo will appear as a broken link logo.
 - **Email footer** - Toggle to enable the report email footer. Select **Sent by** or **None**.
 - **Footer link text** - Text of the link in the report email footer. Defaults to `Grafana`.
 - **Footer link URL** - Link of the report email footer.

--- a/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
+++ b/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
@@ -46,7 +46,7 @@ The options in this section control the branding and theming of the report attac
 - **Company logo** - Company logo displayed in the report PDF.
   Configure it by specifying a URL or uploading a file.
   The maximum file size is 16 MB.
-  If not set, defaults to the Grafana logo. If the URL specified is not correct, the logo will appear as broken link logo.
+  If not set, defaults to the Grafana logo. If the specified URL isn't valid, the logo image appears as broken.
 
 - **Theme** - Theme of the PDF attached to the report.
   The selected theme is also applied to the PDFs generated when you click **Preview PDF** during report creation or select the **Export as PDF** option on a dashboard.

--- a/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
+++ b/docs/sources/visualizations/dashboards/create-reports/report-settings/index.md
@@ -66,7 +66,7 @@ The options in this section control the branding and theming of the report attac
 
 <!-- vale Grafana.WordList = YES -->
 
-- **Company logo** - Company logo displayed in the report email. Configure it by specifying a URL or uploading a file. The maximum file size is 16 MB. If not set, defaults to the Grafana logo. If the URL specified is not correct, the logo will appear as a broken link logo.
+- **Company logo** - Company logo displayed in the report email. Configure it by specifying a URL or uploading a file. The maximum file size is 16 MB. If not set, defaults to the Grafana logo. If the specified URL isn't valid, the logo image appears as broken.
 - **Email footer** - Toggle to enable the report email footer. Select **Sent by** or **None**.
 - **Footer link text** - Text of the link in the report email footer. Defaults to `Grafana`.
 - **Footer link URL** - Link of the report email footer.


### PR DESCRIPTION
Based on an [internal issue](https://grafana.zendesk.com/agent/tickets/204765).

On the latest version of the Grafana Renderer in the Cloud, if the URL of the logo is not correct (not reachable) it won't default to Grafana logo, but would include a broken link logo

<img width="97" height="65" alt="image" src="https://github.com/user-attachments/assets/884d59f2-438e-42b6-b524-871d8c0bda21" />

Not sure if better include this as note or directly on the logo bullet point.

**What is this feature?**

Documentation improvement.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
