### PR TITLE
feat: enhance InviteUserButton to support upgrade functionality

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
@@ -262,5 +262,41 @@ describe('InviteUserButton', () => {
 
       consoleSpy.mockRestore();
     });
+
+    it('should handle URL generation errors gracefully', async () => {
+      mockGetExternalUserMngLinkUrl.mockImplementation(() => {
+        throw new Error('URL generation failed');
+      });
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const user = userEvent.setup();
+
+      render(<InviteUserButton />);
+
+      // Should not crash when URL generation fails
+      await user.click(screen.getByRole('button', { name: /invite user/i }));
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle button click:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
+
+    it('should handle popup blocking gracefully', async () => {
+      mockWindowOpen.mockImplementation(() => {
+        throw new Error('Popup blocked');
+      });
+
+      const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const user = userEvent.setup();
+
+      render(<InviteUserButton />);
+
+      // Should not crash when popup is blocked
+      await user.click(screen.getByRole('button', { name: /invite user/i }));
+
+      expect(consoleSpy).toHaveBeenCalledWith('Failed to handle button click:', expect.any(Error));
+
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.test.tsx
@@ -1,3 +1,4 @@
+import { skipToken } from '@reduxjs/toolkit/query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -220,10 +221,8 @@ describe('InviteUserButton', () => {
 
       render(<InviteUserButton />);
 
-      // Should skip the query
-      expect(mockUseGetCurrentOrgQuotaQuery).toHaveBeenCalledWith(undefined, {
-        skip: true,
-      });
+      // Should skip the query with skipToken
+      expect(mockUseGetCurrentOrgQuotaQuery).toHaveBeenCalledWith(skipToken);
     });
 
     it('should fetch quotas on cloud instances when button will render', () => {
@@ -231,10 +230,8 @@ describe('InviteUserButton', () => {
 
       render(<InviteUserButton />);
 
-      // Should not skip the query
-      expect(mockUseGetCurrentOrgQuotaQuery).toHaveBeenCalledWith(undefined, {
-        skip: false,
-      });
+      // Should not skip the query (pass undefined)
+      expect(mockUseGetCurrentOrgQuotaQuery).toHaveBeenCalledWith(undefined);
     });
   });
 

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -31,10 +31,14 @@ export function InviteUserButton() {
   }
 
   const handleClick = () => {
-    if (shouldShowUpgrade) {
-      performUpgradeClick('top_bar_right', 'upgrade-user-top-bar');
-    } else {
-      performInviteUserClick('top_bar_right', 'invite-user-top-bar');
+    try {
+      if (shouldShowUpgrade) {
+        performUpgradeClick('top_bar_right', 'upgrade-user-top-bar');
+      } else {
+        performInviteUserClick('top_bar_right', 'invite-user-top-bar');
+      }
+    } catch (error) {
+      console.error('Failed to handle button click:', error);
     }
   };
 

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -20,7 +20,8 @@ export function InviteUserButton() {
 
   // Check if org_user quota is reached
   const userQuota = quotas?.find((quota) => quota.target === 'org_user');
-  const isQuotaReached = userQuota ? userQuota.used! >= userQuota.limit! : false;
+  const isQuotaReached =
+    userQuota != null && userQuota.used != null && userQuota.limit != null && userQuota.used >= userQuota.limit;
 
   // Only show upgrade button on Grafana Cloud when quota is reached
   const shouldShowUpgrade = isCloudInstance && isQuotaReached;

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,33 +1,61 @@
 import { t } from '@grafana/i18n';
 import { ToolbarButton } from '@grafana/ui';
+import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
+import { isOnPrem } from 'app/features/provisioning/utils/isOnPrem';
 
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 
-import { performInviteUserClick, shouldRenderInviteUserButton } from './InviteUserButtonUtils';
+import { performInviteUserClick, performUpgradeClick, shouldRenderInviteUserButton } from './InviteUserButtonUtils';
 
 export function InviteUserButton() {
   const isLargeScreen = useMediaQueryMinWidth('lg');
+  const shouldRender = shouldRenderInviteUserButton();
+  const isCloudInstance = !isOnPrem();
+
+  // Only fetch quotas when button will render AND on Grafana Cloud
+  const { data: quotas, error } = useGetCurrentOrgQuotaQuery(undefined, {
+    skip: !shouldRender || !isCloudInstance,
+  });
+
+  // Check if org_user quota is reached
+  const userQuota = quotas?.find((quota) => quota.target === 'org_user');
+  const isQuotaReached = userQuota ? userQuota.used! >= userQuota.limit! : false;
+
+  // Only show upgrade button on Grafana Cloud when quota is reached
+  const shouldShowUpgrade = isCloudInstance && isQuotaReached;
+
+  if (error) {
+    console.error('Failed to fetch org quotas:', error);
+  }
 
   const handleClick = () => {
-    try {
+    if (shouldShowUpgrade) {
+      performUpgradeClick('top_bar_right', 'upgrade-user-top-bar');
+    } else {
       performInviteUserClick('top_bar_right', 'invite-user-top-bar');
-    } catch (error) {
-      console.error('Failed to handle invite user click:', error);
     }
   };
 
+  const buttonLabel = shouldShowUpgrade
+    ? t('navigation.invite-user.upgrade-tooltip', 'Upgrade to invite more users')
+    : t('navigation.invite-user.invite-tooltip', 'Invite user');
+
   return (
-    shouldRenderInviteUserButton() && (
+    shouldRender && (
       <>
         <ToolbarButton
-          icon="add-user"
+          icon={shouldShowUpgrade ? 'rocket' : 'add-user'}
           iconOnly={!isLargeScreen}
           onClick={handleClick}
-          tooltip={t('navigation.invite-user.invite-tooltip', 'Invite user')}
-          aria-label={t('navigation.invite-user.invite-tooltip', 'Invite user')}
+          tooltip={buttonLabel}
+          aria-label={buttonLabel}
         >
-          {isLargeScreen ? t('navigation.invite-user.invite-button', 'Invite') : undefined}
+          {isLargeScreen
+            ? shouldShowUpgrade
+              ? t('navigation.invite-user.upgrade-button', 'Upgrade')
+              : t('navigation.invite-user.invite-button', 'Invite')
+            : undefined}
         </ToolbarButton>
         <NavToolbarSeparator />
       </>

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -1,3 +1,5 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+
 import { t } from '@grafana/i18n';
 import { ToolbarButton } from '@grafana/ui';
 import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
@@ -14,9 +16,7 @@ export function InviteUserButton() {
   const isCloudInstance = !isOnPrem();
 
   // Only fetch quotas when button will render AND on Grafana Cloud
-  const { data: quotas, error } = useGetCurrentOrgQuotaQuery(undefined, {
-    skip: !shouldRender || !isCloudInstance,
-  });
+  const { data: quotas, error } = useGetCurrentOrgQuotaQuery(!shouldRender || !isCloudInstance ? skipToken : undefined);
 
   // Check if org_user quota is reached
   const userQuota = quotas?.find((quota) => quota.target === 'org_user');

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
@@ -12,7 +12,7 @@ export const performInviteUserClick = (placement: string, cnt: string) => {
   });
 
   const url = getExternalUserMngLinkUrl(cnt);
-  window.open(url.toString(), '_blank');
+  window.open(url, '_blank');
 };
 
 export const performUpgradeClick = (placement: string, cnt: string) => {
@@ -21,5 +21,5 @@ export const performUpgradeClick = (placement: string, cnt: string) => {
   });
 
   const url = getUpgradeUrl(cnt);
-  window.open(url.toString(), '_blank');
+  window.open(url, '_blank');
 };

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButtonUtils.tsx
@@ -1,6 +1,6 @@
 import { reportInteraction, config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { getExternalUserMngLinkUrl } from 'app/features/users/utils';
+import { getExternalUserMngLinkUrl, getUpgradeUrl } from 'app/features/users/utils';
 import { AccessControlAction } from 'app/types/accessControl';
 
 export const shouldRenderInviteUserButton = () =>
@@ -12,5 +12,14 @@ export const performInviteUserClick = (placement: string, cnt: string) => {
   });
 
   const url = getExternalUserMngLinkUrl(cnt);
+  window.open(url.toString(), '_blank');
+};
+
+export const performUpgradeClick = (placement: string, cnt: string) => {
+  reportInteraction('upgrade_user_button_clicked', {
+    placement,
+  });
+
+  const url = getUpgradeUrl(cnt);
   window.open(url.toString(), '_blank');
 };

--- a/public/app/features/users/utils.ts
+++ b/public/app/features/users/utils.ts
@@ -19,3 +19,25 @@ export function getExternalUserMngLinkUrl(cnt: string) {
 
   return url.toString();
 }
+
+export function getUpgradeUrl(cnt?: string) {
+  const orgName = config.bootData?.user?.orgName;
+
+  let baseUrl: string;
+  if (orgName) {
+    // Use org-specific URL: https://grafana.com/orgs/<org-name>/my-account/manage-plan
+    baseUrl = `https://grafana.com/orgs/${encodeURIComponent(orgName)}/my-account/manage-plan`;
+  } else {
+    // Fallback to generic subscription page
+    baseUrl = 'https://grafana.com/profile/org/subscription';
+  }
+
+  // Add cnt parameter for conversion tracking if provided
+  if (cnt) {
+    const url = new URL(baseUrl);
+    url.searchParams.append('cnt', cnt);
+    return url.toString();
+  }
+
+  return baseUrl;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10729,7 +10729,9 @@
     "invite-user": {
       "invite-button": "Invite",
       "invite-new-user-button": "Invite new user",
-      "invite-tooltip": "Invite user"
+      "invite-tooltip": "Invite user",
+      "upgrade-button": "Upgrade",
+      "upgrade-tooltip": "Upgrade to invite more users"
     },
     "item": {
       "add-bookmark": "Add to Bookmarks",


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Replaces the "Invite" button in the top navigation bar with an "Upgrade" button when a Grafana Cloud organization reaches its `org_user` quota limit. Clicking the Upgrade button opens the organization's Manage Plan page at `https://grafana.com/orgs/<org-name>/my-account/manage-plan`

**Why do we need this feature?**

When free or trial organizations reach their user limit (e.g., 3 users) and click "Invite," they currently hit a dead end—being redirected to the Members page with an error message saying they've reached their limit. This creates friction and confusion, requiring users to search for upgrade options elsewhere. Reaching the user limit signals the org is growing and ready for more collaboration. The "Upgrade" button provides a clear, frictionless path forward at the exact moment users need it, preventing frustration and improving conversion for orgs ready to expand.

**Who is this feature for?**

Free and trial Grafana Cloud organizations that have reached their `org_user` quota limit. Organizations actively growing their teams who hit the seat limit and need to upgrade to add more users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Addresses https://github.com/grafana/OGPM/issues/352

**Special notes for your reviewer:**

- Set `stack_id = 12345` in `conf/custom.ini` to simulate Grafana Cloud
- Set `[quota] org_user = 1` to simulate reaching the limit
- Verify button changes to "Upgrade"
- Click button and verify it opens: `https://grafana.com/orgs/<org-name>/my-account/manage-plan?cnt=upgrade-user-top-bar`
- Test on-prem mode (no `stack_id`) shows "Invite" without quota checks

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
