### PR TITLE
Transformations PoC: Drawer open/closed state via session storage

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.test.tsx
@@ -24,6 +24,16 @@ import { testDashboard } from '../testfiles/testDashboard';
 
 import { PanelDataTransformationsTab, PanelDataTransformationsTabRendered } from './PanelDataTransformationsTab';
 
+// Mock getDashboardSceneFor to return a mock dashboard
+jest.mock('../../utils/utils', () => ({
+  ...jest.requireActual('../../utils/utils'),
+  getDashboardSceneFor: jest.fn(() => ({
+    state: {
+      uid: 'test-dashboard-uid',
+    },
+  })),
+}));
+
 function createModelMock(
   panelData: PanelData,
   transformations?: DataTransformerConfig[],
@@ -33,6 +43,15 @@ function createModelMock(
     getDataTransformer: () => new SceneDataTransformer({ data: panelData, transformations: transformations || [] }),
     getQueryRunner: () => new SceneQueryRunner({ queries: [], data: panelData }),
     onChangeTransformations: onChangeTransformationsMock,
+    state: {
+      panelRef: {
+        resolve: () => ({
+          state: {
+            key: 'test-panel-key',
+          },
+        }),
+      },
+    },
   } as unknown as PanelDataTransformationsTab;
 }
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/usePersistedTransformationState.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/usePersistedTransformationState.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+
+/**
+ * Session storage key prefix for persisting transformation row collapse states.
+ * Full key format: grafana.panelEditor.transformations.${dashboardUID}-${panelKey}
+ */
+export const TRANSFORMATION_ROWS_STATE_KEY = 'grafana.panelEditor.transformations';
+
+/**
+ * Persists transformation row collapse states in sessionStorage.
+ * Scoped by dashboard UID and panel ID for uniqueness across dashboards.
+ * Reads/writes directly from sessionStorage.
+ */
+export function usePersistedTransformationState(storageKey: string) {
+  const fullStorageKey = `${TRANSFORMATION_ROWS_STATE_KEY}.${storageKey}`;
+
+  const isOpen = useCallback(
+    (transformationId: string): boolean | undefined => {
+      try {
+        const stored = sessionStorage.getItem(fullStorageKey);
+        if (!stored) {
+          return undefined;
+        }
+        const rowStates = JSON.parse(stored);
+        return rowStates[transformationId];
+      } catch {
+        return undefined;
+      }
+    },
+    [fullStorageKey]
+  );
+
+  const setIsOpen = useCallback(
+    (transformationId: string, open: boolean) => {
+      try {
+        const stored = sessionStorage.getItem(fullStorageKey);
+        const rowStates = stored ? JSON.parse(stored) : {};
+        rowStates[transformationId] = open;
+        sessionStorage.setItem(fullStorageKey, JSON.stringify(rowStates));
+      } catch (error) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn(`Failed to persist transformation state for ${transformationId}:`, error);
+        }
+        // Silently fail in production if storage unavailable or quota exceeded
+      }
+    },
+    [fullStorageKey]
+  );
+
+  return { isOpen, setIsOpen };
+}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRow.tsx
@@ -36,6 +36,8 @@ interface TransformationOperationRowProps {
   configs: TransformationsEditorTransformation[];
   onRemove: (index: number) => void;
   onChange: (index: number, config: DataTransformerConfig) => void;
+  isOpen?: boolean;
+  onOpenChanged: (isOpen: boolean) => void;
 }
 
 export const TransformationOperationRow = ({
@@ -46,6 +48,8 @@ export const TransformationOperationRow = ({
   configs,
   uiConfig,
   onChange,
+  isOpen,
+  onOpenChanged,
 }: TransformationOperationRowProps) => {
   const [showDeleteModal, setShowDeleteModal] = useToggle(false);
   const [showDebug, toggleShowDebug] = useToggle(false);
@@ -227,6 +231,9 @@ export const TransformationOperationRow = ({
         draggable
         actions={renderActions}
         disabled={disabled}
+        isOpen={isOpen}
+        onOpen={() => onOpenChanged(true)}
+        onClose={() => onOpenChanged(false)}
         expanderMessages={{
           close: 'Collapse transformation row',
           open: 'Expand transformation row',

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
@@ -9,8 +9,8 @@ interface TransformationOperationRowsProps {
   configs: TransformationsEditorTransformation[];
   onRemove: (index: number) => void;
   onChange: (index: number, config: DataTransformerConfig) => void;
-  getIsOpen: (id: string) => boolean | undefined;
-  setIsOpen: (id: string, isOpen: boolean) => void;
+  getIsOpen?: (id: string) => boolean | undefined;
+  setIsOpen?: (id: string, isOpen: boolean) => void;
 }
 
 export const TransformationOperationRows = ({
@@ -40,8 +40,8 @@ export const TransformationOperationRows = ({
             uiConfig={uiConfig}
             onRemove={onRemove}
             onChange={onChange}
-            isOpen={getIsOpen(t.id)}
-            onOpenChanged={(isOpen) => setIsOpen(t.id, isOpen)}
+            isOpen={getIsOpen?.(t.id)}
+            onOpenChanged={(isOpen) => setIsOpen?.(t.id, isOpen)}
           />
         );
       })}

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationOperationRows.tsx
@@ -9,6 +9,8 @@ interface TransformationOperationRowsProps {
   configs: TransformationsEditorTransformation[];
   onRemove: (index: number) => void;
   onChange: (index: number, config: DataTransformerConfig) => void;
+  getIsOpen: (id: string) => boolean | undefined;
+  setIsOpen: (id: string, isOpen: boolean) => void;
 }
 
 export const TransformationOperationRows = ({
@@ -16,6 +18,8 @@ export const TransformationOperationRows = ({
   onChange,
   onRemove,
   configs,
+  getIsOpen,
+  setIsOpen,
 }: TransformationOperationRowsProps) => {
   return (
     <>
@@ -36,6 +40,8 @@ export const TransformationOperationRows = ({
             uiConfig={uiConfig}
             onRemove={onRemove}
             onChange={onChange}
+            isOpen={getIsOpen(t.id)}
+            onOpenChanged={(isOpen) => setIsOpen(t.id, isOpen)}
           />
         );
       })}


### PR DESCRIPTION
## What does this PR do?

Transformation row collapse states now persist across page reloads and navigation within the same session.

Previously, users had to re-expand transformation rows every time they returned to the panel editor. This adds sessionStorage-backed persistence scoped by dashboard and panel, matching the existing pattern used for dashboard state preservation.

**Key changes:**
- New `usePersistedTransformationState` hook manages collapse state in sessionStorage
- State scoped by `dashboardUID-panelKey` for uniqueness across dashboards
- Error handling

#### Demo 🎥 

https://github.com/user-attachments/assets/0f4f81c7-04e9-429f-9223-03c02a1ee5b0