### PR TITLE
docs: add readme for unified storage on-prem migrations

### DIFF
--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -11,6 +11,34 @@ By default it runs in-process within Grafana, but it can also be run as a standa
 
 There are 2 main tables, the `resource` table stores a "current" view of the objects, and the `resource_history` table stores a record of each revision of a given object.
 
+## Migrations
+
+Unified storage includes an automated migration system to move legacy resources (folders, dashboards, library panels) from traditional SQL storage to unified storage. Migrations run automatically on Grafana startup when enabled.
+
+### Key Features
+
+- **Automatic Migration**: Runs on startup when `disable_data_migrations = false`
+- **Validation**: Built-in validators ensure data integrity
+  - `CountValidator`: Verifies resource counts match
+  - `FolderTreeValidator`: Validates folder parent-child relationships
+- **Multi-Database Support**: PostgreSQL, MySQL, SQLite
+
+### Quick Start
+
+Enable migrations in `grafana.ini`:
+
+```ini
+[unified_storage]
+disable_data_migrations = false
+
+[grafana-apiserver]
+storage_type = unified
+```
+
+### Documentation
+
+- **Migration Architecture**: See [`migrations/README.md`](./migrations/README.md) for detailed information about migration implementation, validators, and troubleshooting
+
 ## Running Unified Storage
 
 ### Playlists: baseline configuration

--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -11,34 +11,6 @@ By default it runs in-process within Grafana, but it can also be run as a standa
 
 There are 2 main tables, the `resource` table stores a "current" view of the objects, and the `resource_history` table stores a record of each revision of a given object.
 
-## Migrations
-
-Unified storage includes an automated migration system to move legacy resources (folders, dashboards, library panels) from traditional SQL storage to unified storage. Migrations run automatically on Grafana startup when enabled.
-
-### Key Features
-
-- **Automatic Migration**: Runs on startup when `disable_data_migrations = false`
-- **Validation**: Built-in validators ensure data integrity
-  - `CountValidator`: Verifies resource counts match
-  - `FolderTreeValidator`: Validates folder parent-child relationships
-- **Multi-Database Support**: PostgreSQL, MySQL, SQLite
-
-### Quick Start
-
-Enable migrations in `grafana.ini`:
-
-```ini
-[unified_storage]
-disable_data_migrations = false
-
-[grafana-apiserver]
-storage_type = unified
-```
-
-### Documentation
-
-- **Migration Architecture**: See [`migrations/README.md`](./migrations/README.md) for detailed information about migration implementation, validators, and troubleshooting
-
 ## Running Unified Storage
 
 ### Playlists: baseline configuration
@@ -1374,4 +1346,31 @@ Key metrics for monitoring Unified Search:
 - `unified_search_shadow_requests_total`: Shadow traffic request counts
 - `unified_search_ring_members`: Number of active search server instances
 
+## Data Migrations
 
+Unified storage includes an automated migration system to move legacy resources (folders, dashboards, library panels) from traditional SQL storage to unified storage. Migrations run automatically on Grafana startup when enabled.
+
+### Key Features
+
+- **Automatic Migration**: Runs on startup when `disable_data_migrations = false`
+- **Validation**: Built-in validators ensure data integrity
+  - `CountValidator`: Verifies resource counts match
+  - `FolderTreeValidator`: Validates folder parent-child relationships
+- **Multi-Database Support**: PostgreSQL, MySQL, SQLite
+
+### Quick Start
+
+Enable migrations in `grafana.ini`:
+
+```ini
+[unified_storage]
+disable_data_migrations = false
+
+[grafana-apiserver]
+storage_type = unified
+```
+
+### Documentation
+
+- **Migration Architecture**: See [`migrations/README.md`](./migrations/README.md) for detailed information about migration implementation, validators, and troubleshooting
+## 

--- a/pkg/storage/unified/README.md
+++ b/pkg/storage/unified/README.md
@@ -1346,31 +1346,34 @@ Key metrics for monitoring Unified Search:
 - `unified_search_shadow_requests_total`: Shadow traffic request counts
 - `unified_search_ring_members`: Number of active search server instances
 
-## Data Migrations
+## Data migrations
 
-Unified storage includes an automated migration system to move legacy resources (folders, dashboards, library panels) from traditional SQL storage to unified storage. Migrations run automatically on Grafana startup when enabled.
+Unified storage includes an automated migration system that transfers resources from legacy SQL tables to unified storage. Migrations run automatically during Grafana startup when enabled.
 
-### Key Features
+### Supported resources
 
-- **Automatic Migration**: Runs on startup when `disable_data_migrations = false`
-- **Validation**: Built-in validators ensure data integrity
-  - `CountValidator`: Verifies resource counts match
-  - `FolderTreeValidator`: Validates folder parent-child relationships
-- **Multi-Database Support**: PostgreSQL, MySQL, SQLite
+- Folders
+- Dashboards
+- Library panels
+- Playlists
 
-### Quick Start
+### Validation
+
+Built-in validators ensure data integrity after migration:
+
+- **CountValidator**: Verifies resource counts match between legacy and unified storage
+- **FolderTreeValidator**: Validates folder parent-child relationships are preserved
+
+### Configuration
 
 Enable migrations in `grafana.ini`:
 
 ```ini
 [unified_storage]
 disable_data_migrations = false
-
-[grafana-apiserver]
-storage_type = unified
 ```
 
 ### Documentation
 
-- **Migration Architecture**: See [`migrations/README.md`](./migrations/README.md) for detailed information about migration implementation, validators, and troubleshooting
-## 
+For detailed information about migration architecture, validators, and troubleshooting, refer to [migrations/README.md](./migrations/README.md).
+ 

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -1,4 +1,4 @@
-# Unified Storage Migrations
+# Unified Storage Data Migrations
 
 Automated migration system for moving legacy resources from traditional SQL storage to Grafana's unified storage backend.
 

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -1,0 +1,387 @@
+# Unified Storage Migrations
+
+Automated migration system for moving legacy resources from traditional SQL storage to Grafana's unified storage backend.
+
+## Overview
+
+The migration system migrates Grafana resources (folders, dashboards) from legacy SQL tables to unified storage while maintaining data integrity through built-in validators.
+
+### Migration Path
+
+```
+Legacy SQL Storage → Validation → Unified Storage (Kubernetes-based)
+     (dashboard table)              (resource + resource_history tables)
+```
+
+### Supported Resources
+
+- **Folders**: Including nested folder hierarchies with parent-child relationships
+- **Dashboards**: With folder associations preserved
+
+## Architecture
+
+### Components
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    ResourceMigration                         │
+│  (Orchestrates migration for specific resource types)        │
+└──────────────────┬──────────────────────────────────────────┘
+                   │
+                   ├──> UnifiedMigrator
+                   │    (Reads from legacy, writes to unified storage)
+                   │
+                   └──> Validators (run after migration)
+                        ├─> CountValidator
+                        │   (Verifies resource counts match)
+                        └─> FolderTreeValidator
+                            (Validates folder hierarchy)
+```
+
+### Key Files
+
+- **`migrator.go`**: Core migration logic, handles reading from legacy SQL and writing to unified storage
+- **`validator.go`**: Validation implementations (CountValidator, FolderTreeValidator)
+- **`resource_migration.go`**: Migration execution framework
+- **`service.go`**: Migration registration and startup integration
+
+## How Migrations Work
+
+### Automatic Execution
+
+Migrations run automatically during Grafana startup when:
+
+1. `disable_data_migrations = false` in configuration
+2. Migration hasn't been completed previously (checked via `unifiedstorage_migration_log` table)
+3. Database is accessible and unified storage is enabled
+
+### Migration Flow
+
+```
+1. Grafana Startup
+   ↓
+2. Check unifiedstorage_migration_log table
+   ↓
+3. If not completed:
+   ├─> Read legacy resources from SQL
+   ├─> Transform to unified storage format
+   ├─> Write to unified storage via BulkProcess API
+   └─> Run validators
+       ├─> CountValidator: Compare counts
+       ├─> FolderTreeValidator: Verify hierarchy
+       └─> Record success/failure in unifiedstorage_migration_log
+   ↓
+4. Continue Grafana startup
+```
+
+### Per-Organization Migration
+
+Migrations run independently for each organization:
+- Namespace format: `org-<orgId>` (e.g., `org-1`, `org-42`)
+- Isolated validation per org
+- Parallel execution possible
+
+## Validators
+
+### CountValidator
+
+**Purpose**: Ensures all resources were migrated successfully by comparing counts.
+
+**How it works**:
+1. Counts resources in legacy SQL table (e.g., `SELECT COUNT(*) FROM dashboard WHERE org_id = ? AND is_folder = false`)
+2. Counts resources in unified storage via Search API
+3. Fails if counts don't match
+
+**Example Configuration**:
+```go
+folderCountValidator := NewCountValidator(
+    client,
+    schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"},
+    "dashboard",
+    "org_id = ? and is_folder = true",
+)
+```
+
+### FolderTreeValidator
+
+**Purpose**: Validates that folder parent-child relationships are preserved correctly.
+
+**How it works**:
+1. Builds legacy folder hierarchy map from SQL:
+   - Queries `dashboard` table for folders
+   - Resolves `folder_uid` (string) to parent UID via uid→uid mapping
+2. Builds unified storage hierarchy map via Search API:
+   - Queries unified storage for folders
+   - Extracts parent UID from `folder` column
+3. Compares both maps and reports mismatches
+
+**Example Validation**:
+```
+Legacy:   folder-child-1 → parent: folder-parent-1
+Unified:  folder-child-1 → parent: folder-parent-1 ✓
+
+Legacy:   folder-child-2 → parent: folder-parent-1
+Unified:  folder-child-2 → parent: folder-parent-2 ✗
+         → FAIL: Parent mismatch detected
+```
+
+## Configuration
+
+### Required Settings
+
+Enable unified storage and migrations:
+
+```ini
+[unified_storage]
+disable_data_migrations = false  # CRITICAL: Enables migrations
+
+[grafana-apiserver]
+storage_type = unified
+```
+
+### Database-Specific Configuration
+
+#### PostgreSQL
+```ini
+[database]
+type = postgres
+host = localhost:5432
+name = grafanatest
+user = grafanatest
+password = grafanatest
+```
+
+#### MySQL
+```ini
+[database]
+type = mysql
+host = localhost:3306
+name = grafanatest
+user = grafanatest
+password = grafanatest
+```
+
+#### SQLite
+```ini
+[database]
+type = sqlite3
+path = /var/lib/grafana/grafana.db
+```
+
+## Monitoring Migrations
+
+### Log Messages
+
+Successful migration logs:
+
+```
+info: storage.unified.RegisterMigrations Registering unified storage migrations
+info: storage.unified.resource_migration.folders-dashboards Running validators count=3
+info: storage.unified.resource_migration.folders-dashboards Validator CountValidator passed
+info: storage.unified.resource_migration.folders-dashboards Validator FolderTreeValidator passed
+info: storage.unified.resource_migration.folders-dashboards All validators passed
+info: Unified storage migrations completed successfully
+```
+
+Failed migration logs:
+
+```
+error: validator CountValidator failed: count mismatch: legacy=100, unified=98
+error: validator FolderTreeValidator failed: folder tree structure mismatch: 3 folders have incorrect parents
+error: unified storage data migration failed: migration validation failed
+```
+
+### Migration Table
+
+Check migration status in database:
+
+```sql
+-- PostgreSQL/MySQL
+SELECT id, migration_id, success, error, timestamp 
+FROM unifiedstorage_migration_log 
+ORDER BY timestamp DESC;
+
+-- SQLite
+SELECT id, migration_id, success, error, timestamp 
+FROM unifiedstorage_migration_log 
+ORDER BY timestamp DESC;
+```
+
+### API Verification
+
+Verify migrated resources via API:
+
+```bash
+# List folders
+curl -u admin:admin http://localhost:3000/api/folders
+
+# Search dashboards
+curl -u admin:admin http://localhost:3000/api/search?type=dash-db
+
+# Check specific folder
+curl -u admin:admin http://localhost:3000/api/folders/{uid}
+```
+
+## Troubleshooting
+
+### Migration Not Running
+
+**Symptoms**:
+- No migration logs during startup
+- `unifiedstorage_migration_log` table has no unified storage entries
+
+**Checks**:
+1. Verify `disable_data_migrations = false` in config
+2. Ensure `unifiedStorage = true` feature toggle is enabled
+3. Check database connectivity: `/api/health` should show `"database": "ok"`
+4. Review startup logs for errors
+
+### CountValidator Failures
+
+**Symptom**: `count mismatch: legacy=X, unified=Y`
+
+**Common Causes**:
+- Resources failed validation during bulk processing
+- Network issues during migration
+- Resource schema validation errors
+- Permissions issues
+
+**Investigation**:
+```bash
+# Check for rejected resources
+grep -i "rejected\|validation failed" /var/log/grafana/grafana.log
+
+# Verify resource counts
+psql -c "SELECT COUNT(*) FROM dashboard WHERE org_id = 1 AND is_folder = false"
+```
+
+### FolderTreeValidator Failures
+
+**Symptom**: `folder tree structure mismatch: N folders have incorrect parents`
+
+**Common Causes**:
+- Circular folder references in legacy data
+- Missing parent folders
+- Race conditions during migration
+- Data corruption in legacy storage
+
+**Investigation**:
+```bash
+# Find parent mismatches in logs
+grep "Folder parent mismatch" /var/log/grafana/grafana.log
+
+# Check folder hierarchy in SQL
+SELECT uid, title, folder_id, folder_uid 
+FROM dashboard 
+WHERE org_id = 1 AND is_folder = true 
+ORDER BY folder_id;
+```
+
+### Retry Migration
+
+If migration fails and needs to be retried:
+
+1. **Delete migration record**:
+```sql
+DELETE FROM unifiedstorage_migration_log 
+WHERE migration_id LIKE '%folders-dashboards%';
+```
+
+2. **Restart Grafana**:
+```bash
+systemctl restart grafana-server
+```
+
+### Common Issues
+
+#### Issue: "database connection refused"
+**Solution**: Verify database is running and accessible, check connection string
+
+#### Issue: "permission denied on table resource"
+**Solution**: Grant required permissions to Grafana database user
+
+#### Issue: "namespace not found"
+**Solution**: Ensure organization exists in database, use correct namespace format
+
+#### Issue: "validator timeout"
+**Solution**: Increase timeout settings for large datasets, consider batching
+
+## Development
+
+### Adding a New Validator
+
+1. Implement the `Validator` interface:
+```go
+type MyValidator struct {
+    client resourcepb.ResourceIndexClient
+    // ... fields
+}
+
+func (v *MyValidator) Name() string {
+    return "MyValidator"
+}
+
+func (v *MyValidator) Validate(
+    ctx context.Context, 
+    sess *xorm.Session, 
+    response *resourcepb.BulkResponse, 
+    log log.Logger,
+) error {
+    // Validation logic
+}
+```
+
+2. Register in `service.go`:
+```go
+myValidator := NewMyValidator(client, options)
+migration := NewResourceMigration(
+    migrator,
+    resources,
+    "migration-id",
+    []Validator{existingValidator, myValidator},
+)
+```
+
+### Testing Validators
+
+Create test scenarios in `validator_test.go`:
+```go
+func TestMyValidator(t *testing.T) {
+    validator := NewMyValidator(mockClient, options)
+    response := &resourcepb.BulkResponse{
+        // Test data
+    }
+    err := validator.Validate(ctx, sess, response, logger)
+    require.NoError(t, err)
+}
+```
+
+## References
+
+### Code Structure
+
+```
+pkg/storage/unified/migrations/
+├── migrator.go              # Core migration logic
+├── validator.go             # Validator implementations
+├── resource_migration.go    # Migration execution framework
+├── service.go              # Registration and startup
+└── README.md               # This file
+```
+
+### External Resources
+
+- [Grafana Unified Storage Design](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/README.md)
+- [Kubernetes API Conventions](https://kubernetes.io/docs/reference/using-api/api-concepts/)
+
+## Support
+
+For migration issues:
+
+1. **Check logs first**: Look for validator errors and stack traces
+2. **Verify configuration**: Ensure all required settings are present
+3. **Test database connectivity**: Use health API and direct database queries
+4. **Review validator output**: Specific error messages indicate the issue
+5. **Consult testing guide**: Comprehensive troubleshooting in on-prem migrations README
+
+For questions or bug reports, refer to migration code in `pkg/storage/unified/migrations/`.

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -19,8 +19,8 @@ The migration system transfers resources from legacy SQL tables to Grafana's uni
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│                    ResourceMigration                         │
-│        (Orchestrates per-organization migration)             │
+│                    ResourceMigration                        │
+│        (Orchestrates per-organization migration)            │
 └──────────────────────────┬──────────────────────────────────┘
                            │
        ┌───────────────────┼───────────────────┐

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -42,12 +42,12 @@ The migration system transfers resources from legacy SQL tables to Grafana's uni
 
 ### Migration flow
 
-1. Grafana starts and checks migration status in `migration_log` table
+1. Grafana starts and checks migration status in `unifiedstorage_migration_log` table
 2. For each organization, the migrator:
    - Reads resources from legacy SQL tables
    - Streams resources to unified storage via BulkProcess API
    - Runs validators to verify data integrity
-3. Records migration result in `migration_log` table
+3. Records migration result in `unifiedstorage_migration_log` table
 
 ### Per-organization execution
 
@@ -94,7 +94,7 @@ error: storage.unified.resource_migration Migration validation failed
 Query the migration log table to check status:
 
 ```sql
-SELECT * FROM migration_log WHERE migration_id LIKE '%folders-dashboards%';
+SELECT * FROM unifiedstorage_migration_log WHERE migration_id LIKE '%folders-dashboards%';
 ```
 
 ## Development

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -97,6 +97,8 @@ Query the migration log table to check status:
 SELECT * FROM unifiedstorage_migration_log WHERE migration_id LIKE '%folders-dashboards%';
 ```
 
+The `migration_id` is defined in `service.go` during registration. Ideally, it should be the resource type(s) being migrated.
+
 ## Development
 
 ### Adding a new validator

--- a/pkg/storage/unified/migrations/README.md
+++ b/pkg/storage/unified/migrations/README.md
@@ -1,387 +1,120 @@
-# Unified Storage Data Migrations
+# Unified storage data migrations
 
-Automated migration system for moving legacy resources from traditional SQL storage to Grafana's unified storage backend.
+Automated migration system for moving Grafana resources from legacy SQL storage to unified storage.
 
 ## Overview
 
-The migration system migrates Grafana resources (folders, dashboards) from legacy SQL tables to unified storage while maintaining data integrity through built-in validators.
+The migration system transfers resources from legacy SQL tables to Grafana's unified storage backend. It runs automatically during Grafana startup and validates data integrity after each migration.
 
-### Migration Path
+### Supported resources
 
-```
-Legacy SQL Storage → Validation → Unified Storage (Kubernetes-based)
-     (dashboard table)              (resource + resource_history tables)
-```
-
-### Supported Resources
-
-- **Folders**: Including nested folder hierarchies with parent-child relationships
-- **Dashboards**: With folder associations preserved
+| Resource | API Group | Legacy table |
+|----------|-----------|--------------|
+| Folders | `folder.grafana.app` | `dashboard` |
+| Dashboards | `dashboard.grafana.app` | `dashboard` |
+| Library panels | `dashboard.grafana.app` | `library_element` |
+| Playlists | `playlist.grafana.app` | `playlist` |
 
 ## Architecture
-
-### Components
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                    ResourceMigration                         │
-│  (Orchestrates migration for specific resource types)        │
-└──────────────────┬──────────────────────────────────────────┘
-                   │
-                   ├──> UnifiedMigrator
-                   │    (Reads from legacy, writes to unified storage)
-                   │
-                   └──> Validators (run after migration)
-                        ├─> CountValidator
-                        │   (Verifies resource counts match)
-                        └─> FolderTreeValidator
-                            (Validates folder hierarchy)
+│        (Orchestrates per-organization migration)             │
+└──────────────────────────┬──────────────────────────────────┘
+                           │
+       ┌───────────────────┼───────────────────┐
+       ▼                   ▼                   ▼
+  UnifiedMigrator      Validators         BulkProcess API
+  (Stream legacy     (Validate after      (Write to unified
+   resources)         migration)           storage)
 ```
 
-### Key Files
+### Components
 
-- **`migrator.go`**: Core migration logic, handles reading from legacy SQL and writing to unified storage
-- **`validator.go`**: Validation implementations (CountValidator, FolderTreeValidator)
-- **`resource_migration.go`**: Migration execution framework
-- **`service.go`**: Migration registration and startup integration
+- **`service.go`**: Migration service entry point and registration
+- **`migrator.go`**: Core migration logic using streaming BulkProcess API
+- **`resource_migration.go`**: Per-organization migration execution
+- **`validator.go`**: Post-migration validation (CountValidator, FolderTreeValidator)
+- **`resources.go`**: Registry of migratable resource types
 
-## How Migrations Work
+## How migrations work
 
-### Automatic Execution
+### Migration flow
 
-Migrations run automatically during Grafana startup when:
+1. Grafana starts and checks migration status in `migration_log` table
+2. For each organization, the migrator:
+   - Reads resources from legacy SQL tables
+   - Streams resources to unified storage via BulkProcess API
+   - Runs validators to verify data integrity
+3. Records migration result in `migration_log` table
 
-1. `disable_data_migrations = false` in configuration
-2. Migration hasn't been completed previously (checked via `unifiedstorage_migration_log` table)
-3. Database is accessible and unified storage is enabled
+### Per-organization execution
 
-### Migration Flow
-
-```
-1. Grafana Startup
-   ↓
-2. Check unifiedstorage_migration_log table
-   ↓
-3. If not completed:
-   ├─> Read legacy resources from SQL
-   ├─> Transform to unified storage format
-   ├─> Write to unified storage via BulkProcess API
-   └─> Run validators
-       ├─> CountValidator: Compare counts
-       ├─> FolderTreeValidator: Verify hierarchy
-       └─> Record success/failure in unifiedstorage_migration_log
-   ↓
-4. Continue Grafana startup
-```
-
-### Per-Organization Migration
-
-Migrations run independently for each organization:
-- Namespace format: `org-<orgId>` (e.g., `org-1`, `org-42`)
-- Isolated validation per org
-- Parallel execution possible
+Migrations run independently for each organization using namespace format `org-{orgId}`.
 
 ## Validators
 
 ### CountValidator
 
-**Purpose**: Ensures all resources were migrated successfully by comparing counts.
-
-**How it works**:
-1. Counts resources in legacy SQL table (e.g., `SELECT COUNT(*) FROM dashboard WHERE org_id = ? AND is_folder = false`)
-2. Counts resources in unified storage via Search API
-3. Fails if counts don't match
-
-**Example Configuration**:
-```go
-folderCountValidator := NewCountValidator(
-    client,
-    schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"},
-    "dashboard",
-    "org_id = ? and is_folder = true",
-)
-```
+Compares resource counts between legacy SQL and unified storage. Accounts for rejected items during validation.
 
 ### FolderTreeValidator
 
-**Purpose**: Validates that folder parent-child relationships are preserved correctly.
-
-**How it works**:
-1. Builds legacy folder hierarchy map from SQL:
-   - Queries `dashboard` table for folders
-   - Resolves `folder_uid` (string) to parent UID via uid→uid mapping
-2. Builds unified storage hierarchy map via Search API:
-   - Queries unified storage for folders
-   - Extracts parent UID from `folder` column
-3. Compares both maps and reports mismatches
-
-**Example Validation**:
-```
-Legacy:   folder-child-1 → parent: folder-parent-1
-Unified:  folder-child-1 → parent: folder-parent-1 ✓
-
-Legacy:   folder-child-2 → parent: folder-parent-1
-Unified:  folder-child-2 → parent: folder-parent-2 ✗
-         → FAIL: Parent mismatch detected
-```
+Verifies folder parent-child relationships are preserved after migration.
 
 ## Configuration
 
-### Required Settings
-
-Enable unified storage and migrations:
+To enable migrations, set the following in your Grafana configuration:
 
 ```ini
 [unified_storage]
-disable_data_migrations = false  # CRITICAL: Enables migrations
-
-[grafana-apiserver]
-storage_type = unified
+disable_data_migrations = false
 ```
 
-### Database-Specific Configuration
+## Monitoring
 
-#### PostgreSQL
-```ini
-[database]
-type = postgres
-host = localhost:5432
-name = grafanatest
-user = grafanatest
-password = grafanatest
-```
+### Log messages
 
-#### MySQL
-```ini
-[database]
-type = mysql
-host = localhost:3306
-name = grafanatest
-user = grafanatest
-password = grafanatest
-```
-
-#### SQLite
-```ini
-[database]
-type = sqlite3
-path = /var/lib/grafana/grafana.db
-```
-
-## Monitoring Migrations
-
-### Log Messages
-
-Successful migration logs:
+Successful migration:
 
 ```
-info: storage.unified.RegisterMigrations Registering unified storage migrations
-info: storage.unified.resource_migration.folders-dashboards Running validators count=3
-info: storage.unified.resource_migration.folders-dashboards Validator CountValidator passed
-info: storage.unified.resource_migration.folders-dashboards Validator FolderTreeValidator passed
-info: storage.unified.resource_migration.folders-dashboards All validators passed
-info: Unified storage migrations completed successfully
+info: storage.unified.resource_migration Starting migration for all organizations
+info: storage.unified.resource_migration Migration completed successfully for all organizations
 ```
 
-Failed migration logs:
+Failed migration:
 
 ```
-error: validator CountValidator failed: count mismatch: legacy=100, unified=98
-error: validator FolderTreeValidator failed: folder tree structure mismatch: 3 folders have incorrect parents
-error: unified storage data migration failed: migration validation failed
+error: storage.unified.resource_migration Migration validation failed
 ```
 
-### Migration Table
+### Migration status
 
-Check migration status in database:
+Query the migration log table to check status:
 
 ```sql
--- PostgreSQL/MySQL
-SELECT id, migration_id, success, error, timestamp 
-FROM unifiedstorage_migration_log 
-ORDER BY timestamp DESC;
-
--- SQLite
-SELECT id, migration_id, success, error, timestamp 
-FROM unifiedstorage_migration_log 
-ORDER BY timestamp DESC;
+SELECT * FROM migration_log WHERE migration_id LIKE '%folders-dashboards%';
 ```
-
-### API Verification
-
-Verify migrated resources via API:
-
-```bash
-# List folders
-curl -u admin:admin http://localhost:3000/api/folders
-
-# Search dashboards
-curl -u admin:admin http://localhost:3000/api/search?type=dash-db
-
-# Check specific folder
-curl -u admin:admin http://localhost:3000/api/folders/{uid}
-```
-
-## Troubleshooting
-
-### Migration Not Running
-
-**Symptoms**:
-- No migration logs during startup
-- `unifiedstorage_migration_log` table has no unified storage entries
-
-**Checks**:
-1. Verify `disable_data_migrations = false` in config
-2. Ensure `unifiedStorage = true` feature toggle is enabled
-3. Check database connectivity: `/api/health` should show `"database": "ok"`
-4. Review startup logs for errors
-
-### CountValidator Failures
-
-**Symptom**: `count mismatch: legacy=X, unified=Y`
-
-**Common Causes**:
-- Resources failed validation during bulk processing
-- Network issues during migration
-- Resource schema validation errors
-- Permissions issues
-
-**Investigation**:
-```bash
-# Check for rejected resources
-grep -i "rejected\|validation failed" /var/log/grafana/grafana.log
-
-# Verify resource counts
-psql -c "SELECT COUNT(*) FROM dashboard WHERE org_id = 1 AND is_folder = false"
-```
-
-### FolderTreeValidator Failures
-
-**Symptom**: `folder tree structure mismatch: N folders have incorrect parents`
-
-**Common Causes**:
-- Circular folder references in legacy data
-- Missing parent folders
-- Race conditions during migration
-- Data corruption in legacy storage
-
-**Investigation**:
-```bash
-# Find parent mismatches in logs
-grep "Folder parent mismatch" /var/log/grafana/grafana.log
-
-# Check folder hierarchy in SQL
-SELECT uid, title, folder_id, folder_uid 
-FROM dashboard 
-WHERE org_id = 1 AND is_folder = true 
-ORDER BY folder_id;
-```
-
-### Retry Migration
-
-If migration fails and needs to be retried:
-
-1. **Delete migration record**:
-```sql
-DELETE FROM unifiedstorage_migration_log 
-WHERE migration_id LIKE '%folders-dashboards%';
-```
-
-2. **Restart Grafana**:
-```bash
-systemctl restart grafana-server
-```
-
-### Common Issues
-
-#### Issue: "database connection refused"
-**Solution**: Verify database is running and accessible, check connection string
-
-#### Issue: "permission denied on table resource"
-**Solution**: Grant required permissions to Grafana database user
-
-#### Issue: "namespace not found"
-**Solution**: Ensure organization exists in database, use correct namespace format
-
-#### Issue: "validator timeout"
-**Solution**: Increase timeout settings for large datasets, consider batching
 
 ## Development
 
-### Adding a New Validator
+### Adding a new validator
 
-1. Implement the `Validator` interface:
+Implement the `Validator` interface:
+
 ```go
-type MyValidator struct {
-    client resourcepb.ResourceIndexClient
-    // ... fields
-}
-
-func (v *MyValidator) Name() string {
-    return "MyValidator"
-}
-
-func (v *MyValidator) Validate(
-    ctx context.Context, 
-    sess *xorm.Session, 
-    response *resourcepb.BulkResponse, 
-    log log.Logger,
-) error {
-    // Validation logic
+type Validator interface {
+    Name() string
+    Validate(ctx context.Context, sess *xorm.Session, response *resourcepb.BulkResponse, log log.Logger) error
 }
 ```
 
-2. Register in `service.go`:
-```go
-myValidator := NewMyValidator(client, options)
-migration := NewResourceMigration(
-    migrator,
-    resources,
-    "migration-id",
-    []Validator{existingValidator, myValidator},
-)
-```
+Register the validator in `service.go` when creating the `ResourceMigration`.
 
-### Testing Validators
+### Adding a new resource type
 
-Create test scenarios in `validator_test.go`:
-```go
-func TestMyValidator(t *testing.T) {
-    validator := NewMyValidator(mockClient, options)
-    response := &resourcepb.BulkResponse{
-        // Test data
-    }
-    err := validator.Validate(ctx, sess, response, logger)
-    require.NoError(t, err)
-}
-```
+1. Add the resource definition to `registeredResources` in `resources.go`
+2. Implement the migrator function in the `MigrationDashboardAccessor` interface
+3. Register the migration in `service.go`
 
-## References
-
-### Code Structure
-
-```
-pkg/storage/unified/migrations/
-├── migrator.go              # Core migration logic
-├── validator.go             # Validator implementations
-├── resource_migration.go    # Migration execution framework
-├── service.go              # Registration and startup
-└── README.md               # This file
-```
-
-### External Resources
-
-- [Grafana Unified Storage Design](https://github.com/grafana/grafana/blob/main/pkg/storage/unified/README.md)
-- [Kubernetes API Conventions](https://kubernetes.io/docs/reference/using-api/api-concepts/)
-
-## Support
-
-For migration issues:
-
-1. **Check logs first**: Look for validator errors and stack traces
-2. **Verify configuration**: Ensure all required settings are present
-3. **Test database connectivity**: Use health API and direct database queries
-4. **Review validator output**: Specific error messages indicate the issue
-5. **Consult testing guide**: Comprehensive troubleshooting in on-prem migrations README
-
-For questions or bug reports, refer to migration code in `pkg/storage/unified/migrations/`.


### PR DESCRIPTION
Add readme which depicts the general structure of unified storage data migrations. This intends to make the migration architecture a bit clearer for the respective teams that want to contribute.

Ticket: https://github.com/grafana/search-and-storage-team/issues/605