### PR TITLE
Histogram: Fix runaway bucket densification with extremely sparse + large datasets

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/histogram.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.test.ts
@@ -896,6 +896,24 @@ describe('getHistogramFields', () => {
       }
     `);
   });
+
+  it('should prevent excessive densification when sparse histogram has large gaps', () => {
+    const result = getHistogramFields(
+      toDataFrame({
+        meta: {
+          type: DataFrameType.HeatmapCells,
+        },
+        fields: [
+          { name: 'yMin', type: FieldType.number, values: [0.001, 1000] },
+          { name: 'yMax', type: FieldType.number, values: [0.00101, 1010] },
+          { name: 'count', type: FieldType.number, values: [10, 20] },
+        ],
+      })
+    );
+
+    expect(result).toBeDefined();
+    expect(result!.counts[0].values.length).toBeLessThanOrEqual(1001);
+  });
 });
 
 describe('joinHistograms', () => {

--- a/packages/grafana-data/src/transformations/transformers/histogram.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.test.ts
@@ -914,6 +914,24 @@ describe('getHistogramFields', () => {
     expect(result).toBeDefined();
     expect(result!.counts[0].values.length).toBeLessThanOrEqual(1001);
   });
+
+  it('should handle multiple observed buckets when hitting densification limit', () => {
+    const result = getHistogramFields(
+      toDataFrame({
+        meta: {
+          type: DataFrameType.HeatmapCells,
+        },
+        fields: [
+          { name: 'yMin', type: FieldType.number, values: [0.001, 1000, 2000] },
+          { name: 'yMax', type: FieldType.number, values: [0.00101, 1010, 2020] },
+          { name: 'count', type: FieldType.number, values: [10, 20, 30] },
+        ],
+      })
+    );
+
+    expect(result).toBeDefined();
+    expect(result!.counts[0].values.every((v) => !isNaN(v))).toBe(true);
+  });
 });
 
 describe('joinHistograms', () => {

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -210,6 +210,8 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
     let denseMins: number[] = [];
     let denseMaxs: number[] = [];
 
+    const MAX_DENSIFIED_BUCKETS = 1000;
+
     for (let i = 0; i < uniqueMaxs.length; i++) {
       let curMax = uniqueMaxs[i];
       let curMin = uniqueMins[i];
@@ -223,12 +225,16 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
         curMax = curMax * bucketFactor;
         curMin = curMin * bucketFactor;
 
-        while (curMax < nextMax * 0.999999) {
+        while (curMax < nextMax * 0.999999 && denseMaxs.length < MAX_DENSIFIED_BUCKETS) {
           denseMaxs.push(curMax);
           denseMins.push(curMin);
 
           curMax = curMax * bucketFactor;
           curMin = curMin * bucketFactor;
+        }
+
+        if (denseMaxs.length >= MAX_DENSIFIED_BUCKETS) {
+          break;
         }
       }
     }

--- a/packages/grafana-data/src/transformations/transformers/histogram.ts
+++ b/packages/grafana-data/src/transformations/transformers/histogram.ts
@@ -244,7 +244,10 @@ export function getHistogramFields(frame: DataFrame): HistogramFields | undefine
 
     for (let i = 0; i < yMaxField.values.length; i++) {
       let max = yMaxField.values[i];
-      countsByMax.set(max, countsByMax.get(max) + countField.values[i]);
+      let currentCount = countsByMax.get(max);
+      if (currentCount !== undefined) {
+        countsByMax.set(max, currentCount + countField.values[i]);
+      }
     }
 
     let fields = {


### PR DESCRIPTION
**What is this feature?**

A [previous feature enhancement](https://github.com/grafana/grafana/pull/112907) to densify sparse histogram buckets could be triggered into a runaway loop, OOM error, and resulting browser tab crash when handling _extremely_ sparse + large datasets.

**Why do we need this feature?**

This fixes a bug leading to an OOM error, and browser tab crash for an edge case.

**Who is this feature for?**

Users of Histogram, especially those with sparse (native) histogram data.

**Which issue(s) does this PR fix?**:

Fixes escalation https://github.com/grafana/support-escalations/issues/19546

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
