### PR TITLE
CloudWatch Logs: Hide internal logs field

### DIFF
--- a/pkg/tsdb/cloudwatch/log_query.go
+++ b/pkg/tsdb/cloudwatch/log_query.go
@@ -109,7 +109,8 @@ func logsResultsToDataframes(response *cloudwatchlogs.GetQueryResultsOutput, gro
 			newFields[len(newFields)-1].SetConfig(
 				&data.FieldConfig{
 					Custom: map[string]any{
-						"hidden": true,
+						"hidden":   true,
+						"hideFrom": map[string]any{"viz": true},
 					},
 				},
 			)

--- a/pkg/tsdb/cloudwatch/log_query_test.go
+++ b/pkg/tsdb/cloudwatch/log_query_test.go
@@ -169,7 +169,8 @@ func TestLogsResultsToDataframes(t *testing.T) {
 	})
 	hiddenLogStreamField.SetConfig(&data.FieldConfig{
 		Custom: map[string]any{
-			"hidden": true,
+			"hidden":   true,
+			"hideFrom": map[string]any{"viz": true},
 		},
 	})
 
@@ -180,7 +181,8 @@ func TestLogsResultsToDataframes(t *testing.T) {
 	})
 	hiddenLogField.SetConfig(&data.FieldConfig{
 		Custom: map[string]any{
-			"hidden": true,
+			"hidden":   true,
+			"hideFrom": map[string]any{"viz": true},
 		},
 	})
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When viewing logs query in a table visualization internal fields: `__log__grafana_internal__` and `__logstream__grafana_internal__` would be shown as well. This PR uses the new `hideFrom.viz` property to hide these fields. This field is used by the new Table panel that is now enabled by default in Grafana.

Before:
<img width="1475" height="145" alt="before" src="https://github.com/user-attachments/assets/60cc6dae-adbc-4aec-a40f-6fc130b21ef9" />

After:
<img width="1204" height="145" alt="after" src="https://github.com/user-attachments/assets/6776b002-40aa-4243-bb5f-82077a15672c" />


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
