### PR TITLE
Hotfix: Granting None role Viewer access for a fixed API group list

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/role.go
+++ b/pkg/services/apiserver/auth/authorizer/role.go
@@ -3,6 +3,7 @@ package authorizer
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
 
@@ -11,6 +12,10 @@ import (
 )
 
 var _ authorizer.Authorizer = &roleAuthorizer{}
+
+var orgRoleNoneAsViewerAPIGroups = []string{
+	"productactivation.ext.grafana.com",
+}
 
 type roleAuthorizer struct{}
 
@@ -43,6 +48,16 @@ func (auth roleAuthorizer) Authorize(ctx context.Context, a authorizer.Attribute
 			return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 		}
 	case org.RoleNone:
+		// HOTFIX: granting Viewer actions to None roles to a fixed group of APIs,
+		//  while we work on a proper fix.
+		if slices.Contains(orgRoleNoneAsViewerAPIGroups, a.GetAPIGroup()) {
+			switch a.GetVerb() {
+			case "get", "list", "watch":
+				return authorizer.DecisionAllow, "", nil
+			default:
+				return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
+			}
+		}
 		return authorizer.DecisionDeny, errorMessageForGrafanaOrgRole(orgRole, a), nil
 	}
 	return authorizer.DecisionDeny, "", nil


### PR DESCRIPTION
**What is this feature?**

This is a followup from https://github.com/grafana/grafana/pull/114224.
Since we need to grant Viewer access to None org role for a certain API group, we're bringing that back as a hotfix while we plan a proper fix

**Who is this feature for?**

Users of that API group. 
