### PR TITLE
Auth: Remember the user's last org for SSO logins

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1562,4 +1562,9 @@ export interface FeatureToggles {
   * @default false
   */
   managedPluginsV2?: boolean;
+  /**
+  * Remember the last viewed organization for users using SSO
+  * @default true
+  */
+  rememberUserOrgForSso?: boolean;
 }

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Masterminds/semver/v3"
 	claims "github.com/grafana/authlib/types"
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/singleflight"
@@ -343,7 +344,7 @@ func (s *UserSync) SyncUserHook(ctx context.Context, id *authn.Identity, _ *auth
 		}
 	}
 
-	syncUserToIdentity(usr, id)
+	syncUserToIdentity(ctx, usr, id)
 	return nil
 }
 
@@ -722,7 +723,7 @@ func (s *UserSync) lookupByOneOf(ctx context.Context, params login.UserLookupPar
 
 // syncUserToIdentity syncs a user to an identity.
 // This is used to update the identity with the latest user information.
-func syncUserToIdentity(usr *user.User, id *authn.Identity) {
+func syncUserToIdentity(ctx context.Context, usr *user.User, id *authn.Identity) {
 	id.ID = strconv.FormatInt(usr.ID, 10)
 	id.UID = usr.UID
 	id.Type = claims.TypeUser
@@ -731,8 +732,12 @@ func syncUserToIdentity(usr *user.User, id *authn.Identity) {
 	id.Name = usr.Name
 	id.EmailVerified = usr.EmailVerified
 	id.IsGrafanaAdmin = &usr.IsAdmin
-	if id.OrgID == 0 {
-		id.OrgID = usr.OrgID
+
+	featureClient := openfeature.NewDefaultClient()
+	if featureClient.Boolean(ctx, featuremgmt.FlagRememberUserOrgForSso, true, openfeature.TransactionContext(ctx)) {
+		if id.OrgID == 0 {
+			id.OrgID = usr.OrgID
+		}
 	}
 }
 

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -728,10 +728,12 @@ func syncUserToIdentity(usr *user.User, id *authn.Identity) {
 	id.Type = claims.TypeUser
 	id.Login = usr.Login
 	id.Email = usr.Email
-	id.OrgID = usr.OrgID
 	id.Name = usr.Name
 	id.EmailVerified = usr.EmailVerified
 	id.IsGrafanaAdmin = &usr.IsAdmin
+	if id.OrgID == 0 {
+		id.OrgID = usr.OrgID
+	}
 }
 
 // syncSignedInUserToIdentity syncs a user to an identity.

--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -728,6 +728,7 @@ func syncUserToIdentity(usr *user.User, id *authn.Identity) {
 	id.Type = claims.TypeUser
 	id.Login = usr.Login
 	id.Email = usr.Email
+	id.OrgID = usr.OrgID
 	id.Name = usr.Name
 	id.EmailVerified = usr.EmailVerified
 	id.IsGrafanaAdmin = &usr.IsAdmin

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -946,7 +946,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 			},
 		},
 		{
-			name: "sync - identity org not populated from user",
+			name: "sync - identity org not populated from user when rememberUserOrgForSso is disabled",
 			fields: fields{
 				userService:     userService,
 				authInfoService: authFakeNil,

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -2074,6 +2074,8 @@ func TestUserSync_SyncUserHook_SCIMUserSAMLLoginUpdatesExistingUserAuth(t *testi
 		return cmd.UserId == 333 && cmd.AuthModule == login.SAMLAuthModule && cmd.AuthId == "saml-generated-auth-id"
 	})).Return(nil).Once()
 
+	provider.UsingFlags(t, defaultFeatureFlags)
+
 	s := ProvideUserSync(
 		userSrv,
 		authinfoimpl.ProvideOSSUserProtectionService(),
@@ -2125,6 +2127,8 @@ func TestUserSync_SyncUserHook_NonProvisionedSAMLUserCreatesNewAuthConnection(t 
 	authInfoSrv.On("SetAuthInfo", mock.Anything, mock.MatchedBy(func(cmd *login.SetAuthInfoCommand) bool {
 		return cmd.UserId == 444 && cmd.AuthModule == login.SAMLAuthModule && cmd.AuthId == "saml-auth-id"
 	})).Return(nil).Once()
+
+	provider.UsingFlags(t, defaultFeatureFlags)
 
 	s := ProvideUserSync(
 		userSrv,

--- a/pkg/services/authn/authnimpl/sync/user_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync_test.go
@@ -11,6 +11,10 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
+
 	claims "github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -37,6 +41,21 @@ func ptrString(s string) *string {
 
 func ptrBool(b bool) *bool {
 	return &b
+}
+
+var (
+	provider            = oftesting.NewTestProvider()
+	defaultFeatureFlags = map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagRememberUserOrgForSso: setting.NewInMemoryFlag(featuremgmt.FlagRememberUserOrgForSso, true),
+	}
+)
+
+func TestMain(m *testing.M) {
+	if err := openfeature.SetProvider(provider); err != nil {
+		panic(err)
+	}
+
+	m.Run()
 }
 
 func TestUserSync_SyncUserHook(t *testing.T) {
@@ -67,6 +86,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 		Login: "test",
 		Name:  "test",
 		Email: "test",
+		OrgID: 42,
 	}}
 
 	userServiceMod := &usertest.FakeUserService{ExpectedUser: &user.User{
@@ -206,11 +226,12 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 		id *authn.Identity
 	}
 	tests := []struct {
-		name    string
-		fields  fields
-		args    args
-		wantErr bool
-		wantID  *authn.Identity
+		name                         string
+		fields                       fields
+		args                         args
+		wantErr                      bool
+		wantID                       *authn.Identity
+		disableRememberUserOrgForSso bool
 	}{
 		{
 			name: "no sync",
@@ -271,6 +292,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ID:             "1",
 				UID:            "1",
 				Type:           claims.TypeUser,
+				OrgID:          42,
 				Login:          "test",
 				Name:           "test",
 				Email:          "test",
@@ -310,6 +332,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ID:             "1",
 				UID:            "1",
 				Type:           claims.TypeUser,
+				OrgID:          42,
 				Login:          "test",
 				Name:           "test",
 				Email:          "test",
@@ -351,6 +374,7 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				ID:              "1",
 				UID:             "1",
 				Type:            claims.TypeUser,
+				OrgID:           42,
 				AuthID:          "2032",
 				AuthenticatedBy: "oauth",
 				Login:           "test",
@@ -880,6 +904,87 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sync - incoming identity org not superseded by user org",
+			fields: fields{
+				userService:     userService,
+				authInfoService: authFakeNil,
+				quotaService:    &quotatest.FakeQuotaService{},
+			},
+			args: args{
+				id: &authn.Identity{
+					OrgID: 3,
+					Login: "test",
+					Name:  "test",
+					Email: "test",
+					ClientParams: authn.ClientParams{
+						SyncUser: true,
+						LookUpParams: login.UserLookupParams{
+							Email: ptrString("test"),
+							Login: nil,
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantID: &authn.Identity{
+				ID:             "1",
+				UID:            "1",
+				Type:           claims.TypeUser,
+				OrgID:          3,
+				Login:          "test",
+				Name:           "test",
+				Email:          "test",
+				IsGrafanaAdmin: ptrBool(false),
+				ClientParams: authn.ClientParams{
+					SyncUser: true,
+					LookUpParams: login.UserLookupParams{
+						Email: ptrString("test"),
+						Login: nil,
+					},
+				},
+			},
+		},
+		{
+			name: "sync - identity org not populated from user",
+			fields: fields{
+				userService:     userService,
+				authInfoService: authFakeNil,
+				quotaService:    &quotatest.FakeQuotaService{},
+			},
+			args: args{
+				id: &authn.Identity{
+					Login: "test",
+					Name:  "test",
+					Email: "test",
+					ClientParams: authn.ClientParams{
+						SyncUser: true,
+						LookUpParams: login.UserLookupParams{
+							Email: ptrString("test"),
+							Login: nil,
+						},
+					},
+				},
+			},
+			wantErr: false,
+			wantID: &authn.Identity{
+				ID:             "1",
+				UID:            "1",
+				Type:           claims.TypeUser,
+				Login:          "test",
+				Name:           "test",
+				Email:          "test",
+				IsGrafanaAdmin: ptrBool(false),
+				ClientParams: authn.ClientParams{
+					SyncUser: true,
+					LookUpParams: login.UserLookupParams{
+						Email: ptrString("test"),
+						Login: nil,
+					},
+				},
+			},
+			disableRememberUserOrgForSso: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -887,6 +992,12 @@ func TestUserSync_SyncUserHook(t *testing.T) {
 			cfg.Raw.Section("auth.scim").Key("user_sync_enabled").SetValue("true")
 			cfg.Raw.Section("auth.scim").Key("reject_non_provisioned_users").SetValue("true")
 
+			provider.UsingFlags(t, defaultFeatureFlags)
+			if tt.disableRememberUserOrgForSso {
+				provider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
+					featuremgmt.FlagRememberUserOrgForSso: setting.NewInMemoryFlag(featuremgmt.FlagRememberUserOrgForSso, false),
+				})
+			}
 			s := ProvideUserSync(tt.fields.userService, userProtection, tt.fields.authInfoService, tt.fields.quotaService, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures(), cfg, nil)
 			err := s.SyncUserHook(context.Background(), tt.args.id, nil)
 			if tt.wantErr {
@@ -906,6 +1017,7 @@ func TestUserSync_SyncUserRetryFetch(t *testing.T) {
 	userSrv.On("Create", mock.Anything, mock.Anything).Return(nil, user.ErrUserAlreadyExists).Once()
 	userSrv.On("GetByEmail", mock.Anything, mock.Anything).Return(&user.User{ID: 1}, nil).Once()
 
+	provider.UsingFlags(t, defaultFeatureFlags)
 	s := ProvideUserSync(
 		userSrv,
 		authinfoimpl.ProvideOSSUserProtectionService(),
@@ -2062,6 +2174,8 @@ func TestUserSync_SyncUserHook_SCIMAuthModuleMismatch(t *testing.T) {
 		return q.AuthModule == "oauth_azuread"
 	})).Return(nil, user.ErrUserNotFound).Once()
 
+	provider.UsingFlags(t, defaultFeatureFlags)
+
 	s := ProvideUserSync(
 		userSrv,
 		authinfoimpl.ProvideOSSUserProtectionService(),
@@ -2112,6 +2226,8 @@ func TestUserSync_SyncUserHook_SCIMUserAllowsGCOMLogin(t *testing.T) {
 		Email:         "test@test.com",
 		IsProvisioned: true,
 	}, nil).Once()
+
+	provider.UsingFlags(t, defaultFeatureFlags)
 
 	s := ProvideUserSync(
 		userSrv,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2475,6 +2475,14 @@ var (
 			Owner:        grafanaPluginsPlatformSquad,
 			Expression:   "false",
 		},
+		{
+			Name:         "rememberUserOrgForSso",
+			Description:  "Remember the last viewed organization for users using SSO",
+			Stage:        FeatureStageGeneralAvailability,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "true", // enabled by default
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -307,3 +307,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,frontendServiceUseSettingsService,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-02-22,functionalSharedPreferences,experimental,@grafana/grafana-frontend-platform,false,false,true
 2026-02-25,managedPluginsV2,experimental,@grafana/plugins-platform-backend,false,false,false
+2026-02-25,rememberUserOrgForSso,GA,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -845,4 +845,8 @@ const (
 	// FlagManagedPluginsV2
 	// Enables managed plugins v2 (expanded rollout, community plugin coverage)
 	FlagManagedPluginsV2 = "managedPluginsV2"
+
+	// FlagRememberUserOrgForSso
+	// Remember the last viewed organization for users using SSO
+	FlagRememberUserOrgForSso = "rememberUserOrgForSso"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3686,6 +3686,20 @@
     },
     {
       "metadata": {
+        "name": "rememberUserOrgForSso",
+        "resourceVersion": "1772028086169",
+        "creationTimestamp": "2026-02-25T14:01:26Z"
+      },
+      "spec": {
+        "description": "Remember the last viewed organization for users using SSO",
+        "stage": "GA",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "renderAuthJWT",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2023-04-03T16:53:38Z"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This bugfix loads the user's current organization ID during SSO authentication.

**Why do we need this feature?**

Without this bugfix, the user's last organization will be forgotten, and when they log in their current organization will be set to the lowest-numbered organization to which they belong.

**Who is this feature for?**

This fix addresses a bug that could be encountered by users using SSO (LDAP, SAML, OAuth) who also use the Organizations feature.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #78168

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Here's what's going wrong currently:
- A user logs in and the SyncOrgRolesHook() is called [expecting the user's org ID to be set](https://github.com/grafana/grafana/blob/main/pkg/services/authn/authnimpl/sync/org_sync.go#L132).
- Because the org ID is not set, the [lowest-numbered org](https://github.com/grafana/grafana/blob/main/pkg/services/authn/authnimpl/sync/org_sync.go#L132) is chosen from the list of sorted org IDs.

The proposed solution sets the org ID in the SyncUserHook() which runs before the SyncOrgRolesHook().