### PR TITLE
AuthZ: Set span errors

### DIFF
--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -9,6 +9,7 @@ import (
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
@@ -25,6 +26,8 @@ func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.C
 
 	res, err := s.check(ctx, r)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform check request", "error", err, "namespace", r.GetNamespace())
 		return nil, errors.New("failed to perform check request")
 	}

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -13,6 +13,7 @@ import (
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
@@ -28,6 +29,8 @@ func (s *Server) List(ctx context.Context, r *authzv1.ListRequest) (*authzv1.Lis
 
 	res, err := s.list(ctx, r)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform list request", "error", err, "namespace", r.GetNamespace())
 		return nil, errors.New("failed to perform list request")
 	}

--- a/pkg/services/authz/zanzana/server/server_mutate.go
+++ b/pkg/services/authz/zanzana/server/server_mutate.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"go.opentelemetry.io/otel/codes"
 )
 
 type OperationGroup string
@@ -27,6 +28,8 @@ func (s *Server) Mutate(ctx context.Context, req *authzextv1.MutateRequest) (*au
 
 	res, err := s.mutate(ctx, req)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform mutate request", "error", err, "namespace", req.GetNamespace())
 		return nil, errors.New("failed to perform mutate request")
 	}

--- a/pkg/services/authz/zanzana/server/server_query.go
+++ b/pkg/services/authz/zanzana/server/server_query.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"go.opentelemetry.io/otel/codes"
 )
 
 func (s *Server) Query(ctx context.Context, req *authzextv1.QueryRequest) (*authzextv1.QueryResponse, error) {
@@ -20,6 +21,8 @@ func (s *Server) Query(ctx context.Context, req *authzextv1.QueryRequest) (*auth
 
 	res, err := s.query(ctx, req)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform query request", "error", err, "namespace", req.GetNamespace())
 		return nil, errors.New("failed to perform query request")
 	}

--- a/pkg/services/authz/zanzana/server/server_read.go
+++ b/pkg/services/authz/zanzana/server/server_read.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"go.opentelemetry.io/otel/codes"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
@@ -22,6 +23,8 @@ func (s *Server) Read(ctx context.Context, req *authzextv1.ReadRequest) (*authze
 
 	res, err := s.read(ctx, req)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform read request", "error", err, "namespace", req.GetNamespace())
 		return nil, errors.New("failed to perform read request")
 	}

--- a/pkg/services/authz/zanzana/server/server_write.go
+++ b/pkg/services/authz/zanzana/server/server_write.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"go.opentelemetry.io/otel/codes"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
@@ -22,6 +23,8 @@ func (s *Server) Write(ctx context.Context, req *authzextv1.WriteRequest) (*auth
 
 	res, err := s.write(ctx, req)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		s.logger.Error("failed to perform write request", "error", err, "namespace", req.GetNamespace())
 		return nil, errors.New("failed to perform write request")
 	}


### PR DESCRIPTION
This PR adds the errors in the authZ service as a part of the span. It also sets the status of the spans as an error.

Relates to https://github.com/grafana/identity-access-team/issues/1822