### PR TITLE
Suggestions: Add plugin.json flag to indicate a panel should be inclu…

### DIFF
--- a/apps/plugins/kinds/plugin.cue
+++ b/apps/plugins/kinds/plugin.cue
@@ -67,6 +67,7 @@ pluginV0Alpha1: {
 	multiValueFilterOperators?: bool
 	pascalName?: string
 	preload?: bool
+  suggestions?: bool
 	queryOptions?: #QueryOptions
 	// +listType=atomic
 	routes?: [...#Route]

--- a/apps/plugins/pkg/apis/plugins/v0alpha1/plugin_getmeta_response_types_gen.go
+++ b/apps/plugins/pkg/apis/plugins/v0alpha1/plugin_getmeta_response_types_gen.go
@@ -186,6 +186,7 @@ type GetMeta struct {
 	MultiValueFilterOperators *bool         `json:"multiValueFilterOperators,omitempty"`
 	PascalName                *string       `json:"pascalName,omitempty"`
 	Preload                   *bool         `json:"preload,omitempty"`
+	Suggestions               *bool         `json:"suggestions,omitempty"`
 	QueryOptions              *QueryOptions `json:"queryOptions,omitempty"`
 	// +listType=atomic
 	Routes        []Route       `json:"routes,omitempty"`

--- a/apps/plugins/pkg/apis/plugins_manifest.go
+++ b/apps/plugins/pkg/apis/plugins_manifest.go
@@ -228,6 +228,11 @@ var appManifestData = app.ManifestData{
 																					Type: []string{"boolean"},
 																				},
 																			},
+																			"suggestions": {
+																				SchemaProps: spec.SchemaProps{
+																					Type: []string{"boolean"},
+																				},
+																			},
 																			"tracing": {
 																				SchemaProps: spec.SchemaProps{
 																					Type: []string{"boolean"},

--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -341,6 +341,10 @@
       "type": "boolean",
       "description": "Initialize plugin on startup. By default, the plugin initializes on first use, but when preload is set to true the plugin loads when the Grafana web app loads the first time. Only applicable to app plugins. When setting to `true`, implement [frontend code splitting](https://grafana.com/developers/plugin-tools/get-started/best-practices#app-plugins) to minimise performance implications."
     },
+    "suggestions": {
+      "type": "boolean",
+      "description": "For panel plugins. If set to true, the plugin's suggestions supplier will be invoked and any suggestions returned will be included in the Suggestions pane in the Panel Editor."
+    },
     "queryOptions": {
       "type": "object",
       "description": "For data source plugins. There is a query options section in the plugin's query editor and these options can be turned on if needed.",

--- a/packages/grafana-data/src/types/panel.ts
+++ b/packages/grafana-data/src/types/panel.ts
@@ -20,6 +20,8 @@ export type InterpolateFunction = (value: string, scopedVars?: ScopedVars, forma
 export interface PanelPluginMeta extends PluginMeta {
   /** Indicates that panel does not issue queries */
   skipDataQuery?: boolean;
+  /** Indicates that the panel implements suggestions */
+  suggestions?: boolean;
   /** Indicates that panel should not be available in visualisation picker */
   hideFromList?: boolean;
   /** Sort order */

--- a/pkg/api/frontendsettings.go
+++ b/pkg/api/frontendsettings.go
@@ -163,6 +163,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 			ModuleHash:      hs.pluginAssets.ModuleHash(c.Req.Context(), panel),
 			BaseURL:         panel.BaseURL,
 			SkipDataQuery:   panel.SkipDataQuery,
+			Suggestions:     panel.Suggestions,
 			HideFromList:    panel.HideFromList,
 			ReleaseState:    string(panel.State),
 			Signature:       string(panel.Signature),

--- a/pkg/plugins/models.go
+++ b/pkg/plugins/models.go
@@ -318,6 +318,7 @@ type PanelDTO struct {
 	HideFromList    bool              `json:"hideFromList"`
 	Sort            int               `json:"sort"`
 	SkipDataQuery   bool              `json:"skipDataQuery"`
+	Suggestions     bool              `json:"suggestions,omitempty"`
 	ReleaseState    string            `json:"state"`
 	BaseURL         string            `json:"baseUrl"`
 	Signature       string            `json:"signature"`

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -105,6 +105,7 @@ type JSONData struct {
 
 	// Panel settings
 	SkipDataQuery bool `json:"skipDataQuery"`
+	Suggestions   bool `json:"suggestions,omitempty"`
 
 	// App settings
 	AutoEnabled bool       `json:"autoEnabled"`

--- a/public/app/features/panel/state/util.ts
+++ b/public/app/features/panel/state/util.ts
@@ -18,6 +18,10 @@ export function getVizPluginMeta(): PanelPluginMeta[] {
   return getAllPanelPluginMeta().filter((panel) => !panel.skipDataQuery);
 }
 
+export function getSuggestionsPluginsMeta(): PanelPluginMeta[] {
+  return getAllPanelPluginMeta().filter((panel) => panel.suggestions);
+}
+
 export function filterPluginList(
   pluginsList: PanelPluginMeta[],
   searchQuery: string, // Note: this will be an escaped regex string as it comes from `FilterInput`

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -10,7 +10,7 @@ import {
 import { config } from '@grafana/runtime';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
-import { getAllPanelPluginMeta } from '../state/util';
+import { getSuggestionsPluginsMeta } from '../state/util';
 
 export const panelsToCheckFirst = [
   'timeseries',
@@ -40,7 +40,7 @@ async function getPanelsWithSuggestions(): Promise<PanelPlugin[]> {
 
     // list of plugins to load is determined by the feature flag
     const pluginIds: string[] = config.featureToggles.externalVizSuggestions
-      ? getAllPanelPluginMeta().map((m) => m.id)
+      ? getSuggestionsPluginsMeta().map((m) => m.id)
       : panelsToCheckFirst;
 
     // import the plugins in parallel using Promise.allSettled

--- a/public/app/plugins/panel/barchart/plugin.json
+++ b/public/app/plugins/panel/barchart/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Bar chart",
   "id": "barchart",
-
+  "suggestions": true,
   "info": {
     "description": "Categorical charts with group support",
     "author": {

--- a/public/app/plugins/panel/bargauge/plugin.json
+++ b/public/app/plugins/panel/bargauge/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Bar gauge",
   "id": "bargauge",
-
+  "suggestions": true,
   "info": {
     "description": "Horizontal and vertical gauges",
     "author": {

--- a/public/app/plugins/panel/candlestick/plugin.json
+++ b/public/app/plugins/panel/candlestick/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Candlestick",
   "id": "candlestick",
-
+  "suggestions": true,
   "info": {
     "description": "Graphical representation of price movements of a security, derivative, or currency.",
     "keywords": ["financial", "price", "currency", "k-line"],

--- a/public/app/plugins/panel/flamegraph/plugin.json
+++ b/public/app/plugins/panel/flamegraph/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Flame Graph",
   "id": "flamegraph",
-
+  "suggestions": true,
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/public/app/plugins/panel/gauge/plugin.json
+++ b/public/app/plugins/panel/gauge/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Gauge",
   "id": "gauge",
-
+  "suggestions": true,
   "info": {
     "description": "Standard gauge visualization",
     "author": {

--- a/public/app/plugins/panel/heatmap/plugin.json
+++ b/public/app/plugins/panel/heatmap/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Heatmap",
   "id": "heatmap",
-
+  "suggestions": true,
   "info": {
     "description": "Like a histogram over time",
     "author": {

--- a/public/app/plugins/panel/logs/plugin.json
+++ b/public/app/plugins/panel/logs/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Logs",
   "id": "logs",
-
+  "suggestions": true,
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/public/app/plugins/panel/nodeGraph/plugin.json
+++ b/public/app/plugins/panel/nodeGraph/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Node Graph",
   "id": "nodeGraph",
-
+  "suggestions": true,
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/public/app/plugins/panel/piechart/plugin.json
+++ b/public/app/plugins/panel/piechart/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Pie chart",
   "id": "piechart",
-
+  "suggestions": true,
   "info": {
     "description": "The new core pie chart visualization",
     "author": {

--- a/public/app/plugins/panel/radialbar/plugin.json
+++ b/public/app/plugins/panel/radialbar/plugin.json
@@ -3,6 +3,7 @@
   "name": "New Gauge",
   "id": "radialbar",
   "state": "alpha",
+  "suggestions": true,
   "info": {
     "description": "Standard gauge visualization",
     "author": {

--- a/public/app/plugins/panel/stat/plugin.json
+++ b/public/app/plugins/panel/stat/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Stat",
   "id": "stat",
-
+  "suggestions": true,
   "info": {
     "description": "Big stat values & sparklines",
     "author": {

--- a/public/app/plugins/panel/state-timeline/plugin.json
+++ b/public/app/plugins/panel/state-timeline/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "State timeline",
   "id": "state-timeline",
-
+  "suggestions": true,
   "info": {
     "description": "State changes and durations",
     "author": {

--- a/public/app/plugins/panel/status-history/plugin.json
+++ b/public/app/plugins/panel/status-history/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Status history",
   "id": "status-history",
-
+  "suggestions": true,
   "info": {
     "description": "Periodic status history",
     "author": {

--- a/public/app/plugins/panel/table/plugin.json
+++ b/public/app/plugins/panel/table/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Table",
   "id": "table",
-
+  "suggestions": true,
   "info": {
     "description": "Supports many column styles",
     "author": {

--- a/public/app/plugins/panel/timeseries/plugin.json
+++ b/public/app/plugins/panel/timeseries/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Time series",
   "id": "timeseries",
-
+  "suggestions": true,
   "info": {
     "description": "Time based line, area and bar charts",
     "author": {

--- a/public/app/plugins/panel/traces/plugin.json
+++ b/public/app/plugins/panel/traces/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Traces",
   "id": "traces",
-
+  "suggestions": true,
   "info": {
     "author": {
       "name": "Grafana Labs",

--- a/public/app/plugins/panel/trend/plugin.json
+++ b/public/app/plugins/panel/trend/plugin.json
@@ -4,7 +4,7 @@
   "id": "trend",
 
   "state": "beta",
-
+  "suggestions": true,
   "info": {
     "description": "Like timeseries, but when x != time",
     "author": {


### PR DESCRIPTION
This PR proposes that `suggestions` be added as an optional boolean to the plugin.json schema. When set, a plugin would be included for suggestions. This is important to add to avoid loading plugins which are unnecessary the first time we render suggestions in a given suggestion, since in some instances that could involve loading dozens more plugins more than we need.