### PR TITLE
Folders: Add additional query param to legacy API for tracking purposes

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -103,10 +103,17 @@ const combineFolderResponses = (
 
 export async function getFolderByUidFacade(uid: string): Promise<FolderDTO> {
   const isVirtualFolder = uid && [GENERAL_FOLDER_UID, config.sharedWithMeFolderUID].includes(uid);
-  // We need the legacy API call regardless, for now
-  const legacyApiCall = dispatch(browseDashboardsAPI.endpoints.getFolder.initiate(uid));
-
   const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
+
+  // We need the legacy API call regardless, for now
+  const legacyApiCall = dispatch(
+    browseDashboardsAPI.endpoints.getFolder.initiate({
+      folderUID: uid,
+      accesscontrol: true,
+      isLegacyCall: shouldUseAppPlatformAPI,
+    })
+  );
+
   if (shouldUseAppPlatformAPI) {
     let virtualFolderResponse;
     if (isVirtualFolder) {
@@ -165,7 +172,9 @@ export function useGetFolderQueryFacade(uid?: string) {
   // This may look weird that we call the legacy folder anyway all the time, but the issue is we don't have good API
   // for the access control metadata yet, and so we still take it from the old api.
   // see https://github.com/grafana/identity-access-team/issues/1103
-  const legacyFolderResult = useGetFolderQueryLegacy(uid || skipToken);
+  const legacyFolderResult = useGetFolderQueryLegacy(
+    uid ? { folderUID: uid, accesscontrol: true, isLegacyCall: true } : skipToken
+  );
   let resultFolder = useGetFolderQuery(shouldUseAppPlatformAPI && !isVirtualFolder ? params : skipToken);
   // We get parents and folders for virtual folders too. Parents should just return empty array but it's easier to
   // stitch the responses this way and access can actually return different response based on the grafana setup.

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -94,9 +94,17 @@ export const browseDashboardsAPI = createApi({
     }),
 
     // get folder info (e.g. title, parents) but *not* children
-    getFolder: builder.query<FolderDTO, string>({
-      providesTags: (_result, _error, folderUID) => [{ type: 'getFolder', id: folderUID }],
-      query: (folderUID) => ({ url: `/folders/${folderUID}`, params: { accesscontrol: true } }),
+    getFolder: builder.query<FolderDTO, { folderUID: string; accesscontrol: boolean; isLegacyCall: boolean }>({
+      providesTags: (_result, _error, { folderUID }) => [{ type: 'getFolder', id: folderUID }],
+      query: ({ folderUID, accesscontrol, isLegacyCall }) => ({
+        url: `/folders/${folderUID}`,
+        params: {
+          accesscontrol,
+          // Add additional query param so we can tell when
+          // this was called for app platform compatibility purposes vs. actually needing to use the legacy API
+          isLegacyCall,
+        },
+      }),
     }),
 
     // create a new folder


### PR DESCRIPTION
**What is this feature?**
Adds additional query param to legacy API folders call when we're calling for compatibility purposes (i.e. when we're only using that endpoint to get the access control information)

**Why do we need this feature?**
So we can more easily distinguish our API calls and work out what is being called now, but will eventually be refactored away when we have a way to get access control info differently

**Who is this feature for?**
UI devs/SNO team