### PR TITLE
[release-12.2.3] chore(deps): update dependency node-forge to v1.3.2

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -23501,9 +23501,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
+  version: 1.3.2
+  resolution: "node-forge@npm:1.3.2"
+  checksum: 10/dcc54aaffe0cf52367214a20c0032aa9b209d9095dd14526504f1972d1900a07e96046b3684cb0c8d0cc3d48744dd18e02b7b447ab28fac615ffb850beeabf18
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/114522 to release-12.2.3 to bump node-forge to v1.3.2

Cherry-pick was discarded and `yarn up -R node-forge` ran manually