### PR TITLE
Geomap: Fix data filter for layers

### DIFF
--- a/public/app/plugins/panel/geomap/utils/layers.test.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.test.ts
@@ -1,0 +1,123 @@
+jest.mock('ol-mapbox-style', () => ({}));
+jest.mock('geotiff', () => ({}));
+
+import BaseLayer from 'ol/layer/Base';
+
+import {
+  DataFrame,
+  DataQueryRequest,
+  FieldType,
+  LoadingState,
+  MapLayerHandler,
+  MapLayerOptions,
+  PanelData,
+  TimeRange,
+} from '@grafana/data';
+
+import { applyLayerFilter } from './layers';
+
+describe('applyLayerFilter', () => {
+  const createDataFrame = (refId: string): DataFrame => ({
+    refId,
+    fields: [{ name: 'value', type: FieldType.number, values: [1, 2, 3], config: {} }],
+    length: 3,
+  });
+
+  it('should apply filter when query exists and is visible', () => {
+    const update = jest.fn();
+    const handler: MapLayerHandler = {
+      init: () => ({}) as BaseLayer,
+      update,
+    };
+    const options: MapLayerOptions = {
+      name: 'Test',
+      type: 'markers',
+      filterData: { id: 'byRefId', options: 'A' },
+    };
+    const panelData: PanelData = {
+      series: [createDataFrame('A'), createDataFrame('B')],
+      state: LoadingState.Done,
+      timeRange: {} as TimeRange,
+      request: { targets: [{ refId: 'A' }, { refId: 'B' }] } as DataQueryRequest,
+    };
+
+    applyLayerFilter(handler, options, panelData);
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        series: [createDataFrame('A')],
+      })
+    );
+  });
+
+  it('should return empty series when query exists but is hidden', () => {
+    const update = jest.fn();
+    const handler: MapLayerHandler = {
+      init: () => ({}) as BaseLayer,
+      update,
+    };
+    const options: MapLayerOptions = {
+      name: 'Test',
+      type: 'markers',
+      filterData: { id: 'byRefId', options: 'A' },
+    };
+    const panelData: PanelData = {
+      series: [createDataFrame('B')],
+      state: LoadingState.Done,
+      timeRange: {} as TimeRange,
+      request: { targets: [{ refId: 'A', hide: true }, { refId: 'B' }] } as DataQueryRequest,
+    };
+
+    applyLayerFilter(handler, options, panelData);
+
+    expect(update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        series: [],
+      })
+    );
+  });
+
+  it('should not apply filter when query does not exist', () => {
+    const update = jest.fn();
+    const handler: MapLayerHandler = {
+      init: () => ({}) as BaseLayer,
+      update,
+    };
+    const options: MapLayerOptions = {
+      name: 'Test',
+      type: 'markers',
+      filterData: { id: 'byRefId', options: 'C' },
+    };
+    const panelData: PanelData = {
+      series: [createDataFrame('A'), createDataFrame('B')],
+      state: LoadingState.Done,
+      timeRange: {} as TimeRange,
+      request: { targets: [{ refId: 'A' }, { refId: 'B' }] } as DataQueryRequest,
+    };
+
+    applyLayerFilter(handler, options, panelData);
+
+    expect(update).toHaveBeenCalledWith(panelData);
+  });
+
+  it('should pass through all data when no filter is configured', () => {
+    const update = jest.fn();
+    const handler: MapLayerHandler = {
+      init: () => ({}) as BaseLayer,
+      update,
+    };
+    const options: MapLayerOptions = {
+      name: 'Test',
+      type: 'markers',
+    };
+    const panelData: PanelData = {
+      series: [createDataFrame('A'), createDataFrame('B')],
+      state: LoadingState.Done,
+      timeRange: {} as TimeRange,
+    };
+
+    applyLayerFilter(handler, options, panelData);
+
+    expect(update).toHaveBeenCalledWith(panelData);
+  });
+});

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -26,7 +26,14 @@ export const applyLayerFilter = (
     let panelData = panelDataProps;
     if (options.filterData) {
       const matcherFunc = getFrameMatchers(options.filterData);
-      if (panelData.series.some(matcherFunc)) {
+
+      const queryExists = panelData.request?.targets.some((target) => {
+        return target.refId === options.filterData?.options;
+      });
+
+      // Only apply filter if the target query exists
+      // If query doesn't exist, fall back to no filter
+      if (queryExists) {
         panelData = {
           ...panelData,
           series: panelData.series.filter(matcherFunc),

--- a/public/app/plugins/panel/geomap/utils/layers.ts
+++ b/public/app/plugins/panel/geomap/utils/layers.ts
@@ -32,7 +32,6 @@ export const applyLayerFilter = (
       });
 
       // Only apply filter if the target query exists
-      // If query doesn't exist, fall back to no filter
       if (queryExists) {
         panelData = {
           ...panelData,


### PR DESCRIPTION
For geomap layer data filter, if a query refid matches, but the data is empty, it should render nothing, as expected. Previously in this case, it would fall back to default behavior, ignoring the filter.

Before:
Hiding (or making it empty) the query that is being filtered causes it to fallback to default behavior which is to look for the first available matching data, in this case query B...
![Nov-26-2025 12-28-12](https://github.com/user-attachments/assets/48fe41a5-1593-4f90-b979-01bbf6e3699e)
When no refId match is found, default behavior with no filtering should be applied (UNCHANGED)...
![Nov-26-2025 12-28-49](https://github.com/user-attachments/assets/0ab5e775-caed-4742-94c1-1c64ceb5d416)


After:
Hidden (or empty) queries that match data filter should render nothing...
![Nov-26-2025 12-23-21](https://github.com/user-attachments/assets/f8292743-b6cd-4f37-ab47-e0f64019dba4)
When no refId match is found, default behavior with no filtering should be applied (UNCHANGED)...
![Nov-26-2025 12-24-11](https://github.com/user-attachments/assets/024ee2d1-bd57-49ac-bdf1-cfbe2332cd39)

Fixes https://github.com/grafana/support-escalations/issues/19622