### PR TITLE
Use infra/log instead of slog in pkg/storage/unified

### DIFF
--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"crypto/tls"
 	"fmt"
-	"log/slog"
 	"net/http"
 
 	"github.com/fullstorydev/grpchan"
@@ -24,6 +23,7 @@ import (
 	"github.com/grafana/authlib/types"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	authnGrpcUtils "github.com/grafana/grafana/pkg/services/authn/grpcutils"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
@@ -158,7 +158,7 @@ func NewRemoteResourceClient(tracer trace.Tracer, conn grpc.ClientConnInterface,
 	return newResourceClient(cc, cci), nil
 }
 
-var authLogger = slog.Default().With("logger", "resource-client-auth-interceptor")
+var authLogger = log.New("resource-client-auth-interceptor")
 
 func idTokenExtractor(ctx context.Context) (string, error) {
 	if identity.IsServiceIdentity(ctx) {
@@ -175,7 +175,7 @@ func idTokenExtractor(ctx context.Context) (string, error) {
 	}
 
 	if !types.IsIdentityType(info.GetIdentityType(), types.TypeAccessPolicy) {
-		authLogger.Warn(
+		authLogger.FromContext(ctx).Warn(
 			"calling resource store as the service without id token or marking it as the service identity",
 			"subject", info.GetSubject(),
 			"uid", info.GetUID(),

--- a/pkg/storage/unified/resource/grpc/authenticator.go
+++ b/pkg/storage/unified/resource/grpc/authenticator.go
@@ -2,7 +2,6 @@ package grpc
 
 import (
 	"context"
-	"log/slog"
 	"strconv"
 
 	"google.golang.org/grpc"
@@ -14,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 )
 
 const (
@@ -25,7 +25,7 @@ const (
 	mdOrgRole = "grafana-org-role"
 )
 
-var logger = slog.Default().With("logger", "legacy.grpc.Authenticator")
+var logger = log.New("legacy.grpc.Authenticator")
 
 // This is in a package we can no import
 // var _ interceptors.Authenticator = (*Authenticator)(nil)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"iter"
-	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apimachinery/validation"
+	"github.com/grafana/grafana/pkg/infra/log"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util/scheduler"
@@ -320,7 +320,7 @@ func NewResourceServer(opts ResourceServerOptions) (*server, error) {
 		}
 	}
 
-	logger := slog.Default().With("logger", "resource-server")
+	logger := log.New("resource-server")
 
 	// Make this cancelable
 	ctx, cancel := context.WithCancel(context.Background())
@@ -366,7 +366,7 @@ func NewResourceServer(opts ResourceServerOptions) (*server, error) {
 var _ ResourceServer = &server{}
 
 type server struct {
-	log            *slog.Logger
+	log            log.Logger
 	backend        StorageBackend
 	blob           BlobSupport
 	secure         secrets.InlineSecureValueSupport
@@ -470,14 +470,15 @@ func (s *server) newEvent(ctx context.Context, user claims.AuthInfo, key *resour
 		return nil, AsErrorResult(err)
 	}
 
+	l := s.log.FromContext(ctx)
 	if obj.GetUID() == "" {
 		// TODO! once https://github.com/grafana/grafana/pull/96086 is deployed everywhere
 		// return nil, NewBadRequestError("object is missing UID")
-		s.log.Error("object is missing UID", "key", key)
+		l.Error("object is missing UID", "key", key)
 	}
 
 	if obj.GetResourceVersion() != "" {
-		s.log.Error("object must not include a resource version", "key", key)
+		l.Error("object must not include a resource version", "key", key)
 	}
 
 	// Make sure the command labels are not saved
@@ -694,7 +695,7 @@ func (s *server) create(ctx context.Context, user claims.AuthInfo, req *resource
 	if err != nil {
 		rsp.Error = AsErrorResult(err)
 	}
-	s.log.Debug("server.WriteEvent", "type", event.Type, "rv", rsp.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "name", event.Key.Name, "resource", event.Key.Resource)
+	s.log.FromContext(ctx).Debug("server.WriteEvent", "type", event.Type, "rv", rsp.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "name", event.Key.Name, "resource", event.Key.Resource)
 	return rsp, nil
 }
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
 	"net/http"
 	"strings"
 	"sync"
@@ -581,7 +580,7 @@ func newTestServerWithQueue(t *testing.T, maxSizePerTenant int, numWorkers int) 
 			MaxRetries: 2,
 			MinBackoff: 10 * time.Millisecond,
 		},
-		log: slog.Default(),
+		log: log.NewNopLogger(),
 	}
 	return s, q
 }
@@ -589,7 +588,7 @@ func newTestServerWithQueue(t *testing.T, maxSizePerTenant int, numWorkers int) 
 func TestArtificialDelayAfterSuccessfulOperation(t *testing.T) {
 	s := &server{
 		artificialSuccessfulWriteDelay: 1 * time.Millisecond,
-		log:                            slog.Default(),
+		log:                            log.NewNopLogger(),
 	}
 
 	check := func(t *testing.T, expectedSleep bool, res responseWithErrorResult, err error) {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"math"
 	"os"
 	"path/filepath"
@@ -26,7 +25,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	"github.com/grafana/grafana/pkg/infra/log/logtest"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
@@ -772,7 +771,7 @@ func setupBleveBackend(t *testing.T, options ...setupOption) (*bleveBackend, pro
 	opts := BleveOptions{
 		FileThreshold: defaultFileThreshold,
 		IndexCacheTTL: defaultIndexCacheTTL,
-		Logger:        slog.New(logtest.NewNopHandler(t)),
+		Logger:        log.NewNopLogger(),
 		BuildVersion:  buildVersion,
 	}
 	for _, opt := range options {


### PR DESCRIPTION
Use `log.FromContext` to add contextual info to log messages.

This makes sure that we log traceID related to search request:

```console
logger=resource-search traceID=c9cf8837389b463ea69d3aaad7d7a9f1 t=2025-11-21T12:23:52.368506+01:00 level=debug msg="Index updated before search" namespace=default group=dashboard.grafana.app resource=dashboards reason=search duration=1.124292ms rv=1763724220375671
logger=resource-search traceID=c9cf8837389b463ea69d3aaad7d7a9f1 t=2025-11-21T12:23:52.369347+01:00 level=debug msg="Index updated before search" namespace=default group=folder.grafana.app resource=folders reason=federatedSearch duration=816.417�s rv=1763724206117248
logger=resource-search traceID=c9cf8837389b463ea69d3aaad7d7a9f1 t=2025-11-21T12:23:52.371481+01:00 level=debug msg="Search stats" operation=Search elapsedTime=4.112375ms indexBuildTime=0s indexUpdateTime=1.940709ms requestConversionTime=1.789583ms searchTime=263.375�s totalHits=1 returnedDocuments=1 resultsConversionTime=46.209�s namespace=default group=dashboard.grafana.app resource=dashboards query=New
```