### PR TITLE
Tempo: Bump gRPC limit to allow for larger streaming queries

### DIFF
--- a/pkg/tsdb/tempo/grpc.go
+++ b/pkg/tsdb/tempo/grpc.go
@@ -88,6 +88,7 @@ func getDialOpts(ctx context.Context, settings backend.DataSourceInstanceSetting
 
 	var dialOps []grpc.DialOption
 
+	dialOps = append(dialOps, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(100*1024*1024)))
 	dialOps = append(dialOps, grpc.WithChainStreamInterceptor(CustomHeadersStreamInterceptor(opts)))
 	if settings.BasicAuthEnabled {
 		// If basic authentication is enabled, it uses TLS transport credentials and sets the basic authentication header for each RPC call.


### PR DESCRIPTION
We want to support larger streaming queries in Tempo. right now we're capped at 4MB. Our first idea was to simply bump the limit to 100MB, but that exposed other bottlenecks inside Grafana Live. The main issue turned out to be the hard-coded `client_queue_max_size` (see https://github.com/grafana/grafana/pull/114225)

~This PR builds on that change by using the configured `client_queue_max_size` as the gRPC limit for Tempo’s streaming responses. Since the Tempo limit can't be larger than Grafana Live’s client queue size, this keeps everything aligned and prevents the crashes we were seeing with bigger queries.~

Due to complications accessing config_ini files from plugins, we will just bump this limit to 100MB, `client_queue_max_size` will have to be bumped independently. 