### PR TITLE
Alerting: Collate rule_group column as binary

### DIFF
--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -1516,11 +1516,9 @@ func TestIntegrationListAlertRulesByGroupCaseSensitiveOrdering(t *testing.T) {
 		}
 
 		// Verify case-sensitive alphabetical ordering
-		// different databases may sort uppercase before lowercase or vice versa depending on character set, the important part is that the order is consistent and case-sensitive
-		expectedOrder := []string{"test", "Test", "TEST"}
-		alternateExpectedOrder := []string{"TEST", "Test", "test"}
-		if !slices.Equal(groupOrder, expectedOrder) && !slices.Equal(groupOrder, alternateExpectedOrder) {
-			t.Fatalf("groups are not ordered case-sensitively as expected. got: %v, want: %v or %v", groupOrder, expectedOrder, alternateExpectedOrder)
+		expectedOrder := []string{"TEST", "Test", "test"}
+		if !slices.Equal(groupOrder, expectedOrder) {
+			t.Fatalf("groups are not ordered case-sensitively as expected. got: %v, want: %v", groupOrder, expectedOrder)
 		}
 
 		// Verify each group contains the correct rules

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -162,4 +162,6 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	ualert.ExpandAlertRuleUpdatedByMigration(mg)
 
 	ualert.AddAlertRuleGroupIndexMigration(mg)
+
+	ualert.CollateBinAlertRuleGroup(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation_bin.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation_bin.go
@@ -1,0 +1,9 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// CollateBinAlertRuleGroup ensures that rule_group column collates in the same way go sorts strings.
+func CollateBinAlertRuleGroup(mg *migrator.Migrator) {
+	mg.AddMigration("ensure rule_group column sorts the same way as golang", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;"))
+}

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation_bin.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_group_collation_bin.go
@@ -5,5 +5,6 @@ import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 // CollateBinAlertRuleGroup ensures that rule_group column collates in the same way go sorts strings.
 func CollateBinAlertRuleGroup(mg *migrator.Migrator) {
 	mg.AddMigration("ensure rule_group column sorts the same way as golang", migrator.NewRawSQLMigration("").
-		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;"))
+		Mysql("ALTER TABLE alert_rule MODIFY rule_group VARCHAR(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;").
+		Postgres(`ALTER TABLE alert_rule ALTER COLUMN rule_group SET DATA TYPE varchar(190) COLLATE "C";`))
 }


### PR DESCRIPTION

**What is this feature?**

Modify the collation of alert_rule.rule_group (again) to use `utf8mb4_bin` or `C` in MySQL and PostgreSQL respectively, which should match the ordering when strings are sorted by golang.

**Why do we need this feature?**

This ensures this column is sorted identically by the database and golang, which should eliminate issues related to a mismatch in sort order.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
