### PR TITLE
E2E Selectors: Fix readme typo

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/README.md
+++ b/packages/grafana-e2e-selectors/src/selectors/README.md
@@ -16,7 +16,7 @@ const components = {
 
 A few things to keep in mind:
 
-- Strive to use e2e selector for all components in grafana/ui.
+- Strive to use e2e selectors for all components in grafana/ui.
 - Don't ever delete selectors. Even though a selector may not be used in the Grafana repository, it can still be used in external plugins.
 - Only create new selector in case you're creating a new piece of UI. If you're changing an existing piece of UI that already has a selector defined, you need to keep using that selector. Otherwise you might break plugin end-to-end tests.
 - Prefer using string selectors in favour of function selectors. The purpose of the selectors is to provide a canonical way to select elements.


### PR DESCRIPTION
**What is this feature?**

Fix a typo in the readme. Also want to see if this change triggers a change of the `modified` dist-tag (see https://github.com/grafana/grafana/pull/114471 for reference). 

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
