### PR TITLE
ConditionalRendering: Fix for repeated items

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
@@ -4,6 +4,8 @@ import { test, expect, E2ESelectorGroups, DashboardPage, DashboardPageArgs } fro
 
 import testDashboard from '../dashboards/DashboardWithAllConditionalRendering.json';
 
+import { checkRepeatedPanelTitles } from './utils';
+
 test.use({
   featureToggles: {
     kubernetesDashboards: true,
@@ -406,5 +408,18 @@ test.describe('Dashboard - Conditional Rendering - Load and Change', { tag: ['@d
     await expect(getTabHideMatches(dashboardPage, selectors)).toBeVisible();
     await expect(getTabShowNotMatches(dashboardPage, selectors)).toBeVisible();
     await expect(getTabHideNotMatches(dashboardPage, selectors)).not.toBeVisible();
+  });
+
+  test('Load with variable repeat and hide when equals/no data', async ({ page, gotoDashboardPage, selectors }) => {
+    const dashboardPage = await loadDashboard(page, gotoDashboardPage);
+
+    await getTab(dashboardPage, selectors, 'repeated items').click();
+
+    const options = ['go_build_info', 'grafana_build_info'];
+
+    await checkRepeatedPanelTitles(dashboardPage, selectors, 'Hide panel - ', [
+      ...options.map((o) => `custom variable equals x (current = ${o})`),
+      ...options.map((o) => `no data (current = ${o})`),
+    ]);
   });
 });

--- a/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
@@ -410,16 +410,54 @@ test.describe('Dashboard - Conditional Rendering - Load and Change', { tag: ['@d
     await expect(getTabHideNotMatches(dashboardPage, selectors)).not.toBeVisible();
   });
 
-  test('Load with variable repeat and hide when equals/no data', async ({ page, gotoDashboardPage, selectors }) => {
-    const dashboardPage = await loadDashboard(page, gotoDashboardPage);
+  test.describe('Variable repeat', () => {
+    const repeatOptions = ['a', 'b', 'c'];
 
-    await getTab(dashboardPage, selectors, 'repeated items').click();
+    async function failTestDataRequestForOption(page: Page, option: string) {
+      await page.route(
+        /^http:\/\/localhost:[^/]+\/api\/ds\/query\?.*\bds_type=grafana-testdata-datasource/,
+        async (route) => {
+          const rawPostData = route.request().postData();
+          if (!rawPostData) {
+            return;
+          }
 
-    const options = ['go_build_info', 'grafana_build_info'];
+          // the first panel query has a label set to the current variable value
+          if (JSON.parse(rawPostData).queries[0].labels === `key=${option}`) {
+            await route.fulfill({ status: 500, body: '{}' });
+          } else {
+            await route.continue();
+          }
+        }
+      );
+    }
 
-    await checkRepeatedPanelTitles(dashboardPage, selectors, 'Hide panel - ', [
-      ...options.map((o) => `custom variable equals x (current = ${o})`),
-      ...options.map((o) => `no data (current = ${o})`),
-    ]);
+    test('Hide when equals, hide when no data', async ({ page, gotoDashboardPage, selectors }) => {
+      const dashboardPage = await loadDashboard(page, gotoDashboardPage);
+
+      await getTab(dashboardPage, selectors, 'repeated items').click();
+
+      const optionForHiddenPanels = repeatOptions[0];
+
+      await failTestDataRequestForOption(page, optionForHiddenPanels);
+
+      await checkRepeatedPanelTitles(
+        dashboardPage,
+        selectors,
+        'Hide panel - ',
+        [
+          `custom variable equals ${optionForHiddenPanels} (current = ${optionForHiddenPanels})`,
+          `no data (current = ${optionForHiddenPanels})`,
+        ],
+        true
+      );
+
+      const optionsForVisiblePanels = repeatOptions.slice(1);
+
+      await checkRepeatedPanelTitles(dashboardPage, selectors, 'Hide panel - ', [
+        ...optionsForVisiblePanels.map((o) => `custom variable equals ${optionForHiddenPanels} (current = ${o})`),
+        ...optionsForVisiblePanels.map((o) => `no data (current = ${o})`),
+      ]);
+    });
   });
 });

--- a/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
@@ -414,22 +414,19 @@ test.describe('Dashboard - Conditional Rendering - Load and Change', { tag: ['@d
     const repeatOptions = ['a', 'b', 'c'];
 
     async function failTestDataRequestForOption(page: Page, option: string) {
-      await page.route(
-        /^http:\/\/localhost:[^/]+\/api\/ds\/query\?.*\bds_type=grafana-testdata-datasource/,
-        async (route) => {
-          const rawPostData = route.request().postData();
-          if (!rawPostData) {
-            return;
-          }
-
-          // the first panel query has a label set to the current variable value
-          if (JSON.parse(rawPostData).queries[0].labels === `key=${option}`) {
-            await route.fulfill({ status: 500, body: '{}' });
-          } else {
-            await route.continue();
-          }
+      await page.route(/\/api\/ds\/query\?.*\bds_type=grafana-testdata-datasource/, async (route) => {
+        const rawPostData = route.request().postData();
+        if (!rawPostData) {
+          return;
         }
-      );
+
+        // the first panel query has a label set to the current variable value
+        if (JSON.parse(rawPostData).queries[0].labels === `key=${option}`) {
+          await route.fulfill({ status: 500, body: '{}' });
+        } else {
+          await route.continue();
+        }
+      });
     }
 
     test('Hide when equals, hide when no data', async ({ page, gotoDashboardPage, selectors }) => {

--- a/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-conditional-rendering-load-change.spec.ts
@@ -93,7 +93,7 @@ test.describe('Dashboard - Conditional Rendering - Load and Change', { tag: ['@d
 
   test.afterAll(async ({ request }) => {
     if (uid) {
-      await request.delete(`/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/${uid}`);
+      await request.delete(`/apis/dashboard.grafana.app/v1beta1/namespaces/stacks-12345/dashboards/${uid}`);
     }
   });
 

--- a/e2e-playwright/dashboard-new-layouts/utils.ts
+++ b/e2e-playwright/dashboard-new-layouts/utils.ts
@@ -97,12 +97,18 @@ export async function checkRepeatedPanelTitles(
   dashboardPage: DashboardPage,
   selectors: E2ESelectorGroups,
   title: string,
-  options: Array<string | number>
+  options: Array<string | number>,
+  expectHidden = false
 ) {
   for (const option of options) {
-    await expect(
-      dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title(`${title}${option}`))
-    ).toBeVisible();
+    const titleLocator = dashboardPage.getByGrafanaSelector(
+      selectors.components.Panels.Panel.title(`${title}${option}`)
+    );
+    if (expectHidden) {
+      await expect(titleLocator).toBeHidden();
+    } else {
+      await expect(titleLocator).toBeVisible();
+    }
   }
 }
 

--- a/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
+++ b/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
@@ -3355,7 +3355,7 @@
                 "mode": "markdown"
               }
             },
-            "version": "12.4.0-pre"
+            "version": "12.2.0-pre"
           }
         }
       },
@@ -3470,7 +3470,7 @@
                 }
               }
             },
-            "version": "12.4.0-pre"
+            "version": "12.2.0-pre"
           }
         }
       },

--- a/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
+++ b/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
@@ -3308,6 +3308,172 @@
           }
         }
       },
+      "panel-37": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "",
+                      "kind": "DataQuery",
+                      "spec": {},
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 37,
+          "links": [],
+          "title": "Hide panel - custom variable equals x (current = ${myCustomVariable})",
+          "vizConfig": {
+            "group": "text",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": []
+              },
+              "options": {
+                "code": {
+                  "language": "plaintext",
+                  "showLineNumbers": false,
+                  "showMiniMap": false
+                },
+                "content": "",
+                "mode": "markdown"
+              }
+            },
+            "version": "12.4.0-pre"
+          }
+        }
+      },
+      "panel-38": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "gdev-prometheus"
+                      },
+                      "group": "prometheus",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "editorMode": "code",
+                        "expr": "${myCustomVariable}",
+                        "instant": false,
+                        "legendFormat": "__auto",
+                        "range": true
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 38,
+          "links": [],
+          "title": "Hide panel - no data (current = ${myCustomVariable})",
+          "vizConfig": {
+            "group": "timeseries",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "12.4.0-pre"
+          }
+        }
+      },
       "panel-4": {
         "kind": "Panel",
         "spec": {
@@ -5091,6 +5257,80 @@
               },
               "title": "Tab - hide - time range <7d"
             }
+          },
+          {
+            "kind": "TabsLayoutTab",
+            "spec": {
+              "layout": {
+                "kind": "AutoGridLayout",
+                "spec": {
+                  "columnWidthMode": "standard",
+                  "items": [
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingVariable",
+                                "spec": {
+                                  "operator": "equals",
+                                  "value": "x",
+                                  "variable": "myCustomVariable"
+                                }
+                              }
+                            ],
+                            "visibility": "hide"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-37"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "myCustomVariable"
+                        }
+                      }
+                    },
+                    {
+                      "kind": "AutoGridLayoutItem",
+                      "spec": {
+                        "conditionalRendering": {
+                          "kind": "ConditionalRenderingGroup",
+                          "spec": {
+                            "condition": "and",
+                            "items": [
+                              {
+                                "kind": "ConditionalRenderingData",
+                                "spec": {
+                                  "value": false
+                                }
+                              }
+                            ],
+                            "visibility": "hide"
+                          }
+                        },
+                        "element": {
+                          "kind": "ElementReference",
+                          "name": "panel-38"
+                        },
+                        "repeat": {
+                          "mode": "variable",
+                          "value": "myCustomVariable"
+                        }
+                      }
+                    }
+                  ],
+                  "maxColumnCount": 3,
+                  "rowHeightMode": "standard"
+                }
+              },
+              "title": "Tab - repeated items"
+            }
           }
         ]
       }
@@ -5120,6 +5360,39 @@
           "hide": "dontHide",
           "name": "myVariable",
           "query": "",
+          "skipUrlSync": false
+        }
+      },
+      {
+        "kind": "CustomVariable",
+        "spec": {
+          "allowCustomValue": false,
+          "current": {
+            "text": "All",
+            "value": "$__all"
+          },
+          "hide": "dontHide",
+          "includeAll": true,
+          "multi": false,
+          "name": "myCustomVariable",
+          "options": [
+            {
+              "selected": false,
+              "text": "x",
+              "value": "x"
+            },
+            {
+              "selected": false,
+              "text": "go_build_info",
+              "value": "go_build_info"
+            },
+            {
+              "selected": false,
+              "text": "grafana_build_info",
+              "value": "grafana_build_info"
+            }
+          ],
+          "query": "x, go_build_info, grafana_build_info",
           "skipUrlSync": false
         }
       }

--- a/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
+++ b/e2e-playwright/dashboards/DashboardWithAllConditionalRendering.json
@@ -3336,7 +3336,7 @@
           "description": "",
           "id": 37,
           "links": [],
-          "title": "Hide panel - custom variable equals x (current = ${myCustomVariable})",
+          "title": "Hide panel - custom variable equals a (current = ${myCustomVariable})",
           "vizConfig": {
             "group": "text",
             "kind": "VizConfig",
@@ -3372,16 +3372,14 @@
                     "hidden": false,
                     "query": {
                       "datasource": {
-                        "name": "gdev-prometheus"
+                        "name": "PD8C576611E62080A"
                       },
-                      "group": "prometheus",
+                      "group": "grafana-testdata-datasource",
                       "kind": "DataQuery",
                       "spec": {
-                        "editorMode": "code",
-                        "expr": "${myCustomVariable}",
-                        "instant": false,
-                        "legendFormat": "__auto",
-                        "range": true
+                        "labels": "key=$myCustomVariable",
+                        "scenarioId": "random_walk",
+                        "seriesCount": 1
                       },
                       "version": "v0"
                     },
@@ -5278,7 +5276,7 @@
                                 "kind": "ConditionalRenderingVariable",
                                 "spec": {
                                   "operator": "equals",
-                                  "value": "x",
+                                  "value": "a",
                                   "variable": "myCustomVariable"
                                 }
                               }
@@ -5378,21 +5376,21 @@
           "options": [
             {
               "selected": false,
-              "text": "x",
-              "value": "x"
+              "text": "a",
+              "value": "a"
             },
             {
               "selected": false,
-              "text": "go_build_info",
-              "value": "go_build_info"
+              "text": "b",
+              "value": "b"
             },
             {
               "selected": false,
-              "text": "grafana_build_info",
-              "value": "grafana_build_info"
+              "text": "c",
+              "value": "c"
             }
           ],
-          "query": "x, go_build_info, grafana_build_info",
+          "query": "a, b, c",
           "skipUrlSync": false
         }
       }

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
@@ -68,21 +68,28 @@ export class ConditionalRenderingData extends SceneObjectBase<ConditionalRenderi
     };
   }
 
-  private _getObjectDataProvider(): SceneDataProvider | undefined {
+  private _getPanelFromObject(): VizPanel | undefined {
     const object = getObject(this);
 
     if (!object) {
       return undefined;
     }
 
-    let panel: VizPanel | undefined;
+    if (object instanceof VizPanel) {
+      return object;
+    }
 
     for (const val of Object.values(object.state)) {
       if (val instanceof VizPanel) {
-        panel = val;
-        break;
+        return val;
       }
     }
+
+    return undefined;
+  }
+
+  private _getObjectDataProvider(): SceneDataProvider | undefined {
+    const panel = this._getPanelFromObject();
 
     if (!panel) {
       return undefined;

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
@@ -140,6 +140,10 @@ export class ConditionalRenderingData extends SceneObjectBase<ConditionalRenderi
     }
   }
 
+  public forceCheck() {
+    this._check();
+  }
+
   public renderCmp(): ReactElement {
     return <this.Component model={this} key={this.state.key} />;
   }

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
@@ -80,6 +80,10 @@ export class ConditionalRenderingTimeRangeSize extends SceneObjectBase<Condition
     }
   }
 
+  public forceCheck() {
+    this._check();
+  }
+
   public renderCmp(): ReactElement {
     return <this.Component model={this} key={this.state.key} />;
   }

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -20,7 +20,7 @@ import { getLowerTranslatedObjectType } from '../object';
 
 import { ConditionalRenderingConditionWrapper } from './ConditionalRenderingConditionWrapper';
 import { ConditionalRenderingConditionsSerializerRegistryItem } from './serializers';
-import { checkGroup, getObjectType } from './utils';
+import { checkGroup, getObject, getObjectType } from './utils';
 
 type VariableConditionValueOperator = '=' | '!=' | '=~' | '!~';
 
@@ -40,14 +40,6 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
     deserialize: this.deserialize,
   };
 
-  protected _variableDependency = new VariableDependencyConfig(this, {
-    onAnyVariableChanged: (v) => {
-      if (v.state.name === this.state.variable) {
-        this._check();
-      }
-    },
-  });
-
   public constructor(state: ConditionalRenderingVariableState) {
     super(state);
 
@@ -55,6 +47,20 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
   }
 
   private _activationHandler() {
+    const object = getObject(this);
+
+    if (!object) {
+      return;
+    }
+
+    this._variableDependency = new VariableDependencyConfig(object, {
+      onAnyVariableChanged: (v) => {
+        if (v.state.name === this.state.variable) {
+          this._check();
+        }
+      },
+    });
+
     this.forEachChild((child) => {
       if (!child.isActive) {
         this._subs.add(child.activate());
@@ -78,7 +84,13 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
       return undefined;
     }
 
-    const variable = sceneGraph.getVariables(this).getByName(this.state.variable);
+    const object = getObject(this);
+
+    if (!object) {
+      return undefined;
+    }
+
+    const variable = sceneGraph.getVariables(object).getByName(this.state.variable);
 
     if (!variable) {
       return undefined;

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -139,6 +139,10 @@ export class ConditionalRenderingVariable extends SceneObjectBase<ConditionalRen
     }
   }
 
+  public forceCheck() {
+    this._check();
+  }
+
   public renderCmp(): ReactElement {
     return <this.Component model={this} key={this.state.key} />;
   }

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/utils.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/utils.ts
@@ -15,9 +15,10 @@ export function getGroup(condition: ConditionalRenderingConditions): Conditional
 
 export function getObject(condition: ConditionalRenderingConditions): SceneObject | undefined {
   const group = getGroup(condition);
+  const groupTarget = group.getTarget();
 
-  if (group.state.target) {
-    return group.state.target.resolve();
+  if (groupTarget) {
+    return groupTarget;
   }
 
   return getGroup(condition).parent;

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/utils.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/utils.ts
@@ -14,6 +14,12 @@ export function getGroup(condition: ConditionalRenderingConditions): Conditional
 }
 
 export function getObject(condition: ConditionalRenderingConditions): SceneObject | undefined {
+  const group = getGroup(condition);
+
+  if (group.state.target) {
+    return group.state.target.resolve();
+  }
+
   return getGroup(condition).parent;
 }
 

--- a/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
@@ -33,7 +33,6 @@ export interface ConditionalRenderingGroupState extends SceneObjectState {
   condition: GroupConditionCondition;
   renderHidden: boolean;
   result: boolean;
-  target?: SceneObjectRef<SceneObject>;
 }
 
 export class ConditionalRenderingGroup extends SceneObjectBase<ConditionalRenderingGroupState> {
@@ -41,6 +40,7 @@ export class ConditionalRenderingGroup extends SceneObjectBase<ConditionalRender
 
   private _shouldShow: boolean;
   private _shouldMatchAll: boolean;
+  private _target?: SceneObjectRef<SceneObject>;
 
   public constructor(state: ConditionalRenderingGroupState) {
     super(state);
@@ -58,6 +58,19 @@ export class ConditionalRenderingGroup extends SceneObjectBase<ConditionalRender
     });
 
     this.check();
+  }
+
+  public setTarget(target: SceneObject | undefined) {
+    this._target = target ? target.getRef() : undefined;
+    this.forceCheck();
+  }
+
+  public getTarget(): SceneObject | undefined {
+    return this._target?.resolve();
+  }
+
+  public forceCheck() {
+    this.state.conditions.forEach((condition) => condition.forceCheck());
   }
 
   public check() {

--- a/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
@@ -2,7 +2,14 @@ import { lowerCase } from 'lodash';
 import { useMemo } from 'react';
 
 import { t } from '@grafana/i18n';
-import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
+import {
+  SceneComponentProps,
+  sceneGraph,
+  SceneObject,
+  SceneObjectBase,
+  SceneObjectRef,
+  SceneObjectState,
+} from '@grafana/scenes';
 import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 import { Stack } from '@grafana/ui';
 
@@ -26,6 +33,7 @@ export interface ConditionalRenderingGroupState extends SceneObjectState {
   condition: GroupConditionCondition;
   renderHidden: boolean;
   result: boolean;
+  target?: SceneObjectRef<SceneObject>;
 }
 
 export class ConditionalRenderingGroup extends SceneObjectBase<ConditionalRenderingGroupState> {

--- a/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.tsx
@@ -1,12 +1,13 @@
 import { ReactNode } from 'react';
 
-import { SceneObject, useSceneObjectState } from '@grafana/scenes';
+import { useSceneObjectState } from '@grafana/scenes';
 
 import { ConditionalRenderingGroup } from '../group/ConditionalRenderingGroup';
 
 import { ConditionalRenderingOverlay } from './ConditionalRenderingOverlay';
 
 let placeholderConditionalRendering: ConditionalRenderingGroup | undefined;
+
 function getPlaceholderConditionalRendering(): ConditionalRenderingGroup {
   if (!placeholderConditionalRendering) {
     placeholderConditionalRendering = ConditionalRenderingGroup.createEmpty();
@@ -15,30 +16,9 @@ function getPlaceholderConditionalRendering(): ConditionalRenderingGroup {
 }
 
 export function useIsConditionallyHidden(
-  scene: SceneObject,
-  itemIdx?: number
+  conditionalRendering: ConditionalRenderingGroup = getPlaceholderConditionalRendering()
 ): [boolean, string | undefined, ReactNode | null, boolean] {
-  let conditionalRenderingToRender = getPlaceholderConditionalRendering();
-
-  if (itemIdx !== undefined) {
-    if (
-      'repeatedConditionalRendering' in scene.state &&
-      Array.isArray(scene.state.repeatedConditionalRendering) &&
-      scene.state.repeatedConditionalRendering[itemIdx] &&
-      scene.state.repeatedConditionalRendering[itemIdx] instanceof ConditionalRenderingGroup
-    ) {
-      conditionalRenderingToRender = scene.state.repeatedConditionalRendering[itemIdx];
-    }
-  } else {
-    if (
-      'conditionalRendering' in scene.state &&
-      scene.state.conditionalRendering instanceof ConditionalRenderingGroup
-    ) {
-      conditionalRenderingToRender = scene.state.conditionalRendering;
-    }
-  }
-
-  const { result, renderHidden } = useSceneObjectState(conditionalRenderingToRender, {
+  const { result, renderHidden } = useSceneObjectState(conditionalRendering, {
     shouldActivateOrKeepAlive: true,
   });
 

--- a/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/hooks/useIsConditionallyHidden.tsx
@@ -14,11 +14,29 @@ function getPlaceholderConditionalRendering(): ConditionalRenderingGroup {
   return placeholderConditionalRendering;
 }
 
-export function useIsConditionallyHidden(scene: SceneObject): [boolean, string | undefined, ReactNode | null, boolean] {
-  const conditionalRenderingToRender =
-    'conditionalRendering' in scene.state && scene.state.conditionalRendering instanceof ConditionalRenderingGroup
-      ? scene.state.conditionalRendering
-      : getPlaceholderConditionalRendering();
+export function useIsConditionallyHidden(
+  scene: SceneObject,
+  itemIdx?: number
+): [boolean, string | undefined, ReactNode | null, boolean] {
+  let conditionalRenderingToRender = getPlaceholderConditionalRendering();
+
+  if (itemIdx !== undefined) {
+    if (
+      'repeatedConditionalRendering' in scene.state &&
+      Array.isArray(scene.state.repeatedConditionalRendering) &&
+      scene.state.repeatedConditionalRendering[itemIdx] &&
+      scene.state.repeatedConditionalRendering[itemIdx] instanceof ConditionalRenderingGroup
+    ) {
+      conditionalRenderingToRender = scene.state.repeatedConditionalRendering[itemIdx];
+    }
+  } else {
+    if (
+      'conditionalRendering' in scene.state &&
+      scene.state.conditionalRendering instanceof ConditionalRenderingGroup
+    ) {
+      conditionalRenderingToRender = scene.state.conditionalRendering;
+    }
+  }
 
   const { result, renderHidden } = useSceneObjectState(conditionalRenderingToRender, {
     shouldActivateOrKeepAlive: true,

--- a/public/app/features/dashboard-scene/conditional-rendering/object.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/object.ts
@@ -1,7 +1,7 @@
 import { capitalize, lowerCase } from 'lodash';
 
 import { t } from '@grafana/i18n';
-import { SceneObject } from '@grafana/scenes';
+import { SceneObject, VizPanel } from '@grafana/scenes';
 
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
 import { RowItem } from '../scene/layout-rows/RowItem';
@@ -50,7 +50,7 @@ export function getLowerTranslatedObjectType(type: ObjectsWithConditionalRenderi
 export function extractObjectType(object: SceneObject | undefined): ObjectsWithConditionalRendering {
   if (!object) {
     return 'element';
-  } else if (object instanceof AutoGridItem) {
+  } else if (object instanceof AutoGridItem || object instanceof VizPanel) {
     return 'panel';
   } else if (object instanceof RowItem) {
     return 'row';

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -31,6 +31,7 @@ export interface AutoGridItemState extends SceneObjectState {
   variableName?: string;
   isHidden?: boolean;
   conditionalRendering?: ConditionalRenderingGroup;
+  repeatedConditionalRendering?: ConditionalRenderingGroup[];
 }
 
 export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements DashboardLayoutItem {
@@ -130,7 +131,21 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
       }
     }
 
-    this.setState({ repeatedPanels });
+    let repeatedConditionalRendering: ConditionalRenderingGroup[] | undefined;
+
+    if (this.state.conditionalRendering) {
+      this.state.conditionalRendering.setState({ target: undefined });
+
+      repeatedConditionalRendering = repeatedPanels.reduce<ConditionalRenderingGroup[]>((acc, panel) => {
+        acc.push(this.state.conditionalRendering!.clone({ target: panel.getRef() }));
+
+        return acc;
+      }, []);
+
+      this.state.conditionalRendering.setState({ target: panelToRepeat.getRef() });
+    }
+
+    this.setState({ repeatedPanels, repeatedConditionalRendering });
     this._prevRepeatValues = values;
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItem.tsx
@@ -134,15 +134,15 @@ export class AutoGridItem extends SceneObjectBase<AutoGridItemState> implements 
     let repeatedConditionalRendering: ConditionalRenderingGroup[] | undefined;
 
     if (this.state.conditionalRendering) {
-      this.state.conditionalRendering.setState({ target: undefined });
-
       repeatedConditionalRendering = repeatedPanels.reduce<ConditionalRenderingGroup[]>((acc, panel) => {
-        acc.push(this.state.conditionalRendering!.clone({ target: panel.getRef() }));
+        const conditionalRendering = this.state.conditionalRendering!.clone();
+        conditionalRendering.setTarget(panel);
+        acc.push(conditionalRendering);
 
         return acc;
       }, []);
 
-      this.state.conditionalRendering.setState({ target: panelToRepeat.getRef() });
+      this.state.conditionalRendering.setTarget(panelToRepeat);
     }
 
     this.setState({ repeatedPanels, repeatedConditionalRendering });

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -5,6 +5,7 @@ import { GrafanaTheme2 } from '@grafana/data/';
 import { LazyLoader, SceneComponentProps, VizPanel } from '@grafana/scenes';
 import { useStyles2 } from '@grafana/ui';
 
+import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
 import { useIsConditionallyHidden } from '../../conditional-rendering/hooks/useIsConditionallyHidden';
 import { useDashboardState } from '../../utils/utils';
 import { renderMatchingSoloPanels, useSoloPanelContext } from '../SoloPanelContext';
@@ -27,21 +28,21 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
       memo(
         ({
           item,
-          itemIdx,
+          conditionalRendering,
           addDndContainer,
           isDragged,
           isDragging,
           isRepeat = false,
         }: {
           item: VizPanel;
-          itemIdx?: number;
+          conditionalRendering?: ConditionalRenderingGroup;
           addDndContainer: boolean;
           isDragged: boolean;
           isDragging: boolean;
           isRepeat?: boolean;
         }) => {
           const [isConditionallyHidden, conditionalRenderingClass, conditionalRenderingOverlay, renderHidden] =
-            useIsConditionallyHidden(model, itemIdx);
+            useIsConditionallyHidden(conditionalRendering);
 
           return isConditionallyHidden && !isEditing && !renderHidden ? null : (
             <div
@@ -96,11 +97,18 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
 
   return (
     <>
-      <Wrapper item={body} addDndContainer={true} key={body.state.key!} isDragged={isDragged} isDragging={isDragging} />
+      <Wrapper
+        item={body}
+        conditionalRendering={model.state.conditionalRendering}
+        addDndContainer={true}
+        key={body.state.key!}
+        isDragged={isDragged}
+        isDragging={isDragging}
+      />
       {repeatedPanels.map((item, idx) => (
         <Wrapper
           item={item}
-          itemIdx={idx}
+          conditionalRendering={model.state.repeatedConditionalRendering?.[idx]}
           addDndContainer={false}
           key={item.state.key!}
           isDragged={isDragged}

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -20,8 +20,9 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
   const { layout, collapse: isCollapsed, fillScreen, hideHeader: isHeaderHidden, isDropTarget, key } = model.useState();
   const isClone = isRepeatCloneOrChildOf(model);
   const { isEditing } = useDashboardState(model);
-  const [isConditionallyHidden, conditionalRenderingClass, conditionalRenderingOverlay] =
-    useIsConditionallyHidden(model);
+  const [isConditionallyHidden, conditionalRenderingClass, conditionalRenderingOverlay] = useIsConditionallyHidden(
+    model.state.conditionalRendering
+  );
   const { isSelected, onSelect, isSelectable } = useElementSelection(key);
   const title = useInterpolatedTitle(model);
   const { rows } = model.getParentLayout().useState();

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRepeater.tsx
@@ -112,7 +112,10 @@ export function performRowRepeats(variable: MultiValueVariable, row: RowItem, co
     });
 
     if (!isSourceRow) {
+      rowClone.state.conditionalRendering?.setTarget(rowClone);
       clonedRows.push(rowClone);
+    } else {
+      row.state.conditionalRendering?.setTarget(row);
     }
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -292,6 +292,8 @@ export class RowsLayoutManager extends SceneObjectBase<RowsLayoutManagerState> i
 
         const conditionalRendering = tab.state.conditionalRendering;
         conditionalRendering?.clearParent();
+        // We need to clear the target since we don't want to point the original tab anymore (if it was set)
+        conditionalRendering?.setTarget(undefined);
 
         rows.push(
           new RowItem({

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -29,7 +29,7 @@ export function TabItemRenderer({ model }: SceneComponentProps<TabItem>) {
   const href = textUtil.sanitize(locationUtil.getUrlForPartial(location, { [urlKey]: mySlug }));
   const styles = useStyles2(getStyles);
   const pointerDistance = usePointerDistance();
-  const [isConditionallyHidden] = useIsConditionallyHidden(model);
+  const [isConditionallyHidden] = useIsConditionallyHidden(model.state.conditionalRendering);
   const isClone = isRepeatCloneOrChildOf(model);
   const soloPanelContext = useSoloPanelContext();
 
@@ -116,7 +116,9 @@ interface TabItemLayoutRendererProps {
 export function TabItemLayoutRenderer({ tab, isEditing }: TabItemLayoutRendererProps) {
   const { layout, key } = tab.useState();
   const styles = useStyles2(getStyles);
-  const [_, conditionalRenderingClass, conditionalRenderingOverlay] = useIsConditionallyHidden(tab);
+  const [_, conditionalRenderingClass, conditionalRenderingOverlay] = useIsConditionallyHidden(
+    tab.state.conditionalRendering
+  );
 
   return (
     <TabContent

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRepeater.tsx
@@ -167,7 +167,10 @@ export function createTabRepeats({
     });
 
     if (!isSourceTab) {
+      tabClone.state.conditionalRendering?.setTarget(tabClone);
       repeats.push(tabClone);
+    } else {
+      tab.state.conditionalRendering?.setTarget(tab);
     }
   }
   return repeats;

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -417,6 +417,8 @@ export class TabsLayoutManager extends SceneObjectBase<TabsLayoutManagerState> i
 
         const conditionalRendering = row.state.conditionalRendering;
         conditionalRendering?.clearParent();
+        // We need to clear the target since we don't want to point the original row anymore (if it was set)
+        conditionalRendering?.setTarget(undefined);
 
         tabs.push(
           new TabItem({


### PR DESCRIPTION
**What is this feature?**

A fix to prevent all repeated items to be hidden/shown when only the first panel should be hidden/shown.

This happens because, before this PR, the conditional rendering was evaluated at the container level (`AutoGridItem`) and its single boolean result was applied to all repeats. So if the source panel hid, all repeated panels hid.

This PR makes sure that the conditional rendering is evaluated for each panel. This is done by cloning the `ConditionalRenderingGroup` and making it target-aware so that each condition evaluates against the specific panel. The group then combines the results per target, and the renderer reads the per‑panel visibility.

The fix is also applied to repeated tabs and rows.

**Why do we need this feature?**

Bugfix

**Who is this feature for?**

All dynamic dashboard users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/108340

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
