### PR TITLE
Alerting: Fix NotificationPreview permission checking

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -4,8 +4,10 @@ import { useEffectOnce } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Button, LoadingPlaceholder, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { Alert, Button, LoadingPlaceholder, Stack, Text, Tooltip, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
 import { alertRuleApi } from 'app/features/alerting/unified/api/alertRuleApi';
+import { AccessControlAction } from 'app/types/accessControl';
 import { AlertQuery, Labels } from 'app/types/unified-alerting-dto';
 
 import { Folder, KBObjectArray } from '../../../types/rule-form';
@@ -36,6 +38,7 @@ export const NotificationPreview = ({
   alertUid,
 }: NotificationPreviewProps) => {
   const styles = useStyles2(getStyles);
+
   const previewRoutingDisabled = !condition || !folder;
 
   const [trigger, { data = [], isLoading, isUninitialized: previewUninitialized }] = preview.useMutation();
@@ -67,9 +70,7 @@ export const NotificationPreview = ({
   };
 
   useEffectOnce(() => {
-    if (!previewRoutingDisabled) {
-      onPreview();
-    }
+    onPreview();
   });
 
   //  Get alert managers's data source information
@@ -77,16 +78,16 @@ export const NotificationPreview = ({
   const singleAlertManagerConfigured = alertManagerDataSources.length === 1;
 
   const getTooltipContent = () => {
+    if (!condition) {
+      return (
+        <Trans i18nKey="alerting.notification-preview.no-condition-tooltip">
+          Select a query condition to preview routing
+        </Trans>
+      );
+    }
     if (!folder) {
       return (
         <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">Select a folder to preview routing</Trans>
-      );
-    }
-    if (previewRoutingDisabled) {
-      return (
-        <Trans i18nKey="alerting.notification-preview.disabled-tooltip">
-          You don&apos;t have sufficient permissions to preview
-        </Trans>
       );
     }
     return '';
@@ -146,10 +147,12 @@ export const NotificationPreview = ({
                 </Stack>
               )}
               {alertManagerSource.name === 'grafana' ? (
-                <NotificationPreviewForGrafanaManaged
-                  alertManagerSource={alertManagerSource}
-                  instances={potentialInstances}
-                />
+                <NotificationPreviewGrafanaPermissionCheck>
+                  <NotificationPreviewForGrafanaManaged
+                    alertManagerSource={alertManagerSource}
+                    instances={potentialInstances}
+                  />
+                </NotificationPreviewGrafanaPermissionCheck>
               ) : (
                 <NotificationPreviewByAlertManager
                   alertManagerSource={alertManagerSource}
@@ -163,6 +166,32 @@ export const NotificationPreview = ({
     </Stack>
   );
 };
+
+/**
+ * Permission check for Grafana notification preview.
+ * This is a workaround because useGetAlertManagerDataSourcesByPermissionAndConfig
+ * doesn't properly filter by the new K8s-style RBAC permissions.
+ *
+ * We check for either:
+ * - alert.notifications:read (legacy permission)
+ * - alert.notifications.routes:read (new granular permission)
+ */
+function NotificationPreviewGrafanaPermissionCheck({ children }: React.PropsWithChildren) {
+  const hasLegacyNotificationPermission = contextSrv.hasPermission(AccessControlAction.AlertingNotificationsRead);
+  const hasNotificationPolicyTreePermission = contextSrv.hasPermission(AccessControlAction.AlertingRoutesRead);
+
+  if (hasLegacyNotificationPermission || hasNotificationPolicyTreePermission) {
+    return <>{children}</>;
+  }
+
+  return (
+    <Alert severity="warning" title={t('alerting.notification-preview.permission-warning', 'Preview not available')}>
+      <Trans i18nKey="alerting.notification-preview.permission-warning-message">
+        You don&apos;t have permission to view notification policies. Preview is not available.
+      </Trans>
+    </Alert>
+  );
+}
 
 const getStyles = (theme: GrafanaTheme2) => ({
   firstAlertManagerLine: css({

--- a/public/app/features/alerting/unified/hooks/useAbilities.ts
+++ b/public/app/features/alerting/unified/hooks/useAbilities.ts
@@ -125,6 +125,22 @@ const AlwaysSupported = true;
 const NotSupported = false;
 
 export type Action = AlertmanagerAction | AlertingAction | AlertRuleAction | FolderBulkAction;
+
+/**
+ * Represents the ability to perform an action, with two distinct checks:
+ *
+ * @param actionSupported - Whether the action is technically possible in the current context.
+ *   This depends on system capabilities (e.g., API availability), feature availability
+ *   (e.g., Grafana vs external alertmanager), and rule state (e.g., provisioned/immutable rules).
+ *   Examples: Can't edit provisioned rules, can't export from external alertmanagers.
+ *
+ * @param actionAllowed - Whether the user has permission to perform the action.
+ *   This is based on RBAC permissions, folder-specific permissions, and admin status.
+ *   Examples: User lacks AlertingRuleUpdate permission, user can't edit in this folder.
+ *
+ * Both must be true for an action to be available. This separation allows showing appropriate
+ * messages: "Feature not available" vs "You don't have permission".
+ */
 export type Ability = [actionSupported: boolean, actionAllowed: boolean];
 export type Abilities<T extends Action> = Record<T, Ability>;
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1982,9 +1982,11 @@
     },
     "notification-preview": {
       "alertmanager": "Alertmanager:",
-      "disabled-tooltip": "You don't have sufficient permissions to preview",
       "error": "Could not load routing preview for {{alertmanager}}",
       "initialized": "Based on the labels added, alert instances are routed to the following notification policies. Expand each notification policy below to view more details.",
+      "no-condition-tooltip": "Select a query condition to preview routing",
+      "permission-warning": "Preview not available",
+      "permission-warning-message": "You don't have permission to view notification policies. Preview is not available.",
       "preview-routing": "Preview routing",
       "select-folder-tooltip": "Select a folder to preview routing",
       "text-loading-preview": "Loading preview...",


### PR DESCRIPTION
### Problem
Editor users without notification policy permissions were seeing confusing error messages immediately when opening the alert rule creation form:

**Root Cause:**
The notification preview component was attempting to fetch routing trees data without checking if the user had the required permissions (`alert.notifications:read` or `alert.notifications.routes:read`), resulting in 403 errors displayed as error messages.

### Solution
Added permission check before attempting to fetch routing data. Users without proper permissions now see a clean warning message only when they have potential instances to route, instead of seeing error messages on page load.

### Changes
- Added `NotificationPreviewGrafanaPermissionCheck` component that validates permissions before showing preview
- Shows user-friendly warning: "You don't have permission to view notification policies. Preview is not available."
- Only applies to Grafana alertmanager (external alertmanagers have different permission requirements)
- Fixed tooltip ordering and simplified preview trigger logic