### PR TITLE
FS: Check session expiration and rotate if needed

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -260,17 +260,7 @@
         }
 
         async function rotateSession() {
-          const resp = await fetch('/api/user/auth-tokens/rotate', { method: 'POST' });
-
-          if (resp.status === 200) {
-            return true;
-          }
-
-          if (resp.status === 401) {
-            return false;
-          }
-
-          return undefined;
+          await fetch('/api/user/auth-tokens/rotate', { method: 'POST' });
         }
 
         /**
@@ -338,7 +328,8 @@
                   await rotateSession();
                 }
               } catch (error) {
-                console.error(error);
+                // Just ignore any errors in session rotation. The user can just log in again.
+                console.warn("Failed to rotate session", error);
               }
 
               try {

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -239,6 +239,40 @@
 
         const CHECK_INTERVAL = 1 * 1000;
 
+        function getCookie(name) {
+          const cookies = document.cookie.split(";").map(c => c.trim());
+
+          for (const cookie of cookies) {
+            if (cookie.startsWith(name + "=")) {
+              return cookie.substring(name.length + 1);
+            }
+          }
+
+          return null;
+        }
+
+        function getSessionExpiration() {
+          const value = getCookie("grafana_session_expiry") || "0";
+          const realExpiresSeconds = parseInt(value, 10);
+          const expiresSeconds = Math.max(realExpiresSeconds - 10, 0); // Rotate 10s before the real expiration
+          const expiration = new Date(expiresSeconds * 1000);
+          return expiration;
+        }
+
+        async function rotateSession() {
+          const resp = await fetch('/api/user/auth-tokens/rotate', { method: 'POST' });
+
+          if (resp.status === 200) {
+            return true;
+          }
+
+          if (resp.status === 401) {
+            return false;
+          }
+
+          return undefined;
+        }
+
         /**
          * Fetches boot data from the server. If it returns undefined, it should be retried later.
          * Will return a rejected promise on unrecoverable errors.
@@ -295,6 +329,18 @@
         function loadBootData() {
           return new Promise((resolve, reject) => {
             const attemptFetch = async () => {
+              try {
+                const sessionExpiration = getSessionExpiration();
+                const now = new Date();
+
+                // If the session has expired, don't continue trying to fetch boot data
+                if (now >= sessionExpiration) {
+                  await rotateSession();
+                }
+              } catch (error) {
+                console.error(error);
+              }
+
               try {
                 const bootData = await fetchBootData();
 


### PR DESCRIPTION
Fixes an issue where you're logged out after being away from Grafana for 10 minutes, when using the frontend service.

When you log into Grafana, you have a session cookie which itself is only valid for 10 minutes. In the old ST grafana, when you navigate to Grafana and your session has expired, you're redirected to a session rotation endpoint. The frontend service does not (and cannot) do this, which resulted in being logged out next time you visit Grafana.

It's important that we have a valid session cookie _before_ `/bootdata` is called so the response contains per-user information (such as auth state, data sources, preferences, etc).

The solution is to check the `grafana_session_expiry` cookie value, and if it's 10 seconds away from rotating, call `/api/user/auth-tokens/rotate` to refresh the session cookie.

Fixes https://github.com/grafana/grafana-frontend-platform/issues/89


---

To reproduce/test, edit `devenv/frontend-service/configs/grafana-api.local.ini` to add

```
[auth]
token_rotation_interval_minutes = 1
```

Then log into grafana, close the tab, and go back 1 minute later. Before this change you would be logged out, after this change you'll still be logged in.