### PR TITLE
Sparkline: Move codeownership to dataviz

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -721,9 +721,9 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-ui/src/components/Gauge/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/RadialGauge/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/PluginSignatureBadge/ @grafana/plugins-platform-frontend
-/packages/grafana-ui/src/components/Sparkline/ @grafana/grafana-frontend-platform @grafana/app-o11y-visualizations
+/packages/grafana-ui/src/components/Sparkline/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/Table/ @grafana/dataviz-squad
-/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx @grafana/dataviz-squad @grafana/app-o11y-visualizations
+/packages/grafana-ui/src/components/Table/Cells/SparklineCell.tsx @grafana/dataviz-squad
 /packages/grafana-ui/src/components/uPlot/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/ValuePicker/ @grafana/dataviz-squad
 /packages/grafana-ui/src/components/VizLayout/ @grafana/dataviz-squad
@@ -992,7 +992,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/plugins/panel/state-timeline/ @grafana/dataviz-squad
 /public/app/plugins/panel/status-history/ @grafana/dataviz-squad
 /public/app/plugins/panel/table/ @grafana/dataviz-squad
-/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx @grafana/dataviz-squad @grafana/app-o11y-visualizations
+/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx @grafana/dataviz-squad
 /public/app/plugins/panel/timeseries/ @grafana/dataviz-squad
 /public/app/plugins/panel/trend/ @grafana/dataviz-squad
 /public/app/plugins/panel/geomap/ @grafana/dataviz-squad


### PR DESCRIPTION
In recent months, there have been a handful of PRs related to Sparkline and related integrations which the dataviz team has been responsible for fixing, particular as they relate to the new Table, but also some related to errors thrown in Stat or Gauge panels.

- https://github.com/grafana/grafana/pull/109702
- https://github.com/grafana/grafana/pull/114203
- https://github.com/grafana/grafana/pull/114326
- https://github.com/grafana/grafana/pull/107991
- https://github.com/grafana/grafana/pull/113373
- https://github.com/grafana/grafana/pull/113059
- https://github.com/grafana/grafana/pull/112244

Given the use of Sparklines in many of the core panels Dataviz owns, I want to propose that Dataviz own Sparklin, to make it clear that we should be the ones investing in improvements to quality and testing of the component.