### PR TITLE
LogLine: add trailing spaces for copying

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -334,14 +334,14 @@ const Log = memo(
       <>
         {showTime && (
           <span className={`${styles.timestamp} level-${log.logLevel} field`}>
-            {timestampResolution === 'ms' ? log.timestamp : log.timestampNs}
+            {timestampResolution === 'ms' ? log.timestamp : log.timestampNs}{' '}
           </span>
         )}
         {
           // When logs are unwrapped, we want an empty column space to align with other log lines.
         }
         {(log.displayLevel || !wrapLogMessage) && (
-          <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}</span>
+          <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}{' '}</span>
         )}
         {showUniqueLabels && log.uniqueLabels && (
           <span className="field">
@@ -395,7 +395,7 @@ const DisplayedFields = ({
     if (field === OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME && syntaxHighlighting) {
       return (
         <span className="field log-syntax-highlight" title={getNormalizedFieldName(field)} key={field}>
-          <HighlightedLogRenderer tokens={log.highlightedLogAttributesTokens} />
+          <HighlightedLogRenderer tokens={log.highlightedLogAttributesTokens} />{' '}
         </span>
       );
     }
@@ -410,7 +410,7 @@ const DisplayedFields = ({
           />
         ) : (
           log.getDisplayedFieldValue(field)
-        )}
+        )}{' '}
       </span>
     );
   });
@@ -434,7 +434,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
   if (log.hasAnsi) {
     return (
       <span className="field no-highlighting">
-        <LogMessageAnsi value={log.body} highlight={highlight} />
+        <LogMessageAnsi value={log.body} highlight={highlight} />{' '}
       </span>
     );
   }
@@ -448,13 +448,13 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
         highlightClassName={styles.matchHighLight}
       />
     ) : (
-      <span className="field no-highlighting">{log.body}</span>
+      <span className="field no-highlighting">{log.body}{' '}</span>
     );
   }
 
   return (
     <span className="field log-syntax-highlight">
-      <HighlightedLogRenderer tokens={log.highlightedBodyTokens} />
+      <HighlightedLogRenderer tokens={log.highlightedBodyTokens} />{' '}
     </span>
   );
 };

--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -341,7 +341,7 @@ const Log = memo(
           // When logs are unwrapped, we want an empty column space to align with other log lines.
         }
         {(log.displayLevel || !wrapLogMessage) && (
-          <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel}{' '}</span>
+          <span className={`${styles.level} level-${log.logLevel} field`}>{log.displayLevel} </span>
         )}
         {showUniqueLabels && log.uniqueLabels && (
           <span className="field">
@@ -448,7 +448,7 @@ const LogLineBody = ({ log, styles }: { log: LogListModel; styles: LogLineStyles
         highlightClassName={styles.matchHighLight}
       />
     ) : (
-      <span className="field no-highlighting">{log.body}{' '}</span>
+      <span className="field no-highlighting">{log.body} </span>
     );
   }
 


### PR DESCRIPTION
Addresses the comment in https://github.com/grafana/grafana/issues/77553#issuecomment-3582808918

How to test:

- Query logs, and either select displayed fields or use the default state
- Make sure line wrapping is enabled
- Select and copy logs

Expected result: timestamp, level, fields or body, should be separated by an space.