### PR TITLE
QueryEditor: datasource getQueryDisplayText error

### DIFF
--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -310,11 +310,18 @@ export class QueryEditorRow<TQuery extends DataQuery> extends PureComponent<Prop
 
   renderCollapsedText(): string | null {
     const { datasource } = this.state;
-    if (datasource?.getQueryDisplayText) {
-      return datasource.getQueryDisplayText(this.props.query);
+
+    if (!datasource || typeof datasource.getQueryDisplayText !== 'function') {
+      return null;
     }
 
-    return null;
+    try {
+      return datasource.getQueryDisplayText(this.props.query);
+    } catch (error) {
+      // Some datasource plugins may throw errors in getQueryDisplayText
+      // Return null gracefully to prevent the query editor from crashing.
+      return null;
+    }
   }
 
   renderWarnings = (type: string): JSX.Element | null => {


### PR DESCRIPTION
**Who is this feature for?**

Users using datasource plugins that may have errors in their `getQueryDisplayText` implementation (ex: Infinity datasource)

**Which issue(s) does this PR fix?**:

Fixes query editor crashes when datasource plugins throw errors in `getQueryDisplayText` (observed with Infinity datasource).

**Before (when you collapse Infinity datasource query row):** 
<img width="834" height="710" alt="image" src="https://github.com/user-attachments/assets/7a34095c-a409-4de6-87b3-f61ed3e77087" />


**After:**
<img width="834" height="631" alt="image" src="https://github.com/user-attachments/assets/c26b8a46-2429-4878-ac19-e41d6508bfff" />


**Special notes for your reviewer:**

Please check that:
- [ ] You're able to collapse infinity datasource query row without without app crashing
