### PR TITLE
Docs: Fix alias for next and latest docs

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/sql-expressions/index.md
@@ -1,6 +1,6 @@
 ---
 aliases:
-  - ../../panels-visualizations/query-transform-data/sql-expressions/ # /docs/grafana/next/panels-visualizations/query-transform-data/sql-expressions/
+  - ../../../panels-visualizations/query-transform-data/sql-expressions/ # /docs/grafana/next/panels-visualizations/query-transform-data/sql-expressions/
 labels:
   products:
     - cloud


### PR DESCRIPTION
Alias addition on [this PR](https://github.com/grafana/grafana/commit/0b020c5e30fbc4b1f5585cb3107ed60f77c6ea8f) worked for versions before 12.3. This fix updates the alias for versions 12.3+.