### PR TITLE
feat(piechart): add center value option for donut charts

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/pie-chart/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/pie-chart/index.md
@@ -160,6 +160,13 @@ The following example shows a pie chart with **Name** and **Percent** labels dis
 
 {{< figure src="/static/img/docs/pie-chart-panel/pie-chart-labels-7-5.png" alt="Pie chart labels" max-width="350px" >}}
 
+#### Center value
+
+When using the **Donut** chart type, you can display the total sum of all values in the center of the chart. This option is only available when the pie chart type is set to **Donut**. Choose from:
+
+- **None** - Don't display anything in the center (default).
+- **Total** - Display the sum of all values in the center.
+
 ### Tooltip options
 
 {{< docs/shared lookup="visualizations/tooltip-options-1.md" source="grafana" version="<GRAFANA_VERSION>" leveloffset="+1" >}}

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -475,6 +475,9 @@ export const versionedComponents = {
         svgSlice: {
           '10.3.0': 'data testid Pie Chart Slice',
         },
+        svgCenterValue: {
+          '12.4.0': 'data-testid Pie Chart Center Value',
+        },
       },
       Text: {
         container: { [MIN_GRAFANA_VERSION]: () => '.markdown-html' },

--- a/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/piechart/panelcfg/x/PieChartPanelCfg_types.gen.ts
@@ -42,6 +42,16 @@ export enum PieChartLegendValues {
   Value = 'value',
 }
 
+/**
+ * Select what to display in the center of a donut chart.
+ *  - None: Do not display anything in the center.
+ *  - Total: Display the total sum of all values.
+ */
+export enum PieChartCenterValue {
+  None = 'none',
+  Total = 'total',
+}
+
 export interface PieChartLegendOptions extends common.VizLegendOptions {
   values: Array<PieChartLegendValues>;
 }
@@ -51,6 +61,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 };
 
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
+  centerValue?: PieChartCenterValue;
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
   pieType: PieChartType;

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/simplifiedRouting/__snapshots__/SimplifiedRuleEditor.test.tsx.snap
@@ -1,5 +1,171 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Can create a new grafana managed alert using simplified routing allows selecting a contact point 1`] = `
+[
+  {
+    "body": {
+      "interval": "1m",
+      "name": "grafana-group-1",
+      "rules": [
+        {
+          "annotations": {
+            "summary": "Test alert",
+          },
+          "for": "5m",
+          "grafana_alert": {
+            "condition": "A",
+            "data": [
+              {
+                "datasourceUid": "datasource-uid",
+                "model": {
+                  "datasource": {
+                    "type": "prometheus",
+                    "uid": "datasource-uid",
+                  },
+                  "expression": "vector(1)",
+                  "queryType": "alerting",
+                  "refId": "A",
+                },
+                "queryType": "alerting",
+                "refId": "A",
+                "relativeTimeRange": {
+                  "from": 1000,
+                  "to": 2000,
+                },
+              },
+            ],
+            "exec_err_state": "Error",
+            "is_paused": false,
+            "namespace_uid": "uuid020c61ef",
+            "no_data_state": "NoData",
+            "rule_group": "grafana-group-1",
+            "title": "Grafana-rule",
+            "uid": "4d7125fee983",
+          },
+          "labels": {
+            "region": "nasa",
+            "severity": "critical",
+          },
+        },
+        {
+          "annotations": {},
+          "for": "1m",
+          "grafana_alert": {
+            "condition": "C",
+            "data": [
+              {
+                "datasourceUid": "prometheus",
+                "model": {
+                  "instant": true,
+                  "refId": "A",
+                },
+                "queryType": "",
+                "refId": "A",
+                "relativeTimeRange": {
+                  "from": 600,
+                  "to": 0,
+                },
+              },
+              {
+                "datasourceUid": "__expr__",
+                "model": {
+                  "conditions": [
+                    {
+                      "evaluator": {
+                        "params": [],
+                        "type": "gt",
+                      },
+                      "operator": {
+                        "type": "and",
+                      },
+                      "query": {
+                        "params": [],
+                      },
+                      "reducer": {
+                        "params": [],
+                        "type": "last",
+                      },
+                      "type": "query",
+                    },
+                  ],
+                  "datasource": {
+                    "type": "__expr__",
+                    "uid": "__expr__",
+                  },
+                  "expression": "A",
+                  "reducer": "last",
+                  "refId": "B",
+                  "type": "reduce",
+                },
+                "queryType": "",
+                "refId": "B",
+              },
+              {
+                "datasourceUid": "__expr__",
+                "model": {
+                  "conditions": [
+                    {
+                      "evaluator": {
+                        "params": [
+                          0,
+                        ],
+                        "type": "gt",
+                      },
+                      "operator": {
+                        "type": "and",
+                      },
+                      "query": {
+                        "params": [],
+                      },
+                      "reducer": {
+                        "params": [],
+                        "type": "last",
+                      },
+                      "type": "query",
+                    },
+                  ],
+                  "datasource": {
+                    "type": "__expr__",
+                    "uid": "__expr__",
+                  },
+                  "expression": "B",
+                  "refId": "C",
+                  "type": "threshold",
+                },
+                "queryType": "",
+                "refId": "C",
+              },
+            ],
+            "exec_err_state": "Error",
+            "is_paused": false,
+            "missing_series_evals_to_resolve": 0,
+            "no_data_state": "NoData",
+            "notification_settings": {
+              "receiver": "lotsa-emails",
+            },
+            "title": "my great new rule",
+          },
+          "keep_firing_for": "0s",
+          "labels": {},
+        },
+      ],
+    },
+    "headers": [
+      [
+        "content-type",
+        "application/json",
+      ],
+      [
+        "accept",
+        "application/json, text/plain, */*",
+      ],
+    ],
+    "method": "POST",
+    "url": "http://localhost/api/ruler/grafana/api/v1/rules/uuid020c61ef?subtype=cortex",
+  },
+]
+`;
+
 exports[`Can create a new grafana managed alert using simplified routing can create new grafana managed alert when using simplified routing and selecting a contact point 1`] = `
 [
   {

--- a/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.test.tsx
@@ -14,7 +14,7 @@ import {
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
 
 import { PieChartPanel, comparePieChartItemsByValue } from './PieChartPanel';
-import { Options, PieChartType, PieChartLegendValues } from './panelcfg.gen';
+import { Options, PieChartType, PieChartLegendValues, PieChartCenterValue } from './panelcfg.gen';
 
 jest.mock('react-use', () => ({
   ...jest.requireActual('react-use'),
@@ -161,6 +161,70 @@ describe('PieChartPanel', () => {
         const slices = screen.queryAllByTestId('data testid Pie Chart Slice');
         expect(slices.length).toBe(3);
       });
+    });
+  });
+
+  describe('center value', () => {
+    const defaultConfig = {
+      custom: {
+        hideFrom: {
+          legend: false,
+          viz: false,
+          tooltip: false,
+        },
+      },
+    };
+
+    const seriesWithData = [
+      toDataFrame({
+        fields: [
+          { name: 'A', config: defaultConfig, type: FieldType.number, values: [60] },
+          { name: 'B', config: defaultConfig, type: FieldType.number, values: [40] },
+        ],
+      }),
+    ];
+
+    const baseOptions: Options = {
+      pieType: PieChartType.Donut,
+      sort: SortOrder.Descending,
+      displayLabels: [],
+      legend: {
+        displayMode: LegendDisplayMode.List,
+        showLegend: true,
+        placement: 'right',
+        calcs: [],
+        values: [PieChartLegendValues.Percent],
+      },
+      reduceOptions: { calcs: [] },
+      orientation: VizOrientation.Auto,
+      tooltip: { mode: TooltipDisplayMode.Multi, sort: SortOrder.Ascending },
+    };
+
+    it('should not show center value when set to none', () => {
+      setup({
+        data: { series: seriesWithData },
+        options: { ...baseOptions, centerValue: PieChartCenterValue.None },
+      });
+
+      expect(screen.queryByTestId('data-testid Pie Chart Center Value')).not.toBeInTheDocument();
+    });
+
+    it('should show total in center when centerValue is total', () => {
+      setup({
+        data: { series: seriesWithData },
+        options: { ...baseOptions, centerValue: PieChartCenterValue.Total },
+      });
+
+      expect(screen.queryByTestId('data-testid Pie Chart Center Value')).toBeInTheDocument();
+    });
+
+    it('should not show center value for pie chart type even when centerValue is set', () => {
+      setup({
+        data: { series: seriesWithData },
+        options: { ...baseOptions, pieType: PieChartType.Pie, centerValue: PieChartCenterValue.Total },
+      });
+
+      expect(screen.queryByTestId('data-testid Pie Chart Center Value')).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/plugins/panel/piechart/PieChartPanel.tsx
+++ b/public/app/plugins/panel/piechart/PieChartPanel.tsx
@@ -69,6 +69,7 @@ export function PieChartPanel(props: Props) {
             pieType={options.pieType}
             sort={options.sort}
             displayLabels={options.displayLabels}
+            centerValue={options.centerValue}
           />
         );
       }}

--- a/public/app/plugins/panel/piechart/module.tsx
+++ b/public/app/plugins/panel/piechart/module.tsx
@@ -8,7 +8,14 @@ import { addStandardDataReduceOptions } from '../stat/common';
 
 import { PieChartPanel } from './PieChartPanel';
 import { PieChartPanelChangedHandler } from './migrations';
-import { Options, FieldConfig, PieChartType, PieChartLabels, PieChartLegendValues } from './panelcfg.gen';
+import {
+  Options,
+  FieldConfig,
+  PieChartType,
+  PieChartLabels,
+  PieChartLegendValues,
+  PieChartCenterValue,
+} from './panelcfg.gen';
 import { PieChartSuggestionsSupplier } from './suggestions';
 
 export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
@@ -74,6 +81,20 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(PieChartPanel)
             { value: PieChartLabels.Value, label: t('piechart.labels-options.label-value', 'Value') },
           ],
         },
+      })
+      .addSelect({
+        name: t('piechart.name-center-value', 'Center value'),
+        category,
+        path: 'centerValue',
+        description: t('piechart.description-center-value', 'Select what to display in the center of the donut'),
+        settings: {
+          options: [
+            { value: PieChartCenterValue.None, label: t('piechart.center-value-options.label-none', 'None') },
+            { value: PieChartCenterValue.Total, label: t('piechart.center-value-options.label-total', 'Total') },
+          ],
+        },
+        defaultValue: PieChartCenterValue.None,
+        showIf: (options) => options.pieType === PieChartType.Donut,
       });
 
     commonOptionsBuilder.addTooltipOptions(builder, false, false, optsWithHideZeros);

--- a/public/app/plugins/panel/piechart/panelcfg.cue
+++ b/public/app/plugins/panel/piechart/panelcfg.cue
@@ -38,6 +38,10 @@ composableKinds: PanelCfg: {
 				//  - Percent: The percentage of the whole.
 				//  - Value: The raw numerical value.
 				PieChartLegendValues: "value" | "percent" @cuetsy(kind="enum")
+				// Select what to display in the center of a donut chart.
+				//  - None: Do not display anything in the center.
+				//  - Total: Display the total sum of all values.
+				PieChartCenterValue: "none" | "total" @cuetsy(kind="enum")
 				PieChartLegendOptions: {
 					common.VizLegendOptions
 					values: [...PieChartLegendValues]
@@ -49,6 +53,7 @@ composableKinds: PanelCfg: {
 				sort: common.SortOrder
 					displayLabels: [...PieChartLabels]
 					legend: PieChartLegendOptions
+					centerValue?: PieChartCenterValue
 				} @cuetsy(kind="interface")
 				FieldConfig: common.HideableFieldConfig @cuetsy(kind="interface")
 			}

--- a/public/app/plugins/panel/piechart/panelcfg.gen.ts
+++ b/public/app/plugins/panel/piechart/panelcfg.gen.ts
@@ -40,6 +40,16 @@ export enum PieChartLegendValues {
   Value = 'value',
 }
 
+/**
+ * Select what to display in the center of a donut chart.
+ *  - None: Do not display anything in the center.
+ *  - Total: Display the total sum of all values.
+ */
+export enum PieChartCenterValue {
+  None = 'none',
+  Total = 'total',
+}
+
 export interface PieChartLegendOptions extends common.VizLegendOptions {
   values: Array<PieChartLegendValues>;
 }
@@ -49,6 +59,7 @@ export const defaultPieChartLegendOptions: Partial<PieChartLegendOptions> = {
 };
 
 export interface Options extends common.OptionsWithTooltip, common.SingleStatBaseOptions {
+  centerValue?: PieChartCenterValue;
   displayLabels: Array<PieChartLabels>;
   legend: PieChartLegendOptions;
   pieType: PieChartType;


### PR DESCRIPTION
Adds ability to display total sum in the center of donut pie charts. Closes #93699


**What is this feature?**

Allows the user to add a total value in the center of the donut

<img width="1593" height="402" alt="donut empty" src="https://github.com/user-attachments/assets/1178c8c4-5bca-420a-83af-ba10391053e8" />
Donut empty

<img width="1592" height="454" alt="donut total" src="https://github.com/user-attachments/assets/7b8feb70-8293-49c9-a05f-d9e153551640" />
Donut with center total

<img width="1592" height="401" alt="donut total with values" src="https://github.com/user-attachments/assets/2b4d2ecc-f7f4-40ef-b1f9-67cdf3afe5b7" />
Donut with center total and values


**Why do we need this feature?**

Gives user the ability to see the total of the donut values at a quick glance

**Who is this feature for?**

Feature requested in #93699 

**Which issue(s) does this PR fix?**:


Fixes #93699

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [N/A] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
