### PR TITLE
TimePicker: Show new shortcut for zoom out when experimental flag toggled on

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { dateTime, makeTimeRange, TimeRange } from '@grafana/data';
+import { dateTime, makeTimeRange, TimeRange, BootData } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 
 import { TimeRangeProvider } from './TimeRangeContext';
@@ -150,6 +150,58 @@ it('does not submit wrapping forms', async () => {
   await Promise.all(clicks);
 
   expect(onSubmit).not.toHaveBeenCalled();
+});
+
+it('shows CTRL+Z in zoom out tooltip when feature flag is disabled', async () => {
+  window.grafanaBootData = {
+    settings: {
+      featureToggles: {
+        newTimeRangeZoomShortcuts: false,
+      },
+    },
+  } as BootData;
+
+  render(
+    <TimeRangePicker
+      onChangeTimeZone={() => {}}
+      onChange={(value) => {}}
+      value={value}
+      onMoveBackward={() => {}}
+      onMoveForward={() => {}}
+      onZoom={() => {}}
+    />
+  );
+
+  const zoomButton = screen.getByLabelText('Zoom out time range');
+  await userEvent.hover(zoomButton);
+
+  expect(await screen.findByText(/CTRL\+Z/)).toBeInTheDocument();
+});
+
+it('shows t - in zoom out tooltip when feature flag is enabled', async () => {
+  window.grafanaBootData = {
+    settings: {
+      featureToggles: {
+        newTimeRangeZoomShortcuts: true,
+      },
+    },
+  } as BootData;
+
+  render(
+    <TimeRangePicker
+      onChangeTimeZone={() => {}}
+      onChange={(value) => {}}
+      value={value}
+      onMoveBackward={() => {}}
+      onMoveForward={() => {}}
+      onZoom={() => {}}
+    />
+  );
+
+  const zoomButton = screen.getByLabelText('Zoom out time range');
+  await userEvent.hover(zoomButton);
+
+  expect(await screen.findByText(/t -/)).toBeInTheDocument();
 });
 
 describe('TimePickerTooltip', () => {

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -19,6 +19,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
+import { getFeatureToggle } from '../../utils/featureToggle';
 import { ButtonGroup } from '../Button/ButtonGroup';
 import { getModalStyles } from '../Modal/getModalStyles';
 import { getPortalContainer } from '../Portal/Portal';
@@ -243,13 +244,22 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
 
 TimeRangePicker.displayName = 'TimeRangePicker';
 
-const ZoomOutTooltip = () => (
-  <>
-    <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip">
-      Time range zoom out <br /> CTRL+Z
-    </Trans>
-  </>
-);
+const ZoomOutTooltip = () => {
+  const newShortcuts = getFeatureToggle('newTimeRangeZoomShortcuts');
+  return (
+    <>
+      {newShortcuts ? (
+        <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip-new">
+          Time range zoom out <br /> t -
+        </Trans>
+      ) : (
+        <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip">
+          Time range zoom out <br /> CTRL+Z
+        </Trans>
+      )}
+    </>
+  );
+};
 
 export const TimePickerTooltip = ({ timeRange, timeZone }: { timeRange: TimeRange; timeZone?: TimeZone }) => {
   const styles = useStyles2(getLabelStyles);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13411,7 +13411,8 @@
       "forwards-time-aria-label": "Move time range forwards",
       "to": "to",
       "zoom-out-button": "Zoom out time range",
-      "zoom-out-tooltip": "Time range zoom out <br /> CTRL+Z"
+      "zoom-out-tooltip": "Time range zoom out <br /> CTRL+Z",
+      "zoom-out-tooltip-new": "Time range zoom out <br /> t -"
     },
     "time-range": {
       "apply": "Apply time range",


### PR DESCRIPTION
**What is this feature?**

Whoops! 😅 This fixes a small bug I missed this in the initial implementation: https://github.com/grafana/grafana/pull/114190

#### Flag off
✅ Shows old shortcut
<img width="431" height="119" alt="Screenshot 2025-11-26 at 12 19 18" src="https://github.com/user-attachments/assets/c9a7e2b2-714e-4e5f-82dc-33b2e26b54c1" />

#### Flag on
🆕 ✅ Now shows new shortcut
<img width="426" height="112" alt="Screenshot 2025-11-26 at 12 18 54" src="https://github.com/user-attachments/assets/c4470ff3-984a-4207-90ed-0c97729cc53d" />

**Why do we need this feature?**

To fix a bug where the old shortcut was shown in this tooltip, even when the new shortcuts are enabled.

**Who is this feature for?**

Anyone with the experimental`newTimeRangeZoomShortcuts` feature flag turned on for now, eventually all Grafana users.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114482

**Special notes for your reviewer:**

🎏 Make sure you have the `newTimeRangeZoomShortcuts` flag toggled on to try it out.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
