### PR TITLE
Swagger: Load embedded icons from CDN

### DIFF
--- a/pkg/api/swagger.go
+++ b/pkg/api/swagger.go
@@ -30,10 +30,8 @@ func (hs *HTTPServer) registerSwaggerUI(r routing.RouteRegister) {
 		}
 
 		data := map[string]any{
-			"Nonce":          c.RequestNonce,
-			"Assets":         assets,
-			"FavIcon":        "public/img/fav32.png",
-			"AppleTouchIcon": "public/img/apple-touch-icon.png",
+			"Nonce":  c.RequestNonce,
+			"Assets": assets,
 		}
 		if hs.Cfg.CSPEnabled {
 			data["CSPEnabled"] = true

--- a/public/swagger/SwaggerPage.tsx
+++ b/public/swagger/SwaggerPage.tsx
@@ -5,10 +5,9 @@ import SwaggerUI from 'swagger-ui-react';
 
 import { createTheme, monacoLanguageRegistry, SelectableValue } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Stack, Select, UserIcon, UserView, Button } from '@grafana/ui';
+import { Icon, Stack, Select, UserIcon, UserView, Button } from '@grafana/ui';
 import { setMonacoEnv } from 'app/core/monacoEnv';
 import { ThemeProvider } from 'app/core/utils/ConfigProvider';
-import grafanaIconSvg from 'img/grafana_icon.svg';
 
 import { NamespaceContext, WrappedPlugins } from './plugins';
 
@@ -85,7 +84,7 @@ export const Page = () => {
         <NamespaceContext.Provider value={namespace.value}>
           <div style={{ backgroundColor: '#000', padding: '10px' }}>
             <Stack justifyContent={'space-between'}>
-              <img height="40" src={grafanaIconSvg} alt="Grafana" />
+              <Icon name="grafana" size="xxl" />
               <Select
                 options={urls.value}
                 isClearable={false /* TODO -- when we allow a landing page, this can be true */}

--- a/public/views/swagger.html
+++ b/public/views/swagger.html
@@ -18,9 +18,13 @@
 
     <link rel="stylesheet" href="[[.Assets.Light]]" />
 
-    <link rel="icon" type="image/png" href="[[.FavIcon]]" />
-    <link rel="apple-touch-icon" sizes="180x180" href="[[.AppleTouchIcon]]" />
-    <link rel="mask-icon" href="[[.Assets.ContentDeliveryURL]]public/img/grafana_mask_icon.svg" color="#F05A28" />
+    <link rel="icon" type="image/png" href="[[.Assets.ContentDeliveryURL]]public/build/img/fav32.png" />
+    <link
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="[[.Assets.ContentDeliveryURL]]public/build/img/apple-touch-icon.png"
+    />
+    <link rel="mask-icon" href="[[.Assets.ContentDeliveryURL]]public/build/img/grafana_mask_icon.svg" color="#F05A28" />
   </head>
 
   <body>


### PR DESCRIPTION
This updates the swagger UI to load the favicon and apple touch icon (…do we really need this in here anyway??) from the CDN, using the same paths as the regular index.html file.

Also changes the logo in the header to use the <Icon /> component to load the SVG icon form the CDN.

Part of https://github.com/grafana/grafana-frontend-platform/issues/86 