### PR TITLE
Dashboard: Fixed Dashboard shows unsaved changes warning after saving

### DIFF
--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -606,24 +606,25 @@ export class DashboardModel implements TimeModel {
     });
   }
 
-  clearUnsavedChanges(savedModel: Dashboard, options: CloneOptions) {
-    for (const panel of this.panels) {
-      panel.configRev = 0;
-    }
-
-    if (this.panelInEdit) {
-      // Remember that we have a saved a change in panel editor so we apply it when leaving panel edit
-      this.panelInEdit.hasSavedPanelEditChange = this.panelInEdit.configRev > 0;
-      this.panelInEdit.configRev = 0;
-    }
-
-    this.originalDashboard = savedModel;
-    this.originalTemplating = savedModel.templating;
-
-    if (options.saveTimerange) {
-      this.originalTime = savedModel.time;
-    }
+clearUnsavedChanges(savedModel: Dashboard, options: CloneOptions) {
+  for (const panel of this.panels) {
+    panel.configRev = 0;
   }
+
+  if (this.panelInEdit) {
+    // Remember that we have a saved a change in panel editor so we apply it when leaving panel edit
+    this.panelInEdit.hasSavedPanelEditChange = this.panelInEdit.configRev > 0;
+    this.panelInEdit.configRev = 0;
+  }
+  
+  this.originalDashboard = cloneDeep(savedModel);
+  this.originalTemplating = cloneDeep(savedModel.templating);
+  this.snapshot = cloneDeep(savedModel);
+
+  if (options.saveTimerange) {
+    this.originalTime = cloneDeep(savedModel.time);
+  }
+}
 
   hasUnsavedChanges() {
     const changedPanel = this.panels.find((p) => p.hasChanged);

--- a/public/app/features/dashboard/state/DashboardModel.ts
+++ b/public/app/features/dashboard/state/DashboardModel.ts
@@ -606,25 +606,25 @@ export class DashboardModel implements TimeModel {
     });
   }
 
-clearUnsavedChanges(savedModel: Dashboard, options: CloneOptions) {
-  for (const panel of this.panels) {
-    panel.configRev = 0;
-  }
+  clearUnsavedChanges(savedModel: Dashboard, options: CloneOptions) {
+    for (const panel of this.panels) {
+      panel.configRev = 0;
+    }
 
-  if (this.panelInEdit) {
-    // Remember that we have a saved a change in panel editor so we apply it when leaving panel edit
-    this.panelInEdit.hasSavedPanelEditChange = this.panelInEdit.configRev > 0;
-    this.panelInEdit.configRev = 0;
-  }
-  
-  this.originalDashboard = cloneDeep(savedModel);
-  this.originalTemplating = cloneDeep(savedModel.templating);
-  this.snapshot = cloneDeep(savedModel);
+    if (this.panelInEdit) {
+      // Remember that we have a saved a change in panel editor so we apply it when leaving panel edit
+      this.panelInEdit.hasSavedPanelEditChange = this.panelInEdit.configRev > 0;
+      this.panelInEdit.configRev = 0;
+    }
+    
+    this.originalDashboard = cloneDeep(savedModel);
+    this.originalTemplating = cloneDeep(savedModel.templating);
+    this.snapshot = cloneDeep(savedModel);
 
-  if (options.saveTimerange) {
-    this.originalTime = cloneDeep(savedModel.time);
+    if (options.saveTimerange) {
+      this.originalTime = cloneDeep(savedModel.time);
+    }
   }
-}
 
   hasUnsavedChanges() {
     const changedPanel = this.panels.find((p) => p.hasChanged);


### PR DESCRIPTION
# PR Description:

## Problem
fixes - #114015

After saving a dashboard, users were incorrectly warned about unsaved changes when trying to leave the page, even though they had just saved successfully.

## Root Cause
- The `clearUnsavedChanges()` method was copying references, not the actual data.
So `originalDashboard`, `originalTemplating`, and `snapshot` were all pointing to the same object as `savedModel`.
- When the dashboard state was updated, these "original" references were also modified, making it hard to accurately detect actual unsaved changes.

## Solution
Updated `clearUnsavedChanges()` to use `cloneDeep()` to create independent copies.
This ensures the saved state remains unchanged and can be properly compared against the current state to detect real unsaved changes.

## Changes
- Modified `clearUnsavedChanges()` method to use `cloneDeep()` for creating independent object copies.

Testing
- Save a dashboard.
- Verify no "unsaved changes" warning appears when trying to leave.
- Make actual changes to the dashboard.
- Verify "unsaved changes" warning correctly appears.