### PR TITLE
Alerting: Remove unknown state filter

### DIFF
--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -574,7 +574,6 @@ function RuleStateField() {
               { label: t('alerting.rules.state.normal', 'Normal'), value: PromAlertingRuleState.Inactive },
               { label: t('alerting.rules.state.pending', 'Pending'), value: PromAlertingRuleState.Pending },
               { label: t('alerting.rules.state.recovering', 'Recovering'), value: PromAlertingRuleState.Recovering },
-              { label: t('alerting.rules.state.unknown', 'Unknown'), value: PromAlertingRuleState.Unknown },
             ]}
             value={field.value}
             onChange={field.onChange}
@@ -734,7 +733,10 @@ function SearchQueryHelp() {
           title={t('alerting.search-query-help.title-labels', 'Labels')}
           expr='label:team=A label:"cluster=new york"'
         />
-        <HelpRow title={t('alerting.search-query-help.title-state', 'State')} expr="state:firing|normal|pending" />
+        <HelpRow
+          title={t('alerting.search-query-help.title-state', 'State')}
+          expr="state:firing|normal|pending|recovering"
+        />
         <HelpRow title={t('alerting.search-query-help.title-type', 'Type')} expr="type:alerting|recording" />
         <HelpRow title={t('alerting.search-query-help.title-health', 'Health')} expr="health:ok|nodata|error" />
         <HelpRow

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2598,8 +2598,7 @@
         "firing": "Firing",
         "normal": "Normal",
         "pending": "Pending",
-        "recovering": "Recovering",
-        "unknown": "Unknown"
+        "recovering": "Recovering"
       },
       "type": {
         "alert": "Alert rule",


### PR DESCRIPTION
The `unknown` rule state is not a real state. It exists only to indicate that a rule has not been yet evaluated or that there was an issue with loading a rule status.
Additionally, backend does not support filtering by `unknown` state