### PR TITLE
datasources: querier: configurable concurrent-query-limit

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -338,8 +338,8 @@ func prepareQuery(
 	}, nil
 }
 
-func handlePreparedQuery(ctx context.Context, pq *preparedQuery) (*backend.QueryDataResponse, error) {
-	resp, err := service.QueryData(ctx, pq.logger, pq.cache, pq.exprSvc, pq.mReq, pq.builder, pq.headers)
+func handlePreparedQuery(ctx context.Context, pq *preparedQuery, concurrentQueryLimit int) (*backend.QueryDataResponse, error) {
+	resp, err := service.QueryData(ctx, pq.logger, pq.cache, pq.exprSvc, pq.mReq, pq.builder, pq.headers, concurrentQueryLimit)
 	pq.reportMetrics()
 	return resp, err
 }
@@ -357,7 +357,7 @@ func handleQuery(
 		responder.Error(err)
 		return nil, err
 	}
-	return handlePreparedQuery(ctx, pq)
+	return handlePreparedQuery(ctx, pq, b.concurrentQueryLimit)
 }
 
 type responderWrapper struct {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -226,7 +226,7 @@ func buildErrorResponses(err error, queries []*simplejson.Json) splitResponse {
 	return splitResponse{er, http.Header{}}
 }
 
-func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheService, exprService *expr.Service, reqDTO dtos.MetricRequest, qsDatasourceClientBuilder dsquerierclient.QSDatasourceClientBuilder, headers map[string]string) (*backend.QueryDataResponse, error) {
+func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheService, exprService *expr.Service, reqDTO dtos.MetricRequest, qsDatasourceClientBuilder dsquerierclient.QSDatasourceClientBuilder, headers map[string]string, concurrentQueryLimit int) (*backend.QueryDataResponse, error) {
 	s := &ServiceImpl{
 		log:                        log,
 		dataSourceCache:            dscache,
@@ -234,7 +234,7 @@ func QueryData(ctx context.Context, log log.Logger, dscache datasources.CacheSer
 		dataSourceRequestValidator: validations.ProvideValidator(),
 		qsDatasourceClientBuilder:  qsDatasourceClientBuilder,
 		headers:                    headers,
-		concurrentQueryLimit:       16, // TODO: make it configurable
+		concurrentQueryLimit:       concurrentQueryLimit,
 	}
 
 	user, err := identity.GetRequester(ctx)


### PR DESCRIPTION
fixes https://github.com/grafana/grafana-enterprise/issues/9486.

the `/api/ds/query` endpoint has a configurable `concurrent query limit` setting. for the single-tenant query-service, we only had it hardcoded to 16. now we calculate it the same way as how [/api/ds/query does it.](https://github.com/grafana/grafana/blob/ce72dc6224329ca2b95730ac71abc859d609f89d/pkg/services/query/query.go#L62)