### PR TITLE
CI: run publish artifacts on self-hosted runner

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -212,6 +212,7 @@ jobs:
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
+      runs-on: ubuntu-x64-small
 
   publish-dockerhub:
     if: github.ref_name == 'main'


### PR DESCRIPTION
It is currently failing because the GitHub runner's storage is too low