### PR TITLE
 Alerting: add sync timer support

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1251,4 +1251,8 @@ export interface FeatureToggles {
   * Enables profiles exemplars support in profiles drilldown
   */
   profilesExemplars?: boolean;
+  /**
+  * Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods
+  */
+  alertingSyncDispatchTimer?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -981,7 +981,8 @@ var (
 			Stage:       FeatureStageDeprecated,
 			Owner:       grafanaPartnerPluginsSquad,
 			Expression:  "true", // Enabled by default for now
-		}, {
+		},
+		{
 			Name:         "alertingFilterV2",
 			Description:  "Enable the new alerting search experience",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2069,6 +2069,14 @@ var (
 			Owner:        grafanaObservabilityTracesAndProfilingSquad,
 			FrontendOnly: false,
 		},
+		{
+			Name:            "alertingSyncDispatchTimer",
+			Description:     "Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaAlertingSquad,
+			RequiresRestart: true,
+			HideFromDocs:    true,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -280,3 +280,4 @@ multiPropsVariables,experimental,@grafana/dashboards-squad,false,false,true
 smoothingTransformation,experimental,@grafana/datapro,false,false,true
 secretsManagementAppPlatformAwsKeeper,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 profilesExemplars,experimental,@grafana/observability-traces-and-profiling,false,false,false
+alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -789,4 +789,8 @@ const (
 	// FlagProfilesExemplars
 	// Enables profiles exemplars support in profiles drilldown
 	FlagProfilesExemplars = "profilesExemplars"
+
+	// FlagAlertingSyncDispatchTimer
+	// Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods
+	FlagAlertingSyncDispatchTimer = "alertingSyncDispatchTimer"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -676,7 +676,8 @@
       "metadata": {
         "name": "auditLoggingAppPlatform",
         "resourceVersion": "1767013056996",
-        "creationTimestamp": "2025-12-29T12:57:36Z"
+        "creationTimestamp": "2025-12-29T12:57:36Z",
+        "deletionTimestamp": "2026-01-06T09:18:36Z"
       },
       "spec": {
         "description": "Enable audit logging with Kubernetes under app platform",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -513,6 +513,20 @@
     },
     {
       "metadata": {
+        "name": "alertingSyncDispatchTimer",
+        "resourceVersion": "1766161788928",
+        "creationTimestamp": "2025-12-19T16:29:48Z"
+      },
+      "spec": {
+        "description": "Use synchronized dispatch timer to minimize duplicate notifications across alertmanager HA pods",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingTriage",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-07-31T22:56:50Z",

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -222,7 +222,7 @@ func (ng *AlertNG) init() error {
 			ExternalURL:       ng.Cfg.AppURL,
 			SmtpConfig:        smtpCfg,
 			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
-			DispatchTimer:     notifier.GetDispatchTimer(initCtx, ng.FeatureToggles).String(),
+			DispatchTimer:     notifier.GetDispatchTimer(ng.FeatureToggles).String(),
 		}
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, invalidReceiverAction notifier.InvalidReceiversAction) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, invalidReceiverAction, ng.FeatureToggles)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -222,6 +222,7 @@ func (ng *AlertNG) init() error {
 			ExternalURL:       ng.Cfg.AppURL,
 			SmtpConfig:        smtpCfg,
 			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
+			DispatchTimer:     notifier.GetDispatchTimer(initCtx, ng.FeatureToggles).String(),
 		}
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, invalidReceiverAction notifier.InvalidReceiversAction) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, invalidReceiverAction, ng.FeatureToggles)

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -213,6 +213,9 @@ func (ng *AlertNG) init() error {
 			SkipVerify:     ng.Cfg.Smtp.SkipVerify,
 			StaticHeaders:  ng.Cfg.Smtp.StaticHeaders,
 		}
+		runtimeConfig := remoteClient.RuntimeConfig{
+			DispatchTimer: notifier.GetDispatchTimer(ng.FeatureToggles).String(),
+		}
 
 		cfg := remote.AlertmanagerConfig{
 			BasicAuthPassword: ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Password,
@@ -222,7 +225,7 @@ func (ng *AlertNG) init() error {
 			ExternalURL:       ng.Cfg.AppURL,
 			SmtpConfig:        smtpCfg,
 			Timeout:           ng.Cfg.UnifiedAlerting.RemoteAlertmanager.Timeout,
-			DispatchTimer:     notifier.GetDispatchTimer(ng.FeatureToggles).String(),
+			RuntimeConfig:     runtimeConfig,
 		}
 		autogenFn := func(ctx context.Context, logger log.Logger, orgID int64, cfg *definitions.PostableApiAlertingConfig, invalidReceiverAction notifier.InvalidReceiversAction) error {
 			return notifier.AddAutogenConfig(ctx, logger, ng.store, orgID, cfg, invalidReceiverAction, ng.FeatureToggles)

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -134,9 +134,9 @@ func NewAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store A
 
 	dispatchTimer := GetDispatchTimer(featureToggles)
 
-	var flushLogOptions maintenanceOptions
+	var flushLogOptions *maintenanceOptions
 	if dispatchTimer == alertingNotify.DispatchTimerSync {
-		flushLogOptions = maintenanceOptions{
+		flushLogOptions = &maintenanceOptions{
 			initialState:         flushLog,
 			retention:            flushRetention,
 			maintenanceFrequency: maintenanceInterval,

--- a/pkg/services/ngalert/notifier/alertmanager.go
+++ b/pkg/services/ngalert/notifier/alertmanager.go
@@ -132,7 +132,7 @@ func NewAlertmanager(ctx context.Context, orgID int64, cfg *setting.Cfg, store A
 	}
 	l := log.New("ngalert.notifier")
 
-	dispatchTimer := GetDispatchTimer(ctx, featureToggles)
+	dispatchTimer := GetDispatchTimer(featureToggles)
 
 	var flushLogOptions maintenanceOptions
 	if dispatchTimer == alertingNotify.DispatchTimerSync {

--- a/pkg/services/ngalert/notifier/dispatch_timer.go
+++ b/pkg/services/ngalert/notifier/dispatch_timer.go
@@ -1,15 +1,15 @@
 package notifier
 
 import (
-	"context"
-
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
 // GetDispatchTimer returns the appropriate dispatch timer based on feature toggles.
-func GetDispatchTimer(ctx context.Context, features featuremgmt.FeatureToggles) (dt alertingNotify.DispatchTimer) {
-	if features.IsEnabled(ctx, featuremgmt.FlagAlertingSyncDispatchTimer) {
+func GetDispatchTimer(features featuremgmt.FeatureToggles) (dt alertingNotify.DispatchTimer) {
+	//nolint:staticcheck // not yet migrated to OpenFeature
+	enabled := features.IsEnabledGlobally(featuremgmt.FlagAlertingSyncDispatchTimer)
+	if enabled {
 		dt = alertingNotify.DispatchTimerSync
 	}
 	return

--- a/pkg/services/ngalert/notifier/dispatch_timer.go
+++ b/pkg/services/ngalert/notifier/dispatch_timer.go
@@ -1,0 +1,16 @@
+package notifier
+
+import (
+	"context"
+
+	alertingNotify "github.com/grafana/alerting/notify"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// GetDispatchTimer returns the appropriate dispatch timer based on feature toggles.
+func GetDispatchTimer(ctx context.Context, features featuremgmt.FeatureToggles) (dt alertingNotify.DispatchTimer) {
+	if features.IsEnabled(ctx, featuremgmt.FlagAlertingSyncDispatchTimer) {
+		dt = alertingNotify.DispatchTimerSync
+	}
+	return
+}

--- a/pkg/services/ngalert/notifier/dispatch_timer_test.go
+++ b/pkg/services/ngalert/notifier/dispatch_timer_test.go
@@ -1,0 +1,36 @@
+package notifier
+
+import (
+	"testing"
+
+	alertingNotify "github.com/grafana/alerting/notify"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDispatchTimer(t *testing.T) {
+	tests := []struct {
+		name             string
+		featureFlagValue bool
+		expected         alertingNotify.DispatchTimer
+	}{
+		{
+			name:             "feature flag enabled returns sync timer",
+			featureFlagValue: true,
+			expected:         alertingNotify.DispatchTimerSync,
+		},
+		{
+			name:             "feature flag disabled returns default timer",
+			featureFlagValue: false,
+			expected:         alertingNotify.DispatchTimerDefault,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			features := featuremgmt.WithFeatures(featuremgmt.FlagAlertingSyncDispatchTimer, tt.featureFlagValue)
+			result := GetDispatchTimer(features)
+			require.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/pkg/services/ngalert/notifier/file_store.go
+++ b/pkg/services/ngalert/notifier/file_store.go
@@ -15,6 +15,7 @@ const (
 	KVNamespace             = "alertmanager"
 	NotificationLogFilename = "notifications"
 	SilencesFilename        = "silences"
+	FlushLogFilename        = "flushes"
 )
 
 // FileStore is in charge of persisting the alertmanager files to the database.
@@ -40,6 +41,10 @@ func (fileStore *FileStore) GetSilences(ctx context.Context) (string, error) {
 
 func (fileStore *FileStore) GetNotificationLog(ctx context.Context) (string, error) {
 	return fileStore.contentFor(ctx, NotificationLogFilename)
+}
+
+func (fileStore *FileStore) GetFlushLog(ctx context.Context) (string, error) {
+	return fileStore.contentFor(ctx, FlushLogFilename)
 }
 
 // contentFor returns the content for the given Alertmanager kvstore key.
@@ -72,6 +77,11 @@ func (fileStore *FileStore) SaveSilences(ctx context.Context, st alertingNotify.
 // SaveNotificationLog saves the notification log to the database and returns the size of the unencoded state.
 func (fileStore *FileStore) SaveNotificationLog(ctx context.Context, st alertingNotify.State) (int64, error) {
 	return fileStore.persist(ctx, NotificationLogFilename, st)
+}
+
+// SaveFlushLog saves the flush log to the database and returns the size of the unencoded state.
+func (fileStore *FileStore) SaveFlushLog(ctx context.Context, st alertingNotify.State) (int64, error) {
+	return fileStore.persist(ctx, FlushLogFilename, st)
 }
 
 // persist takes care of persisting the binary representation of internal state to the database as a base64 encoded string.

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -82,6 +82,7 @@ type Alertmanager interface {
 type ExternalState struct {
 	Silences []byte
 	Nflog    []byte
+	FlushLog []byte
 }
 
 // StateMerger describes a type that is able to merge external state (nflog, silences) with its own.
@@ -378,7 +379,7 @@ func (moa *MultiOrgAlertmanager) SyncAlertmanagersForOrgs(ctx context.Context, o
 func (moa *MultiOrgAlertmanager) cleanupOrphanLocalOrgState(ctx context.Context,
 	activeOrganizations map[int64]struct{},
 ) {
-	storedFiles := []string{NotificationLogFilename, SilencesFilename}
+	storedFiles := []string{NotificationLogFilename, SilencesFilename, FlushLogFilename}
 	for _, fileName := range storedFiles {
 		keys, err := moa.kvStore.Keys(ctx, kvstore.AllOrganizations, KVNamespace, fileName)
 		if err != nil {

--- a/pkg/services/ngalert/notifier/state.go
+++ b/pkg/services/ngalert/notifier/state.go
@@ -8,5 +8,5 @@ func (am *alertmanager) MergeState(state ExternalState) error {
 	if err := am.Base.MergeSilences(state.Silences); err != nil {
 		return err
 	}
-	return am.Base.MergeFlushLog()
+	return am.Base.MergeFlushLog(state.FlushLog)
 }

--- a/pkg/services/ngalert/notifier/state.go
+++ b/pkg/services/ngalert/notifier/state.go
@@ -5,5 +5,8 @@ func (am *alertmanager) MergeState(state ExternalState) error {
 	if err := am.Base.MergeNflog(state.Nflog); err != nil {
 		return err
 	}
-	return am.Base.MergeSilences(state.Silences)
+	if err := am.Base.MergeSilences(state.Silences); err != nil {
+		return err
+	}
+	return am.Base.MergeFlushLog()
 }

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -88,7 +88,7 @@ type Alertmanager struct {
 	promoteConfig bool
 	externalURL   string
 
-	dispatchTimer string
+	runtimeConfig remoteClient.RuntimeConfig
 }
 
 type AlertmanagerConfig struct {
@@ -115,8 +115,8 @@ type AlertmanagerConfig struct {
 	// Timeout for the HTTP client.
 	Timeout time.Duration
 
-	// DispatchTimer specifies which timer to use in the dispatcher
-	DispatchTimer string
+	// RuntimeConfig specifies runtime behavior settings for the remote Alertmanager.
+	RuntimeConfig remoteClient.RuntimeConfig
 }
 
 func (cfg *AlertmanagerConfig) Validate() error {
@@ -209,7 +209,7 @@ func NewAlertmanager(ctx context.Context, cfg AlertmanagerConfig, store stateSto
 		externalURL:   cfg.ExternalURL,
 		promoteConfig: cfg.PromoteConfig,
 		smtp:          cfg.SmtpConfig,
-		dispatchTimer: cfg.DispatchTimer,
+		runtimeConfig: cfg.RuntimeConfig,
 	}
 
 	// Parse the default configuration once and remember its hash so we can compare it later.
@@ -338,13 +338,11 @@ func (am *Alertmanager) buildConfiguration(ctx context.Context, raw []byte, crea
 			AlertmanagerConfig: mergeResult.Config,
 			Templates:          templates,
 		},
-		CreatedAt:   createdAtEpoch,
-		Promoted:    am.promoteConfig,
-		ExternalURL: am.externalURL,
-		SmtpConfig:  am.smtp,
-		RuntimeConfig: remoteClient.RuntimeConfig{
-			DispatchTimer: am.dispatchTimer,
-		},
+		CreatedAt:     createdAtEpoch,
+		Promoted:      am.promoteConfig,
+		ExternalURL:   am.externalURL,
+		SmtpConfig:    am.smtp,
+		RuntimeConfig: am.runtimeConfig,
 	}
 
 	cfgHash, err := calculateUserGrafanaConfigHash(payload)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -86,6 +86,8 @@ type Alertmanager struct {
 
 	promoteConfig bool
 	externalURL   string
+
+	dispatchTimer string
 }
 
 type AlertmanagerConfig struct {
@@ -111,6 +113,9 @@ type AlertmanagerConfig struct {
 
 	// Timeout for the HTTP client.
 	Timeout time.Duration
+
+	// DispatchTimer specifies which timer to use in the dispatcher
+	DispatchTimer string
 }
 
 func (cfg *AlertmanagerConfig) Validate() error {
@@ -203,6 +208,7 @@ func NewAlertmanager(ctx context.Context, cfg AlertmanagerConfig, store stateSto
 		externalURL:   cfg.ExternalURL,
 		promoteConfig: cfg.PromoteConfig,
 		smtp:          cfg.SmtpConfig,
+		dispatchTimer: cfg.DispatchTimer,
 	}
 
 	// Parse the default configuration once and remember its hash so we can compare it later.
@@ -331,10 +337,11 @@ func (am *Alertmanager) buildConfiguration(ctx context.Context, raw []byte, crea
 			AlertmanagerConfig: mergeResult.Config,
 			Templates:          templates,
 		},
-		CreatedAt:   createdAtEpoch,
-		Promoted:    am.promoteConfig,
-		ExternalURL: am.externalURL,
-		SmtpConfig:  am.smtp,
+		CreatedAt:     createdAtEpoch,
+		Promoted:      am.promoteConfig,
+		ExternalURL:   am.externalURL,
+		SmtpConfig:    am.smtp,
+		DispatchTimer: am.dispatchTimer,
 	}
 
 	cfgHash, err := calculateUserGrafanaConfigHash(payload)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -338,11 +338,13 @@ func (am *Alertmanager) buildConfiguration(ctx context.Context, raw []byte, crea
 			AlertmanagerConfig: mergeResult.Config,
 			Templates:          templates,
 		},
-		CreatedAt:     createdAtEpoch,
-		Promoted:      am.promoteConfig,
-		ExternalURL:   am.externalURL,
-		SmtpConfig:    am.smtp,
-		DispatchTimer: am.dispatchTimer,
+		CreatedAt:   createdAtEpoch,
+		Promoted:    am.promoteConfig,
+		ExternalURL: am.externalURL,
+		SmtpConfig:  am.smtp,
+		RuntimeConfig: remoteClient.RuntimeConfig{
+			DispatchTimer: am.dispatchTimer,
+		},
 	}
 
 	cfgHash, err := calculateUserGrafanaConfigHash(payload)

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -37,6 +37,7 @@ type UserGrafanaConfig struct {
 	Promoted                  bool                      `json:"promoted"`
 	ExternalURL               string                    `json:"external_url"`
 	SmtpConfig                SmtpConfig                `json:"smtp_config"`
+	DispatchTimer             string                    `json:"dispatch_timer"`
 }
 
 func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error) {

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -29,6 +29,10 @@ func (u *GrafanaAlertmanagerConfig) MarshalJSON() ([]byte, error) {
 	return definition.MarshalJSONWithSecrets((*cfg)(u))
 }
 
+type RuntimeConfig struct {
+	DispatchTimer string `json:"dispatch_timer"`
+}
+
 type UserGrafanaConfig struct {
 	GrafanaAlertmanagerConfig GrafanaAlertmanagerConfig `json:"configuration"`
 	Hash                      string                    `json:"configuration_hash"`
@@ -37,7 +41,7 @@ type UserGrafanaConfig struct {
 	Promoted                  bool                      `json:"promoted"`
 	ExternalURL               string                    `json:"external_url"`
 	SmtpConfig                SmtpConfig                `json:"smtp_config"`
-	DispatchTimer             string                    `json:"dispatch_timer"`
+	RuntimeConfig             RuntimeConfig             `json:"runtime_config"`
 }
 
 func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error) {


### PR DESCRIPTION
## Context
- Add support for the alertmanager sync timer
- Sync timer synchronizes the flush times across HA nodes to decrease the chance of duplicate notifications
- If opt timer is set to sync timer, we initialize the flush log and set the sync timer factory when initializing the dispatcher

Related to https://github.com/grafana/alerting/pull/419