### PR TITLE
Logs: Fixed prettify JSON behavior with unescaped content

### DIFF
--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -190,6 +190,45 @@ describe('preProcessLogs', () => {
       expect(logListModel.body).not.toBe(entry);
     });
 
+    test('Prettifies and escapes wrapped JSON', () => {
+      const entry = '{"key": "value", "otherKey": "other\\nValue"}';
+      const logListModel = createLogLine(
+        { entry, hasUnescapedContent: true },
+        {
+          escape: true, // escape
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: true, // wrapped
+          prettifyJSON: true,
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).toBe(`{
+  "key": "value",
+  "otherKey": "other
+Value"
+}`);
+    });
+
+    test('Prettifies JSON without escaping', () => {
+      const entry = '{"key": "value", "otherKey": "other\\nValue"}';
+      const logListModel = createLogLine(
+        { entry, hasUnescapedContent: true },
+        {
+          escape: false, // escape = false
+          order: LogsSortOrder.Descending,
+          timeZone: 'browser',
+          wrapLogMessage: true, // wrapped
+          prettifyJSON: true,
+        }
+      );
+      expect(logListModel.entry).toBe(entry);
+      expect(logListModel.body).toBe(`{
+  "key": "value",
+  "otherKey": "other\\nValue"
+}`);
+    });
+
     test('Uses lossless parsing', () => {
       const entry = '{"number": 90071992547409911}';
       const logListModel = createLogLine(

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -62,6 +62,7 @@ export class LogListModel implements LogRowModel {
   private _highlightedBody: string | undefined = undefined;
   private _highlightedLogAttributesTokens: Array<string | Token> | undefined = undefined;
   private _highlightTokens: Array<string | Token> | undefined = undefined;
+  private _escapeUnescapedString = false;
   private _fields: FieldDef[] | undefined = undefined;
   private _getFieldLinks: GetFieldLinksFn | undefined = undefined;
   private _prettifyJSON: boolean;
@@ -111,11 +112,10 @@ export class LogListModel implements LogRowModel {
     this._virtualization = virtualization;
     this._wrapLogMessage = wrapLogMessage;
 
-    let raw = log.raw;
     if (escape && log.hasUnescapedContent) {
-      raw = escapeUnescapedString(raw);
+      this._escapeUnescapedString = true;
     }
-    this.raw = raw;
+    this.raw = log.raw;
 
     if (config.featureToggles.otelLogsFormatting && this.otelLanguage) {
       this.labels[OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME] = getOtelAttributesField(this, wrapLogMessage);
@@ -142,6 +142,9 @@ export class LogListModel implements LogRowModel {
         const reStringified = this._wrapLogMessage && this._prettifyJSON ? stringify(parsed, undefined, 2) : this.raw;
         if (reStringified) {
           this.raw = reStringified;
+        }
+        if (this._escapeUnescapedString) {
+          this.raw = escapeUnescapedString(this.raw);
         }
       } catch (error) {}
       const raw = this.raw;


### PR DESCRIPTION
Reoccurrence of https://github.com/grafana/grafana/pull/105390 in the new logs panel, same fix.

An easy way to reproduce it with test data: 

https://github.com/grafana/grafana/blob/1d4067216db58a862d3237ea7f8c6f82f4387a1d/devenv/docker/blocks/loki/data/data.js#L92
Add: `stacktrace:"stack line 1\n\tat stack line 2\n\tat stack line 3\n\tat stack line 4\n\t..."`

Fixes #104049