### PR TITLE
Table: Clamp Safari exclusions to 26.0 and 26.1

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1102,12 +1102,18 @@ export function parseStyleJson(rawValue: unknown): CSSProperties | void {
   }
 }
 
-// Safari 26 introduced rendering bugs which require us to disable several features of the table.
+// Safari 26.0 introduced rendering bugs which require us to disable several features of the table.
+// The bugs were later fixed in Safari 26.2.
 export const IS_SAFARI_26 = (() => {
   if (navigator == null) {
     return false;
   }
   const userAgent = navigator.userAgent;
-  const safariVersionMatch = userAgent.match(/Version\/(\d+)\./);
-  return safariVersionMatch && parseInt(safariVersionMatch[1], 10) === 26;
+  const safariVersionMatch = userAgent.match(/Version\/(\d+)\.(\d+)/);
+  if (!safariVersionMatch) {
+    return false;
+  }
+  const majorVersion = +safariVersionMatch[1];
+  const minorVersion = +safariVersionMatch[2];
+  return majorVersion === 26 && minorVersion <= 1;
 })();


### PR DESCRIPTION
Relates to https://github.com/grafana/support-escalations/issues/19612, https://github.com/grafana/grafana/issues/111590

In https://github.com/grafana/grafana/pull/111834, we disabled table virtualization and other features to "keep the lights on" with table in Safari 26 after some rendering bugs broke that visualization. These seem to have been addressed in Safari 26, as I just played around with a beta release with the exclusions off and it works great.

**We should wait for the proper release of Safari 26.2 and test with that before actually merging this.**