### PR TITLE
Expressions: Distinguish SQL creation vs navigation tracking

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
@@ -69,11 +69,6 @@ export function NewEmptyTransformationsMessage(props: EmptyTransformationsProps)
   }, []);
 
   const handleSqlTransformationClick = () => {
-    reportInteraction('dashboards_expression_interaction', {
-      action: 'add_expression',
-      expression_type: 'sql',
-      context: 'empty_transformations_placeholder',
-    });
     props.onGoToQueries?.();
   };
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -5,6 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import { DataTransformerConfig, GrafanaTheme2, PanelData } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import {
   SceneObjectBase,
   SceneComponentProps,
@@ -102,6 +103,14 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
 
     const queries = queriesTab.getQueries();
     const existingSqlQuery = findSqlExpression(queries);
+
+    // Track the interaction with context about whether SQL expression already existed
+    reportInteraction('dashboards_expression_interaction', {
+      action: 'add_expression',
+      expression_type: 'sql',
+      context: 'empty_transformations_placeholder',
+      expression_exists: !!existingSqlQuery,
+    });
 
     if (!existingSqlQuery) {
       // Create new SQL expression


### PR DESCRIPTION
## What does this PR do?

Tracks separate actions when users click the SQL tile from the transformations tab, distinguishing between creating a new SQL expression versus navigating to an existing one.

## Changes

When clicking the SQL transformation tile:
- **New SQL expression**: Tracks `add_expression` action with `expression_exists: false`
- **Existing SQL expression**: Tracks `add_expression` action  `expression_exists: true`
- Adds `expression_exists` boolean property for additional analytics context