### PR TITLE
DataSource: Register deprecated apiservers for each alias

### DIFF
--- a/pkg/registry/apis/datasource/openapi.go
+++ b/pkg/registry/apis/datasource/openapi.go
@@ -7,6 +7,7 @@ import (
 	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	"github.com/grafana/grafana/pkg/registry/apis/query/queryschema"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 )
 
 func (b *DataSourceAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI, error) {
@@ -68,6 +69,16 @@ func (b *DataSourceAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.Op
 				},
 			},
 		},
+	}
+
+	// Mark all alias APIServers as deprecated
+	if b.isAlias {
+		oas.Info.Description = "Deprecated.  Please use: " + b.pluginJSON.ID
+		for _, p := range oas.Paths.Paths {
+			for _, op := range builder.GetPathOperations(p) {
+				op.Deprecated = true
+			}
+		}
 	}
 
 	return oas, nil

--- a/pkg/services/apiserver/builder/openapi.go
+++ b/pkg/services/apiserver/builder/openapi.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"maps"
+	"net/http"
 	"strings"
 	"sync"
 
@@ -217,11 +218,9 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []s
 						parent := copy.Paths.Paths[path[:idx+6]]
 						if parent != nil && parent.Get != nil {
 							for _, op := range GetPathOperations(spec) {
-								if op != nil && op.Extensions != nil {
-									action, ok := op.Extensions.GetString("x-kubernetes-action")
-									if ok && action == "connect" {
-										op.Tags = parent.Get.Tags
-									}
+								action, ok := op.Extensions.GetString("x-kubernetes-action")
+								if ok && action == "connect" {
+									op.Tags = parent.Get.Tags
 								}
 							}
 						}
@@ -234,15 +233,32 @@ func getOpenAPIPostProcessor(version string, builders []APIGroupBuilder, gvs []s
 	}
 }
 
-func GetPathOperations(path *spec3.Path) []*spec3.Operation {
-	return []*spec3.Operation{
-		path.Get,
-		path.Head,
-		path.Delete,
-		path.Patch,
-		path.Post,
-		path.Put,
-		path.Trace,
-		path.Options,
+// GetPathOperations returns the set of non-nil operations defined on a path
+func GetPathOperations(path *spec3.Path) map[string]*spec3.Operation {
+	ops := make(map[string]*spec3.Operation)
+	if path.Get != nil {
+		ops[http.MethodGet] = path.Get
 	}
+	if path.Head != nil {
+		ops[http.MethodHead] = path.Head
+	}
+	if path.Delete != nil {
+		ops[http.MethodDelete] = path.Delete
+	}
+	if path.Post != nil {
+		ops[http.MethodPost] = path.Post
+	}
+	if path.Put != nil {
+		ops[http.MethodPut] = path.Put
+	}
+	if path.Patch != nil {
+		ops[http.MethodPatch] = path.Patch
+	}
+	if path.Trace != nil {
+		ops[http.MethodTrace] = path.Trace
+	}
+	if path.Options != nil {
+		ops[http.MethodOptions] = path.Options
+	}
+	return ops
 }

--- a/pkg/services/apiserver/builder/openapi_test.go
+++ b/pkg/services/apiserver/builder/openapi_test.go
@@ -1,0 +1,76 @@
+package builder
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/kube-openapi/pkg/spec3"
+)
+
+func TestOpenAPI_GetPathOperations(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   *spec3.Path
+		expect  []string // the methods we should see
+		exclude []string // the methods we should never see
+	}{
+		{
+			name: "some operations",
+			input: &spec3.Path{
+				PathProps: spec3.PathProps{
+					Get:    &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "get"}},
+					Post:   &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "post"}},
+					Delete: &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "delete"}},
+				},
+			},
+			expect:  []string{"GET", "POST", "DELETE"},
+			exclude: []string{"PUT", "PATCH", "OPTIONS", "HEAD", "TRACE"},
+		},
+		{
+			name: "all operations",
+			input: &spec3.Path{
+				PathProps: spec3.PathProps{
+					Get:     &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "get"}},
+					Post:    &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "post"}},
+					Delete:  &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "delete"}},
+					Put:     &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "put"}},
+					Patch:   &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "patch"}},
+					Options: &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "options"}},
+					Head:    &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "head"}},
+					Trace:   &spec3.Operation{OperationProps: spec3.OperationProps{Summary: "trace"}},
+				},
+			},
+			expect:  []string{"GET", "POST", "DELETE", "PUT", "PATCH", "OPTIONS", "HEAD", "TRACE"},
+			exclude: []string{},
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			expect := make(map[string]bool)
+			for _, k := range tt.expect {
+				expect[k] = true
+			}
+
+			for k, op := range GetPathOperations(tt.input) {
+				require.NotNil(t, op)
+				require.Equal(t, strings.ToLower(k), op.Summary)
+
+				if !expect[k] {
+					if slices.Contains(tt.expect, k) {
+						require.Fail(t, "method returned multiple times", k)
+					} else {
+						require.Fail(t, "unexpected method", k)
+					}
+				}
+				delete(expect, k)
+				require.NotContains(t, tt.exclude, k, "exclude")
+			}
+
+			if len(expect) > 0 {
+				require.Fail(t, "missing expected method", expect)
+			}
+		})
+	}
+}


### PR DESCRIPTION
@dafydd-t  is looking at how to move from the currnet group (xxx.datasource.grafana.app) to the plugin id.  Easy if we could just change it... BUT we will need a transition where the same thing is registered in multiple places.  This PR explores how we could register the same server in multiple groups.

<img width="1361" height="1043" alt="image" src="https://github.com/user-attachments/assets/2cdf57a9-819e-4ded-931d-e17d7f01d92e" />

<img width="1361" height="1043" alt="image" src="https://github.com/user-attachments/assets/3b680d24-c16e-4576-b6a3-dce0d5fc7347" />

<img width="1361" height="1043" alt="image" src="https://github.com/user-attachments/assets/a16f2c73-dc64-4cfc-82dc-9d45a10f15a2" />

We will likely want to skip/avoid registering "testdata" since that was never used anyway.


ALTERNATIVELY... we could try a URL rewrite rule that resolves the previous alias to the new route


