### PR TITLE
TS checker: Increase memory limit

### DIFF
--- a/scripts/webpack/webpack.dev.js
+++ b/scripts/webpack/webpack.dev.js
@@ -135,7 +135,7 @@ module.exports = (env = {}) => {
             async: true, // don't block webpack emit
             typescript: {
               mode: 'write-references',
-              memoryLimit: 5096,
+              memoryLimit: 8192,
               diagnosticOptions: {
                 semantic: true,
                 syntactic: true,


### PR DESCRIPTION
**What is this feature?**

During local development, there are frequent out-of-memory issues caused by the ForkTsCheckerWebpackPlugin. Let’s increase the memory limit to 8 GB.

