### PR TITLE
Docker: Install busybox with version 1.37.0-r20 to address CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,6 +171,11 @@ ENV PATH="/usr/share/grafana/bin:$PATH" \
 
 WORKDIR $GF_PATHS_HOME
 
+# Addresses CVE-2025-46394 and CVE-2024-58251.
+# Currently the base alpine:3.22.2 image comes with busybox 1.37.0-r19 which does not have the fix.
+# When the base image updates busybox, this line can be removed.
+RUN apk add --no-cache busybox=1.37.0-r20
+
 # Install dependencies
 RUN if grep -i -q alpine /etc/issue; then \
   apk add --no-cache ca-certificates bash curl tzdata musl-utils && \


### PR DESCRIPTION
**What is this feature?**

Installs `busybox` with version `1.37.0-r20` which addresses CVE-2025-46394 and CVE-2024-58251.

**Why do we need this feature?**

The base Alpine image does not have the fixes, and already comes with `busybox`. So we can update that dependency to address the open CVEs associated with it, until the base image updates.

**Who is this feature for?**

Operators

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
