### PR TITLE
Dashboard Favorites: Dashboard star icon stuck in loading state on initial load 

### DIFF
--- a/public/app/features/stars/StarToolbarButton.test.tsx
+++ b/public/app/features/stars/StarToolbarButton.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, testWithFeatureToggles } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { GrafanaConfig, locationUtil } from '@grafana/data';
+import { selectors } from '@grafana/e2e-selectors';
 import { config, setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
@@ -109,6 +110,44 @@ describe('StarToolbarButton', () => {
       await user.click(await findStarButton(existingStarredItem.title, true));
 
       expect(screen.queryByTestId(expectedTestId)).not.toBeInTheDocument();
+    });
+
+    it('shows spinner initially and transitions to empty star when loading completes with no starred items', async () => {
+      setup(itemToStar);
+      const button = screen.getByTestId(selectors.components.NavToolbar.markAsFavorite);
+
+      // Initially, button should be disabled (loading state)
+      expect(button).toBeDisabled();
+
+      // Wait for loading to complete
+      await waitFor(
+        () => {
+          expect(button).not.toBeDisabled();
+        },
+        { timeout: 3000 }
+      );
+
+      // After loading, should show "Mark as favorite" (empty star state)
+      expect(await findStarButton(itemToStar.title, false)).toBeInTheDocument();
+    });
+
+    it('shows spinner initially and transitions to filled star when loading completes with starred item', async () => {
+      setup(existingStarredItem);
+      const button = screen.getByTestId(selectors.components.NavToolbar.markAsFavorite);
+
+      // Initially, button should be disabled (loading state)
+      expect(button).toBeDisabled();
+
+      // Wait for loading to complete
+      await waitFor(
+        () => {
+          expect(button).not.toBeDisabled();
+        },
+        { timeout: 3000 }
+      );
+
+      // After loading, should show "Unmark as favorite" (filled star state)
+      expect(await findStarButton(existingStarredItem.title, true)).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/stars/StarToolbarButton.tsx
+++ b/public/app/features/stars/StarToolbarButton.tsx
@@ -39,7 +39,7 @@ export function StarToolbarButton({ title, group, kind, id, onStarChange }: Prop
     onStarChange?.(id, !isStarred);
   };
 
-  const iconProps = (() => {
+  const iconProps = useMemo(() => {
     if (isLoading) {
       return { name: 'spinner', type: 'default' } as const;
     }
@@ -47,15 +47,15 @@ export function StarToolbarButton({ title, group, kind, id, onStarChange }: Prop
       return { name: 'favorite', type: 'mono' } as const;
     }
     return { name: 'star', type: 'default' } as const;
-  })();
+  }, [isLoading, isStarred]);
 
-  const tooltipAndLabel = (() => {
+  const tooltipAndLabel = useMemo(() => {
     return isStarred
       ? { tooltip: tooltips.unstar, label: isLoading ? undefined : tooltips.unstarWithTitle }
       : { tooltip: tooltips.star, label: isLoading ? undefined : tooltips.starWithTitle };
-  })();
+  }, [isStarred, isLoading, tooltips]);
 
-  const icon = <Icon {...iconProps} size="lg" />;
+  const icon = <Icon {...iconProps} size="lg" key={`${isLoading}-${isStarred}`} />;
   return (
     <ToolbarButton
       disabled={isLoading}

--- a/public/app/features/stars/StarToolbarButton.tsx
+++ b/public/app/features/stars/StarToolbarButton.tsx
@@ -49,11 +49,11 @@ export function StarToolbarButton({ title, group, kind, id, onStarChange }: Prop
     return { name: 'star', type: 'default' } as const;
   }, [isLoading, isStarred]);
 
-  const tooltipAndLabel = useMemo(() => {
+  const tooltipAndLabel = (() => {
     return isStarred
       ? { tooltip: tooltips.unstar, label: isLoading ? undefined : tooltips.unstarWithTitle }
       : { tooltip: tooltips.star, label: isLoading ? undefined : tooltips.starWithTitle };
-  }, [isStarred, isLoading, tooltips]);
+  })();
 
   const icon = <Icon {...iconProps} size="lg" key={`${isLoading}-${isStarred}`} />;
   return (

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -61,26 +61,132 @@ export const useStarredItems = (group: string, kind: string) => {
   const name = `user-${contextSrv.user.uid}`;
   const appPlatform = config.featureToggles.starsFromAPIServer;
   const legacyResponse = useLegacyGetStarsQuery(appPlatform ? skipToken : undefined);
-  const appPlatformResponse = useListStarsQuery(!appPlatform ? skipToken : { fieldSelector: `metadata.name=${name}` });
+  const queryArgs = !appPlatform ? skipToken : { fieldSelector: `metadata.name=${name}` };
+  const appPlatformResponse = useListStarsQuery(queryArgs);
 
   const appPlatformStarredItems = useMemo(() => {
-    const { data } = appPlatformResponse;
-    if (data) {
-      const starredItems = appPlatformResponse.data?.items || [];
-      if (!starredItems.length) {
+    const { data, isLoading, isUninitialized, isFetching, isSuccess, isError } = appPlatformResponse;
+
+    // If query hasn't been initiated yet, return undefined to show loading state
+    if (isUninitialized) {
+      return undefined;
+    }
+
+    // If query is still loading (initial load), return undefined to show loading state
+    if (isLoading) {
+      return undefined;
+    }
+
+    // Helper function to extract starred items from data
+    const extractStarredItems = (responseData: typeof data): string[] => {
+      if (!responseData || !('items' in responseData)) {
         return [];
       }
-      return starredItems[0]?.spec.resource.find((info) => info.group === group && info.kind === kind)?.names || [];
+
+      const items = Array.isArray(responseData.items) ? responseData.items : [];
+      if (!items.length) {
+        return [];
+      }
+
+      const firstItem = items[0];
+      if (!firstItem || typeof firstItem !== 'object' || !('spec' in firstItem)) {
+        return [];
+      }
+
+      const spec = firstItem.spec;
+      if (!spec || typeof spec !== 'object' || !('resource' in spec)) {
+        return [];
+      }
+
+      const resources = Array.isArray(spec.resource) ? spec.resource : [];
+      const resourceInfo = resources.find((info: unknown) => {
+        if (typeof info !== 'object' || info === null) {
+          return false;
+        }
+        if (!('group' in info) || !('kind' in info)) {
+          return false;
+        }
+        // TypeScript knows info has 'group' and 'kind' properties at this point
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const groupValue = (info as { group: unknown }).group;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const kindValue = (info as { kind: unknown }).kind;
+        return groupValue === group && kindValue === kind;
+      });
+
+      if (resourceInfo && typeof resourceInfo === 'object' && resourceInfo !== null && 'names' in resourceInfo) {
+        // TypeScript knows resourceInfo has 'names' property at this point
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        const namesValue = (resourceInfo as { names: unknown }).names;
+        return Array.isArray(namesValue) ? namesValue : [];
+      }
+
+      return [];
+    };
+
+    // If query completed successfully, process the data
+    if (isSuccess && data) {
+      return extractStarredItems(data);
     }
-    return undefined;
+
+    // If query completed with error, return empty array
+    if (isError) {
+      return [];
+    }
+
+    // If query completed successfully but no data, return empty array
+    if (isSuccess && !data) {
+      return [];
+    }
+
+    // If we're still fetching but have cached data, use it
+    // Otherwise, if fetching without cached data, show loading
+    if (isFetching) {
+      // If we have data from a previous fetch, use it
+      if (data) {
+        return extractStarredItems(data);
+      }
+      // No cached data and still fetching - show loading
+      return undefined;
+    }
+
+    // Fallback: if we have data, use it
+    if (data) {
+      return extractStarredItems(data);
+    }
+
+    // Default: no data available, return empty array
+    return [];
   }, [appPlatformResponse, group, kind]);
 
-  return appPlatform
-    ? {
-        ...appPlatformResponse,
-        data: appPlatformStarredItems,
-      }
-    : legacyResponse;
+  // Determine loading state: true if we don't have processed data yet
+  // This ensures the component shows loading spinner until we have actual data to display
+  // Key fix: when query is uninitialized, RTK Query's isLoading is false, but we need it to be true
+  const isLoadingState = appPlatformStarredItems === undefined || appPlatformResponse.isUninitialized;
+
+  if (appPlatform) {
+    return {
+      ...appPlatformResponse,
+      data: appPlatformStarredItems,
+      // Override isLoading to be true when we don't have processed data OR when query is uninitialized
+      // This is the key fix: even if RTK Query says isLoading: false (which it does when uninitialized),
+      // if we don't have data to show, we should still show loading
+      isLoading: isLoadingState,
+      // Also ensure isFetching doesn't interfere - if uninitialized, we're effectively "fetching"
+      isFetching: isLoadingState ? true : appPlatformResponse.isFetching,
+    };
+  }
+
+  // For legacy response, handle loading state properly
+  // Legacy query returns string[] directly, so if we have data or the query completed, we're not loading
+  // Only show loading if query is uninitialized, actively loading, or fetching without data
+  const legacyIsLoading =
+    legacyResponse.isUninitialized || legacyResponse.isLoading || (legacyResponse.isFetching && !legacyResponse.data);
+
+  return {
+    ...legacyResponse,
+    isLoading: legacyIsLoading,
+  };
 };
 
 /**

--- a/public/app/features/stars/hooks.ts
+++ b/public/app/features/stars/hooks.ts
@@ -65,127 +65,40 @@ export const useStarredItems = (group: string, kind: string) => {
   const appPlatformResponse = useListStarsQuery(queryArgs);
 
   const appPlatformStarredItems = useMemo(() => {
-    const { data, isLoading, isUninitialized, isFetching, isSuccess, isError } = appPlatformResponse;
+    const { data, isLoading, isUninitialized } = appPlatformResponse;
 
-    // If query hasn't been initiated yet, return undefined to show loading state
-    if (isUninitialized) {
+    // If query hasn't been initiated yet or is still loading, return undefined to show loading state
+    if (isUninitialized || isLoading) {
       return undefined;
     }
 
-    // If query is still loading (initial load), return undefined to show loading state
-    if (isLoading) {
-      return undefined;
-    }
-
-    // Helper function to extract starred items from data
-    const extractStarredItems = (responseData: typeof data): string[] => {
-      if (!responseData || !('items' in responseData)) {
-        return [];
-      }
-
-      const items = Array.isArray(responseData.items) ? responseData.items : [];
-      if (!items.length) {
-        return [];
-      }
-
-      const firstItem = items[0];
-      if (!firstItem || typeof firstItem !== 'object' || !('spec' in firstItem)) {
-        return [];
-      }
-
-      const spec = firstItem.spec;
-      if (!spec || typeof spec !== 'object' || !('resource' in spec)) {
-        return [];
-      }
-
-      const resources = Array.isArray(spec.resource) ? spec.resource : [];
-      const resourceInfo = resources.find((info: unknown) => {
-        if (typeof info !== 'object' || info === null) {
-          return false;
-        }
-        if (!('group' in info) || !('kind' in info)) {
-          return false;
-        }
-        // TypeScript knows info has 'group' and 'kind' properties at this point
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const groupValue = (info as { group: unknown }).group;
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const kindValue = (info as { kind: unknown }).kind;
-        return groupValue === group && kindValue === kind;
-      });
-
-      if (resourceInfo && typeof resourceInfo === 'object' && resourceInfo !== null && 'names' in resourceInfo) {
-        // TypeScript knows resourceInfo has 'names' property at this point
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const namesValue = (resourceInfo as { names: unknown }).names;
-        return Array.isArray(namesValue) ? namesValue : [];
-      }
-
-      return [];
-    };
-
-    // If query completed successfully, process the data
-    if (isSuccess && data) {
-      return extractStarredItems(data);
-    }
-
-    // If query completed with error, return empty array
-    if (isError) {
+    // If query completed but no data, return empty array
+    if (!data) {
       return [];
     }
 
-    // If query completed successfully but no data, return empty array
-    if (isSuccess && !data) {
+    const starredItems = appPlatformResponse.data?.items || [];
+    if (!starredItems.length) {
       return [];
     }
 
-    // If we're still fetching but have cached data, use it
-    // Otherwise, if fetching without cached data, show loading
-    if (isFetching) {
-      // If we have data from a previous fetch, use it
-      if (data) {
-        return extractStarredItems(data);
-      }
-      // No cached data and still fetching - show loading
-      return undefined;
-    }
-
-    // Fallback: if we have data, use it
-    if (data) {
-      return extractStarredItems(data);
-    }
-
-    // Default: no data available, return empty array
-    return [];
+    return starredItems[0]?.spec.resource.find((info) => info.group === group && info.kind === kind)?.names || [];
   }, [appPlatformResponse, group, kind]);
-
-  // Determine loading state: true if we don't have processed data yet
-  // This ensures the component shows loading spinner until we have actual data to display
-  // Key fix: when query is uninitialized, RTK Query's isLoading is false, but we need it to be true
-  const isLoadingState = appPlatformStarredItems === undefined || appPlatformResponse.isUninitialized;
 
   if (appPlatform) {
     return {
       ...appPlatformResponse,
       data: appPlatformStarredItems,
-      // Override isLoading to be true when we don't have processed data OR when query is uninitialized
-      // This is the key fix: even if RTK Query says isLoading: false (which it does when uninitialized),
-      // if we don't have data to show, we should still show loading
-      isLoading: isLoadingState,
-      // Also ensure isFetching doesn't interfere - if uninitialized, we're effectively "fetching"
-      isFetching: isLoadingState ? true : appPlatformResponse.isFetching,
+      // Ensure isLoading is true when data is undefined (still loading or uninitialized)
+      isLoading: appPlatformStarredItems === undefined ? true : appPlatformResponse.isLoading,
     };
   }
 
-  // For legacy response, handle loading state properly
-  // Legacy query returns string[] directly, so if we have data or the query completed, we're not loading
-  // Only show loading if query is uninitialized, actively loading, or fetching without data
-  const legacyIsLoading =
-    legacyResponse.isUninitialized || legacyResponse.isLoading || (legacyResponse.isFetching && !legacyResponse.data);
-
+  // For legacy response, ensure isLoading is true when query is uninitialized
+  // RTK Query sets isLoading: false when uninitialized, but we need it to be true
   return {
     ...legacyResponse,
-    isLoading: legacyIsLoading,
+    isLoading: legacyResponse.isUninitialized || legacyResponse.isLoading,
   };
 };
 


### PR DESCRIPTION
Noticed this issue while testing short URLs in my local host env

## Problem

The dashboard star/favorite icon was stuck displaying a spinner on first load, even after the starred items data had been fetched. The icon would only update correctly after manually clicking to favorite/unfavorite the dashboard.

## Root Cause

The issue had two parts:

1. **Component rendering**: React wasn't re-rendering the `Icon` component when the `isLoading` state changed from `true` to `false`, even though the hook was returning the correct state.

2. **Loading state handling**: RTK Query sets `isLoading: false` when a query is `isUninitialized: true`, but we need to show a loading state until the query has actually completed.

## Solution

### Component Changes (`StarToolbarButton.tsx`)
- Wrapped `iconProps` in `useMemo` with `[isLoading, isStarred]` dependencies to ensure React detects state changes
- Added `key={`${isLoading}-${isStarred}`}` prop to the `Icon` component to force React to re-render when state changes

### Hook Changes (`hooks.ts`)
- Simplified `appPlatformStarredItems` logic to properly handle `isUninitialized` and `isLoading` states
- Fixed loading state for app platform API: set `isLoading: true` when `appPlatformStarredItems === undefined`
- Fixed loading state for legacy API: set `isLoading: true` when `isUninitialized || isLoading`

## Testing

Added two new test cases to verify loading state transitions:
- Shows spinner initially and transitions to empty star when loading completes with no starred items
- Shows spinner initially and transitions to filled star when loading completes with starred item

All existing tests pass, and the new tests cover both app platform and legacy API paths.

## Verification

- ✅ All tests pass
- ✅ No linting errors
- ✅ Works correctly with both app platform and legacy APIs
- ✅ Icon correctly transitions from spinner → empty star → filled star (or vice versa)

Before 


https://github.com/user-attachments/assets/929a791d-65d4-4e60-b8ae-e0c2ccde2dd4



After


https://github.com/user-attachments/assets/6c87ea3e-1d2a-4664-b08f-e44d5e2f757f

