### PR TITLE
feat: define unified disable migrations flag

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -575,7 +575,9 @@ type Cfg struct {
 	ShortLinkExpiration int
 
 	// Unified Storage
-	UnifiedStorage                             map[string]UnifiedStorageConfig
+	UnifiedStorage map[string]UnifiedStorageConfig
+	// DisableDataMigrations will disable resources data migration to unified storage at startup
+	DisableDataMigrations                      bool
 	MaxPageSizeBytes                           int
 	IndexPath                                  string
 	IndexWorkers                               int


### PR DESCRIPTION
The new config should run migrations by default for on-prem and enable all required configuration for customers to run on mode 5.

The flag needs to be opted-out in cloud, and on-prem installations can switch it off in case of issues with the migration.

This PR forcefully disables the migration flag until we have it enabled on the cloud environment.

Ticket: https://github.com/grafana/search-and-storage-team/issues/563