### PR TITLE
Plugins: Add extension points for grafana-setupguide-app in top nav and menu

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -218,6 +218,8 @@ export enum PluginExtensionPoints {
   LogsViewResourceAttributes = 'grafana/logsview/resource-attributes',
   AppChrome = 'grafana/app/chrome/v1',
   ExtensionSidebar = 'grafana/extension-sidebar/v0-alpha',
+  MegaMenuAction = 'grafana/megamenu/action',
+  SingleTopBarAction = 'grafana/singletopbar/action',
 }
 
 // Don't use directly in a plugin!

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -7,13 +7,13 @@ import { usePatchUserPreferencesMutation } from '@grafana/api-clients/rtkq/legac
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { renderLimitedComponents, reportInteraction } from '@grafana/runtime';
+import { reportInteraction } from '@grafana/runtime';
 import { ScrollContainer, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { setBookmark } from 'app/core/reducers/navBarTree';
-import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 import { useDispatch, useSelector } from 'app/types/store';
 
+import { MegaMenuExtensionPoint } from './MegaMenuExtensionPoint';
 import { MegaMenuHeader } from './MegaMenuHeader';
 import { MegaMenuItem } from './MegaMenuItem';
 import { usePinnedItems } from './hooks';
@@ -35,11 +35,6 @@ export const MegaMenu = memo(
     const state = chrome.useState();
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
-
-    // Plugin extension point restricted to grafana-setupguide-app
-    const { components } = usePluginComponents({
-      extensionPointId: 'grafana/megamenu/action',
-    });
 
     // Remove profile + help from tree
     const navItems = navTree
@@ -129,12 +124,7 @@ export const MegaMenu = memo(
                   />
                 ))}
               </ul>
-              {renderLimitedComponents({
-                props: {},
-                components: components,
-                limit: 1,
-                pluginId: 'grafana-setupguide-app',
-              })}
+              <MegaMenuExtensionPoint />
             </>
           </ScrollContainer>
         </nav>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -7,10 +7,11 @@ import { usePatchUserPreferencesMutation } from '@grafana/api-clients/rtkq/legac
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { renderLimitedComponents, reportInteraction } from '@grafana/runtime';
 import { ScrollContainer, useStyles2 } from '@grafana/ui';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 import { setBookmark } from 'app/core/reducers/navBarTree';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 import { useDispatch, useSelector } from 'app/types/store';
 
 import { MegaMenuHeader } from './MegaMenuHeader';
@@ -34,6 +35,11 @@ export const MegaMenu = memo(
     const state = chrome.useState();
     const [patchPreferences] = usePatchUserPreferencesMutation();
     const pinnedItems = usePinnedItems();
+
+    // Plugin extension point restricted to grafana-setupguide-app
+    const { components } = usePluginComponents({
+      extensionPointId: 'grafana/megamenu/action',
+    });
 
     // Remove profile + help from tree
     const navItems = navTree
@@ -110,18 +116,26 @@ export const MegaMenu = memo(
         <MegaMenuHeader handleDockedMenu={handleDockedMenu} handleMegaMenu={handleMegaMenu} onClose={onClose} />
         <nav className={styles.content}>
           <ScrollContainer height="100%" overflowX="hidden" showScrollIndicators>
-            <ul className={styles.itemList} aria-label={t('navigation.megamenu.list-label', 'Navigation')}>
-              {navItems.map((link, index) => (
-                <MegaMenuItem
-                  key={link.text}
-                  link={link}
-                  isPinned={isPinned}
-                  onClick={state.megaMenuDocked ? undefined : onClose}
-                  activeItem={activeItem}
-                  onPin={onPinItem}
-                />
-              ))}
-            </ul>
+            <>
+              <ul className={styles.itemList} aria-label={t('navigation.megamenu.list-label', 'Navigation')}>
+                {navItems.map((link, index) => (
+                  <MegaMenuItem
+                    key={link.text}
+                    link={link}
+                    isPinned={isPinned}
+                    onClick={state.megaMenuDocked ? undefined : onClose}
+                    activeItem={activeItem}
+                    onPin={onPinItem}
+                  />
+                ))}
+              </ul>
+              {renderLimitedComponents({
+                props: {},
+                components: components,
+                limit: 1,
+                pluginId: 'grafana-setupguide-app',
+              })}
+            </>
           </ScrollContainer>
         </nav>
       </div>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
@@ -1,7 +1,4 @@
-import { useContext } from 'react';
-
 import { renderLimitedComponents } from '@grafana/runtime';
-import { AddedComponentsRegistryContext } from 'app/features/plugins/extensions/ExtensionRegistriesContext';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 /**
@@ -9,18 +6,14 @@ import { usePluginComponents } from 'app/features/plugins/extensions/usePluginCo
  * Currently restricted to grafana-setupguide-app plugin.
  */
 export function MegaMenuExtensionPoint() {
-  // Check if plugin extension context is available (not available in tests)
-  const context = useContext(AddedComponentsRegistryContext);
-
-  if (!context) {
-    // Silently return null in test environments or when plugin context is not available
-    return null;
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { components } = usePluginComponents({
     extensionPointId: 'grafana/megamenu/action',
   });
+
+  // Return null if no components are registered
+  if (components.length === 0) {
+    return null;
+  }
 
   return (
     <>

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
@@ -1,0 +1,35 @@
+import { useContext } from 'react';
+
+import { renderLimitedComponents } from '@grafana/runtime';
+import { AddedComponentsRegistryContext } from 'app/features/plugins/extensions/ExtensionRegistriesContext';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
+
+/**
+ * Extension point for plugins to add components to the mega menu.
+ * Currently restricted to grafana-setupguide-app plugin.
+ */
+export function MegaMenuExtensionPoint() {
+  // Check if plugin extension context is available (not available in tests)
+  const context = useContext(AddedComponentsRegistryContext);
+
+  if (!context) {
+    // Silently return null in test environments or when plugin context is not available
+    return null;
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { components } = usePluginComponents({
+    extensionPointId: 'grafana/megamenu/action',
+  });
+
+  return (
+    <>
+      {renderLimitedComponents({
+        props: {},
+        components: components,
+        limit: 1,
+        pluginId: 'grafana-setupguide-app',
+      })}
+    </>
+  );
+}

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
@@ -1,3 +1,4 @@
+import { PluginExtensionPoints } from '@grafana/data';
 import { renderLimitedComponents } from '@grafana/runtime';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
@@ -7,7 +8,7 @@ import { usePluginComponents } from 'app/features/plugins/extensions/usePluginCo
  */
 export function MegaMenuExtensionPoint() {
   const { components } = usePluginComponents({
-    extensionPointId: 'grafana/megamenu/action',
+    extensionPointId: PluginExtensionPoints.MegaMenuAction,
   });
 
   // Return null if no components are registered

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
@@ -15,14 +15,10 @@ export function MegaMenuExtensionPoint() {
     return null;
   }
 
-  return (
-    <>
-      {renderLimitedComponents({
-        props: {},
-        components: components,
-        limit: 1,
-        pluginId: 'grafana-setupguide-app',
-      })}
-    </>
-  );
+  return renderLimitedComponents({
+    props: {},
+    components: components,
+    limit: 1,
+    pluginId: 'grafana-setupguide-app',
+  });
 }

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -4,7 +4,7 @@ import React, { memo } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { renderLimitedComponents, ScopesContextValue } from '@grafana/runtime';
+import { ScopesContextValue } from '@grafana/runtime';
 import { Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
@@ -12,7 +12,6 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { contextSrv } from 'app/core/services/context_srv';
-import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 import { useSelector } from 'app/types/store';
 
@@ -29,6 +28,7 @@ import { InviteUserButton } from './InviteUserButton';
 import { ProfileButton } from './ProfileButton';
 import { SignInLink } from './SignInLink';
 import { SingleTopBarActions } from './SingleTopBarActions';
+import { TopBarExtensionPoint } from './TopBarExtensionPoint';
 import { TopSearchBarCommandPaletteTrigger } from './TopSearchBarCommandPaletteTrigger';
 import { getChromeHeaderLevelHeight } from './useChromeHeaderHeight';
 
@@ -65,11 +65,6 @@ export const SingleTopBar = memo(function SingleTopBar({
   const isLargeScreen = useMediaQueryMinWidth('lg');
   const topLevelScopes = !showToolbarLevel && isLargeScreen && scopes?.state.enabled;
 
-  // Plugin extension point restricted to grafana-setupguide-app
-  const { components } = usePluginComponents({
-    extensionPointId: 'grafana/singletopbar/action',
-  });
-
   return (
     <>
       <div className={styles.layout}>
@@ -100,12 +95,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           data-testid={!showToolbarLevel ? Components.NavToolbar.container : undefined}
           minWidth={{ xs: 'unset', lg: 0 }}
         >
-          {renderLimitedComponents({
-            props: {},
-            components: components,
-            limit: 1,
-            pluginId: 'grafana-setupguide-app',
-          })}
+          <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {unifiedHistoryEnabled && !isSmallScreen && <HistoryContainer />}
           {!isSmallScreen && <QuickAdd />}

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -4,7 +4,7 @@ import React, { memo } from 'react';
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { Components } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
-import { ScopesContextValue } from '@grafana/runtime';
+import { renderLimitedComponents, ScopesContextValue } from '@grafana/runtime';
 import { Icon, Stack, ToolbarButton, useStyles2 } from '@grafana/ui';
 import { config } from 'app/core/config';
 import { MEGA_MENU_TOGGLE_ID } from 'app/core/constants';
@@ -12,6 +12,7 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { HOME_NAV_ID } from 'app/core/reducers/navModel';
 import { contextSrv } from 'app/core/services/context_srv';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 import { ScopesSelector } from 'app/features/scopes/selector/ScopesSelector';
 import { useSelector } from 'app/types/store';
 
@@ -64,6 +65,11 @@ export const SingleTopBar = memo(function SingleTopBar({
   const isLargeScreen = useMediaQueryMinWidth('lg');
   const topLevelScopes = !showToolbarLevel && isLargeScreen && scopes?.state.enabled;
 
+  // Plugin extension point restricted to grafana-setupguide-app
+  const { components } = usePluginComponents({
+    extensionPointId: 'grafana/singletopbar/action',
+  });
+
   return (
     <>
       <div className={styles.layout}>
@@ -94,6 +100,12 @@ export const SingleTopBar = memo(function SingleTopBar({
           data-testid={!showToolbarLevel ? Components.NavToolbar.container : undefined}
           minWidth={{ xs: 'unset', lg: 0 }}
         >
+          {renderLimitedComponents({
+            props: {},
+            components: components,
+            limit: 1,
+            pluginId: 'grafana-setupguide-app',
+          })}
           <TopSearchBarCommandPaletteTrigger />
           {unifiedHistoryEnabled && !isSmallScreen && <HistoryContainer />}
           {!isSmallScreen && <QuickAdd />}

--- a/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
@@ -1,3 +1,4 @@
+import { PluginExtensionPoints } from '@grafana/data';
 import { renderLimitedComponents } from '@grafana/runtime';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
@@ -7,7 +8,7 @@ import { usePluginComponents } from 'app/features/plugins/extensions/usePluginCo
  */
 export function TopBarExtensionPoint() {
   const { components } = usePluginComponents({
-    extensionPointId: 'grafana/singletopbar/action',
+    extensionPointId: PluginExtensionPoints.SingleTopBarAction,
   });
 
   // Return null if no components are registered

--- a/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
@@ -1,0 +1,35 @@
+import { useContext } from 'react';
+
+import { renderLimitedComponents } from '@grafana/runtime';
+import { AddedComponentsRegistryContext } from 'app/features/plugins/extensions/ExtensionRegistriesContext';
+import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
+
+/**
+ * Extension point for plugins to add components to the top bar.
+ * Currently restricted to grafana-setupguide-app plugin.
+ */
+export function TopBarExtensionPoint() {
+  // Check if plugin extension context is available (not available in tests)
+  const context = useContext(AddedComponentsRegistryContext);
+
+  if (!context) {
+    // Silently return null in test environments or when plugin context is not available
+    return null;
+  }
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const { components } = usePluginComponents({
+    extensionPointId: 'grafana/singletopbar/action',
+  });
+
+  return (
+    <>
+      {renderLimitedComponents({
+        props: {},
+        components: components,
+        limit: 1,
+        pluginId: 'grafana-setupguide-app',
+      })}
+    </>
+  );
+}

--- a/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
@@ -15,14 +15,10 @@ export function TopBarExtensionPoint() {
     return null;
   }
 
-  return (
-    <>
-      {renderLimitedComponents({
-        props: {},
-        components: components,
-        limit: 1,
-        pluginId: 'grafana-setupguide-app',
-      })}
-    </>
-  );
+  return renderLimitedComponents({
+    props: {},
+    components: components,
+    limit: 1,
+    pluginId: 'grafana-setupguide-app',
+  });
 }

--- a/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
@@ -1,7 +1,4 @@
-import { useContext } from 'react';
-
 import { renderLimitedComponents } from '@grafana/runtime';
-import { AddedComponentsRegistryContext } from 'app/features/plugins/extensions/ExtensionRegistriesContext';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 /**
@@ -9,18 +6,14 @@ import { usePluginComponents } from 'app/features/plugins/extensions/usePluginCo
  * Currently restricted to grafana-setupguide-app plugin.
  */
 export function TopBarExtensionPoint() {
-  // Check if plugin extension context is available (not available in tests)
-  const context = useContext(AddedComponentsRegistryContext);
-
-  if (!context) {
-    // Silently return null in test environments or when plugin context is not available
-    return null;
-  }
-
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   const { components } = usePluginComponents({
     extensionPointId: 'grafana/singletopbar/action',
   });
+
+  // Return null if no components are registered
+  if (components.length === 0) {
+    return null;
+  }
 
   return (
     <>

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -23,6 +23,9 @@ import { useLoadAppPlugins } from './useLoadAppPlugins';
 import { usePluginComponents } from './usePluginComponents';
 import { isGrafanaDevMode } from './utils';
 
+// Unmock usePluginComponents to test the real implementation
+jest.unmock('./usePluginComponents');
+
 jest.mock('./useLoadAppPlugins');
 
 jest.mock('./utils', () => ({

--- a/public/test/setupTests.ts
+++ b/public/test/setupTests.ts
@@ -34,6 +34,18 @@ i18next.use(initReactI18next).init({
 // the factory uses import.meta.url so we can't use it in CommonJS modules.
 jest.mock('app/features/dashboard-scene/saving/createDetectChangesWorker.ts');
 
+// Mock useLoadAppPlugins to prevent async state updates in tests
+jest.mock('app/features/plugins/extensions/useLoadAppPlugins', () => ({
+  useLoadAppPlugins: jest.fn().mockReturnValue({ isLoading: false }),
+}));
+
+// Mock usePluginComponents to return empty components for all tests by default
+// Tests that need to test plugin components can override this mock
+jest.mock('app/features/plugins/extensions/usePluginComponents', () => ({
+  ...jest.requireActual('app/features/plugins/extensions/usePluginComponents'),
+  usePluginComponents: jest.fn().mockReturnValue({ components: [], isLoading: false }),
+}));
+
 // our tests are heavy in CI due to parallelisation and monaco and kusto
 // so we increase the default timeout to 2secs to avoid flakiness
 configure({ asyncUtilTimeout: 2000 });


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds support for plugin extension points in both the MegaMenu and SingleTopBar components, allowing plugins (specifically restricted to the `grafana-setupguide-app`) to inject custom actions into these UI areas. The changes introduce the use of `usePluginComponents` and `renderLimitedComponents` to render at most one plugin-provided component in each location.

**Why do we need this feature?**

This feature enables the Growth team to run self-serve experiments in key parts of the Grafana application without requiring core changes. By adding plugin extension points restricted to the `grafana-setupguide-app` plugin.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]
Growth plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Lays groundwork for 
https://github.com/grafana/OGPM/issues/200
https://github.com/grafana/OGPM/issues/349

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.