### PR TITLE
Dashboards: Prevent panic in validation

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
@@ -66,6 +66,9 @@ func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorLis
 }
 
 func formatErrorPath(path []string) string {
+	if len(path) <= 4 {
+		return strings.Join(path, ".")
+	}
 	// omitting the "lineage.schemas[0].schema.spec" prefix here.
 	return strings.Join(path[4:], ".")
 }

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
@@ -67,6 +67,9 @@ func ValidateDashboardSpec(obj *Dashboard, forceValidation bool) (field.ErrorLis
 }
 
 func formatErrorPath(path []string) string {
+	if len(path) <= 4 {
+		return strings.Join(path, ".")
+	}
 	// omitting the "lineage.schemas[0].schema.spec" prefix here.
 	return strings.Join(path[4:], ".")
 }


### PR DESCRIPTION
If the dashboard spec json contains illegal bytes, this will panic as there is no field to return here.