### PR TITLE
Alerting: Return empty rule groups when limit_rules=0

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -328,6 +328,10 @@ export interface FeatureToggles {
   */
   alertingUIUseFullyCompatBackendFilters?: boolean;
   /**
+  * Enables the UI to use limit_rules=0 when calling the API and rules information is not needed
+  */
+  alertingUIUseLimitRules?: boolean;
+  /**
   * Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
   */
   alertmanagerRemotePrimary?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -528,6 +528,13 @@ var (
 			HideFromDocs: true,
 		},
 		{
+			Name:         "alertingUIUseLimitRules",
+			Description:  "Enables the UI to use limit_rules=0 when calling the API and rules information is not needed",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+		},
+		{
 			Name:        "alertmanagerRemotePrimary",
 			Description: "Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -73,6 +73,7 @@ alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,fal
 alertingProvenanceLockWrites,experimental,@grafana/alerting-squad,false,false,false
 alertingUIUseBackendFilters,experimental,@grafana/alerting-squad,false,false,false
 alertingUIUseFullyCompatBackendFilters,experimental,@grafana/alerting-squad,false,false,false
+alertingUIUseLimitRules,experimental,@grafana/alerting-squad,false,false,false
 alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
 dashboardSceneForViewers,GA,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -247,6 +247,10 @@ const (
 	// Enables the UI to use rules backend-side filters 100% compatible with the frontend filters
 	FlagAlertingUIUseFullyCompatBackendFilters = "alertingUIUseFullyCompatBackendFilters"
 
+	// FlagAlertingUIUseLimitRules
+	// Enables the UI to use limit_rules=0 when calling the API and rules information is not needed
+	FlagAlertingUIUseLimitRules = "alertingUIUseLimitRules"
+
 	// FlagAlertmanagerRemotePrimary
 	// Enable Grafana to have a remote Alertmanager instance as the primary Alertmanager.
 	FlagAlertmanagerRemotePrimary = "alertmanagerRemotePrimary"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -568,6 +568,19 @@
     },
     {
       "metadata": {
+        "name": "alertingUIUseLimitRules",
+        "resourceVersion": "1765891213465",
+        "creationTimestamp": "2025-12-16T13:20:13Z"
+      },
+      "spec": {
+        "description": "Enables the UI to use limit_rules=0 when calling the API and rules information is not needed",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingUseNewSimplifiedRoutingHashAlgorithm",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-08-29T14:46:39Z",

--- a/pkg/services/ngalert/api/tooling/definitions/prom.go
+++ b/pkg/services/ngalert/api/tooling/definitions/prom.go
@@ -435,7 +435,8 @@ type GetGrafanaRuleStatusesParams struct {
 	// default: -1
 	LimitAlerts int64 `json:"limit_alerts"`
 
-	// Limit the number of rules per group.
+	// Limit the number of rules per group. When set to 0, returns empty rule groups (only group metadata without rules).
+	// limit_rules=0 cannot be used together with state or health filters, and returns an empty response.
 	// in: query
 	// required: false
 	// default: -1

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -7525,7 +7525,7 @@
      },
      {
       "default": -1,
-      "description": "Limit the number of rules per group.",
+      "description": "Limit the number of rules per group. When set to 0, returns empty rule groups (only group metadata without rules).\nlimit_rules=0 cannot be used together with state or health filters, and returns an empty response.",
       "format": "int64",
       "in": "query",
       "name": "limit_rules",

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1913,7 +1913,7 @@
             "type": "integer",
             "format": "int64",
             "default": -1,
-            "description": "Limit the number of rules per group.",
+            "description": "Limit the number of rules per group. When set to 0, returns empty rule groups (only group metadata without rules).\nlimit_rules=0 cannot be used together with state or health filters, and returns an empty response.",
             "name": "limit_rules",
             "in": "query"
           },

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -40,6 +40,7 @@ export type GrafanaPromRulesOptions = Omit<PromRulesOptions, 'ruleSource' | 'nam
   datasources?: string[];
   panelId?: number;
   limitAlerts?: number;
+  limitRules?: number;
   ruleLimit?: number;
   contactPoint?: string;
   health?: RuleHealth[];
@@ -98,6 +99,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
         groupLimit,
         ruleLimit,
         limitAlerts,
+        limitRules,
         groupNextToken,
         title,
         datasources,
@@ -115,6 +117,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           state: state,
           rule_type: type,
           limit_alerts: limitAlerts,
+          limit_rules: limitRules?.toFixed(0),
           rule_limit: ruleLimit?.toFixed(0),
           group_limit: groupLimit?.toFixed(0),
           group_next_token: groupNextToken,

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv } from '@grafana/runtime';
 import { ComboboxOption } from '@grafana/ui';
 import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
@@ -63,8 +63,10 @@ export function useNamespaceAndGroupOptions(): {
   const namespaceOptions = useCallback(
     async (inputValue: string) => {
       // Grafana namespaces - fetch with limit to check threshold
+      const useLimitRules = config.featureToggles.alertingUIUseLimitRules;
       const grafanaResponse = await fetchGrafanaGroups({
         limitAlerts: 0,
+        limitRules: useLimitRules ? 0 : undefined,
         groupLimit: NAMESPACE_THRESHOLD_LIMIT + 1,
       }).unwrap();
       const grafanaFolderNames = Array.from(
@@ -135,8 +137,10 @@ export function useNamespaceAndGroupOptions(): {
 
       try {
         // Use the backend search with lightweight response
+        const useLimitRules = config.featureToggles.alertingUIUseLimitRules;
         const grafanaResponse = await fetchGrafanaGroups({
           limitAlerts: 0, // Lightweight - no alert data
+          limitRules: useLimitRules ? 0 : undefined,
           searchGroupName: trimmedInput, // Backend filtering via search.rule_group parameter
           groupLimit: GROUP_SEARCH_LIMIT, // Reasonable limit for dropdown results
         }).unwrap();


### PR DESCRIPTION
**What is this feature?**

Currently when `limit_rules=0` is passed to `/api/prometheus/grafana/api/v1/rules`, the API returns an empty response, because all empty rule groups are filtered out. This PR changes the API to return empty rule groups, so the API can be used in combination with other filters to search rule groups by names (`search.rule_group`), etc.

Part of https://github.com/grafana/alerting-squad/issues/1270

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
