### PR TITLE
feat(annotations): add colorByTags for tag-based coloring (#12290)

### DIFF
--- a/devenv/dev-dashboards/annotations/annotation-filtering.json
+++ b/devenv/dev-dashboards/annotations/annotation-filtering.json
@@ -80,6 +80,19 @@
           "refId": "Anno",
           "scenarioId": "annotations"
         }
+      },
+      {
+        "datasource": {
+          "type": "grafana-testdata-datasource"
+        },
+        "enable": true,
+        "iconColor": "blue",
+        "name": "Blue everywhere",
+        "target": {
+          "lines": 3,
+          "refId": "Anno",
+          "scenarioId": "annotations"
+        }
       }
     ]
   },

--- a/devenv/dev-dashboards/annotations/color-by-tag-demo.json
+++ b/devenv/dev-dashboards/annotations/color-by-tag-demo.json
@@ -1,0 +1,202 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "red",
+        "name": "Critical",
+        "colorByTags": "critical",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": ["critical"],
+          "type": "tags"
+        }
+      },
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "orange",
+        "name": "Warning",
+        "colorByTags": "warning",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": ["warning"],
+          "type": "tags"
+        }
+      },
+      {
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": false,
+        "iconColor": "blue",
+        "name": "Info",
+        "colorByTags": "info",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": ["info"],
+          "type": "tags"
+        }
+      }
+    ]
+  },
+  "description": "Demonstrates the colorByTags feature with priority-based coloring",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "code": {
+          "language": "plaintext",
+          "showLineNumbers": false,
+          "showMiniMap": false
+        },
+        "content": "## Color by Tags Demo\n\nThis dashboard demonstrates the **colorByTags** feature with **priority-based coloring**.\n\n### How It Works\n\n1. Each annotation query **filters** by a specific tag (critical, warning, info)\n2. The `colorByTags` setting determines the color based on priority\n3. Toggle queries ON/OFF to show/hide annotations with that tag\n\n### Test Instructions\n\n1. Click on the time series panel and add 3 annotations:\n   - First: tag = `critical`\n   - Second: tag = `warning`\n   - Third: tag = `info`\n2. Each annotation should appear with its respective color\n3. Toggle the queries to show/hide each severity level\n\n### Priority Demo\n\nTo test priority, add an annotation with **multiple tags** (e.g., `critical, warning`):\n- It will appear in both Critical and Warning queries\n- Each query colors it by its highest priority matching tag",
+        "mode": "markdown"
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "title": "Instructions",
+      "type": "text"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "random_walk"
+        }
+      ],
+      "title": "Add annotations here (click on the panel)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "tags": ["gdev", "annotations", "demo"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Color by Tags Demo",
+  "uid": "color-by-tag-demo",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -151,6 +151,7 @@ To add a new annotation query to a dashboard, follow these steps:
 1. If you don't want to use the annotation query right away, clear the **Enabled** checkbox.
 1. If you don't want the annotation query toggle to be displayed in the dashboard, select the **Hidden** checkbox.
 1. Select a color for the event markers.
+1. (Optional) In the **Color by tags** field, enter a comma-separated list of tag names (for example, `critical, warning, info`) to automatically color annotations based on their tags. Annotations with matching tags are colored by that tag value. The order defines priority—if an annotation has multiple matching tags, the first match in the list determines the color. If no tags match, the annotation uses the color selected above.
 1. In the **Show in** drop-down, choose one of the following options:
    - **All panels** - The annotations are displayed on all panels that support annotations.
    - **Selected panels** - The annotations are displayed on all the panels you select.

--- a/e2e-playwright/various-suite/annotation-color-by-tag.spec.ts
+++ b/e2e-playwright/various-suite/annotation-color-by-tag.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test.describe(
+  'Annotation color by tags',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    const DASHBOARD_ID = 'ed155665';
+
+    test('Color by tags input is visible and can be edited', async ({ page, selectors, gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_ID });
+
+      const editButton = dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton);
+      await expect(editButton).toBeVisible();
+      await editButton.click();
+
+      const settingsButton = dashboardPage.getByGrafanaSelector(
+        selectors.components.NavToolbar.editDashboard.settingsButton
+      );
+      await expect(settingsButton).toBeVisible();
+      await settingsButton.click();
+
+      const annotationsTab = dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('Annotations'));
+      await annotationsTab.click();
+
+      const newQueryButton = page.getByText('New query');
+      await newQueryButton.click();
+
+      const nameInput = dashboardPage.getByGrafanaSelector(
+        selectors.pages.Dashboard.Settings.Annotations.Settings.name
+      );
+      await nameInput.fill('Color by tags test');
+
+      const colorByTagsInput = dashboardPage.getByGrafanaSelector(
+        selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.colorByTags
+      );
+      await expect(colorByTagsInput).toBeVisible();
+
+      await expect(colorByTagsInput).toHaveValue('');
+
+      await colorByTagsInput.fill('critical, warning, info');
+
+      await expect(colorByTagsInput).toHaveValue('critical, warning, info');
+
+      await colorByTagsInput.fill('');
+
+      await expect(colorByTagsInput).toHaveValue('');
+    });
+  }
+);

--- a/packages/grafana-e2e-selectors/src/selectors/pages.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/pages.ts
@@ -359,6 +359,9 @@ export const versionedPages = {
           hide: {
             '10.4.0': 'data-testid annotation-hide',
           },
+          colorByTags: {
+            '12.0.0': 'data-testid annotation-color-by-tags',
+          },
         },
       },
       Variables: {

--- a/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
+++ b/packages/grafana-schema/src/raw/dashboard/x/dashboard_types.gen.ts
@@ -103,6 +103,11 @@ export interface AnnotationQuery {
    */
   iconColor: string;
   /**
+   * Comma-separated list of tag names to color by (e.g., "critical, warning, info").
+   * When set, the annotation color is determined by the first matching tag.
+   */
+  colorByTags?: string;
+  /**
    * Name of annotation.
    */
   name: string;

--- a/pkg/kinds/dashboard/dashboard_spec_gen.go
+++ b/pkg/kinds/dashboard/dashboard_spec_gen.go
@@ -960,6 +960,9 @@ type AnnotationQuery struct {
 	Hide *bool `json:"hide,omitempty"`
 	// Color to use for the annotation event markers
 	IconColor string `json:"iconColor"`
+	// Comma-separated list of tag names to color by (e.g., "critical, warning, info").
+	// When set, the annotation color is determined by the first matching tag.
+	ColorByTags *string `json:"colorByTags,omitempty"`
 	// Filters to apply when fetching annotations
 	Filter *AnnotationPanelFilter `json:"filter,omitempty"`
 	// TODO.. this should just be a normal query target

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.test.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.test.tsx
@@ -102,6 +102,7 @@ describe('AnnotationSettingsEdit', () => {
     const enableToggle = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.enable);
     const hideToggle = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.hide);
     const iconColorToggle = getByTestId(selectors.components.ColorSwatch.name);
+    const colorByTagsInput = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.colorByTags);
     const panelSelect = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.showInLabel);
     const deleteAnno = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.delete);
     const apply = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.apply);
@@ -111,6 +112,7 @@ describe('AnnotationSettingsEdit', () => {
     expect(enableToggle).toBeInTheDocument();
     expect(hideToggle).toBeInTheDocument();
     expect(iconColorToggle).toBeInTheDocument();
+    expect(colorByTagsInput).toBeInTheDocument();
     expect(panelSelect).toBeInTheDocument();
     expect(deleteAnno).toBeInTheDocument();
     expect(apply).toBeInTheDocument();
@@ -165,6 +167,19 @@ describe('AnnotationSettingsEdit', () => {
 
     expect(mockOnUpdate).toHaveBeenCalledTimes(1);
     expect(mockOnUpdate).toHaveBeenCalledWith(annoArg, 1);
+  });
+
+  it('should update annotation colorByTags on change', async () => {
+    const {
+      renderer: { getByTestId },
+      user,
+    } = await setup();
+
+    const colorByTagsInput = getByTestId(selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.colorByTags);
+
+    await user.type(colorByTagsInput, 'critical, warning, info');
+
+    expect(mockOnUpdate).toHaveBeenCalled();
   });
 
   it('should set annotation filter', async () => {

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
@@ -240,6 +240,26 @@ export const AnnotationSettingsEdit = ({ annotation, editIndex, panels, onUpdate
           </Stack>
         </Field>
         <Field
+          noMargin
+          label={t('dashboard-scene.annotation-settings-edit.label-color-by-tags', 'Color by tags')}
+          description={t(
+            'dashboard-scene.annotation-settings-edit.description-color-by-tags',
+            'Comma-separated list of tag names (e.g., "critical, warning, info"). Annotations with matching tags will be colored by that tag value.'
+          )}
+        >
+          <Input
+            name="colorByTags"
+            id="colorByTags"
+            value={annotation.colorByTags ?? ''}
+            onChange={onChange}
+            placeholder={t(
+              'dashboard-scene.annotation-settings-edit.placeholder-color-by-tags',
+              'e.g., critical, warning, info'
+            )}
+            data-testid={selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.colorByTags}
+          />
+        </Field>
+        <Field
           label={t('dashboard-scene.annotation-settings-edit.label-show-in', 'Show in')}
           data-testid={selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.showInLabel}
         >

--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -224,6 +224,26 @@ export const AnnotationSettingsEdit = ({ editIdx, dashboard }: Props) => {
           </Stack>
         </Field>
         <Field
+          noMargin
+          label={t('dashboard.annotation-settings-edit.label-color-by-tags', 'Color by tags')}
+          description={t(
+            'dashboard.annotation-settings-edit.description-color-by-tags',
+            'Comma-separated list of tag names (e.g., "critical, warning, info"). Annotations with matching tags will be colored by that tag value.'
+          )}
+        >
+          <Input
+            name="colorByTags"
+            id="colorByTags"
+            value={annotation.colorByTags ?? ''}
+            onChange={onChange}
+            placeholder={t(
+              'dashboard.annotation-settings-edit.placeholder-color-by-tags',
+              'e.g., critical, warning, info'
+            )}
+            data-testid={selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.colorByTags}
+          />
+        </Field>
+        <Field
           label={t('dashboard.annotation-settings-edit.label-show-in', 'Show in')}
           data-testid={selectors.pages.Dashboard.Settings.Annotations.NewAnnotation.showInLabel}
         >

--- a/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
+++ b/public/app/features/query/state/DashboardQueryRunner/utils.test.ts
@@ -1,0 +1,187 @@
+import { AnnotationEvent, AnnotationQuery } from '@grafana/data';
+import { getTagColorsFromName } from '@grafana/ui';
+
+import { findMatchingTag, translateQueryResult } from './utils';
+
+describe('findMatchingTag', () => {
+  it('should find matching tag (case-insensitive)', () => {
+    const eventTags = ['env-prod', 'Critical', 'team-backend'];
+    expect(findMatchingTag(eventTags, 'critical, warning, info')).toBe('Critical');
+  });
+
+  it('should respect priority order from colorByTags (not event tag order)', () => {
+    const eventTags = ['warning', 'critical'];
+    expect(findMatchingTag(eventTags, 'critical, warning')).toBe('critical');
+  });
+
+  it('should return highest priority tag when event has multiple matches', () => {
+    const eventTags = ['info', 'warning', 'critical'];
+    expect(findMatchingTag(eventTags, 'critical, warning, info')).toBe('critical');
+  });
+
+  it('should return lower priority tag when higher priority not present', () => {
+    const eventTags = ['info', 'warning'];
+    expect(findMatchingTag(eventTags, 'critical, warning, info')).toBe('warning');
+  });
+
+  it('should return undefined when no match', () => {
+    const eventTags = ['env-prod', 'team-backend'];
+    expect(findMatchingTag(eventTags, 'critical, warning, info')).toBeUndefined();
+  });
+
+  it('should handle whitespace in colorByTags', () => {
+    const eventTags = ['critical'];
+    expect(findMatchingTag(eventTags, '  critical ,  warning  ,  info  ')).toBe('critical');
+  });
+
+  it('should return undefined for empty event tags', () => {
+    expect(findMatchingTag([], 'critical, warning')).toBeUndefined();
+  });
+});
+
+describe('translateQueryResult', () => {
+  describe('colorByTags', () => {
+    it('should use matching tag color when colorByTags matches', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ tags: ['env-prod', 'critical'], time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      const expectedColor = getTagColorsFromName('critical').color;
+      expect(translated[0].color).toBe(expectedColor);
+    });
+
+    it('should use different colors for different matching tags', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+
+      const results1 = translateQueryResult(annotation, [{ tags: ['critical'], time: 1 }]);
+      const results2 = translateQueryResult(annotation, [{ tags: ['warning'], time: 2 }]);
+
+      expect(results1[0].color).not.toBe(results2[0].color);
+    });
+
+    it('should give same color for same matching tags', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+
+      const results1 = translateQueryResult(annotation, [{ tags: ['critical', 'env-prod'], time: 1 }]);
+      const results2 = translateQueryResult(annotation, [{ tags: ['team-backend', 'critical'], time: 2 }]);
+
+      expect(results1[0].color).toBe(results2[0].color);
+    });
+
+    it('should fallback to iconColor when no matching tag', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ tags: ['env-prod', 'team-backend'], time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].color).toBeDefined();
+      expect(translated[0].color).not.toBe(getTagColorsFromName('critical').color);
+    });
+
+    it('should fallback to iconColor when no tags', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].color).toBeDefined();
+    });
+
+    it('should use iconColor when colorByTags is not set', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'red',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ tags: ['critical'], time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].color).not.toBe(getTagColorsFromName('critical').color);
+    });
+
+    it('should use iconColor when colorByTags is empty string', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'red',
+        colorByTags: '',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ tags: ['critical'], time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].color).not.toBe(getTagColorsFromName('critical').color);
+    });
+
+    it('should still override with alert state colors', () => {
+      const annotation = {
+        name: 'test',
+        iconColor: 'blue',
+        colorByTags: 'critical, warning, info',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ tags: ['critical'], time: 1, newState: 'alerting' }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].color).toBe('red');
+    });
+  });
+
+  describe('basic functionality', () => {
+    it('should set source, type, and isRegion', () => {
+      const annotation = {
+        name: 'test-annotation',
+        iconColor: 'blue',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ time: 1, timeEnd: 2 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].source).toBe(annotation);
+      expect(translated[0].type).toBe('test-annotation');
+      expect(translated[0].isRegion).toBe(true);
+    });
+
+    it('should set isRegion to false when no timeEnd', () => {
+      const annotation = {
+        name: 'test-annotation',
+        iconColor: 'blue',
+        enable: true,
+      } as AnnotationQuery;
+      const results: AnnotationEvent[] = [{ time: 1 }];
+
+      const translated = translateQueryResult(annotation, results);
+
+      expect(translated[0].isRegion).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
**What is this feature?**

This feature allows users to specify a comma-separated list of tag names (e.g., `critical, warning, info`) that determine annotation colors. When an annotation has a matching tag, it's colored by that tag value. The order defines priority - if an annotation has multiple matching tags, the first one in the list wins.

**Why do we need this feature?**

Feature request in #12290 - Pick annotation color based on tag value

**Which issue(s) does this PR fix?**:

Fixes #12290 - Pick annotation color based on tag value

## Changes

### Schema
- Added `colorByTags?: string` to `AnnotationQuery` interface (TypeScript)
- Added `ColorByTags *string` to Go schema

### Core Logic
- Added `findMatchingTag()` function with priority-based matching
- Updated `translateQueryResult()` to color annotations by matching tags
- Falls back to `iconColor` if no matching tag is found

### UI
- Added "Color by tags" input field in annotation settings
- Placeholder: "e.g., critical, warning, info"
- Description explains the priority-based coloring behavior

### Tests
- Unit tests for `findMatchingTag()` priority logic
- Unit tests for `translateQueryResult()` colorByTags behavior  
- E2E test for the colorByTags input field
- UI component tests updated

### Demo Dashboard
- Added `devenv/dev-dashboards/annotations/color-by-tag-demo.json`
- 3 annotation queries (Critical, Warning, Info) with tag filtering
- Instructions panel explaining how to test

## How to Test

### Using the Demo Dashboard

1. Start Grafana: `make devenv sources=default`
2. Navigate to: Dashboards → gdev dashboards → Color by Tags Demo
3. Click on the time series panel to add annotations:
   - Add one with tag `critical`
   - Add one with tag `warning`
   - Add one with tag `info`
4. Use the toggles to show/hide each severity level

### Testing Priority with API

Create an annotation with multiple tags via POST request:

```bash
curl -X POST http://admin:admin@localhost:3000/api/annotations \
  -H "Content-Type: application/json" \
  -d '{
    "dashboardUID": "color-by-tag-demo",
    "time": '$(date +%s000)',
    "tags": ["critical", "warning", "info"],
    "text": "Multi-tag test annotation"
  }'
```

Or use Postman:
- **POST** `http://localhost:3000/api/annotations`
- **Auth**: Basic Auth (admin/admin)
- **Body**:
```json
{
  "dashboardUID": "color-by-tag-demo",
  "time": <current_epoch_ms>,
  "tags": ["critical", "warning", "info"],
  "text": "Multi-tag test annotation"
}
```

**Expected behavior**:
- With all toggles ON: Critical color shows (highest priority, rendered last)
- Toggle Critical OFF: Warning color shows
- Toggle Warning OFF: Info color shows

## Screenshots

<img width="1432" height="767" alt="annotations all" src="https://github.com/user-attachments/assets/ca54d18f-ab8e-4ce4-b0a0-19992621588e" />
<img width="1578" height="788" alt="annotations no critical" src="https://github.com/user-attachments/assets/e3c3a660-62e6-4983-bc8e-f35216dc41c8" />
<img width="1576" height="791" alt="annotations warning only" src="https://github.com/user-attachments/assets/ec829443-04f7-4e6e-9272-5b945efd6126" />

https://github.com/user-attachments/assets/c92556eb-1241-4329-8718-655171a0b121



Please check that:
- [x] It works as expected from a user's perspective.
- [N/A] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
