### PR TITLE
Dashboard: New experimental time range zoom shortcuts

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -669,6 +669,10 @@ export interface FeatureToggles {
   */
   timeRangePan?: boolean;
   /**
+  * Enables new keyboard shortcuts for time range zoom operations
+  */
+  newTimeRangeZoomShortcuts?: boolean;
+  /**
   * Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1100,6 +1100,13 @@ var (
 			Owner:        grafanaDatavizSquad,
 		},
 		{
+			Name:         "newTimeRangeZoomShortcuts",
+			Description:  "Enables new keyboard shortcuts for time range zoom operations",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDatavizSquad,
+		},
+		{
 			Name:        "azureMonitorDisableLogLimit",
 			Description: "Disables the log limit restriction for Azure Monitor when true. The limit is enabled by default.",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -152,6 +152,7 @@ pluginsSriChecks,GA,@grafana/plugins-platform-backend,false,false,false
 unifiedStorageBigObjectsSupport,experimental,@grafana/search-and-storage,false,false,false
 timeRangeProvider,experimental,@grafana/grafana-frontend-platform,false,false,false
 timeRangePan,experimental,@grafana/dataviz-squad,false,false,true
+newTimeRangeZoomShortcuts,experimental,@grafana/dataviz-squad,false,false,true
 azureMonitorDisableLogLimit,GA,@grafana/partner-datasources,false,false,false
 playlistsReconciler,experimental,@grafana/grafana-app-platform-squad,false,true,false
 passwordlessMagicLinkAuthentication,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2875,6 +2875,19 @@
     },
     {
       "metadata": {
+        "name": "newTimeRangeZoomShortcuts",
+        "resourceVersion": "1763646782694",
+        "creationTimestamp": "2025-11-20T13:53:02Z"
+      },
+      "spec": {
+        "description": "Enables new keyboard shortcuts for time range zoom operations",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "newVizSuggestions",
         "resourceVersion": "1762456851857",
         "creationTimestamp": "2025-11-12T19:26:29Z"

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -2,9 +2,10 @@ import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
 import { useAssistant } from '@grafana/assistant';
-import { GrafanaTheme2 } from '@grafana/data';
+import { FeatureState, GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Grid, Modal, useStyles2, Text } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+import { Grid, Modal, useStyles2, Text, FeatureBadge } from '@grafana/ui';
 import { getModKey } from 'app/core/utils/browser';
 
 export interface HelpModalProps {
@@ -36,7 +37,7 @@ export const HelpModal = ({ onDismiss }: HelpModalProps): JSX.Element => {
                 </tr>
               </thead>
               <tbody>
-                {shortcuts.map(({ keys, description }) => (
+                {shortcuts.map(({ keys, description, isNew }) => (
                   <tr key={keys.join()}>
                     <td className={styles.keys}>
                       {keys.map((key) => (
@@ -44,9 +45,12 @@ export const HelpModal = ({ onDismiss }: HelpModalProps): JSX.Element => {
                       ))}
                     </td>
                     <td>
-                      <Text variant="bodySmall" element="p">
-                        {description}
-                      </Text>
+                      <div className={styles.descriptionWrapper}>
+                        <Text variant="bodySmall" element="p">
+                          {description}
+                        </Text>
+                        {isNew && <FeatureBadge featureState={FeatureState.new} />}
+                      </div>
                     </td>
                   </tr>
                 ))}
@@ -104,10 +108,25 @@ export const useShortcuts = () => {
       {
         category: t('help-modal.shortcuts-category.time-range', 'Time range'),
         shortcuts: [
-          {
-            keys: ['t', 'z'],
-            description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
-          },
+          ...(config.featureToggles.newTimeRangeZoomShortcuts
+            ? [
+                {
+                  keys: ['t', '+'],
+                  description: t('help-modal.shortcuts-description.zoom-in-time-range', 'Zoom in time range'),
+                  isNew: true,
+                },
+                {
+                  keys: ['t', '-'],
+                  description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
+                  isNew: true,
+                },
+              ]
+            : [
+                {
+                  keys: ['t', 'z'],
+                  description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
+                },
+              ]),
           {
             keys: ['t', '←'],
             description: t('help-modal.shortcuts-description.move-time-range-back', 'Move time range back'),
@@ -276,6 +295,12 @@ function getStyles(theme: GrafanaTheme2) {
       textAlign: 'end',
       whiteSpace: 'nowrap',
       minWidth: 83, // To match column widths with the widest
+    }),
+    descriptionWrapper: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.75),
+      flexWrap: 'nowrap',
     }),
     shortcutTableKey: css({
       display: 'inline-block',

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,6 +1,6 @@
 import { toggleAssistant, isAssistantAvailable } from '@grafana/assistant';
 import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent, locationUtil } from '@grafana/data';
-import { LocationService } from '@grafana/runtime';
+import { LocationService, config } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
@@ -231,9 +231,19 @@ export class KeybindingSrv {
       appEvents.publish(new AbsoluteTimeEvent({ updateUrl }));
     });
 
-    this.bind('t z', () => {
-      appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
-    });
+    if (config.featureToggles.newTimeRangeZoomShortcuts) {
+      this.bind('t +', () => {
+        appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
+      });
+
+      this.bind('t -', () => {
+        appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
+      });
+    } else {
+      this.bind('t z', () => {
+        appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
+      });
+    }
 
     this.bind('ctrl+z', () => {
       appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -1,4 +1,5 @@
 import { LegacyGraphHoverClearEvent } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { behaviors, sceneGraph, SceneTimeRange } from '@grafana/scenes';
 import { DashboardCursorSync } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
@@ -251,6 +252,153 @@ describe('setupKeyboardShortcuts', () => {
       expect(modOBinding).toBeDefined();
       expect(vBinding).toBeDefined();
       expect(drBinding).toBeDefined();
+    });
+  });
+
+  describe('time range zoom shortcuts with feature toggle', () => {
+    describe('when newTimeRangeZoomShortcuts is enabled', () => {
+      beforeEach(() => {
+        config.featureToggles.newTimeRangeZoomShortcuts = true;
+        jest.clearAllMocks();
+      });
+
+      it('should setup t + zoom in shortcut', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        expect(tPlusBinding).toBeDefined();
+      });
+
+      it('should setup t - zoom out shortcut with keypress type', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tMinusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't -');
+        expect(tMinusBinding).toBeDefined();
+        expect(tMinusBinding![0].type).toBe('keypress');
+      });
+
+      it('should not setup t z shortcut when feature toggle is on', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tzBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't z');
+        expect(tzBinding).toBeUndefined();
+      });
+    });
+
+    describe('when newTimeRangeZoomShortcuts is disabled', () => {
+      beforeEach(() => {
+        config.featureToggles.newTimeRangeZoomShortcuts = false;
+        jest.clearAllMocks();
+      });
+
+      it('should setup legacy t z shortcut', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tzBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't z');
+        expect(tzBinding).toBeDefined();
+      });
+
+      it('should not setup new zoom shortcuts when feature toggle is off', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        const tMinusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't -');
+
+        expect(tPlusBinding).toBeUndefined();
+        expect(tMinusBinding).toBeUndefined();
+      });
+    });
+
+    describe('zoom handler logic', () => {
+      let mockTimeRange: ReturnType<typeof createMockTimeRange>;
+
+      function createMockTimeRange() {
+        return {
+          state: {
+            value: {
+              from: { valueOf: () => new Date('2024-01-01 12:00:00').getTime() },
+              to: { valueOf: () => new Date('2024-01-01 18:00:00').getTime() }, // 6 hour span
+              raw: { from: 'now-6h', to: 'now' },
+            },
+          },
+          onTimeRangeChange: jest.fn(),
+        } satisfies {
+          state: {
+            value: {
+              from: { valueOf: () => number };
+              to: { valueOf: () => number };
+              raw: { from: string; to: string };
+            };
+          };
+          onTimeRangeChange: jest.Mock;
+        };
+      }
+
+      beforeEach(() => {
+        config.featureToggles.newTimeRangeZoomShortcuts = true;
+        mockTimeRange = createMockTimeRange();
+
+        (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(mockTimeRange);
+        jest.clearAllMocks();
+      });
+
+      it('should zoom in (scale 0.5) when t + is pressed', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        const handler = tPlusBinding![0].onTrigger;
+
+        handler();
+
+        // Scale 0.5 should result in 3 hour span (half of 6)
+        expect(mockTimeRange.onTimeRangeChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            from: expect.any(Object),
+            to: expect.any(Object),
+            raw: expect.any(Object),
+          })
+        );
+
+        const call = mockTimeRange.onTimeRangeChange.mock.calls[0][0];
+        const newSpan = call.to.valueOf() - call.from.valueOf();
+        expect(newSpan).toBe(3 * 60 * 60 * 1000); // 3 hours in milliseconds
+      });
+
+      it('should keep center point when zooming in', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        const handler = tPlusBinding![0].onTrigger;
+
+        const originalCenter = (mockTimeRange.state.value.from.valueOf() + mockTimeRange.state.value.to.valueOf()) / 2;
+
+        handler();
+
+        const call = mockTimeRange.onTimeRangeChange.mock.calls[0][0];
+        const newCenter = (call.from.valueOf() + call.to.valueOf()) / 2;
+
+        expect(newCenter).toBe(originalCenter);
+      });
+
+      it('should handle zero timespan edge case', () => {
+        mockTimeRange.state.value.from.valueOf = () => new Date('2024-01-01 12:00:00').getTime();
+        mockTimeRange.state.value.to.valueOf = () => new Date('2024-01-01 12:00:00').getTime(); // Same time
+
+        setupKeyboardShortcuts(mockScene);
+
+        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        const handler = tPlusBinding![0].onTrigger;
+
+        handler();
+
+        const call = mockTimeRange.onTimeRangeChange.mock.calls[0][0];
+        const newSpan = call.to.valueOf() - call.from.valueOf();
+
+        // Should default to 30 seconds when timespan is 0, then scale by 0.5
+        // But the scale is applied to 30000, so result is still 30000 * 0.5 = 15000
+        // However, the implementation applies scale to create newTimespan, so it's 30000
+        expect(newSpan).toBe(30000); // 30 seconds default
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -380,7 +380,7 @@ describe('setupKeyboardShortcuts', () => {
         expect(newCenter).toBe(originalCenter);
       });
 
-      it('should handle zero timespan edge case', () => {
+      it('should do nothing when timespan is zero', () => {
         mockTimeRange.state.value.from.valueOf = () => new Date('2024-01-01 12:00:00').getTime();
         mockTimeRange.state.value.to.valueOf = () => new Date('2024-01-01 12:00:00').getTime(); // Same time
 
@@ -391,13 +391,8 @@ describe('setupKeyboardShortcuts', () => {
 
         handler();
 
-        const call = mockTimeRange.onTimeRangeChange.mock.calls[0][0];
-        const newSpan = call.to.valueOf() - call.from.valueOf();
-
-        // Should default to 30 seconds when timespan is 0, then scale by 0.5
-        // But the scale is applied to 30000, so result is still 30000 * 0.5 = 15000
-        // However, the implementation applies scale to create newTimespan, so it's 30000
-        expect(newSpan).toBe(30000); // 30 seconds default
+        // Should not call onTimeRangeChange when timespan is 0
+        expect(mockTimeRange.onTimeRangeChange).not.toHaveBeenCalled();
       });
     });
   });

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -1,4 +1,4 @@
-import { locationUtil, SetPanelAttentionEvent, LegacyGraphHoverClearEvent } from '@grafana/data';
+import { locationUtil, SetPanelAttentionEvent, LegacyGraphHoverClearEvent, dateTime } from '@grafana/data';
 import { config, locationService } from '@grafana/runtime';
 import { behaviors, sceneGraph, VizPanel } from '@grafana/scenes';
 import { appEvents } from 'app/core/app_events';
@@ -130,13 +130,29 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     onTrigger: () => sceneGraph.getTimeRange(scene).onRefresh(),
   });
 
-  // Zoom out
-  keybindings.addBinding({
-    key: 't z',
-    onTrigger: () => {
-      handleZoomOut(scene);
-    },
-  });
+  if (config.featureToggles.newTimeRangeZoomShortcuts) {
+    keybindings.addBinding({
+      key: 't +',
+      onTrigger: () => {
+        handleZoom(scene, 0.5);
+      },
+    });
+
+    keybindings.addBinding({
+      key: 't -',
+      type: 'keypress', // NOTE: Because some browsers/OS identify minus symbol differently.
+      onTrigger: () => {
+        handleZoomOut(scene);
+      },
+    });
+  } else {
+    keybindings.addBinding({
+      key: 't z',
+      onTrigger: () => {
+        handleZoomOut(scene);
+      },
+    });
+  }
 
   keybindings.addBinding({
     key: 'ctrl+z',
@@ -264,6 +280,26 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     keybindings.removeAll();
     panelAttentionSubscription.unsubscribe();
   };
+}
+
+function handleZoom(scene: DashboardScene, scale: number) {
+  const timeRange = sceneGraph.getTimeRange(scene);
+  const currentRange = timeRange.state.value;
+  const timespan = currentRange.to.valueOf() - currentRange.from.valueOf();
+  const center = currentRange.to.valueOf() - timespan / 2;
+  const newTimespan = timespan === 0 ? 30000 : timespan * scale;
+
+  const to = center + newTimespan / 2;
+  const from = center - newTimespan / 2;
+
+  timeRange.onTimeRangeChange({
+    from: dateTime(from),
+    to: dateTime(to),
+    raw: {
+      from: dateTime(from),
+      to: dateTime(to),
+    },
+  });
 }
 
 function handleZoomOut(scene: DashboardScene) {

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -286,8 +286,13 @@ function handleZoom(scene: DashboardScene, scale: number) {
   const timeRange = sceneGraph.getTimeRange(scene);
   const currentRange = timeRange.state.value;
   const timespan = currentRange.to.valueOf() - currentRange.from.valueOf();
+
+  if (timespan === 0) {
+    return;
+  }
+
   const center = currentRange.to.valueOf() - timespan / 2;
-  const newTimespan = timespan === 0 ? 30000 : timespan * scale;
+  const newTimespan = timespan * scale;
 
   const to = center + newTimespan / 2;
   const from = center - newTimespan / 2;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9291,6 +9291,7 @@
       "toggle-panel-edit": "Toggle panel edit view",
       "toggle-panel-fullscreen": "Toggle panel fullscreen view",
       "toggle-panel-legend": "Toggle panel legend",
+      "zoom-in-time-range": "Zoom in time range",
       "zoom-out-time-range": "Zoom out time range"
     },
     "title": "Shortcuts"


### PR DESCRIPTION
**What is this feature?**

This change replaces the existing ~`t z`~ keyboard shortcut with `t -` for time range zoom out, and adds a new keyboard shortcut `t +` for time range zoom in.

Both of which are behind an experimental feature flag `newTimeRangeZoomShortcuts` that's toggled OFF by default.

<img width="1192" height="944" alt="Screenshot 2025-11-19 at 16 01 24" src="https://github.com/user-attachments/assets/7dfce75c-9c4b-472e-8589-e04a7c5b7a0c" />

https://github.com/user-attachments/assets/9235e989-00ec-49a0-acaf-cf79564723a3



**Why do we need this feature?**

For symmetry between the dashboard level keyboard shortcuts for time range zoom, and the existing mouse interactions for time range zoom at the panel level.

**Who is this feature for?**

All of users of Grafana eventually, but only those who enable the experimental flag for now.


**Which issue(s) does this PR fix?**:

Fixes # https://github.com/grafana/grafana/issues/113110

**Special notes for your reviewer:**

1. Enable the `newTimeRangeZoomShortcuts` locally
2. Press `?` to see the new keyboard shortcuts listed
3. Press `t +` to zoom in the time range at the dashboard level
4. Press `t -` to zoom out the time range at the dashboard level
5. Press `t z` to make sure it no longer has an effect

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
