### PR TITLE
Docs: Add dashboard dto information

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -632,7 +632,9 @@ Status Codes:
 
 `GET /apis/dashboard.grafana.app/v1beta1/namespaces/:namespace/dashboards/:uid/dto`
 
-Retrieves a dashboard with additional access information, including if it is a public dashboard and the request users permissions on the dashboard. The `GET` response will include an additional `access` section with this data.
+Retrieves a dashboard with additional access information.
+
+The `GET` response includes an additional `access` section with data such as if it's a public dashboard, or the request user permissions. 
 
 ## List Dashboards
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -634,7 +634,7 @@ Status Codes:
 
 Retrieves a dashboard with additional access information.
 
-The `GET` response includes an additional `access` section with data such as if it's a public dashboard, or the request user permissions. 
+The `GET` response includes an additional `access` section with data such as if it's a public dashboard, or the dashboard permissions (admin, editor) of the user who made the request. 
 
 ## List Dashboards
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -628,7 +628,7 @@ Status Codes:
 - **403** – Access denied
 - **404** – Not Found
 
-### Retrieving additional access information
+### Retrieve additional access information
 
 `GET /apis/dashboard.grafana.app/v1beta1/namespaces/:namespace/dashboards/:uid/dto`
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -634,7 +634,7 @@ Status Codes:
 
 Retrieves a dashboard with additional access information.
 
-The `GET` response includes an additional `access` section with data such as if it's a public dashboard, or the dashboard permissions (admin, editor) of the user who made the request. 
+The `GET` response includes an additional `access` section with data such as if it's a public dashboard, or the dashboard permissions (admin, editor) of the user who made the request.
 
 ## List Dashboards
 

--- a/docs/sources/developer-resources/api-reference/http-api/dashboard.md
+++ b/docs/sources/developer-resources/api-reference/http-api/dashboard.md
@@ -628,6 +628,12 @@ Status Codes:
 - **403** – Access denied
 - **404** – Not Found
 
+### Retrieving additional access information
+
+`GET /apis/dashboard.grafana.app/v1beta1/namespaces/:namespace/dashboards/:uid/dto`
+
+Retrieves a dashboard with additional access information, including if it is a public dashboard and the request users permissions on the dashboard. The `GET` response will include an additional `access` section with this data.
+
 ## List Dashboards
 
 `GET /apis/dashboard.grafana.app/v1beta1/namespaces/:namespace/dashboards`


### PR DESCRIPTION
This PR adds additional information around the `/dto` endpoint for dashboards

Fixes https://github.com/grafana/support-escalations/issues/19506