### PR TITLE
Dashboard Import: disable importing V2 dashboards when dashboardNewLayouts is disabled

### DIFF
--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -123,7 +123,7 @@ class UnthemedDashboardImport extends PureComponent<Props> {
     if ((dashboard.spec?.elements || dashboard.elements) && !config.featureToggles.dashboardNewLayouts) {
       return appEvents.emit(AppEvents.alertError, [
         'Import failed',
-        'Cannot import v2 dashboards when dashboardNewLayouts feature toggle is disabled',
+        'Dashboard using new layout cannot be imported because the feature is not enabled',
       ]);
     }
 

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -94,17 +94,14 @@ class UnthemedDashboardImport extends PureComponent<Props> {
       const json = JSON.parse(String(result));
 
       if (json.spec?.elements) {
-        dispatch(importDashboardV2Json(json.spec));
-        return;
+        return dispatch(importDashboardV2Json(json.spec));
       } else if (json.elements) {
-        dispatch(importDashboardV2Json(json));
-        return;
+        return dispatch(importDashboardV2Json(json));
       }
 
       // check if it's a v1 resource format
       if (json.spec) {
-        this.props.importDashboardJson(json.spec);
-        return;
+        return this.props.importDashboardJson(json.spec);
       }
 
       this.props.importDashboardJson(json);
@@ -124,27 +121,25 @@ class UnthemedDashboardImport extends PureComponent<Props> {
     const dashboard = JSON.parse(formData.dashboardJson);
 
     if ((dashboard.spec?.elements || dashboard.elements) && !config.featureToggles.dashboardNewLayouts) {
-      appEvents.emit(AppEvents.alertError, [
+      return appEvents.emit(AppEvents.alertError, [
         'Import failed',
         'Cannot import v2 dashboards when dashboardNewLayouts feature toggle is disabled',
       ]);
-      return;
     }
 
     // check if it's a v2 resource format
     if (dashboard.spec?.elements) {
-      dispatch(importDashboardV2Json(dashboard.spec));
-      return;
-      // check if it's just a v2 spec
-    } else if (dashboard.elements) {
-      dispatch(importDashboardV2Json(dashboard));
-      return;
+      return dispatch(importDashboardV2Json(dashboard.spec));
+    }
+
+    // check if it's just a v2 spec
+    if (dashboard.elements) {
+      return dispatch(importDashboardV2Json(dashboard));
     }
 
     // check if it's a v1 resource format
     if (dashboard.spec) {
-      this.props.importDashboardJson(dashboard.spec);
-      return;
+      return this.props.importDashboardJson(dashboard.spec);
     }
 
     this.props.importDashboardJson(dashboard);

--- a/public/app/features/manage-dashboards/DashboardImportPage.tsx
+++ b/public/app/features/manage-dashboards/DashboardImportPage.tsx
@@ -123,6 +123,14 @@ class UnthemedDashboardImport extends PureComponent<Props> {
 
     const dashboard = JSON.parse(formData.dashboardJson);
 
+    if ((dashboard.spec?.elements || dashboard.elements) && !config.featureToggles.dashboardNewLayouts) {
+      appEvents.emit(AppEvents.alertError, [
+        'Import failed',
+        'Cannot import v2 dashboards when dashboardNewLayouts feature toggle is disabled',
+      ]);
+      return;
+    }
+
     // check if it's a v2 resource format
     if (dashboard.spec?.elements) {
       dispatch(importDashboardV2Json(dashboard.spec));


### PR DESCRIPTION
Disables imports for v2 dashboards when dashboardNewLayouts  as this would cause errors during dashboard runtime since v1 runtime can't support dynamic layouts. If user attempts this, we display the following:


<img width="614" height="187" alt="Screenshot 2025-11-20 at 9 35 44 AM" src="https://github.com/user-attachments/assets/015eedc5-dc68-45d2-bce7-d47d3d85a3fc" />


Fixes https://github.com/grafana/grafana/issues/113300

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective
