### PR TITLE
Table: Add interactive hover support to sparkline cells

### DIFF
--- a/packages/grafana-schema/src/common/common.gen.ts
+++ b/packages/grafana-schema/src/common/common.gen.ts
@@ -831,8 +831,16 @@ export interface TableBarGaugeCellOptions {
  */
 export interface TableSparklineCellOptions extends GraphFieldConfig {
   hideValue?: boolean;
+  /**
+   * Enable interactive hover to inspect values along the sparkline
+   */
+  interactionEnabled?: boolean;
   type: TableCellDisplayMode.Sparkline;
 }
+
+export const defaultTableSparklineCellOptions: Partial<TableSparklineCellOptions> = {
+  interactionEnabled: true,
+};
 
 /**
  * Colored background cell options

--- a/packages/grafana-schema/src/common/table.cue
+++ b/packages/grafana-schema/src/common/table.cue
@@ -63,6 +63,8 @@ TableSparklineCellOptions: {
 	GraphFieldConfig
 	type: TableCellDisplayMode & "sparkline"
   hideValue?: bool
+  // Enable interactive hover to inspect values along the sparkline
+  interactionEnabled?: bool | *true
 } @cuetsy(kind="interface")
 
 // Colored background cell options

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import uPlot from 'uplot';
 
 import { createTheme, FieldConfig, FieldSparkline, FieldType } from '@grafana/data';
 import { GraphFieldConfig } from '@grafana/schema';
@@ -36,10 +37,10 @@ describe('Sparkline', () => {
       const config: FieldConfig<GraphFieldConfig> = {
         custom: {
           interactionEnabled: true,
-        } as any,
+        } as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -51,7 +52,9 @@ describe('Sparkline', () => {
       );
 
       // Get the Sparkline instance to access the config builder
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -63,7 +66,9 @@ describe('Sparkline', () => {
           const mockUPlot = {
             cursor: { idxs: [2, 2] },
             data: [mockSparkline.x!.values, mockSparkline.y.values],
-          };
+          } as Partial<uPlot>;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setLegendHook(mockUPlot as any);
 
           expect(onHover).toHaveBeenCalledWith(3, 2);
@@ -76,10 +81,10 @@ describe('Sparkline', () => {
       const config: FieldConfig<GraphFieldConfig> = {
         custom: {
           interactionEnabled: true,
-        } as any,
+        } as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -90,7 +95,8 @@ describe('Sparkline', () => {
         />
       );
 
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -102,6 +108,7 @@ describe('Sparkline', () => {
             cursor: { idxs: [null, null] },
             data: [mockSparkline.x!.values, mockSparkline.y.values],
           };
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setLegendHook(mockUPlot as any);
 
           expect(onHover).toHaveBeenCalledWith(null, null);
@@ -114,10 +121,10 @@ describe('Sparkline', () => {
       const config: FieldConfig<GraphFieldConfig> = {
         custom: {
           interactionEnabled: false,
-        } as any,
+        } as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -128,7 +135,8 @@ describe('Sparkline', () => {
         />
       );
 
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -142,10 +150,10 @@ describe('Sparkline', () => {
       const config: FieldConfig<GraphFieldConfig> = {
         custom: {
           interactionEnabled: true,
-        } as any,
+        } as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -155,7 +163,8 @@ describe('Sparkline', () => {
         />
       );
 
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -168,10 +177,10 @@ describe('Sparkline', () => {
     it('should enable interaction by default when not explicitly configured', () => {
       const onHover = jest.fn();
       const config: FieldConfig<GraphFieldConfig> = {
-        custom: {} as any,
+        custom: {} as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -182,7 +191,8 @@ describe('Sparkline', () => {
         />
       );
 
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -198,7 +208,7 @@ describe('Sparkline', () => {
       const config: FieldConfig<GraphFieldConfig> = {
         custom: {
           interactionEnabled: true,
-        } as any,
+        } as GraphFieldConfig & { interactionEnabled?: boolean },
       };
 
       const sparklineWithNaN: FieldSparkline = {
@@ -209,7 +219,7 @@ describe('Sparkline', () => {
         },
       };
 
-      const component = render(
+      const view = render(
         <Sparkline
           width={800}
           height={600}
@@ -220,7 +230,8 @@ describe('Sparkline', () => {
         />
       );
 
-      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const instance = (view.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
       if (instance?.state?.configBuilder) {
         const builder = instance.state.configBuilder;
         const hooks = builder.getConfig().hooks;
@@ -231,7 +242,8 @@ describe('Sparkline', () => {
           const mockUPlot1 = {
             cursor: { idxs: [1, 1] },
             data: [sparklineWithNaN.x!.values, sparklineWithNaN.y.values],
-          };
+          } as Partial<uPlot>;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setLegendHook(mockUPlot1 as any);
           expect(onHover).toHaveBeenCalledWith(null, null);
 
@@ -241,7 +253,8 @@ describe('Sparkline', () => {
           const mockUPlot3 = {
             cursor: { idxs: [3, 3] },
             data: [sparklineWithNaN.x!.values, sparklineWithNaN.y.values],
-          };
+          } as Partial<uPlot>;
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
           setLegendHook(mockUPlot3 as any);
           expect(onHover).toHaveBeenCalledWith(null, null);
         }

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.test.tsx
@@ -1,30 +1,251 @@
 import { render } from '@testing-library/react';
 
-import { createTheme, FieldSparkline, FieldType } from '@grafana/data';
+import { createTheme, FieldConfig, FieldSparkline, FieldType } from '@grafana/data';
+import { GraphFieldConfig } from '@grafana/schema';
 
 import { Sparkline } from './Sparkline';
 
 describe('Sparkline', () => {
+  const mockSparkline: FieldSparkline = {
+    x: {
+      name: 'x',
+      values: [1679839200000, 1680444000000, 1681048800000, 1681653600000, 1682258400000],
+      type: FieldType.time,
+      config: {},
+    },
+    y: {
+      name: 'y',
+      values: [1, 2, 3, 4, 5],
+      type: FieldType.number,
+      config: {},
+      state: {
+        range: { min: 1, max: 5, delta: 1 },
+      },
+    },
+  };
+
   it('should render without throwing an error', () => {
-    const sparkline: FieldSparkline = {
-      x: {
-        name: 'x',
-        values: [1679839200000, 1680444000000, 1681048800000, 1681653600000, 1682258400000],
-        type: FieldType.time,
-        config: {},
-      },
-      y: {
-        name: 'y',
-        values: [1, 2, 3, 4, 5],
-        type: FieldType.number,
-        config: {},
-        state: {
-          range: { min: 1, max: 5, delta: 1 },
-        },
-      },
-    };
     expect(() =>
-      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={sparkline} />)
+      render(<Sparkline width={800} height={600} theme={createTheme()} sparkline={mockSparkline} />)
     ).not.toThrow();
+  });
+
+  describe('hover interaction', () => {
+    it('should call onHover with value when interaction is enabled and cursor moves', () => {
+      const onHover = jest.fn();
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {
+          interactionEnabled: true,
+        } as any,
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={mockSparkline}
+          config={config}
+          onHover={onHover}
+        />
+      );
+
+      // Get the Sparkline instance to access the config builder
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        // Find and execute the setLegend hook
+        const setLegendHook = hooks?.setLegend?.[0];
+        if (setLegendHook) {
+          // Simulate hover over data point at index 2 (value: 3)
+          const mockUPlot = {
+            cursor: { idxs: [2, 2] },
+            data: [mockSparkline.x!.values, mockSparkline.y.values],
+          };
+          setLegendHook(mockUPlot as any);
+
+          expect(onHover).toHaveBeenCalledWith(3, 2);
+        }
+      }
+    });
+
+    it('should call onHover with null when cursor leaves', () => {
+      const onHover = jest.fn();
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {
+          interactionEnabled: true,
+        } as any,
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={mockSparkline}
+          config={config}
+          onHover={onHover}
+        />
+      );
+
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        const setLegendHook = hooks?.setLegend?.[0];
+        if (setLegendHook) {
+          // Simulate cursor leaving (no valid index)
+          const mockUPlot = {
+            cursor: { idxs: [null, null] },
+            data: [mockSparkline.x!.values, mockSparkline.y.values],
+          };
+          setLegendHook(mockUPlot as any);
+
+          expect(onHover).toHaveBeenCalledWith(null, null);
+        }
+      }
+    });
+
+    it('should not set up hover hooks when interaction is disabled', () => {
+      const onHover = jest.fn();
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {
+          interactionEnabled: false,
+        } as any,
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={mockSparkline}
+          config={config}
+          onHover={onHover}
+        />
+      );
+
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        // setLegend hook should not be registered
+        expect(hooks?.setLegend).toBeUndefined();
+      }
+    });
+
+    it('should not set up hover hooks when onHover is not provided', () => {
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {
+          interactionEnabled: true,
+        } as any,
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={mockSparkline}
+          config={config}
+        />
+      );
+
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        // setLegend hook should not be registered when no onHover callback
+        expect(hooks?.setLegend).toBeUndefined();
+      }
+    });
+
+    it('should enable interaction by default when not explicitly configured', () => {
+      const onHover = jest.fn();
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {} as any,
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={mockSparkline}
+          config={config}
+          onHover={onHover}
+        />
+      );
+
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        // setLegend hook should be registered (interaction enabled by default)
+        expect(hooks?.setLegend).toBeDefined();
+        expect(hooks?.setLegend?.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('should handle non-finite values correctly during hover', () => {
+      const onHover = jest.fn();
+      const config: FieldConfig<GraphFieldConfig> = {
+        custom: {
+          interactionEnabled: true,
+        } as any,
+      };
+
+      const sparklineWithNaN: FieldSparkline = {
+        ...mockSparkline,
+        y: {
+          ...mockSparkline.y,
+          values: [1, NaN, 3, Infinity, 5],
+        },
+      };
+
+      const component = render(
+        <Sparkline
+          width={800}
+          height={600}
+          theme={createTheme()}
+          sparkline={sparklineWithNaN}
+          config={config}
+          onHover={onHover}
+        />
+      );
+
+      const instance = (component.container.firstChild as any)?.__reactFiber$?.return?.stateNode;
+      if (instance?.state?.configBuilder) {
+        const builder = instance.state.configBuilder;
+        const hooks = builder.getConfig().hooks;
+
+        const setLegendHook = hooks?.setLegend?.[0];
+        if (setLegendHook) {
+          // Hover over NaN value at index 1
+          const mockUPlot1 = {
+            cursor: { idxs: [1, 1] },
+            data: [sparklineWithNaN.x!.values, sparklineWithNaN.y.values],
+          };
+          setLegendHook(mockUPlot1 as any);
+          expect(onHover).toHaveBeenCalledWith(null, null);
+
+          onHover.mockClear();
+
+          // Hover over Infinity value at index 3
+          const mockUPlot3 = {
+            cursor: { idxs: [3, 3] },
+            data: [sparklineWithNaN.x!.values, sparklineWithNaN.y.values],
+          };
+          setLegendHook(mockUPlot3 as any);
+          expect(onHover).toHaveBeenCalledWith(null, null);
+        }
+      }
+    });
   });
 });

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -112,8 +112,10 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
     const builder = new UPlotConfigBuilder();
 
     // Check if interaction is enabled (default to true)
-    // Use type assertion since interactionEnabled is on TableSparklineCellOptions
-    const interactionEnabled = (config?.custom as any)?.interactionEnabled ?? true;
+    // interactionEnabled is on TableSparklineCellOptions which extends GraphFieldConfig
+    const customConfig = config?.custom;
+    const interactionEnabled =
+      customConfig && 'interactionEnabled' in customConfig ? customConfig.interactionEnabled : true;
 
     // X is the first field in the alligned frame
     const xField = data.fields[0];
@@ -214,11 +216,11 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
         focus: {
           prox: 30, // proximity in CSS pixels for hover detection
         },
-      } as any); // Type assertion needed for cursor styling properties
+      });
 
       // Track cursor position and call onHover with the value at that position
       // Using setLegend hook which fires on hover (not just drag-to-select like setSelect)
-      builder.addHook('setLegend', (u) => {
+      builder.addHook('setLegend', (u: uPlot) => {
         const dataIdx = u.cursor.idxs?.[1]; // Get the data index from the cursor
         if (dataIdx != null) {
           const yData = u.data[1]; // Y-axis data (values)
@@ -250,12 +252,12 @@ export class Sparkline extends PureComponent<SparklineProps, State> {
     const { width, height } = this.props;
 
     // Style the vertical cursor bar to be more visible on small sparklines
-    const cursorStyles = css`
-      .u-cursor-x {
-        border-left: 2px solid !important;
-        opacity: 1 !important;
-      }
-    `;
+    const cursorStyles = css({
+      '.u-cursor-x': {
+        borderLeft: '2px solid !important',
+        opacity: '1 !important',
+      },
+    });
 
     return (
       <div className={cursorStyles}>

--- a/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
+++ b/public/app/plugins/panel/table/cells/SparklineCellOptionsEditor.tsx
@@ -12,6 +12,7 @@ import { TableCellEditorProps } from '../TableCellOptionEditor';
 type OptionKey = keyof TableSparklineCellOptions;
 
 const optionIds: Array<keyof TableSparklineCellOptions> = [
+  'interactionEnabled',
   'hideValue',
   'drawStyle',
   'lineInterpolation',
@@ -31,6 +32,12 @@ function getChartCellConfig(cfg: GraphFieldConfig): SetFieldConfigOptionsArgs<Gr
     ...graphFieldConfig,
     useCustomConfig: (builder) => {
       graphFieldConfig.useCustomConfig?.(builder);
+      builder.addBooleanSwitch({
+        path: 'interactionEnabled',
+        name: 'Enable hover interaction',
+        description: 'Allow users to hover over the sparkline to inspect values',
+        defaultValue: true,
+      });
       builder.addBooleanSwitch({
         path: 'hideValue',
         name: 'Hide value',


### PR DESCRIPTION
This adds hover interaction to sparkline table cells, allowing users to see the value at a specific point by hovering over the sparkline chart.

Key changes:
- Added `interactionEnabled` configuration option (defaults to true)
- Sparkline component now accepts an `onHover` callback prop
- SparklineCell manages hover state and updates the displayed value
- Visual indicator uses a 2px solid vertical bar (more visible on small sparklines)
- setLegend hook tracks cursor position and calls onHover with the value