### PR TITLE
Sidebar: Fix resizing

### DIFF
--- a/packages/grafana-ui/src/components/Sidebar/SidebarResizer.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/SidebarResizer.tsx
@@ -37,6 +37,12 @@ export function SidebarResizer() {
         return;
       }
 
+      // mouse is moving with no buttons pressed
+      if (!e.buttons) {
+        dragStart.current = null;
+        return;
+      }
+
       const diff = e.clientX - dragStart.current;
       dragStart.current = e.clientX;
 


### PR DESCRIPTION
**What is this feature?**

A fix to prevent an issue when resizing the sidebar were the resizing still occurs even after the pointer button has been released.

In this video made with an Apple magic mouse (does it happen with other devices?) the issue manifests after the 3rd drag to the left. At that point, the mouse button has been released but hovering over the edge of the sidebar still resizes it:

https://github.com/user-attachments/assets/576e5ae3-456c-4990-97ab-bf97ac085be7

**Why do we need this feature?**

Bug fix

**Who is this feature for?**

Dynamic dashboards users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

`-`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
