### PR TITLE
Plugins: Pass build mode to frontend

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -37,6 +37,7 @@ export type AppPluginConfig = {
   dependencies: PluginDependencies;
   extensions: PluginExtensions;
   moduleHash?: string;
+  buildMode?: string;
 };
 
 export type PreinstalledPlugin = {

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -637,6 +637,7 @@ func (hs *HTTPServer) newAppDTO(ctx context.Context, plugin pluginstore.Plugin, 
 		Dependencies:    plugin.Dependencies,
 		ModuleHash:      hs.pluginAssets.ModuleHash(ctx, plugin),
 		Translations:    plugin.Translations,
+		BuildMode:       plugin.BuildMode,
 	}
 
 	if settings.Enabled {

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -339,6 +339,7 @@ type AppDTO struct {
 	Dependencies    Dependencies      `json:"dependencies"`
 	ModuleHash      string            `json:"moduleHash,omitempty"`
 	Translations    map[string]string `json:"translations,omitempty"`
+	BuildMode       string            `json:"buildMode,omitempty"`
 }
 
 const (

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -133,6 +133,9 @@ type JSONData struct {
 
 	// List of languages supported by the plugin
 	Languages []string `json:"languages,omitempty"`
+
+	// Build mode of the plugin (set automatically at build time)
+	BuildMode string `json:"buildMode,omitempty"`
 }
 
 func ReadPluginJSON(reader io.Reader) (JSONData, error) {


### PR DESCRIPTION
**What is this feature?**

The [Plugin Extensions DevTools app ](https://github.com/grafana/extensionsdevtools-app) would benefit from knowing which out of the installed plugins are built for development. The `buildMode` property in `plugin.json` is set by webpack in plugins that were scaffolded with the create-plugin tool. 

This PR forwards the `buildMode` property to the frontend. It also changes the webpack config used by plugin in this repository so that `buildMode` is added build time. 

**Why do we need this feature?**

So that we can provide tailored DevEx for plugins that are in dev mode. 

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
