### PR TITLE
Chore: updated caniuse dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13464,9 +13464,9 @@ __metadata:
   linkType: hard
 
 "caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001702, caniuse-lite@npm:^1.0.30001726":
-  version: 1.0.30001727
-  resolution: "caniuse-lite@npm:1.0.30001727"
-  checksum: 10/6155a4141332c337d6317325bea58a09036a65f45bd9bd834ec38978b40c27d214baa04d25b21a5661664f3fbd00cb830e2bdb7eee8df09970bdd98a71f4dabf
+  version: 1.0.30001757
+  resolution: "caniuse-lite@npm:1.0.30001757"
+  checksum: 10/2efcb3614a6e2618727e6ae7fc76668496650605010a7471128885cc7d8d6c789a94154ee78cb7907719e1c29b6d43bb5e14937e25e28b774f9b8dde51191968
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

```
❯ npx update-browserslist-db@latest
Need to install the following packages:
update-browserslist-db@1.1.4
Ok to proceed? (y) 

Latest version:     1.0.30001757
Updating caniuse-lite version
$ yarn up -R caniuse-lite
caniuse-lite has been successfully updated

No target browser changes
```
