### PR TITLE
Live: Add configuration for client_queue_max_size

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1959,6 +1959,10 @@ max_connections = 100
 # The limit can be disabled by setting it to -1.
 message_size_limit = 8388608
 
+# client_queue_max_size is the maximum size in bytes of the client queue
+# for Live connections. Defaults to 4MB.
+client_queue_max_size = 4194304
+
 # allowed_origins is a comma-separated list of origins that can establish connection with Grafana Live.
 # If not set then origin will be matched over root_url. Supports wildcard symbol "*".
 allowed_origins =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1903,6 +1903,10 @@ default_datasource_uid =
 # ha_prefix is a prefix for keys in the HA engine. It's used to separate keys for different Grafana instances.
 ;ha_prefix =
 
+# client_queue_max_size is the maximum size in bytes of the client queue
+# for Live connections. Defaults to 4MB.
+;client_queue_max_size = 
+
 #################################### Grafana Image Renderer Plugin ##########################
 [plugin.grafana-image-renderer]
 # Instruct headless browser instance to use a default timezone when not provided by Grafana, e.g. when rendering panel image of alert.

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -120,7 +120,7 @@ func ProvideService(plugCtxProvider *plugincontext.Provider, cfg *setting.Cfg, r
 		Metrics: centrifuge.MetricsConfig{
 			MetricsNamespace: "grafana_live",
 		},
-		ClientQueueMaxSize: 4194304, // 4MB
+		ClientQueueMaxSize: cfg.LiveClientQueueMaxSize,
 		// Use reasonably large expiration interval for stream meta key,
 		// much bigger than maximum HistoryLifetime value in Node config.
 		// This way stream meta data will expire, in some cases you may want

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -480,6 +480,9 @@ type Cfg struct {
 	// LiveMessageSizeLimit is the maximum size in bytes of Websocket messages
 	// from clients. Defaults to 64KB.
 	LiveMessageSizeLimit int
+	// LiveClientQueueMaxSize is the maximum size in bytes of the client queue
+	// for Live connections. Defaults to 4MB.
+	LiveClientQueueMaxSize int
 
 	// Grafana.com URL, used for OAuth redirect.
 	GrafanaComURL string
@@ -2066,6 +2069,11 @@ func (cfg *Cfg) readLiveSettings(iniFile *ini.File) error {
 	if cfg.LiveMessageSizeLimit < -1 {
 		return fmt.Errorf("unexpected value %d for [live] message_size_limit", cfg.LiveMaxConnections)
 	}
+	cfg.LiveClientQueueMaxSize = section.Key("client_queue_max_size").MustInt(4194304)
+	if cfg.LiveClientQueueMaxSize <= 0 {
+		return fmt.Errorf("unexpected value %d for [live] client_queue_max_size", cfg.LiveMaxConnections)
+	}
+
 	cfg.LiveHAEngine = section.Key("ha_engine").MustString("")
 	switch cfg.LiveHAEngine {
 	case "", "redis":


### PR DESCRIPTION
This pull request adds support for configuring the maximum size of the client queue for Live connections in Grafana.

**Configuration changes:**
Added a new `client_queue_max_size` setting (default 4MB) to `conf/defaults.ini`.
Added `client_queue_max_size` setting in `conf/sample.ini` for sample configurations.

**Code changes:**
Added `LiveClientQueueMaxSize` in the `Cfg` to store the client queue size configuration.
Updated the `readLiveSettings` function to read and validate the `client_queue_max_size` value from the configuration file.
Updated the `ProvideService` function in `live.go` to use the configured `LiveClientQueueMaxSize` instead of a hardcoded value when creating the Live service.

**Why do we need this change:**
In Tempo we use Grafana Live for streaming query results, and the current hard-coded 4MB limit is starting to get in the way. After increasing the size of our streamed queries, we found that Grafana Live crashes because the queue size can’t be adjusted. Making this value configurable lets us raise the limit when needed and avoids the crashes we’re seeing with larger queries.