### PR TITLE
Notifications: Prevent triggering duplicate notifications

### DIFF
--- a/packages/grafana-data/src/events/EventBus.test.ts
+++ b/packages/grafana-data/src/events/EventBus.test.ts
@@ -91,8 +91,10 @@ describe('EventBus', () => {
     it('Supports legacy events', () => {
       const bus = new EventBusSrv();
       const events: LegacyEventPayload[] = [];
-      const handler = (event: LegacyEventPayload) => {
-        events.push(event);
+      const handler = (event?: LegacyEventPayload) => {
+        if (event) {
+          events.push(event);
+        }
       };
 
       bus.on(legacyEvent, handler);
@@ -111,7 +113,9 @@ describe('EventBus', () => {
       const newEvents: AlertSuccessEvent[] = [];
 
       bus.on(legacyEvent, (event) => {
-        legacyEvents.push(event);
+        if (event) {
+          legacyEvents.push(event);
+        }
       });
 
       bus.subscribe(AlertSuccessEvent, (event) => {

--- a/packages/grafana-data/src/events/types.ts
+++ b/packages/grafana-data/src/events/types.ts
@@ -133,12 +133,12 @@ export interface LegacyEmitter {
   /**
    * @deprecated use $on
    */
-  off<T>(event: AppEvent<T> | string, handler: (payload?: T) => void): void;
+  off<T>(event: AppEvent<T> | string, handler: LegacyEventHandler<T>): void;
 }
 
 /** @public */
 export interface LegacyEventHandler<T> {
-  (payload: T): void;
+  (payload?: T): void;
   wrapper?: (event: BusEvent) => void;
 }
 

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -43,32 +43,28 @@ export function AppNotificationList() {
       if (isKioskDashboard || !payload) {
         return;
       }
-      const [title, text, traceId] = payload;
-      dispatch(notifyApp(createErrorNotification(title, text, traceId)));
+      dispatch(notifyApp(createErrorNotification(...payload)));
     };
 
     const handleWarningAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
-      const [title, text, traceId] = payload;
-      dispatch(notifyApp(createWarningNotification(title, text, traceId)));
+      dispatch(notifyApp(createWarningNotification(...payload)));
     };
 
     const handleSuccessAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
-      const [title, text, traceId] = payload;
-      dispatch(notifyApp(createSuccessNotification(title, text, traceId)));
+      dispatch(notifyApp(createSuccessNotification(...payload)));
     };
 
     const handleInfoAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
-      const [title, text, traceId] = payload;
-      dispatch(notifyApp(createInfoNotification(title, text, traceId)));
+      dispatch(notifyApp(createInfoNotification(...payload)));
     };
 
     appEvents.on(AppEvents.alertWarning, handleWarningAlert);

--- a/public/app/core/components/AppNotifications/AppNotificationList.tsx
+++ b/public/app/core/components/AppNotifications/AppNotificationList.tsx
@@ -47,7 +47,7 @@ export function AppNotificationList() {
       dispatch(notifyApp(createErrorNotification(title, text, traceId)));
     };
 
-    const handleWarning = (payload?: AlertPayload) => {
+    const handleWarningAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
@@ -55,7 +55,7 @@ export function AppNotificationList() {
       dispatch(notifyApp(createWarningNotification(title, text, traceId)));
     };
 
-    const handleSuccess = (payload?: AlertPayload) => {
+    const handleSuccessAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
@@ -63,7 +63,7 @@ export function AppNotificationList() {
       dispatch(notifyApp(createSuccessNotification(title, text, traceId)));
     };
 
-    const handleInfo = (payload?: AlertPayload) => {
+    const handleInfoAlert = (payload?: AlertPayload) => {
       if (!payload) {
         return;
       }
@@ -71,17 +71,17 @@ export function AppNotificationList() {
       dispatch(notifyApp(createInfoNotification(title, text, traceId)));
     };
 
-    appEvents.on(AppEvents.alertWarning, handleWarning);
-    appEvents.on(AppEvents.alertSuccess, handleSuccess);
+    appEvents.on(AppEvents.alertWarning, handleWarningAlert);
+    appEvents.on(AppEvents.alertSuccess, handleSuccessAlert);
     appEvents.on(AppEvents.alertError, handleErrorAlert);
-    appEvents.on(AppEvents.alertInfo, handleInfo);
+    appEvents.on(AppEvents.alertInfo, handleInfoAlert);
 
     return () => {
       // Unsubscribe from events on unmount to avoid memory leaks
-      appEvents.off(AppEvents.alertWarning, handleWarning);
-      appEvents.off(AppEvents.alertSuccess, handleSuccess);
+      appEvents.off(AppEvents.alertWarning, handleWarningAlert);
+      appEvents.off(AppEvents.alertSuccess, handleSuccessAlert);
       appEvents.off(AppEvents.alertError, handleErrorAlert);
-      appEvents.off(AppEvents.alertInfo, handleInfo);
+      appEvents.off(AppEvents.alertInfo, handleInfoAlert);
     };
   }, [dispatch, chrome]);
 


### PR DESCRIPTION
## What is this feature?

This PR fixes a bug in `AppNotificationList` where event listeners were not being cleaned up and were being unnecessarily re-registered on route changes. The issue surfaced during IRM plugin development.

## Why do we need this feature?

This fix addresses several underlying problems:

- Event listeners were not being cleaned up, which could lead to memory leaks.
- Event handlers were re-registered each time the route changed, causing duplicate notifications.
- TypeScript type errors occurred due to mismatched event handler signatures.

## Who is this feature for?

This affects all Grafana users because it involves the core notification system that displays alerts, errors, warnings, and info messages across the application.

## Which issue(s) does this PR fix?

Fixes: https://github.com/orgs/grafana/projects/677/views/1?pane=issue&itemId=139797435&issue=grafana%7Cirm%7C7580

## How to reproduce the issue

1. In a Grafana Cloud account, navigate to **Alert & IRM → IRM → Integrations**, and create a new integration.
2. Navigate through several pages using internal navigation, ending on the integration created in step 1.
3. Use the **Send demo alert** button to trigger an alert and produce a success toast.

**Note:**  
Refreshing the page while on the integration view (where the **Send demo alert** button exists) results in a single toast because the event handler is not re-registered on a page refresh. This behaviour was key to discovering the underlying issue.

**Before:**

https://github.com/user-attachments/assets/35811cbf-aa09-46d0-8618-9ecb0329ad1e

**After:**

https://github.com/user-attachments/assets/1a378971-44dc-45c6-9f93-d78bedee0763

## Special notes for your reviewer

Please confirm that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A, this is a bug fix.)
- [x] Documentation updates are included where needed. If this is a notable improvement, it is added to the What’s New doc. (N/A, this is a bug fix.)

## Technical details

- Adds a cleanup function to remove event listeners on unmount.
- Uses `useRef` to track the current location without triggering effect re-runs on route changes.
- Updates handler signatures to use optional payloads compatible with `appEvents.off()`.
- Destructures tuple payloads rather than spreading them, which allows TypeScript to apply correct type narrowing.
- All event handlers are now consistently defined inside the `useEffect` block.
