### PR TITLE
Alerting: Update docs for ash AI helper button

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-state-history.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state-history.md
@@ -73,6 +73,37 @@ To access the History page, complete the following steps.
 
    {{< figure src="/media/docs/alerting/alerting-alert-history-tab.png" max-width="750px" alt="Alert History tab in Grafana Alerting" >}}
 
+## Use Grafana Assistant to analyze alert state history
+
+{{< admonition type="note" >}}
+This feature is available in Grafana Cloud when Grafana Assistant is enabled.
+{{< /admonition >}}
+
+The **Analyze with Assistant** button provides AI-powered analysis of your alert history to help you understand and troubleshoot alert patterns. Located in the top-right corner of the History page event list, this button uses Grafana Assistant to analyze the events displayed in your current view.
+
+When you click the AI Triage button, the Grafana Assistant analyzes:
+
+- Alert state transitions over the selected time range
+- Alert instance patterns and frequency
+- Common labels and characteristics of firing alerts
+- Temporal patterns in alert behavior
+
+The AI assistant can help you:
+
+- Identify root causes of alert storms
+- Detect patterns in alert firing behavior
+- Understand correlations between different alert instances
+- Get suggestions for improving alert configurations
+
+To use the Analyze with Assistant feature:
+
+1. Navigate to the History page as described above.
+2. Filter the events to focus on the alerts you want to analyze using labels, states, or time range.
+3. Click the **Analyze with Assistant** button in the top-right corner of the event list.
+4. Review the AI-generated analysis and recommendations.
+
+The AI analysis is based on the currently displayed events, so filtering your view to specific alerts or time periods will result in more focused insights.
+
 ## View from the State history view
 
 Use the State history view to get insight into how your individual alert instances behave over time.


### PR DESCRIPTION
This PR adds docs for the new AI Helper button on the central alert state history.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
