### PR TITLE
FeatureToggles: Remove feedbackButton unused toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -748,10 +748,6 @@ export interface FeatureToggles {
   */
   alertingNotificationsStepMode?: boolean;
   /**
-  * Enables a button to send feedback from the Grafana UI
-  */
-  feedbackButton?: boolean;
-  /**
   * Enable unified storage search UI
   */
   unifiedStorageSearchUI?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1299,13 +1299,6 @@ var (
 			Expression:   "true",
 		},
 		{
-			Name:         "feedbackButton",
-			Description:  "Enables a button to send feedback from the Grafana UI",
-			Stage:        FeatureStageExperimental,
-			Owner:        grafanaOperatorExperienceSquad,
-			HideFromDocs: true,
-		},
-		{
 			Name:              "unifiedStorageSearchUI",
 			Description:       "Enable unified storage search UI",
 			Stage:             FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -169,7 +169,6 @@ alertingEnrichmentPerRule,experimental,@grafana/alerting-squad,false,false,false
 alertingEnrichmentAssistantInvestigations,experimental,@grafana/alerting-squad,false,false,false
 alertingAIAnalyzeCentralStateHistory,experimental,@grafana/alerting-squad,false,false,false
 alertingNotificationsStepMode,GA,@grafana/alerting-squad,false,false,true
-feedbackButton,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 unifiedStorageSearchUI,experimental,@grafana/search-and-storage,false,false,false
 elasticsearchCrossClusterSearch,GA,@grafana/partner-datasources,false,false,false
 unifiedHistory,experimental,@grafana/grafana-search-navigate-organise,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -687,10 +687,6 @@ const (
 	// Enables simplified step mode in the notifications section
 	FlagAlertingNotificationsStepMode = "alertingNotificationsStepMode"
 
-	// FlagFeedbackButton
-	// Enables a button to send feedback from the Grafana UI
-	FlagFeedbackButton = "feedbackButton"
-
 	// FlagUnifiedStorageSearchUI
 	// Enable unified storage search UI
 	FlagUnifiedStorageSearchUI = "unifiedStorageSearchUI"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1731,7 +1731,8 @@
       "metadata": {
         "name": "feedbackButton",
         "resourceVersion": "1753448760331",
-        "creationTimestamp": "2024-12-02T17:08:15Z"
+        "creationTimestamp": "2024-12-02T17:08:15Z",
+        "deletionTimestamp": "2025-11-20T09:53:52Z"
       },
       "spec": {
         "description": "Enables a button to send feedback from the Grafana UI",


### PR DESCRIPTION
Never implemented, if we choose to do so we can reintroduce the toggle later on.

Closes https://github.com/grafana/grafana-operator-experience-squad/issues/1615