### PR TITLE
Log details: set log clone as not collapsed

### DIFF
--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -128,6 +128,7 @@ export class LogListModel implements LogRowModel {
     clone._wrapLogMessage = true;
     clone._body = undefined;
     clone._highlightTokens = undefined;
+    clone.collapsed = false;
     return clone;
   }
 


### PR DESCRIPTION
When a log line triggered truncation, the one shown in log details was also truncated. This change makes it be fully displayed.