### PR TITLE
Lets try a compromise

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -164,14 +164,18 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       className={cx(styles.controls, editPanel && styles.controlsPanelEdit)}
     >
       <div className={cx(styles.rightControls, editPanel && styles.rightControlsWrap)}>
-        {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
         {!hideTimeControls && (
           <div className={styles.timeControls}>
             <timePicker.Component model={timePicker} />
             <refreshPicker.Component model={refreshPicker} />
           </div>
         )}
-        {!hideDashboardControls && model.hasDashboardControls() && <DashboardControlsButton dashboard={dashboard} />}
+        {!hideDashboardControls && model.hasDashboardControls() && (
+          <div className={styles.dashboardControlsButton}>
+            <DashboardControlsButton dashboard={dashboard} />
+          </div>
+        )}
+        {!hideLinksControls && !editPanel && <DashboardLinksControls links={links} dashboard={dashboard} />}
       </div>
       {!hideVariableControls && (
         <>
@@ -230,17 +234,26 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     rightControls: css({
       display: 'flex',
-      justifyContent: 'flex-end',
       gap: theme.spacing(1),
-      marginBottom: theme.spacing(1),
       float: 'right',
       alignItems: 'center',
+      flexWrap: 'wrap',
+      maxWidth: '100%',
+      minWidth: 0,
     }),
     timeControls: css({
       display: 'flex',
       justifyContent: 'flex-end',
       gap: theme.spacing(1),
       marginBottom: theme.spacing(1),
+      order: 2,
+      marginLeft: 'auto',
+      flexShrink: 0,
+      alignSelf: 'flex-start',
+    }),
+    dashboardControlsButton: css({
+      order: 2,
+      marginLeft: 'auto',
     }),
     rightControlsWrap: css({
       flexWrap: 'wrap',

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
@@ -1,5 +1,9 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
 import { sceneGraph } from '@grafana/scenes';
 import { DashboardLink } from '@grafana/schema';
+import { useStyles2 } from '@grafana/ui';
 
 import { DashboardLinkRenderer } from './DashboardLinkRenderer';
 import { DashboardScene } from './DashboardScene';
@@ -12,18 +16,33 @@ export interface Props {
 export function DashboardLinksControls({ links, dashboard }: Props) {
   sceneGraph.getTimeRange(dashboard).useState();
   const uid = dashboard.state.uid;
+  const styles = useStyles2(getStyles);
 
   if (!links || !uid) {
     return null;
   }
 
   return (
-    <>
+    <div className={styles.linksContainer}>
       {links
         .filter((link) => link.placement === undefined)
         .map((link: DashboardLink, index: number) => (
           <DashboardLinkRenderer link={link} dashboardUID={uid} key={`${link.title}-$${index}`} />
         ))}
-    </>
+    </div>
   );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    linksContainer: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(1),
+      maxWidth: '100%',
+      minWidth: 0,
+      order: 1,
+      flex: '1 1 0%',
+    }),
+  };
 }


### PR DESCRIPTION
Try to compromise on white space. Having a lot of links will create unnecessary empty space under the time controls, but it is necessary if we want to be able to have the links on the right

Variables will wrap nicely and create no extra empty space, links are always on the right next to time controls:
<img width="955" height="470" alt="image" src="https://github.com/user-attachments/assets/10c49ed9-fd06-4a74-9b9c-3d0b94021bca" />


Having many links will however create empty space:
<img width="1786" height="1097" alt="image" src="https://github.com/user-attachments/assets/07396797-e43a-46e3-8dea-81ea721bad6d" />

All in all this is still an improvement over the original behavior where everything caused a lot of empty space under the time controls.