### PR TITLE
IAM: Optionally make refresh tokens required if use_refresh_token is enabled

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -497,6 +497,10 @@ export interface FeatureToggles {
   */
   oauthRequireSubClaim?: boolean;
   /**
+  * Require that refresh tokens are present in oauth tokens.
+  */
+  refreshTokenRequired?: boolean;
+  /**
   * Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.
   */
   newDashboardWithFiltersAndGroupBy?: boolean;

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -55,6 +55,8 @@ var (
 	errOAuthTokenExchange = errutil.Internal("auth.oauth.token.exchange", errutil.WithPublicMessage("Failed to get token from provider"))
 	errOAuthUserInfo      = errutil.Internal("auth.oauth.userinfo.error")
 
+	errOAuthMissingRefreshToken = errutil.Unauthorized("auth.oauth.token.refresh-token.missing", errutil.WithPublicMessage("Provider did not return a refresh token"))
+
 	errOAuthMissingRequiredEmail = errutil.Unauthorized("auth.oauth.email.missing", errutil.WithPublicMessage("Provider didn't return an email address"))
 	errOAuthEmailNotAllowed      = errutil.Unauthorized("auth.oauth.email.not-allowed", errutil.WithPublicMessage("Required email domain not fulfilled"))
 )
@@ -165,6 +167,15 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 		return nil, errOAuthTokenExchange.Errorf("failed to exchange code to token: %w", err)
 	}
 	token.TokenType = "Bearer"
+
+	if oauthCfg.UseRefreshToken && token.RefreshToken == "" {
+		c.log.FromContext(ctx).Warn("No refresh token available with use_refresh_token enabled", "authmodule", c.moduleName)
+		//nolint:staticcheck // not yet migrated to OpenFeature
+		if c.features.IsEnabledGlobally(featuremgmt.FlagRefreshTokenRequired) {
+			return nil, errOAuthMissingRefreshToken.Errorf("provider did not return a refresh token")
+		}
+
+	}
 
 	userInfo, err := connector.UserInfo(ctx, connector.Client(clientCtx, token), token)
 	if err != nil {

--- a/pkg/services/authn/clients/oauth.go
+++ b/pkg/services/authn/clients/oauth.go
@@ -170,11 +170,11 @@ func (c *OAuth) Authenticate(ctx context.Context, r *authn.Request) (*authn.Iden
 
 	if oauthCfg.UseRefreshToken && token.RefreshToken == "" {
 		c.log.FromContext(ctx).Warn("No refresh token available with use_refresh_token enabled", "authmodule", c.moduleName)
+
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if c.features.IsEnabledGlobally(featuremgmt.FlagRefreshTokenRequired) {
 			return nil, errOAuthMissingRefreshToken.Errorf("provider did not return a refresh token")
 		}
-
 	}
 
 	userInfo, err := connector.UserInfo(ctx, connector.Client(clientCtx, token), token)

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -43,8 +43,6 @@ func TestOAuth_Authenticate(t *testing.T) {
 		addPKCECookie   bool
 		pkceCookieValue string
 
-		token *oauth2.Token
-
 		features []any
 
 		isEmailAllowed bool

--- a/pkg/services/authn/clients/oauth_test.go
+++ b/pkg/services/authn/clients/oauth_test.go
@@ -43,6 +43,8 @@ func TestOAuth_Authenticate(t *testing.T) {
 		addPKCECookie   bool
 		pkceCookieValue string
 
+		token *oauth2.Token
+
 		features []any
 
 		isEmailAllowed bool
@@ -253,6 +255,63 @@ func TestOAuth_Authenticate(t *testing.T) {
 				AuthenticatedBy: login.AzureADAuthModule,
 				AuthID:          "123",
 				Name:            "name",
+				OAuthToken:      &oauth2.Token{},
+				OrgRoles:        map[int64]org.RoleType{1: org.RoleAdmin},
+				ClientParams: authn.ClientParams{
+					SyncUser:        true,
+					SyncTeams:       true,
+					AllowSignUp:     true,
+					FetchSyncedUser: true,
+					SyncOrgRoles:    true,
+					LookUpParams:    login.UserLookupParams{},
+				},
+			},
+		},
+		{
+			desc: "should return error when no refresh token is available and feature toggle is enabled",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{},
+					URL:    mustParseURL("http://grafana.com/?state=some-state"),
+				},
+			},
+			oauthCfg:              &social.OAuthInfo{UsePKCE: true, Enabled: true, UseRefreshToken: true},
+			features:              []any{featuremgmt.FlagRefreshTokenRequired},
+			allowInsecureTakeover: true,
+			addStateCookie:        true,
+			stateCookieValue:      "some-state",
+			addPKCECookie:         true,
+			pkceCookieValue:       "some-pkce-value",
+			isEmailAllowed:        true,
+			expectedErr:           errOAuthMissingRefreshToken,
+		},
+		{
+			desc: "should return identity when no refresh token is available and feature toggle is disabled",
+			req: &authn.Request{
+				HTTPRequest: &http.Request{
+					Header: map[string][]string{},
+					URL:    mustParseURL("http://grafana.com/?state=some-state"),
+				},
+			},
+			oauthCfg:         &social.OAuthInfo{UsePKCE: true, Enabled: true, UseRefreshToken: true},
+			addStateCookie:   true,
+			stateCookieValue: "some-state",
+			addPKCECookie:    true,
+			pkceCookieValue:  "some-pkce-value",
+			isEmailAllowed:   true,
+			userInfo: &social.BasicUserInfo{
+				Id:     "123",
+				Name:   "name",
+				Email:  "some@email.com",
+				Role:   "Admin",
+				Groups: []string{"grp1", "grp2"},
+			},
+			expectedIdentity: &authn.Identity{
+				Email:           "some@email.com",
+				AuthenticatedBy: login.AzureADAuthModule,
+				AuthID:          "123",
+				Name:            "name",
+				Groups:          []string{"grp1", "grp2"},
 				OAuthToken:      &oauth2.Token{},
 				OrgRoles:        map[int64]org.RoleType{1: org.RoleAdmin},
 				ClientParams: authn.ClientParams{

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -851,6 +851,14 @@ var (
 			HideFromAdminPage: true,
 		},
 		{
+			Name:              "refreshTokenRequired",
+			Description:       "Require that refresh tokens are present in oauth tokens.",
+			Stage:             FeatureStageExperimental,
+			Owner:             identityAccessTeam,
+			HideFromDocs:      true,
+			HideFromAdminPage: true,
+		},
+		{
 			Name:              "newDashboardWithFiltersAndGroupBy",
 			Description:       "Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -111,6 +111,7 @@ kubernetesAggregatorCapTokenAuth,experimental,@grafana/grafana-app-platform-squa
 groupByVariable,experimental,@grafana/dashboards-squad,false,false,false
 scopeFilters,experimental,@grafana/dashboards-squad,false,false,false
 oauthRequireSubClaim,experimental,@grafana/identity-access-team,false,false,false
+refreshTokenRequired,experimental,@grafana/identity-access-team,false,false,false
 newDashboardWithFiltersAndGroupBy,experimental,@grafana/dashboards-squad,false,false,false
 cloudWatchNewLabelParsing,GA,@grafana/aws-datasources,false,false,false
 disableNumericMetricsSortingInExpressions,experimental,@grafana/oss-big-tent,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -455,6 +455,10 @@ const (
 	// Require that sub claims is present in oauth tokens.
 	FlagOauthRequireSubClaim = "oauthRequireSubClaim"
 
+	// FlagRefreshTokenRequired
+	// Require that refresh tokens are present in oauth tokens.
+	FlagRefreshTokenRequired = "refreshTokenRequired"
+
 	// FlagNewDashboardWithFiltersAndGroupBy
 	// Enables filters and group by variables on all new dashboards. Variables are added only if default data source supports filtering.
 	FlagNewDashboardWithFiltersAndGroupBy = "newDashboardWithFiltersAndGroupBy"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3542,6 +3542,20 @@
     },
     {
       "metadata": {
+        "name": "refreshTokenRequired",
+        "resourceVersion": "1763561990273",
+        "creationTimestamp": "2025-11-19T14:19:50Z"
+      },
+      "spec": {
+        "description": "Require that refresh tokens are present in oauth tokens.",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromAdminPage": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "regressionTransformation",
         "resourceVersion": "1762442825881",
         "creationTimestamp": "2023-11-24T14:49:16Z",

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -473,6 +473,10 @@ func (o *Service) tryGetOrRefreshOAuthToken(ctx context.Context, persistedToken 
 			)
 		}
 
+		if token.RefreshToken == "" {
+			ctxLogger.Error("Refresh token is missing during token refresh", "authmodule", tokenRefreshMetadata.AuthModule)
+		}
+
 		//nolint:staticcheck // not yet migrated to OpenFeature
 		if !o.features.IsEnabledGlobally(featuremgmt.FlagImprovedExternalSessionHandling) {
 			updateAuthCommand := &login.UpdateAuthInfoCommand{

--- a/pkg/services/oauthtoken/oauth_token.go
+++ b/pkg/services/oauthtoken/oauth_token.go
@@ -474,7 +474,7 @@ func (o *Service) tryGetOrRefreshOAuthToken(ctx context.Context, persistedToken 
 		}
 
 		if token.RefreshToken == "" {
-			ctxLogger.Error("Refresh token is missing during token refresh", "authmodule", tokenRefreshMetadata.AuthModule)
+			ctxLogger.Warn("Refresh token is missing after token refresh", "authmodule", tokenRefreshMetadata.AuthModule)
 		}
 
 		//nolint:staticcheck // not yet migrated to OpenFeature


### PR DESCRIPTION
**What is this feature?**

This PR introduces a feature toggle that, when enabled, prevents OAuth logins when the OAuth provider does not return a refresh token. This only applies if `use_refresh_token = true`. 

It also adds some logging around this to make it obvious when it happens even if the `refreshTokenRequired` feature flag is not enabled.

**Why do we need this feature?**

This is particularly useful to quickly detect misconfigured OAuth integrations. For instance, with this change, if you enable "Use Refresh Token" but do not configure your provider to issue refresh tokens, logins will be prevented immediately. Whereas, without it, the issue would manifest itself by logging users out after their access tokens are expired.

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/support-escalations/issues/19489.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
