### PR TITLE
chore: move enable search to US configuration

### DIFF
--- a/e2e/dashboards-search-suite/mode0.ini
+++ b/e2e/dashboards-search-suite/mode0.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 0

--- a/e2e/dashboards-search-suite/mode1.ini
+++ b/e2e/dashboards-search-suite/mode1.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 1

--- a/e2e/dashboards-search-suite/mode2-legacy-search-api.ini
+++ b/e2e/dashboards-search-suite/mode2-legacy-search-api.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = false
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 2

--- a/e2e/dashboards-search-suite/mode2.ini
+++ b/e2e/dashboards-search-suite/mode2.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 2

--- a/e2e/dashboards-search-suite/mode3.ini
+++ b/e2e/dashboards-search-suite/mode3.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 3

--- a/e2e/dashboards-search-suite/mode4.ini
+++ b/e2e/dashboards-search-suite/mode4.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 4

--- a/e2e/dashboards-search-suite/mode5.ini
+++ b/e2e/dashboards-search-suite/mode5.ini
@@ -1,10 +1,12 @@
 [server]
 
 [feature_toggles]
-unifiedStorageSearch = true
 unifiedStorageSearchUI = true
 grafanaAPIServerWithExperimentalAPIs = true
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+enable_search = true
 
 [unified_storage.folders.folder.grafana.app]
 dualWriterMode = 5

--- a/pkg/api/folder_test.go
+++ b/pkg/api/folder_test.go
@@ -534,55 +534,49 @@ func TestGetFolderLegacyAndUnifiedStorage(t *testing.T) {
 			legacyFolder               folder.Folder
 			expectedFolder             dtos.Folder
 			expectedFolderServiceError error
-			unifiedStorageEnabled      bool
 			unifiedStorageMode         grafanarest.DualWriterMode
 			expectedCode               int
 		}
 
 		tcs := []testCase{
 			{
-				description:           "General folder - Legacy",
-				expectedCode:          http.StatusOK,
-				legacyFolder:          legacyFolder,
-				folderUID:             legacyFolder.UID,
-				expectedFolder:        expectedFolder,
-				unifiedStorageEnabled: false,
+				description:    "General folder - Legacy",
+				expectedCode:   http.StatusOK,
+				legacyFolder:   legacyFolder,
+				folderUID:      legacyFolder.UID,
+				expectedFolder: expectedFolder,
 			},
 			{
-				description:           "General folder - Unified storage, mode 1",
-				expectedCode:          http.StatusOK,
-				legacyFolder:          legacyFolder,
-				folderUID:             legacyFolder.UID,
-				expectedFolder:        expectedFolder,
-				unifiedStorageEnabled: true,
-				unifiedStorageMode:    grafanarest.Mode1,
+				description:        "General folder - Unified storage, mode 1",
+				expectedCode:       http.StatusOK,
+				legacyFolder:       legacyFolder,
+				folderUID:          legacyFolder.UID,
+				expectedFolder:     expectedFolder,
+				unifiedStorageMode: grafanarest.Mode1,
 			},
 			{
-				description:           "General folder - Unified storage, mode 2",
-				expectedCode:          http.StatusOK,
-				legacyFolder:          legacyFolder,
-				folderUID:             legacyFolder.UID,
-				expectedFolder:        expectedFolder,
-				unifiedStorageEnabled: true,
-				unifiedStorageMode:    grafanarest.Mode2,
+				description:        "General folder - Unified storage, mode 2",
+				expectedCode:       http.StatusOK,
+				legacyFolder:       legacyFolder,
+				folderUID:          legacyFolder.UID,
+				expectedFolder:     expectedFolder,
+				unifiedStorageMode: grafanarest.Mode2,
 			},
 			{
-				description:           "General folder - Unified storage, mode 3",
-				expectedCode:          http.StatusOK,
-				legacyFolder:          legacyFolder,
-				folderUID:             legacyFolder.UID,
-				expectedFolder:        expectedFolder,
-				unifiedStorageEnabled: true,
-				unifiedStorageMode:    grafanarest.Mode3,
+				description:        "General folder - Unified storage, mode 3",
+				expectedCode:       http.StatusOK,
+				legacyFolder:       legacyFolder,
+				folderUID:          legacyFolder.UID,
+				expectedFolder:     expectedFolder,
+				unifiedStorageMode: grafanarest.Mode3,
 			},
 			{
-				description:           "General folder - Unified storage, mode 4",
-				expectedCode:          http.StatusOK,
-				legacyFolder:          legacyFolder,
-				folderUID:             legacyFolder.UID,
-				expectedFolder:        expectedFolder,
-				unifiedStorageEnabled: true,
-				unifiedStorageMode:    grafanarest.Mode4,
+				description:        "General folder - Unified storage, mode 4",
+				expectedCode:       http.StatusOK,
+				legacyFolder:       legacyFolder,
+				folderUID:          legacyFolder.UID,
+				expectedFolder:     expectedFolder,
+				unifiedStorageMode: grafanarest.Mode4,
 			},
 		}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -604,6 +604,7 @@ type Cfg struct {
 	CACertPath                                 string
 	HttpsSkipVerify                            bool
 	ResourceServerJoinRingTimeout              time.Duration
+	EnableSearch                               bool
 
 	// Secrets Management
 	SecretsManagement SecretsManagerSettings

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -51,6 +51,8 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 
 	// Set indexer config for unified storage
 	section := cfg.Raw.Section("unified_storage")
+
+	cfg.EnableSearch = section.Key("enable_search").MustBool(false)
 	cfg.MaxPageSizeBytes = section.Key("max_page_size_bytes").MustInt(0)
 	cfg.IndexPath = section.Key("index_path").String()
 	cfg.IndexWorkers = section.Key("index_workers").MustInt(10)

--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -253,16 +253,18 @@ go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 - to compile all protobuf files in the repository run `make protobuf` at its top level
 
 ## Setting up search
-To enable it, add the following to your `custom.ini` under the `[feature_toggles]` section:
+To enable it, add the following to your `custom.ini` under the `[feature_toggles]` and `[unified_storage]` sections:
 ```ini
 [feature_toggles]
 ; Used by the Grafana instance
 unifiedStorageSearchUI = true
 
-; Used by unified storage
-unifiedStorageSearch = true
 ; (optional) Allows you to sort dashboards by usage insights fields when using enterprise
 ; unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+; Used by unified storage server
+enable_search = true
 ```
 
 The dashboard search page has been set up to search unified storage. Additionally, all legacy search calls (e.g. `/api/search`) will go to
@@ -371,10 +373,10 @@ mode = "on-prem"
 
 [feature_toggles]
 unifiedStorage = true
-unifiedStorageSearch = true
 
 [unified_storage]
 enable_sharding = true
+enable_search = true
 instance_id = node-0
 memberlist_bind_addr = "127.0.0.2"
 memberlist_advertise_addr = "127.0.0.2"
@@ -873,19 +875,21 @@ Unified Search requires several feature flags to be enabled depending on the des
 
 | Feature Flag | Purpose | Stage | Required For |
 |--------------|---------|-------|--------------|
-| `unifiedStorageSearch` | Core search functionality | Experimental | Search API servers, indexing |
 | `unifiedStorageSearchUI` | Frontend search interface | Experimental | Grafana UI search |
 | `unifiedStorageSearchSprinkles` | Usage insights integration | Experimental | Dashboard usage sorting (Enterprise) |
 | `unifiedStorageSearchDualReaderEnabled` | Shadow traffic to unified search | Experimental | Shadow traffic during migration |
+
+#### Unified Search Specific Configuration
+
+| Configuration   | Purpose | Stage | Required For |
+|-----------------|---------|-------|--------------|
+| `enable_search` | Core search functionality | Experimental | Search API servers, indexing |
 
 #### Basic Configuration
 ```ini
 [feature_toggles]
 ; Prerequisites for unified storage (required)
 grafanaAPIServerWithExperimentalAPIs = true
-
-; Core search functionality (required)
-unifiedStorageSearch = true
 
 ; Enable search UI (required for frontend)
 unifiedStorageSearchUI = true
@@ -895,6 +899,10 @@ unifiedStorageSearchDualReaderEnabled = true
 
 ; Enable usage insights sorting (Enterprise only)
 unifiedStorageSearchSprinkles = true
+
+[unified_storage]
+; Enable core search functionality (required)
+enable_search = true
 ```
 
 ### Request Flow Diagrams

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -21,7 +21,7 @@ func NewSearchOptions(
 	ownsIndexFn func(key resource.NamespacedResource) (bool, error),
 ) (resource.SearchOptions, error) {
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearch) || features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
+	if cfg.EnableSearch || features.IsEnabledGlobally(featuremgmt.FlagUnifiedStorageSearch) || features.IsEnabledGlobally(featuremgmt.FlagProvisioning) {
 		root := cfg.IndexPath
 		if root == "" {
 			root = filepath.Join(cfg.DataPath, "unified-search", "bleve")

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/slugify"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/testinfra"
@@ -307,20 +306,15 @@ func runDashboardSearchTest(t *testing.T, mode rest.DualWriterMode) {
 	t.Run(fmt.Sprintf("search types with dual writer mode %d", mode), func(t *testing.T) {
 		ctx := context.Background()
 
-		flags := []string{}
-		if mode >= rest.Mode3 {
-			flags = append(flags, featuremgmt.FlagUnifiedStorageSearch)
-		}
-
 		helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 			AppModeProduction:    true,
 			DisableAnonymous:     true,
 			APIServerStorageType: "unified",
-			EnableFeatureToggles: flags,
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 				"dashboards.dashboard.grafana.app": {DualWriterMode: mode},
 				"folders.folder.grafana.app":       {DualWriterMode: mode},
 			},
+			UnifiedStorageEnableSearch: mode >= rest.Mode3,
 		})
 		defer helper.Shutdown()
 

--- a/pkg/tests/apis/dashboard/integration/api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/api_validation_test.go
@@ -70,14 +70,15 @@ func TestIntegrationDashboardAPIValidation(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
 					featuremgmt.FlagKubernetesDashboards, // Enable FE-only dashboard feature flag
 				},
 				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 					"dashboards.dashboard.grafana.app": {
 						DualWriterMode: dualWriterMode,
 					},
-				}})
+				},
+				UnifiedStorageEnableSearch: true,
+			})
 
 			t.Cleanup(func() {
 				helper.Shutdown()
@@ -105,9 +106,6 @@ func TestIntegrationDashboardAPIValidation(t *testing.T) {
 			// Create a K8sTestHelper which will set up a real API server
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
 				DisableFeatureToggles: []string{
 					featuremgmt.FlagKubernetesDashboards,
 				},
@@ -115,7 +113,9 @@ func TestIntegrationDashboardAPIValidation(t *testing.T) {
 					"dashboards.dashboard.grafana.app": {
 						DualWriterMode: dualWriterMode,
 					},
-				}})
+				},
+				UnifiedStorageEnableSearch: true,
+			})
 
 			t.Cleanup(func() {
 				helper.Shutdown()
@@ -139,9 +139,6 @@ func TestIntegrationDashboardAPIAuthorization(t *testing.T) {
 		t.Run(fmt.Sprintf("DualWriterMode %d", dualWriterMode), func(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
 				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 					"dashboards.dashboard.grafana.app": {
 						DualWriterMode: dualWriterMode,
@@ -149,7 +146,9 @@ func TestIntegrationDashboardAPIAuthorization(t *testing.T) {
 					"folders.folder.grafana.app": {
 						DualWriterMode: dualWriterMode,
 					},
-				}})
+				},
+				UnifiedStorageEnableSearch: true,
+			})
 
 			t.Cleanup(func() {
 				helper.Shutdown()
@@ -188,7 +187,6 @@ func TestIntegrationDashboardAPI(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
 					featuremgmt.FlagKubernetesDashboards,
 				},
 				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
@@ -198,7 +196,9 @@ func TestIntegrationDashboardAPI(t *testing.T) {
 					"folders.folder.grafana.app": {
 						DualWriterMode: dualWriterMode,
 					},
-				}})
+				},
+				UnifiedStorageEnableSearch: true,
+			})
 
 			t.Cleanup(func() {
 				helper.Shutdown()

--- a/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
+++ b/pkg/tests/apis/dashboard/integration/library_panels_api_validation_test.go
@@ -31,9 +31,9 @@ func TestIntegrationLibraryPanelConnections(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{
-					"unifiedStorageSearch",
 					"kubernetesLibraryPanels",
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 			ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 			adminClient := getResourceClient(t, ctx.Helper, ctx.AdminUser, getDashboardGVR())
@@ -95,10 +95,10 @@ func TestIntegrationLibraryElementPermissions(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{
-					"unifiedStorageSearch",
 					"kubernetesLibraryPanels",
 					"grafanaAPIServerWithExperimentalAPIs", // needed until we move it to v0beta1 at least (currently v0alpha1)
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 			ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 
@@ -298,9 +298,9 @@ func TestIntegrationLibraryPanelConnectionsWithFolderAccess(t *testing.T) {
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				DisableAnonymous: true,
 				EnableFeatureToggles: []string{
-					"unifiedStorageSearch",
 					"kubernetesLibraryPanels",
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 			ctx := createTestContext(t, helper, helper.Org1, dualWriterMode)
 

--- a/pkg/tests/apis/folder/folder_tree_test.go
+++ b/pkg/tests/apis/folder/folder_tree_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/search/model"
 	"github.com/grafana/grafana/pkg/setting"
@@ -48,15 +47,10 @@ func TestIntegrationFolderTree(t *testing.T) {
 	}
 	for _, mode := range modes {
 		t.Run(fmt.Sprintf("mode %d", mode), func(t *testing.T) {
-			flags := []string{}
-			if mode >= grafanarest.Mode3 { // make sure modes 0-3 work without it
-				flags = append(flags, featuremgmt.FlagUnifiedStorageSearch)
-			}
 			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 				AppModeProduction:    true,
 				DisableAnonymous:     true,
 				APIServerStorageType: "unified",
-				EnableFeatureToggles: flags,
 				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 					"dashboards.dashboard.grafana.app": {
 						DualWriterMode: mode,
@@ -65,6 +59,7 @@ func TestIntegrationFolderTree(t *testing.T) {
 						DualWriterMode: mode,
 					},
 				},
+				UnifiedStorageEnableSearch: mode >= grafanarest.Mode3, // make sure modes 0-3 work without search enabled
 			})
 			defer helper.Shutdown()
 

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -249,9 +249,7 @@ func TestIntegrationFolderDeletionBlockedByAlertRules(t *testing.T) {
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 				folders.RESOURCEGROUP: {DualWriterMode: grafanarest.Mode5},
 			},
-			EnableFeatureToggles: []string{
-				featuremgmt.FlagUnifiedStorageSearch,
-			},
+			UnifiedStorageEnableSearch: true,
 		})
 
 		client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1265,9 +1263,7 @@ func TestIntegrationFoldersGetAPIEndpointK8S(t *testing.T) {
 						DualWriterMode: modeDw,
 					},
 				},
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			// Run all test cases within the same server instance
@@ -1380,9 +1376,9 @@ func TestIntegrationFolderDeletionBlockedByLibraryElements(t *testing.T) {
 					},
 				},
 				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
 					featuremgmt.FlagKubernetesLibraryPanels,
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1460,9 +1456,9 @@ func TestIntegrationRootFolderDeletionBlockedByLibraryElementsInSubfolder(t *tes
 					},
 				},
 				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
 					featuremgmt.FlagKubernetesLibraryPanels,
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1558,9 +1554,7 @@ func TestIntegrationFolderDeletionBlockedByConnectedLibraryPanels(t *testing.T) 
 						DualWriterMode: modeDw,
 					},
 				},
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1635,9 +1629,7 @@ func TestIntegrationFolderDeletionWithDanglingLibraryPanels(t *testing.T) {
 						DualWriterMode: modeDw,
 					},
 				},
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1826,13 +1818,13 @@ func TestIntegrationMoveNestedFolderToRootK8S(t *testing.T) {
 	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
 		AppModeProduction:    true,
 		DisableAnonymous:     true,
-		EnableFeatureToggles: []string{featuremgmt.FlagUnifiedStorageSearch},
 		APIServerStorageType: "unified",
 		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
 			folders.RESOURCEGROUP: {
 				DualWriterMode: grafanarest.Mode5,
 			},
 		},
+		UnifiedStorageEnableSearch: true,
 	})
 
 	client := helper.GetResourceClient(apis.ResourceClientArgs{
@@ -1910,9 +1902,7 @@ func TestIntegrationDeleteNestedFoldersPostorder(t *testing.T) {
 						DualWriterMode: modeDw,
 					},
 				},
-				EnableFeatureToggles: []string{
-					featuremgmt.FlagUnifiedStorageSearch,
-				},
+				UnifiedStorageEnableSearch: true,
 			})
 			client := helper.GetResourceClient(apis.ResourceClientArgs{
 				User: helper.Org1.Admin,

--- a/pkg/tests/apis/iam/user_integration_test.go
+++ b/pkg/tests/apis/iam/user_integration_test.go
@@ -36,8 +36,8 @@ func TestIntegrationUsers(t *testing.T) {
 				EnableFeatureToggles: []string{
 					featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
 					featuremgmt.FlagKubernetesAuthnMutation,
-					featuremgmt.FlagUnifiedStorageSearch,
 				},
+				UnifiedStorageEnableSearch: true,
 			})
 
 			t.Cleanup(func() {

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -526,6 +526,12 @@ func CreateGrafDir(t *testing.T, opts GrafanaOpts) (string, string) {
 			require.NoError(t, err)
 		}
 	}
+	if opts.UnifiedStorageEnableSearch {
+		section, err := getOrCreateSection("unified_storage")
+		require.NoError(t, err)
+		_, err = section.NewKey("enable_search", "true")
+		require.NoError(t, err)
+	}
 	if opts.UnifiedStorageMaxPageSizeBytes > 0 {
 		section, err := getOrCreateSection("unified_storage")
 		require.NoError(t, err)
@@ -622,6 +628,7 @@ type GrafanaOpts struct {
 	QueryRetries                          int64
 	GrafanaComAPIURL                      string
 	UnifiedStorageConfig                  map[string]setting.UnifiedStorageConfig
+	UnifiedStorageEnableSearch            bool
 	UnifiedStorageMaxPageSizeBytes        int
 	PermittedProvisioningPaths            string
 	GrafanaComSSOAPIToken                 string


### PR DESCRIPTION
**What is this feature?**

The feature toggle `unifiedStorageSearch` is a startup-option used to control if we start the search server functionalities.

Since it needs to be enabled in the search-api server and is disabled in the storage-api, we can move it to be a configuration instead.

**Why do we need this feature?**

Some feature toggles and configurations need to be enforced when we run on-prem migrations to unified storage. Because of that, we want to move feature toggles to configuration if they are not going to be removed.

In subsequent PRs, we will enforce `enable_search` to be enabled in `unified` storage type when running on-prem migrations.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/search-and-storage-team/issues/580

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
