### PR TITLE
Chore: Finalize removal of updateNode & expandOrFilter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ public/css/*.min.css
 .vs/
 .cursor/
 .devcontainer/
+.claude/
 
 .eslintcache
 .stylelintcache

--- a/public/app/features/commandPalette/actions/scopeActions.test.tsx
+++ b/public/app/features/commandPalette/actions/scopeActions.test.tsx
@@ -22,7 +22,7 @@ jest.mock('./scopesUtils', () => {
 });
 
 const mockScopeServicesState = {
-  updateNode: jest.fn(),
+  filterNode: jest.fn(),
   selectScope: jest.fn(),
   resetSelection: jest.fn(),
   nodes: {},
@@ -99,12 +99,12 @@ describe('useRegisterScopesActions', () => {
   });
 
   it('should register scope tree actions and return scopesRow when scopes are selected', () => {
-    const mockUpdateNode = jest.fn();
+    const mockFilterNode = jest.fn();
 
     // First run with empty scopes in the scopes service
     (useScopeServicesState as jest.Mock).mockReturnValue({
       ...mockScopeServicesState,
-      updateNode: mockUpdateNode,
+      filterNode: mockFilterNode,
       selectedScopes: [{ scopeId: 'scope1', name: 'Scope 1' }],
     });
 
@@ -112,14 +112,14 @@ describe('useRegisterScopesActions', () => {
       return useRegisterScopesActions('', jest.fn());
     });
 
-    expect(mockUpdateNode).toHaveBeenCalledWith('', true, '');
+    expect(mockFilterNode).toHaveBeenCalledWith('', '');
     expect(useRegisterActions).toHaveBeenLastCalledWith([rootScopeAction], [[rootScopeAction]]);
     expect(result.current.scopesRow).toBeDefined();
 
     // Simulate loading of scopes in the service
     (useScopeServicesState as jest.Mock).mockReturnValue({
       ...mockScopeServicesState,
-      updateNode: mockUpdateNode,
+      filterNode: mockFilterNode,
       selectedScopes: [{ scopeId: 'scope1', name: 'Scope 1' }],
       nodes,
       tree,
@@ -151,12 +151,12 @@ describe('useRegisterScopesActions', () => {
   });
 
   it('should load next level of scopes', () => {
-    const mockUpdateNode = jest.fn();
+    const mockFilterNode = jest.fn();
 
     // First run with empty scopes in the scopes service
     (useScopeServicesState as jest.Mock).mockReturnValue({
       ...mockScopeServicesState,
-      updateNode: mockUpdateNode,
+      filterNode: mockFilterNode,
       nodes,
       tree,
     });
@@ -165,7 +165,7 @@ describe('useRegisterScopesActions', () => {
       return useRegisterScopesActions('', jest.fn(), 'scopes/scope1');
     });
 
-    expect(mockUpdateNode).toHaveBeenCalledWith('scope1', true, '');
+    expect(mockFilterNode).toHaveBeenCalledWith('scope1', '');
   });
 
   it('does not return component if no scopes are selected', () => {
@@ -259,12 +259,12 @@ describe('useRegisterScopesActions', () => {
   });
 
   it('should not use global scope search when searching in some deeper scope category', async () => {
-    const mockUpdateNode = jest.fn();
+    const mockFilterNode = jest.fn();
 
     // First run with empty scopes in the scopes service
     (useScopeServicesState as jest.Mock).mockReturnValue({
       ...mockScopeServicesState,
-      updateNode: mockUpdateNode,
+      filterNode: mockFilterNode,
       nodes,
       tree,
     });
@@ -273,17 +273,17 @@ describe('useRegisterScopesActions', () => {
       return useRegisterScopesActions('something', jest.fn(), 'scopes/scope1');
     });
 
-    expect(mockUpdateNode).toHaveBeenCalledWith('scope1', true, 'something');
+    expect(mockFilterNode).toHaveBeenCalledWith('scope1', 'something');
     expect(mockScopeServicesState.searchAllNodes).not.toHaveBeenCalled();
   });
 
   it('should not use global scope search if feature flag is off', async () => {
     config.featureToggles.scopeSearchAllLevels = false;
-    const mockUpdateNode = jest.fn();
+    const mockFilterNode = jest.fn();
     // First run with empty scopes in the scopes service
     (useScopeServicesState as jest.Mock).mockReturnValue({
       ...mockScopeServicesState,
-      updateNode: mockUpdateNode,
+      filterNode: mockFilterNode,
       nodes,
       tree,
     });
@@ -292,7 +292,7 @@ describe('useRegisterScopesActions', () => {
       return useRegisterScopesActions('something', jest.fn(), '');
     });
 
-    expect(mockUpdateNode).toHaveBeenCalledWith('', true, 'something');
+    expect(mockFilterNode).toHaveBeenCalledWith('', 'something');
     expect(mockScopeServicesState.searchAllNodes).not.toHaveBeenCalled();
   });
 

--- a/public/app/features/commandPalette/actions/scopeActions.tsx
+++ b/public/app/features/commandPalette/actions/scopeActions.tsx
@@ -58,22 +58,22 @@ export function useRegisterScopesActions(
  * @param parentId
  */
 function useScopeTreeActions(searchQuery: string, parentId?: string | null) {
-  const { updateNode, selectScope, resetSelection, nodes, tree, selectedScopes } = useScopeServicesState();
+  const { filterNode, selectScope, resetSelection, nodes, tree, selectedScopes } = useScopeServicesState();
 
   // Initialize the scopes the first time this runs and reset the scopes that were selected on unmount.
   useEffect(() => {
-    updateNode('', true, '');
+    filterNode('', '');
     resetSelection();
     return () => {
       resetSelection();
     };
-  }, [updateNode, resetSelection]);
+  }, [filterNode, resetSelection]);
 
   // Load the next level of scopes when the parentId changes.
   useEffect(() => {
     const parentScopeId = !parentId || parentId === 'scopes' ? '' : last(parentId.split('/'))!;
-    updateNode(parentScopeId, true, searchQuery);
-  }, [updateNode, searchQuery, parentId]);
+    filterNode(parentScopeId, searchQuery);
+  }, [filterNode, searchQuery, parentId]);
 
   return useMemo(
     () => mapScopesNodesTreeToActions(nodes, tree!, selectedScopes, selectScope),

--- a/public/app/features/commandPalette/actions/scopesUtils.ts
+++ b/public/app/features/commandPalette/actions/scopesUtils.ts
@@ -14,7 +14,7 @@ export function useScopeServicesState() {
   const services = useScopesServices();
   if (!services) {
     return {
-      updateNode: () => {},
+      filterNode: () => Promise.resolve(),
       selectScope: () => {},
       resetSelection: () => {},
       searchAllNodes: () => Promise.resolve([]),
@@ -32,7 +32,7 @@ export function useScopeServicesState() {
       },
     };
   }
-  const { updateNode, filterNode, selectScope, resetSelection, searchAllNodes, deselectScope, apply, getScopeNodes } =
+  const { filterNode, selectScope, resetSelection, searchAllNodes, deselectScope, apply, getScopeNodes } =
     services.scopesSelectorService;
   const selectorServiceState: ScopesSelectorServiceState | undefined = useObservable(
     services.scopesSelectorService.stateObservable ?? new Observable(),
@@ -42,7 +42,6 @@ export function useScopeServicesState() {
   return {
     getScopeNodes,
     filterNode,
-    updateNode,
     selectScope,
     resetSelection,
     searchAllNodes,

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -247,7 +247,7 @@ describe('ScopesSelectorService', () => {
     });
 
     it('should clear navigation scope when removing all scopes', async () => {
-      await service.updateNode('', true, '');
+      await service.filterNode('', '');
       await service.selectScope('test-scope-node');
       await service.apply();
       await service.removeAllScopes();

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -129,32 +129,42 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
 
   // Resets query and toggles expanded state of a node
   public toggleExpandedNode = async (scopeNodeId: string) => {
-    const path = getPathOfNode(scopeNodeId, this.state.nodes);
-    const nodeToToggle = treeNodeAtPath(this.state.tree!, path);
+    this.interactionProfiler?.startInteraction('scopeToggleExpandedNode');
 
-    if (!nodeToToggle) {
-      throw new Error(`Node ${scopeNodeId} not found in tree`);
-    }
+    try {
+      const path = getPathOfNode(scopeNodeId, this.state.nodes);
+      const nodeToToggle = treeNodeAtPath(this.state.tree!, path);
 
-    if (nodeToToggle.scopeNodeId !== '' && !isNodeExpandable(this.state.nodes[nodeToToggle.scopeNodeId])) {
-      throw new Error(`Trying to expand node at id ${scopeNodeId} that is not expandable`);
-    }
-
-    const newTree = modifyTreeNodeAtPath(this.state.tree!, path, (treeNode) => {
-      treeNode.expanded = !nodeToToggle.expanded;
-      treeNode.query = '';
-    });
-
-    this.updateState({ tree: newTree });
-    // If we are collapsing, we need to make sure that all the parent's children are avilable
-    if (nodeToToggle.expanded === true) {
-      const parentPath = path.slice(0, -1);
-      const parentNode = treeNodeAtPath(this.state.tree!, parentPath);
-      if (parentNode) {
-        await this.loadNodeChildren(parentPath, parentNode, parentNode.query);
+      if (!nodeToToggle) {
+        throw new Error(`Node ${scopeNodeId} not found in tree`);
       }
-    } else {
-      await this.loadNodeChildren(path, nodeToToggle);
+
+      if (nodeToToggle.scopeNodeId !== '' && !isNodeExpandable(this.state.nodes[nodeToToggle.scopeNodeId])) {
+        throw new Error(`Trying to expand node at id ${scopeNodeId} that is not expandable`);
+      }
+
+      const newTree = modifyTreeNodeAtPath(this.state.tree!, path, (treeNode) => {
+        treeNode.expanded = !nodeToToggle.expanded;
+        treeNode.query = '';
+      });
+
+      this.updateState({ tree: newTree });
+      // If we are collapsing, we need to make sure that all the parent's children are available
+      if (nodeToToggle.expanded) {
+        const parentPath = path.slice(0, -1);
+        const parentNode = treeNodeAtPath(this.state.tree!, parentPath);
+        if (parentNode) {
+          await this.loadNodeChildren(parentPath, parentNode, parentNode.query);
+        }
+      } else {
+        await this.loadNodeChildren(path, nodeToToggle);
+      }
+      // Catch and throw error so we can ensure the profiler is stopped
+      // todo: leverage component-level
+    } catch (error) {
+      throw error;
+    } finally {
+      this.interactionProfiler?.stopInteraction();
     }
   };
 
@@ -180,6 +190,7 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       this.updateState({ tree: newTree });
 
       await this.loadNodeChildren(path, nodeToFilter, query);
+      // Catch and throw error so we can ensure the profiler is stopped
     } catch (error) {
       throw error;
     } finally {


### PR DESCRIPTION
**What is this feature?**

Refactor internal Scopes tree functions, expanding on https://github.com/grafana/grafana/pull/111553

- Remove references to, and related private functions for, `updateNode` and `expandOrFilter`
- Remove obsolete tests
- Update all usages of `updateNode` to `filterNode`
- Integrate `expandOrFilter` functionality into `filterNode` funciton
- Add profiler to `filterNode`
- Add `.claude` to `.gitignore` IDE junk section
- PR Update: Add UTs for `toggleExpandedNode` and `filterNode`

**Why do we need this feature?**

Old code was overly complex and was split into new functions. However, the previous PR did not finish removing the replaced functions. This finishes the cleanup.

**Who is this feature for?**

Anyone using the Scopes feature (should be invisible to users)

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/grafana-operator-experience-squad/issues/1566

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
