### PR TITLE
Be more tolerant to invalid JSON when parsing dashboards for indexing

### DIFF
--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -497,7 +497,7 @@ func findDatasourceRefsForVariables(dsVariableRefs []DataSourceRef, datasourceVa
 	return referencedDs
 }
 
-// will always return strings for now
+// nolint:gocyclo
 func readpanelInfo(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath string, lc map[string]any) (PanelSummaryInfo, bool) {
 	panel := PanelSummaryInfo{}
 

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -186,8 +186,15 @@ func readDashboardIter(iter *jsoniter.Iterator, lookup DatasourceLookup) (*Dashb
 			}
 
 		case "tags":
-			for iter.ReadArray() {
-				dash.Tags = append(dash.Tags, iter.ReadString())
+			// Only support string array tags. Ignore everything else.
+			if iter.WhatIsNext() == jsoniter.ArrayValue {
+				for iter.ReadArray() {
+					if iter.WhatIsNext() == jsoniter.StringValue {
+						dash.Tags = append(dash.Tags, iter.ReadString())
+					}
+				}
+			} else {
+				iter.Skip()
 			}
 
 		case "links":

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -154,13 +154,6 @@ func readDashboardIter(jsonPath string, iter *jsoniter.Iterator, lookup Datasour
 			}
 			dash.ID = iter.ReadInt64()
 
-		case "uid":
-			if !checkAndSkipUnexpectedElement(iter, jsonPath+".uid", lc, jsoniter.StringValue) {
-				continue
-			}
-			//dash.UID = iter.ReadString()
-			iter.Skip()
-
 		case "title":
 			if !checkAndSkipUnexpectedElement(iter, jsonPath+".title", lc, jsoniter.StringValue) {
 				continue

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -55,6 +55,7 @@ func dsLookupForTests() DatasourceLookup {
 
 func TestReadDashboard(t *testing.T) {
 	inputs := []string{
+		"absolute-garbage",
 		"check-string-datasource-id",
 		"all-panels",
 		"panel-graph/graph-shared-tooltips",

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -73,6 +73,7 @@ func TestReadDashboard(t *testing.T) {
 		"panel-with-library-panel-field",
 		"k8s-wrapper",
 		"k8s-wrapper-editable-string",
+		"k8s-wrapper-tags-string",
 	}
 
 	devdash := "../../../../../devenv/dev-dashboards/"

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -55,8 +55,7 @@ func (s *targetInfo) addDatasource(iter *jsoniter.Iterator) {
 		}
 
 	default:
-		v := iter.Read()
-		logf("[Panel.datasource.unknown] %v\n", v)
+		iter.Skip()
 	}
 }
 
@@ -67,6 +66,11 @@ func (s *targetInfo) addRef(ref *DataSourceRef) {
 }
 
 func (s *targetInfo) addTarget(iter *jsoniter.Iterator) {
+	if iter.WhatIsNext() != jsoniter.ObjectValue {
+		iter.Skip()
+		return
+	}
+
 	for l1Field := iter.ReadObject(); l1Field != ""; l1Field = iter.ReadObject() {
 		switch l1Field {
 		case "datasource":
@@ -76,8 +80,7 @@ func (s *targetInfo) addTarget(iter *jsoniter.Iterator) {
 			iter.Skip()
 
 		default:
-			v := iter.Read()
-			logf("[Panel.TARGET] %s=%v\n", l1Field, v)
+			iter.Skip()
 		}
 	}
 }

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -27,7 +27,11 @@ func (s *targetInfo) GetDatasourceInfo() []DataSourceRef {
 }
 
 // the node will either be string (name|uid) OR ref
-func (s *targetInfo) addDatasource(iter *jsoniter.Iterator) {
+func (s *targetInfo) addDatasource(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) {
+	if !checkAndSkipUnexpectedElement(iter, jsonPath, lc, jsoniter.StringValue, jsoniter.NilValue, jsoniter.ObjectValue) {
+		return
+	}
+
 	switch iter.WhatIsNext() {
 	case jsoniter.StringValue:
 		key := iter.ReadString()
@@ -65,16 +69,15 @@ func (s *targetInfo) addRef(ref *DataSourceRef) {
 	}
 }
 
-func (s *targetInfo) addTarget(iter *jsoniter.Iterator) {
-	if iter.WhatIsNext() != jsoniter.ObjectValue {
-		iter.Skip()
+func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) {
+	if !checkAndSkipUnexpectedElement(iter, jsonPath, lc, jsoniter.ObjectValue) {
 		return
 	}
 
-	for l1Field := iter.ReadObject(); l1Field != ""; l1Field = iter.ReadObject() {
-		switch l1Field {
+	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
+		switch f {
 		case "datasource":
-			s.addDatasource(iter)
+			s.addDatasource(iter, jsonPath+".datasource", lc)
 
 		case "refId":
 			iter.Skip()

--- a/pkg/services/store/kind/dashboard/testdata/absolute-garbage-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/absolute-garbage-info.json
@@ -1,0 +1,58 @@
+{
+  "title": "adfbg6f",
+  "tags": null,
+  "datasource": [
+    {
+      "uid": "default.uid",
+      "type": "default.type"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "green pie",
+      "libraryPanel": "a7975b7a-fb53-4ab7-951d-15810953b54f",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 0,
+      "title": "",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 0,
+  "linkCount": 4,
+  "timeFrom": "",
+  "timeTo": "",
+  "timezone": ""
+}

--- a/pkg/services/store/kind/dashboard/testdata/absolute-garbage.json
+++ b/pkg/services/store/kind/dashboard/testdata/absolute-garbage.json
@@ -1,0 +1,84 @@
+{
+  "metadata": 123,
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": "true",
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": "not a number",
+    "links": [
+      "http://12345",
+      {
+        "object": "goes, here"
+      },
+      null,
+      true
+    ],
+    "liveNow": false,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "libraryPanel": {
+          "name": "green pie",
+          "uid": "a7975b7a-fb53-4ab7-951d-15810953b54f"
+        },
+        "title": "green pie"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": "not a number",
+        "title": true
+      },
+      {
+        "id": 7,
+        "type": null
+      },
+      {
+        "id": 8,
+        "type": {
+          "a": 123
+        }
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": null,
+    "tags": 1234,
+    "templating": {
+      "list": []
+    },
+    "time": false,
+    "timepicker": {},
+    "timezone": 3.141592653589793,
+    "title": "adfbg6f",
+    "uid": ["aaa", "bbb", "cc"],
+    "description": [null, true],
+    "version": [],
+    "weekStart": false
+  }
+}

--- a/pkg/services/store/kind/dashboard/testdata/k8s-wrapper-tags-string-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/k8s-wrapper-tags-string-info.json
@@ -1,0 +1,74 @@
+{
+  "id": 141,
+  "title": "pppp",
+  "tags": null,
+  "datasource": [
+    {
+      "uid": "default.uid",
+      "type": "default.type"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "green pie",
+      "libraryPanel": "a7975b7a-fb53-4ab7-951d-15810953b54f",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "green pie",
+      "libraryPanel": "e1d5f519-dabd-47c6-9ad7-83d181ce1cee",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "title": "",
+      "type": "barchart",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "title": "",
+      "type": "graph",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "collapsed row",
+      "type": "row",
+      "collapsed": [
+        {
+          "id": 42,
+          "title": "blue pie",
+          "libraryPanel": "l3d2s634-fdgf-75u4-3fg3-67j966ii7jur"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 38,
+  "linkCount": 0,
+  "timeFrom": "now-6h",
+  "timeTo": "now",
+  "timezone": ""
+}

--- a/pkg/services/store/kind/dashboard/testdata/k8s-wrapper-tags-string.json
+++ b/pkg/services/store/kind/dashboard/testdata/k8s-wrapper-tags-string.json
@@ -1,0 +1,122 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "metadata": {
+    "name": "adfbg6f",
+    "namespace": "default",
+    "uid": "b396894e-56bf-4a01-837b-64157912ca00",
+    "creationTimestamp": "2024-10-30T18:30:54Z",
+    "annotations": {
+      "grafana.app/createdBy": "user:be2g71ke8yoe8b",
+      "grafana.app/originHash": "Grafana v9.2.0 (NA)",
+      "grafana.app/originName": "UI",
+      "grafana.app/originPath": "/dashboard/new"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 141,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "libraryPanel": {
+          "name": "green pie",
+          "uid": "a7975b7a-fb53-4ab7-951d-15810953b54f"
+        },
+        "title": "green pie"
+      },
+      {
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "libraryPanel": {
+          "name": "red pie",
+          "uid": "e1d5f519-dabd-47c6-9ad7-83d181ce1cee"
+        },
+        "title": "green pie"
+      },
+      {
+        "id": 7,
+        "type": "barchart"
+      },
+      {
+        "id": 8,
+        "type": "graph"
+      },
+      {
+        "collapsed": true,
+        "gridPos": {
+          "h": 1,
+          "w": 24,
+          "x": 0,
+          "y": 9
+        },
+        "id": 3,
+        "panels": [
+          {
+            "gridPos": {
+              "h": 8,
+              "w": 12,
+              "x": 12,
+              "y": 0
+            },
+            "id": 42,
+            "libraryPanel": {
+              "name": "blue pie",
+              "uid": "l3d2s634-fdgf-75u4-3fg3-67j966ii7jur"
+            },
+            "title": "blue pie"
+          }
+        ],
+        "title": "collapsed row",
+        "type": "row"
+      }
+    ],
+    "refresh": "",
+    "schemaVersion": 38,
+    "tags": "tag1,tag2, tag3,,",
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "",
+    "title": "pppp",
+    "uid": "adfbg6f",
+    "version": 3,
+    "weekStart": ""
+  }
+}

--- a/pkg/storage/unified/search/dashboard.go
+++ b/pkg/storage/unified/search/dashboard.go
@@ -194,9 +194,9 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 	if namespaced == nil {
 		namespaced = func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 			return &DashboardDocumentBuilder{
-				Namespace:        namespace,
-				Blob:             blob,
-				Stats:            nil,
+				Namespace: namespace,
+				Blob:      blob,
+				Stats:     nil,
 				DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{
 					// empty values (does not resolve anything)
 				}),
@@ -261,7 +261,10 @@ func (s *DashboardDocumentBuilder) BuildDocument(ctx context.Context, key *resou
 		value = rsp.Value
 	}
 
-	summary, err := dashboard.ReadDashboard(bytes.NewReader(value), s.DatasourceLookup)
+	summary, err := dashboard.ReadDashboardWithLogContext(bytes.NewReader(value), s.DatasourceLookup, map[string]any{
+		"document": fmt.Sprintf("%s/%s/%s/%s", key.GetNamespace(), key.GetGroup(), key.GetResource(), key.GetName()),
+		"rv":       rv,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/search/dashboard.go
+++ b/pkg/storage/unified/search/dashboard.go
@@ -194,9 +194,9 @@ func DashboardBuilder(namespaced resource.NamespacedDocumentSupplier) (resource.
 	if namespaced == nil {
 		namespaced = func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
 			return &DashboardDocumentBuilder{
-				Namespace: namespace,
-				Blob:      blob,
-				Stats:     nil,
+				Namespace:        namespace,
+				Blob:             blob,
+				Stats:            nil,
 				DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{
 					// empty values (does not resolve anything)
 				}),


### PR DESCRIPTION
This PR modifies how parsing of dashboards before indexing works. Previously many violations of the schema resulted in parsing error, and indexing of the document was skipped.

After this PR, we try to parse as much as possible, but if the resource is not compatible with our expectations, we still index what we can, instead of erroring.

Example log messages generated by this code:
```
logger=services.store.kind.dashboard t=2025-11-18T11:55:41.779975+01:00 level=error msg="Unexpected element in Dashboard JSON" jsonPath=$.spec.panels[0].title got=number expected=string document=default/dashboard.grafana.app/dashboards/adfbg6f rv=1763463341730986
logger=services.store.kind.dashboard t=2025-11-18T11:55:41.780056+01:00 level=error msg="Unexpected element in Dashboard JSON" jsonPath=$.spec.panels[2].type got=bool expected=string document=default/dashboard.grafana.app/dashboards/adfbg6f rv=1763463341730986
```