### PR TITLE
chore(testid): added missing testid to add datasource button

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -85,6 +85,9 @@ export const versionedPages = {
     dataSources: {
       [MIN_GRAFANA_VERSION]: (dataSourceName: string) => `Data source list item ${dataSourceName}`,
     },
+    dataSourceAddButton: {
+      '12.4.0': 'data-testid data-source-add-button',
+    },
   },
   EditDataSource: {
     url: {

--- a/public/app/features/datasources/components/DataSourceAddButton.tsx
+++ b/public/app/features/datasources/components/DataSourceAddButton.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 
+import { Pages } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { LinkButton } from '@grafana/ui';
@@ -7,7 +8,6 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { ROUTES } from 'app/features/connections/constants';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { Pages } from '@grafana/e2e-selectors';
 import { trackAddNewDsClicked } from '../tracking';
 
 export function DataSourceAddButton(): JSX.Element | null {

--- a/public/app/features/datasources/components/DataSourceAddButton.tsx
+++ b/public/app/features/datasources/components/DataSourceAddButton.tsx
@@ -16,7 +16,12 @@ export function DataSourceAddButton(): JSX.Element | null {
   }, []);
 
   return canCreateDataSource ? (
-    <LinkButton icon="plus" href={config.appSubUrl + ROUTES.DataSourcesNew} onClick={handleClick}>
+    <LinkButton
+      icon="plus"
+      href={config.appSubUrl + ROUTES.DataSourcesNew}
+      onClick={handleClick}
+      data-testid="data-source-add-button"
+    >
       <Trans i18nKey="data-sources.datasource-add-button.label">Add new data source</Trans>
     </LinkButton>
   ) : null;

--- a/public/app/features/datasources/components/DataSourceAddButton.tsx
+++ b/public/app/features/datasources/components/DataSourceAddButton.tsx
@@ -7,6 +7,7 @@ import { contextSrv } from 'app/core/services/context_srv';
 import { ROUTES } from 'app/features/connections/constants';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { Pages } from '@grafana/e2e-selectors';
 import { trackAddNewDsClicked } from '../tracking';
 
 export function DataSourceAddButton(): JSX.Element | null {
@@ -20,7 +21,7 @@ export function DataSourceAddButton(): JSX.Element | null {
       icon="plus"
       href={config.appSubUrl + ROUTES.DataSourcesNew}
       onClick={handleClick}
-      data-testid="data-source-add-button"
+      data-testid={Pages.DataSources.dataSourceAddButton}
     >
       <Trans i18nKey="data-sources.datasource-add-button.label">Add new data source</Trans>
     </LinkButton>


### PR DESCRIPTION
Add the missing testID to Add new datasource button in Grafana. Provides a better anchor for Pathfinder to use. 
