### PR TITLE
Dashboard Query Variable: Revert adding ds ref by default

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/QueryVariableForm.tsx
@@ -89,13 +89,13 @@ export function QueryVariableEditorForm({
       onQueryChange(query);
     }
 
-    if (!datasourceRef) {
-      const instanceSettings = getDataSourceSrv().getInstanceSettings({ type: datasource.type, uid: datasource.uid });
+    // if (!datasourceRef) {
+    //   const instanceSettings = getDataSourceSrv().getInstanceSettings({ type: datasource.type, uid: datasource.uid });
 
-      if (instanceSettings) {
-        onDataSourceChange(instanceSettings);
-      }
-    }
+    //   if (instanceSettings) {
+    //     onDataSourceChange(instanceSettings);
+    //   }
+    // }
 
     return { datasource, VariableQueryEditor };
   }, [datasourceRef]);

--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.test.tsx
@@ -148,19 +148,19 @@ describe('QueryVariableEditor', () => {
     expect(staticOptionsToggle).toBeInTheDocument();
   });
 
-  it('should update the variable with default datasource when opening editor', async () => {
-    const onRunQueryMock = jest.fn();
-    const variable = new QueryVariable({ datasource: undefined, query: '' });
+  // it('should update the variable with default datasource when opening editor', async () => {
+  //   const onRunQueryMock = jest.fn();
+  //   const variable = new QueryVariable({ datasource: undefined, query: '' });
 
-    await setup({
-      variable,
-      onRunQuery: onRunQueryMock,
-    });
+  //   await setup({
+  //     variable,
+  //     onRunQuery: onRunQueryMock,
+  //   });
 
-    await waitFor(async () => {
-      expect(variable.state.datasource).not.toBe(undefined);
-    });
-  });
+  //   await waitFor(async () => {
+  //     expect(variable.state.datasource).not.toBe(undefined);
+  //   });
+  // });
 
   it('should update the variable with default query for the selected DS', async () => {
     const onRunQueryMock = jest.fn();


### PR DESCRIPTION
Reverts https://github.com/grafana/grafana/pull/113843 as this is breaking current dashboards that don't have ds ref by resetting query and definition fields. 

This happens when `onDataSourceChange` is triggered and then in here we are resetting query and definition: https://github.com/grafana/grafana/blob/f4e7dfe82727d1050a47cb522774a73d6d89d619/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx#L71-L80

I'm not sure if there's a fix that would support both options. I'm just commenting out for now because we've received several reports where this issue happens. 

Fixes #https://github.com/grafana/support-escalations/issues/19592

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.

