### PR TITLE
NPM: Fix e2e-selectors change detection

### DIFF
--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -60,7 +60,7 @@ if (( ${#failed_packages[@]} > 0 )); then
 fi
 
 # Check if any files in packages/grafana-e2e-selectors were changed. If so, add a 'modified' tag to the package
-CHANGES_COUNT=$(git diff HEAD~1..HEAD --name-only -- packages/grafana-e2e-selectors | awk 'END{print NR}')
+CHANGES_COUNT=$(git show --name-only --format= HEAD -- packages/grafana-e2e-selectors | awk 'END{print NR}')
 if (( CHANGES_COUNT > 0 )); then
     # Wait a little bit to allow the package to be published to the registry
     sleep 5s


### PR DESCRIPTION
**What is this feature?**

The script that detects changes to the grafana-e2e-selectors package was broken when the NPM publishing workflow was refactored to run as a separate dispatched workflow. The issue occurred because the workflow checks out a specific commit SHA (detached HEAD state), making `git diff HEAD~1..HEAD` compare the wrong commits. This fix uses `git show HEAD` instead which should correctly shows files changed in the current commit regardless of HEAD state.

**Why do we need this feature?**

Only if the commit to main _actually changes_ the e2e-selectors package we want to update the `modified` dist-tag. plugin-e2e uses Renovate to follow the `modified` tag to be in synch with latest Grafana.

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
