### PR TITLE
Logs in Explore: Persist table sorting in the url

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -85,6 +85,9 @@ export interface ExploreLogsPanelState {
   refId?: string;
   displayedFields?: string[];
   sortOrder?: LogsSortOrder;
+  // Column sort state for table view. Persists between query changes.
+  tableSortBy?: string;
+  tableSortDir?: 'asc' | 'desc';
 }
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -308,6 +308,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         refId: undefined,
         displayedFields: undefined,
         sortOrder: undefined,
+        tableSortBy: undefined,
+        tableSortDir: undefined,
       })
     );
   });
@@ -324,6 +326,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
             labelFieldName: logsPanelState.labelFieldName,
             refId: logsPanelState.refId ?? panelState?.logs?.refId,
             displayedFields: logsPanelState.displayedFields ?? panelState?.logs?.displayedFields,
+            tableSortBy: logsPanelState.tableSortBy ?? panelState?.logs?.tableSortBy,
+            tableSortDir: logsPanelState.tableSortDir ?? panelState?.logs?.tableSortDir,
           })
         );
       }
@@ -334,6 +338,8 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       panelState?.logs?.columns,
       panelState?.logs?.displayedFields,
       panelState?.logs?.refId,
+      panelState?.logs?.tableSortBy,
+      panelState?.logs?.tableSortDir,
       visualisationType,
     ]
   );

--- a/public/app/features/explore/Logs/LogsTable.tsx
+++ b/public/app/features/explore/Logs/LogsTable.tsx
@@ -18,7 +18,7 @@ import {
   ValueLinkConfig,
 } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { AdHocFilterItem, Table } from '@grafana/ui';
+import { AdHocFilterItem, Table, TableSortByFieldState } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { LogsFrame } from 'app/features/logs/logsFrame';
 
@@ -38,10 +38,25 @@ interface Props {
   onClickFilterLabel?: (key: string, value: string, frame?: DataFrame) => void;
   onClickFilterOutLabel?: (key: string, value: string, frame?: DataFrame) => void;
   logsFrame: LogsFrame | null;
+  tableSortBy?: string;
+  tableSortDir?: 'asc' | 'desc';
+  onSortByChange?: (sortBy: TableSortByFieldState[]) => void;
 }
 
 export function LogsTable(props: Props) {
-  const { timeZone, splitOpen, range, logsSortOrder, width, dataFrame, columnsWithMeta, logsFrame } = props;
+  const {
+    timeZone,
+    splitOpen,
+    range,
+    logsSortOrder,
+    width,
+    dataFrame,
+    columnsWithMeta,
+    logsFrame,
+    tableSortBy,
+    tableSortDir,
+    onSortByChange,
+  } = props;
   const [tableFrame, setTableFrame] = useState<DataFrame | undefined>(undefined);
   const timeIndex = logsFrame?.timeField.index;
 
@@ -167,6 +182,13 @@ export function LogsTable(props: Props) {
     }
   };
 
+  // Use persisted sortBy if available, otherwise default to time field based on logsSortOrder
+  const defaultSortBy: TableSortByFieldState[] = [
+    { displayName: logsFrame?.timeField.name || '', desc: logsSortOrder === LogsSortOrder.Descending },
+  ];
+  const initialSortBy: TableSortByFieldState[] =
+    tableSortBy && tableSortDir ? [{ displayName: tableSortBy, desc: tableSortDir === 'desc' }] : defaultSortBy;
+
   return (
     <Table
       data={tableFrame}
@@ -174,9 +196,8 @@ export function LogsTable(props: Props) {
       onCellFilterAdded={props.onClickFilterLabel && props.onClickFilterOutLabel ? onCellFilterAdded : undefined}
       height={props.height}
       footerOptions={{ show: true, reducer: ['count'], countRows: true }}
-      initialSortBy={[
-        { displayName: logsFrame?.timeField.name || '', desc: logsSortOrder === LogsSortOrder.Descending },
-      ]}
+      initialSortBy={initialSortBy}
+      onSortByChange={onSortByChange}
     />
   );
 }

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -278,6 +278,19 @@ export function LogsTableWrap(props: Props) {
 
   const styles = useStyles2(getStyles, height, sidebarWidth);
 
+  const onSortByChange = useCallback(
+    (sortBy: Array<{ displayName: string; desc?: boolean }>) => {
+      // Transform from Table format to URL format - only store the first sort column
+      if (sortBy.length > 0) {
+        updatePanelState({
+          tableSortBy: sortBy[0].displayName,
+          tableSortDir: sortBy[0].desc ? 'desc' : 'asc',
+        });
+      }
+    },
+    [updatePanelState]
+  );
+
   if (!columnsWithMeta) {
     return null;
   }
@@ -512,6 +525,9 @@ export function LogsTableWrap(props: Props) {
               dataFrame={currentDataFrame}
               columnsWithMeta={columnsWithMeta}
               height={height}
+              tableSortBy={panelState?.tableSortBy}
+              tableSortDir={panelState?.tableSortDir}
+              onSortByChange={onSortByChange}
             />
           </div>
         </div>

--- a/public/app/features/explore/Logs/LogsTableWrap.tsx
+++ b/public/app/features/explore/Logs/LogsTableWrap.tsx
@@ -282,10 +282,16 @@ export function LogsTableWrap(props: Props) {
     (sortBy: Array<{ displayName: string; desc?: boolean }>) => {
       // Transform from Table format to URL format - only store the first sort column
       if (sortBy.length > 0) {
-        updatePanelState({
-          tableSortBy: sortBy[0].displayName,
-          tableSortDir: sortBy[0].desc ? 'desc' : 'asc',
-        });
+        // Defer the Redux dispatch to avoid updating ExploreActions during Table's render cycle
+        // Even though this is called from an event handler, the synchronous Redux dispatch
+        // can cause ExploreActions (which subscribes to panes state) to re-render while
+        // Table is still rendering, triggering the React warning
+        setTimeout(() => {
+          updatePanelState({
+            tableSortBy: sortBy[0].displayName,
+            tableSortDir: sortBy[0].desc ? 'desc' : 'asc',
+          });
+        }, 0);
       }
     },
     [updatePanelState]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Persist table sorting in the url. 
Breaking apart this [table PR](https://github.com/grafana/grafana/pull/112558). 
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
