### PR TITLE
[release-12.3.1] PanelChrome: Wrap in a div to allow for hover headers

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { CSSProperties, ReactElement, ReactNode, useId, useState } from 'react';
+import { CSSProperties, PropsWithChildren, ReactElement, ReactNode, useId, useState } from 'react';
 import * as React from 'react';
 import { useMeasure, useToggle } from 'react-use';
 
@@ -109,6 +109,11 @@ interface HoverHeader {
   hoverHeader?: boolean;
   hoverHeaderOffset?: number;
 }
+
+const MaybeWrap = ({ children }: PropsWithChildren<{}>) => {
+  const styles = useStyles2(getStyles);
+  return getFeatureToggle('preventPanelChromeOverflow') ? <div className={styles.container}>{children}</div> : children;
+};
 
 /**
  * @internal
@@ -330,102 +335,104 @@ export function PanelChrome({
   );
 
   return (
-    // tabIndex={0} is needed for keyboard accessibility in the plot area
-    <section
-      className={cx(
-        styles.container,
-        isPanelTransparent && styles.transparentContainer,
-        isSelected && 'dashboard-selected-element',
-        !isSelected && isSelectable && selectableHighlight && 'dashboard-selectable-element'
-      )}
-      style={containerStyles}
-      aria-labelledby={!!title ? panelTitleId : undefined}
-      data-testid={testid}
-      tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
-      onFocus={onFocus}
-      onMouseMove={onMouseMove}
-      onMouseEnter={onMouseEnter}
-      ref={ref}
-    >
-      <div className={styles.loadingBarContainer}>
-        {loadingState === LoadingState.Loading ? (
-          <LoadingBar
-            width={loadingBarWidth}
-            ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-loading', 'Panel loading bar')}
-          />
-        ) : null}
-      </div>
+    <MaybeWrap>
+      {/* tabIndex={0} is needed for keyboard accessibility in the plot area */}
+      <section
+        className={cx(
+          styles.panel,
+          isPanelTransparent && styles.panelTransparent,
+          isSelected && 'dashboard-selected-element',
+          !isSelected && isSelectable && selectableHighlight && 'dashboard-selectable-element'
+        )}
+        style={containerStyles}
+        aria-labelledby={!!title ? panelTitleId : undefined}
+        data-testid={testid}
+        tabIndex={0} // eslint-disable-line jsx-a11y/no-noninteractive-tabindex
+        onFocus={onFocus}
+        onMouseMove={onMouseMove}
+        onMouseEnter={onMouseEnter}
+        ref={ref}
+      >
+        <div className={styles.loadingBarContainer}>
+          {loadingState === LoadingState.Loading ? (
+            <LoadingBar
+              width={loadingBarWidth}
+              ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-loading', 'Panel loading bar')}
+            />
+          ) : null}
+        </div>
 
-      {hoverHeader && (
-        <>
-          <HoverWidget
-            menu={menu}
-            title={typeof title === 'string' ? title : undefined}
-            offset={hoverHeaderOffset}
-            dragClass={dragClass}
-            onOpenMenu={onOpenMenu}
-          >
-            {headerContent}
-          </HoverWidget>
-
-          {statusMessage && (
-            <div className={styles.errorContainerFloating}>
-              <PanelStatus
-                message={statusMessage}
-                onClick={statusMessageOnClick}
-                ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-status', 'Panel status')}
-              />
-            </div>
-          )}
-        </>
-      )}
-
-      {hasHeader && (
-        <div
-          className={cx(styles.headerContainer, dragClass)}
-          style={headerStyles}
-          data-testid={selectors.components.Panels.Panel.headerContainer}
-          onPointerDown={onPointerDown}
-          onMouseEnter={isSelectable ? onHeaderEnter : undefined}
-          onMouseLeave={isSelectable ? onHeaderLeave : undefined}
-          onPointerUp={onPointerUp}
-        >
-          {statusMessage && (
-            <div className={dragClassCancel}>
-              <PanelStatus
-                message={statusMessage}
-                onClick={statusMessageOnClick}
-                ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-status', 'Panel status')}
-              />
-            </div>
-          )}
-
-          {headerContent}
-
-          {menu && (
-            <PanelMenu
+        {hoverHeader && (
+          <>
+            <HoverWidget
               menu={menu}
               title={typeof title === 'string' ? title : undefined}
-              placement="bottom-end"
-              menuButtonClass={cx(styles.menuItem, dragClassCancel, showOnHoverClass)}
+              offset={hoverHeaderOffset}
+              dragClass={dragClass}
               onOpenMenu={onOpenMenu}
-            />
-          )}
-        </div>
-      )}
+            >
+              {headerContent}
+            </HoverWidget>
 
-      {!collapsed && (
-        <div
-          id={panelContentId}
-          data-testid={selectors.components.Panels.Panel.content}
-          className={cx(styles.content, height === undefined && styles.containNone)}
-          style={contentStyle}
-          onPointerDown={onContentPointerDown}
-        >
-          {typeof children === 'function' ? children(innerWidth, innerHeight) : children}
-        </div>
-      )}
-    </section>
+            {statusMessage && (
+              <div className={styles.errorContainerFloating}>
+                <PanelStatus
+                  message={statusMessage}
+                  onClick={statusMessageOnClick}
+                  ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-status', 'Panel status')}
+                />
+              </div>
+            )}
+          </>
+        )}
+
+        {hasHeader && (
+          <div
+            className={cx(styles.headerContainer, dragClass)}
+            style={headerStyles}
+            data-testid={selectors.components.Panels.Panel.headerContainer}
+            onPointerDown={onPointerDown}
+            onMouseEnter={isSelectable ? onHeaderEnter : undefined}
+            onMouseLeave={isSelectable ? onHeaderLeave : undefined}
+            onPointerUp={onPointerUp}
+          >
+            {statusMessage && (
+              <div className={dragClassCancel}>
+                <PanelStatus
+                  message={statusMessage}
+                  onClick={statusMessageOnClick}
+                  ariaLabel={t('grafana-ui.panel-chrome.ariaLabel-panel-status', 'Panel status')}
+                />
+              </div>
+            )}
+
+            {headerContent}
+
+            {menu && (
+              <PanelMenu
+                menu={menu}
+                title={typeof title === 'string' ? title : undefined}
+                placement="bottom-end"
+                menuButtonClass={cx(styles.menuItem, dragClassCancel, showOnHoverClass)}
+                onOpenMenu={onOpenMenu}
+              />
+            )}
+          </div>
+        )}
+
+        {!collapsed && (
+          <div
+            id={panelContentId}
+            data-testid={selectors.components.Panels.Panel.content}
+            className={cx(styles.content, height === undefined && styles.containNone)}
+            style={contentStyle}
+            onPointerDown={onContentPointerDown}
+          >
+            {typeof children === 'function' ? children(innerWidth, innerHeight) : children}
+          </div>
+        )}
+      </section>
+    </MaybeWrap>
   );
 }
 
@@ -481,10 +488,13 @@ const getStyles = (theme: GrafanaTheme2) => {
 
   return {
     container: css({
+      position: 'relative',
+    }),
+    panel: css({
       label: 'panel-container',
       backgroundColor: background,
       border: `1px solid ${borderColor}`,
-      position: 'relative',
+      position: getFeatureToggle('preventPanelChromeOverflow') ? 'unset' : 'relative',
       borderRadius: theme.shape.radius.default,
       height: '100%',
       display: 'flex',
@@ -521,7 +531,7 @@ const getStyles = (theme: GrafanaTheme2) => {
         },
       },
     }),
-    transparentContainer: css({
+    panelTransparent: css({
       label: 'panel-transparent-container',
       backgroundColor: 'transparent',
       border: '1px solid transparent',


### PR DESCRIPTION
Backport 3f008acde277a63860866bd8ddde0c18c426a8cd from #114037

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- with the introduction of `preventPanelChromeOverflow`, hover headers are being clipped outside of the panel container
- originally thought we could position these with `position: fixed;`, but the use of `transforms` by e.g. react-grid-layout creates a new containing block (thanks claude! 🤖)
- similarly, portalling creates a different problem where the tab order is then incorrect
- settled on this change, which i _think_ is safe:
  - wrap the panel in a new `<div>` with `position: relative;`. this is outside of `overflow: hidden;`
  - remove `position: relative` from the panel
  - any floating elements are now positioned with respect to the outer div, outside of `overflow: hidden;`
  - all of this is gated behind the `preventPanelChromeOverflow` toggle for ease of turning off
- will deploy an ephemeral instance with the toggle enabled so we can poke around 🔧 
 
**Why do we need this feature?**

- so hover headers can exist outside of the panel chrome 

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

hide whitespace makes it easier to review 👍 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
