### PR TITLE
Dashboards: Fix margin of time controls

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -240,6 +240,7 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       justifyContent: 'flex-end',
       gap: theme.spacing(1),
+      marginBottom: theme.spacing(1),
     }),
     rightControlsWrap: css({
       flexWrap: 'wrap',


### PR DESCRIPTION
**What is this feature?**

Adds margin to the bottom of time controls.

In https://github.com/grafana/grafana/pull/113765 I removed 8px of margin bottom from the dashboard controls so that I could add 8px of margin bottom to the variable controls. This was because I needed there to be some margin between the rows of variables.

I did however forget to add the same margin bottom to the time controls. So when there are no variables on the dashboard the empty space between the controls and the first panels is only the 8px from the margin on the dashboard controls container. This adds that missing empty space back by adding margin to the time controls.
