### PR TITLE
Alerting: Change group filtering to search-based using lightweight BE endpoint

### DIFF
--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.test.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from 'test/test-utils';
+
+import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { prometheusApi } from '../../../api/prometheusApi';
+import { setupMswServer } from '../../../mockApi';
+
+import { useNamespaceAndGroupOptions } from './useRuleFilterAutocomplete';
+
+setupMswServer();
+
+jest.mock('../../../api/prometheusApi', () => ({
+  prometheusApi: {
+    useLazyGetGrafanaGroupsQuery: jest.fn(),
+    useLazyGetGroupsQuery: jest.fn(),
+  },
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getDataSourceSrv: () => ({
+    getList: jest.fn().mockReturnValue([]),
+  }),
+}));
+
+describe('useNamespaceAndGroupOptions', () => {
+  let mockFetchGrafanaGroups: jest.Mock;
+  let mockFetchExternalGroups: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockFetchGrafanaGroups = jest.fn();
+    mockFetchExternalGroups = jest.fn();
+
+    (prometheusApi.useLazyGetGrafanaGroupsQuery as jest.Mock).mockReturnValue([mockFetchGrafanaGroups]);
+    (prometheusApi.useLazyGetGroupsQuery as jest.Mock).mockReturnValue([mockFetchExternalGroups]);
+  });
+
+  describe('groupOptions', () => {
+    it('should require minimum 3 characters before searching', async () => {
+      const { result } = renderHook(() => useNamespaceAndGroupOptions());
+
+      const options = await result.current.groupOptions('ab');
+
+      expect(options).toHaveLength(1);
+      expect(options[0]).toEqual({
+        label: 'Type at least 3 characters to search groups',
+        value: '__GRAFANA_INFO_OPTION__',
+        infoOption: true,
+      });
+      expect(mockFetchGrafanaGroups).not.toHaveBeenCalled();
+    });
+
+    it('should call API with searchGroupName when 3+ characters entered', async () => {
+      const mockGroups: GrafanaPromRuleGroupDTO[] = [
+        { name: 'cpu-alerts', file: 'folder1', folderUid: 'uid1', interval: 60, rules: [] },
+        { name: 'cpu-usage', file: 'folder2', folderUid: 'uid2', interval: 60, rules: [] },
+      ];
+
+      mockFetchGrafanaGroups.mockReturnValue({
+        unwrap: () =>
+          Promise.resolve({
+            data: { groups: mockGroups },
+          }),
+      });
+
+      const { result } = renderHook(() => useNamespaceAndGroupOptions());
+
+      const options = await result.current.groupOptions('cpu');
+
+      expect(mockFetchGrafanaGroups).toHaveBeenCalledWith({
+        limitAlerts: 0,
+        searchGroupName: 'cpu',
+        groupLimit: 100,
+      });
+
+      expect(options).toHaveLength(2);
+      expect(options[0]).toEqual({ label: 'cpu-alerts', value: 'cpu-alerts' });
+      expect(options[1]).toEqual({ label: 'cpu-usage', value: 'cpu-usage' });
+    });
+
+    it('should show message when no groups match search', async () => {
+      mockFetchGrafanaGroups.mockReturnValue({
+        unwrap: () =>
+          Promise.resolve({
+            data: { groups: [] },
+          }),
+      });
+
+      const { result } = renderHook(() => useNamespaceAndGroupOptions());
+
+      const options = await result.current.groupOptions('xyz123');
+
+      expect(options).toHaveLength(1);
+      expect(options[0]).toEqual({
+        label: 'No groups found matching "xyz123"',
+        value: '__GRAFANA_INFO_OPTION__',
+        infoOption: true,
+      });
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+      mockFetchGrafanaGroups.mockReturnValue({
+        unwrap: () => Promise.reject(new Error('API Error')),
+      });
+
+      const { result } = renderHook(() => useNamespaceAndGroupOptions());
+
+      const options = await result.current.groupOptions('cpu');
+
+      expect(options).toHaveLength(1);
+      expect(options[0]).toEqual({
+        label: 'Error searching groups',
+        value: '__GRAFANA_INFO_OPTION__',
+        infoOption: true,
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -173,7 +173,7 @@ export function useNamespaceAndGroupOptions(): {
   );
 
   const namespacePlaceholder = t('alerting.rules-filter.filter-options.placeholder-namespace', 'Select namespace');
-  const groupPlaceholder = t('alerting.rules-filter.placeholder-group-search', 'Search group (min 3 characters)');
+  const groupPlaceholder = t('alerting.rules-filter.placeholder-group-search', 'Search group');
 
   return { namespaceOptions, groupOptions, namespacePlaceholder, groupPlaceholder };
 }

--- a/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
+++ b/public/app/features/alerting/unified/components/rules/Filter/useRuleFilterAutocomplete.ts
@@ -1,3 +1,4 @@
+import { chain } from 'lodash';
 import { useCallback } from 'react';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
@@ -140,16 +141,11 @@ export function useNamespaceAndGroupOptions(): {
           groupLimit: GROUP_SEARCH_LIMIT, // Reasonable limit for dropdown results
         }).unwrap();
 
-        // Deduplicate group names efficiently
-        const groupNamesSet = new Set<string>();
-        grafanaResponse.data.groups.forEach((g: GrafanaPromRuleGroupDTO) => {
-          if (g.name) {
-            groupNamesSet.add(g.name);
-          }
-        });
+        // Deduplicate group names
+        const groupNames = chain(grafanaResponse.data.groups).map('name').compact().uniq().value();
 
         // No results found
-        if (groupNamesSet.size === 0) {
+        if (groupNames.length === 0) {
           return [
             createInfoOption(
               t('alerting.rules-filter.group-no-results', 'No groups found matching "{{search}}"', {
@@ -159,7 +155,7 @@ export function useNamespaceAndGroupOptions(): {
           ];
         }
 
-        const options: Array<ComboboxOption<string>> = Array.from(groupNamesSet)
+        const options: Array<ComboboxOption<string>> = groupNames
           .map((name) => ({ label: name, value: name }))
           .sort((a, b) => collator.compare(a.label ?? '', b.label ?? ''));
 

--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -439,13 +439,7 @@ function GroupField({
   groupPlaceholder: string;
   portalContainer?: HTMLElement;
 }) {
-  const { control, setValue } = useFormContext<AdvancedFilters>();
-
-  const wrappedOptions = useCallback(
-    (inputValue: string) =>
-      createThresholdAwareOptions(groupOptions, (value) => setValue('groupName', value), 'groupName')(inputValue),
-    [groupOptions, setValue]
-  );
+  const { control } = useFormContext<AdvancedFilters>();
 
   return (
     <>
@@ -458,7 +452,7 @@ function GroupField({
         render={({ field }) => (
           <Combobox<string>
             placeholder={groupPlaceholder}
-            options={wrappedOptions}
+            options={groupOptions}
             onChange={(option) => {
               if (!option?.infoOption) {
                 field.onChange(option?.value || null);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2624,7 +2624,9 @@
         "placeholder-search-input": "Search by name or enter filter query..."
       },
       "grafana-folder": "Grafana folder",
-      "group-autocomplete-unavailable": "Due to large number of groups, autocomplete is not available",
+      "group-no-results": "No groups found matching \"{{search}}\"",
+      "group-search-error": "Error searching groups",
+      "group-search-prompt": "Type at least 3 characters to search groups",
       "health": "Health",
       "label": {
         "hide": "Hide",
@@ -2635,6 +2637,7 @@
       "placeholder-all-data-sources": "All data sources",
       "placeholder-contact-point": "Select contact point",
       "placeholder-data-sources": "Select data sources",
+      "placeholder-group-search": "Search group (min 3 characters)",
       "placeholder-labels": "Select labels",
       "plugin-rules": "Plugin rules",
       "rule-source": {
@@ -8123,8 +8126,7 @@
       "edit-pane": {
         "go-back": "Go back"
       }
-    },
-    "select-group": "Select group"
+    }
   },
   "grafana-data": {
     "datetime": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2637,7 +2637,7 @@
       "placeholder-all-data-sources": "All data sources",
       "placeholder-contact-point": "Select contact point",
       "placeholder-data-sources": "Select data sources",
-      "placeholder-group-search": "Search group (min 3 characters)",
+      "placeholder-group-search": "Search group",
       "placeholder-labels": "Select labels",
       "plugin-rules": "Plugin rules",
       "rule-source": {


### PR DESCRIPTION
This PR improves the performance of the alert rule group filter by switching from a load-all approach to search-based fetching, using lightweight backend endpoint. Using `limitAlerts: 0` only returns rule/group metadata and doesn't include alert instance data in the response. 
It requires a minimum of 3 characters before searching for groups instead of loading all groups upfront.

https://github.com/user-attachments/assets/75234892-e5d6-4c52-922f-e21e30b4daae


