### PR TITLE
Sparkline: Add warnings for invalid series, and add more test cases

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -833,11 +833,6 @@
       "count": 13
     }
   },
-  "packages/grafana-ui/src/components/Sparkline/Sparkline.tsx": {
-    "react-prefer-function-component/react-prefer-function-component": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/StatsPicker/StatsPicker.story.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -196,48 +196,49 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
                   return sparkline.y.values.length - 1;
                 case ReducerID.first:
                   return 0;
-                case ReducerID.lastNotNull: {
-                  for (let k = sparkline.y.values.length - 1; k >= 0; k--) {
-                    const v = sparkline.y.values[k];
-                    if (v !== null && v !== undefined && !Number.isNaN(v)) {
-                      return k;
-                    }
-                  }
-                  return;
-                }
-                case ReducerID.firstNotNull: {
-                  for (let k = 0; k < sparkline.y.values.length; k++) {
-                    const v = sparkline.y.values[k];
-                    if (v !== null && v !== undefined && !Number.isNaN(v)) {
-                      return k;
-                    }
-                  }
-                  return;
-                }
-                case ReducerID.min: {
-                  let minIdx = -1;
-                  let prevMin = Infinity;
-                  for (let k = 0; k < sparkline.y.values.length; k++) {
-                    const v = sparkline.y.values[k];
-                    if (v !== null && v !== undefined && !Number.isNaN(v) && v < prevMin) {
-                      prevMin = v;
-                      minIdx = k;
-                    }
-                  }
-                  return minIdx >= 0 ? minIdx : undefined;
-                }
-                case ReducerID.max: {
-                  let maxIdx = -1;
-                  let prevMax = -Infinity;
-                  for (let k = 0; k < sparkline.y.values.length; k++) {
-                    const v = sparkline.y.values[k];
-                    if (v !== null && v !== undefined && !Number.isNaN(v) && v > prevMax) {
-                      prevMax = v;
-                      maxIdx = k;
-                    }
-                  }
-                  return maxIdx >= 0 ? maxIdx : undefined;
-                }
+                // TODO: #112977 enable more reducers for highlight index
+                // case ReducerID.lastNotNull: {
+                //   for (let k = sparkline.y.values.length - 1; k >= 0; k--) {
+                //     const v = sparkline.y.values[k];
+                //     if (v !== null && v !== undefined && !Number.isNaN(v)) {
+                //       return k;
+                //     }
+                //   }
+                //   return;
+                // }
+                // case ReducerID.firstNotNull: {
+                //   for (let k = 0; k < sparkline.y.values.length; k++) {
+                //     const v = sparkline.y.values[k];
+                //     if (v !== null && v !== undefined && !Number.isNaN(v)) {
+                //       return k;
+                //     }
+                //   }
+                //   return;
+                // }
+                // case ReducerID.min: {
+                //   let minIdx = -1;
+                //   let prevMin = Infinity;
+                //   for (let k = 0; k < sparkline.y.values.length; k++) {
+                //     const v = sparkline.y.values[k];
+                //     if (v !== null && v !== undefined && !Number.isNaN(v) && v < prevMin) {
+                //       prevMin = v;
+                //       minIdx = k;
+                //     }
+                //   }
+                //   return minIdx >= 0 ? minIdx : undefined;
+                // }
+                // case ReducerID.max: {
+                //   let maxIdx = -1;
+                //   let prevMax = -Infinity;
+                //   for (let k = 0; k < sparkline.y.values.length; k++) {
+                //     const v = sparkline.y.values[k];
+                //     if (v !== null && v !== undefined && !Number.isNaN(v) && v > prevMax) {
+                //       prevMax = v;
+                //       maxIdx = k;
+                //     }
+                //   }
+                //   return maxIdx >= 0 ? maxIdx : undefined;
+                // }
                 default:
                   return;
               }

--- a/packages/grafana-data/src/field/fieldDisplay.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.ts
@@ -190,10 +190,61 @@ export const getFieldDisplayValues = (options: GetFieldDisplayValuesOptions): Fi
               y: dataFrame.fields[i],
               x: timeField,
             };
-            if (calc === ReducerID.last) {
-              sparkline.highlightIndex = sparkline.y.values.length - 1;
-            } else if (calc === ReducerID.first) {
-              sparkline.highlightIndex = 0;
+            let highlightIdx: number | undefined = (() => {
+              switch (calc) {
+                case ReducerID.last:
+                  return sparkline.y.values.length - 1;
+                case ReducerID.first:
+                  return 0;
+                case ReducerID.lastNotNull: {
+                  for (let k = sparkline.y.values.length - 1; k >= 0; k--) {
+                    const v = sparkline.y.values[k];
+                    if (v !== null && v !== undefined && !Number.isNaN(v)) {
+                      return k;
+                    }
+                  }
+                  return;
+                }
+                case ReducerID.firstNotNull: {
+                  for (let k = 0; k < sparkline.y.values.length; k++) {
+                    const v = sparkline.y.values[k];
+                    if (v !== null && v !== undefined && !Number.isNaN(v)) {
+                      return k;
+                    }
+                  }
+                  return;
+                }
+                case ReducerID.min: {
+                  let minIdx = -1;
+                  let prevMin = Infinity;
+                  for (let k = 0; k < sparkline.y.values.length; k++) {
+                    const v = sparkline.y.values[k];
+                    if (v !== null && v !== undefined && !Number.isNaN(v) && v < prevMin) {
+                      prevMin = v;
+                      minIdx = k;
+                    }
+                  }
+                  return minIdx >= 0 ? minIdx : undefined;
+                }
+                case ReducerID.max: {
+                  let maxIdx = -1;
+                  let prevMax = -Infinity;
+                  for (let k = 0; k < sparkline.y.values.length; k++) {
+                    const v = sparkline.y.values[k];
+                    if (v !== null && v !== undefined && !Number.isNaN(v) && v > prevMax) {
+                      prevMax = v;
+                      maxIdx = k;
+                    }
+                  }
+                  return maxIdx >= 0 ? maxIdx : undefined;
+                }
+                default:
+                  return;
+              }
+            })();
+
+            if (typeof highlightIdx === 'number') {
+              sparkline.highlightIndex = highlightIdx;
             }
           }
 

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -2,7 +2,14 @@ import { css, cx } from '@emotion/css';
 import { isNumber } from 'lodash';
 import { useId } from 'react';
 
-import { DisplayValueAlignmentFactors, FieldDisplay, getDisplayProcessor, GrafanaTheme2 } from '@grafana/data';
+import {
+  DisplayValueAlignmentFactors,
+  FieldDisplay,
+  FieldType,
+  getDisplayProcessor,
+  GrafanaTheme2,
+  TimeRange,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 
 import { useStyles2, useTheme2 } from '../../themes/ThemeContext';
@@ -66,6 +73,7 @@ export interface RadialGaugeProps {
   showScaleLabels?: boolean;
   /** For data links */
   onClick?: React.MouseEventHandler<HTMLElement>;
+  timeRange?: TimeRange;
 }
 
 export type RadialGradientMode = 'none' | 'auto';
@@ -240,6 +248,9 @@ export function RadialGauge(props: RadialGaugeProps) {
       }
 
       if (displayValue.sparkline) {
+        if (props.timeRange && displayValue.sparkline.x?.type === FieldType.time) {
+          displayValue.sparkline.timeRange = props.timeRange;
+        }
         sparklineElement = (
           <RadialSparkline
             sparkline={displayValue.sparkline}

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -248,9 +248,6 @@ export function RadialGauge(props: RadialGaugeProps) {
       }
 
       if (displayValue.sparkline) {
-        if (props.timeRange && displayValue.sparkline.x?.type === FieldType.time) {
-          displayValue.sparkline.timeRange = props.timeRange;
-        }
         sparklineElement = (
           <RadialSparkline
             sparkline={displayValue.sparkline}

--- a/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialGauge.tsx
@@ -5,7 +5,6 @@ import { useId } from 'react';
 import {
   DisplayValueAlignmentFactors,
   FieldDisplay,
-  FieldType,
   getDisplayProcessor,
   GrafanaTheme2,
   TimeRange,

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
@@ -1,74 +1,127 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
-import { createTheme, FieldSparkline, FieldType } from '@grafana/data';
+import { createTheme, Field, FieldSparkline, FieldType } from '@grafana/data';
 
 import { Sparkline } from './Sparkline';
 
 describe('Sparkline', () => {
-  it('should render without throwing an error', () => {
-    const sparkline: FieldSparkline = {
-      x: {
-        name: 'x',
-        values: [1679839200000, 1680444000000, 1681048800000, 1681653600000, 1682258400000],
-        type: FieldType.time,
-        config: {},
-      },
-      y: {
-        name: 'y',
-        values: [1, 2, 3, 4, 5],
-        type: FieldType.number,
-        config: {},
-        state: {
-          range: { min: 1, max: 5, delta: 1 },
+  describe('renders without error', () => {
+    const numField = (name: string, numVals: number): Field => ({
+      name,
+      values: Array.from({ length: numVals }, (_, i) => i + 1),
+      type: FieldType.number,
+      config: {},
+      state:
+        numVals > 0
+          ? {
+              range: { min: 1, max: numVals, delta: numVals - 1 },
+            }
+          : {},
+    });
+
+    const startTime = 1679839200000;
+    const timeField = (name: string, numVals: number): Field => ({
+      name,
+      values: Array.from({ length: numVals }, (_, i) => startTime + (i + 1) * 1000),
+      type: FieldType.time,
+      config: {},
+      state:
+        numVals > 0
+          ? {
+              range: { min: 1, max: numVals, delta: numVals - 1 },
+            }
+          : {},
+    });
+
+    it.each<{ description: string; input: FieldSparkline; warning?: boolean }>([
+      {
+        description: 'x=time, y=number, 5 values',
+        input: {
+          x: timeField('x', 5),
+          y: numField('y', 5),
         },
       },
-    };
-    expect(() =>
-      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
-    ).not.toThrow();
-  });
-
-  it('should not throw an error if there is a single value', () => {
-    const sparkline: FieldSparkline = {
-      x: {
-        name: 'x',
-        values: [1679839200000],
-        type: FieldType.time,
-        config: {},
+      {
+        description: 'x=time, y=number, 1 value',
+        input: {
+          x: timeField('x', 1),
+          y: numField('y', 1),
+        },
+        warning: true,
       },
-      y: {
-        name: 'y',
-        values: [1],
-        type: FieldType.number,
-        config: {},
-        state: {
-          range: { min: 1, max: 1, delta: 0 },
+      {
+        description: 'x=time, y=number, 0 values',
+        input: {
+          x: timeField('x', 0),
+          y: numField('y', 0),
+        },
+        warning: true,
+      },
+      {
+        description: 'x=time (unordered), y=number, 5 values',
+        input: {
+          x: {
+            ...timeField('x', 5),
+            values: timeField('x', 5).values.reverse(),
+          },
+          y: timeField('y', 5),
+        },
+        warning: true,
+      },
+      {
+        description: 'x=number, y=number, 5 values',
+        input: {
+          x: numField('x', 5),
+          y: numField('y', 5),
         },
       },
-    };
-    expect(() =>
-      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
-    ).not.toThrow();
-  });
+      {
+        description: 'x=number, y=number, 1 value',
+        input: {
+          x: numField('x', 1),
+          y: numField('y', 1),
+        },
+        warning: true,
+      },
+      {
+        description: 'x=number, y=number, 0 values',
+        input: {
+          x: numField('x', 0),
+          y: numField('y', 0),
+        },
+        warning: true,
+      },
+      {
+        description: 'y=number, 5 values',
+        input: {
+          y: numField('y', 5),
+        },
+      },
+      {
+        description: 'y=number, 1 value',
+        input: {
+          y: numField('y', 1),
+        },
+        warning: true,
+      },
+      {
+        description: 'y=number, 0 values',
+        input: {
+          y: numField('y', 0),
+        },
+        warning: true,
+      },
+    ])('does not throw for "$description"', ({ input, warning }) => {
+      expect(() =>
+        render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={input} />)
+      ).not.toThrow();
 
-  it('should not throw an error if there are no values', () => {
-    const sparkline: FieldSparkline = {
-      x: {
-        name: 'x',
-        values: [],
-        type: FieldType.time,
-        config: {},
-      },
-      y: {
-        name: 'y',
-        values: [],
-        type: FieldType.number,
-        config: {},
-        state: {},
-      },
-    };
-    expect(() =>
-      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
-    ).not.toThrow();
+      if (warning) {
+        expect(screen.getByRole('alert')).toBeInTheDocument();
+      } else {
+        expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+        expect(screen.getByTestId('uplot-main-div')).toBeInTheDocument();
+      }
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
@@ -27,4 +27,48 @@ describe('Sparkline', () => {
       render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
     ).not.toThrow();
   });
+
+  it('should ot throw an error if there is a single value', () => {
+    const sparkline: FieldSparkline = {
+      x: {
+        name: 'x',
+        values: [1679839200000],
+        type: FieldType.time,
+        config: {},
+      },
+      y: {
+        name: 'y',
+        values: [1],
+        type: FieldType.number,
+        config: {},
+        state: {
+          range: { min: 1, max: 1, delta: 0 },
+        },
+      },
+    };
+    expect(() =>
+      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
+    ).not.toThrow();
+  });
+
+  it('should ot throw an error if there are no values', () => {
+    const sparkline: FieldSparkline = {
+      x: {
+        name: 'x',
+        values: [],
+        type: FieldType.time,
+        config: {},
+      },
+      y: {
+        name: 'y',
+        values: [],
+        type: FieldType.number,
+        config: {},
+        state: {},
+      },
+    };
+    expect(() =>
+      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
+    ).not.toThrow();
+  });
 });

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
@@ -28,7 +28,7 @@ describe('Sparkline', () => {
     ).not.toThrow();
   });
 
-  it('should ot throw an error if there is a single value', () => {
+  it('should not throw an error if there is a single value', () => {
     const sparkline: FieldSparkline = {
       x: {
         name: 'x',
@@ -51,7 +51,7 @@ describe('Sparkline', () => {
     ).not.toThrow();
   });
 
-  it('should ot throw an error if there are no values', () => {
+  it('should not throw an error if there are no values', () => {
     const sparkline: FieldSparkline = {
       x: {
         name: 'x',

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -1,29 +1,13 @@
 import React, { memo } from 'react';
 
-import {
-  DataFrame,
-  FieldConfig,
-  FieldSparkline,
-  FieldType,
-  getFieldColorModeForField,
-  GrafanaTheme2,
-  nullToValue,
-} from '@grafana/data';
-import {
-  AxisPlacement,
-  GraphDrawStyle,
-  GraphFieldConfig,
-  VisibilityMode,
-  ScaleDirection,
-  ScaleOrientation,
-} from '@grafana/schema';
+import { FieldConfig, FieldSparkline } from '@grafana/data';
+import { GraphFieldConfig } from '@grafana/schema';
 
 import { Themeable2 } from '../../types/theme';
 import { UPlotChart } from '../uPlot/Plot';
-import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 import { preparePlotData2, getStackingGroups } from '../uPlot/utils';
 
-import { getYRange, preparePlotFrame } from './utils';
+import { prepareSeries, prepareConfig } from './utils';
 
 export interface SparklineProps extends Themeable2 {
   width: number;
@@ -32,106 +16,11 @@ export interface SparklineProps extends Themeable2 {
   sparkline: FieldSparkline;
 }
 
-const defaultConfig: GraphFieldConfig = {
-  drawStyle: GraphDrawStyle.Line,
-  showPoints: VisibilityMode.Auto,
-  axisPlacement: AxisPlacement.Hidden,
-  pointSize: 2,
-};
-
-const prepareConfig = (sparkline: FieldSparkline, dataFrame: DataFrame, theme: GrafanaTheme2): UPlotConfigBuilder => {
-  const builder = new UPlotConfigBuilder();
-
-  builder.setCursor({
-    show: false,
-    x: false,
-    y: false,
-  });
-
-  // X is the first field in the aligned frame
-  const xField = dataFrame.fields[0];
-  builder.addScale({
-    scaleKey: 'x',
-    orientation: ScaleOrientation.Horizontal,
-    direction: ScaleDirection.Right,
-    isTime: false,
-    range: () => {
-      if (sparkline.x) {
-        if (sparkline.timeRange && sparkline.x.type === FieldType.time) {
-          return [sparkline.timeRange.from.valueOf(), sparkline.timeRange.to.valueOf()];
-        }
-        const vals = sparkline.x.values;
-        return [vals[0], vals[vals.length - 1]];
-      }
-      return [0, sparkline.y.values.length - 1];
-    },
-  });
-
-  builder.addAxis({
-    scaleKey: 'x',
-    theme,
-    placement: AxisPlacement.Hidden,
-  });
-
-  for (let i = 0; i < dataFrame.fields.length; i++) {
-    const field = dataFrame.fields[i];
-    const config: FieldConfig<GraphFieldConfig> = field.config;
-    const customConfig: GraphFieldConfig = {
-      ...defaultConfig,
-      ...config.custom,
-    };
-
-    if (field === xField || field.type !== FieldType.number) {
-      continue;
-    }
-
-    const scaleKey = config.unit || '__fixed';
-    builder.addScale({
-      scaleKey,
-      orientation: ScaleOrientation.Vertical,
-      direction: ScaleDirection.Up,
-      range: () => getYRange(field, dataFrame),
-    });
-
-    builder.addAxis({
-      scaleKey,
-      theme,
-      placement: AxisPlacement.Hidden,
-    });
-
-    const colorMode = getFieldColorModeForField(field);
-    const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
-    const pointsMode =
-      customConfig.drawStyle === GraphDrawStyle.Points ? VisibilityMode.Always : customConfig.showPoints;
-
-    builder.addSeries({
-      pxAlign: false,
-      scaleKey,
-      theme,
-      colorMode,
-      thresholds: config.thresholds,
-      drawStyle: customConfig.drawStyle!,
-      lineColor: customConfig.lineColor ?? seriesColor,
-      lineWidth: customConfig.lineWidth,
-      lineInterpolation: customConfig.lineInterpolation,
-      showPoints: pointsMode,
-      pointSize: customConfig.pointSize,
-      fillOpacity: customConfig.fillOpacity,
-      fillColor: customConfig.fillColor,
-      lineStyle: customConfig.lineStyle,
-      gradientMode: customConfig.gradientMode,
-      spanNulls: customConfig.spanNulls,
-    });
-  }
-
-  return builder;
-};
-
 export const Sparkline: React.FC<SparklineProps> = memo((props) => {
   const { sparkline, config: fieldConfig, theme, width, height } = props;
-  const alignedDataFrame = nullToValue(preparePlotFrame(sparkline, fieldConfig));
-  // do not render sparklines for fields with 1 or less values - this can cause an infinite loop in uPlot
-  if (alignedDataFrame.fields.some((f) => f.values.length <= 1)) {
+
+  const { frame: alignedDataFrame, warning } = prepareSeries(sparkline, fieldConfig);
+  if (warning) {
     return null;
   }
 
@@ -140,4 +29,5 @@ export const Sparkline: React.FC<SparklineProps> = memo((props) => {
 
   return <UPlotChart data={data} config={configBuilder} width={width} height={height} />;
 });
+
 Sparkline.displayName = 'Sparkline';

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -1,9 +1,14 @@
+import { css } from '@emotion/css';
 import React, { memo } from 'react';
 
-import { FieldConfig, FieldSparkline } from '@grafana/data';
+import { colorManipulator, FieldConfig, FieldSparkline, GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
 import { GraphFieldConfig } from '@grafana/schema';
 
+import { useStyles2 } from '../../themes/ThemeContext';
 import { Themeable2 } from '../../types/theme';
+import { Icon } from '../Icon/Icon';
+import { Tooltip } from '../Tooltip/Tooltip';
 import { UPlotChart } from '../uPlot/Plot';
 import { preparePlotData2, getStackingGroups } from '../uPlot/utils';
 
@@ -16,12 +21,59 @@ export interface SparklineProps extends Themeable2 {
   sparkline: FieldSparkline;
 }
 
+const CompactAlert = ({ children, width }: { width: number; children: string | React.ReactElement }) => {
+  const styles = useStyles2(getCompactAlertStyles);
+
+  return (
+    <div role="alert" style={{ width, display: 'flex', justifyContent: 'center' }}>
+      {width >= 400 ? (
+        <div role="alert" className={styles.content}>
+          <Icon className={styles.icon} name="exclamation-triangle" />
+          {children}
+        </div>
+      ) : (
+        <Tooltip content={children} placement="top">
+          <div className={styles.content}>
+            <Icon className={styles.icon} size="lg" name="exclamation-triangle" />
+            <Trans i18nKey="grafana-ui.components.sparkline.alert.title">Cannot render sparkline</Trans>
+          </div>
+        </Tooltip>
+      )}
+    </div>
+  );
+};
+
+const getCompactAlertStyles = (theme: GrafanaTheme2) => ({
+  content: css({
+    margin: theme.spacing(1),
+    fontSize: theme.typography.bodySmall.fontSize,
+    fontWeight: theme.typography.fontWeightMedium,
+    padding: theme.spacing(0.5, 1),
+    color: theme.colors.warning.contrastText,
+    background: colorManipulator.alpha(theme.colors.warning.main, 0.85),
+    borderRadius: theme.shape.radius.default,
+    display: 'flex',
+    justifyContent: 'center',
+
+    '& a': {
+      color: theme.colors.warning.contrastText,
+      textDecoration: 'underline',
+      '&:hover': {
+        textDecoration: 'none',
+      },
+    },
+  }),
+  icon: css({
+    marginRight: theme.spacing(1),
+  }),
+});
+
 export const Sparkline: React.FC<SparklineProps> = memo((props) => {
   const { sparkline, config: fieldConfig, theme, width, height } = props;
 
   const { frame: alignedDataFrame, warning } = prepareSeries(sparkline, fieldConfig);
   if (warning) {
-    return null;
+    return <CompactAlert width={width}>{warning}</CompactAlert>;
   }
 
   const data = preparePlotData2(alignedDataFrame, getStackingGroups(alignedDataFrame));

--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -1,16 +1,29 @@
 import { Range } from 'uplot';
 
 import {
+  applyNullInsertThreshold,
   DataFrame,
+  Field,
   FieldConfig,
   FieldSparkline,
   FieldType,
+  getFieldColorModeForField,
+  GrafanaTheme2,
   isLikelyAscendingVector,
+  nullToValue,
   sortDataFrame,
-  applyNullInsertThreshold,
-  Field,
 } from '@grafana/data';
-import { GraphFieldConfig } from '@grafana/schema';
+import { t } from '@grafana/i18n';
+import {
+  AxisPlacement,
+  GraphDrawStyle,
+  GraphFieldConfig,
+  VisibilityMode,
+  ScaleDirection,
+  ScaleOrientation,
+} from '@grafana/schema';
+
+import { UPlotConfigBuilder } from '../uPlot/config/UPlotConfigBuilder';
 
 /** @internal
  * Given a sparkline config returns a DataFrame ready to be turned into Plot data set
@@ -85,3 +98,129 @@ export function getYRange(field: Field, alignedFrame: DataFrame): Range.MinMax {
 
   return [min, max];
 }
+
+// const HIGHLIGHT_IDX_POINT_SIZE = 6;
+
+const defaultConfig: GraphFieldConfig = {
+  drawStyle: GraphDrawStyle.Line,
+  showPoints: VisibilityMode.Auto,
+  axisPlacement: AxisPlacement.Hidden,
+  pointSize: 2,
+};
+
+export const prepareSeries = (
+  sparkline: FieldSparkline,
+  fieldConfig?: FieldConfig<GraphFieldConfig>
+): { frame: DataFrame; warning?: string } => {
+  const frame = nullToValue(preparePlotFrame(sparkline, fieldConfig));
+  if (frame.fields.some((f) => f.values.length <= 1)) {
+    return {
+      warning: t(
+        'grafana-ui.components.sparkline.warning.too-few-values',
+        'Sparkline requires at least two values to render.'
+      ),
+      frame,
+    };
+  }
+  return { frame };
+};
+
+export const prepareConfig = (
+  sparkline: FieldSparkline,
+  dataFrame: DataFrame,
+  theme: GrafanaTheme2
+): UPlotConfigBuilder => {
+  const builder = new UPlotConfigBuilder();
+  // const rangePad = HIGHLIGHT_IDX_POINT_SIZE / 2;
+
+  builder.setCursor({
+    show: false,
+    x: false, // no crosshairs
+    y: false,
+  });
+
+  // X is the first field in the aligned frame
+  const xField = dataFrame.fields[0];
+  builder.addScale({
+    scaleKey: 'x',
+    orientation: ScaleOrientation.Horizontal,
+    direction: ScaleDirection.Right,
+    isTime: false, // xField.type === FieldType.time,
+    range: () => {
+      if (sparkline.x) {
+        if (sparkline.timeRange && sparkline.x.type === FieldType.time) {
+          return [sparkline.timeRange.from.valueOf(), sparkline.timeRange.to.valueOf()];
+        }
+        const vals = sparkline.x.values;
+        return [vals[0], vals[vals.length - 1]];
+      }
+      return [0, sparkline.y.values.length - 1];
+    },
+  });
+
+  builder.addAxis({
+    scaleKey: 'x',
+    theme,
+    placement: AxisPlacement.Hidden,
+  });
+
+  for (let i = 0; i < dataFrame.fields.length; i++) {
+    const field = dataFrame.fields[i];
+    const config: FieldConfig<GraphFieldConfig> = field.config;
+    const customConfig: GraphFieldConfig = {
+      ...defaultConfig,
+      ...config.custom,
+    };
+
+    if (field === xField || field.type !== FieldType.number) {
+      continue;
+    }
+
+    const scaleKey = config.unit || '__fixed';
+    builder.addScale({
+      scaleKey,
+      orientation: ScaleOrientation.Vertical,
+      direction: ScaleDirection.Up,
+      range: () => getYRange(field, dataFrame),
+    });
+
+    builder.addAxis({
+      scaleKey,
+      theme,
+      placement: AxisPlacement.Hidden,
+    });
+
+    const colorMode = getFieldColorModeForField(field);
+    const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
+    // const hasHighlightIndex = typeof sparkline.highlightIndex === 'number';
+    // if (hasHighlightIndex) {
+    //   builder.setPadding([rangePad, rangePad, rangePad, rangePad]);
+    // }
+    const pointsMode =
+      customConfig.drawStyle === GraphDrawStyle.Points // || hasHighlightIndex
+        ? VisibilityMode.Always
+        : customConfig.showPoints;
+
+    builder.addSeries({
+      pxAlign: false,
+      scaleKey,
+      theme,
+      colorMode,
+      thresholds: config.thresholds,
+      drawStyle: customConfig.drawStyle!,
+      lineColor: customConfig.lineColor ?? seriesColor,
+      lineWidth: customConfig.lineWidth,
+      lineInterpolation: customConfig.lineInterpolation,
+      showPoints: pointsMode,
+      // pointSize: hasHighlightIndex ? HIGHLIGHT_IDX_POINT_SIZE : customConfig.pointSize,
+      // pointsFilter: hasHighlightIndex ? [sparkline.highlightIndex!] : undefined,
+      fillOpacity: customConfig.fillOpacity,
+      fillColor: customConfig.fillColor,
+      lineStyle: customConfig.lineStyle,
+      gradientMode: customConfig.gradientMode,
+      spanNulls: customConfig.spanNulls,
+    });
+  }
+
+  return builder;
+};

--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -99,6 +99,7 @@ export function getYRange(field: Field, alignedFrame: DataFrame): Range.MinMax {
   return [min, max];
 }
 
+// TODO: #112977 enable highlight index
 // const HIGHLIGHT_IDX_POINT_SIZE = 6;
 
 const defaultConfig: GraphFieldConfig = {
@@ -192,6 +193,7 @@ export const prepareConfig = (
 
     const colorMode = getFieldColorModeForField(field);
     const seriesColor = colorMode.getCalculator(field, theme)(0, 0);
+    // TODO: #112977 enable highlight index and adjust padding accordingly
     // const hasHighlightIndex = typeof sparkline.highlightIndex === 'number';
     // if (hasHighlightIndex) {
     //   builder.setPadding([rangePad, rangePad, rangePad, rangePad]);
@@ -212,6 +214,7 @@ export const prepareConfig = (
       lineWidth: customConfig.lineWidth,
       lineInterpolation: customConfig.lineInterpolation,
       showPoints: pointsMode,
+      // TODO: #112977 enable highlight index
       // pointSize: hasHighlightIndex ? HIGHLIGHT_IDX_POINT_SIZE : customConfig.pointSize,
       // pointsFilter: hasHighlightIndex ? [sparkline.highlightIndex!] : undefined,
       fillOpacity: customConfig.fillOpacity,

--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -123,6 +123,15 @@ export const prepareSeries = (
       frame,
     };
   }
+  if (sparkline.x && !isLikelyAscendingVector(sparkline.x.values)) {
+    return {
+      warning: t(
+        'grafana-ui.components.sparkline.warning.x-not-ascending',
+        "The data in your Sparkline's x series must be sorted in ascending order."
+      ),
+      frame,
+    };
+  }
   return { frame };
 };
 

--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -215,7 +215,7 @@ export const prepareConfig = (
       lineInterpolation: customConfig.lineInterpolation,
       showPoints: pointsMode,
       // TODO: #112977 enable highlight index
-      // pointSize: hasHighlightIndex ? HIGHLIGHT_IDX_POINT_SIZE : customConfig.pointSize,
+      pointSize: /* hasHighlightIndex ? HIGHLIGHT_IDX_POINT_SIZE : */ customConfig.pointSize,
       // pointsFilter: hasHighlightIndex ? [sparkline.highlightIndex!] : undefined,
       fillOpacity: customConfig.fillOpacity,
       fillColor: customConfig.fillColor,

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -9,20 +9,20 @@ import { config } from '@grafana/runtime';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
 export const panelsToCheckFirst = [
-  // 'timeseries',
-  // 'barchart',
+  'timeseries',
+  'barchart',
   'gauge',
-  // 'stat',
-  // 'piechart',
-  // 'bargauge',
-  // 'table',
-  // 'state-timeline',
-  // 'status-history',
-  // 'logs',
-  // 'candlestick',
-  // 'flamegraph',
-  // 'traces',
-  // 'nodeGraph',
+  'stat',
+  'piechart',
+  'bargauge',
+  'table',
+  'state-timeline',
+  'status-history',
+  'logs',
+  'candlestick',
+  'flamegraph',
+  'traces',
+  'nodeGraph',
 ];
 
 export async function getAllSuggestions(

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -9,20 +9,20 @@ import { config } from '@grafana/runtime';
 import { importPanelPlugin } from 'app/features/plugins/importPanelPlugin';
 
 export const panelsToCheckFirst = [
-  'timeseries',
-  'barchart',
+  // 'timeseries',
+  // 'barchart',
   'gauge',
-  'stat',
-  'piechart',
-  'bargauge',
-  'table',
-  'state-timeline',
-  'status-history',
-  'logs',
-  'candlestick',
-  'flamegraph',
-  'traces',
-  'nodeGraph',
+  // 'stat',
+  // 'piechart',
+  // 'bargauge',
+  // 'table',
+  // 'state-timeline',
+  // 'status-history',
+  // 'logs',
+  // 'candlestick',
+  // 'flamegraph',
+  // 'traces',
+  // 'nodeGraph',
 ];
 
 export async function getAllSuggestions(

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8695,8 +8695,12 @@
     },
     "components": {
       "sparkline": {
+        "alert": {
+          "title": "Cannot render sparkline"
+        },
         "warning": {
-          "too-few-values": "Sparkline requires at least two values to render."
+          "too-few-values": "Sparkline requires at least two values to render.",
+          "x-not-ascending": "The data in your Sparkline's x series must be sorted in ascending order."
         }
       }
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8693,6 +8693,13 @@
       "aria-label-default": "Pick a color",
       "aria-label-selected-color": "{{colorLabel}} color"
     },
+    "components": {
+      "sparkline": {
+        "warning": {
+          "too-few-values": "Sparkline requires at least two values to render."
+        }
+      }
+    },
     "confirm-button": {
       "aria-label-delete": "Delete",
       "cancel": "Cancel",


### PR DESCRIPTION
Since we are adding some protective cases in front of Sparkline, I think showing a warning in place of the Sparkline rather than no-oping gives the user much more information on what might have happened and how to fix their visualization.


https://github.com/user-attachments/assets/b54e225b-58e1-45d9-9d5a-365ca1e50d28

<img width="665" height="293" alt="Screenshot 2025-11-21 at 3 02 36 PM" src="https://github.com/user-attachments/assets/ffe2057c-351f-4814-a1b9-a2523211708e" />
