### PR TITLE
Tempo: Correctly escape/unescape tag when looking for tag values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,6 @@
 - **Dynamic Dashboards:** Expand dashboards_init_dashboard_completed tracking info [#111102](https://github.com/grafana/grafana/pull/111102), [@idastambuk](https://github.com/idastambuk)
 - **ErrorBoundary:** Report specific boundary type to Faro [#112071](https://github.com/grafana/grafana/pull/112071), [@tskarhed](https://github.com/tskarhed)
 - **Explore:** Use compact mode only when targeting Tempo [#113037](https://github.com/grafana/grafana/pull/113037), [@ifrost](https://github.com/ifrost)
-- **Explore:** Fix issue where tags were double escaped before passing to Tempo resulting in errors. [#114275](https://github.com/grafana/grafana/pull/114275), [@joe-elliott](https://github.com/joe-elliott)
 - **FeatureToggles:** Remove deprecated experimental apiserver [#111617](https://github.com/grafana/grafana/pull/111617), [@ryantxu](https://github.com/ryantxu)
 - **Fields Selector:** Add component and integrate with Logs and Logs table visualization [#112534](https://github.com/grafana/grafana/pull/112534), [@matyax](https://github.com/matyax)
 - **Flame Graph:** Anchor exact match when clicking a table symbol in search [#111101](https://github.com/grafana/grafana/pull/111101), [@samarthbagga-meesho](https://github.com/samarthbagga-meesho)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - **Dynamic Dashboards:** Expand dashboards_init_dashboard_completed tracking info [#111102](https://github.com/grafana/grafana/pull/111102), [@idastambuk](https://github.com/idastambuk)
 - **ErrorBoundary:** Report specific boundary type to Faro [#112071](https://github.com/grafana/grafana/pull/112071), [@tskarhed](https://github.com/tskarhed)
 - **Explore:** Use compact mode only when targeting Tempo [#113037](https://github.com/grafana/grafana/pull/113037), [@ifrost](https://github.com/ifrost)
+- **Explore:** Fix issue where tags were double escaped before passing to Tempo resulting in errors. [#114275](https://github.com/grafana/grafana/pull/114275), [@joe-elliott](https://github.com/joe-elliott)
 - **FeatureToggles:** Remove deprecated experimental apiserver [#111617](https://github.com/grafana/grafana/pull/111617), [@ryantxu](https://github.com/ryantxu)
 - **Fields Selector:** Add component and integrate with Logs and Logs table visualization [#112534](https://github.com/grafana/grafana/pull/112534), [@matyax](https://github.com/matyax)
 - **Flame Graph:** Anchor exact match when clicking a table symbol in search [#111101](https://github.com/grafana/grafana/pull/111101), [@samarthbagga-meesho](https://github.com/samarthbagga-meesho)

--- a/pkg/tsdb/tempo/tempo.go
+++ b/pkg/tsdb/tempo/tempo.go
@@ -280,7 +280,15 @@ func (s *Service) handleTagValues(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	tempoPath := fmt.Sprintf("api/v2/search/tag/%s/values", encodedTag)
+	// escape tag
+	tag, err := url.PathUnescape(encodedTag)
+	if err != nil {
+		s.logger.Error("Failed to unescape", "error", err, "tag", encodedTag)
+		http.Error(rw, "Invalid 'tag' parameter", http.StatusBadRequest)
+		return
+	}
+
+	tempoPath := fmt.Sprintf("api/v2/search/tag/%s/values", tag)
 	s.proxyToTempo(rw, req, tempoPath)
 }
 

--- a/public/app/plugins/datasource/tempo/language_provider.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.ts
@@ -190,9 +190,7 @@ export default class TempoLanguageProvider extends LanguageProvider {
    * @returns the encoded tag
    */
   private encodeTag = (tag: string): string => {
-    // If we call `encodeURIComponent` only once, we still get an error when issuing a request to the backend
-    // Reference: https://stackoverflow.com/a/37456192
-    return encodeURIComponent(encodeURIComponent(tag));
+    return encodeURIComponent(tag);
   };
 
   generateQueryFromFilters({


### PR DESCRIPTION
**What is this feature?**

Fixes an issue where the tag name was being passed to tempo double url escaped which caused it to fail to return values for tag names with colons like: `span:name`.

**Why do we need this feature?**

I mean, you don't NEED it, but it makes the Tempo explore experience better.

**Who is this feature for?**

Anyone using Tempo's explore.

**Which issue(s) does this PR fix?**:

Fixes #111626

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
