### PR TITLE
chore: Add retries to the setup enterprise action

### DIFF
--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -47,6 +47,11 @@ runs:
             break
           fi
 
+          if [ $i -eq $RETRIES ]; then
+            echo "Clone failed after $RETRIES attempts, failing pipeline."
+            exit 1
+          fi
+
           sleep 1
         done
 
@@ -64,6 +69,11 @@ runs:
           if [ $? -eq 0 ]; then
             echo "Checkout succeeded, breaking retry loop"
             break
+          fi
+
+          if [ $i -eq $RETRIES ]; then
+            echo "Chekout failed after $RETRIES attempts, failing pipeline."
+            exit 1
           fi
 
           sleep 1

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -2,7 +2,7 @@ name: 'Setup Grafana Enterprise'
 description: 'Clones and sets up Grafana Enterprise repository for testing'
 
 inputs:
-  retires:
+  retries:
     description: 'Number of times to retry'
     required: false
     default: '5'

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -51,6 +51,8 @@ runs:
           sleep 1
         done
 
+        cd ../grafana-enterprise
+
         for i in $(seq 1 $RETRIES); do
           echo "Attempt $i to checkout..."
 

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -48,7 +48,7 @@ runs:
             exit 1
           fi
 
-          sleep 1
+          sleep "$i"
         done
 
         cd ../grafana-enterprise
@@ -74,7 +74,7 @@ runs:
             exit 1
           fi
 
-          sleep 1
+          sleep "$i"
         done
 
         QUIET=1 ./build.sh

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -2,6 +2,10 @@ name: 'Setup Grafana Enterprise'
 description: 'Clones and sets up Grafana Enterprise repository for testing'
 
 inputs:
+  retires:
+    description: 'Number of times to retry'
+    required: false
+    default: '5'
   github-app-name:
     description: 'Name of the GitHub App in Vault'
     required: false
@@ -33,16 +37,36 @@ runs:
       env:
         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
       run: |
-        git clone https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana-enterprise.git ../grafana-enterprise;
+        RETRIES="${{ inputs.retries }}"
 
-        cd ../grafana-enterprise
+        for i in $(seq 1 $RETRIES); do
+          echo "Attempt $i to clone..."
 
-        if git checkout ${GITHUB_HEAD_REF}; then
-          echo "checked out ${GITHUB_HEAD_REF}"
-        elif git checkout ${GITHUB_BASE_REF}; then
-          echo "checked out ${GITHUB_BASE_REF}"
-        else
-          git checkout main
-        fi
+          if git clone https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana-enterprise.git ../grafana-enterprise;; then
+            echo "Clone succeeded on attempt $i"
+            break
+          fi
+
+          sleep 1
+        done
+
+        for i in $(seq 1 $RETRIES); do
+          echo "Attempt $i to checkout..."
+
+          if git checkout ${GITHUB_HEAD_REF}; then
+            echo "checked out ${GITHUB_HEAD_REF}"
+          elif git checkout ${GITHUB_BASE_REF}; then
+            echo "checked out ${GITHUB_BASE_REF}"
+          else
+            git checkout main
+          fi
+
+          if [ $? -eq 0 ]; then
+            echo "Checkout succeeded, breaking retry loop"
+            break
+          fi
+
+          sleep 1
+        done
 
         QUIET=1 ./build.sh

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -42,7 +42,7 @@ runs:
         for i in $(seq 1 $RETRIES); do
           echo "Attempt $i to clone..."
 
-          if git clone https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana-enterprise.git ../grafana-enterprise;; then
+          if git clone https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana-enterprise.git ../grafana-enterprise; then
             echo "Clone succeeded on attempt $i"
             break
           fi
@@ -72,7 +72,7 @@ runs:
           fi
 
           if [ $i -eq $RETRIES ]; then
-            echo "Chekout failed after $RETRIES attempts, failing pipeline."
+            echo "Checkout failed after $RETRIES attempts, failing pipeline."
             exit 1
           fi
 

--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -2,10 +2,6 @@ name: 'Setup Grafana Enterprise'
 description: 'Clones and sets up Grafana Enterprise repository for testing'
 
 inputs:
-  retries:
-    description: 'Number of times to retry'
-    required: false
-    default: '5'
   github-app-name:
     description: 'Name of the GitHub App in Vault'
     required: false
@@ -37,7 +33,7 @@ runs:
       env:
         GH_TOKEN: ${{ steps.generate_token.outputs.token }}
       run: |
-        RETRIES="${{ inputs.retries }}"
+        RETRIES="5"
 
         for i in $(seq 1 $RETRIES); do
           echo "Attempt $i to clone..."

--- a/apps/iam/go.sum
+++ b/apps/iam/go.sum
@@ -1410,8 +1410,6 @@ github.com/segmentio/encoding v0.5.3 h1:OjMgICtcSFuNvQCdwqMCv9Tg7lEOXGwm1J5RPQcc
 github.com/segmentio/encoding v0.5.3/go.mod h1:HS1ZKa3kSN32ZHVZ7ZLPLXWvOVIiZtyJnO1gPH1sKt0=
 github.com/sercand/kuberesolver/v6 v6.0.0 h1:ScvS2Ga9snVkpOahln/BCLySr3/iBAHJf25u66DweZ0=
 github.com/sercand/kuberesolver/v6 v6.0.0/go.mod h1:Dxkqms3OJadP5zirIBPLi9FV8Qpys3T3w40XPEcVsu0=
-github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
-github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/shadowspore/fossil-delta v0.0.0-20241213113458-1d797d70cbe3 h1:/4/IJi5iyTdh6mqOUaASW148HQpujYiHl0Wl78dSOSc=
@@ -1534,10 +1532,6 @@ github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGC
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 h1:ilQV1hzziu+LLM3zUTJ0trRztfwgjqKnBWNtSRkbmwM=
 github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78/go.mod h1:aL8wCCfTfSfmXjznFBSZNN13rSJjlIOI1fUNAtF7rmI=
-github.com/yudai/gojsondiff v1.0.0 h1:27cbfqXLVEJ1o8I6v3y9lg8Ydm53EKqHXAOMxEGlCOA=
-github.com/yudai/gojsondiff v1.0.0/go.mod h1:AY32+k2cwILAkW1fbgxQ5mUmMiZFgLIV+FBNExI05xg=
-github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82 h1:BHyfKlQyqbsFN5p3IfnEUduWvb9is428/nNb5L3U01M=
-github.com/yudai/golcs v0.0.0-20170316035057-ecda9a501e82/go.mod h1:lgjkn3NuSvDfVJdfcVVdX+jpBxNmX4rDAzaS45IcYoM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
We see a lot of intermittent errors on setup enterprise step due to token permissions. The problem seems to be on GH side.

Adding retires to clone step to unblock PRs