### PR TITLE
Revert "TimeComparison: Ensure headerActions are activated"

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -16,7 +16,6 @@ import {
   sceneGraph,
   sceneUtils,
   VizPanel,
-  isSceneObject,
 } from '@grafana/scenes';
 import { Panel } from '@grafana/schema';
 import { OptionFilter } from 'app/features/dashboard/components/PanelEditor/OptionsPaneOptions';
@@ -102,16 +101,6 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     );
 
     const deactivateParents = activateSceneObjectAndParentTree(panel);
-
-    // Ensure headerActions are activated
-    const headerActions = panel.state.headerActions;
-    if (headerActions) {
-      (Array.isArray(headerActions) ? headerActions : [headerActions]).forEach((action) => {
-        if (isSceneObject(action)) {
-          action.activate();
-        }
-      });
-    }
 
     this.waitForPlugin();
 


### PR DESCRIPTION
Reverts grafana/grafana#111224

I do not understand why this was ever needed? 