### PR TITLE
Rudderstack Event: When click dashboard list item, add uid to rudderstack event

### DIFF
--- a/public/app/features/browse-dashboards/components/NameCell.tsx
+++ b/public/app/features/browse-dashboards/components/NameCell.tsx
@@ -97,6 +97,7 @@ export function NameCell({ row: { original: data }, onFolderClick, treeID }: Nam
                   itemKind: item.kind,
                   parent: item.parentUID ? 'folder' : 'root',
                   source: 'browseDashboardsPage_BrowseView',
+                  uid: item.uid,
                 });
               }}
               href={item.url}


### PR DESCRIPTION
**What is this feature?**

This PR adds the dashboard UID to the `grafana_browse_dashboards_page_click_list_item` RudderStack event. Today, this event does not include a dashboard UID, which means we can only track generic “item clicked” actions without knowing which dashboard the user interacted with. 

**Why do we need this feature?**

Adding the UID enables Project Konmari (and other analytics workstreams) to measure dashboard-level behaviors, specifically the metric for dashboard reopen rate and other navigation patterns.

**Who is this feature for?**

team that analyze user behaviors

**Which issue(s) does this PR fix?**:

Fixes 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
