### PR TITLE
Chore: update path for plugin schema in workflow

### DIFF
--- a/.github/workflows/update-schema-types.yml
+++ b/.github/workflows/update-schema-types.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
     paths:
-      - docs/sources/developers/plugins/plugin.schema.json
+      - docs/sources/developer-resources/plugins/plugin.schema.json
   workflow_dispatch:
 
 # These permissions are needed to assume roles from Github's OIDC.


### PR DESCRIPTION
**What is this feature?**

This pull request updates the workflow trigger path in `.github/workflows/update-schema-types.yml` to reflect a file move. The change ensures the workflow runs when the correct schema file is modified.

**Why do we need this feature?**

So it triggers on correct path

**Who is this feature for?**

Plugin platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
