### PR TITLE
Alerting: Align OpenAPI definition with notification settings header

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -555,7 +555,7 @@ const injectedRtkApi = api
             'x-grafana-alerting-alert-rules-paused': queryArg['x-grafana-alerting-alert-rules-paused'],
             'x-grafana-alerting-target-datasource-uid': queryArg['x-grafana-alerting-target-datasource-uid'],
             'x-grafana-alerting-folder-uid': queryArg['x-grafana-alerting-folder-uid'],
-            'x-grafana-alerting-notification-receiver': queryArg['x-grafana-alerting-notification-receiver'],
+            'x-grafana-alerting-notification-settings': queryArg['x-grafana-alerting-notification-settings'],
           },
         }),
         invalidatesTags: ['convert_prometheus'],
@@ -622,7 +622,7 @@ const injectedRtkApi = api
             'x-grafana-alerting-alert-rules-paused': queryArg['x-grafana-alerting-alert-rules-paused'],
             'x-grafana-alerting-target-datasource-uid': queryArg['x-grafana-alerting-target-datasource-uid'],
             'x-grafana-alerting-folder-uid': queryArg['x-grafana-alerting-folder-uid'],
-            'x-grafana-alerting-notification-receiver': queryArg['x-grafana-alerting-notification-receiver'],
+            'x-grafana-alerting-notification-settings': queryArg['x-grafana-alerting-notification-settings'],
           },
         }),
         invalidatesTags: ['convert_prometheus'],
@@ -2498,7 +2498,7 @@ export type RouteConvertPrometheusCortexPostRuleGroupApiArg = {
   'x-grafana-alerting-alert-rules-paused'?: boolean;
   'x-grafana-alerting-target-datasource-uid'?: string;
   'x-grafana-alerting-folder-uid'?: string;
-  'x-grafana-alerting-notification-receiver'?: string;
+  'x-grafana-alerting-notification-settings'?: string;
   prometheusRuleGroup: PrometheusRuleGroup;
 };
 export type RouteConvertPrometheusCortexDeleteRuleGroupApiResponse =
@@ -2535,7 +2535,7 @@ export type RouteConvertPrometheusPostRuleGroupApiArg = {
   'x-grafana-alerting-alert-rules-paused'?: boolean;
   'x-grafana-alerting-target-datasource-uid'?: string;
   'x-grafana-alerting-folder-uid'?: string;
-  'x-grafana-alerting-notification-receiver'?: string;
+  'x-grafana-alerting-notification-settings'?: string;
   prometheusRuleGroup: PrometheusRuleGroup;
 };
 export type RouteConvertPrometheusDeleteRuleGroupApiResponse =

--- a/pkg/services/ngalert/api/tooling/api.json
+++ b/pkg/services/ngalert/api/tooling/api.json
@@ -1707,6 +1707,10 @@
     "is_paused": {
      "type": "boolean"
     },
+    "message": {
+     "description": "Field is only populated when listing alert rule versions.",
+     "type": "string"
+    },
     "metadata": {
      "$ref": "#/definitions/AlertRuleMetadata"
     },
@@ -2544,6 +2548,28 @@
     "TLSConfig": {
      "$ref": "#/definitions/TLSConfig"
     },
+    "audience": {
+     "description": "Audience optionally specifies the intended audience of the\nrequest.  If empty, the value of TokenURL is used as the\nintended audience. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "string"
+    },
+    "claims": {
+     "additionalProperties": {},
+     "description": "Claims is a map of claims to be added to the JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "object"
+    },
+    "client_certificate_key": {
+     "$ref": "#/definitions/Secret"
+    },
+    "client_certificate_key_file": {
+     "type": "string"
+    },
+    "client_certificate_key_id": {
+     "type": "string"
+    },
+    "client_certificate_key_ref": {
+     "description": "ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client\nsecret.",
+     "type": "string"
+    },
     "client_id": {
      "type": "string"
     },
@@ -2562,6 +2588,14 @@
       "type": "string"
      },
      "type": "object"
+    },
+    "grant_type": {
+     "description": "GrantType is the OAuth2 grant type to use. It can be one of\n\"client_credentials\" or \"urn:ietf:params:oauth:grant-type:jwt-bearer\" (RFC 7523).\nDefault value is \"client_credentials\"",
+     "type": "string"
+    },
+    "iss": {
+     "description": "Iss is the OAuth client identifier used when communicating with\nthe configured OAuth provider. Default value is client_id. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "string"
     },
     "no_proxy": {
      "description": "NoProxy contains addresses that should not use a proxy.",
@@ -2582,6 +2616,10 @@
       "type": "string"
      },
      "type": "array"
+    },
+    "signature_algorithm": {
+     "description": "SignatureAlgorithm is the RSA algorithm used to sign JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".\nDefault value is RS256 and valid values RS256, RS384, RS512",
+     "type": "string"
     },
     "token_url": {
      "type": "string"
@@ -5781,7 +5819,7 @@
      },
      {
       "in": "header",
-      "name": "x-grafana-alerting-notification-receiver",
+      "name": "x-grafana-alerting-notification-settings",
       "type": "string"
      },
      {
@@ -6071,7 +6109,7 @@
      },
      {
       "in": "header",
-      "name": "x-grafana-alerting-notification-receiver",
+      "name": "x-grafana-alerting-notification-settings",
       "type": "string"
      },
      {

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -259,7 +259,7 @@ type RouteConvertPrometheusPostRuleGroupParams struct {
 	// in: header
 	FolderUID string `json:"x-grafana-alerting-folder-uid"`
 	// in: header
-	NotificationReceiver string `json:"x-grafana-alerting-notification-receiver"`
+	NotificationSettings string `json:"x-grafana-alerting-notification-settings"`
 	// in:body
 	Body PrometheusRuleGroup
 }

--- a/pkg/services/ngalert/api/tooling/post.json
+++ b/pkg/services/ngalert/api/tooling/post.json
@@ -1707,6 +1707,10 @@
     "is_paused": {
      "type": "boolean"
     },
+    "message": {
+     "description": "Field is only populated when listing alert rule versions.",
+     "type": "string"
+    },
     "metadata": {
      "$ref": "#/definitions/AlertRuleMetadata"
     },
@@ -2544,6 +2548,28 @@
     "TLSConfig": {
      "$ref": "#/definitions/TLSConfig"
     },
+    "audience": {
+     "description": "Audience optionally specifies the intended audience of the\nrequest.  If empty, the value of TokenURL is used as the\nintended audience. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "string"
+    },
+    "claims": {
+     "additionalProperties": {},
+     "description": "Claims is a map of claims to be added to the JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "object"
+    },
+    "client_certificate_key": {
+     "$ref": "#/definitions/Secret"
+    },
+    "client_certificate_key_file": {
+     "type": "string"
+    },
+    "client_certificate_key_id": {
+     "type": "string"
+    },
+    "client_certificate_key_ref": {
+     "description": "ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client\nsecret.",
+     "type": "string"
+    },
     "client_id": {
      "type": "string"
     },
@@ -2562,6 +2588,14 @@
       "type": "string"
      },
      "type": "object"
+    },
+    "grant_type": {
+     "description": "GrantType is the OAuth2 grant type to use. It can be one of\n\"client_credentials\" or \"urn:ietf:params:oauth:grant-type:jwt-bearer\" (RFC 7523).\nDefault value is \"client_credentials\"",
+     "type": "string"
+    },
+    "iss": {
+     "description": "Iss is the OAuth client identifier used when communicating with\nthe configured OAuth provider. Default value is client_id. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+     "type": "string"
     },
     "no_proxy": {
      "description": "NoProxy contains addresses that should not use a proxy.",
@@ -2582,6 +2616,10 @@
       "type": "string"
      },
      "type": "array"
+    },
+    "signature_algorithm": {
+     "description": "SignatureAlgorithm is the RSA algorithm used to sign JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".\nDefault value is RS256 and valid values RS256, RS384, RS512",
+     "type": "string"
     },
     "token_url": {
      "type": "string"
@@ -6834,7 +6872,7 @@
      },
      {
       "in": "header",
-      "name": "x-grafana-alerting-notification-receiver",
+      "name": "x-grafana-alerting-notification-settings",
       "type": "string"
      },
      {
@@ -7241,7 +7279,7 @@
      },
      {
       "in": "header",
-      "name": "x-grafana-alerting-notification-receiver",
+      "name": "x-grafana-alerting-notification-settings",
       "type": "string"
      },
      {

--- a/pkg/services/ngalert/api/tooling/spec.json
+++ b/pkg/services/ngalert/api/tooling/spec.json
@@ -1220,7 +1220,7 @@
           },
           {
             "type": "string",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "in": "header"
           },
           {
@@ -1634,7 +1634,7 @@
           },
           {
             "type": "string",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "in": "header"
           },
           {
@@ -6124,6 +6124,10 @@
         "is_paused": {
           "type": "boolean"
         },
+        "message": {
+          "description": "Field is only populated when listing alert rule versions.",
+          "type": "string"
+        },
         "metadata": {
           "$ref": "#/definitions/AlertRuleMetadata"
         },
@@ -6963,6 +6967,28 @@
         "TLSConfig": {
           "$ref": "#/definitions/TLSConfig"
         },
+        "audience": {
+          "description": "Audience optionally specifies the intended audience of the\nrequest.  If empty, the value of TokenURL is used as the\nintended audience. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "string"
+        },
+        "claims": {
+          "description": "Claims is a map of claims to be added to the JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "client_certificate_key": {
+          "$ref": "#/definitions/Secret"
+        },
+        "client_certificate_key_file": {
+          "type": "string"
+        },
+        "client_certificate_key_id": {
+          "type": "string"
+        },
+        "client_certificate_key_ref": {
+          "description": "ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client\nsecret.",
+          "type": "string"
+        },
         "client_id": {
           "type": "string"
         },
@@ -6981,6 +7007,14 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "grant_type": {
+          "description": "GrantType is the OAuth2 grant type to use. It can be one of\n\"client_credentials\" or \"urn:ietf:params:oauth:grant-type:jwt-bearer\" (RFC 7523).\nDefault value is \"client_credentials\"",
+          "type": "string"
+        },
+        "iss": {
+          "description": "Iss is the OAuth client identifier used when communicating with\nthe configured OAuth provider. Default value is client_id. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "string"
         },
         "no_proxy": {
           "description": "NoProxy contains addresses that should not use a proxy.",
@@ -7001,6 +7035,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "signature_algorithm": {
+          "description": "SignatureAlgorithm is the RSA algorithm used to sign JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".\nDefault value is RS256 and valid values RS256, RS384, RS512",
+          "type": "string"
         },
         "token_url": {
           "type": "string"

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -2885,7 +2885,7 @@
           },
           {
             "type": "string",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "in": "header"
           },
           {
@@ -3175,7 +3175,7 @@
           },
           {
             "type": "string",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "in": "header"
           },
           {
@@ -16720,6 +16720,10 @@
         "is_paused": {
           "type": "boolean"
         },
+        "message": {
+          "description": "Field is only populated when listing alert rule versions.",
+          "type": "string"
+        },
         "metadata": {
           "$ref": "#/definitions/AlertRuleMetadata"
         },
@@ -18273,6 +18277,28 @@
         "TLSConfig": {
           "$ref": "#/definitions/TLSConfig"
         },
+        "audience": {
+          "description": "Audience optionally specifies the intended audience of the\nrequest.  If empty, the value of TokenURL is used as the\nintended audience. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "string"
+        },
+        "claims": {
+          "description": "Claims is a map of claims to be added to the JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "object",
+          "additionalProperties": {}
+        },
+        "client_certificate_key": {
+          "$ref": "#/definitions/Secret"
+        },
+        "client_certificate_key_file": {
+          "type": "string"
+        },
+        "client_certificate_key_id": {
+          "type": "string"
+        },
+        "client_certificate_key_ref": {
+          "description": "ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client\nsecret.",
+          "type": "string"
+        },
         "client_id": {
           "type": "string"
         },
@@ -18291,6 +18317,14 @@
           "additionalProperties": {
             "type": "string"
           }
+        },
+        "grant_type": {
+          "description": "GrantType is the OAuth2 grant type to use. It can be one of\n\"client_credentials\" or \"urn:ietf:params:oauth:grant-type:jwt-bearer\" (RFC 7523).\nDefault value is \"client_credentials\"",
+          "type": "string"
+        },
+        "iss": {
+          "description": "Iss is the OAuth client identifier used when communicating with\nthe configured OAuth provider. Default value is client_id. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+          "type": "string"
         },
         "no_proxy": {
           "description": "NoProxy contains addresses that should not use a proxy.",
@@ -18311,6 +18345,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "signature_algorithm": {
+          "description": "SignatureAlgorithm is the RSA algorithm used to sign JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".\nDefault value is RS256 and valid values RS256, RS384, RS512",
+          "type": "string"
         },
         "token_url": {
           "type": "string"

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -6207,6 +6207,10 @@
           "is_paused": {
             "type": "boolean"
           },
+          "message": {
+            "description": "Field is only populated when listing alert rule versions.",
+            "type": "string"
+          },
           "metadata": {
             "$ref": "#/components/schemas/AlertRuleMetadata"
           },
@@ -7759,6 +7763,28 @@
           "TLSConfig": {
             "$ref": "#/components/schemas/TLSConfig"
           },
+          "audience": {
+            "description": "Audience optionally specifies the intended audience of the\nrequest.  If empty, the value of TokenURL is used as the\nintended audience. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+            "type": "string"
+          },
+          "claims": {
+            "additionalProperties": {},
+            "description": "Claims is a map of claims to be added to the JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+            "type": "object"
+          },
+          "client_certificate_key": {
+            "$ref": "#/components/schemas/Secret"
+          },
+          "client_certificate_key_file": {
+            "type": "string"
+          },
+          "client_certificate_key_id": {
+            "type": "string"
+          },
+          "client_certificate_key_ref": {
+            "description": "ClientCertificateKeyRef is the name of the secret within the secret manager to use as the client\nsecret.",
+            "type": "string"
+          },
           "client_id": {
             "type": "string"
           },
@@ -7777,6 +7803,14 @@
               "type": "string"
             },
             "type": "object"
+          },
+          "grant_type": {
+            "description": "GrantType is the OAuth2 grant type to use. It can be one of\n\"client_credentials\" or \"urn:ietf:params:oauth:grant-type:jwt-bearer\" (RFC 7523).\nDefault value is \"client_credentials\"",
+            "type": "string"
+          },
+          "iss": {
+            "description": "Iss is the OAuth client identifier used when communicating with\nthe configured OAuth provider. Default value is client_id. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".",
+            "type": "string"
           },
           "no_proxy": {
             "description": "NoProxy contains addresses that should not use a proxy.",
@@ -7797,6 +7831,10 @@
               "type": "string"
             },
             "type": "array"
+          },
+          "signature_algorithm": {
+            "description": "SignatureAlgorithm is the RSA algorithm used to sign JWT token. Only used if\nGrantType is set to \"urn:ietf:params:oauth:grant-type:jwt-bearer\".\nDefault value is RS256 and valid values RS256, RS384, RS512",
+            "type": "string"
           },
           "token_url": {
             "type": "string"
@@ -17019,7 +17057,7 @@
           },
           {
             "in": "header",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "schema": {
               "type": "string"
             }
@@ -17378,7 +17416,7 @@
           },
           {
             "in": "header",
-            "name": "x-grafana-alerting-notification-receiver",
+            "name": "x-grafana-alerting-notification-settings",
             "schema": {
               "type": "string"
             }


### PR DESCRIPTION
**What is this feature?**

This PR corrects a discrepancy in the OpenAPI definition for the `RouteConvertPrometheusPostRuleGroup` endpoint.

Specifically, it updates the Swagger definition for the notification settings header to match the backend implementation:

**Old Definition:** `X-Grafana-Alerting-Notification-Receiver` (Incorrect)

**New Definition:** `X-Grafana-Alerting-Notification-Settings` (Correct)

I have regenerated the OpenAPI specifications and the internal API clients to reflect this change.

**Why do we need this feature?**

The backend code expects the header `X-Grafana-Alerting-Notification-Settings` to parse the JSON settings object. However, the OpenAPI specification previously defined this header as `X-Grafana-Alerting-Notification-Receiver`.

Because of this mismatch, generated API clients (both the external Go client and the internal TypeScript/RTK Query client) were generating code that sent the wrong header name. As a result, notification settings passed during Prometheus rule conversion were ignored by the server.

This fix ensures that downstream clients generate the correct parameter name so that settings are correctly received and processed by the backend.

**Who is this feature for?**

Developers using the Grafana API to provision alerting rules (specifically converting Prometheus rules) and maintainers of the generated API clients.

**Which issue(s) does this PR fix?**:

Fixes #

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
