### PR TITLE
Alerting: Fix RuleEditorCloudRules test flakiness in CI

### DIFF
--- a/public/app/features/alerting/unified/rule-editor/RuleEditorCloudRules.test.tsx
+++ b/public/app/features/alerting/unified/rule-editor/RuleEditorCloudRules.test.tsx
@@ -3,6 +3,7 @@ import { clickSelectOption } from 'test/helpers/selectOptionInTest';
 import { screen } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
+import * as pluginSettings from 'app/features/plugins/pluginSettings';
 import { AccessControlAction } from 'app/types/accessControl';
 
 import { ExpressionEditorProps } from '../components/rule-editor/ExpressionEditor';
@@ -33,6 +34,10 @@ setupPluginsExtensionsHook();
 
 describe('RuleEditor cloud', () => {
   beforeEach(() => {
+    // Mock getPluginSettings to ensure labels plugin is not detected
+    // This ensures consistent test behavior across OSS and Enterprise environments
+    jest.spyOn(pluginSettings, 'getPluginSettings').mockRejectedValue(new Error('Plugin not found'));
+
     grantUserPermissions([
       AccessControlAction.AlertingRuleRead,
       AccessControlAction.AlertingRuleUpdate,


### PR DESCRIPTION

**What is this feature?**
Mock the labels plugin as not installed to ensure consistent test behavior across OSS and Enterprise environments. The labels plugin detection was causing different API calls to be made in CI vs local, leading to snapshot mismatches.

This test is focused on cloud rule creation, not label plugin functionality, so explicitly disabling the plugin ensures the test remains stable.

**Why do we need this feature?**

fixes CI tests failing


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
