### PR TITLE
Expressions: Fix duplicate SQL expression tracking events

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { CoreApp, DataSourceApi, DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
@@ -337,22 +339,23 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
   const { data, queries } = model.queryRunner.useState();
   const { openDrawer: openQueryLibraryDrawer, queryLibraryEnabled } = useQueryLibraryContext();
 
+  const handleAddExpression = useCallback(
+    (type: ExpressionQueryType) => {
+      reportInteraction('dashboards_expression_interaction', {
+        action: 'add_expression',
+        expression_type: type,
+        context: 'panel_query_section',
+      });
+      model.onAddExpressionOfType(type);
+    },
+    [model]
+  );
+
   if (!datasource || !dsSettings || !data) {
     return null;
   }
 
   const showAddButton = !isSharedDashboardQuery(dsSettings.name);
-
-  // Wrapper for adding expressions that tracks the interaction
-  const handleAddExpression = (type: ExpressionQueryType) => {
-    // Track when user adds a new expression from the dropdown
-    reportInteraction('dashboards_expression_interaction', {
-      action: 'add_expression',
-      expression_type: type,
-      context: 'panel_query_section',
-    });
-    model.onAddExpressionOfType(type);
-  };
 
   const onSelectQueryFromLibrary = async (query: DataQuery) => {
     // ensure all queries explicitly define a datasource

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -1,7 +1,7 @@
 import { CoreApp, DataSourceApi, DataSourceInstanceSettings, getDataSourceRef } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
-import { config, getDataSourceSrv } from '@grafana/runtime';
+import { config, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
 import {
   SceneObjectBase,
   SceneComponentProps,
@@ -342,6 +342,18 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
   }
 
   const showAddButton = !isSharedDashboardQuery(dsSettings.name);
+
+  // Wrapper for adding expressions that tracks the interaction
+  const handleAddExpression = (type: ExpressionQueryType) => {
+    // Track when user adds a new expression from the dropdown
+    reportInteraction('dashboards_expression_interaction', {
+      action: 'add_expression',
+      expression_type: type,
+      context: 'panel_query_section',
+    });
+    model.onAddExpressionOfType(type);
+  };
+
   const onSelectQueryFromLibrary = async (query: DataQuery) => {
     // ensure all queries explicitly define a datasource
     const enrichedQueries = queries.map((q) =>
@@ -421,7 +433,7 @@ export function PanelDataQueriesTabRendered({ model }: SceneComponentProps<Panel
           </>
         )}
         {config.expressionsEnabled && model.isExpressionsSupported(dsSettings) && (
-          <ExpressionTypeDropdown handleOnSelect={model.onAddExpressionOfType}>
+          <ExpressionTypeDropdown handleOnSelect={handleAddExpression}>
             <Button icon="plus" variant="secondary" data-testid={selectors.components.QueryTab.addExpression}>
               <Trans i18nKey="dashboard-scene.panel-data-queries-tab-rendered.expression">Expression&nbsp;</Trans>
             </Button>

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef } from 'react';
 
 import { DataSourceApi, FeatureState, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
 import { Button, FeatureBadge, IconButton, InlineField, PopoverContent, useStyles2 } from '@grafana/ui';
 
 import { ClassicConditions } from './components/ClassicConditions';
@@ -96,22 +95,6 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
   const { getCachedExpression, setCachedExpression } = useExpressionsCache();
 
   const styles = useStyles2(getStyles);
-
-  const initialExpressionRef = useRef(query.expression);
-  const hasTrackedAddExpression = useRef(false);
-
-  useEffect(() => {
-    // Only track if 1) query has a type, and 2) we haven't tracked yet for this component instance, and
-    // 3) initial expression was empty (indicating a new expression, not editing existing)
-    if (query.type && !hasTrackedAddExpression.current && !initialExpressionRef.current) {
-      reportInteraction('dashboards_expression_interaction', {
-        action: 'add_expression',
-        expression_type: query.type,
-        context: 'panel_query_section',
-      });
-      hasTrackedAddExpression.current = true;
-    }
-  }, [query.type, query.refId]);
 
   useEffect(() => {
     setCachedExpression(query.type, query.expression);

--- a/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
+++ b/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
@@ -2,7 +2,6 @@ import { css } from '@emotion/css';
 import { ReactElement, useCallback, useMemo, memo } from 'react';
 
 import { FeatureState, GrafanaTheme2, SelectableValue } from '@grafana/data';
-import { reportInteraction } from '@grafana/runtime';
 import { Dropdown, FeatureBadge, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
 import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 
@@ -29,15 +28,7 @@ const ExpressionMenuItem = memo<ExpressionMenuItemProps>(({ item, onSelect }) =>
   const { value, label, description } = item;
   const styles = useStyles2(getStyles);
 
-  const handleClick = useCallback(() => {
-    // Track the interaction when user clicks an expression type in the dropdown
-    reportInteraction('dashboards_expression_interaction', {
-      action: 'add_expression',
-      expression_type: value,
-      context: 'panel_query_section',
-    });
-    onSelect(value!);
-  }, [value, onSelect]);
+  const handleClick = useCallback(() => onSelect(value!), [value, onSelect]);
 
   return (
     <Menu.Item

--- a/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
+++ b/public/app/features/expressions/components/ExpressionTypeDropdown.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { ReactElement, useCallback, useMemo, memo } from 'react';
 
 import { FeatureState, GrafanaTheme2, SelectableValue } from '@grafana/data';
+import { reportInteraction } from '@grafana/runtime';
 import { Dropdown, FeatureBadge, Icon, Menu, Tooltip, useStyles2 } from '@grafana/ui';
 import { ExpressionQueryType, expressionTypes } from 'app/features/expressions/types';
 
@@ -28,7 +29,15 @@ const ExpressionMenuItem = memo<ExpressionMenuItemProps>(({ item, onSelect }) =>
   const { value, label, description } = item;
   const styles = useStyles2(getStyles);
 
-  const handleClick = useCallback(() => onSelect(value!), [value, onSelect]);
+  const handleClick = useCallback(() => {
+    // Track the interaction when user clicks an expression type in the dropdown
+    reportInteraction('dashboards_expression_interaction', {
+      action: 'add_expression',
+      expression_type: value,
+      context: 'panel_query_section',
+    });
+    onSelect(value!);
+  }, [value, onSelect]);
 
   return (
     <Menu.Item


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate `reportInteraction` events when adding SQL expressions from the transformation tab.

## Problem

Previously, when adding a SQL expression from the transformation tab, two tracking events would fire:
1. The transformation tab event (with `context: 'empty_transformations_placeholder'`) - correct ✓
2. The query tab event (with `context: 'panel_query_section'`) - incorrect ❌

This caused duplicate and incorrect tracking data.

## Solution

Moved the tracking to the point of user interaction in `ExpressionTypeDropdown`:
- **Query tab**: Event fires when user clicks expression type in the dropdown menu
- **Transformation tab**: Event fires in `EmptyTransformationsMessage` before programmatically creating the expression