### PR TITLE
FS: Fix HTML loader jumping a few pixels

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -79,6 +79,7 @@
           font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
             Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
             "Segoe UI Symbol";
+          line-height: 1; /* prevent shift when css loads in that changes the body line-height */
         }
 
         .fs-variant-loader, .fs-variant-error, .fs-custom-domain-error {


### PR DESCRIPTION
Fixes an issue where the spinner loader in the HTML would jump up a few pixels a few seconds after it appears.
It was caused by the CSS files loading in and changing the body-line height from the default. This fixes it by just always having a fixed line-height for the loader div.


Part of https://github.com/grafana/grafana-frontend-platform/issues/86