### PR TITLE
Chore: Run some React 19 codemods

### DIFF
--- a/packages/grafana-data/src/utils/OptionsUIBuilders.ts
+++ b/packages/grafana-data/src/utils/OptionsUIBuilders.ts
@@ -1,4 +1,5 @@
 import { set, cloneDeep } from 'lodash';
+import type { JSX } from 'react';
 
 import {
   FieldNamePickerConfigSettings,

--- a/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
+++ b/packages/grafana-prometheus/src/configuration/AlertingSettingsOverhaul.tsx
@@ -1,5 +1,6 @@
 // Core Grafana history https://github.com/grafana/grafana/blob/v11.0.0-preview/public/app/plugins/datasource/prometheus/configuration/AlertingSettingsOverhaul.tsx
 import { cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';

--- a/packages/grafana-prometheus/src/configuration/shared/utils.tsx
+++ b/packages/grafana-prometheus/src/configuration/shared/utils.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';

--- a/packages/grafana-runtime/src/services/pluginExtensions/utils.test.tsx
+++ b/packages/grafana-runtime/src/services/pluginExtensions/utils.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
   ComponentTypeWithExtensionMeta,

--- a/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
+++ b/packages/grafana-ui/src/components/BarGauge/BarGauge.tsx
@@ -1,6 +1,6 @@
 // Library
 import { cx } from '@emotion/css';
-import { CSSProperties, PureComponent, ReactNode } from 'react';
+import { CSSProperties, PureComponent, ReactNode, type JSX } from 'react';
 import * as React from 'react';
 import tinycolor from 'tinycolor2';
 

--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react';
+import { CSSProperties, type JSX } from 'react';
 import * as React from 'react';
 import tinycolor from 'tinycolor2';
 

--- a/packages/grafana-ui/src/components/Button/Button.test.tsx
+++ b/packages/grafana-ui/src/components/Button/Button.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { Button, LinkButton } from './Button';
 

--- a/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.story.tsx
+++ b/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.story.tsx
@@ -1,5 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { StoryFn, Meta } from '@storybook/react';
+import type { JSX } from 'react';
 
 import { Button } from '../Button/Button';
 

--- a/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.tsx
+++ b/packages/grafana-ui/src/components/CallToActionCard/CallToActionCard.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.test.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { ClipboardButton } from './ClipboardButton';
 

--- a/packages/grafana-ui/src/components/Collapse/Collapse.test.tsx
+++ b/packages/grafana-ui/src/components/Collapse/Collapse.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { Collapse } from './Collapse';
 

--- a/packages/grafana-ui/src/components/ColorPicker/NamedColorsPalette.tsx
+++ b/packages/grafana-ui/src/components/ColorPicker/NamedColorsPalette.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { IconName } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
+++ b/packages/grafana-ui/src/components/ContextMenu/WithContextMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import * as React from 'react';
 
 import { ContextMenu } from '../ContextMenu/ContextMenu';

--- a/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
+++ b/packages/grafana-ui/src/components/CustomScrollbar/CustomScrollbar.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { RefCallback, useCallback, useEffect, useRef } from 'react';
+import { RefCallback, useCallback, useEffect, useRef, type JSX } from 'react';
 import * as React from 'react';
 import Scrollbars, { positionValues } from 'react-custom-scrollbars-2';
 

--- a/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
+++ b/packages/grafana-ui/src/components/DataLinks/DataLinksContextMenu.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { CSSProperties } from 'react';
+import { CSSProperties, type JSX } from 'react';
 import * as React from 'react';
 
 import { ActionModel, GrafanaTheme2, LinkModel } from '@grafana/data';

--- a/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/AlertingSettings.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 

--- a/packages/grafana-ui/src/components/DataSourceSettings/SecureSocksProxySettings.tsx
+++ b/packages/grafana-ui/src/components/DataSourceSettings/SecureSocksProxySettings.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { useOverlay } from '@react-aria/overlays';
-import { memo, createRef, useState, useEffect } from 'react';
+import { memo, createRef, useState, useEffect, type JSX } from 'react';
 
 import {
   rangeUtil,

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeZonePicker/TimeZoneOption.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { isString } from 'lodash';
-import { PropsWithChildren, RefCallback } from 'react';
+import { PropsWithChildren, RefCallback, type JSX } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2, SelectableValue, getTimeZoneInfo } from '@grafana/data';

--- a/packages/grafana-ui/src/components/DateTimePickers/utils/useTimeSync.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/utils/useTimeSync.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect } from 'react';
+import { useCallback, useEffect, type JSX } from 'react';
 import { usePrevious } from 'react-use';
 
 import { TimeRange } from '@grafana/data';

--- a/packages/grafana-ui/src/components/EmptySearchResult/EmptySearchResult.tsx
+++ b/packages/grafana-ui/src/components/EmptySearchResult/EmptySearchResult.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/FilterPill/FilterPill.test.tsx
+++ b/packages/grafana-ui/src/components/FilterPill/FilterPill.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { FilterPill } from './FilterPill';
 

--- a/packages/grafana-ui/src/components/Forms/FieldArray.tsx
+++ b/packages/grafana-ui/src/components/Forms/FieldArray.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import { FC, type JSX } from 'react';
 import { useFieldArray, UseFieldArrayProps } from 'react-hook-form';
 
 import { FieldArrayApi } from '../../types/forms';

--- a/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
@@ -14,7 +14,7 @@ export enum LegacyInputStatus {
 export interface Props extends React.HTMLProps<HTMLInputElement> {
   validationEvents?: ValidationEvents;
   hideErrorMessage?: boolean;
-  inputRef?: React.LegacyRef<HTMLInputElement>;
+  inputRef?: React.Ref<HTMLInputElement>;
 
   // Override event props and append status as argument
   onBlur?: (event: React.FocusEvent<HTMLInputElement>, status?: LegacyInputStatus) => void;

--- a/packages/grafana-ui/src/components/Gauge/Gauge.tsx
+++ b/packages/grafana-ui/src/components/Gauge/Gauge.tsx
@@ -168,7 +168,9 @@ export class Gauge extends PureComponent<Props> {
     const gaugeElement = (
       <div
         style={{ height: `${autoProps.gaugeHeight}px`, width: gaugeWidth }}
-        ref={(element) => (this.canvasElement = element)}
+        ref={(element) => {
+          this.canvasElement = element;
+        }}
       />
     );
 

--- a/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
+++ b/packages/grafana-ui/src/components/InfoBox/InfoBox.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/List/AbstractList.tsx
+++ b/packages/grafana-ui/src/components/List/AbstractList.tsx
@@ -1,5 +1,5 @@
 import { cx, css } from '@emotion/css';
-import { PureComponent } from 'react';
+import { PureComponent, type JSX } from 'react';
 
 import { stylesFactory } from '../../themes/stylesFactory';
 

--- a/packages/grafana-ui/src/components/Modal/Modal.tsx
+++ b/packages/grafana-ui/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import { cx } from '@emotion/css';
 import { useDialog } from '@react-aria/dialog';
 import { FocusScope } from '@react-aria/focus';
 import { OverlayContainer, useOverlay } from '@react-aria/overlays';
-import { PropsWithChildren, useRef } from 'react';
+import { PropsWithChildren, useRef, type JSX } from 'react';
 import * as React from 'react';
 
 import { t } from '@grafana/i18n';

--- a/packages/grafana-ui/src/components/Pagination/Pagination.tsx
+++ b/packages/grafana-ui/src/components/Pagination/Pagination.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 

--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -211,7 +211,9 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
       <div className={cx(wrapperClassName, styles.wrapper)}>
         <div className="slate-query-field" data-testid={selectors.components.QueryField.container}>
           <Editor
-            ref={(editor) => (this.editor = editor!)}
+            ref={(editor) => {
+              this.editor = editor!;
+            }}
             schema={SCHEMA}
             autoCorrect={false}
             readOnly={this.props.disabled}

--- a/packages/grafana-ui/src/components/RenderUserContentAsHTML/RenderUserContentAsHTML.tsx
+++ b/packages/grafana-ui/src/components/RenderUserContentAsHTML/RenderUserContentAsHTML.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, PropsWithChildren } from 'react';
+import { HTMLAttributes, PropsWithChildren, type JSX } from 'react';
 import * as React from 'react';
 
 import { textUtil } from '@grafana/data';

--- a/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
+++ b/packages/grafana-ui/src/components/Segment/SegmentInput.story.tsx
@@ -1,6 +1,6 @@
 import { action } from '@storybook/addon-actions';
 import { Meta, StoryFn } from '@storybook/react';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 import * as React from 'react';
 
 import { Icon } from '../Icon/Icon';

--- a/packages/grafana-ui/src/components/Select/InputControl.tsx
+++ b/packages/grafana-ui/src/components/Select/InputControl.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { forwardRef } from 'react';
+import { forwardRef, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/Select/MultiValue.tsx
+++ b/packages/grafana-ui/src/components/Select/MultiValue.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 

--- a/packages/grafana-ui/src/components/Select/SelectMenu.tsx
+++ b/packages/grafana-ui/src/components/Select/SelectMenu.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { max } from 'lodash';
-import { RefCallback, useLayoutEffect, useMemo, useRef } from 'react';
+import { RefCallback, useLayoutEffect, useMemo, useRef, type JSX } from 'react';
 import * as React from 'react';
 import { FixedSizeList as List } from 'react-window';
 

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { JSX } from 'react';
 import {
   ActionMeta as SelectActionMeta,
   CommonProps as ReactSelectCommonProps,

--- a/packages/grafana-ui/src/components/TabbedContainer/TabbedContainer.test.tsx
+++ b/packages/grafana-ui/src/components/TabbedContainer/TabbedContainer.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { IconName } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/Table/Cells/GeoCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/GeoCell.tsx
@@ -1,5 +1,6 @@
 import WKT from 'ol/format/WKT';
 import { Geometry } from 'ol/geom';
+import type { JSX } from 'react';
 
 import { TableCellProps } from '../types';
 

--- a/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
+++ b/packages/grafana-ui/src/components/Table/Cells/JSONViewCell.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { isString } from 'lodash';
-import { useState } from 'react';
+import { useState, type JSX } from 'react';
 
 import { getCellLinks } from '../../../utils/table';
 import { CellActions } from '../CellActions';

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -2,7 +2,7 @@ import 'react-data-grid/lib/styles.css';
 
 import { clsx } from 'clsx';
 import memoize from 'micro-memoize';
-import { CSSProperties, Key, ReactNode, useCallback, useMemo, useRef, useState } from 'react';
+import { CSSProperties, Key, ReactNode, useCallback, useMemo, useRef, useState, type JSX } from 'react';
 import {
   Cell,
   CellRendererProps,

--- a/packages/grafana-ui/src/components/Tabs/Tabs.test.tsx
+++ b/packages/grafana-ui/src/components/Tabs/Tabs.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { Tab } from './Tab';
 import { TabsBar } from './TabsBar';

--- a/packages/grafana-ui/src/components/Tags/Tag.test.tsx
+++ b/packages/grafana-ui/src/components/Tags/Tag.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { Tag } from './Tag';
 

--- a/packages/grafana-ui/src/components/Tags/TagList.test.tsx
+++ b/packages/grafana-ui/src/components/Tags/TagList.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { TagList } from './TagList';
 

--- a/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
+++ b/packages/grafana-ui/src/components/Toggletip/Toggletip.tsx
@@ -11,7 +11,7 @@ import {
   useInteractions,
 } from '@floating-ui/react';
 import { Placement } from '@popperjs/core';
-import { memo, cloneElement, isValidElement, useRef, useState } from 'react';
+import { memo, cloneElement, isValidElement, useRef, useState, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/packages/grafana-ui/src/components/Toggletip/types.ts
+++ b/packages/grafana-ui/src/components/Toggletip/types.ts
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 export interface ToggletipContentProps {
   /**
    * @deprecated

--- a/packages/grafana-ui/src/components/Tooltip/PopoverController.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/PopoverController.tsx
@@ -1,5 +1,5 @@
 import { Placement } from '@popperjs/core';
-import { Component } from 'react';
+import { Component, type JSX } from 'react';
 
 import { PopoverContent } from './types';
 

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -10,7 +10,7 @@ import {
   useInteractions,
   safePolygon,
 } from '@floating-ui/react';
-import { forwardRef, cloneElement, isValidElement, useCallback, useId, useRef, useState } from 'react';
+import { forwardRef, cloneElement, isValidElement, useCallback, useId, useRef, useState, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';

--- a/packages/grafana-ui/src/components/Tooltip/types.ts
+++ b/packages/grafana-ui/src/components/Tooltip/types.ts
@@ -1,4 +1,5 @@
 import { Placement } from '@floating-ui/react';
+import type { JSX } from 'react';
 
 export interface PopoverContentProps {
   /**

--- a/packages/grafana-ui/src/components/ValuePicker/ValuePicker.test.tsx
+++ b/packages/grafana-ui/src/components/ValuePicker/ValuePicker.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { ValuePicker } from './ValuePicker';
 

--- a/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegendTable.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 

--- a/packages/grafana-ui/src/components/VizLegend/types.ts
+++ b/packages/grafana-ui/src/components/VizLegend/types.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { DataFrameFieldIndex, DisplayValue } from '@grafana/data';
 import { LegendDisplayMode, LegendPlacement, LineStyle } from '@grafana/schema';

--- a/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
+++ b/packages/grafana-ui/src/components/VizRepeater/VizRepeater.tsx
@@ -1,5 +1,5 @@
 import { clamp } from 'lodash';
-import { PureComponent, CSSProperties } from 'react';
+import { PureComponent, CSSProperties, type JSX } from 'react';
 import * as React from 'react';
 
 import { VizOrientation } from '@grafana/data';

--- a/packages/grafana-ui/src/graveyard/Graph/Graph.tsx
+++ b/packages/grafana-ui/src/graveyard/Graph/Graph.tsx
@@ -1,7 +1,7 @@
 // Libraries
 import $ from 'jquery';
 import { uniqBy } from 'lodash';
-import { PureComponent } from 'react';
+import { PureComponent, type JSX } from 'react';
 import * as React from 'react';
 
 // Types
@@ -384,7 +384,9 @@ export class Graph extends PureComponent<GraphProps, GraphState> {
       <div className="graph-panel" aria-label={ariaLabel}>
         <div
           className="graph-panel__chart"
-          ref={(e) => (this.element = e)}
+          ref={(e) => {
+            this.element = e;
+          }}
           style={{ height, width }}
           onMouseLeave={() => {
             this.setState({ isTooltipVisible: false });

--- a/packages/grafana-ui/src/graveyard/Graph/GraphSeriesToggler.tsx
+++ b/packages/grafana-ui/src/graveyard/Graph/GraphSeriesToggler.tsx
@@ -1,5 +1,5 @@
 import { difference, isEqual } from 'lodash';
-import { Component } from 'react';
+import { Component, type JSX } from 'react';
 import * as React from 'react';
 
 import { GraphSeriesXY } from '@grafana/data';

--- a/public/app/core/components/Animations/FadeIn.tsx
+++ b/public/app/core/components/Animations/FadeIn.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties, useRef } from 'react';
+import { CSSProperties, useRef, type JSX } from 'react';
 import Transition, { ExitHandler } from 'react-transition-group/Transition';
 
 interface Props {

--- a/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { PluginExtensionPoints } from '@grafana/data';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { useGrafana } from 'app/core/context/GrafanaContext';

--- a/public/app/core/components/AppChrome/MegaMenu/FeatureHighlight.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/FeatureHighlight.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { FC } from 'react';
+import { FC, type JSX } from 'react';
 
 import { colorManipulator } from '@grafana/data';
 import { useTheme2 } from '@grafana/ui';

--- a/public/app/core/components/FolderFilter/FolderFilter.tsx
+++ b/public/app/core/components/FolderFilter/FolderFilter.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 import { ComboboxOption, MultiCombobox } from '@grafana/ui';

--- a/public/app/core/components/Layers/LayerDragDropList.tsx
+++ b/public/app/core/components/Layers/LayerDragDropList.tsx
@@ -1,5 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { DragDropContext, Draggable, Droppable, DropResult } from '@hello-pangea/dnd';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, useCallback } from 'react';
+import { memo, useState, useCallback, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 import { FetchError, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';

--- a/public/app/core/components/PanelTypeFilter/PanelTypeFilter.tsx
+++ b/public/app/core/components/PanelTypeFilter/PanelTypeFilter.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useState, type JSX } from 'react';
 
 import { GrafanaTheme2, PanelPluginMeta, SelectableValue } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/core/components/RolePicker/RolePicker.tsx
+++ b/public/app/core/components/RolePicker/RolePicker.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useCallback, useEffect, useState, useRef } from 'react';
+import { FormEvent, useCallback, useEffect, useState, useRef, type JSX } from 'react';
 
 import { OrgRole } from '@grafana/data';
 import { ClickOutsideWrapper, Portal, useTheme2 } from '@grafana/ui';

--- a/public/app/core/components/RolePicker/RolePickerInput.tsx
+++ b/public/app/core/components/RolePicker/RolePickerInput.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { FormEvent, HTMLProps, useEffect, useRef } from 'react';
+import { FormEvent, HTMLProps, useEffect, useRef, type JSX } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/core/components/RolePicker/RolePickerMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerMenu.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type JSX } from 'react';
 
 import { OrgRole } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/core/components/RolePicker/RolePickerSubMenu.tsx
+++ b/public/app/core/components/RolePicker/RolePickerSubMenu.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { Button, ScrollContainer, Stack, useStyles2, useTheme2 } from '@grafana/ui';

--- a/public/app/core/components/Select/OrgPicker.test.tsx
+++ b/public/app/core/components/Select/OrgPicker.test.tsx
@@ -1,5 +1,6 @@
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { OrgPicker } from './OrgPicker';
 

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { useAssistant } from '@grafana/assistant';
 import { FeatureState, GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/admin/ServerStatsCard.tsx
+++ b/public/app/features/admin/ServerStatsCard.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
+++ b/public/app/features/alerting/unified/RedirectToRuleViewer.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { type JSX, useMemo } from 'react';
 import { Navigate } from 'react-router-dom-v5-compat';
 import { useLocation } from 'react-use';
 

--- a/public/app/features/alerting/unified/components/ConditionalWrap.tsx
+++ b/public/app/features/alerting/unified/components/ConditionalWrap.tsx
@@ -1,4 +1,4 @@
-import { Ref, cloneElement, forwardRef } from 'react';
+import { type JSX, Ref, cloneElement, forwardRef } from 'react';
 
 interface ConditionalWrapProps {
   shouldWrap: boolean;

--- a/public/app/features/alerting/unified/components/GrafanaAlertmanagerWarning.test.tsx
+++ b/public/app/features/alerting/unified/components/GrafanaAlertmanagerWarning.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';

--- a/public/app/features/alerting/unified/components/WithReturnButton.tsx
+++ b/public/app/features/alerting/unified/components/WithReturnButton.tsx
@@ -1,4 +1,4 @@
-import { cloneElement, useCallback } from 'react';
+import { type JSX, cloneElement, useCallback } from 'react';
 
 import { useReturnToPrevious } from '@grafana/runtime';
 

--- a/public/app/features/alerting/unified/components/common/DetailText.tsx
+++ b/public/app/features/alerting/unified/components/common/DetailText.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { t } from '@grafana/i18n';
 import { Box, ClipboardButton, Stack, Text, Tooltip } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { Fragment, useState } from 'react';
+import { Fragment, type JSX, useState } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/alerting/unified/components/contact-points/EditContactPoint.test.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/EditContactPoint.test.tsx
@@ -1,4 +1,5 @@
 import 'core-js/stable/structured-clone';
+import type { JSX } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { render, screen, within } from 'test/test-utils';

--- a/public/app/features/alerting/unified/components/contact-points/useExportContactPoint.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/useExportContactPoint.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { type JSX, useCallback, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 
 import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';

--- a/public/app/features/alerting/unified/components/extensions/AlertingRuleExtensionPointMenu.tsx
+++ b/public/app/features/alerting/unified/components/extensions/AlertingRuleExtensionPointMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from 'react';
+import { type JSX, ReactElement, useMemo } from 'react';
 
 import { PluginExtensionLink } from '@grafana/data';
 import { Menu } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/mute-timings/useExportMuteTimingsDrawer.tsx
+++ b/public/app/features/alerting/unified/components/mute-timings/useExportMuteTimingsDrawer.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { type JSX, useCallback, useMemo, useState } from 'react';
 import { useToggle } from 'react-use';
 
 import { GrafanaMuteTimingsExporter } from '../export/GrafanaMuteTimingsExporter';

--- a/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Modals.tsx
@@ -1,5 +1,5 @@
 import { groupBy } from 'lodash';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, type JSX, useCallback, useMemo, useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { Button, Icon, Modal, ModalProps, Spinner, Stack } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { first, noop } from 'lodash';
+import type { JSX } from 'react';
 import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render } from 'test/test-utils';
 

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { isArray, sumBy, uniqueId } from 'lodash';
 import pluralize from 'pluralize';
 import * as React from 'react';
-import { FC, Fragment, ReactNode, useState } from 'react';
+import { FC, Fragment, type JSX, ReactNode, useState } from 'react';
 import { useToggle } from 'react-use';
 
 import { AlertLabel, getInheritedProperties } from '@grafana/alerting';

--- a/public/app/features/alerting/unified/components/permissions/ManagePermissions.tsx
+++ b/public/app/features/alerting/unified/components/permissions/ManagePermissions.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from 'react';
+import { ComponentProps, type JSX, useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { Button, Drawer } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplateDataDocs.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.test.tsx
@@ -1,4 +1,4 @@
-import { default as React } from 'react';
+import { type JSX, default as React } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Provider } from 'react-redux';
 import { render, screen, waitFor, within } from 'test/test-utils';

--- a/public/app/features/alerting/unified/components/receivers/TemplatePreview.tsx
+++ b/public/app/features/alerting/unified/components/receivers/TemplatePreview.tsx
@@ -1,6 +1,7 @@
 import { css, cx } from '@emotion/css';
 import { compact, uniqueId } from 'lodash';
 import * as React from 'react';
+import type { JSX } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelOptions.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { JSX } from 'react';
 import { DeepMap, FieldError, FieldErrors, useFormContext } from 'react-hook-form';
 
 import { Field, SecretInput } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ChannelSubForm.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { sortBy } from 'lodash';
 import * as React from 'react';
-import { useEffect, useMemo } from 'react';
+import { type JSX, useEffect, useMemo } from 'react';
 import { Controller, FieldErrors, useFormContext } from 'react-hook-form';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';

--- a/public/app/features/alerting/unified/components/receivers/form/fields/DeletedSubform.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/DeletedSubform.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { type JSX, useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 interface Props {

--- a/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/AnnotationsStep.test.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { render, screen, within } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';

--- a/public/app/features/alerting/unified/components/rule-editor/CloudRulesSourcePicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/CloudRulesSourcePicker.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { type JSX, useCallback } from 'react';
 
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { DataSourcePicker, DataSourcePickerProps } from 'app/features/datasources/components/picker/DataSourcePicker';

--- a/public/app/features/alerting/unified/components/rule-editor/NeedHelpInfo.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NeedHelpInfo.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';

--- a/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/DeleteModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react';
+import { type JSX, useCallback, useMemo, useState } from 'react';
 
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerLayout.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerLayout.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { GrafanaTheme2, NavModelItem } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/RuleViewerVisualization.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { PanelData } from '@grafana/data';
 
 import { VizWrapper } from '../rule-editor/VizWrapper';

--- a/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleActionsButtons.tsx
@@ -1,5 +1,5 @@
 import { isString } from 'lodash';
-import { useState } from 'react';
+import { type JSX, useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { LinkButton, Stack } from '@grafana/ui';

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsAnnotations.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsAnnotations.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { useStyles2 } from '@grafana/ui';
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsButtons.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsButtons.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { Fragment, type JSX } from 'react';
 
 import { textUtil } from '@grafana/data';
 import { Trans } from '@grafana/i18n';

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsDataSources.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { type JSX, useMemo } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsExpression.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsExpression.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 import { CombinedRule, RulesSource } from 'app/types/unified-alerting';

--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { SerializedError } from '@reduxjs/toolkit';
-import { FC, ReactElement, useMemo, useState } from 'react';
+import { FC, type JSX, ReactElement, useMemo, useState } from 'react';
 import { useLocalStorage } from 'react-use';
 
 import { DataSourceInstanceSettings, GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
+++ b/public/app/features/alerting/unified/components/settings/AlertmanagerConfig.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { type JSX, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import AutoSizer from 'react-virtualized-auto-sizer';
 

--- a/public/app/features/alerting/unified/rule-list/components/RuleActionsButtons.V2.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleActionsButtons.V2.tsx
@@ -1,5 +1,5 @@
 import { isString } from 'lodash';
-import { useState } from 'react';
+import { type JSX, useState } from 'react';
 import { RequireAtLeastOne } from 'type-fest';
 
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/auth-config/ErrorContainer.tsx
+++ b/public/app/features/auth-config/ErrorContainer.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Alert } from '@grafana/ui';

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManagerEditor.tsx
@@ -117,7 +117,9 @@ function GridLayoutColumns({ layoutManager }: { layoutManager: AutoGridLayoutMan
             id="min-column-width"
             defaultValue={columnWidth}
             onBlur={onCustomMinWidthChanged}
-            ref={(ref) => setInputRef(ref)}
+            ref={(ref) => {
+              setInputRef(ref);
+            }}
             type="number"
             min={50}
             max={2000}
@@ -233,7 +235,9 @@ function GridLayoutRows({ layoutManager }: { layoutManager: AutoGridLayoutManage
             id="min-height"
             defaultValue={rowHeight}
             onBlur={onCustomHeightChanged}
-            ref={(ref) => setInputRef(ref)}
+            ref={(ref) => {
+              setInputRef(ref);
+            }}
             type="number"
             min={50}
             max={2000}

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -56,7 +56,9 @@ export function TabItemRenderer({ model }: SceneComponentProps<TabItem>) {
     <Draggable key={key!} draggableId={key!} index={myIndex} isDragDisabled={!isDraggable}>
       {(dragProvided, dragSnapshot) => (
         <div
-          ref={(ref) => dragProvided.innerRef(ref)}
+          ref={(ref) => {
+            dragProvided.innerRef(ref);
+          }}
           className={cx(dragSnapshot.isDragging && styles.dragging)}
           {...dragProvided.draggableProps}
           {...dragProvided.dragHandleProps}

--- a/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/DataSourceVariableEditor.test.tsx
@@ -2,6 +2,7 @@
 
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { DataSourceVariable } from '@grafana/scenes';

--- a/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/IntervalVariableEditor.test.tsx
@@ -2,6 +2,7 @@
 
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';
 import { IntervalVariable } from '@grafana/scenes';

--- a/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
+++ b/public/app/features/dashboard/components/DashboardSettings/GeneralSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, ChangeEvent, useState } from 'react';
+import { useCallback, ChangeEvent, useState, type JSX } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { TimeZone } from '@grafana/data';

--- a/public/app/features/dashboard/components/PanelEditor/PanelHeaderCorner.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelHeaderCorner.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useCallback } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import { GrafanaTheme2, renderMarkdown, LinkModelSupplier, ScopedVars, IconName } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';

--- a/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/PanelNotSupported.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import { Trans } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';

--- a/public/app/features/dashboard/components/ShareModal/ViewJsonModal.tsx
+++ b/public/app/features/dashboard/components/ShareModal/ViewJsonModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, type JSX } from 'react';
 import AutoSizer from 'react-virtualized-auto-sizer';
 
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/dashboard/components/SubMenu/AnnotationPicker.tsx
+++ b/public/app/features/dashboard/components/SubMenu/AnnotationPicker.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 
 import { AnnotationQuery, EventBus, GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyExtensionPoint.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyExtensionPoint.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { PluginExtensionPoints } from '@grafana/data';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';

--- a/public/app/features/dashboard/dashgrid/PanelLinks.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelLinks.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { DataLink, GrafanaTheme2, LinkModel } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/features/datasources/components/DataSourceAddButton.tsx
+++ b/public/app/features/datasources/components/DataSourceAddButton.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, type JSX } from 'react';
 
 import { Pages } from '@grafana/e2e-selectors';
 import { Trans } from '@grafana/i18n';

--- a/public/app/features/explore/Explore.tsx
+++ b/public/app/features/explore/Explore.tsx
@@ -640,7 +640,9 @@ export class Explore extends PureComponent<Props, ExploreState> {
             )}
             <ScrollContainer
               data-testid={selectors.pages.Explore.General.scrollView}
-              ref={(scrollElement) => (this.scrollElement = scrollElement || undefined)}
+              ref={(scrollElement) => {
+                this.scrollElement = scrollElement || undefined;
+              }}
             >
               <div className={styles.exploreContainer}>
                 {datasourceInstance ? (

--- a/public/app/features/explore/Logs/LogsSamplePanel.tsx
+++ b/public/app/features/explore/Logs/LogsSamplePanel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useRef } from 'react';
+import { useRef, type JSX } from 'react';
 
 import {
   CoreApp,

--- a/public/app/features/explore/MetaInfoText.tsx
+++ b/public/app/features/explore/MetaInfoText.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { memo } from 'react';
+import { memo, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/Scrubber.test.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/Scrubber.test.tsx
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 import { render, screen, fireEvent, within } from '@testing-library/react';
+import type { JSX } from 'react';
 
 import Scrubber, { ScrubberProps } from './Scrubber';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/index.tsx
@@ -197,7 +197,9 @@ export class UnthemedTraceTimelineViewer extends PureComponent<TProps, State> {
     return (
       <div
         className={styles.TraceTimelineViewer}
-        ref={(ref: HTMLDivElement | null) => ref && this.setState({ height: ref.getBoundingClientRect().height })}
+        ref={(ref: HTMLDivElement | null) => {
+          ref && this.setState({ height: ref.getBoundingClientRect().height });
+        }}
       >
         <TimelineHeaderRow
           duration={trace.duration}

--- a/public/app/features/explore/extensions/ToolbarExtensionPointMenu.tsx
+++ b/public/app/features/explore/extensions/ToolbarExtensionPointMenu.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useMemo } from 'react';
+import { ReactElement, useMemo, type JSX } from 'react';
 
 import { PluginExtensionLink } from '@grafana/data';
 import { Menu } from '@grafana/ui';

--- a/public/app/features/expressions/components/QueryToolbox.tsx
+++ b/public/app/features/expressions/components/QueryToolbox.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/features/library-panels/components/ChangeLibraryPanelModal/ChangeLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/ChangeLibraryPanelModal/ChangeLibraryPanelModal.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { t } from '@grafana/i18n';
 import { ConfirmModal } from '@grafana/ui';
 

--- a/public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelCard/LibraryPanelCard.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { ReactElement, useState } from 'react';
+import { ReactElement, useState, type JSX } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelsSearch/LibraryPanelsSearch.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { memo, useCallback, useState } from 'react';
+import { memo, useCallback, useState, type JSX } from 'react';
 import { useDebounce } from 'react-use';
 
 import { GrafanaTheme2, PanelPluginMeta, SelectableValue } from '@grafana/data';

--- a/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
@@ -1,5 +1,5 @@
 import debounce from 'debounce-promise';
-import { MouseEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { MouseEvent, useCallback, useEffect, useMemo, useState, type JSX } from 'react';
 
 import { SelectableValue, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/logs/components/LogLabels.tsx
+++ b/public/app/features/logs/components/LogLabels.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { memo, forwardRef, useMemo, useState } from 'react';
+import { memo, forwardRef, useMemo, useState, type JSX } from 'react';
 
 import { GrafanaTheme2, Labels } from '@grafana/data';
 import { t } from '@grafana/i18n';

--- a/public/app/features/logs/components/fieldSelector/AvailableFields.tsx
+++ b/public/app/features/logs/components/fieldSelector/AvailableFields.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/logs/components/panel/LogListControlsOption.tsx
+++ b/public/app/features/logs/components/panel/LogListControlsOption.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Dropdown, Icon, IconButton, Tooltip, useStyles2 } from '@grafana/ui';

--- a/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardButton.tsx
+++ b/public/app/features/manage-dashboards/components/PublicDashboardListTable/DeletePublicDashboardButton.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import type { JSX } from 'react';
 
 import { t } from '@grafana/i18n';
 import { Button, ModalsController, ButtonProps } from '@grafana/ui';

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
+import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
 import { PluginType } from '@grafana/data';

--- a/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsBody.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { GrafanaTheme2, PluginContextProvider, UrlQueryMap, PluginType } from '@grafana/data';
 import { Trans } from '@grafana/i18n';

--- a/public/app/features/plugins/admin/components/PluginSubtitle.tsx
+++ b/public/app/features/plugins/admin/components/PluginSubtitle.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { Fragment } from 'react';
+import { Fragment, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Alert, Stack, useStyles2 } from '@grafana/ui';

--- a/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
 import { config } from '@grafana/runtime';

--- a/public/app/features/plugins/admin/components/VersionList.test.tsx
+++ b/public/app/features/plugins/admin/components/VersionList.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import type { JSX } from 'react';
 import { Provider } from 'react-redux';
 
 import { configureStore } from 'app/store/configureStore';

--- a/public/app/features/plugins/admin/pages/PluginDetails.tsx
+++ b/public/app/features/plugins/admin/pages/PluginDetails.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { useParams } from 'react-router-dom-v5-compat';
 
 import { PluginDetailsPage } from '../components/PluginDetailsPage';

--- a/public/app/features/plugins/extensions/registry/useRegistrySlice.test.tsx
+++ b/public/app/features/plugins/extensions/registry/useRegistrySlice.test.tsx
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import { ExtensionRegistriesProvider } from '../ExtensionRegistriesContext';
 

--- a/public/app/features/plugins/extensions/usePluginComponent.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponent.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
 
 import { PluginContextProvider, PluginLoadingStrategy, PluginMeta, PluginType } from '@grafana/data';
 import { config } from '@grafana/runtime';

--- a/public/app/features/plugins/extensions/usePluginComponents.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, renderHook, screen } from '@testing-library/react';
-import React from 'react';
+import React, { type JSX } from 'react';
 
 import {
   PluginContextProvider,

--- a/public/app/features/plugins/extensions/usePluginComponents.tsx
+++ b/public/app/features/plugins/extensions/usePluginComponents.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import {
   type ComponentTypeWithExtensionMeta,

--- a/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginFunctions.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import type { JSX } from 'react';
 
 import {
   PluginContextProvider,

--- a/public/app/features/plugins/extensions/usePluginLinks.test.tsx
+++ b/public/app/features/plugins/extensions/usePluginLinks.test.tsx
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react';
+import type { JSX } from 'react';
 
 import {
   PluginContextProvider,

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.test.tsx
@@ -1,6 +1,7 @@
 import { QueryStatus } from '@reduxjs/toolkit/query';
 import { screen, waitFor } from '@testing-library/react';
 import { UserEvent } from '@testing-library/user-event';
+import type { JSX } from 'react';
 import { render } from 'test/test-utils';
 
 import {

--- a/public/app/features/query/components/QueryActionComponent.ts
+++ b/public/app/features/query/components/QueryActionComponent.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { CoreApp, DataQuery, DataSourceInstanceSettings, TimeRange } from '@grafana/data';
 
 interface ActionComponentProps {

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { cloneDeep, filter, uniqBy, uniqueId } from 'lodash';
 import pluralize from 'pluralize';
-import { PureComponent, ReactNode } from 'react';
+import { PureComponent, ReactNode, type JSX } from 'react';
 
 import {
   CoreApp,

--- a/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountCreatePage.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type JSX } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { OrgRole } from '@grafana/data';

--- a/public/app/features/serviceaccounts/ServiceAccountPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { ConnectedProps, connect } from 'react-redux';
 import { useParams } from 'react-router-dom-v5-compat';
 

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.test.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { OrgRole } from '@grafana/data';

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { GrafanaTheme2, OrgRole } from '@grafana/data';

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfile.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 
 import { GrafanaTheme2, OrgRole, TimeZone, dateTimeFormat } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/serviceaccounts/components/ServiceAccountProfileRow.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountProfileRow.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type JSX } from 'react';
 import * as React from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountRoleRow.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { OrgRole } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Label } from '@grafana/ui';

--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { dateTimeFormat, GrafanaTheme2, TimeZone } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/support-bundles/SupportBundlesCreate.tsx
+++ b/public/app/features/support-bundles/SupportBundlesCreate.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, type JSX } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/users/UsersActionBar.tsx
+++ b/public/app/features/users/UsersActionBar.tsx
@@ -1,3 +1,4 @@
+import type { JSX } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { Trans, t } from '@grafana/i18n';

--- a/public/app/features/variables/datasource/DataSourceVariableEditor.test.tsx
+++ b/public/app/features/variables/datasource/DataSourceVariableEditor.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { JSX } from 'react';
 import { selectOptionInTest, getSelectParent } from 'test/helpers/selectOptionInTest';
 
 import { DataSourceVariableEditorUnConnected as DataSourceVariableEditor } from './DataSourceVariableEditor';

--- a/public/app/features/variables/inspect/NetworkGraphModal.tsx
+++ b/public/app/features/variables/inspect/NetworkGraphModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useState, type JSX } from 'react';
 
 import { Modal } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/AzureCredentialsForm.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { AzureAuthType, AzureCredentials, getAzureClouds } from '@grafana/azure-sdk';
 import { SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/ConfigEditor/CurrentUserFallbackCredentials.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, type JSX } from 'react';
 
 import { AadCurrentUserCredentials, AzureCredentials, instanceOfAzureCredential } from '@grafana/azure-sdk';
 import { SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filter.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/TracesQueryEditor/Filter.tsx
@@ -1,5 +1,5 @@
 import { cx } from '@emotion/css';
-import { RefCallback, SyntheticEvent, useState } from 'react';
+import { RefCallback, SyntheticEvent, useState, type JSX } from 'react';
 import * as React from 'react';
 import { lastValueFrom } from 'rxjs';
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/SecureSocksProxySettingsNewStyling.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { DataSourceJsonData, DataSourcePluginOptionsEditorProps } from '@grafana/data';
 import { ConfigSection } from '@grafana/plugin-ui';
 import { Field, Switch } from '@grafana/ui';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/LogsQueryEditor/LogsQueryEditor.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState, type JSX } from 'react';
 import { useEffectOnce } from 'react-use';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/MetricsQueryEditor/MetricsQueryEditor.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useCallback, useEffect, useState } from 'react';
+import { ChangeEvent, useCallback, useEffect, useState, type JSX } from 'react';
 import * as React from 'react';
 
 import { QueryEditorProps, SelectableValue } from '@grafana/data';
@@ -139,7 +139,6 @@ export const MetricsQueryEditor = (props: Props) => {
   return (
     <>
       <Space v={0.5} />
-
       {query.metricQueryType === MetricQueryType.Search && (
         <>
           {query.metricEditorMode === MetricEditorMode.Builder && (

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type JSX } from 'react';
 
 import { QueryEditorProps } from '@grafana/data';
 

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryHeader.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { CoreApp, LoadingState, QueryEditorProps, SelectableValue } from '@grafana/data';
 import { EditorHeader, InlineSelect, FlexItem } from '@grafana/plugin-ui';
 import { config } from '@grafana/runtime';

--- a/public/app/plugins/datasource/graphite/configuration/MappingsConfiguration.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/MappingsConfiguration.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useState, type JSX } from 'react';
 
 import { Box, Button, Icon, InlineField, InlineFieldRow, Input } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/graphite/configuration/MappingsHelp.tsx
+++ b/public/app/plugins/datasource/graphite/configuration/MappingsHelp.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { Alert } from '@grafana/ui';
 
 type Props = {

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/QueryEditorModeSwitcher.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/QueryEditorModeSwitcher.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 
 import { Button, ConfirmModal } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/code/RawInfluxQLEditor.tsx
@@ -1,4 +1,4 @@
-import { useId } from 'react';
+import { useId, type JSX } from 'react';
 
 import { Stack, InlineField, Input, Select, TextArea } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/AddButton.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/AddButton.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { SelectableValue } from '@grafana/data';
 
 import { unwrap } from '../utils/unwrap';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/FormatAsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/FormatAsSection.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { Select } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/FromSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/FromSection.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { AccessoryButton } from '@grafana/plugin-ui';
 
 import { DEFAULT_POLICY } from '../../../../../types';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/InputSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/InputSection.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { Input } from '@grafana/ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/OrderByTimeSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/OrderByTimeSection.tsx
@@ -1,4 +1,5 @@
 import { cx } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { SelectableValue } from '@grafana/data';
 import { Select } from '@grafana/ui';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/PartListSection.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useMemo, type JSX } from 'react';
 
 import { GrafanaTheme2, SelectableValue } from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/Seg.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/Seg.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import debouncePromise from 'debounce-promise';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type JSX } from 'react';
 import { useAsyncFn } from 'react-use';
 
 import { SelectableValue } from '@grafana/data';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/TagsSection.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { SelectableValue } from '@grafana/data';
 import { AccessoryButton } from '@grafana/plugin-ui';
 

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.test.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.test.tsx
@@ -1,4 +1,5 @@
 import { render, waitFor } from '@testing-library/react';
+import type { JSX } from 'react';
 
 import InfluxDatasource from '../../../../../datasource';
 import { getMockInfluxDS, getMockDSInstanceSettings } from '../../../../../mocks/datasource';

--- a/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
+++ b/public/app/plugins/datasource/influxdb/components/editor/query/influxql/visual/VisualInfluxQLEditor.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useId, useMemo } from 'react';
+import { useId, useMemo, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { InlineLabel, SegmentSection, useStyles2 } from '@grafana/ui';

--- a/public/app/plugins/datasource/mssql/types.ts
+++ b/public/app/plugins/datasource/mssql/types.ts
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import { AzureCredentials } from '@grafana/azure-sdk';
 import { SQLOptions } from '@grafana/sql';
 import { HttpSettingsBaseProps } from '@grafana/ui/internal';

--- a/public/app/plugins/datasource/prometheus/configuration/ConfigEditorPackage.tsx
+++ b/public/app/plugins/datasource/prometheus/configuration/ConfigEditorPackage.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import type { JSX } from 'react';
 
 import { SIGV4ConnectionConfig } from '@grafana/aws-sdk';
 import { hasCredentials } from '@grafana/azure-sdk';

--- a/public/app/plugins/panel/annolist/AnnoListPanel.tsx
+++ b/public/app/plugins/panel/annolist/AnnoListPanel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { createRef, PureComponent } from 'react';
+import { createRef, PureComponent, type JSX } from 'react';
 import { Subscription } from 'rxjs';
 
 import {

--- a/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
+++ b/public/app/plugins/panel/bargauge/BarGaugePanel.tsx
@@ -1,5 +1,5 @@
 import { isNumber } from 'lodash';
-import { PureComponent } from 'react';
+import { PureComponent, type JSX } from 'react';
 
 import {
   DisplayProcessor,

--- a/public/app/plugins/panel/gauge/GaugePanel.tsx
+++ b/public/app/plugins/panel/gauge/GaugePanel.tsx
@@ -1,4 +1,4 @@
-import { PureComponent } from 'react';
+import { PureComponent, type JSX } from 'react';
 
 import { FieldDisplay, getDisplayProcessor, getFieldDisplayValues, PanelProps } from '@grafana/data';
 import { BarGaugeSizing, VizOrientation } from '@grafana/schema';

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -576,7 +576,9 @@ export const LogsPanel = ({
           onMouseLeave={onLogContainerMouseLeave}
           className={style.logListContainer}
           style={height ? { minHeight: height } : undefined}
-          ref={(element: HTMLDivElement) => setScrollElement(element)}
+          ref={(element: HTMLDivElement) => {
+            setScrollElement(element);
+          }}
         >
           {deduplicatedRows.length > 0 && scrollElement && (
             <LogList
@@ -635,7 +637,11 @@ export const LogsPanel = ({
         </div>
       )}
       {!config.featureToggles.newLogsPanel && !showControls && (
-        <ScrollContainer ref={(scrollElement) => setScrollElement(scrollElement)}>
+        <ScrollContainer
+          ref={(scrollElement) => {
+            setScrollElement(scrollElement);
+          }}
+        >
           <div onMouseLeave={onLogContainerMouseLeave} className={style.container} ref={logsContainerRef}>
             {showCommonLabels && !isAscending && renderCommonLabels()}
             <InfiniteScroll
@@ -697,7 +703,9 @@ export const LogsPanel = ({
         <div onMouseLeave={onLogContainerMouseLeave} className={style.controlledLogsContainer}>
           {showCommonLabels && !isAscending && renderCommonLabels()}
           <ControlledLogRows
-            ref={(scrollElement: HTMLDivElement | null) => setScrollElement(scrollElement)}
+            ref={(scrollElement: HTMLDivElement | null) => {
+              setScrollElement(scrollElement);
+            }}
             visualisationType="logs"
             loading={infiniteScrolling}
             loadMoreLogs={enableInfiniteScrolling ? loadMoreLogs : undefined}

--- a/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
+++ b/public/app/plugins/panel/nodeGraph/EdgeLabel.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { memo } from 'react';
+import { memo, type JSX } from 'react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/plugins/panel/nodeGraph/useContextMenu.tsx
+++ b/public/app/plugins/panel/nodeGraph/useContextMenu.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { MouseEvent, useCallback, useState } from 'react';
+import { MouseEvent, useCallback, useState, type JSX } from 'react';
 import * as React from 'react';
 
 import { DataFrame, Field, GrafanaTheme2, LinkModel, LinkTarget } from '@grafana/data';

--- a/public/app/plugins/panel/radialbar/RadialBarPanel.tsx
+++ b/public/app/plugins/panel/radialbar/RadialBarPanel.tsx
@@ -1,3 +1,5 @@
+import type { JSX } from 'react';
+
 import {
   DisplayValueAlignmentFactors,
   FieldDisplay,

--- a/public/app/plugins/panel/stat/StatPanel.tsx
+++ b/public/app/plugins/panel/stat/StatPanel.tsx
@@ -1,5 +1,5 @@
 import { isNumber } from 'lodash';
-import { memo, useCallback } from 'react';
+import { memo, useCallback, type JSX } from 'react';
 
 import {
   DisplayValueAlignmentFactors,

--- a/public/app/routes/RoutesWrapper.tsx
+++ b/public/app/routes/RoutesWrapper.tsx
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactNode, type JSX } from 'react';
 import { Router } from 'react-router-dom';
 import { CompatRouter } from 'react-router-dom-v5-compat';
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- runs some of the [react 19 typescript codemods](https://github.com/eps1lon/types-react-codemod/) across the codebase. specifically:
  - `deprecated-legacy-ref`, `deprecated-prop-types-types`, `deprecated-react-child`, `deprecated-react-node-array`, `deprecated-react-fragment`, `deprecated-react-text`, `deprecated-void-function-component`
    - these do nothing for us i think
  - `no-implicit-ref-callback-return`
    - [in react 19, refs can return a cleanup function](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#ref-cleanup-required)
    - this means refs that assign and implicitly return need to be changed, e.g. 
      ```tsx
        ref={(element) => (this.element = element)}
      ```
      becomes
      ```tsx
        ref={(element) => {
          this.element = element
        }}
      ```
  - `scoped-jsx`
    - this is ~95% of the changes
    - [`JSX` is no longer global in react 19](https://react.dev/blog/2024/04/25/react-19-upgrade-guide#the-jsx-namespace-in-typescript). this changes to import `JSX` from react directly. this will do nothing in react 18 (it's already a global), but is required in react 19, so we might as well do it now to make the diff easier later

**Why do we need this feature?**

- deliver some (currently no-op) changes in preparation for react 19

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/98813

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
