### PR TITLE
appinstaller: Use  grafana-app-sdk `apiserver.KubernetesGenericAPIServer` to wrap the generic API server

### DIFF
--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -147,7 +147,7 @@ func InstallAPIs(
 		logger.Debug("Installing APIs for app installer", "app", installer.ManifestData().AppName)
 		wrapper := &serverWrapper{
 			ctx:               ctx,
-			GenericAPIServer:  server,
+			GenericAPIServer:  appsdkapiserver.NewKubernetesGenericAPIServer(server),
 			installer:         installer,
 			storageOpts:       storageOpts,
 			restOptionsGetter: restOpsGetter,

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -26,8 +26,8 @@ import (
 var _ appsdkapiserver.GenericAPIServer = (*serverWrapper)(nil)
 
 type serverWrapper struct {
-	ctx context.Context
-	*genericapiserver.GenericAPIServer
+	ctx               context.Context
+	GenericAPIServer  appsdkapiserver.GenericAPIServer
 	installer         appsdkapiserver.AppInstaller
 	restOptionsGetter generic.RESTOptionsGetter
 	storageOpts       *grafanaapiserveroptions.StorageOptions
@@ -143,8 +143,5 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 }
 
 func (s *serverWrapper) RegisteredWebServices() []*restful.WebService {
-	if s.Handler != nil && s.Handler.GoRestfulContainer != nil {
-		return s.Handler.GoRestfulContainer.RegisteredWebServices()
-	}
-	return nil
+	return s.GenericAPIServer.RegisteredWebServices()
 }


### PR DESCRIPTION
**What is this feature?**

In `appinstaller.InstallAPIs`, wrap the kubernetes `*genericapiserver.GenericAPIServer` in the app-sdk's `KubernetesGenericAPIServer`. This ensures that any additional logic for handling custom routes is called when `InstallAPIs` is called.

**Why do we need this feature?**

[This PR](https://github.com/grafana/grafana-app-sdk/pull/1122) in the `grafana-app-sdk` introduced the ability to have custom resource routes without needing kinds when installing the app onto an API server. Part of this logic was that if no `WebService` is registered by the underlying call to `kubernetes genericapiserver.GenericAPIServer.InstallAPIGroup`. to create and register one so that the custom routes can later be added to it. This functionality was added to the grafana-app-sdk's `apiserver.KubernetesGenericAPIServer` implementation of `apiserver.GenericAPIServer`, but that implementation is not used by `appinstaller.InstallAPIs`, as it needs its own custom logic in `InstallAPIGroup`. This PR has the `serverWrapper` call a downstream `apiserver.KubernetesGenericAPIServer`'s `InstallAPIGroup` in order to also include the logic from `apiserver.KubernetesGenericAPIServer.InstallAPIGroup`.

**Who is this feature for?**

App authors who want to register custom routes without any kinds for the APIVersion.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
