### PR TITLE
Chore: Remove references to `editors_can_admin`

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -581,10 +581,6 @@ external_manage_info =
 # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
 viewers_can_edit = false
 
-# Deprecated: Assign your editors to admins.
-# Editors can administrate dashboard, folders and teams they create
-editors_can_admin = false
-
 # The duration in time a user invitation remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 24h (24 hours). The minimum supported duration is 15m (15 minutes).
 user_invite_max_lifetime_duration = 24h
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -568,10 +568,6 @@
 # Viewers can edit/inspect dashboard settings in the browser. But not save the dashboard.
 ;viewers_can_edit = false
 
-# Deprecated: Assign your editors to admins.
-# Editors can administrate dashboard, folders and teams they create
-;editors_can_admin = false
-
 # The duration in time a user invitation remains valid before expiring. This setting should be expressed as a duration. Examples: 6h (hours), 2d (days), 1w (week). Default is 24h (24 hours). The minimum supported duration is 15m (15 minutes).
 ;user_invite_max_lifetime_duration = 24h
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -987,15 +987,6 @@ This option is deprecated - assign your viewers as editors, if you are using RBA
 
 Viewers can access and use [Explore](../../explore/) and perform temporary edits on panels in dashboards they have access to. They cannot save their changes. Default is `false`.
 
-#### `editors_can_admin`
-
-{{< admonition type="note" >}}
-This option is deprecated - assign your editors as admins, if you are using RBAC assign the team creator role to your users.
-{{< /admonition >}}
-
-Editors can administrate dashboards, folders and teams they create.
-Default is `false`.
-
 #### `user_invite_max_lifetime_duration`
 
 The duration in time a user invitation remains valid before expiring.


### PR DESCRIPTION
**What is this feature?**

This config option has been deprecated for a while now (see the announcement [here](https://grafana.com/whats-new/2025-05-04-removal-of-editors_can_admin-configuration/)), and has no effect. So I think it's time to remove references to it, otherwise it's just confusing.
