### PR TITLE
alerting docs: restore config feature toggle info

### DIFF
--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -62,6 +62,9 @@ The following steps describe a basic configuration:
 
    # The URL of the Loki server
    loki_remote_url = http://localhost:3100
+
+   [feature_toggles]
+   enable = alertStateHistoryLokiSecondary, alertStateHistoryLokiPrimary, alertStateHistoryLokiOnly
    ```
 
 1. **Configure the Loki data source in Grafana**

--- a/docs/sources/alerting/set-up/configure-alert-state-history/index.md
+++ b/docs/sources/alerting/set-up/configure-alert-state-history/index.md
@@ -64,7 +64,7 @@ The following steps describe a basic configuration:
    loki_remote_url = http://localhost:3100
 
    [feature_toggles]
-   enable = alertStateHistoryLokiSecondary, alertStateHistoryLokiPrimary, alertStateHistoryLokiOnly
+   enable = alertingCentralAlertHistory
    ```
 
 1. **Configure the Loki data source in Grafana**


### PR DESCRIPTION
per a customer report:

History menu item under Alerting menu is not displayed in Grafana OSS v12.2.1 despite everything is configured as mentioned in [grafana.com/docs/grafana/latest/alerting/set-up/configure-alert-state-history#configure-loki-for-alert-state](https://grafana.com/docs/grafana/latest/alerting/set-up/configure-alert-state-history/#configure-loki-for-alert-state)

I guess documentation related to "adding feature toggles" part was removed in v12 as I can see it in v11.6's docs: [grafana.com/docs/grafana/v11.6/alerting/set-up/configure-alert-state-history#configuring-grafana](https://grafana.com/docs/grafana/v11.6/alerting/set-up/configure-alert-state-history/#configuring-grafana)