### PR TITLE
Alerting: Fetch only silenced alerts on the Silences page

### DIFF
--- a/public/app/features/alerting/unified/Silences.test.tsx
+++ b/public/app/features/alerting/unified/Silences.test.tsx
@@ -1,3 +1,4 @@
+import { HttpResponse, http } from 'msw';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render, screen, userEvent, waitFor, within } from 'test/test-utils';
 import { byLabelText, byPlaceholderText, byRole, byTestId, byText } from 'testing-library-selector';
@@ -150,6 +151,28 @@ describe('Silences', () => {
       expect(activeSilences).toHaveLength(expectedActiveSilences);
       expect(activeSilences[0]).toHaveTextContent('foo=bar');
       expect(activeSilences[1]).toHaveTextContent('foo!=bar');
+    },
+    TEST_TIMEOUT
+  );
+
+  it(
+    'fetches silenced alerts with correct filter parameters',
+    async () => {
+      let capturedParams: URLSearchParams | undefined;
+      server.use(
+        http.get('/api/alertmanager/:datasourceUid/api/v2/alerts', ({ request }) => {
+          capturedParams = new URL(request.url).searchParams;
+          return HttpResponse.json([]);
+        })
+      );
+
+      renderSilences();
+
+      await waitFor(() => expect(capturedParams).toBeDefined());
+
+      expect(capturedParams?.get('silenced')).toBe('true');
+      expect(capturedParams?.get('active')).toBe('false');
+      expect(capturedParams?.get('inhibited')).toBe('false');
     },
     TEST_TIMEOUT
   );

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -56,7 +56,7 @@ const SilencesTable = () => {
 
   const { data: alertManagerAlerts = [], isLoading: amAlertsIsLoading } =
     alertmanagerApi.endpoints.getAlertmanagerAlerts.useQuery(
-      { amSourceName: alertManagerSourceName, filter: { silenced: true, active: true, inhibited: true } },
+      { amSourceName: alertManagerSourceName, filter: { silenced: true, active: false, inhibited: false } },
       { ...API_QUERY_OPTIONS, skip: !canPreview }
     );
 


### PR DESCRIPTION
**What is this feature?**

Currently the Silences page fetches all alerts from the API (active, silenced, inhibited) instead of only silenced alerts, and then filters them by silence ID to display in each silence. With a large number of alerts it can be slow.

**Why do we need this feature?**

Improves performance of the Silences page.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
