### PR TITLE
Auth: Fix token refresh when using Entra ID OAuth with workload_identity (federated credentials)

### DIFF
--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -17,6 +17,7 @@ import (
 	"github.com/google/uuid"
 	"golang.org/x/oauth2"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/login/social"
@@ -56,9 +57,10 @@ var _ ssosettings.Reloadable = (*SocialAzureAD)(nil)
 
 type SocialAzureAD struct {
 	*SocialBase
-	cache                remotecache.CacheStorage
-	allowedOrganizations []string
-	forceUseGraphAPI     bool
+	cache                        remotecache.CacheStorage
+	allowedOrganizations         []string
+	forceUseGraphAPI             bool
+	managedIdentityTokenProvider func(context.Context, *social.OAuthInfo) (string, error)
 }
 
 type azureClaims struct {
@@ -100,10 +102,11 @@ func NewAzureADProvider(info *social.OAuthInfo, cfg *setting.Cfg, orgRoleMapper 
 	}
 
 	provider := &SocialAzureAD{
-		SocialBase:           s,
-		cache:                cache,
-		allowedOrganizations: allowedOrganizations,
-		forceUseGraphAPI:     MustBool(info.Extra[forceUseGraphAPIKey], ExtraAzureADSettingKeys[forceUseGraphAPIKey].DefaultValue.(bool)),
+		SocialBase:                   s,
+		cache:                        cache,
+		allowedOrganizations:         allowedOrganizations,
+		forceUseGraphAPI:             MustBool(info.Extra[forceUseGraphAPIKey], ExtraAzureADSettingKeys[forceUseGraphAPIKey].DefaultValue.(bool)),
+		managedIdentityTokenProvider: getManagedIdentityToken,
 	}
 
 	if info.UseRefreshToken {
@@ -215,19 +218,118 @@ func (s *SocialAzureAD) Exchange(ctx context.Context, code string, authOptions .
 	return s.Config.Exchange(ctx, code, authOptions...)
 }
 
+func (s *SocialAzureAD) TokenSource(ctx context.Context, t *oauth2.Token) oauth2.TokenSource {
+	s.reloadMutex.RLock()
+	defer s.reloadMutex.RUnlock()
+
+	if s.info.ClientAuthentication == social.ManagedIdentity {
+		return &AzureADTokenSource{
+			ctx:      ctx,
+			conf:     s.Config,
+			token:    t,
+			provider: s,
+		}
+	}
+
+	return s.Config.TokenSource(ctx, t)
+}
+
+type AzureADTokenSource struct {
+	ctx      context.Context
+	conf     *oauth2.Config
+	token    *oauth2.Token
+	provider *SocialAzureAD
+}
+
+func (s *AzureADTokenSource) Token() (*oauth2.Token, error) {
+	log := logging.FromContext(s.ctx)
+	log.Debug("Fetching Token from AzureAD Token Source")
+	if s.token.Valid() {
+		return s.token, nil
+	}
+
+	clientAssertion, err := s.provider.managedIdentityCallback(s.ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get client assertion: %w", err)
+	}
+
+	log.Debug("Using Client assertion")
+	v := url.Values{}
+	v.Set("grant_type", "refresh_token")
+	v.Set("refresh_token", s.token.RefreshToken)
+	v.Set("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-bearer")
+	v.Set("client_assertion", clientAssertion)
+
+	// We also need to pass client_id if it's not implied by client assertion (it usually is, but good to be safe or check spec).
+	// Azure AD with Client Assertion: https://learn.microsoft.com/en-us/entra/identity-platform/v2-oauth2-client-creds-grant-flow#second-case-access-token-request-with-a-certificate
+	// It says: client_id is required.
+	v.Set("client_id", s.conf.ClientID)
+
+	return s.fetchToken(v)
+}
+
+func (s *AzureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error) {
+	log := logging.FromContext(s.ctx)
+	req, err := http.NewRequestWithContext(s.ctx, "POST", s.conf.Endpoint.TokenURL, strings.NewReader(params.Encode()))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	// Correct way to get HTTP client from context
+	httpClient, ok := s.ctx.Value(oauth2.HTTPClient).(*http.Client)
+	if !ok {
+		httpClient = http.DefaultClient
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	log.Debug("AzureADToken fetchToken upstream response size: %d, response status: %d", resp.ContentLength, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return nil, fmt.Errorf("oauth2: cannot fetch token: %v\nResponse: %s", resp.Status, body)
+	}
+
+	var rawResponse interface{}
+	if err := json.Unmarshal(body, &rawResponse); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal raw response body: %w", err)
+	}
+
+	var token *oauth2.Token
+	if err := json.Unmarshal(body, &token); err != nil {
+		return nil, fmt.Errorf("unable to unmarshal token response body: %w", err)
+	}
+
+	log.Debug("AzureADToken fetchToken completed, expires at %s", token.Expiry.String())
+	return token.WithExtra(rawResponse), nil
+}
+
 // ManagedIdentityCallback retrieves a token using the managed identity credential of the Azure service.
 func (s *SocialAzureAD) managedIdentityCallback(ctx context.Context) (string, error) {
+	return s.managedIdentityTokenProvider(ctx, s.info)
+}
+
+func getManagedIdentityToken(ctx context.Context, info *social.OAuthInfo) (string, error) {
 	// Validate required fields for Managed Identity authentication
-	if s.info.ManagedIdentityClientID == "" {
+	if info.ManagedIdentityClientID == "" {
 		return "", fmt.Errorf("ManagedIdentityClientID is required for Managed Identity authentication")
 	}
-	if s.info.FederatedCredentialAudience == "" {
+	if info.FederatedCredentialAudience == "" {
 		return "", fmt.Errorf("FederatedCredentialAudience is required for Managed Identity authentication")
 	}
 
 	// Prepare Managed Identity Credential
 	mic, err := azidentity.NewManagedIdentityCredential(&azidentity.ManagedIdentityCredentialOptions{
-		ID: azidentity.ClientID(s.info.ManagedIdentityClientID),
+		ID: azidentity.ClientID(info.ManagedIdentityClientID),
 	})
 	if err != nil {
 		return "", fmt.Errorf("error constructing managed identity credential: %w", err)
@@ -235,7 +337,7 @@ func (s *SocialAzureAD) managedIdentityCallback(ctx context.Context) (string, er
 
 	// Request token and return
 	tk, err := mic.GetToken(ctx, policy.TokenRequestOptions{
-		Scopes: []string{fmt.Sprintf("%s/.default", s.info.FederatedCredentialAudience)},
+		Scopes: []string{fmt.Sprintf("%s/.default", info.FederatedCredentialAudience)},
 	})
 	if err != nil {
 		return "", fmt.Errorf("error getting managed identity token: %w", err)

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -296,7 +296,7 @@ func (s *azureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		s.log.Warn("oauth2: cannot fetch token", "status", resp.Status, "body", body)
+		s.log.Debug("oauth2: cannot fetch token", "status", resp.Status, "body", body)
 		return nil, fmt.Errorf("oauth2: cannot fetch token: %v", resp.Status)
 	}
 

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -312,10 +312,10 @@ func (s *AzureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error
 func (s *SocialAzureAD) managedIdentityCallback(ctx context.Context) (string, error) {
 	// Validate required fields for Managed Identity authentication
 	if s.info.ManagedIdentityClientID == "" {
-		return "", fmt.Errorf("ManagedIdentityClientID is required for Managed Identity or Workoload Identity authentication")
+		return "", fmt.Errorf("ManagedIdentityClientID is required for Managed Identity or Workload Identity authentication")
 	}
 	if s.info.FederatedCredentialAudience == "" {
-		return "", fmt.Errorf("FederatedCredentialAudience is required for Managed Identity or Workoload Identity authentication")
+		return "", fmt.Errorf("FederatedCredentialAudience is required for Managed Identity or Workload Identity authentication")
 	}
 
 	// Prepare Managed Identity Credential

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -314,7 +314,7 @@ func (s *azureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error
 		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
 	}
 
-	s.log.Debug("AzureADToken fetchToken completed", "access_token", token.AccessToken, "refresh_token", token.RefreshToken, "expiry", token.Expiry)
+	s.log.Debug("AzureADToken fetchToken completed", "expiry", token.Expiry)
 	return token.WithExtra(rawResponse), nil
 }
 

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -249,7 +249,7 @@ func (s *AzureADTokenSource) Token() (*oauth2.Token, error) {
 		return s.token, nil
 	}
 
-	// exchange auth code to a valid token
+	// refresh the expired token using the refresh token
 	federatedToken, err := os.ReadFile(s.workloadIdentityTokenFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read workload identity token file: %w", err)

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -309,7 +310,11 @@ func (s *azureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error
 		return nil, fmt.Errorf("unable to unmarshal token response body: %w", err)
 	}
 
-	s.log.Debug("AzureADToken fetchToken completed")
+	if token.ExpiresIn > 0 {
+		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+
+	s.log.Debug("AzureADToken fetchToken completed", "access_token", token.AccessToken, "refresh_token", token.RefreshToken, "expiry", token.Expiry)
 	return token.WithExtra(rawResponse), nil
 }
 

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -249,6 +249,11 @@ func (s *AzureADTokenSource) Token() (*oauth2.Token, error) {
 		return s.token, nil
 	}
 
+	if s.token.RefreshToken == "" {
+		log.Warn("AzureADToken fetchToken failed: no refresh token available")
+		return nil, fmt.Errorf("no refresh token available to refresh the access token")
+	}
+
 	// refresh the expired token using the refresh token
 	federatedToken, err := os.ReadFile(s.workloadIdentityTokenFile)
 	if err != nil {

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -17,6 +17,7 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
+	"golang.org/x/oauth2"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
@@ -28,7 +29,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"golang.org/x/oauth2"
 )
 
 const (

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -17,7 +17,6 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
-	"golang.org/x/oauth2"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
@@ -29,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"golang.org/x/oauth2"
 )
 
 const (
@@ -288,7 +288,11 @@ func (s *azureADTokenSource) fetchToken(params url.Values) (*oauth2.Token, error
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.log.Error("Failed to close response body", "error", err)
+		}
+	}()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
-	"golang.org/x/oauth2"
 )
 
 const (

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -17,6 +17,7 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
+	"golang.org/x/oauth2"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"

--- a/pkg/login/social/connectors/azuread_oauth.go
+++ b/pkg/login/social/connectors/azuread_oauth.go
@@ -17,7 +17,6 @@ import (
 	jose "github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
 	"github.com/google/uuid"
-	"golang.org/x/oauth2"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
@@ -29,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ssosettings/validation"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
+	"golang.org/x/oauth2"
 )
 
 const (

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1502,10 +1502,11 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 		s.Endpoint.TokenURL = server.URL
 
 		// Create a token source with an expired token
+		now := time.Now()
 		token := &oauth2.Token{
 			AccessToken:  "old-access-token",
 			RefreshToken: "old-refresh-token",
-			Expiry:       time.Now().Add(-time.Hour),
+			Expiry:       now.Add(-time.Hour),
 		}
 
 		// Create a context with the mock client
@@ -1517,7 +1518,7 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", newToken.AccessToken)
 		assert.Equal(t, "new-refresh-token", newToken.RefreshToken)
-		assert.EqualValues(t, 3600, newToken.ExpiresIn)
+		assert.EqualValues(t, now.Add(time.Hour), newToken.Expiry)
 	})
 
 	t.Run("error when workload token file does not exist", func(t *testing.T) {

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/go-jose/go-jose/v4"
 	"github.com/go-jose/go-jose/v4/jwt"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/oauth2"
 
@@ -1492,7 +1493,7 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 			"access_token":  "new-access-token",
 			"token_type":    "Bearer",
 			"refresh_token": "new-refresh-token",
-			"expires_in":    time.Now().Add(time.Hour).Unix(),
+			"expires_in":    3600,
 		})
 	}))
 	defer server.Close()
@@ -1514,6 +1515,7 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 	ts := s.TokenSource(ctx, token)
 	newToken, err := ts.Token()
 	require.NoError(t, err)
-	require.Equal(t, "new-access-token", newToken.AccessToken)
-	require.Equal(t, "new-refresh-token", newToken.RefreshToken)
+	assert.Equal(t, "new-access-token", newToken.AccessToken)
+	assert.Equal(t, "new-refresh-token", newToken.RefreshToken)
+	assert.EqualValues(t, 3600, newToken.ExpiresIn)
 }

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1454,9 +1454,9 @@ func TestSocialAzureAD_Reload_ExtraFields(t *testing.T) {
 
 func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 	info := &social.OAuthInfo{
-		ClientId:                    "client-id",
-		ClientAuthentication:        social.WorkloadIdentity,
-		ManagedIdentityClientID:     "mi-client-id",
+		ClientId:             "some-client-id",
+		ClientAuthentication: social.WorkloadIdentity,
+		//	ManagedIdentityClientID:     "mi-client-id",
 		FederatedCredentialAudience: "api://AzureADTokenExchange",
 		TokenUrl:                    "https://login.microsoftonline.com/token",
 	}
@@ -1482,6 +1482,9 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 		}
 		if r.FormValue("grant_type") != "refresh_token" {
 			t.Errorf("expected grant_type to be 'refresh_token', got '%s'", r.FormValue("grant_type"))
+		}
+		if r.FormValue("client_id") != "some-client-id" {
+			t.Errorf("expected client_id to be 'client-id', got '%s'", r.FormValue("client_id"))
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1518,7 +1518,7 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", newToken.AccessToken)
 		assert.Equal(t, "new-refresh-token", newToken.RefreshToken)
-		assert.EqualValues(t, now.Add(time.Hour), newToken.Expiry)
+		assert.WithinDuration(t, now.Add(time.Hour), newToken.Expiry, time.Second)
 	})
 
 	t.Run("error when workload token file does not exist", func(t *testing.T) {

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1455,67 +1455,166 @@ func TestSocialAzureAD_Reload_ExtraFields(t *testing.T) {
 
 func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 	info := &social.OAuthInfo{
-		ClientId:             "some-client-id",
-		ClientAuthentication: social.WorkloadIdentity,
-		//	ManagedIdentityClientID:     "mi-client-id",
+		ClientId:                    "some-client-id",
+		ClientAuthentication:        social.WorkloadIdentity,
 		FederatedCredentialAudience: "api://AzureADTokenExchange",
 		TokenUrl:                    "https://login.microsoftonline.com/token",
 	}
 
-	workloadFile := path.Join(t.TempDir(), "workload.json")
-	err := os.WriteFile(workloadFile, []byte("mock-client-assertion"), 0600)
-	require.NoError(t, err)
+	t.Run("success", func(t *testing.T) {
+		workloadFile := path.Join(t.TempDir(), "workload.json")
+		err := os.WriteFile(workloadFile, []byte("mock-client-assertion"), 0600)
+		require.NoError(t, err)
 
-	s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
-	s.info.WorkloadIdentityTokenFile = workloadFile
+		s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
+		s.info.WorkloadIdentityTokenFile = workloadFile
 
-	// Mock the token endpoint
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := r.ParseForm(); err != nil {
-			t.Error(err)
+		// Mock the token endpoint
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := r.ParseForm(); err != nil {
+				t.Error(err)
+			}
+			// Verify that client_assertion is present in the request
+			if r.FormValue("client_assertion") != "mock-client-assertion" {
+				t.Errorf("expected client_assertion to be 'mock-client-assertion', got '%s'", r.FormValue("client_assertion"))
+			}
+			if r.FormValue("client_assertion_type") != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+				t.Errorf("expected client_assertion_type to be 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', got '%s'", r.FormValue("client_assertion_type"))
+			}
+			if r.FormValue("grant_type") != "refresh_token" {
+				t.Errorf("expected grant_type to be 'refresh_token', got '%s'", r.FormValue("grant_type"))
+			}
+			if r.FormValue("client_id") != "some-client-id" {
+				t.Errorf("expected client_id to be 'client-id', got '%s'", r.FormValue("client_id"))
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"access_token":  "new-access-token",
+				"token_type":    "Bearer",
+				"refresh_token": "new-refresh-token",
+				"expires_in":    3600,
+			})
+		}))
+		defer server.Close()
+
+		// Update TokenURL to point to the mock server
+		s.Endpoint.TokenURL = server.URL
+
+		// Create a token source with an expired token
+		token := &oauth2.Token{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			Expiry:       time.Now().Add(-time.Hour),
 		}
-		// Verify that client_assertion is present in the request
-		if r.FormValue("client_assertion") != "mock-client-assertion" {
-			t.Errorf("expected client_assertion to be 'mock-client-assertion', got '%s'", r.FormValue("client_assertion"))
+
+		// Create a context with the mock client
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+
+		// Get a new token (this should trigger a refresh)
+		ts := s.TokenSource(ctx, token)
+		newToken, err := ts.Token()
+		require.NoError(t, err)
+		assert.Equal(t, "new-access-token", newToken.AccessToken)
+		assert.Equal(t, "new-refresh-token", newToken.RefreshToken)
+		assert.EqualValues(t, 3600, newToken.ExpiresIn)
+	})
+
+	t.Run("error when workload token file does not exist", func(t *testing.T) {
+		s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
+		s.info.WorkloadIdentityTokenFile = "/non/existent/file"
+
+		token := &oauth2.Token{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			Expiry:       time.Now().Add(-time.Hour),
 		}
-		if r.FormValue("client_assertion_type") != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
-			t.Errorf("expected client_assertion_type to be 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer', got '%s'", r.FormValue("client_assertion_type"))
+
+		ts := s.TokenSource(context.Background(), token)
+		_, err := ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "failed to read workload identity token file")
+	})
+
+	t.Run("error when token endpoint returns error", func(t *testing.T) {
+		workloadFile := path.Join(t.TempDir(), "workload.json")
+		err := os.WriteFile(workloadFile, []byte("mock-client-assertion"), 0600)
+		require.NoError(t, err)
+
+		s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
+		s.info.WorkloadIdentityTokenFile = workloadFile
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+		s.Endpoint.TokenURL = server.URL
+
+		token := &oauth2.Token{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			Expiry:       time.Now().Add(-time.Hour),
 		}
-		if r.FormValue("grant_type") != "refresh_token" {
-			t.Errorf("expected grant_type to be 'refresh_token', got '%s'", r.FormValue("grant_type"))
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+
+		ts := s.TokenSource(ctx, token)
+		_, err = ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "oauth2: cannot fetch token: 500 Internal Server Error")
+	})
+
+	t.Run("error when missing refresh token", func(t *testing.T) {
+		workloadFile := path.Join(t.TempDir(), "workload.json")
+		err := os.WriteFile(workloadFile, []byte("mock-client-assertion"), 0600)
+		require.NoError(t, err)
+
+		s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
+		s.info.WorkloadIdentityTokenFile = workloadFile
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadRequest)
+		}))
+		defer server.Close()
+		s.Endpoint.TokenURL = server.URL
+
+		token := &oauth2.Token{
+			AccessToken: "old-access-token",
+			// No RefreshToken
+			Expiry: time.Now().Add(-time.Hour),
 		}
-		if r.FormValue("client_id") != "some-client-id" {
-			t.Errorf("expected client_id to be 'client-id', got '%s'", r.FormValue("client_id"))
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
+
+		ts := s.TokenSource(ctx, token)
+		_, err = ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "oauth2: cannot fetch token: 400 Bad Request")
+	})
+
+	t.Run("error when invalid token response", func(t *testing.T) {
+		workloadFile := path.Join(t.TempDir(), "workload.json")
+		err := os.WriteFile(workloadFile, []byte("mock-client-assertion"), 0600)
+		require.NoError(t, err)
+
+		s := NewAzureADProvider(info, setting.NewCfg(), nil, ssosettingstests.NewFakeService(), featuremgmt.WithFeatures(), remotecache.FakeCacheStorage{})
+		s.info.WorkloadIdentityTokenFile = workloadFile
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte("invalid-json"))
+		}))
+		defer server.Close()
+		s.Endpoint.TokenURL = server.URL
+
+		token := &oauth2.Token{
+			AccessToken:  "old-access-token",
+			RefreshToken: "old-refresh-token",
+			Expiry:       time.Now().Add(-time.Hour),
 		}
+		ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
 
-		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"access_token":  "new-access-token",
-			"token_type":    "Bearer",
-			"refresh_token": "new-refresh-token",
-			"expires_in":    3600,
-		})
-	}))
-	defer server.Close()
-
-	// Update TokenURL to point to the mock server
-	s.Endpoint.TokenURL = server.URL
-
-	// Create a token source with an expired token
-	token := &oauth2.Token{
-		AccessToken:  "old-access-token",
-		RefreshToken: "old-refresh-token",
-		Expiry:       time.Now().Add(-time.Hour),
-	}
-
-	// Create a context with the mock client
-	ctx := context.WithValue(context.Background(), oauth2.HTTPClient, server.Client())
-
-	// Get a new token (this should trigger a refresh)
-	ts := s.TokenSource(ctx, token)
-	newToken, err := ts.Token()
-	require.NoError(t, err)
-	assert.Equal(t, "new-access-token", newToken.AccessToken)
-	assert.Equal(t, "new-refresh-token", newToken.RefreshToken)
-	assert.EqualValues(t, 3600, newToken.ExpiresIn)
+		ts := s.TokenSource(ctx, token)
+		_, err = ts.Token()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "unable to unmarshal raw response body")
+	})
 }

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1452,7 +1452,7 @@ func TestSocialAzureAD_Reload_ExtraFields(t *testing.T) {
 	}
 }
 
-func TestSocialAzureAD_TokenSource_ManagedIdentity(t *testing.T) {
+func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 	info := &social.OAuthInfo{
 		ClientId:                    "client-id",
 		ClientAuthentication:        social.WorkloadIdentity,

--- a/pkg/login/social/connectors/azuread_oauth_test.go
+++ b/pkg/login/social/connectors/azuread_oauth_test.go
@@ -1489,12 +1489,13 @@ func TestSocialAzureAD_TokenSource_WorkloadIdentity(t *testing.T) {
 			}
 
 			w.Header().Set("Content-Type", "application/json")
-			json.NewEncoder(w).Encode(map[string]interface{}{
+			err := json.NewEncoder(w).Encode(map[string]interface{}{
 				"access_token":  "new-access-token",
 				"token_type":    "Bearer",
 				"refresh_token": "new-refresh-token",
 				"expires_in":    3600,
 			})
+			require.NoError(t, err)
 		}))
 		defer server.Close()
 


### PR DESCRIPTION
**What is this feature?**

Fixes a bug with the new AzureAD SSO using `workload_identity`. This upgrades Grafana to use `client_assertion` when refreshing the token.

This code should be upgraded in the future if Go adds support

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/98919
Fixes https://github.com/grafana/grafana/issues/112509
Fixes https://github.com/equinor/radix-flux/issues/3039

**Special notes for your reviewer:**

It would be way better with native support from Golang (https://github.com/golang/oauth2/issues/744), this is a hotfix identical to the PR merged in oauth2proxy (https://github.com/oauth2-proxy/oauth2-proxy/pull/3031)

Please check that:
- [x] It works as expected from a user's perspective.
  - [x] Running correct in our dev-environment
  - [x] Running correct in alll our prod-environment
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

This PR/Fork is currently running correctly in all our dev and production clusters


Azure AD config this is run with:
```toml
[auth.azuread]
name = Microsoft
icon = microsoft
enabled = true
allow_sign_up = true
auto_login = false
client_authentication = workload_identity
client_id = f545deb5-f721-4d20-87cd-b046b5119d70
client_secret =
managed_identity_client_id =
federated_credential_audience = api://AzureADTokenExchange
workload_identity_token_file = ./.tmp/grafana.jwt
scopes = openid email profile
auth_url = https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/oauth2/v2.0/authorize
token_url = https://login.microsoftonline.com/3aa4a235-b6e2-48d5-9195-7fcf05b459b0/oauth2/v2.0/token
signout_redirect_url =
allowed_domains =
allowed_groups =
allowed_organizations = 3aa4a235-b6e2-48d5-9195-7fcf05b459b0
role_attribute_strict = false
org_mapping =
allow_assign_grafana_admin = false
force_use_graph_api = false
tls_skip_verify_insecure = false
tls_client_cert =
tls_client_key =
tls_client_ca =
use_pkce = true
skip_org_role_sync = false
use_refresh_token = true
```