### PR TITLE
GitSync: Fix documentation link

### DIFF
--- a/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
+++ b/public/app/features/provisioning/GettingStarted/FeaturesList.tsx
@@ -48,9 +48,7 @@ export const FeaturesList = ({ hasRequiredFeatures, onSetupFeatures }: FeaturesL
           Want to learn more? See our{' '}
           <TextLink
             external
-            href={
-              'https://grafana.com/docs/grafana-cloud/developer-resources/observability-as-code/provision-resources'
-            }
+            href={'https://grafana.com/docs/grafana-cloud/as-code/observability-as-code/provision-resources/'}
           >
             documentation
           </TextLink>


### PR DESCRIPTION
The docs were recently moved and the link no longer resolves.  This updates the link to the new location