### PR TITLE
Docs: Fix SCIM EntraId broken link

### DIFF
--- a/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams/_index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams/_index.md
@@ -282,5 +282,5 @@ Team membership maintenance:
 ## Next steps
 
 - [Troubleshoot SCIM provisioning](../troubleshooting/)
-- [Configure SCIM with Entra ID](../configure-scim-with-azuread/)
+- [Configure SCIM with Entra ID](../configure-scim-with-entraid/)
 - [Configure SCIM with Okta](../configure-scim-with-okta/)


### PR DESCRIPTION
**What is this feature?**

Fix SCIM Entraid broken link that was pointing to azuread instead (this was has been renamed to entraid).
The fixed link can be found in this url below
```
<grafana_url>/docs/sources/setup-grafana/configure-access/configure-scim-provisioning/manage-users-teams
```