### PR TITLE
Logs: Persist sort order in the Explore URL

### DIFF
--- a/packages/grafana-data/src/types/explore.ts
+++ b/packages/grafana-data/src/types/explore.ts
@@ -1,4 +1,4 @@
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LogsSortOrder } from '@grafana/schema';
 
 import { PreferredVisualisationType } from './data';
 import { SelectableValue } from './select';
@@ -84,6 +84,7 @@ export interface ExploreLogsPanelState {
   // Used for logs table visualisation, contains the refId of the dataFrame that is currently visualized
   refId?: string;
   displayedFields?: string[];
+  sortOrder?: LogsSortOrder;
 }
 
 export interface SplitOpenOptions<T extends AnyQuery = AnyQuery> {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -287,19 +287,17 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   useUnmount(() => {
     // If we're unmounting logs (e.g. switching to another datasource), we need to remove the logs specific panel state, otherwise it will persist in the explore url
-    if (panelState?.logs) {
-      dispatch(
-        changePanelState(exploreId, 'logs', {
-          ...panelState?.logs,
-          columns: undefined,
-          visualisationType: visualisationType,
-          labelFieldName: undefined,
-          refId: undefined,
-          displayedFields: undefined,
-          sortOrder: undefined,
-        })
-      );
-    }
+    dispatch(
+      changePanelState(exploreId, 'logs', {
+        ...panelState?.logs,
+        columns: undefined,
+        visualisationType: visualisationType,
+        labelFieldName: undefined,
+        refId: undefined,
+        displayedFields: undefined,
+        sortOrder: undefined,
+      })
+    );
   });
 
   const updatePanelState = useCallback(

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -592,7 +592,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
       const urlState = getUrlStateFromPaneState(getState().explore.panes[exploreId]!);
       urlState.panelsState = {
         ...panelState,
-        logs: { id: row.uid, visualisationType: visualisationType ?? getDefaultVisualisationType(), displayedFields },
+        logs: {
+          id: row.uid,
+          visualisationType: visualisationType ?? getDefaultVisualisationType(),
+          displayedFields,
+          sortOrder: logsSortOrder,
+        },
       };
       urlState.range = getLogsPermalinkRange(row, logRows, absoluteRange);
 
@@ -608,7 +613,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         logRowLevel: row.logLevel,
       });
     },
-    [absoluteRange, displayedFields, exploreId, logRows, panelState, visualisationType]
+    [absoluteRange, displayedFields, exploreId, logRows, logsSortOrder, panelState, visualisationType]
   );
 
   const scrollToTopLogs = useCallback(() => {

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -197,7 +197,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   );
   const [dedupStrategy, setDedupStrategy] = useState<LogsDedupStrategy>(LogsDedupStrategy.none);
   const [logsSortOrder, setLogsSortOrder] = useState<LogsSortOrder>(
-    store.get(SETTINGS_KEYS.logsSortOrder) || LogsSortOrder.Descending
+    panelState?.logs?.sortOrder ?? store.get(SETTINGS_KEYS.logsSortOrder) ?? LogsSortOrder.Descending
   );
   const [isFlipping, setIsFlipping] = useState<boolean>(false);
   const [displayedFields, setDisplayedFields] = useState<string[]>(panelState?.logs?.displayedFields ?? []);
@@ -287,12 +287,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
 
   useUnmount(() => {
     // If we're unmounting logs (e.g. switching to another datasource), we need to remove the logs specific panel state, otherwise it will persist in the explore url
-    if (
-      panelState?.logs?.columns ||
-      panelState?.logs?.refId ||
-      panelState?.logs?.labelFieldName ||
-      panelState?.logs?.displayedFields
-    ) {
+    if (panelState?.logs) {
       dispatch(
         changePanelState(exploreId, 'logs', {
           ...panelState?.logs,
@@ -301,6 +296,7 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           labelFieldName: undefined,
           refId: undefined,
           displayedFields: undefined,
+          sortOrder: undefined,
         })
       );
     }
@@ -398,8 +394,16 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         dispatch(changeQueries({ exploreId, queries: newQueries }));
         dispatch(runQueries({ exploreId }));
       }
+      if (panelState?.logs) {
+        dispatch(
+          changePanelState(exploreId, 'logs', {
+            ...panelState?.logs,
+            sortOrder: newSortOrder,
+          })
+        );
+      }
     },
-    [dispatch, exploreId, logsQueries]
+    [dispatch, exploreId, logsQueries, panelState?.logs]
   );
 
   const onChangeLogsSortOrder = useCallback(

--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -270,6 +270,18 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
   }, [dispatch, exploreId, loading, panelState, previousLoading]);
 
   useEffect(() => {
+    // Initialize URL sort order
+    if (!panelState?.logs?.sortOrder) {
+      dispatch(
+        changePanelState(exploreId, 'logs', {
+          ...panelState,
+          sortOrder: logsSortOrder,
+        })
+      );
+    }
+  }, [dispatch, exploreId, logsSortOrder, panelState]);
+
+  useEffect(() => {
     const visualisationType = panelState?.logs?.visualisationType ?? getDefaultVisualisationType();
     setVisualisationType(visualisationType);
 
@@ -392,14 +404,12 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
         dispatch(changeQueries({ exploreId, queries: newQueries }));
         dispatch(runQueries({ exploreId }));
       }
-      if (panelState?.logs) {
-        dispatch(
-          changePanelState(exploreId, 'logs', {
-            ...panelState?.logs,
-            sortOrder: newSortOrder,
-          })
-        );
-      }
+      dispatch(
+        changePanelState(exploreId, 'logs', {
+          ...panelState?.logs,
+          sortOrder: newSortOrder,
+        })
+      );
     },
     [dispatch, exploreId, logsQueries, panelState?.logs]
   );

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 import { ReactNode } from 'react';
 import { Provider } from 'react-redux';
 
-import { PluginExtensionPoints, PluginExtensionTypes } from '@grafana/data';
+import { ExplorePanelsState, PluginExtensionPoints, PluginExtensionTypes } from '@grafana/data';
 import { usePluginLinks } from '@grafana/runtime';
-import { DataQuery } from '@grafana/schema';
+import { DataQuery, LogsSortOrder } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { configureStore } from 'app/store/configureStore';
 import { ExplorePanelData, ExploreState } from 'app/types/explore';
@@ -27,13 +27,14 @@ const usePluginLinksMock = jest.mocked(usePluginLinks);
 type storeOptions = {
   targets: DataQuery[];
   data: ExplorePanelData;
+  panelsState?: ExplorePanelsState;
 };
 
 function renderWithExploreStore(
   children: ReactNode,
   options: storeOptions = { targets: [{ refId: 'A' }], data: createEmptyQueryResponse() }
 ) {
-  const { targets, data } = options;
+  const { targets, data, panelsState } = options;
   const store = configureStore({
     explore: {
       panes: {
@@ -43,6 +44,7 @@ function renderWithExploreStore(
           range: {
             raw: { from: 'now-1h', to: 'now' },
           },
+          panelsState,
         },
       },
     } as unknown as ExploreState,
@@ -89,6 +91,9 @@ describe('ToolbarExtensionPoint', () => {
         ],
         isLoading: false,
       });
+    });
+    beforeEach(() => {
+      jest.mocked(usePluginLinksMock).mockClear();
     });
 
     it('should render "Add" extension point menu button', () => {
@@ -179,6 +184,20 @@ describe('ToolbarExtensionPoint', () => {
       const { extensionPointId } = options;
 
       expect(extensionPointId).toBe(PluginExtensionPoints.ExploreToolbarAction);
+    });
+
+    it('should pass panelsState to the extensions', async () => {
+      const panelsState: ExplorePanelsState = {
+        logs: { sortOrder: LogsSortOrder.Ascending, displayedFields: ['time', 'body'] },
+      };
+      const targets = [{ refId: 'A' }];
+      const data = createEmptyQueryResponse();
+      renderWithExploreStore(setupToolbarExtensionPoint(), { targets, data, panelsState });
+
+      const [options] = usePluginLinksMock.mock.calls[0];
+      const { context } = options;
+
+      expect(context).toHaveProperty('panelsState', panelsState);
     });
   });
 

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -2,7 +2,7 @@ import { ReactElement, useMemo, useState } from 'react';
 
 import { type PluginExtensionLink, PluginExtensionPoints, RawTimeRange, getTimeZone } from '@grafana/data';
 import { reportInteraction, usePluginLinks } from '@grafana/runtime';
-import { DataQuery, TimeZone } from '@grafana/schema';
+import { DataQuery, LogsSortOrder, TimeZone } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { ExplorePanelData } from 'app/types/explore';
@@ -89,13 +89,14 @@ export type PluginExtensionExploreContext = {
   timeRange: RawTimeRange;
   timeZone: TimeZone;
   shouldShowAddCorrelation: boolean;
+  sortOrder?: LogsSortOrder;
 };
 
 function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
   const { exploreId, timeZone } = props;
   const isCorrelationDetails = useSelector(selectCorrelationDetails);
   const isCorrelationsEditorMode = isCorrelationDetails?.editorMode || false;
-  const { queries, queryResponse, range } = useSelector(getExploreItemSelector(exploreId))!;
+  const { queries, queryResponse, range, panelsState } = useSelector(getExploreItemSelector(exploreId))!;
   const isLeftPane = useSelector(isLeftPaneSelector(exploreId));
 
   const datasourceUids = queries.map((query) => query?.datasource?.uid).filter((uid) => uid !== undefined);
@@ -110,16 +111,18 @@ function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
       timeRange: range.raw,
       timeZone: getTimeZone({ timeZone }),
       shouldShowAddCorrelation: canWriteCorrelations && !isCorrelationsEditorMode && isLeftPane && numUniqueIds === 1,
+      sortOrder: panelsState?.logs?.sortOrder,
     };
   }, [
+    canWriteCorrelations,
     exploreId,
+    isCorrelationsEditorMode,
+    isLeftPane,
+    numUniqueIds,
+    panelsState?.logs?.sortOrder,
     queries,
     queryResponse,
     range.raw,
     timeZone,
-    canWriteCorrelations,
-    isCorrelationsEditorMode,
-    isLeftPane,
-    numUniqueIds,
   ]);
 }

--- a/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPoint.tsx
@@ -1,8 +1,14 @@
 import { ReactElement, useMemo, useState } from 'react';
 
-import { type PluginExtensionLink, PluginExtensionPoints, RawTimeRange, getTimeZone } from '@grafana/data';
+import {
+  type ExplorePanelsState,
+  type PluginExtensionLink,
+  PluginExtensionPoints,
+  RawTimeRange,
+  getTimeZone,
+} from '@grafana/data';
 import { reportInteraction, usePluginLinks } from '@grafana/runtime';
-import { DataQuery, LogsSortOrder, TimeZone } from '@grafana/schema';
+import { DataQuery, TimeZone } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { ExplorePanelData } from 'app/types/explore';
@@ -89,7 +95,7 @@ export type PluginExtensionExploreContext = {
   timeRange: RawTimeRange;
   timeZone: TimeZone;
   shouldShowAddCorrelation: boolean;
-  sortOrder?: LogsSortOrder;
+  panelsSate?: ExplorePanelsState;
 };
 
 function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
@@ -111,7 +117,7 @@ function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
       timeRange: range.raw,
       timeZone: getTimeZone({ timeZone }),
       shouldShowAddCorrelation: canWriteCorrelations && !isCorrelationsEditorMode && isLeftPane && numUniqueIds === 1,
-      sortOrder: panelsState?.logs?.sortOrder,
+      panelsState,
     };
   }, [
     canWriteCorrelations,
@@ -119,7 +125,7 @@ function useExtensionPointContext(props: Props): PluginExtensionExploreContext {
     isCorrelationsEditorMode,
     isLeftPane,
     numUniqueIds,
-    panelsState?.logs?.sortOrder,
+    panelsState,
     queries,
     queryResponse,
     range.raw,


### PR DESCRIPTION
Closes #100714

- Keep sortOrder in the URL
- Read sortOrder from URL and links
- Include sortOrder when switching to Drilldown Logs

### How to test

- Change sort order while browsing logs
- Share the URL: the sort order must be respected.
- Go to Drilldown Logs: the sort order must be respected.