### PR TITLE
Docs: Clarify the uid is metadata.name

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -767,8 +767,8 @@ Status Codes:
 
 Deletes a dashboard via the dashboard uid.
 
-- namespace: to read more about the namespace to use, see the [API overview](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/apis/).
-- uid: the unique identifier of the dashboard to update. this will be the _name_ in the dashboard response
+- **`namespace`**: To read more about the namespace to use, see the [API overview](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/developers/http_api/apis/).
+- **`uid`**: The unique identifier of the dashboard to update. This is the `metadata.name` field in the dashboard response and _not_ the `metadata.uid` field.
 
 **Required permissions**
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -772,7 +772,7 @@ Deletes a dashboard via the dashboard uid.
 
 **Required permissions**
 
-See note in the [introduction]({{< ref "#dashboard-api" >}}) for an explanation.
+See note in the [introduction](#new-dashboard-apis) for an explanation.
 
 <!-- prettier-ignore-start -->
 | Action              | Scope                                                                                                   |


### PR DESCRIPTION
**What is this feature?**

Clarifies that for the DELETE api request, the `uid` you supply is the `metadata.name` field in the dashboard response and not the `metadata.uid`. 

**Why do we need this feature?**

Because users see a field containing `uid` in their dashboard responses they sometimes assume this is the `uid` to use for this request so clarifying and being more explicit reduces confusion.

**Who is this feature for?**

All users of Grafana API docs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/support-escalations/issues/19533

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
