### PR TITLE
TimeRange: Avoid x-axis pan jump caused by data loading latency

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -29,7 +29,7 @@ const cursorDefaults: Cursor = {
 type PrepData = (frames: DataFrame[]) => AlignedData | FacetedData;
 type PreDataStacked = (frames: DataFrame[], stackingGroups: StackingGroup[]) => AlignedData | FacetedData;
 
-type PlotState = { isPanning: false } | { isPanning: true; min: number; max: number; waitingForSync?: boolean };
+type PlotState = { isPanning: false } | { isPanning: true; min: number; max: number; isTimeRangePending?: boolean };
 
 export class UPlotConfigBuilder {
   readonly uid = Math.random().toString(36).slice(2);

--- a/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotConfigBuilder.ts
@@ -29,7 +29,7 @@ const cursorDefaults: Cursor = {
 type PrepData = (frames: DataFrame[]) => AlignedData | FacetedData;
 type PreDataStacked = (frames: DataFrame[], stackingGroups: StackingGroup[]) => AlignedData | FacetedData;
 
-type PlotState = { isPanning: false } | { isPanning: true; min: number; max: number };
+type PlotState = { isPanning: false } | { isPanning: true; min: number; max: number; waitingForSync?: boolean };
 
 export class UPlotConfigBuilder {
   readonly uid = Math.random().toString(36).slice(2);

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -137,7 +137,7 @@ describe('XAxisInteractionAreaPlugin', () => {
       expect(mockQueryZoom).not.toHaveBeenCalled();
     });
 
-    it('should set isPanning state during drag and clear on mouseup', () => {
+    it('should set isPanning state during drag and mark waitingForSync on mouseup', () => {
       setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
 
       xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
@@ -152,6 +152,20 @@ describe('XAxisInteractionAreaPlugin', () => {
       });
 
       document.dispatchEvent(new MouseEvent('mouseup', { clientX: 350, bubbles: true }));
+
+      expect(mockConfigBuilder.setState).toHaveBeenCalledWith({
+        isPanning: true,
+        min: expectedRange.from,
+        max: expectedRange.to,
+        waitingForSync: true,
+      });
+    });
+
+    it('should clear isPanning state immediately for small drags below threshold', () => {
+      setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
+
+      xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mouseup', { clientX: 402, bubbles: true }));
 
       expect(mockConfigBuilder.setState).toHaveBeenCalledWith({ isPanning: false });
     });

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -137,7 +137,7 @@ describe('XAxisInteractionAreaPlugin', () => {
       expect(mockQueryZoom).not.toHaveBeenCalled();
     });
 
-    it('should set isPanning state during drag and mark waitingForSync on mouseup', () => {
+    it('should set isPanning state during drag and mark isTimeRangePending on mouseup', () => {
       setupXAxisPan(asUPlot(mockUPlot), asConfigBuilder(mockConfigBuilder), mockQueryZoom);
 
       xAxisElement.dispatchEvent(new MouseEvent('mousedown', { clientX: 400, bubbles: true }));
@@ -157,7 +157,7 @@ describe('XAxisInteractionAreaPlugin', () => {
         isPanning: true,
         min: expectedRange.from,
         max: expectedRange.to,
-        waitingForSync: true,
+        isTimeRangePending: true,
       });
     });
 

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
@@ -96,11 +96,14 @@ export const setupXAxisPan = (
 
       xAxisEl.style.cursor = 'grab';
 
-      config.setState({ isPanning: false });
+      const isSignificantDrag = Math.abs(dragPixels) >= MIN_PAN_DIST;
 
-      if (Math.abs(dragPixels) >= MIN_PAN_DIST) {
+      if (isSignificantDrag) {
         const newRange = calculatePanRange(startMin, startMax, dragPixels, u.bbox.width);
+        config.setState({ isPanning: true, min: newRange.from, max: newRange.to, waitingForSync: true });
         queryZoom(newRange);
+      } else {
+        config.setState({ isPanning: false });
       }
 
       document.removeEventListener('mousemove', onMove);

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
@@ -100,7 +100,7 @@ export const setupXAxisPan = (
 
       if (isSignificantDrag) {
         const newRange = calculatePanRange(startMin, startMax, dragPixels, u.bbox.width);
-        config.setState({ isPanning: true, min: newRange.from, max: newRange.to, waitingForSync: true });
+        config.setState({ isPanning: true, min: newRange.from, max: newRange.to, isTimeRangePending: true });
         queryZoom(newRange);
       } else {
         config.setState({ isPanning: false });

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -138,7 +138,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       range: () => {
         const state = builder.getState();
         if (state.isPanning) {
-          if (state.waitingForSync) {
+          if (state.isTimeRangePending) {
             const timeRange = getTimeRange();
             const propsFrom = timeRange.from.valueOf();
             const propsTo = timeRange.to.valueOf();
@@ -146,9 +146,9 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
             const MIN_TIMESPAN_MS = 1;
             const fromMatches = Math.abs(propsFrom - state.min) <= MIN_TIMESPAN_MS;
             const toMatches = Math.abs(propsTo - state.max) <= MIN_TIMESPAN_MS;
-            const timeRangeHasSynced = fromMatches && toMatches;
+            const timeRangeHasUpdated = fromMatches && toMatches;
 
-            if (timeRangeHasSynced) {
+            if (timeRangeHasUpdated) {
               builder.setState({ isPanning: false });
               return [propsFrom, propsTo];
             }

--- a/public/app/core/components/TimeSeries/utils.ts
+++ b/public/app/core/components/TimeSeries/utils.ts
@@ -138,10 +138,26 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn = ({
       range: () => {
         const state = builder.getState();
         if (state.isPanning) {
+          if (state.waitingForSync) {
+            const timeRange = getTimeRange();
+            const propsFrom = timeRange.from.valueOf();
+            const propsTo = timeRange.to.valueOf();
+
+            const MIN_TIMESPAN_MS = 1;
+            const fromMatches = Math.abs(propsFrom - state.min) <= MIN_TIMESPAN_MS;
+            const toMatches = Math.abs(propsTo - state.max) <= MIN_TIMESPAN_MS;
+            const timeRangeHasSynced = fromMatches && toMatches;
+
+            if (timeRangeHasSynced) {
+              builder.setState({ isPanning: false });
+              return [propsFrom, propsTo];
+            }
+          }
+
           return [state.min, state.max];
         }
-        const r = getTimeRange();
-        return [r.from.valueOf(), r.to.valueOf()];
+        const timeRange = getTimeRange();
+        return [timeRange.from.valueOf(), timeRange.to.valueOf()];
       },
     });
 

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -159,7 +159,7 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<UPlotConfigOptions> = (
     range: (u) => {
       const state = builder.getState();
       if (state.isPanning) {
-        if (state.waitingForSync) {
+        if (state.isTimeRangePending) {
           const propsRange = coreConfig.xRange(u);
           const propsFrom = propsRange[0];
           const propsTo = propsRange[1];
@@ -168,9 +168,9 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<UPlotConfigOptions> = (
             const MIN_TIMESPAN_MS = 1;
             const fromMatches = Math.abs(propsFrom - state.min) <= MIN_TIMESPAN_MS;
             const toMatches = Math.abs(propsTo - state.max) <= MIN_TIMESPAN_MS;
-            const timeRangeHasSynced = fromMatches && toMatches;
+            const timeRangeHasUpdated = fromMatches && toMatches;
 
-            if (timeRangeHasSynced) {
+            if (timeRangeHasUpdated) {
               builder.setState({ isPanning: false });
               return propsRange;
             }

--- a/public/app/core/components/TimelineChart/utils.ts
+++ b/public/app/core/components/TimelineChart/utils.ts
@@ -159,6 +159,24 @@ export const preparePlotConfigBuilder: UPlotConfigPrepFn<UPlotConfigOptions> = (
     range: (u) => {
       const state = builder.getState();
       if (state.isPanning) {
+        if (state.waitingForSync) {
+          const propsRange = coreConfig.xRange(u);
+          const propsFrom = propsRange[0];
+          const propsTo = propsRange[1];
+
+          if (propsFrom != null && propsTo != null) {
+            const MIN_TIMESPAN_MS = 1;
+            const fromMatches = Math.abs(propsFrom - state.min) <= MIN_TIMESPAN_MS;
+            const toMatches = Math.abs(propsTo - state.max) <= MIN_TIMESPAN_MS;
+            const timeRangeHasSynced = fromMatches && toMatches;
+
+            if (timeRangeHasSynced) {
+              builder.setState({ isPanning: false });
+              return propsRange;
+            }
+          }
+        }
+
         return [state.min, state.max];
       }
       return coreConfig.xRange(u);


### PR DESCRIPTION
**What is this feature?**

This changes the behaviour of time range panning in the panel where the x-axis was dragged, to avoid the x-axis jumping back and forth while waiting for slower data (or large datasets) to load.

### Before 

❌ The x-axis jumps back and forth with slow loading data:

https://github.com/user-attachments/assets/af110ef5-d495-431d-b9e1-abab054bdb38

### After

✅ The x-axis stays where you drag it to in the panel, while show data is loaded:

https://github.com/user-attachments/assets/7ae24211-996d-4154-af2b-bdb634da8e6b


**Why do we need this feature?**

To make the new experimental x-axis panning feature work more intuitively with large/slow datasets.

**Who is this feature for?**

Anyone with the experimental `timeRangePan` feature flag turned on for now, eventually all Grafana users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114483

**Special notes for your reviewer:**

- 🎏 Make sure you have the `timeRangePan` flag toggled on to try it out.
- I had to artificially throttle my connection in browser dev tools to make the original bug obvious.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
-  `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
