### PR TITLE
Alerting: Fix advanced filter not preserving freewords filter in the list view

### DIFF
--- a/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/filter/RulesFilter.v2.tsx
@@ -82,7 +82,7 @@ export default function RulesFilter({ viewMode, onViewModeChange }: RulesFilterP
   const styles = useStyles2(getStyles);
 
   const [isPopupOpen, setIsPopupOpen] = useState(false);
-  const { searchQuery, updateFilters, setSearchQuery } = useRulesFilter();
+  const { filterState, searchQuery, updateFilters, setSearchQuery } = useRulesFilter();
   const popupRef = useRef<HTMLDivElement>(null);
   const { pluginsFilterEnabled } = usePluginsFilterStatus();
 
@@ -104,7 +104,7 @@ export default function RulesFilter({ viewMode, onViewModeChange }: RulesFilterP
   };
 
   const handleAdvancedFilters: SubmitHandler<AdvancedFilters> = (values) => {
-    updateFilters(formAdvancedFiltersToRuleFilter(values));
+    updateFilters(formAdvancedFiltersToRuleFilter(values, filterState.freeFormWords));
     trackFilterButtonApplyClick(values, pluginsFilterEnabled);
     setIsPopupOpen(false);
   };

--- a/public/app/features/alerting/unified/rule-list/filter/utils.ts
+++ b/public/app/features/alerting/unified/rule-list/filter/utils.ts
@@ -5,9 +5,12 @@ import { RulesFilter } from '../../search/rulesSearchParser';
 
 import { AdvancedFilters } from './types';
 
-export function formAdvancedFiltersToRuleFilter(values: AdvancedFilters): RulesFilter {
+export function formAdvancedFiltersToRuleFilter(
+  values: AdvancedFilters,
+  existingFreeFormWords: string[] = []
+): RulesFilter {
   return {
-    freeFormWords: [],
+    freeFormWords: existingFreeFormWords,
     ...values,
     namespace: values.namespace || undefined,
     groupName: values.groupName || undefined,


### PR DESCRIPTION

**What is this feature?**

This PR fixes the advanced filter in the list view not preserving the free words present in the search bar.

**Why do we need this feature?**


**Who is this feature for?**

Alerting users.


**Special notes for your reviewer:**

With the fix:

https://github.com/user-attachments/assets/6c922511-e492-4bea-b081-996992ed1618




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
