### PR TITLE
Stat: Add icon support with configurable display modes

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -596,6 +596,15 @@ export enum PercentChangeColorMode {
 }
 
 /**
+ * Icon display mode for BigValue component
+ */
+export enum BigValueIconMode {
+  Hidden = 'hidden',
+  IconAndText = 'icon_and_text',
+  IconOnly = 'icon_only',
+}
+
+/**
  * TODO -- should not be table specific!
  * TODO docs
  */

--- a/packages/grafana-schema/src/common/mudball.cue
+++ b/packages/grafana-schema/src/common/mudball.cue
@@ -203,6 +203,9 @@ BigValueTextMode: "auto" | "value" | "value_and_name" | "name" | "none" @cuetsy(
 // TODO docs
 PercentChangeColorMode: "standard" | "inverted" | "same_as_value" @cuetsy(kind="enum",memberNames="Standard|Inverted|SameAsValue")
 
+// Icon display mode for BigValue component
+BigValueIconMode: "hidden" | "icon_and_text" | "icon_only" @cuetsy(kind="enum",memberNames="Hidden|IconAndText|IconOnly")
+
 // TODO -- should not be table specific!
 // TODO docs
 FieldTextAlignment: "auto" | "left" | "right" | "center" @cuetsy(kind="type")

--- a/packages/grafana-schema/src/raw/composable/stat/panelcfg/x/StatPanelCfg_types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/stat/panelcfg/x/StatPanelCfg_types.gen.ts
@@ -15,6 +15,14 @@ export const pluginVersion = "12.4.0-pre";
 export interface Options extends common.SingleStatBaseOptions {
   colorMode: common.BigValueColorMode;
   graphMode: common.BigValueGraphMode;
+  /**
+   * Icon name from Grafana icon library (panel-level default)
+   */
+  icon?: string;
+  /**
+   * How to display the icon (panel-level default)
+   */
+  iconMode?: common.BigValueIconMode;
   justifyMode: common.BigValueJustifyMode;
   percentChangeColorMode: common.PercentChangeColorMode;
   showPercentChange: boolean;
@@ -25,9 +33,21 @@ export interface Options extends common.SingleStatBaseOptions {
 export const defaultOptions: Partial<Options> = {
   colorMode: common.BigValueColorMode.Value,
   graphMode: common.BigValueGraphMode.Area,
+  iconMode: common.BigValueIconMode.Hidden,
   justifyMode: common.BigValueJustifyMode.Auto,
   percentChangeColorMode: common.PercentChangeColorMode.Standard,
   showPercentChange: false,
   textMode: common.BigValueTextMode.Auto,
   wideLayout: true,
 };
+
+export interface FieldConfig {
+  /**
+   * Icon name from Grafana icon library (per-field override)
+   */
+  icon?: string;
+  /**
+   * How to display the icon (per-field override)
+   */
+  iconMode?: common.BigValueIconMode;
+}

--- a/packages/grafana-ui/src/components/BigValue/BigValue.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValue.tsx
@@ -1,12 +1,13 @@
 import { cx } from '@emotion/css';
 import { memo, type MouseEventHandler } from 'react';
 
-import { DisplayValue, DisplayValueAlignmentFactors, FieldSparkline } from '@grafana/data';
-import { PercentChangeColorMode, VizTextDisplayOptions } from '@grafana/schema';
+import { DisplayValue, DisplayValueAlignmentFactors, FieldSparkline, IconName } from '@grafana/data';
+import { BigValueIconMode, PercentChangeColorMode, VizTextDisplayOptions } from '@grafana/schema';
 
 import { Themeable2 } from '../../types/theme';
 import { clearButtonStyles } from '../Button/Button';
 import { FormattedValueDisplay } from '../FormattedValueDisplay/FormattedValueDisplay';
+import { Icon } from '../Icon/Icon';
 
 import { buildLayout } from './BigValueLayout';
 import { PercentChange } from './PercentChange';
@@ -80,6 +81,16 @@ export interface Props extends Themeable2 {
    * Disable the wide layout for the BigValue
    */
   disableWideLayout?: boolean;
+
+  /**
+   * Icon name from Grafana icon library to display with the value
+   */
+  icon?: string;
+
+  /**
+   * How to display the icon (hidden, icon_and_text, icon_only)
+   */
+  iconMode?: BigValueIconMode;
 }
 
 /**
@@ -88,7 +99,15 @@ export interface Props extends Themeable2 {
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/plugins-bigvalue--docs
  */
 export const BigValue = memo<Props>((props) => {
-  const { onClick, className, hasLinks, theme, justifyMode = BigValueJustifyMode.Auto } = props;
+  const {
+    onClick,
+    className,
+    hasLinks,
+    theme,
+    justifyMode = BigValueJustifyMode.Auto,
+    icon,
+    iconMode = BigValueIconMode.Hidden,
+  } = props;
 
   const layout = buildLayout({ ...props, justifyMode });
   const panelStyles = layout.getPanelStyles();
@@ -100,6 +119,11 @@ export const BigValue = memo<Props>((props) => {
   const percentChangeColorMode = props.percentChangeColorMode;
   const showPercentChange = percentChange != null && !Number.isNaN(percentChange);
 
+  // Icon display logic
+  const showIcon = icon && iconMode !== BigValueIconMode.Hidden;
+  const showText = iconMode !== BigValueIconMode.IconOnly;
+  const iconStyles = showIcon ? layout.getIconStyles() : undefined;
+
   // When there is an outer data link this tooltip will override the outer native tooltip
   const tooltip = hasLinks ? undefined : textValues.tooltip;
 
@@ -107,9 +131,12 @@ export const BigValue = memo<Props>((props) => {
     return (
       <div className={className} style={panelStyles} title={tooltip}>
         <div style={valueAndTitleContainerStyles}>
-          {textValues.title && <div style={titleStyles}>{textValues.title}</div>}
-          <FormattedValueDisplay value={textValues} style={valueStyles} />
-          {showPercentChange && (
+          {showIcon && iconStyles && (
+            <Icon name={icon as IconName} style={iconStyles} />
+          )}
+          {showText && textValues.title && <div style={titleStyles}>{textValues.title}</div>}
+          {showText && <FormattedValueDisplay value={textValues} style={valueStyles} />}
+          {showText && showPercentChange && (
             <PercentChange
               percentChange={percentChange}
               styles={layout.getPercentChangeStyles(percentChange, percentChangeColorMode, valueStyles)}
@@ -130,8 +157,11 @@ export const BigValue = memo<Props>((props) => {
       title={tooltip}
     >
       <div style={valueAndTitleContainerStyles}>
-        {textValues.title && <div style={titleStyles}>{textValues.title}</div>}
-        <FormattedValueDisplay value={textValues} style={valueStyles} />
+        {showIcon && iconStyles && (
+          <Icon name={icon as IconName} style={iconStyles} />
+        )}
+        {showText && textValues.title && <div style={titleStyles}>{textValues.title}</div>}
+        {showText && <FormattedValueDisplay value={textValues} style={valueStyles} />}
       </div>
       {layout.renderChart()}
     </button>

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -175,6 +175,33 @@ export abstract class BigValueLayout {
     };
   }
 
+  getIconStyles(): CSSProperties {
+    const ICON_TO_VALUE_RATIO = 0.85;
+    const iconSize = Math.max(this.valueFontSize * ICON_TO_VALUE_RATIO, 16);
+
+    const styles: CSSProperties = {
+      width: iconSize,
+      height: iconSize,
+      marginRight: iconSize / 4,
+      flexShrink: 0,
+    };
+
+    switch (this.props.colorMode) {
+      case BigValueColorMode.Value:
+        styles.color = this.valueColor;
+        break;
+      case BigValueColorMode.Background:
+      case BigValueColorMode.BackgroundSolid:
+        styles.color = getTextColorForAlphaBackground(this.valueColor, this.props.theme.isDark);
+        break;
+      case BigValueColorMode.None:
+        styles.color = this.props.theme.colors.text.primary;
+        break;
+    }
+
+    return styles;
+  }
+
   getValueAndTitleContainerStyles() {
     const styles: CSSProperties = {
       display: 'flex',

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -11,11 +11,11 @@ import {
   PanelProps,
 } from '@grafana/data';
 import { findNumericFieldMinMax } from '@grafana/data/internal';
-import { BigValueTextMode, BigValueGraphMode } from '@grafana/schema';
+import { BigValueGraphMode, BigValueIconMode, BigValueTextMode } from '@grafana/schema';
 import { BigValue, DataLinksContextMenu, useTheme2, VizRepeater, VizRepeaterRenderValueProps } from '@grafana/ui';
 import { DataLinksContextMenuApi } from '@grafana/ui/internal';
 
-import { Options } from './panelcfg.gen';
+import { FieldConfig, Options } from './panelcfg.gen';
 
 export const StatPanel = memo(
   ({
@@ -53,6 +53,15 @@ export const StatPanel = memo(
           sparkline.timeRange = timeRange;
         }
 
+        // Extract icon config from custom field config (field-level takes precedence)
+        const customConfig = value.field?.custom as FieldConfig | undefined;
+        const fieldIcon = customConfig?.icon;
+        const fieldIconMode = customConfig?.iconMode;
+
+        // Field config takes precedence over panel options
+        const icon = fieldIcon || options.icon || '';
+        const iconMode = fieldIconMode ?? options.iconMode ?? BigValueIconMode.Hidden;
+
         return (
           <BigValue
             value={value.display}
@@ -71,6 +80,8 @@ export const StatPanel = memo(
             className={targetClassName}
             disableWideLayout={!options.wideLayout}
             percentChangeColorMode={options.percentChangeColorMode}
+            icon={icon}
+            iconMode={iconMode}
           />
         );
       },

--- a/public/app/plugins/panel/stat/module.tsx
+++ b/public/app/plugins/panel/stat/module.tsx
@@ -3,19 +3,20 @@ import { t } from '@grafana/i18n';
 import {
   BigValueColorMode,
   BigValueGraphMode,
+  BigValueIconMode,
   BigValueJustifyMode,
   BigValueTextMode,
   PercentChangeColorMode,
 } from '@grafana/schema';
-import { commonOptionsBuilder, sharedSingleStatMigrationHandler } from '@grafana/ui';
+import { commonOptionsBuilder, getAvailableIcons, sharedSingleStatMigrationHandler } from '@grafana/ui';
 
 import { statPanelChangedHandler } from './StatMigrations';
 import { StatPanel } from './StatPanel';
 import { addStandardDataReduceOptions, addOrientationOption } from './common';
-import { defaultOptions, Options } from './panelcfg.gen';
+import { defaultOptions, FieldConfig, Options } from './panelcfg.gen';
 import { StatSuggestionsSupplier } from './suggestions';
 
-export const plugin = new PanelPlugin<Options>(StatPanel)
+export const plugin = new PanelPlugin<Options, FieldConfig>(StatPanel)
   .useFieldConfig()
   .setPanelOptions((builder) => {
     const mainCategory = [t('stat.category-stat-styles', 'Stat styles')];
@@ -133,6 +134,41 @@ export const plugin = new PanelPlugin<Options>(StatPanel)
           ],
         },
         showIf: (config) => config.showPercentChange,
+      });
+
+    // Panel-level icon options (defaults)
+    const iconCategory = [t('stat.category-icon', 'Icon')];
+    builder
+      .addSelect({
+        path: 'icon',
+        name: t('stat.name-icon', 'Icon'),
+        description: t('stat.description-icon', 'Default icon to display (can be overridden per field)'),
+        category: iconCategory,
+        settings: {
+          options: [
+            { value: '', label: t('stat.icon-options.label-none', 'None') },
+            ...getAvailableIcons().map((icon) => ({ value: icon, label: icon })),
+          ],
+          allowCustomValue: false,
+        },
+        defaultValue: '',
+      })
+      .addSelect({
+        path: 'iconMode',
+        name: t('stat.name-icon-mode', 'Icon display mode'),
+        description: t('stat.description-icon-mode', 'How to display the icon (can be overridden per field)'),
+        category: iconCategory,
+        settings: {
+          options: [
+            { value: BigValueIconMode.Hidden, label: t('stat.icon-mode-options.label-hidden', 'Hidden') },
+            {
+              value: BigValueIconMode.IconAndText,
+              label: t('stat.icon-mode-options.label-icon-and-text', 'Icon and text'),
+            },
+            { value: BigValueIconMode.IconOnly, label: t('stat.icon-mode-options.label-icon-only', 'Icon only') },
+          ],
+        },
+        defaultValue: defaultOptions.iconMode,
       });
   })
   .setNoPadding()

--- a/public/app/plugins/panel/stat/panelcfg.cue
+++ b/public/app/plugins/panel/stat/panelcfg.cue
@@ -34,6 +34,17 @@ composableKinds: PanelCfg: {
 					wideLayout:             bool | *true
 					showPercentChange:      bool | *false
 					percentChangeColorMode: common.PercentChangeColorMode & (*"standard" | _)
+					// Icon name from Grafana icon library (panel-level default)
+					icon?:                  string
+					// How to display the icon (panel-level default)
+					iconMode?:              common.BigValueIconMode & (*"hidden" | _)
+				} @cuetsy(kind="interface")
+
+				FieldConfig: {
+					// Icon name from Grafana icon library (per-field override)
+					icon?:     string
+					// How to display the icon (per-field override)
+					iconMode?: common.BigValueIconMode
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/stat/panelcfg.gen.ts
+++ b/public/app/plugins/panel/stat/panelcfg.gen.ts
@@ -13,6 +13,14 @@ import * as common from '@grafana/schema';
 export interface Options extends common.SingleStatBaseOptions {
   colorMode: common.BigValueColorMode;
   graphMode: common.BigValueGraphMode;
+  /**
+   * Icon name from Grafana icon library (panel-level default)
+   */
+  icon?: string;
+  /**
+   * How to display the icon (panel-level default)
+   */
+  iconMode?: common.BigValueIconMode;
   justifyMode: common.BigValueJustifyMode;
   percentChangeColorMode: common.PercentChangeColorMode;
   showPercentChange: boolean;
@@ -23,9 +31,21 @@ export interface Options extends common.SingleStatBaseOptions {
 export const defaultOptions: Partial<Options> = {
   colorMode: common.BigValueColorMode.Value,
   graphMode: common.BigValueGraphMode.Area,
+  iconMode: common.BigValueIconMode.Hidden,
   justifyMode: common.BigValueJustifyMode.Auto,
   percentChangeColorMode: common.PercentChangeColorMode.Standard,
   showPercentChange: false,
   textMode: common.BigValueTextMode.Auto,
   wideLayout: true,
 };
+
+export interface FieldConfig {
+  /**
+   * Icon name from Grafana icon library (per-field override)
+   */
+  icon?: string;
+  /**
+   * How to display the icon (per-field override)
+   */
+  iconMode?: common.BigValueIconMode;
+}


### PR DESCRIPTION
## Summary
- Add the ability to display icons in Stat panels with three display modes:
  - `hidden`: No icon displayed (default)
  - `icon_and_text`: Show both icon and value/title
  - `icon_only`: Show only the icon
- Icons can be configured at both panel level (as defaults) and per-field level (as overrides)
- Uses any icon from the Grafana icon library


https://github.com/user-attachments/assets/cbb5a5a0-a0bc-4907-84c9-ff2fd49bf360

