### PR TITLE
Dashboard Nav: Fix star button showing spinner icon on dashboard load

### DIFF
--- a/public/app/features/stars/StarToolbarButton.tsx
+++ b/public/app/features/stars/StarToolbarButton.tsx
@@ -55,7 +55,7 @@ export function StarToolbarButton({ title, group, kind, id, onStarChange }: Prop
       : { tooltip: tooltips.star, label: isLoading ? undefined : tooltips.starWithTitle };
   })();
 
-  const icon = <Icon {...iconProps} size="lg" />;
+  const icon = <Icon {...iconProps} size="lg" key={iconProps.name} />;
   return (
     <ToolbarButton
       disabled={isLoading}


### PR DESCRIPTION
This PR fixes an issue where the star/favorite button in the dashboard toolbar would show a static spinner icon on initial page load, even after the starred items data had finished loading. The root cause was that the `react-inlinesvg` component used internally by the `Icon` component caches loaded SVGs, and when the icon name changed from 'spinner' to 'star'/'favorite' after loading completed, React wasn't creating a new component instance to clear the cache. With this fix, React now properly unmounts and remounts the icon when the name changes, ensuring the correct icon is displayed immediately after loading completes.

Before:

https://github.com/user-attachments/assets/330b730f-1cd4-44e2-878b-ad83b592580f

After:

https://github.com/user-attachments/assets/eca806f8-b907-4db8-af8e-dc9bb539b120



Please check that:
- [ ] It works as expected from a user's perspective.

