### PR TITLE
Alerting: Add search.folder filter to the Prometheus rules API

### DIFF
--- a/pkg/services/ngalert/api/prometheus/util.go
+++ b/pkg/services/ngalert/api/prometheus/util.go
@@ -1,0 +1,41 @@
+package api
+
+import (
+	"strings"
+)
+
+// TextMatcher performs case-insensitive sequential substring matching.
+// It checks if text contains all search words in the order provided,
+// but not necessarily consecutively.
+//
+// Example: NewTextMatcher("api time").Match("API Response Time") returns true
+type TextMatcher struct {
+	words []string
+}
+
+func NewTextMatcher(search string) *TextMatcher {
+	words := strings.Fields(search)
+	for i := range words {
+		words[i] = strings.ToLower(words[i])
+	}
+	return &TextMatcher{words: words}
+}
+
+func (m *TextMatcher) Match(text string) bool {
+	if len(m.words) == 0 {
+		return true
+	}
+	lowerText := strings.ToLower(text)
+	start := 0
+	for _, word := range m.words {
+		if start > len(lowerText) {
+			return false
+		}
+		idx := strings.Index(lowerText[start:], word)
+		if idx == -1 {
+			return false
+		}
+		start += idx + len(word)
+	}
+	return true
+}

--- a/pkg/services/ngalert/api/prometheus/util_test.go
+++ b/pkg/services/ngalert/api/prometheus/util_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTextMatcher(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedWords []string
+	}{
+		{
+			name:          "empty string",
+			input:         "",
+			expectedWords: []string{},
+		},
+		{
+			name:          "whitespace only",
+			input:         "   ",
+			expectedWords: []string{},
+		},
+		{
+			name:          "single word",
+			input:         "alerts",
+			expectedWords: []string{"alerts"},
+		},
+		{
+			name:          "multiple words",
+			input:         "parent alerts",
+			expectedWords: []string{"parent", "alerts"},
+		},
+		{
+			name:          "mixed case normalized to lowercase",
+			input:         "Parent Alerts",
+			expectedWords: []string{"parent", "alerts"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewTextMatcher(tt.input)
+			assert.Equal(t, tt.expectedWords, matcher.words)
+		})
+	}
+}
+
+func TestTextMatcher_Match(t *testing.T) {
+	tests := []struct {
+		name     string
+		search   string
+		text     string
+		expected bool
+	}{
+		{
+			name:     "empty search matches everything",
+			search:   "",
+			text:     "any text",
+			expected: true,
+		},
+		{
+			name:     "whitespace search matches everything",
+			search:   "   ",
+			text:     "any text",
+			expected: true,
+		},
+		{
+			name:     "exact match",
+			search:   "alerts",
+			text:     "alerts",
+			expected: true,
+		},
+		{
+			name:     "case insensitive match",
+			search:   "parent alerts",
+			text:     "Parent Folder/Alerts",
+			expected: true,
+		},
+		{
+			name:     "partial match",
+			search:   "folder",
+			text:     "Parent Folder/Alerts",
+			expected: true,
+		},
+		{
+			name:     "sequential words match",
+			search:   "api time",
+			text:     "API Response Time",
+			expected: true,
+		},
+		{
+			name:     "non-consecutive but sequential words match",
+			search:   "parent rules",
+			text:     "Parent Folder/Alert Rules",
+			expected: true,
+		},
+		{
+			name:     "word not found",
+			search:   "missing",
+			text:     "Parent Folder/Alerts",
+			expected: false,
+		},
+		{
+			name:     "words out of order",
+			search:   "alerts parent",
+			text:     "Parent Folder/Alerts",
+			expected: false,
+		},
+		{
+			name:     "folder path search",
+			search:   "prod alerts",
+			text:     "Monitoring/Production/Alerts",
+			expected: true,
+		},
+		{
+			name:     "multiple spaces in search",
+			search:   "api   response   time",
+			text:     "API Response Time",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher := NewTextMatcher(tt.search)
+			result := matcher.Match(tt.text)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Adds a `search.folder` query parameter to the Prometheus-compatible rules API (`/api/prometheus/grafana/api/v1/rules`) that filters alert rules by full folder path. The filter performs case-insensitive sequential substring matching, the same as [search.rule_name](https://github.com/grafana/grafana/pull/113738) or [search.rule_group](https://github.com/grafana/grafana/pull/113680) when searching for 'prod alert' finds 'Cloud / Production / Alerts'.

Example: https://ephemeral15111821114358alexan.grafana-dev.net/api/prometheus/grafana/api/v1/rules?limit_alerts=0&search.folder=fold+3 finds one alert in `folder-3`, while https://ephemeral15111821114358alexan.grafana-dev.net/api/prometheus/grafana/api/v1/rules?limit_alerts=0&search.folder=cloud finds all alerts in `Grafana Cloud` and `Grafana Cloud / folder-1 / folder-2`

Part of https://github.com/grafana/alerting-squad/issues/1273

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
