### PR TITLE
Provisioning: add URL and Path in setting response

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
@@ -44,10 +44,10 @@ type RepositoryView struct {
 	Branch string `json:"branch,omitempty"`
 
 	// For git, this is the target URL
-	URL string `json:"url"`
+	URL string `json:"url,omitempty"`
 
 	// For git, this is the target path
-	Path string `json:"path"`
+	Path string `json:"path,omitempty"`
 
 	// The supported workflows
 	Workflows []Workflow `json:"workflows"`

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/settings.go
@@ -43,6 +43,12 @@ type RepositoryView struct {
 	// For git, this is the target branch
 	Branch string `json:"branch,omitempty"`
 
+	// For git, this is the target URL
+	URL string `json:"url"`
+
+	// For git, this is the target path
+	Path string `json:"path"`
+
 	// The supported workflows
 	Workflows []Workflow `json:"workflows"`
 }

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1690,6 +1690,22 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 							Format:      "",
 						},
 					},
+					"url": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target URL",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"path": {
+						SchemaProps: spec.SchemaProps{
+							Description: "For git, this is the target path",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 					"workflows": {
 						SchemaProps: spec.SchemaProps{
 							Description: "The supported workflows",
@@ -1707,7 +1723,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "title", "type", "target", "workflows"},
+				Required: []string{"name", "title", "type", "target", "url", "path", "workflows"},
 			},
 		},
 	}

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -1693,7 +1693,6 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 					"url": {
 						SchemaProps: spec.SchemaProps{
 							Description: "For git, this is the target URL",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1701,7 +1700,6 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 					"path": {
 						SchemaProps: spec.SchemaProps{
 							Description: "For git, this is the target path",
-							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -1723,7 +1721,7 @@ func schema_pkg_apis_provisioning_v0alpha1_RepositoryView(ref common.ReferenceCa
 						},
 					},
 				},
-				Required: []string{"name", "title", "type", "target", "url", "path", "workflows"},
+				Required: []string{"name", "title", "type", "target", "workflows"},
 			},
 		},
 	}

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1582,7 +1582,7 @@ export type RepositoryView = {
   /** The k8s name for this repository */
   name: string;
   /** For git, this is the target path */
-  path: string;
+  path?: string;
   /** When syncing, where values are saved
     
     Possible enum values:
@@ -1601,7 +1601,7 @@ export type RepositoryView = {
      - `"local"` */
   type: 'bitbucket' | 'git' | 'github' | 'gitlab' | 'local';
   /** For git, this is the target URL */
-  url: string;
+  url?: string;
   /** The supported workflows */
   workflows: ('branch' | 'write')[];
 };

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1581,6 +1581,8 @@ export type RepositoryView = {
   branch?: string;
   /** The k8s name for this repository */
   name: string;
+  /** For git, this is the target path */
+  path: string;
   /** When syncing, where values are saved
     
     Possible enum values:
@@ -1598,6 +1600,8 @@ export type RepositoryView = {
      - `"gitlab"`
      - `"local"` */
   type: 'bitbucket' | 'git' | 'github' | 'gitlab' | 'local';
+  /** For git, this is the target URL */
+  url: string;
   /** The supported workflows */
   workflows: ('branch' | 'write')[];
 };

--- a/pkg/registry/apis/provisioning/routes.go
+++ b/pkg/registry/apis/provisioning/routes.go
@@ -172,6 +172,8 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 
 	for i, val := range all {
 		branch := val.Branch()
+		url := val.URL()
+		path := val.Path()
 
 		settings.Items[i] = provisioning.RepositoryView{
 			Name:      val.Name,
@@ -179,6 +181,8 @@ func (b *APIBuilder) handleSettings(w http.ResponseWriter, r *http.Request) {
 			Type:      val.Spec.Type,
 			Target:    val.Spec.Sync.Target,
 			Branch:    branch,
+			URL:       url,
+			Path:      path,
 			Workflows: val.Spec.Workflows,
 		}
 	}

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4297,8 +4297,6 @@
           "title",
           "type",
           "target",
-          "url",
-          "path",
           "workflows"
         ],
         "properties": {
@@ -4313,8 +4311,7 @@
           },
           "path": {
             "description": "For git, this is the target path",
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "target": {
             "description": "When syncing, where values are saved\n\nPossible enum values:\n - `\"folder\"` Resources will be saved into a folder managed by this repository It will contain a copy of everything from the remote The folder k8s name will be the same as the repository k8s name\n - `\"instance\"` Resources are saved in the global context Only one repository may specify the `instance` target When this exists, the UI will promote writing to the instance repo rather than the grafana database (where possible)",
@@ -4344,8 +4341,7 @@
           },
           "url": {
             "description": "For git, this is the target URL",
-            "type": "string",
-            "default": ""
+            "type": "string"
           },
           "workflows": {
             "description": "The supported workflows",

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -4297,6 +4297,8 @@
           "title",
           "type",
           "target",
+          "url",
+          "path",
           "workflows"
         ],
         "properties": {
@@ -4306,6 +4308,11 @@
           },
           "name": {
             "description": "The k8s name for this repository",
+            "type": "string",
+            "default": ""
+          },
+          "path": {
+            "description": "For git, this is the target path",
             "type": "string",
             "default": ""
           },
@@ -4334,6 +4341,11 @@
               "gitlab",
               "local"
             ]
+          },
+          "url": {
+            "description": "For git, this is the target URL",
+            "type": "string",
+            "default": ""
           },
           "workflows": {
             "description": "The supported workflows",

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -136,6 +136,18 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 				return
 			}
 
+			for _, i := range settings.Items {
+				switch i.Type {
+				case provisioning.LocalRepositoryType:
+					assert.Empty(collect, i.URL)
+					assert.Equal(collect, i.Path, helper.ProvisioningPath)
+				case provisioning.GitHubRepositoryType:
+					assert.NotEmpty(collect, i.URL)
+					assert.Equal(collect, i.URL, "https://github.com/grafana/grafana-git-sync-demo")
+					assert.Equal(collect, i.Path, "grafana/")
+				}
+			}
+
 			assert.ElementsMatch(collect, []provisioning.RepositoryType{
 				provisioning.LocalRepositoryType,
 				provisioning.GitHubRepositoryType,

--- a/pkg/tests/apis/provisioning/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository_test.go
@@ -139,12 +139,13 @@ func TestIntegrationProvisioning_CreatingAndGetting(t *testing.T) {
 			for _, i := range settings.Items {
 				switch i.Type {
 				case provisioning.LocalRepositoryType:
-					assert.Empty(collect, i.URL)
 					assert.Equal(collect, i.Path, helper.ProvisioningPath)
 				case provisioning.GitHubRepositoryType:
-					assert.NotEmpty(collect, i.URL)
 					assert.Equal(collect, i.URL, "https://github.com/grafana/grafana-git-sync-demo")
 					assert.Equal(collect, i.Path, "grafana/")
+				default:
+					assert.NotEmpty(collect, i.Path)
+					assert.NotEmpty(collect, i.URL)
 				}
 			}
 


### PR DESCRIPTION
**What is this feature?**

Adding `URL` and `Path` fields in setting response, those are coming from the repo's URL and Path entries. 

**Why do we need this feature?**

Such fields are needed for FE to correctly display a link pointing to the as-code dashboard definition when provisioned.

**Who is this feature for?**

Users of GitSync feature

**Which issue(s) does this PR fix?**:

Part of https://github.com/grafana/git-ui-sync-project/issues/487

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
