### PR TITLE
Sidebar: Allow plugin extensions devtools app

### DIFF
--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider.tsx
@@ -18,6 +18,7 @@ const PERMITTED_EXTENSION_SIDEBAR_PLUGINS = [
   // Support both until that migration is complete.
   'grafana-grafanadocsplugin-app',
   'grafana-pathfinder-app',
+  'grafana-extensionsdevtools-app',
 ];
 
 export type ExtensionSidebarContextType = {

--- a/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
+++ b/public/app/core/components/AppChrome/ExtensionSidebar/ExtensionToolbarItemButton.tsx
@@ -19,6 +19,8 @@ function getPluginIcon(pluginId?: string): string {
       return 'book';
     case 'grafana-investigations-app':
       return 'eye';
+    case 'grafana-extensionsdevtools-app':
+      return 'plug';
     default:
       return 'ai-sparkle';
   }


### PR DESCRIPTION
**What is this feature?**

Allow the [Plugin Extensions DevTools app](https://github.com/grafana/extensionsdevtools-app) to use the sidebar. This app plugin is still in development. 

**Why do we need this feature?**

To enhance developer experience for app developers using the extensions framework. 

**Who is this feature for?**

App developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
