### PR TITLE
Dashboard Export/Import: When kubernetesDashboards are enabled, POST directly to V1 dashboard API when importing; simplify exporting options

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2136,11 +2136,6 @@
       "count": 2
     }
   },
-  "public/app/features/dashboard-scene/sharing/ShareExportTab.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx": {
     "no-restricted-syntax": {
       "count": 4
@@ -2939,11 +2934,6 @@
       "count": 1
     },
     "no-restricted-syntax": {
-      "count": 1
-    }
-  },
-  "public/app/features/manage-dashboards/components/ImportDashboardOverview.tsx": {
-    "react-prefer-function-component/react-prefer-function-component": {
       "count": 1
     }
   },

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -44,10 +44,9 @@ export function ResourceExport({
     dashboardJson.value?.json && 'spec' in dashboardJson.value.json && 'elements' in dashboardJson.value.json.spec;
   const showV2LibPanelAlert = isV2Dashboard && isSharingExternally && hasLibraryPanels;
 
-  const switchExportLabel =
-    exportMode === ExportMode.V2Resource
-      ? t('export.json.export-remove-ds-refs', 'Remove deployment details')
-      : t('share-modal.export.share-externally-label', `Export for sharing externally`);
+  const switchExportLabel = isV2Dashboard
+    ? t('export.json.export-remove-ds-refs', 'Remove deployment details')
+    : t('share-modal.export.share-externally-label', `Export for sharing externally`);
   const switchExportModeLabel = t('export.json.export-mode', 'Model');
   const switchExportFormatLabel = t('export.json.export-format', 'Format');
 

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -40,7 +40,6 @@ export function ResourceExport({
   onViewYAML,
 }: Props) {
   const hasLibraryPanels = dashboardJson.value?.hasLibraryPanels;
-  const initialSaveModelVersion = dashboardJson.value?.initialSaveModelVersion;
   const isV2Dashboard =
     dashboardJson.value?.json && 'spec' in dashboardJson.value.json && 'elements' in dashboardJson.value.json.spec;
   const showV2LibPanelAlert = isV2Dashboard && isSharingExternally && hasLibraryPanels;
@@ -55,34 +54,14 @@ export function ResourceExport({
   return (
     <Stack gap={2} direction="column">
       <Stack gap={1} direction="column">
-        {initialSaveModelVersion === 'v1' && (
-          <Stack alignItems="center">
-            <Label>{switchExportModeLabel}</Label>
-            <RadioButtonGroup
-              options={[
-                { label: t('dashboard-scene.resource-export.label.classic', 'Classic'), value: ExportMode.Classic },
-                {
-                  label: t('dashboard-scene.resource-export.label.v1-resource', 'V1 Resource'),
-                  value: ExportMode.V1Resource,
-                },
-                {
-                  label: t('dashboard-scene.resource-export.label.v2-resource', 'V2 Resource'),
-                  value: ExportMode.V2Resource,
-                },
-              ]}
-              value={exportMode}
-              onChange={(value) => onExportModeChange(value)}
-            />
-          </Stack>
-        )}
-        {initialSaveModelVersion === 'v2' && (
+        {!isV2Dashboard && (
           <Stack alignItems="center">
             <Label>{switchExportModeLabel}</Label>
             <RadioButtonGroup
               options={[
                 {
-                  label: t('dashboard-scene.resource-export.label.v2-resource', 'V2 Resource'),
-                  value: ExportMode.V2Resource,
+                  label: t('dashboard-scene.resource-export.label.classic', 'Classic'),
+                  value: ExportMode.Classic,
                 },
                 {
                   label: t('dashboard-scene.resource-export.label.v1-resource', 'V1 Resource'),
@@ -107,9 +86,7 @@ export function ResourceExport({
             />
           </Stack>
         )}
-        {(isV2Dashboard ||
-          exportMode === ExportMode.Classic ||
-          (initialSaveModelVersion === 'v2' && exportMode === ExportMode.V1Resource)) && (
+        {exportMode !== ExportMode.V1Resource && (
           <Stack gap={1} alignItems="start">
             <Label>{switchExportLabel}</Label>
             <Switch

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -19,7 +19,6 @@ interface Props {
   dashboardJson: AsyncState<{
     json: Dashboard | DashboardJson | DashboardV2Spec | ExportableResource | { error: unknown };
     hasLibraryPanels?: boolean;
-    initialSaveModelVersion: 'v1' | 'v2';
   }>;
   isSharingExternally: boolean;
   exportMode: ExportMode;

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -113,9 +113,6 @@ describe('ShareExportTab', () => {
       // Should call transformSceneToV1 (not transform V2→V1)
       expect(transformSceneToV1Spy).toHaveBeenCalled();
       expect(transformV2ToV1Spy).not.toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
 
     // If V2 dashboard → V1 Resource should auto-transform with V1 apiVersion
@@ -136,9 +133,6 @@ describe('ShareExportTab', () => {
       // Should auto-transform V2→V1
       expect(transformSceneToV2Spy).toHaveBeenCalled(); // Get V2 spec first
       expect(transformV2ToV1Spy).toHaveBeenCalled(); // Then transform to V1
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
     });
 
     // If V2 dashboard → V1 Resource with external sharing should transform and apply external sharing
@@ -164,9 +158,6 @@ describe('ShareExportTab', () => {
 
       // Should call makeExportableV1 for external sharing
       expect(makeExportableV1Spy).toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
     });
   });
 
@@ -187,9 +178,6 @@ describe('ShareExportTab', () => {
 
       // Should not call V2→V1 transformation since source is already V2
       expect(transformV2ToV1Spy).not.toHaveBeenCalled();
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v2');
     });
 
     // If V1 dashboard → V2 Resource should detect library panels correctly
@@ -201,7 +189,6 @@ describe('ShareExportTab', () => {
 
       // Should detect library panels from V1 dashboard
       expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
 
     // If V1 dashboard with dashboardNewLayouts disabled → V2 Resource should detect library panels correctly
@@ -213,7 +200,6 @@ describe('ShareExportTab', () => {
 
       // Should detect library panels from V1 dashboard (first branch of the logic)
       expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
 
     // If V1 dashboard without library panels → V2 Resource should return false
@@ -225,7 +211,6 @@ describe('ShareExportTab', () => {
 
       // Should not detect library panels
       expect(result.hasLibraryPanels).toBe(false);
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
   });
 
@@ -247,7 +232,6 @@ describe('ShareExportTab', () => {
 
       // Should detect library panels from V2 dashboard elements (second branch of the logic)
       expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v2');
     });
 
     // Test the second branch: V2 dashboard with V1 initial save model
@@ -259,7 +243,6 @@ describe('ShareExportTab', () => {
 
       // Should detect library panels from V2 dashboard elements (second branch of the logic)
       expect(result.hasLibraryPanels).toBe(true);
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
 
     // If V2 dashboard without library panels → V2 Resource should return false
@@ -271,7 +254,6 @@ describe('ShareExportTab', () => {
 
       // Should not detect library panels
       expect(result.hasLibraryPanels).toBe(false);
-      expect(result.initialSaveModelVersion).toBe('v2');
     });
   });
 
@@ -294,9 +276,6 @@ describe('ShareExportTab', () => {
       expect(result.json).not.toHaveProperty('apiVersion');
       expect(result.json).not.toHaveProperty('kind');
       expect(result.json).not.toHaveProperty('status');
-
-      // Should report correct initial version
-      expect(result.initialSaveModelVersion).toBe('v1');
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -112,10 +112,6 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
     const metadata = getMetadata(scene, Boolean(isSharingExternally));
 
     if (isDashboardV2Spec(origDashboard) && 'elements' in exportable && exportMode !== ExportMode.V1Resource) {
-      this.setState({
-        exportMode: ExportMode.V2Resource,
-      });
-
       // For automatic V2 path, also process library panels when sharing externally
       let finalSpec = exportable;
       if (isSharingExternally && isDashboardV2Spec(exportable)) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6215,7 +6215,6 @@
         "classic": "Classic",
         "json": "JSON",
         "v1-resource": "V1 Resource",
-        "v2-resource": "V2 Resource",
         "yaml": "YAML"
       }
     },


### PR DESCRIPTION
This PR introduces a couple of changes to dashboard export and import experience:

### Import
When `kubernetesDashboards` are enabled:
- Bypass `api/dashboards/import` and use v1 API to save an imported dashboard, this ensures that dashboard is saved as `v1beta1`
- Since we are bypassing  `api/dashboards/import`, we are adding  new library panels during import using `api/library-elements` directly

### Export
We are simplifying export and allowing to export only resource for the current dashboard schema, so if dashboard is V1 we are exporting as Classic and V1 Resource, and if dashboard is V2 we export as V2

V1 Old

<img width="746" height="181" alt="v1-old" src="https://github.com/user-attachments/assets/55a62ec2-9a76-4cbf-b73f-831c90af7a18" />

V1 New - we don't allow exporting V1 dashboard as V2 as these options are confusing 

<img width="751" height="180" alt="v1-new" src="https://github.com/user-attachments/assets/69c13a6f-7e30-4a11-bade-70e040e04b15" />

V2 Old

<img width="726" height="226" alt="V2-old" src="https://github.com/user-attachments/assets/23fbdb70-afec-4c73-a8fa-f93e18fa8e93" />

V2 New - no need to give any format options because V2 can't be exported as Classic and shouldn't be exported as V1  as that can intrdocue confusion for the users

<img width="744" height="140" alt="v2-new" src="https://github.com/user-attachments/assets/81a8cb51-99b8-4946-b7fc-b4cfb0d4e81e" />






Please check that:
- [ ] It works as expected from a user's perspective.

