### PR TITLE
Add a metric to track usage of datasource configuration CRUD

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/setting"
@@ -200,6 +202,11 @@ func (hs *HTTPServer) DeleteDataSourceById(c *contextmodel.ReqContext) response.
 // 404: notFoundError
 // 500: internalServerError
 func (hs *HTTPServer) GetDataSourceByUID(c *contextmodel.ReqContext) response.Response {
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("legacy", "GetDataSourceByUID"), time.Since(start).Seconds())
+	}()
+
 	ds, err := hs.getRawDataSourceByUID(c.Req.Context(), web.Params(c.Req)[":uid"], c.GetOrgID())
 
 	if err != nil {
@@ -231,6 +238,11 @@ func (hs *HTTPServer) GetDataSourceByUID(c *contextmodel.ReqContext) response.Re
 // 404: notFoundError
 // 500: internalServerError
 func (hs *HTTPServer) DeleteDataSourceByUID(c *contextmodel.ReqContext) response.Response {
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("legacy", "DeleteDataSourceByUID"), time.Since(start).Seconds())
+	}()
+
 	uid := web.Params(c.Req)[":uid"]
 
 	if uid == "" {
@@ -361,6 +373,11 @@ func validateJSONData(jsonData *simplejson.Json, cfg *setting.Cfg) error {
 // 409: conflictError
 // 500: internalServerError
 func (hs *HTTPServer) AddDataSource(c *contextmodel.ReqContext) response.Response {
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("legacy", "AddDataSource"), time.Since(start).Seconds())
+	}()
+
 	cmd := datasources.AddDataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)
@@ -478,6 +495,10 @@ func (hs *HTTPServer) UpdateDataSourceByID(c *contextmodel.ReqContext) response.
 // 409: conflictError
 // 500: internalServerError
 func (hs *HTTPServer) UpdateDataSourceByUID(c *contextmodel.ReqContext) response.Response {
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(c.Req.Context(), hs.dsConfigHandlerRequestsDuration.WithLabelValues("legacy", "UpdateDataSourceByUID"), time.Since(start).Seconds())
+	}()
 	cmd := datasources.UpdateDataSourceCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "bad request data", err)

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/db/dbtest"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
@@ -81,6 +83,19 @@ func TestDataSourcesProxy_userLoggedIn(t *testing.T) {
 		}, mockSQLStore)
 }
 
+// setupDsConfigMetrics creates and registers the prometheus metrics needed for HTTPServer tests
+// that call methods using dsConfigHandlerRequestsDuration.
+func setupDsConfigHandlerMetrics() (prometheus.Registerer, *prometheus.HistogramVec) {
+	promRegister := prometheus.NewRegistry()
+	dsConfigHandlerRequestsDuration := metricutil.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: "grafana",
+		Name:      "ds_config_handler_requests_duration_seconds",
+		Help:      "Duration of requests handled by datasource configuration handlers",
+	}, []string{"code_path", "handler"})
+	promRegister.MustRegister(dsConfigHandlerRequestsDuration)
+	return promRegister, dsConfigHandlerRequestsDuration
+}
+
 // Adding data sources with invalid URLs should lead to an error.
 func TestAddDataSource_InvalidURL(t *testing.T) {
 	sc := setupScenarioContext(t, "/api/datasources")
@@ -88,6 +103,7 @@ func TestAddDataSource_InvalidURL(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 
 	sc.m.Post(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
 		c.Req.Body = mockRequestBody(datasources.AddDataSourceCommand{
@@ -118,6 +134,7 @@ func TestAddDataSource_URLWithoutProtocol(t *testing.T) {
 		AccessControl:        acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
 		accesscontrolService: actest.FakeService{},
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources")
 
@@ -143,6 +160,7 @@ func TestAddDataSource_InvalidJSONData(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources")
 
@@ -175,6 +193,7 @@ func TestUpdateDataSource_InvalidURL(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
@@ -199,6 +218,7 @@ func TestUpdateDataSource_InvalidJSONData(t *testing.T) {
 		DataSourcesService: &dataSourcesServiceMock{},
 		Cfg:                setting.NewCfg(),
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
 	hs.Cfg.AuthProxy.Enabled = true
@@ -236,6 +256,7 @@ func TestAddDataSourceTeamHTTPHeaders(t *testing.T) {
 			ExpectedErr:      nil,
 		},
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 	sc := setupScenarioContext(t, fmt.Sprintf("/api/datasources/%s", tenantID))
 	hs.Cfg.AuthProxy.Enabled = true
 
@@ -289,6 +310,7 @@ func TestUpdateDataSource_URLWithoutProtocol(t *testing.T) {
 		AccessControl:        acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
 		accesscontrolService: actest.FakeService{},
 	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 
 	sc := setupScenarioContext(t, "/api/datasources/1234")
 
@@ -429,6 +451,7 @@ func TestAPI_datasources_AccessControl(t *testing.T) {
 				hs.DataSourcesService = &dataSourcesServiceMock{expectedDatasource: &datasources.DataSource{}}
 				hs.accesscontrolService = actest.FakeService{}
 				hs.Live = newTestLive(t, hs.SQLStore)
+				hs.promRegister, hs.dsConfigHandlerRequestsDuration = setupDsConfigHandlerMetrics()
 			})
 
 			for _, url := range tt.urls {

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -203,27 +203,28 @@ type HTTPServer struct {
 	pluginsCDNService            *pluginscdn.Service
 	managedPluginsService        managedplugins.Manager
 
-	userService                 user.Service
-	tempUserService             tempUser.Service
-	loginAttemptService         loginAttempt.Service
-	orgService                  org.Service
-	orgDeletionService          org.DeletionService
-	TeamService                 team.Service
-	accesscontrolService        accesscontrol.Service
-	annotationsRepo             annotations.Repository
-	tagService                  tag.Service
-	oauthTokenService           oauthtoken.OAuthTokenService
-	statsService                stats.Service
-	authnService                authn.Service
-	starApi                     *starApi.API
-	promRegister                prometheus.Registerer
-	promGatherer                prometheus.Gatherer
-	clientConfigProvider        grafanaapiserver.DirectRestConfigProvider
-	namespacer                  request.NamespaceMapper
-	anonService                 anonymous.Service
-	userVerifier                user.Verifier
-	tlsCerts                    TLSCerts
-	htmlHandlerRequestsDuration *prometheus.HistogramVec
+	userService                     user.Service
+	tempUserService                 tempUser.Service
+	loginAttemptService             loginAttempt.Service
+	orgService                      org.Service
+	orgDeletionService              org.DeletionService
+	TeamService                     team.Service
+	accesscontrolService            accesscontrol.Service
+	annotationsRepo                 annotations.Repository
+	tagService                      tag.Service
+	oauthTokenService               oauthtoken.OAuthTokenService
+	statsService                    stats.Service
+	authnService                    authn.Service
+	starApi                         *starApi.API
+	promRegister                    prometheus.Registerer
+	promGatherer                    prometheus.Gatherer
+	clientConfigProvider            grafanaapiserver.DirectRestConfigProvider
+	namespacer                      request.NamespaceMapper
+	anonService                     anonymous.Service
+	userVerifier                    user.Verifier
+	tlsCerts                        TLSCerts
+	htmlHandlerRequestsDuration     *prometheus.HistogramVec
+	dsConfigHandlerRequestsDuration *prometheus.HistogramVec
 }
 
 type TLSCerts struct {
@@ -382,9 +383,15 @@ func ProvideHTTPServer(opts ServerOptions, cfg *setting.Cfg, routeRegister routi
 			Name:      "html_handler_requests_duration_seconds",
 			Help:      "Duration of requests handled by the index.go HTML handler",
 		}, []string{"handler"}),
+		dsConfigHandlerRequestsDuration: metricutil.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: "grafana",
+			Name:      "ds_config_handler_requests_duration_seconds",
+			Help:      "Duration of requests handled by datasource configuration handlers",
+		}, []string{"code_path", "handler"}),
 	}
 
 	promRegister.MustRegister(hs.htmlHandlerRequestsDuration)
+	promRegister.MustRegister(hs.dsConfigHandlerRequestsDuration)
 
 	if hs.Listener != nil {
 		hs.log.Debug("Using provided listener")

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -20,6 +20,7 @@ import (
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	queryV0 "github.com/grafana/grafana/pkg/apis/query/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
+	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager/sources"
 	"github.com/grafana/grafana/pkg/promlib/models"
@@ -218,6 +219,11 @@ func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		legacyStore := &legacyStorage{
 			datasources:  b.datasources,
 			resourceInfo: &ds,
+			dsConfigHandlerRequestsDuration: metricutil.NewHistogramVec(prometheus.HistogramOpts{
+				Namespace: "grafana",
+				Name:      "ds_config_handler_requests_duration_seconds",
+				Help:      "Duration of requests handled by datasource configuration handlers",
+			}, []string{"code_path", "handler"}),
 		}
 		unified, err := grafanaregistry.NewRegistryStore(opts.Scheme, ds, opts.OptsGetter)
 		if err != nil {


### PR DESCRIPTION
This PR adds `ds_config_handler_requests_duration_seconds` metric to help us track the release of the new datasource configuration CRUD api.

Part of https://github.com/grafana/grafana-enterprise/issues/10309
