### PR TITLE
Dashboards: Add variables with datasource to tracking

### DIFF
--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -361,7 +361,7 @@ describe('DashboardSceneSerializer', () => {
           variable_type_textbox_count: 1,
           settings_nowdelay: undefined,
           settings_livenow: true,
-          variablesWithDS: [
+          varsWithDataSource: [
             { type: 'query', datasource: 'influxdb' },
             { type: 'query', datasource: 'elasticsearch' },
           ],
@@ -703,7 +703,7 @@ describe('DashboardSceneSerializer', () => {
           variable_type_datasource_count: 1,
           variable_type_custom_count: 1,
           variable_type_query_count: 1,
-          variablesWithDS: [
+          varsWithDataSource: [
             { type: 'query', datasource: 'cloudwatch' },
             { type: 'adhoc', datasource: 'opensearch' },
             { type: 'datasource', datasource: 'bigquery' },

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.test.ts
@@ -330,10 +330,16 @@ describe('DashboardSceneSerializer', () => {
               {
                 type: 'query',
                 name: 'server',
+                datasource: {
+                  type: 'influxdb',
+                },
               },
               {
                 type: 'query',
                 name: 'host',
+                datasource: {
+                  type: 'elasticsearch',
+                },
               },
               {
                 type: 'textbox',
@@ -355,6 +361,10 @@ describe('DashboardSceneSerializer', () => {
           variable_type_textbox_count: 1,
           settings_nowdelay: undefined,
           settings_livenow: true,
+          variablesWithDS: [
+            { type: 'query', datasource: 'influxdb' },
+            { type: 'query', datasource: 'elasticsearch' },
+          ],
         });
       });
     });
@@ -688,16 +698,23 @@ describe('DashboardSceneSerializer', () => {
           schemaVersion: DASHBOARD_SCHEMA_VERSION,
           settings_nowdelay: undefined,
           settings_livenow: true,
+          panel_type_timeseries_count: 6,
+          variable_type_adhoc_count: 1,
+          variable_type_datasource_count: 1,
           variable_type_custom_count: 1,
           variable_type_query_count: 1,
-          panel_type_timeseries_count: 6,
+          variablesWithDS: [
+            { type: 'query', datasource: 'cloudwatch' },
+            { type: 'adhoc', datasource: 'opensearch' },
+            { type: 'datasource', datasource: 'bigquery' },
+          ],
         });
 
         expect(dashboard.getDynamicDashboardsTrackingInformation()).toEqual({
           panelCount: 6,
           rowCount: 6,
           tabCount: 4,
-          templateVariableCount: 2,
+          templateVariableCount: 4,
           maxNestingLevel: 3,
           dashStructure:
             '[{"kind":"row","children":[{"kind":"row","children":[{"kind":"tab","children":[{"kind":"panel"},{"kind":"panel"},{"kind":"panel"}]},{"kind":"tab","children":[]}]},{"kind":"row","children":[{"kind":"row","children":[{"kind":"panel"}]}]}]},{"kind":"row","children":[{"kind":"row","children":[{"kind":"tab","children":[{"kind":"panel"}]},{"kind":"tab","children":[{"kind":"panel"}]}]}]}]',

--- a/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
+++ b/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
@@ -1133,6 +1133,13 @@
       }
     },
     {
+      "kind": "AdhocVariable",
+      "datasource": {
+        "name": "opensearch"
+      },
+      "spec": {}
+    },
+    {
       "kind": "CustomVariable",
       "spec": {
         "allowCustomValue": true,
@@ -1153,6 +1160,13 @@
         ],
         "query": "test",
         "skipUrlSync": false
+      }
+    },
+    {
+      "kind": "DatasourceVariable",
+      "spec": {
+        "name": "datasourceVar",
+        "pluginId": "bigquery"
       }
     }
   ]

--- a/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
+++ b/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
@@ -1134,10 +1134,11 @@
     },
     {
       "kind": "AdhocVariable",
-      "datasource": {
-        "name": "opensearch"
-      },
-      "spec": {}
+      "datasource": { "name": "esmce00tbim8" },
+      "group": "opensearch",
+      "spec": {
+        "allowCustomValue": true
+      }
     },
     {
       "kind": "CustomVariable",

--- a/public/app/features/dashboard-scene/utils/tracking.test.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.test.ts
@@ -17,9 +17,9 @@ jest.mock('@grafana/runtime', () => ({
     },
   },
   getDataSourceSrv: () => ({
-    getList: () => [],
-    getInstanceSettings: () => {},
-    get: () => undefined,
+    getInstanceSettings: () => {
+      return { apiVersion: 'v1', meta: { multiValueFilterOperators: true } };
+    },
   }),
 }));
 
@@ -77,7 +77,7 @@ describe('dashboard tracking', () => {
         isScene: true,
         tabCount: 4,
         rowCount: 2,
-        templateVariableCount: 3,
+        templateVariableCount: 4,
         maxNestingLevel: 3,
         panel_type_timeseries_count: 6,
         panels_count: 6,
@@ -95,10 +95,15 @@ describe('dashboard tracking', () => {
         variable_type_custom_count: 1,
         variable_type_query_count: 1,
         variable_type_datasource_count: 1,
+        variable_type_adhoc_count: 1,
         varsWithDataSource: [
           {
             datasource: 'cloudwatch',
             type: 'query',
+          },
+          {
+            datasource: 'opensearch',
+            type: 'adhoc',
           },
           {
             datasource: 'bigquery',

--- a/public/app/features/dashboard-scene/utils/tracking.test.ts
+++ b/public/app/features/dashboard-scene/utils/tracking.test.ts
@@ -16,6 +16,11 @@ jest.mock('@grafana/runtime', () => ({
       dashboardNewLayouts: true,
     },
   },
+  getDataSourceSrv: () => ({
+    getList: () => [],
+    getInstanceSettings: () => {},
+    get: () => undefined,
+  }),
 }));
 
 // mock useSaveDashboardMutation
@@ -72,7 +77,7 @@ describe('dashboard tracking', () => {
         isScene: true,
         tabCount: 4,
         rowCount: 2,
-        templateVariableCount: 2,
+        templateVariableCount: 3,
         maxNestingLevel: 3,
         panel_type_timeseries_count: 6,
         panels_count: 6,
@@ -89,6 +94,17 @@ describe('dashboard tracking', () => {
         uid: 'dashboard-test',
         variable_type_custom_count: 1,
         variable_type_query_count: 1,
+        variable_type_datasource_count: 1,
+        varsWithDataSource: [
+          {
+            datasource: 'cloudwatch',
+            type: 'query',
+          },
+          {
+            datasource: 'bigquery',
+            type: 'datasource',
+          },
+        ],
         hasEditPermissions: true,
         hasSavePermissions: true,
       });

--- a/public/app/features/dashboard/utils/tracking.test.ts
+++ b/public/app/features/dashboard/utils/tracking.test.ts
@@ -1,4 +1,3 @@
-import { data } from 'jquery';
 import { getDashboardModel } from 'test/helpers/getDashboardModel';
 
 import * as runtime from '@grafana/runtime';
@@ -53,10 +52,10 @@ describe('trackDashboardLoaded', () => {
       panel_type_geomap_count: 2,
       settings_nowdelay: '1m',
       settings_livenow: true,
-      variablesWithDS: [
+      varsWithDataSource: [
         { type: 'query', datasource: 'prometheus' },
         { type: 'query', datasource: 'cloudwatch' },
-      ]
+      ],
     });
   });
 });

--- a/public/app/features/dashboard/utils/tracking.test.ts
+++ b/public/app/features/dashboard/utils/tracking.test.ts
@@ -1,3 +1,4 @@
+import { data } from 'jquery';
 import { getDashboardModel } from 'test/helpers/getDashboardModel';
 
 import * as runtime from '@grafana/runtime';
@@ -20,9 +21,9 @@ describe('trackDashboardLoaded', () => {
       ],
       templating: {
         list: [
-          { type: 'query', name: 'Query 1' },
+          { type: 'query', name: 'Query 1', datasource: { type: 'prometheus' } },
           { type: 'interval', name: 'Interval 1' },
-          { type: 'query', name: 'Query 2' },
+          { type: 'query', name: 'Query 2', datasource: { type: 'cloudwatch' } },
         ],
       },
       timepicker: {
@@ -52,6 +53,10 @@ describe('trackDashboardLoaded', () => {
       panel_type_geomap_count: 2,
       settings_nowdelay: '1m',
       settings_livenow: true,
+      variablesWithDS: [
+        { type: 'query', datasource: 'prometheus' },
+        { type: 'query', datasource: 'cloudwatch' },
+      ]
     });
   });
 });

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -113,7 +113,7 @@ export const getV2SchemaVariablesWithDatasource = (variableList: VariableKind[])
     /* eslint-disable @typescript-eslint/consistent-type-assertions  */
     switch (v.kind) {
       case 'AdhocVariable':
-        datasource = (v as AdhocVariableKind).datasource?.name ?? '';
+        datasource = (v as AdhocVariableKind).group ?? '';
         break;
       case 'DatasourceVariable':
         datasource = (v as DatasourceVariableKind).spec.pluginId ?? '';


### PR DESCRIPTION
FE team asked us to add additional tracking for variables for datasource usage (for variables that reference them) 
https://github.com/grafana/grafana/issues/112563

structure they need: 
[
 {
  type: 'query',
  datasource: 'cloudwatch'
  }
  ...
]