### PR TITLE
Folders: Make `listFolders` call correct API and fix tags sorting

### DIFF
--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -16,11 +16,11 @@ export async function listFolders(
   page = 1,
   pageSize = PAGE_SIZE
 ): Promise<DashboardViewItem[]> {
-  const results = getGrafanaSearcher();
+  const searcher = getGrafanaSearcher();
 
   let folders: DashboardQueryResult[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
-    const foldersResults = await results.search({
+    const foldersResults = await searcher.search({
       kind: ['folder'],
       location: parentUID || 'general',
       from: (page - 1) * pageSize, // our pages are 1-indexed, so we need to -1 to convert that to correct value to skip

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -1,8 +1,7 @@
-import { getBackendSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
-import { NestedFolderDTO } from 'app/features/search/service/types';
+import { DashboardQueryResult } from 'app/features/search/service/types';
 import { queryResultToViewItem } from 'app/features/search/service/utils';
 import { DashboardViewItem } from 'app/features/search/types';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -17,22 +16,25 @@ export async function listFolders(
   page = 1,
   pageSize = PAGE_SIZE
 ): Promise<DashboardViewItem[]> {
-  const backendSrv = getBackendSrv();
+  const results = getGrafanaSearcher();
 
   // TODO: what to do here for unified search?
-  let folders: NestedFolderDTO[] = [];
+  let folders: DashboardQueryResult[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
-    folders = await backendSrv.get<NestedFolderDTO[]>('/api/folders', {
-      parentUid: parentUID,
-      page,
+    const foldersResults = await results.search({
+      kind: ['folder'],
+      location: parentUID || 'general',
+      from: (page - 1) * pageSize, // our pages are 1-indexed, so we need to -1 to convert that to correct value to skip
       limit: pageSize,
+      offset: (page - 1) * pageSize,
     });
+    folders = foldersResults.view.toArray();
   }
 
   return folders.map((item) => ({
     kind: 'folder',
     uid: item.uid,
-    title: item.title,
+    title: item.name,
     parentTitle,
     parentUID,
     managedBy: item.managedBy,

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -18,7 +18,6 @@ export async function listFolders(
 ): Promise<DashboardViewItem[]> {
   const results = getGrafanaSearcher();
 
-  // TODO: what to do here for unified search?
   let folders: DashboardQueryResult[] = [];
   if (contextSrv.hasPermission(AccessControlAction.FoldersRead)) {
     const foldersResults = await results.search({

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -386,7 +386,9 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
       ...hit,
       uid: hit.name,
       url: toURL(hit.resource, hit.name, hit.title),
-      tags: hit.tags || [],
+      // Sort tags so we aren't reliant on the backend having done this for us
+      // Sorting order can be different between APIs/search implementations
+      tags: (hit.tags || []).sort(),
       folder: hit.folder || 'general',
       location,
       name: hit.title, // 🤯 FIXME hit.name is k8s name, eg grafana dashboards UID


### PR DESCRIPTION
**What is this feature?**
* Fixes the api used for `listFolders` - makes this use `grafanaSearcher`
* ~Removes one additional API call to legacy endpoint when calling for a virtual folder (we don't need to call for this if it's `general` or `sharedwithme`, I think~ - Edit: Removed this to reduce risk, might not be possible depending on write modes so skipping for now
* Sorts the tags on the response so they are in alphabetical order

**Why do we need this feature?**
So we use the correct API (legacy vs app platform) for listing folders
So tags are sorted from the API response

**Who is this feature for?**
Devs! But should be unchanged for users

**Which issue(s) does this PR fix?**:

Fixes #114036
