### PR TITLE
SQL Expression: Always create new SQL Expression block from Transform with SQL tile

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataTransformationsTab.tsx
@@ -25,7 +25,7 @@ import { PanelDataPane } from './PanelDataPane';
 import { PanelDataQueriesTab } from './PanelDataQueriesTab';
 import { TransformationsDrawer } from './TransformationsDrawer';
 import { PanelDataPaneTab, TabId, PanelDataTabHeaderProps } from './types';
-import { findSqlExpression, scrollToQueryRow } from './utils';
+import { scrollToQueryRow } from './utils';
 
 const SET_TIMEOUT = 750;
 
@@ -100,23 +100,21 @@ export function PanelDataTransformationsTabRendered({ model }: SceneComponentPro
       return;
     }
 
-    const queries = queriesTab.getQueries();
-    const existingSqlQuery = findSqlExpression(queries);
-
-    if (!existingSqlQuery) {
-      // Create new SQL expression
-      queriesTab.onAddExpressionOfType(ExpressionQueryType.sql);
-    }
+    // Always create a new SQL expression (it will be added to the end of the queries array)
+    queriesTab.onAddExpressionOfType(ExpressionQueryType.sql);
 
     // Navigate to the Queries tab
     parent.onChangeTab(queriesTab);
 
-    // Scroll to SQL query after tab renders
+    // Scroll to the newly created SQL query after tab renders
     setTimeout(() => {
-      // If SQL already existed, use it; otherwise find the newly created one
-      const targetRefId = existingSqlQuery?.refId || findSqlExpression(queriesTab.getQueries())?.refId;
-      if (targetRefId) {
-        scrollToQueryRow(targetRefId);
+      const queries = queriesTab.getQueries();
+      // The newly added query is the last one in the array
+      if (queries.length > 0) {
+        const newQuery = queries[queries.length - 1];
+        if (newQuery?.refId) {
+          scrollToQueryRow(newQuery.refId);
+        }
       }
     }, SET_TIMEOUT);
   }, [model]);

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/utils.ts
@@ -1,12 +1,3 @@
-import { DataQuery } from '@grafana/schema';
-import { ExpressionQueryType } from 'app/features/expressions/types';
-
-export function findSqlExpression(queries: DataQuery[]) {
-  return queries.find((query) => {
-    return typeof query === 'object' && query !== null && 'type' in query && query.type === ExpressionQueryType.sql;
-  });
-}
-
 export function scrollToQueryRow(refId: string) {
   // Query rows use uniqueId(refId + '_') for their internal id
   // The aria-controls attribute will be like "A_1" for refId "A"


### PR DESCRIPTION
To keep the behavior consistent between adding multiple SQL Expression blocks and the new “Transform with SQL” tile in the transformations tab, I’ve updated the logic.

Now, each click on “Transform with SQL” creates a new SQL Expression block.
Previously, the tile behaved differently: if an SQL Expression already existed, we scrolled to it instead of creating a new one. This conflicted with our support for multiple SQL Expressions and created a dual meaning for the tile (either add new or scroll to existing).

With the new change, the behavior is simple and consistent: always add a new block.