### PR TITLE
Enhancement: Add watch poll interval to KV storage backend

### DIFF
--- a/pkg/storage/unified/apistore/restoptions.go
+++ b/pkg/storage/unified/apistore/restoptions.go
@@ -63,6 +63,7 @@ func NewRESTOptionsGetterMemory(originalStorageConfig storagebackend.Config, sec
 	backend, err := resource.NewKVStorageBackend(resource.KVBackendOptions{
 		KvStore:                      kv,
 		WithExperimentalClusterScope: true,
+		WatchPollInterval:            5 * time.Minute,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Enhancement: Add watch poll interval to KV storage backend
* Introduced a new `WatchPollInterval` option in `KVBackendOptions` to configure the polling frequency for new events.
* Updated the `NewKVStorageBackend` function to utilize the specified `WatchPollInterval`, defaulting to a predefined value if not set.
* Adjusted the event watching mechanism to respect the configured polling interval.

See [thread](https://raintank-corp.slack.com/archives/C09UY1WNT1T/p1764059216234019)