### PR TITLE
Chore: Fix playlist flaky test

### DIFF
--- a/public/app/features/playlist/PlaylistNewPage.test.tsx
+++ b/public/app/features/playlist/PlaylistNewPage.test.tsx
@@ -24,7 +24,21 @@ jest.mock('app/core/components/TagFilter/TagFilter', () => ({
 
 function getTestContext() {
   jest.clearAllMocks();
-  const backendSrvMock = jest.spyOn(backendSrv, 'fetch').mockImplementation(() => of(createFetchResponse({})));
+
+  // Create separate spies for different HTTP methods
+  const postSpy = jest.fn();
+  const otherSpy = jest.fn();
+
+  const backendSrvMock = jest.spyOn(backendSrv, 'fetch').mockImplementation((options) => {
+    if (options.method === 'POST') {
+      postSpy(options);
+      return of(createFetchResponse({}));
+    }
+    // Handle GET and other methods
+    otherSpy(options);
+    return of(createFetchResponse({ items: [] }));
+  });
+
   jest.spyOn(backendSrv, 'search').mockResolvedValue([]);
 
   const { rerender } = render(
@@ -33,7 +47,7 @@ function getTestContext() {
     </TestProvider>
   );
 
-  return { rerender, backendSrvMock };
+  return { rerender, backendSrvMock, postSpy, otherSpy };
 }
 
 describe('PlaylistNewPage', () => {
@@ -47,15 +61,17 @@ describe('PlaylistNewPage', () => {
 
   describe('when submitted', () => {
     it('then correct api should be called', async () => {
-      const { backendSrvMock } = getTestContext();
+      const { postSpy } = getTestContext();
 
       expect(locationService.getLocation().pathname).toEqual('/');
 
       await userEvent.type(screen.getByRole('textbox', { name: selectors.pages.PlaylistForm.name }), 'A new name');
       fireEvent.submit(screen.getByRole('button', { name: /save/i }));
-      await waitFor(() => expect(backendSrvMock).toHaveBeenCalledTimes(1));
-      expect(backendSrvMock).toHaveBeenCalledWith(
+      await waitFor(() => expect(postSpy).toHaveBeenCalledTimes(1));
+
+      expect(postSpy).toHaveBeenCalledWith(
         expect.objectContaining({
+          method: 'POST',
           body: expect.objectContaining({
             spec: {
               title: 'A new name',


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky test where an assertion on a POST request was failing because a race condition with an RTK refetch.
This fix takes into account only the POST used to create a playlist.
[Failing workflow](https://github.com/grafana/grafana/actions/runs/19533577822/job/55922213211?pr=111093)
```
  ● PlaylistNewPage › when submitted › then correct api should be called

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 2
```

[Related discussion](https://raintank-corp.slack.com/archives/C05PEHHJTC5/p1763635340422069)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
