### PR TITLE
usePullRequestParam: Provisioned dashboard preview banner, decode pull request url before sanitize

### DIFF
--- a/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
+++ b/public/app/features/provisioning/components/Shared/PreviewBannerViewPR.tsx
@@ -107,9 +107,14 @@ export function PreviewBannerViewPR({ prParam, isNewPr, behindBranch, repoUrl, b
       {/* when repo type is not local, we show branch information */}
       {showBranchInfo(repoType, branchInfo) && (
         <Box marginTop={1}>
-          <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch: </Trans>
-          <TextLink href={getBranchUrl(repoBaseUrl!, targetBranch!, repoType)}>{targetBranch}</TextLink> {'\u2192'}{' '}
-          <TextLink href={getBranchUrl(repoBaseUrl!, configuredBranch!, repoType)}>{configuredBranch}</TextLink>
+          <Trans i18nKey="provisioned-resource-preview-banner.preview-banner.branch-text">branch:</Trans>{' '}
+          <TextLink href={getBranchUrl(repoBaseUrl!, targetBranch!, repoType)} external>
+            {targetBranch}
+          </TextLink>{' '}
+          {'\u2192'}{' '}
+          <TextLink href={getBranchUrl(repoBaseUrl!, configuredBranch!, repoType)} external>
+            {configuredBranch}
+          </TextLink>
         </Box>
       )}
     </Alert>

--- a/public/app/features/provisioning/hooks/usePullRequestParam.ts
+++ b/public/app/features/provisioning/hooks/usePullRequestParam.ts
@@ -9,9 +9,9 @@ export const usePullRequestParam = () => {
   const repoType = params.get('repo_type');
 
   return {
-    prURL: prParam ? textUtil.sanitizeUrl(prParam) : undefined,
-    newPrURL: newPrParam ? textUtil.sanitizeUrl(newPrParam) : undefined,
-    repoURL: repoUrl ? textUtil.sanitizeUrl(repoUrl) : undefined,
-    repoType: repoType ? textUtil.sanitizeUrl(repoType) : undefined,
+    prURL: prParam ? textUtil.sanitizeUrl(decodeURIComponent(prParam)) : undefined,
+    newPrURL: newPrParam ? textUtil.sanitizeUrl(decodeURIComponent(newPrParam)) : undefined,
+    repoURL: repoUrl ? textUtil.sanitizeUrl(decodeURIComponent(repoUrl)) : undefined,
+    repoType: repoType ? textUtil.sanitizeUrl(decodeURIComponent(repoType)) : undefined,
   };
 };


### PR DESCRIPTION
**What is this feature?**

When user preview dashboard from pull request -> then revisit pull request, the PR url is not decoded correctly. 

**Why do we need this feature?**

Prevent user land on incorrect blank page

**Who is this feature for?**

Git sync user

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/688

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
