### PR TITLE
chore: reduce barrel files

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3742,11 +3742,6 @@
       "count": 2
     }
   },
-  "public/app/plugins/datasource/cloud-monitoring/types/query.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 3
-    }
-  },
   "public/app/plugins/datasource/cloud-monitoring/types/types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1

--- a/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/CloudMonitoringMetricFindQuery.ts
@@ -1,6 +1,7 @@
 import { isString } from 'lodash';
 
 import { ALIGNMENT_PERIODS, SELECTORS } from './constants';
+import { ValueTypes, MetricFindQueryTypes } from './dataquery.gen';
 import CloudMonitoringDatasource from './datasource';
 import {
   extractServicesFromMetricDescriptors,
@@ -9,7 +10,6 @@ import {
   getLabelKeys,
   getMetricTypesByService,
 } from './functions';
-import { ValueTypes, MetricFindQueryTypes } from './types/query';
 import { CloudMonitoringVariableQuery, MetricDescriptor } from './types/types';
 
 export default class CloudMonitoringMetricFindQuery {

--- a/public/app/plugins/datasource/cloud-monitoring/annotationSupport.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/annotationSupport.test.ts
@@ -1,14 +1,9 @@
 import { AnnotationQuery } from '@grafana/data';
 
 import { CloudMonitoringAnnotationSupport } from './annotationSupport';
+import { AlignmentTypes, QueryType, MetricKind, LegacyCloudMonitoringAnnotationQuery } from './dataquery.gen';
 import { createMockDatasource } from './mocks/cloudMonitoringDatasource';
-import {
-  AlignmentTypes,
-  CloudMonitoringQuery,
-  QueryType,
-  MetricKind,
-  LegacyCloudMonitoringAnnotationQuery,
-} from './types/query';
+import { CloudMonitoringQuery } from './types/query';
 
 const query: CloudMonitoringQuery = {
   refId: 'query',

--- a/public/app/plugins/datasource/cloud-monitoring/annotationSupport.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/annotationSupport.ts
@@ -1,8 +1,9 @@
 import { AnnotationSupport, AnnotationQuery } from '@grafana/data';
 
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor';
+import { AlignmentTypes, QueryType, LegacyCloudMonitoringAnnotationQuery } from './dataquery.gen';
 import CloudMonitoringDatasource from './datasource';
-import { AlignmentTypes, CloudMonitoringQuery, QueryType, LegacyCloudMonitoringAnnotationQuery } from './types/query';
+import { CloudMonitoringQuery } from './types/query';
 
 // The legacy query format sets the title and text values to empty strings by default.
 // If the title or text is not undefined at the top-level of the annotation target,

--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { openMenu } from 'react-select-event';
 
-import { MetricKind, ValueTypes } from '../types/query';
+import { MetricKind, ValueTypes } from '../dataquery.gen';
 import { MetricDescriptor } from '../types/types';
 
 import { Aggregation, Props } from './Aggregation';

--- a/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Aggregation.tsx
@@ -4,8 +4,8 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
+import { ValueTypes } from '../dataquery.gen';
 import { getAggregationOptionsByMetric } from '../functions';
-import { ValueTypes } from '../types/query';
 import { MetricDescriptor } from '../types/types';
 
 export interface Props {

--- a/public/app/plugins/datasource/cloud-monitoring/components/Alignment.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Alignment.test.tsx
@@ -4,10 +4,10 @@ import { openMenu } from 'react-select-event';
 
 import { CustomVariableModel } from '@grafana/data';
 
+import { MetricKind, ValueTypes } from '../dataquery.gen';
 import { createMockDatasource } from '../mocks/cloudMonitoringDatasource';
 import { createMockMetricDescriptor } from '../mocks/cloudMonitoringMetricDescriptor';
 import { createMockTimeSeriesList } from '../mocks/cloudMonitoringQuery';
-import { MetricKind, ValueTypes } from '../types/query';
 
 import { Alignment } from './Alignment';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/Alignment.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Alignment.tsx
@@ -4,9 +4,9 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
 
 import { ALIGNMENT_PERIODS } from '../constants';
+import { PreprocessorType, TimeSeriesList } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { alignmentPeriodLabel } from '../functions';
-import { PreprocessorType, TimeSeriesList } from '../types/query';
 import { CustomMetaData, MetricDescriptor } from '../types/types';
 
 import { AlignmentFunction } from './AlignmentFunction';

--- a/public/app/plugins/datasource/cloud-monitoring/components/AlignmentFunction.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AlignmentFunction.tsx
@@ -3,8 +3,8 @@ import { useMemo } from 'react';
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';
 
+import { PreprocessorType, SLOQuery, TimeSeriesList } from '../dataquery.gen';
 import { getAlignmentPickerData } from '../functions';
-import { PreprocessorType, SLOQuery, TimeSeriesList } from '../types/query';
 import { MetricDescriptor } from '../types/types';
 
 export interface Props {

--- a/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/AnnotationQueryEditor.tsx
@@ -6,8 +6,9 @@ import { QueryEditorProps, getDefaultTimeRange, toOption } from '@grafana/data';
 import { EditorField, EditorRows } from '@grafana/plugin-ui';
 import { Input } from '@grafana/ui';
 
+import { TimeSeriesList, QueryType } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { TimeSeriesList, CloudMonitoringQuery, QueryType } from '../types/query';
+import { CloudMonitoringQuery } from '../types/query';
 import { CloudMonitoringOptions } from '../types/types';
 
 import { AnnotationsHelp } from './AnnotationsHelp';

--- a/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/GroupBy.tsx
@@ -5,8 +5,8 @@ import { EditorField, EditorFieldGroup } from '@grafana/plugin-ui';
 import { MultiSelect } from '@grafana/ui';
 
 import { SYSTEM_LABELS } from '../constants';
+import { TimeSeriesList } from '../dataquery.gen';
 import { labelsToGroupedOptions } from '../functions';
-import { TimeSeriesList } from '../types/query';
 import { MetricDescriptor } from '../types/types';
 
 import { Aggregation } from './Aggregation';

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.test.tsx
@@ -4,9 +4,9 @@ import { openMenu } from 'react-select-event';
 
 import { getDefaultTimeRange } from '@grafana/data';
 
+import { QueryType } from '../dataquery.gen';
 import { createMockDatasource } from '../mocks/cloudMonitoringDatasource';
 import { createMockQuery } from '../mocks/cloudMonitoringQuery';
-import { QueryType } from '../types/query';
 
 import { MetricQueryEditor } from './MetricQueryEditor';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/MetricQueryEditor.tsx
@@ -5,8 +5,9 @@ import { SelectableValue, TimeRange } from '@grafana/data';
 import { EditorRows } from '@grafana/plugin-ui';
 import { Stack } from '@grafana/ui';
 
+import { AlignmentTypes, QueryType, TimeSeriesList, TimeSeriesQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { AlignmentTypes, CloudMonitoringQuery, QueryType, TimeSeriesList, TimeSeriesQuery } from '../types/query';
+import { CloudMonitoringQuery } from '../types/query';
 import { CustomMetaData } from '../types/types';
 
 import { AliasBy } from './AliasBy';

--- a/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.test.tsx
@@ -3,9 +3,9 @@ import userEvent from '@testing-library/user-event';
 
 import { CustomVariableModel } from '@grafana/data';
 
+import { MetricKind, ValueTypes } from '../dataquery.gen';
 import { createMockMetricDescriptor } from '../mocks/cloudMonitoringMetricDescriptor';
 import { createMockTimeSeriesList } from '../mocks/cloudMonitoringQuery';
-import { MetricKind, ValueTypes } from '../types/query';
 
 import { Preprocessor } from './Preprocessor';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Preprocessor.tsx
@@ -4,8 +4,8 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
 import { RadioButtonGroup } from '@grafana/ui';
 
+import { PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from '../dataquery.gen';
 import { getAlignmentPickerData } from '../functions';
-import { PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from '../types/query';
 import { MetricDescriptor } from '../types/types';
 
 const NONE_OPTION = { label: 'None', value: PreprocessorType.None };

--- a/public/app/plugins/datasource/cloud-monitoring/components/PromQLEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/PromQLEditor.tsx
@@ -4,9 +4,9 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorRow } from '@grafana/plugin-ui';
 import { TextArea, Input } from '@grafana/ui';
 
+import { PromQLQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { selectors } from '../e2e/selectors';
-import { PromQLQuery } from '../types/query';
 
 import { Project } from './Project';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.test.tsx
@@ -1,10 +1,10 @@
 import { render, waitFor, screen } from '@testing-library/react';
 import { select } from 'react-select-event';
 
+import { QueryType } from '../dataquery.gen';
 import { selectors } from '../e2e/selectors';
 import { createMockDatasource } from '../mocks/cloudMonitoringDatasource';
 import { createMockQuery } from '../mocks/cloudMonitoringQuery';
-import { QueryType } from '../types/query';
 
 import { QueryEditor } from './QueryEditor';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryEditor.tsx
@@ -6,9 +6,10 @@ import { QueryEditorProps, getDefaultTimeRange, toOption } from '@grafana/data';
 import { EditorRows } from '@grafana/plugin-ui';
 import { ConfirmModal } from '@grafana/ui';
 
+import { PromQLQuery, QueryType, SLOQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { selectors } from '../e2e/selectors';
-import { CloudMonitoringQuery, PromQLQuery, QueryType, SLOQuery } from '../types/query';
+import { CloudMonitoringQuery } from '../types/query';
 import { CloudMonitoringOptions } from '../types/types';
 
 import { defaultTimeSeriesList, defaultTimeSeriesQuery, MetricQueryEditor } from './MetricQueryEditor';

--- a/public/app/plugins/datasource/cloud-monitoring/components/QueryHeader.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/QueryHeader.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import { openMenu, select } from 'react-select-event';
 
+import { QueryType } from '../dataquery.gen';
 import { createMockQuery } from '../mocks/cloudMonitoringQuery';
-import { QueryType } from '../types/query';
 
 import { QueryHeader } from './QueryHeader';
 

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLO.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLO.tsx
@@ -4,8 +4,8 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
+import { SLOQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { SLOQuery } from '../types/query';
 
 export interface Props {
   refId: string;

--- a/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/SLOQueryEditor.tsx
@@ -5,10 +5,10 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/plugin-ui';
 
 import { ALIGNMENT_PERIODS, SLO_BURN_RATE_SELECTOR_NAME } from '../constants';
+import { AlignmentTypes, SLOQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { selectors } from '../e2e/selectors';
 import { alignmentPeriodLabel } from '../functions';
-import { AlignmentTypes, SLOQuery } from '../types/query';
 import { CustomMetaData } from '../types/types';
 
 import { AliasBy } from './AliasBy';

--- a/public/app/plugins/datasource/cloud-monitoring/components/Selector.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Selector.tsx
@@ -3,8 +3,8 @@ import { EditorField } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
 import { SELECTORS } from '../constants';
+import { SLOQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { SLOQuery } from '../types/query';
 
 export interface Props {
   refId: string;

--- a/public/app/plugins/datasource/cloud-monitoring/components/Service.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/Service.tsx
@@ -4,8 +4,8 @@ import { SelectableValue } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
+import { SLOQuery } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { SLOQuery } from '../types/query';
 
 export interface Props {
   refId: string;

--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.test.tsx
@@ -2,8 +2,8 @@ import { render, screen, waitFor } from '@testing-library/react';
 
 import { VariableModel } from '@grafana/data';
 
+import { MetricFindQueryTypes } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
-import { MetricFindQueryTypes } from '../types/query';
 import { CloudMonitoringVariableQuery } from '../types/types';
 
 import { CloudMonitoringVariableQueryEditor, Props } from './VariableQueryEditor';

--- a/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VariableQueryEditor.tsx
@@ -3,9 +3,10 @@ import { PureComponent } from 'react';
 import { QueryEditorProps } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
+import { MetricFindQueryTypes } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { extractServicesFromMetricDescriptors, getLabelKeys, getMetricTypes } from '../functions';
-import { CloudMonitoringQuery, MetricFindQueryTypes } from '../types/query';
+import { CloudMonitoringQuery } from '../types/query';
 import {
   CloudMonitoringOptions,
   CloudMonitoringVariableQuery,

--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.test.tsx
@@ -6,10 +6,10 @@ import { CustomVariableModel, getDefaultTimeRange } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { getTemplateSrv } from '@grafana/runtime';
 
+import { PreprocessorType, MetricKind, ValueTypes } from '../dataquery.gen';
 import { createMockDatasource } from '../mocks/cloudMonitoringDatasource';
 import { createMockMetricDescriptor } from '../mocks/cloudMonitoringMetricDescriptor';
 import { createMockTimeSeriesList } from '../mocks/cloudMonitoringQuery';
-import { PreprocessorType, MetricKind, ValueTypes } from '../types/query';
 
 import { defaultTimeSeriesList } from './MetricQueryEditor';
 import { VisualMetricQueryEditor } from './VisualMetricQueryEditor';

--- a/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloud-monitoring/components/VisualMetricQueryEditor.tsx
@@ -9,10 +9,10 @@ import { EditorField, EditorFieldGroup, EditorRow } from '@grafana/plugin-ui';
 import { reportInteraction } from '@grafana/runtime';
 import { getSelectStyles, Select, AsyncSelect, useStyles2, useTheme2 } from '@grafana/ui';
 
+import { PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from '../dataquery.gen';
 import CloudMonitoringDatasource from '../datasource';
 import { selectors } from '../e2e/selectors';
 import { getAlignmentPickerData, getMetricType, setMetricType } from '../functions';
-import { PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from '../types/query';
 import { CustomMetaData, MetricDescriptor } from '../types/types';
 
 import { AliasBy } from './AliasBy';

--- a/public/app/plugins/datasource/cloud-monitoring/constants.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/constants.ts
@@ -1,4 +1,4 @@
-import { QueryType, MetricKind, ValueTypes } from './types/query';
+import { QueryType, MetricKind, ValueTypes } from './dataquery.gen';
 
 // not super excited about using uneven numbers, but this makes it align perfectly with rows that has two fields
 export const INPUT_WIDTH = 71;

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.test.ts
@@ -4,10 +4,11 @@ import { lastValueFrom, of } from 'rxjs';
 import { CustomVariableModel, ScopedVars } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 
+import { PreprocessorType, QueryType, MetricKind } from './dataquery.gen';
 import Datasource from './datasource';
 import { createMockInstanceSetttings } from './mocks/cloudMonitoringInstanceSettings';
 import { createMockQuery } from './mocks/cloudMonitoringQuery';
-import { CloudMonitoringQuery, PreprocessorType, QueryType, MetricKind } from './types/query';
+import { CloudMonitoringQuery } from './types/query';
 
 let getTempVars = () => [] as CustomVariableModel[];
 let replace = () => '';

--- a/public/app/plugins/datasource/cloud-monitoring/datasource.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/datasource.ts
@@ -23,8 +23,9 @@ import {
 
 import { CloudMonitoringAnnotationSupport } from './annotationSupport';
 import { SLO_BURN_RATE_SELECTOR_NAME } from './constants';
+import { QueryType, MetricQuery, Filter } from './dataquery.gen';
 import { getMetricType, setMetricType } from './functions';
-import { CloudMonitoringQuery, QueryType, MetricQuery, Filter } from './types/query';
+import { CloudMonitoringQuery } from './types/query';
 import { CloudMonitoringOptions, MetricDescriptor, PostResponse, Aggregation } from './types/types';
 import { CloudMonitoringVariableSupport } from './variables';
 

--- a/public/app/plugins/datasource/cloud-monitoring/functions.test.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/functions.test.ts
@@ -1,4 +1,5 @@
 import { AGGREGATIONS, SYSTEM_LABELS } from './constants';
+import { AlignmentTypes, TimeSeriesList, MetricKind, ValueTypes } from './dataquery.gen';
 import {
   extractServicesFromMetricDescriptors,
   getAggregationOptionsByMetric,
@@ -14,7 +15,6 @@ import {
   setMetricType,
 } from './functions';
 import { newMockDatasource } from './specs/testData';
-import { AlignmentTypes, TimeSeriesList, MetricKind, ValueTypes } from './types/query';
 import { MetricDescriptor } from './types/types';
 
 jest.mock('@grafana/runtime', () => ({

--- a/public/app/plugins/datasource/cloud-monitoring/functions.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/functions.ts
@@ -4,8 +4,8 @@ import { rangeUtil } from '@grafana/data';
 import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 
 import { AGGREGATIONS, ALIGNMENTS, SYSTEM_LABELS } from './constants';
+import { AlignmentTypes, PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from './dataquery.gen';
 import CloudMonitoringDatasource from './datasource';
-import { AlignmentTypes, PreprocessorType, TimeSeriesList, MetricKind, ValueTypes } from './types/query';
 import { CustomMetaData, MetricDescriptor } from './types/types';
 
 export const extractServicesFromMetricDescriptors = (metricDescriptors: MetricDescriptor[]) =>

--- a/public/app/plugins/datasource/cloud-monitoring/mocks/cloudMonitoringMetricDescriptor.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/mocks/cloudMonitoringMetricDescriptor.ts
@@ -1,4 +1,4 @@
-import { MetricKind, ValueTypes } from '../types/query';
+import { MetricKind, ValueTypes } from '../dataquery.gen';
 import { MetricDescriptor } from '../types/types';
 
 export const createMockMetricDescriptor = (overrides?: Partial<MetricDescriptor>): MetricDescriptor => {

--- a/public/app/plugins/datasource/cloud-monitoring/mocks/cloudMonitoringQuery.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/mocks/cloudMonitoringQuery.ts
@@ -1,11 +1,5 @@
-import {
-  AlignmentTypes,
-  CloudMonitoringQuery,
-  QueryType,
-  SLOQuery,
-  TimeSeriesList,
-  TimeSeriesQuery,
-} from '../types/query';
+import { AlignmentTypes, QueryType, SLOQuery, TimeSeriesList, TimeSeriesQuery } from '../dataquery.gen';
+import { CloudMonitoringQuery } from '../types/query';
 
 type Subset<K> = {
   [attr in keyof K]?: K[attr] extends object ? Subset<K[attr]> : K[attr];

--- a/public/app/plugins/datasource/cloud-monitoring/module.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/module.ts
@@ -7,10 +7,11 @@ import CloudMonitoringCheatSheet from './components/CloudMonitoringCheatSheet';
 import { ConfigEditor } from './components/ConfigEditor/ConfigEditor';
 import { QueryEditor } from './components/QueryEditor';
 import { CloudMonitoringVariableQueryEditor } from './components/VariableQueryEditor';
+import { QueryType } from './dataquery.gen';
 import CloudMonitoringDatasource from './datasource';
 import pluginJson from './plugin.json';
 import { trackCloudMonitoringDashboardLoaded } from './tracking';
-import { CloudMonitoringQuery, QueryType } from './types/query';
+import { CloudMonitoringQuery } from './types/query';
 
 export const plugin = new DataSourcePlugin<CloudMonitoringDatasource, CloudMonitoringQuery>(CloudMonitoringDatasource)
   .setQueryEditorHelp(CloudMonitoringCheatSheet)

--- a/public/app/plugins/datasource/cloud-monitoring/types/query.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types/query.ts
@@ -1,17 +1,5 @@
 import { CloudMonitoringQuery as CloudMonitoringQueryBase, QueryType } from '../dataquery.gen';
 
-export { QueryType };
-export { PreprocessorType, MetricKind, AlignmentTypes, ValueTypes, MetricFindQueryTypes } from '../dataquery.gen';
-export type {
-  TimeSeriesQuery,
-  SLOQuery,
-  TimeSeriesList,
-  MetricQuery,
-  PromQLQuery,
-  LegacyCloudMonitoringAnnotationQuery,
-  Filter,
-} from '../dataquery.gen';
-
 /**
  * Represents the query as it moves through the frontend query editor and datasource files.
  * It can represent new queries that are still being edited, so all properties are optional

--- a/public/app/plugins/datasource/cloud-monitoring/types/types.ts
+++ b/public/app/plugins/datasource/cloud-monitoring/types/types.ts
@@ -1,7 +1,7 @@
 import { DataQuery, SelectableValue, VariableWithMultiSupport } from '@grafana/data';
 import { DataSourceOptions, DataSourceSecureJsonData } from '@grafana/google-sdk';
 
-import { MetricKind } from './query';
+import { MetricKind } from '../dataquery.gen';
 
 export interface CloudMonitoringVariableQuery extends DataQuery {
   selectedQueryType: string;


### PR DESCRIPTION

**What is this feature?**

This PR replaces usage of export * from './directory' in grafana with explicit exports that refer to the file the code lives in and it removes the default export for `appEvents`.
- [x] public/app/plugins/datasource/cloud-monitoring/types/query.ts

**Why do we need this feature?**

Barrel files simplify and centralise imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
