### PR TITLE
fix: update search request for existing provisioned dashboards in modes 3+

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -2009,7 +2009,14 @@ func (dr *DashboardServiceImpl) searchDashboardsThroughK8sRaw(ctx context.Contex
 	request.Limit = query.Limit
 	request.Page = query.Page
 	request.Offset = (query.Page - 1) * query.Limit // only relevant when running in modes 3+
-	request.Fields = dashboardsearch.IncludeFields
+	request.Fields = append(
+		dashboardsearch.IncludeFields,
+		// Include the dashboard legacy ID in the results, as it is needed when
+		// determining whether a provisioned dashboard exists or not, see
+		// `(*DashboardServiceImpl).searchProvisionedDashboardsThroughK8s`.
+		resource.SEARCH_FIELD_LEGACY_ID,
+		resource.SEARCH_FIELD_LABELS+"."+resource.SEARCH_FIELD_LEGACY_ID,
+	)
 
 	namespace := dr.k8sclient.GetNamespace(query.OrgId)
 	var err error


### PR DESCRIPTION
The search query was not requesting the dashboard's "legacy ID". As a result, the provisioning process would not find existing provisioned dashboards, making copies of these dashboards every time there was a change in the provisioned dashboard's definition.

Relates to: https://github.com/grafana/search-and-storage-team/issues/592
