### PR TITLE
Remove unneeded node options

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -49,9 +49,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next-cli extract --sync-primary",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"

--- a/public/app/plugins/datasource/azuremonitor/package.json
+++ b/public/app/plugins/datasource/azuremonitor/package.json
@@ -49,9 +49,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next-cli extract --sync-primary",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -49,9 +49,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/cloud-monitoring/package.json
+++ b/public/app/plugins/datasource/cloud-monitoring/package.json
@@ -49,9 +49,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -34,9 +34,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/package.json
@@ -34,9 +34,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
@@ -43,9 +43,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/package.json
@@ -43,9 +43,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -43,9 +43,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -43,9 +43,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/graphite/package.json
+++ b/public/app/plugins/datasource/graphite/package.json
@@ -45,9 +45,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/graphite/package.json
+++ b/public/app/plugins/datasource/graphite/package.json
@@ -45,9 +45,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -45,9 +45,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -45,9 +45,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/loki/package.json
+++ b/public/app/plugins/datasource/loki/package.json
@@ -46,9 +46,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/loki/package.json
+++ b/public/app/plugins/datasource/loki/package.json
@@ -46,9 +46,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/mssql/package.json
+++ b/public/app/plugins/datasource/mssql/package.json
@@ -35,9 +35,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next-cli extract --sync-primary"
   },
   "packageManager": "yarn@4.11.0"

--- a/public/app/plugins/datasource/mssql/package.json
+++ b/public/app/plugins/datasource/mssql/package.json
@@ -35,9 +35,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "i18n-extract": "i18next-cli extract --sync-primary"
   },
   "packageManager": "yarn@4.11.0"

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -34,9 +34,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/mysql/package.json
+++ b/public/app/plugins/datasource/mysql/package.json
@@ -34,9 +34,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/opentsdb/package.json
+++ b/public/app/plugins/datasource/opentsdb/package.json
@@ -42,9 +42,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/opentsdb/package.json
+++ b/public/app/plugins/datasource/opentsdb/package.json
@@ -42,9 +42,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/parca/package.json
+++ b/public/app/plugins/datasource/parca/package.json
@@ -35,9 +35,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/parca/package.json
+++ b/public/app/plugins/datasource/parca/package.json
@@ -35,9 +35,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -62,10 +62,10 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
     "build:stats": "yarn build --env stats --profile --json=compilation-stats.json",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -62,10 +62,10 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build": "webpack -c ./webpack.config.ts --env production",
     "build:stats": "yarn build --env stats --profile --json=compilation-stats.json",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/zipkin/package.json
+++ b/public/app/plugins/datasource/zipkin/package.json
@@ -38,9 +38,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--experimental-strip-types --no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
+    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },

--- a/public/app/plugins/datasource/zipkin/package.json
+++ b/public/app/plugins/datasource/zipkin/package.json
@@ -38,9 +38,9 @@
     "@grafana/runtime": "*"
   },
   "scripts": {
-    "build": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production",
-    "build:commit": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
-    "dev": "NODE_OPTIONS='--no-warnings=ExperimentalWarning' webpack -w -c ./webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "build:commit": "webpack -c ./webpack.config.ts --env production --env commit=$(git rev-parse --short HEAD)",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --maxWorkers 4"
   },


### PR DESCRIPTION
The Node options flags were needed as a stop-gap measure until Grafana was making use of Node 24. We have now completed the move to Node 24 as it is in LTS, therefore these flags are no longer required.