### PR TITLE
`grafana-iam`: Prevent crashloops of the standalone IAM server

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -219,7 +219,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	}
 
 	storage[teamResource.StoragePath("members")] = team.NewLegacyTeamMemberREST(b.store)
-	storage[teamResource.StoragePath("groups")] = b.teamGroupsHandler
+	// storage[teamResource.StoragePath("groups")] = b.teamGroupsHandler
 
 	teamBindingResource := iamv0.TeamBindingResourceInfo
 	teamBindingUniStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, teamBindingResource, opts.OptsGetter)

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -219,7 +219,9 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	}
 
 	storage[teamResource.StoragePath("members")] = team.NewLegacyTeamMemberREST(b.store)
-	// storage[teamResource.StoragePath("groups")] = b.teamGroupsHandler
+	if b.teamGroupsHandler != nil {
+		storage[teamResource.StoragePath("groups")] = b.teamGroupsHandler
+	}
 
 	teamBindingResource := iamv0.TeamBindingResourceInfo
 	teamBindingUniStore, err := grafanaregistry.NewRegistryStore(opts.Scheme, teamBindingResource, opts.OptsGetter)


### PR DESCRIPTION
The standalone IAM app is crashlooping because it misses the teamGroupsHandler