### PR TITLE
chore: reduce cloudwatch barrel files

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3777,11 +3777,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/cloudwatch/expressions.ts": {
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
-    }
-  },
   "public/app/plugins/datasource/cloudwatch/guards.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1
@@ -3795,9 +3790,6 @@
   "public/app/plugins/datasource/cloudwatch/types.ts": {
     "@typescript-eslint/no-explicit-any": {
       "count": 7
-    },
-    "no-barrel-files/no-barrel-files": {
-      "count": 1
     }
   },
   "public/app/plugins/datasource/cloudwatch/utils/datalinks.ts": {

--- a/public/app/features/dashboard/state/DashboardMigrator.ts
+++ b/public/app/features/dashboard/state/DashboardMigrator.ts
@@ -49,7 +49,8 @@ import {
 } from 'app/features/transformers/timeSeriesTable/timeSeriesTableTransformer';
 import { isConstant, isMulti } from 'app/features/variables/guard';
 import { alignCurrentWithMulti } from 'app/features/variables/shared/multiOptions';
-import { CloudWatchMetricsQuery, LegacyAnnotationQuery } from 'app/plugins/datasource/cloudwatch/types';
+import { CloudWatchMetricsQuery } from 'app/plugins/datasource/cloudwatch/dataquery.gen';
+import { LegacyAnnotationQuery } from 'app/plugins/datasource/cloudwatch/types';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import {

--- a/public/app/plugins/datasource/cloudwatch/annotationSupport.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotationSupport.test.ts
@@ -1,7 +1,8 @@
 import { AnnotationQuery } from '@grafana/data';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
-import { CloudWatchAnnotationQuery, LegacyAnnotationQuery } from './types';
+import { CloudWatchAnnotationQuery } from './dataquery.gen';
+import { LegacyAnnotationQuery } from './types';
 
 const metricStatAnnotationQuery: CloudWatchAnnotationQuery = {
   queryMode: 'Annotations',

--- a/public/app/plugins/datasource/cloudwatch/annotationSupport.ts
+++ b/public/app/plugins/datasource/cloudwatch/annotationSupport.ts
@@ -1,9 +1,10 @@
 import { AnnotationQuery } from '@grafana/data';
 
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor/AnnotationQueryEditor';
+import { CloudWatchAnnotationQuery } from './dataquery.gen';
 import { DEFAULT_ANNOTATIONS_QUERY } from './defaultQueries';
 import { isCloudWatchAnnotation } from './guards';
-import { CloudWatchAnnotationQuery, CloudWatchQuery, LegacyAnnotationQuery } from './types';
+import { CloudWatchQuery, LegacyAnnotationQuery } from './types';
 
 export const CloudWatchAnnotationSupport = {
   // converts legacy angular style queries to new format. Also sets the same default values as in the deprecated angular directive

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor/AnnotationQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor/AnnotationQueryEditor.test.tsx
@@ -3,9 +3,10 @@ import '@testing-library/jest-dom';
 
 import { QueryEditorProps } from '@grafana/data';
 
+import { CloudWatchAnnotationQuery, CloudWatchMetricsQuery } from '../../dataquery.gen';
 import { CloudWatchDatasource } from '../../datasource';
 import { setupMockedDataSource } from '../../mocks/CloudWatchDataSource';
-import { CloudWatchAnnotationQuery, CloudWatchJsonData, CloudWatchMetricsQuery, CloudWatchQuery } from '../../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../../types';
 
 import { AnnotationQueryEditor } from './AnnotationQueryEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor/AnnotationQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/AnnotationQueryEditor/AnnotationQueryEditor.tsx
@@ -4,10 +4,11 @@ import { QueryEditorProps } from '@grafana/data';
 import { EditorField, EditorHeader, EditorRow, EditorSwitch, InlineSelect } from '@grafana/plugin-ui';
 import { Alert, Input, Space } from '@grafana/ui';
 
+import { MetricStat } from '../../dataquery.gen';
 import { CloudWatchDatasource } from '../../datasource';
 import { isCloudWatchAnnotationQuery } from '../../guards';
 import { useRegions } from '../../hooks';
-import { CloudWatchJsonData, CloudWatchQuery, MetricStat } from '../../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../../types';
 import { MetricStatEditor } from '../shared/MetricStatEditor/MetricStatEditor';
 
 export type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>;

--- a/public/app/plugins/datasource/cloudwatch/components/CheatSheet/LogsCheatSheet.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/CheatSheet/LogsCheatSheet.tsx
@@ -6,8 +6,9 @@ import { GrafanaTheme2 } from '@grafana/data';
 import { Collapse, useStyles2, Text, TextLink } from '@grafana/ui';
 import { flattenTokens } from '@grafana/ui/internal';
 
+import { CloudWatchLogsQuery, LogsQueryLanguage } from '../../dataquery.gen';
 import { trackSampleQuerySelection } from '../../tracking';
-import { CloudWatchLogsQuery, CloudWatchQuery, LogsQueryLanguage } from '../../types';
+import { CloudWatchQuery } from '../../types';
 
 import * as sampleQueries from './sampleQueries';
 import { cwliTokenizer, pplTokenizer, sqlTokenizer } from './tokenizer';

--- a/public/app/plugins/datasource/cloudwatch/components/CheatSheet/sampleQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/CheatSheet/sampleQueries.ts
@@ -1,6 +1,6 @@
 import { stripIndents } from 'common-tags';
 
-import { LogsQueryLanguage } from '../../types';
+import { LogsQueryLanguage } from '../../dataquery.gen';
 
 export interface SampleQuery {
   title: string;

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/CloudWatchLink.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/CloudWatchLink.test.tsx
@@ -2,10 +2,10 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 
 import { LoadingState } from '@grafana/data';
 
+import { CloudWatchLogsQuery } from '../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../mocks/CloudWatchDataSource';
 import { RequestMock } from '../../../mocks/Request';
 import { validLogsQuery } from '../../../mocks/queries';
-import { CloudWatchLogsQuery } from '../../../types';
 
 import { CloudWatchLink } from './CloudWatchLink';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/CloudWatchLink.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/CloudWatchLink.tsx
@@ -5,8 +5,8 @@ import { PanelData } from '@grafana/data';
 import { LinkButton } from '@grafana/ui';
 
 import { AwsUrl, encodeUrl } from '../../../aws_url';
+import { CloudWatchLogsQuery } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
-import { CloudWatchLogsQuery } from '../../../types';
 
 interface Props {
   query: CloudWatchLogsQuery;

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryEditor.tsx
@@ -4,9 +4,10 @@ import { useEffectOnce } from 'react-use';
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { InlineSelect } from '@grafana/plugin-ui';
 
+import { CloudWatchLogsQuery, LogsMode, LogsQueryLanguage } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { DEFAULT_CWLI_QUERY_STRING, DEFAULT_PPL_QUERY_STRING, DEFAULT_SQL_QUERY_STRING } from '../../../defaultQueries';
-import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery, LogsMode, LogsQueryLanguage } from '../../../types';
+import { CloudWatchQuery, CloudWatchJsonData } from '../../../types';
 
 import { CloudWatchLink } from './CloudWatchLink';
 import { LogsAnomaliesQueryEditor } from './LogsAnomaliesQueryEditor';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryField.tsx
@@ -4,8 +4,9 @@ import { ReactNode, useCallback } from 'react';
 import { GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';
 
+import { CloudWatchLogsQuery, LogsQueryLanguage } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
-import { CloudWatchJsonData, CloudWatchLogsQuery, CloudWatchQuery, LogsQueryLanguage } from '../../../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../../../types';
 import { LogGroupsFieldWrapper } from '../../shared/LogGroups/LogGroupsField';
 
 import { LogsQLCodeEditor } from './code-editors/LogsQLCodeEditor';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/LogsQLCodeEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/LogsQLCodeEditor.tsx
@@ -3,11 +3,11 @@ import { useCallback, useRef } from 'react';
 
 import { CodeEditor, Monaco } from '@grafana/ui';
 
+import { CloudWatchLogsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import language from '../../../../language/logs/definition';
 import { TRIGGER_SUGGEST } from '../../../../language/monarch/commands';
 import { registerLanguage, reRegisterCompletionProvider } from '../../../../language/monarch/register';
-import { CloudWatchLogsQuery } from '../../../../types';
 import { getStatsGroups } from '../../../../utils/query/getStatsGroups';
 
 import { codeEditorCommonProps } from './PPLQueryEditor';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/PPLQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/PPLQueryEditor.tsx
@@ -4,11 +4,11 @@ import { useCallback, useRef } from 'react';
 import { CodeEditor, Monaco } from '@grafana/ui';
 import { CodeEditorProps } from '@grafana/ui/internal';
 
+import { CloudWatchLogsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import language from '../../../../language/cloudwatch-ppl/definition';
 import { TRIGGER_SUGGEST } from '../../../../language/monarch/commands';
 import { registerLanguage, reRegisterCompletionProvider } from '../../../../language/monarch/register';
-import { CloudWatchLogsQuery } from '../../../../types';
 import { getStatsGroups } from '../../../../utils/query/getStatsGroups';
 
 export const codeEditorCommonProps: Partial<CodeEditorProps> = {

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/SQLCodeEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/code-editors/SQLCodeEditor.tsx
@@ -3,11 +3,11 @@ import { useCallback, useRef } from 'react';
 
 import { CodeEditor, Monaco } from '@grafana/ui';
 
+import { CloudWatchLogsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import language from '../../../../language/cloudwatch-logs-sql/definition';
 import { TRIGGER_SUGGEST } from '../../../../language/monarch/commands';
 import { registerLanguage, reRegisterCompletionProvider } from '../../../../language/monarch/register';
-import { CloudWatchLogsQuery } from '../../../../types';
 import { getStatsGroups } from '../../../../utils/query/getStatsGroups';
 
 import { codeEditorCommonProps } from './PPLQueryEditor';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.test.tsx
@@ -5,10 +5,11 @@ import { CustomVariableModel, DataSourceInstanceSettings } from '@grafana/data';
 // eslint-disable-next-line no-restricted-imports
 import * as ui from '@grafana/ui';
 
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { setupMockedTemplateService } from '../../../mocks/CloudWatchDataSource';
 import { initialVariableModelState } from '../../../mocks/CloudWatchVariables';
-import { CloudWatchJsonData, CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../../../types';
+import { CloudWatchJsonData } from '../../../types';
 
 import { MetricsQueryEditor, Props } from './MetricsQueryEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -6,17 +6,11 @@ import { EditorField, EditorRow, InlineSelect } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { ConfirmModal, Input, RadioButtonGroup, Space } from '@grafana/ui';
 
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, MetricStat } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { DEFAULT_METRICS_QUERY } from '../../../defaultQueries';
 import useMigratedMetricsQuery from '../../../migrations/useMigratedMetricsQuery';
-import {
-  CloudWatchJsonData,
-  CloudWatchMetricsQuery,
-  CloudWatchQuery,
-  MetricEditorMode,
-  MetricQueryType,
-  MetricStat,
-} from '../../../types';
+import { CloudWatchQuery, CloudWatchJsonData } from '../../../types';
 import { MetricStatEditor } from '../../shared/MetricStatEditor/MetricStatEditor';
 
 import { DynamicLabelsField } from './DynamicLabelsField';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderEditor.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen, waitFor } from '@testing-library/react';
 
-import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../../../expressions';
+import {
+  CloudWatchMetricsQuery,
+  MetricEditorMode,
+  MetricQueryType,
+  SQLExpression,
+  QueryEditorExpressionType,
+  QueryEditorPropertyType,
+} from '../../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../../mocks/CloudWatchDataSource';
-import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../../../types';
 
 import { SQLBuilderEditor } from './SQLBuilderEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderEditor.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 import { EditorField, EditorRow, EditorRows } from '@grafana/plugin-ui';
 import { Input } from '@grafana/ui';
 
+import { CloudWatchMetricsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import SQLGenerator from '../../../../language/cloudwatch-sql/SQLGenerator';
-import { CloudWatchMetricsQuery } from '../../../../types';
 
 import SQLBuilderSelectRow from './SQLBuilderSelectRow';
 import SQLFilter from './SQLFilter';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.test.tsx
@@ -1,9 +1,15 @@
 import { act, render, screen } from '@testing-library/react';
 import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 
-import { QueryEditorExpressionType, QueryEditorPropertyType } from '../../../../expressions';
+import {
+  CloudWatchMetricsQuery,
+  MetricEditorMode,
+  MetricQueryType,
+  SQLExpression,
+  QueryEditorExpressionType,
+  QueryEditorPropertyType,
+} from '../../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../../mocks/CloudWatchDataSource';
-import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../../../types';
 
 import SQLBuilderSelectRow from './SQLBuilderSelectRow';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLBuilderSelectRow.tsx
@@ -5,10 +5,10 @@ import { EditorField, EditorFieldGroup, EditorSwitch } from '@grafana/plugin-ui'
 import { config } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
 
+import { CloudWatchMetricsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import { useAccountOptions, useDimensionKeys, useMetrics, useNamespaces } from '../../../../hooks';
 import { STATISTICS } from '../../../../language/cloudwatch-sql/language';
-import { CloudWatchMetricsQuery } from '../../../../types';
 import { appendTemplateVariables } from '../../../../utils/utils';
 import { Account } from '../../../shared/Account';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLFilter.tsx
@@ -6,16 +6,16 @@ import { SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton, EditorList, InputGroup } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Alert, Select, useStyles2 } from '@grafana/ui';
+import {
+  CloudWatchMetricsQuery,
+  QueryEditorExpressionType,
+  QueryEditorPropertyType,
+} from 'app/plugins/datasource/cloudwatch/dataquery.gen';
 
 import { CloudWatchDatasource } from '../../../../datasource';
-import {
-  QueryEditorExpressionType,
-  QueryEditorOperatorExpression,
-  QueryEditorPropertyType,
-} from '../../../../expressions';
+import { QueryEditorOperatorExpression } from '../../../../expressions';
 import { useDimensionKeys, useEnsureVariableHasSingleSelection } from '../../../../hooks';
 import { COMPARISON_OPERATORS, EQUALS } from '../../../../language/cloudwatch-sql/language';
-import { CloudWatchMetricsQuery } from '../../../../types';
 import { appendTemplateVariables } from '../../../../utils/utils';
 
 import {

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.test.tsx
@@ -4,9 +4,9 @@ import selectEvent from 'react-select-event';
 
 import { config } from '@grafana/runtime';
 
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../../mocks/CloudWatchDataSource';
 import { createArray, createGroupBy } from '../../../../mocks/sqlUtils';
-import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType, SQLExpression } from '../../../../types';
 
 import SQLGroupBy from './SQLGroupBy';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLGroupBy.tsx
@@ -5,14 +5,14 @@ import { AccessoryButton, EditorList, InputGroup } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Select } from '@grafana/ui';
 
-import { CloudWatchDatasource } from '../../../../datasource';
 import {
+  CloudWatchMetricsQuery,
   QueryEditorExpressionType,
   QueryEditorGroupByExpression,
   QueryEditorPropertyType,
-} from '../../../../expressions';
+} from '../../../../dataquery.gen';
+import { CloudWatchDatasource } from '../../../../datasource';
 import { useDimensionKeys, useIsMonitoringAccount } from '../../../../hooks';
-import { CloudWatchMetricsQuery } from '../../../../types';
 
 import {
   getFlattenedGroupBys,

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLOrderByGroup.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/SQLOrderByGroup.tsx
@@ -2,9 +2,9 @@ import { SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton, EditorField, EditorFieldGroup, InputGroup } from '@grafana/plugin-ui';
 import { Select } from '@grafana/ui';
 
+import { CloudWatchMetricsQuery } from '../../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../../datasource';
 import { ASC, DESC, STATISTICS } from '../../../../language/cloudwatch-sql/language';
-import { CloudWatchMetricsQuery } from '../../../../types';
 import { appendTemplateVariables } from '../../../../utils/utils';
 
 import { setOrderBy, setSql } from './utils';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/SQLBuilderEditor/utils.ts
@@ -1,15 +1,17 @@
 import { SelectableValue } from '@grafana/data';
 
 import {
+  SQLExpression,
+  CloudWatchMetricsQuery,
+  Dimensions,
   QueryEditorExpressionType,
   QueryEditorPropertyType,
   QueryEditorFunctionParameterExpression,
   QueryEditorArrayExpression,
-  QueryEditorOperatorExpression,
   QueryEditorGroupByExpression,
-} from '../../../../expressions';
+} from '../../../../dataquery.gen';
+import { QueryEditorOperatorExpression } from '../../../../expressions';
 import { SCHEMA } from '../../../../language/cloudwatch-sql/language';
-import { SQLExpression, CloudWatchMetricsQuery, Dimensions } from '../../../../types';
 
 export function getMetricNameFromExpression(selectExpression: SQLExpression['select']): string | undefined {
   return selectExpression?.parameters?.[0].name;

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -5,6 +5,7 @@ import { selectOptionInTest } from 'test/helpers/selectOptionInTest';
 import { QueryEditorProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
 
+import { MetricEditorMode, MetricQueryType, LogsQueryLanguage } from '../../dataquery.gen';
 import { CloudWatchDatasource } from '../../datasource';
 import { DEFAULT_CWLI_QUERY_STRING, DEFAULT_SQL_QUERY_STRING } from '../../defaultQueries';
 import { setupMockedDataSource } from '../../mocks/CloudWatchDataSource';
@@ -15,7 +16,7 @@ import {
   validMetricSearchBuilderQuery,
   validMetricSearchCodeQuery,
 } from '../../mocks/queries';
-import { CloudWatchQuery, CloudWatchJsonData, MetricEditorMode, MetricQueryType, LogsQueryLanguage } from '../../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../../types';
 
 import { QueryEditor } from './QueryEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
@@ -3,10 +3,11 @@ import { EditorHeader, InlineSelect, FlexItem } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';
 import { Badge, Button } from '@grafana/ui';
 
+import { CloudWatchQueryMode } from '../../dataquery.gen';
 import { CloudWatchDatasource } from '../../datasource';
 import { isCloudWatchLogsQuery, isCloudWatchMetricsQuery } from '../../guards';
 import { useIsMonitoringAccount, useRegions } from '../../hooks';
-import { CloudWatchJsonData, CloudWatchQuery, CloudWatchQueryMode } from '../../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../../types';
 
 export interface Props extends QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData> {
   extraHeaderElementLeft?: JSX.Element;

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.test.tsx
@@ -1,8 +1,8 @@
 import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { CloudWatchMetricsQuery } from '../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../mocks/CloudWatchDataSource';
-import { CloudWatchMetricsQuery } from '../../../types';
 
 import { Dimensions } from './Dimensions';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/Dimensions.tsx
@@ -3,8 +3,8 @@ import { useMemo, useState } from 'react';
 
 import { EditorList } from '@grafana/plugin-ui';
 
+import { Dimensions as DimensionsType, MetricStat } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
-import { Dimensions as DimensionsType, MetricStat } from '../../../types';
 
 import { FilterItem } from './FilterItem';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.test.tsx
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { CloudWatchMetricsQuery } from '../../../dataquery.gen';
 import { setupMockedDataSource } from '../../../mocks/CloudWatchDataSource';
-import { CloudWatchMetricsQuery } from '../../../types';
 
 import { FilterItem } from './FilterItem';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/Dimensions/FilterItem.tsx
@@ -6,9 +6,9 @@ import { GrafanaTheme2, SelectableValue, toOption } from '@grafana/data';
 import { AccessoryButton, InputGroup } from '@grafana/plugin-ui';
 import { Alert, Select, useStyles2 } from '@grafana/ui';
 
+import { Dimensions, MetricStat } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { useDimensionKeys, useEnsureVariableHasSingleSelection } from '../../../hooks';
-import { Dimensions, MetricStat } from '../../../types';
 import { appendTemplateVariables } from '../../../utils/utils';
 
 import { DimensionFilterCondition } from './Dimensions';

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -3,10 +3,10 @@ import { useEffect, useState } from 'react';
 
 import { config } from '@grafana/runtime';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { useAccountOptions } from '../../../hooks';
 import { DescribeLogGroupsRequest } from '../../../resources/types';
-import { LogGroup } from '../../../types';
 import { isTemplateVariable } from '../../../utils/templateVariableUtils';
 
 import { LegacyLogGroupSelection } from './LegacyLogGroupNamesSelection';

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -15,8 +15,8 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { DescribeLogGroupsRequest, ResourceResponse, LogGroupResponse } from '../../../resources/types';
-import { LogGroup } from '../../../types';
 import getStyles from '../../styles';
 import { Account, ALL_ACCOUNTS_OPTION } from '../Account';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { LogGroup } from '../../../types';
+import { LogGroup } from '../../../dataquery.gen';
 
 import { SelectedLogGroups } from './SelectedLogGroups';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/SelectedLogGroups.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { Button, ConfirmModal, useStyles2 } from '@grafana/ui';
 
-import { LogGroup } from '../../../types';
+import { LogGroup } from '../../../dataquery.gen';
 import getStyles from '../../styles';
 
 type CrossAccountLogsQueryProps = {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.test.tsx
@@ -4,9 +4,9 @@ import selectEvent from 'react-select-event';
 
 import { config } from '@grafana/runtime';
 
+import { MetricStat } from '../../../dataquery.gen';
 import { setupMockedDataSource, statisticVariable } from '../../../mocks/CloudWatchDataSource';
 import { validMetricSearchBuilderQuery } from '../../../mocks/queries';
-import { MetricStat } from '../../../types';
 
 import { MetricStatEditor } from './MetricStatEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/MetricStatEditor/MetricStatEditor.tsx
@@ -6,10 +6,10 @@ import { EditorField, EditorFieldGroup, EditorRow, EditorRows, EditorSwitch } fr
 import { config } from '@grafana/runtime';
 import { Select, TextLink } from '@grafana/ui';
 
+import { MetricStat } from '../../../dataquery.gen';
 import { CloudWatchDatasource } from '../../../datasource';
 import { useAccountOptions, useMetrics, useNamespaces } from '../../../hooks';
 import { standardStatistics } from '../../../standardStatistics';
-import { MetricStat } from '../../../types';
 import { appendTemplateVariables, toOption } from '../../../utils/utils';
 import { Account } from '../Account';
 import { Dimensions } from '../Dimensions/Dimensions';

--- a/public/app/plugins/datasource/cloudwatch/datasource.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.test.ts
@@ -4,6 +4,13 @@ import { toArray } from 'rxjs/operators';
 import { CoreApp, Field } from '@grafana/data';
 
 import {
+  CloudWatchLogsQuery,
+  CloudWatchMetricsQuery,
+  LogsQueryLanguage,
+  MetricEditorMode,
+  MetricQueryType,
+} from './dataquery.gen';
+import {
   CloudWatchSettings,
   fieldsVariable,
   logGroupNamesVariable,
@@ -13,16 +20,7 @@ import {
 import { setupForLogs } from './mocks/logsTestContext';
 import { validLogsQuery, validMetricSearchBuilderQuery } from './mocks/queries';
 import { TimeRangeMock } from './mocks/timeRange';
-import {
-  CloudWatchDefaultQuery,
-  CloudWatchLogsQuery,
-  CloudWatchLogsRequest,
-  CloudWatchMetricsQuery,
-  CloudWatchQuery,
-  LogsQueryLanguage,
-  MetricEditorMode,
-  MetricQueryType,
-} from './types';
+import { CloudWatchQuery, CloudWatchLogsRequest, CloudWatchDefaultQuery } from './types';
 import * as templateUtils from './utils/templateVariableUtils';
 
 describe('datasource', () => {

--- a/public/app/plugins/datasource/cloudwatch/datasource.ts
+++ b/public/app/plugins/datasource/cloudwatch/datasource.ts
@@ -15,6 +15,12 @@ import {
 import { DataSourceWithBackend, TemplateSrv, getTemplateSrv } from '@grafana/runtime';
 
 import { CloudWatchAnnotationSupport } from './annotationSupport';
+import {
+  CloudWatchAnnotationQuery,
+  CloudWatchLogsAnomaliesQuery,
+  CloudWatchLogsQuery,
+  CloudWatchMetricsQuery,
+} from './dataquery.gen';
 import { DEFAULT_METRICS_QUERY, getDefaultLogsQuery } from './defaultQueries';
 import {
   isCloudWatchAnnotationQuery,
@@ -42,14 +48,7 @@ import { CloudWatchAnnotationQueryRunner } from './query-runner/CloudWatchAnnota
 import { CloudWatchLogsQueryRunner } from './query-runner/CloudWatchLogsQueryRunner';
 import { CloudWatchMetricsQueryRunner } from './query-runner/CloudWatchMetricsQueryRunner';
 import { ResourcesAPI } from './resources/ResourcesAPI';
-import {
-  CloudWatchAnnotationQuery,
-  CloudWatchJsonData,
-  CloudWatchLogsAnomaliesQuery,
-  CloudWatchLogsQuery,
-  CloudWatchMetricsQuery,
-  CloudWatchQuery,
-} from './types';
+import { CloudWatchQuery, CloudWatchJsonData } from './types';
 import { CloudWatchVariableSupport } from './variables';
 
 export class CloudWatchDatasource

--- a/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
+++ b/public/app/plugins/datasource/cloudwatch/defaultQueries.ts
@@ -6,9 +6,8 @@ import {
   LogsQueryLanguage,
   MetricEditorMode,
   MetricQueryType,
-  VariableQuery,
-  VariableQueryType,
-} from './types';
+} from './dataquery.gen';
+import { VariableQuery, VariableQueryType } from './types';
 
 export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
   queryMode: 'Metrics',

--- a/public/app/plugins/datasource/cloudwatch/expressions.ts
+++ b/public/app/plugins/datasource/cloudwatch/expressions.ts
@@ -3,17 +3,6 @@ import {
   QueryEditorOperator as QueryEditorOperatorBase,
   QueryEditorOperatorValueType,
 } from './dataquery.gen';
-export {
-  QueryEditorPropertyType,
-  type QueryEditorProperty,
-  type QueryEditorPropertyExpression,
-  type QueryEditorGroupByExpression,
-  type QueryEditorFunctionExpression,
-  type QueryEditorFunctionParameterExpression,
-  type QueryEditorArrayExpression,
-  QueryEditorExpressionType,
-  type QueryEditorExpression,
-} from './dataquery.gen';
 
 export interface QueryEditorOperator<T extends QueryEditorOperatorValueType> extends QueryEditorOperatorBase {
   value?: T;

--- a/public/app/plugins/datasource/cloudwatch/guards.ts
+++ b/public/app/plugins/datasource/cloudwatch/guards.ts
@@ -5,9 +5,9 @@ import {
   CloudWatchLogsAnomaliesQuery,
   CloudWatchLogsQuery,
   CloudWatchMetricsQuery,
-  CloudWatchQuery,
   LogsMode,
-} from './types';
+} from './dataquery.gen';
+import { CloudWatchQuery } from './types';
 
 export const isCloudWatchLogsQuery = (cloudwatchQuery: CloudWatchQuery): cloudwatchQuery is CloudWatchLogsQuery =>
   cloudwatchQuery.queryMode === 'Logs';

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.test.ts
@@ -1,6 +1,7 @@
 import { CustomVariableModel } from '@grafana/data';
 import { Monaco, monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { setupMockedTemplateService, logGroupNamesVariable } from '../../../mocks/CloudWatchDataSource';
 import { multiLineFullQuery } from '../../../mocks/cloudwatch-logs-sql-test-data/multiLineFullQuery';
 import { multiLineFullQueryWithCaseClause } from '../../../mocks/cloudwatch-logs-sql-test-data/multiLineFullQueryWithCaseClause';
@@ -11,7 +12,7 @@ import MonacoMock from '../../../mocks/monarch/Monaco';
 import TextModel from '../../../mocks/monarch/TextModel';
 import { ResourcesAPI } from '../../../resources/ResourcesAPI';
 import { ResourceResponse } from '../../../resources/types';
-import { LogGroup, LogGroupField } from '../../../types';
+import { LogGroupField } from '../../../types';
 import cloudWatchLogsLanguageDefinition from '../definition';
 import {
   SELECT,

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs-sql/completion/CompletionItemProvider.ts
@@ -1,8 +1,8 @@
 import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import type { Monaco, monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { ResourcesAPI } from '../../../resources/ResourcesAPI';
-import { LogGroup } from '../../../types';
 import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-logs/CloudWatchLogsLanguageProvider.ts
@@ -5,8 +5,9 @@ import { AbsoluteTimeRange, HistoryItem, LanguageProvider } from '@grafana/data'
 import { BackendDataSourceResponse, FetchResponse, TemplateSrv, getTemplateSrv } from '@grafana/runtime';
 import { CompletionItemGroup, SearchFunctionType, Token, TypeaheadInput, TypeaheadOutput } from '@grafana/ui';
 
+import { LogGroup } from '../../dataquery.gen';
 import { CloudWatchDatasource } from '../../datasource';
-import { CloudWatchQuery, LogGroup } from '../../types';
+import { CloudWatchQuery } from '../../types';
 import { fetchLogGroupFields } from '../utils';
 
 import syntax, {

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.test.ts
@@ -1,6 +1,7 @@
 import { CustomVariableModel } from '@grafana/data';
 import { Monaco, monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { logGroupNamesVariable, setupMockedTemplateService } from '../../../mocks/CloudWatchDataSource';
 import { newCommandQuery } from '../../../mocks/cloudwatch-ppl-test-data/newCommandQuery';
 import {
@@ -22,7 +23,7 @@ import MonacoMock from '../../../mocks/monarch/Monaco';
 import TextModel from '../../../mocks/monarch/TextModel';
 import { ResourcesAPI } from '../../../resources/ResourcesAPI';
 import { ResourceResponse } from '../../../resources/types';
-import { LogGroup, LogGroupField } from '../../../types';
+import { LogGroupField } from '../../../types';
 import cloudWatchLogsPPLLanguageDefinition from '../definition';
 import {
   BOOLEAN_LITERALS,

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-ppl/completion/PPLCompletionItemProvider.ts
@@ -1,8 +1,8 @@
 import { getTemplateSrv, type TemplateSrv } from '@grafana/runtime';
 import { Monaco, monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { type ResourcesAPI } from '../../../resources/ResourcesAPI';
-import { LogGroup } from '../../../types';
 import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.test.ts
@@ -1,4 +1,4 @@
-import { QueryEditorExpressionType } from '../../expressions';
+import { SQLExpression, QueryEditorExpressionType } from '../../dataquery.gen';
 import {
   aggregationvariable,
   labelsVariable,
@@ -14,7 +14,6 @@ import {
   createFunction,
   createProperty,
 } from '../../mocks/sqlUtils';
-import { SQLExpression } from '../../types';
 
 import SQLGenerator from './SQLGenerator';
 

--- a/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/cloudwatch-sql/SQLGenerator.ts
@@ -7,10 +7,10 @@ import {
   QueryEditorExpression,
   QueryEditorExpressionType,
   QueryEditorFunctionExpression,
-  QueryEditorOperatorExpression,
   QueryEditorPropertyExpression,
-} from '../../expressions';
-import { SQLExpression } from '../../types';
+  SQLExpression,
+} from '../../dataquery.gen';
+import { QueryEditorOperatorExpression } from '../../expressions';
 
 import { InsightsReservedKeywords } from './consts';
 

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.test.ts
@@ -3,6 +3,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { CustomVariableModel } from '@grafana/data';
 import { monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { setupMockedTemplateService, logGroupNamesVariable } from '../../../mocks/CloudWatchDataSource';
 import { logsTestDataDiffModifierQuery } from '../../../mocks/cloudwatch-logs-test-data/diffModifierQuery';
 import { logsTestDataDiffQuery } from '../../../mocks/cloudwatch-logs-test-data/diffQuery';
@@ -12,7 +13,7 @@ import { logsTestDataNewCommandQuery } from '../../../mocks/cloudwatch-logs-test
 import { logsTestDataSortQuery } from '../../../mocks/cloudwatch-logs-test-data/sortQuery';
 import { ResourcesAPI } from '../../../resources/ResourcesAPI';
 import { ResourceResponse } from '../../../resources/types';
-import { LogGroup, LogGroupField } from '../../../types';
+import { LogGroupField } from '../../../types';
 import cloudWatchLogsLanguageDefinition, { CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID } from '../definition';
 import { DIFF_MODIFIERS, LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS, language } from '../language';
 

--- a/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
+++ b/public/app/plugins/datasource/cloudwatch/language/logs/completion/CompletionItemProvider.ts
@@ -1,8 +1,8 @@
 import { getTemplateSrv, TemplateSrv } from '@grafana/runtime';
 import { Monaco, monacoTypes } from '@grafana/ui';
 
+import { LogGroup } from '../../../dataquery.gen';
 import { type ResourcesAPI } from '../../../resources/ResourcesAPI';
-import { LogGroup } from '../../../types';
 import { CompletionItemProvider } from '../../monarch/CompletionItemProvider';
 import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';

--- a/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.test.ts
@@ -1,6 +1,7 @@
 import { AnnotationQuery, DataQuery } from '@grafana/data';
 
-import { CloudWatchMetricsQuery, LegacyAnnotationQuery, MetricEditorMode, MetricQueryType } from '../types';
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../dataquery.gen';
+import { LegacyAnnotationQuery } from '../types';
 
 import {
   migrateCloudWatchQuery,

--- a/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/dashboardMigrations.ts
@@ -5,7 +5,8 @@
 import { AnnotationQuery, getNextRefId } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
 
-import { CloudWatchMetricsQuery, LegacyAnnotationQuery, MetricQueryType, MetricEditorMode } from '../types';
+import { CloudWatchMetricsQuery, MetricQueryType, MetricEditorMode } from '../dataquery.gen';
+import { LegacyAnnotationQuery } from '../types';
 
 // E.g query.statistics = ['Max', 'Min'] will be migrated to two queries - query1.statistic = 'Max' and query2.statistic = 'Min'
 export function migrateMultipleStatsMetricsQuery(

--- a/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.test.ts
@@ -1,4 +1,4 @@
-import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../types';
+import { CloudWatchMetricsQuery, MetricEditorMode, MetricQueryType } from '../dataquery.gen';
 
 import { migrateAliasPatterns, migrateMetricQuery } from './metricQueryMigrations';
 

--- a/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/metricQueryMigrations.ts
@@ -1,6 +1,6 @@
 import deepEqual from 'fast-deep-equal';
 
-import { CloudWatchMetricsQuery } from '../types';
+import { CloudWatchMetricsQuery } from '../dataquery.gen';
 
 import { migrateCloudWatchQuery } from './dashboardMigrations';
 

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
+import { CloudWatchMetricsQuery } from '../dataquery.gen';
 import { DEFAULT_METRICS_QUERY } from '../defaultQueries';
-import { CloudWatchMetricsQuery } from '../types';
 
 import { migrateAliasPatterns } from './metricQueryMigrations';
 import useMigratedMetricsQuery from './useMigratedMetricsQuery';

--- a/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/useMigratedMetricsQuery.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo } from 'react';
 
-import { CloudWatchMetricsQuery } from '../types';
+import { CloudWatchMetricsQuery } from '../dataquery.gen';
 
 import { migrateMetricQuery } from './metricQueryMigrations';
 

--- a/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/cloudwatch/migrations/variableQueryMigrations.ts
@@ -1,6 +1,7 @@
 import { omit } from 'lodash';
 
-import { Dimensions, VariableQuery, VariableQueryType, OldVariableQuery, MultiFilters } from '../types';
+import { Dimensions } from '../dataquery.gen';
+import { VariableQuery, VariableQueryType, OldVariableQuery, MultiFilters } from '../types';
 
 const jsonVariable = /\${(\w+):json}/g;
 

--- a/public/app/plugins/datasource/cloudwatch/mocks/Request.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/Request.ts
@@ -1,6 +1,7 @@
 import { DataQueryRequest } from '@grafana/data';
 
-import { CloudWatchQuery, CloudWatchLogsQuery } from '../types';
+import { CloudWatchLogsQuery } from '../dataquery.gen';
+import { CloudWatchQuery } from '../types';
 
 import { TimeRangeMock } from './timeRange';
 

--- a/public/app/plugins/datasource/cloudwatch/mocks/queries.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/queries.ts
@@ -1,5 +1,10 @@
-import { QueryEditorExpressionType } from '../expressions';
-import { CloudWatchMetricsQuery, MetricQueryType, MetricEditorMode, CloudWatchLogsQuery } from '../types';
+import {
+  CloudWatchMetricsQuery,
+  MetricQueryType,
+  MetricEditorMode,
+  CloudWatchLogsQuery,
+  QueryEditorExpressionType,
+} from '../dataquery.gen';
 
 export const validMetricSearchCodeQuery: CloudWatchMetricsQuery = {
   id: '',

--- a/public/app/plugins/datasource/cloudwatch/mocks/sqlUtils.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/sqlUtils.ts
@@ -2,13 +2,13 @@ import {
   QueryEditorExpression,
   QueryEditorExpressionType,
   QueryEditorArrayExpression,
-  QueryEditorOperatorExpression,
   QueryEditorPropertyType,
   QueryEditorGroupByExpression,
   QueryEditorFunctionExpression,
   QueryEditorFunctionParameterExpression,
   QueryEditorPropertyExpression,
-} from '../expressions';
+} from '../dataquery.gen';
+import { QueryEditorOperatorExpression } from '../expressions';
 
 export function createArray(
   expressions: QueryEditorExpression[],

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.test.ts
@@ -1,6 +1,6 @@
+import { CloudWatchAnnotationQuery } from '../dataquery.gen';
 import { setupMockedAnnotationQueryRunner } from '../mocks/AnnotationQueryRunner';
 import { namespaceVariable, regionVariable } from '../mocks/CloudWatchDataSource';
-import { CloudWatchAnnotationQuery } from '../types';
 
 describe('CloudWatchAnnotationQueryRunner', () => {
   const queries: CloudWatchAnnotationQuery[] = [

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchAnnotationQueryRunner.ts
@@ -3,7 +3,8 @@ import { Observable } from 'rxjs';
 import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
-import { CloudWatchAnnotationQuery, CloudWatchJsonData, CloudWatchQuery } from '../types';
+import { CloudWatchAnnotationQuery } from '../dataquery.gen';
+import { CloudWatchJsonData, CloudWatchQuery } from '../types';
 
 import { CloudWatchRequest } from './CloudWatchRequest';
 

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.test.ts
@@ -10,12 +10,12 @@ import {
   LogRowModel,
 } from '@grafana/data';
 
+import { CloudWatchLogsAnomaliesQuery, CloudWatchLogsQuery, LogsMode } from '../dataquery.gen'; // Add this import statement
 import { logGroupNamesVariable, regionVariable } from '../mocks/CloudWatchDataSource';
 import { setupMockedLogsQueryRunner } from '../mocks/LogsQueryRunner';
 import { LogsRequestMock } from '../mocks/Request';
 import { validLogsQuery } from '../mocks/queries';
 import { TimeRangeMock } from '../mocks/timeRange';
-import { CloudWatchLogsAnomaliesQuery, CloudWatchLogsQuery, LogsMode } from '../types'; // Add this import statement
 
 import {
   LOGSTREAM_IDENTIFIER_INTERNAL,

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchLogsQueryRunner.ts
@@ -38,17 +38,14 @@ import { type CustomFormatterVariable } from '@grafana/scenes';
 import { GraphDrawStyle } from '@grafana/schema/dist/esm/index';
 import { TableCellDisplayMode } from '@grafana/ui';
 
+import { CloudWatchLogsQuery, LogsMode, CloudWatchLogsAnomaliesQuery, LogsQueryLanguage } from '../dataquery.gen';
 import {
   CloudWatchJsonData,
-  CloudWatchLogsAnomaliesQuery,
-  CloudWatchLogsQuery,
   CloudWatchLogsQueryStatus,
   CloudWatchLogsRequest,
   CloudWatchQuery,
   GetLogEventsRequest,
   LogAction,
-  LogsMode,
-  LogsQueryLanguage,
   QueryParam,
   StartQueryRequest,
 } from '../types';

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.test.ts
@@ -3,6 +3,7 @@ import { of } from 'rxjs';
 import { dateTime, CustomVariableModel, getFrameDisplayName, VariableHide } from '@grafana/data';
 import { toDataQueryResponse } from '@grafana/runtime';
 
+import { MetricQueryType, MetricEditorMode, CloudWatchMetricsQuery } from '../dataquery.gen';
 import {
   namespaceVariable,
   metricVariable,
@@ -15,7 +16,6 @@ import {
 import { initialVariableModelState } from '../mocks/CloudWatchVariables';
 import { setupMockedMetricsQueryRunner } from '../mocks/MetricsQueryRunner';
 import { validMetricSearchBuilderQuery, validMetricSearchCodeQuery } from '../mocks/queries';
-import { MetricQueryType, MetricEditorMode, CloudWatchMetricsQuery } from '../types';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchMetricsQueryRunner.ts
@@ -17,9 +17,10 @@ import {
 import { TemplateSrv, getAppEvents } from '@grafana/runtime';
 
 import { ThrottlingErrorMessage } from '../components/Errors/ThrottlingErrorMessage';
+import { CloudWatchMetricsQuery } from '../dataquery.gen';
 import memoizedDebounce from '../memoizedDebounce';
 import { migrateMetricQuery } from '../migrations/metricQueryMigrations';
-import { CloudWatchJsonData, CloudWatchMetricsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchJsonData, CloudWatchQuery } from '../types';
 import { filterMetricsQuery } from '../utils/utils';
 
 import { CloudWatchRequest } from './CloudWatchRequest';

--- a/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
+++ b/public/app/plugins/datasource/cloudwatch/query-runner/CloudWatchRequest.ts
@@ -3,8 +3,9 @@ import { Observable } from 'rxjs';
 import { DataSourceInstanceSettings, DataSourceRef, getDataSourceRef, ScopedVars, AppEvents } from '@grafana/data';
 import { BackendDataSourceResponse, FetchResponse, getBackendSrv, TemplateSrv, getAppEvents } from '@grafana/runtime';
 
+import { Dimensions } from '../dataquery.gen';
 import memoizedDebounce from '../memoizedDebounce';
-import { CloudWatchJsonData, Dimensions, MetricRequest, MultiFilters } from '../types';
+import { CloudWatchJsonData, MetricRequest, MultiFilters } from '../types';
 import { getVariableName } from '../utils/templateVariableUtils';
 
 export abstract class CloudWatchRequest {

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 
-import { Dimensions } from '../types';
+import { Dimensions } from '../dataquery.gen';
 
 export interface ResourceResponse<T> {
   accountId?: string;

--- a/public/app/plugins/datasource/cloudwatch/tracking.ts
+++ b/public/app/plugins/datasource/cloudwatch/tracking.ts
@@ -1,19 +1,19 @@
 import { DashboardLoadedEvent } from '@grafana/data';
 import { config, reportInteraction } from '@grafana/runtime';
 
+import {
+  CloudWatchLogsQuery,
+  CloudWatchLogsAnomaliesQuery,
+  CloudWatchMetricsQuery,
+  LogsMode,
+  LogsQueryLanguage,
+  MetricQueryType,
+  MetricEditorMode,
+} from './dataquery.gen';
 import { isCloudWatchLogsQuery, isCloudWatchMetricsQuery, isLogsAnomaliesQuery } from './guards';
 import { migrateMetricQuery } from './migrations/metricQueryMigrations';
 import pluginJson from './plugin.json';
-import {
-  CloudWatchLogsAnomaliesQuery,
-  CloudWatchLogsQuery,
-  CloudWatchMetricsQuery,
-  CloudWatchQuery,
-  LogsMode,
-  LogsQueryLanguage,
-  MetricEditorMode,
-  MetricQueryType,
-} from './types';
+import { CloudWatchQuery } from './types';
 import { filterMetricsQuery } from './utils/utils';
 
 type CloudWatchOnDashboardLoadedTrackingEvent = {

--- a/public/app/plugins/datasource/cloudwatch/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/types.ts
@@ -4,8 +4,6 @@ import { DataQuery } from '@grafana/schema';
 
 import * as raw from './dataquery.gen';
 
-export * from './dataquery.gen';
-
 export type CloudWatchQuery =
   | raw.CloudWatchMetricsQuery
   | raw.CloudWatchLogsQuery

--- a/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/datalinks.ts
@@ -10,7 +10,8 @@ import {
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { AwsUrl, encodeUrl } from '../aws_url';
-import { CloudWatchLogsQuery, CloudWatchQuery } from '../types';
+import { CloudWatchLogsQuery } from '../dataquery.gen';
+import { CloudWatchQuery } from '../types';
 
 type ReplaceFn = (
   target?: string,

--- a/public/app/plugins/datasource/cloudwatch/utils/utils.ts
+++ b/public/app/plugins/datasource/cloudwatch/utils/utils.ts
@@ -1,6 +1,6 @@
 import { SelectableValue } from '@grafana/data';
 
-import { CloudWatchMetricsQuery, MetricQueryType, MetricEditorMode } from '../types';
+import { CloudWatchMetricsQuery, MetricQueryType, MetricEditorMode } from '../dataquery.gen';
 
 import { CloudWatchDatasource } from './../datasource';
 


### PR DESCRIPTION
**What is this feature?**

This PR replaces usage of export * from './directory' in grafana with explicit exports that refer to the file the code lives in and it removes the default export for `appEvents`.
- [x] public/app/plugins/datasource/cloudwatch/types.ts
- [x] public/app/plugins/datasource/cloudwatch/expressions.ts

**Why do we need this feature?**

Barrel files simplify and centralise imports making it easier to consume modules. However they also cause the following issues:

- Circular Dependencies - if two modules import from each other's barrel files, it can create a cycle that's hard to detect and debug.
- Tree Shaking Issues - barrel files can interfere with tree shaking
- Name Collisions - re-exporting many symbols from different modules come with the risk of name collisions creating confusing errors
- Hidden Dependencies - barrel files obscure where a symbol is originally defined
- Slower Compilation in Large Projects - using many barrel files can slow down TypeScript compilation and type-checking
- Unintentional Exports - makes it really easy to accidentally export internal or private modules

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates: #107611
**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
