### PR TITLE
MetricFindValue: add missing "properties" field to the TS interface

### DIFF
--- a/packages/grafana-data/src/types/datasource.ts
+++ b/packages/grafana-data/src/types/datasource.ts
@@ -643,6 +643,7 @@ export interface MetricFindValue {
   value?: string | number;
   group?: string;
   expandable?: boolean;
+  properties?: Record<string, string>;
 }
 
 export interface DataSourceGetDrilldownsApplicabilityOptions<TQuery extends DataQuery = DataQuery> {


### PR DESCRIPTION
**What is this feature?**

This PR adds an optional `properties` field to the `MetricFindValue` interface in `@grafana/data`.

After merging this PR, we should update Scenes. See https://github.com/grafana/scenes/pull/1305

**Why do we need this feature?**

The support for handling multiple properties for variable values was introduced to the Scenes library in [grafana/scenes#1236](https://github.com/grafana/scenes/pull/1236). 

By exposing this property in `MetricFindValue`, we allow data source developers to return additional metadata (as a key-value map) for each variable option in a "Query" variable.

**Who is this feature for?**

Data source developers

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-org/issues/555

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
