### PR TITLE
Dashboards: Don't store options when saving a dashboard with Query/Custom variables

### DIFF
--- a/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2_examples.ts
@@ -312,18 +312,7 @@ export const handyTestingSchema: Spec = {
         label: 'Custom Variable',
         multi: true,
         name: 'customVar',
-        options: [
-          {
-            selected: true,
-            text: 'option1',
-            value: 'option1',
-          },
-          {
-            selected: false,
-            text: 'option2',
-            value: 'option2',
-          },
-        ],
+        options: [],
         query: 'option1, option2',
         skipUrlSync: false,
         allowCustomValue: true,

--- a/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
+++ b/public/app/features/dashboard-scene/serialization/__snapshots__/transformSceneToSaveModelSchemaV2.test.ts.snap
@@ -194,18 +194,7 @@ exports[`transformSceneToSaveModelSchemaV2 should transform scene to save model 
         "label": "Custom Variable",
         "multi": true,
         "name": "customVar",
-        "options": [
-          {
-            "selected": true,
-            "text": "option1",
-            "value": "option1",
-          },
-          {
-            "selected": false,
-            "text": "option2",
-            "value": "option2",
-          },
-        ],
+        "options": [],
         "query": "option1, option2",
         "skipUrlSync": false,
       },

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.test.ts
@@ -371,23 +371,7 @@ describe('sceneVariablesSetToVariables', () => {
       "label": "test-label",
       "multi": true,
       "name": "test",
-      "options": [
-        {
-          "selected": true,
-          "text": "test",
-          "value": "test",
-        },
-        {
-          "selected": false,
-          "text": "test1",
-          "value": "test1",
-        },
-        {
-          "selected": true,
-          "text": "test2",
-          "value": "test2",
-        },
-      ],
+      "options": [],
       "query": "test,test1,test2",
       "type": "custom",
     }
@@ -1161,23 +1145,7 @@ describe('sceneVariablesSetToVariables', () => {
         "label": "test-label",
         "multi": true,
         "name": "test",
-        "options": [
-          {
-            "selected": true,
-            "text": "test",
-            "value": "test",
-          },
-          {
-            "selected": false,
-            "text": "test1",
-            "value": "test1",
-          },
-          {
-            "selected": true,
-            "text": "test2",
-            "value": "test2",
-          },
-        ],
+        "options": [],
         "query": "test,test1,test2",
         "skipUrlSync": false,
       },

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -66,9 +66,7 @@ export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptio
 
     if (sceneUtils.isQueryVariable(variable)) {
       let options: VariableOption[] = [];
-      // Not sure if we actually have to still support this option given
-      // that it's not exposed in the UI
-      if (transformVariableRefreshToEnum(variable.state.refresh) === 'never' || keepQueryOptions) {
+      if (keepQueryOptions) {
         options = variableValueOptionsToVariableOptions(variable.state);
       }
       variables.push({
@@ -106,7 +104,7 @@ export function sceneVariablesSetToVariables(set: SceneVariables, keepQueryOptio
           // @ts-expect-error
           value: variable.state.value,
         },
-        options: variableValueOptionsToVariableOptions(variable.state),
+        options: [],
         query: variable.state.query,
         multi: variable.state.isMulti,
         allValue: variable.state.allValue,
@@ -319,9 +317,7 @@ export function sceneVariablesSetToSchemaV2Variables(
 
     // Query variable
     if (sceneUtils.isQueryVariable(variable)) {
-      // Not sure if we actually have to still support this option given
-      // that it's not exposed in the UI
-      if (transformVariableRefreshToEnum(variable.state.refresh) === 'never' || keepQueryOptions) {
+      if (keepQueryOptions) {
         options = variableValueOptionsToVariableOptions(variable.state);
       }
       const query = variable.state.query;
@@ -385,13 +381,12 @@ export function sceneVariablesSetToSchemaV2Variables(
 
       // Custom variable
     } else if (sceneUtils.isCustomVariable(variable)) {
-      options = variableValueOptionsToVariableOptions(variable.state);
       const customVariable: CustomVariableKind = {
         kind: 'CustomVariable',
         spec: {
           ...commonProperties,
           current: currentVariableOption,
-          options,
+          options: [],
           query: variable.state.query,
           multi: variable.state.isMulti || false,
           allValue: variable.state.allValue,


### PR DESCRIPTION
**What is this feature?**

This PR modifies the dashboard saving behavior to prevent the persistence of variable options for query and custom variables.

Before this change, saving a dashboard included the full list of variable options in the JSON model. Now, these options are stripped out during the save process, persisting only the variable configuration and current selection.

See this [Slack thread](https://raintank-corp.slack.com/archives/C07QVGH37D4/p1764179889410289) for more info

**Why do we need this feature?**

Saving variable options is unnecessary because they can always be derived from the query at runtime. Removing them reduces the size of the dashboard JSON and leads to cleaner diffs in the UI version history, as users won't see noisy changes just because the list of available options updated.

**Who is this feature for?**

Not a feature

**Which issue(s) does this PR fix?**:

`-`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
