### PR TITLE
Explore: escape character of break-line in Traceql in Search tab fixing an issue when filtering by a multi line span tag value

### DIFF
--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -764,13 +764,14 @@ describe('Tempo service graph view', () => {
 
   it('should escape span with multi line content correctly', () => {
     const spanContent = [
-      `SELECT * from "my_table"
+      `
+      SELECT * from "my_table"
       WHERE "data_enabled" = 1
-      ORDER BY "name" ASC`
+      ORDER BY "name" ASC`,
     ];
     let escaped = getEscapedRegexValues(getEscapedValues(spanContent));
     expect(escaped).toEqual([
-      'SELECT * from \\"my_table\\"\\nWHERE \\"data_enabled\\" = 1\\nORDER BY \\"name\\" ASC',
+      '\\n      SELECT \\\\* from \\"my_table\\"\\n      WHERE \\"data_enabled\\" = 1\\n      ORDER BY \\"name\\" ASC',
     ]);
   });
 

--- a/public/app/plugins/datasource/tempo/datasource.test.ts
+++ b/public/app/plugins/datasource/tempo/datasource.test.ts
@@ -762,6 +762,18 @@ describe('Tempo service graph view', () => {
     ]);
   });
 
+  it('should escape span with multi line content correctly', () => {
+    const spanContent = [
+      `SELECT * from "my_table"
+      WHERE "data_enabled" = 1
+      ORDER BY "name" ASC`
+    ];
+    let escaped = getEscapedRegexValues(getEscapedValues(spanContent));
+    expect(escaped).toEqual([
+      'SELECT * from \\"my_table\\"\\nWHERE \\"data_enabled\\" = 1\\nORDER BY \\"name\\" ASC',
+    ]);
+  });
+
   it('should get field config correctly', () => {
     let datasourceUid = 's4Jvz8Qnk';
     let tempoDatasourceUid = 'EbPO1fYnz';

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -1168,7 +1168,7 @@ export function getEscapedRegexValues(values: string[]) {
 }
 
 export function getEscapedValues(values: string[]) {
-  return values.map((value: string) => value.replace(/["\\]/g, '\\$&'));
+  return values.map((value: string) => value.replace(/["\\]/g, '\\$&').replace(/[\n]/g, '\\n'));
 }
 
 export function getFieldConfig(


### PR DESCRIPTION
<!--

-->

**What is this feature?**

It's a bug fix related to this issue: https://github.com/grafana/grafana/issues/114671

summary: 
Searching for traces and spans in Grafana Explore, in Search tab, when filtering them by a span attribute that has a multi line value, it raises and error:
<img width="951" height="111" alt="image" src="https://github.com/user-attachments/assets/3ab010a5-a3d6-47ed-a543-55c2ab42d6d8" />

that error is due to a break-line that is not escaped before TraceQL be sent to api.

**Why do we need this feature?**

It fixes an issue when we filter traces or spans by a TraceQL with a span attribute with multi line selected from the Span Tag filter in Search tab.

**Who is this feature for?**

All users that use Grafana Explore with Tempo datasource, from all grafana deployment types
[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/114671

Also, I've created a [docker image of the grafana version with the fix](https://hub.docker.com/layers/ricardogpsf/grafana/12.3.0-traceql-fix/images/sha256-c54605f4fa65b46f6d36ed64d248fc23f9c8f454c8cc108ccca330e7dbd860cd) for test purpose and tested it with my company data, it worked well.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
