### PR TITLE
Alerting: Fix ignored filters when paginating alert rules in the API

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -676,8 +676,10 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 }
 
 func buildGroupCursorCondition(sess *xorm.Session, c ngmodels.GroupCursor) *xorm.Session {
-	return sess.Where("(namespace_uid > ?)", c.NamespaceUID).
-		Or("(namespace_uid = ? AND rule_group > ?)", c.NamespaceUID, c.RuleGroup)
+	return sess.And(
+		"((namespace_uid > ?) OR (namespace_uid = ? AND rule_group > ?))",
+		c.NamespaceUID, c.NamespaceUID, c.RuleGroup,
+	)
 }
 
 func shouldIncludeRule(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesExtendedQuery, groupsMap map[string]struct{}) bool {
@@ -979,10 +981,17 @@ func decodeCursor(token string) (continueCursor, error) {
 }
 
 func buildCursorCondition(sess *xorm.Session, c continueCursor) *xorm.Session {
-	return sess.Where("(namespace_uid > ?)", c.NamespaceUID).
-		Or("(namespace_uid = ? AND rule_group > ?)", c.NamespaceUID, c.RuleGroup).
-		Or("(namespace_uid = ? AND rule_group = ? AND rule_group_idx > ?)", c.NamespaceUID, c.RuleGroup, c.RuleGroupIdx).
-		Or("(namespace_uid = ? AND rule_group = ? AND rule_group_idx = ? AND id > ?)", c.NamespaceUID, c.RuleGroup, c.RuleGroupIdx, c.ID)
+	return sess.And(`(
+		(namespace_uid > ?)
+		OR (namespace_uid = ? AND rule_group > ?)
+		OR (namespace_uid = ? AND rule_group = ? AND rule_group_idx > ?)
+		OR (namespace_uid = ? AND rule_group = ? AND rule_group_idx = ? AND id > ?)
+	)`,
+		c.NamespaceUID,
+		c.NamespaceUID, c.RuleGroup,
+		c.NamespaceUID, c.RuleGroup, c.RuleGroupIdx,
+		c.NamespaceUID, c.RuleGroup, c.RuleGroupIdx, c.ID,
+	)
 }
 
 // Count returns either the number of the alert rules under a specific org (if orgID is not zero)


### PR DESCRIPTION
**What is this feature?**

Fix pagination in `/api/prometheus/grafana/api/v1/rules` endpoint when it's used together with filters.

**Why do we need this feature?**

When using the `/api/prometheus/grafana/api/v1/rules` API with filters (like `search.rule_name=eager`) and pagination (`group_next_token`), the first page would correctly filter results, but subsequent pages would return all rules regardless of the filter.

The issue was that `buildGroupCursorCondition` and `buildCursorCondition` used `.Where().Or()` which adds OR at the top level: `WHERE (filter1 AND filter2 AND cursor_part1) OR cursor_part2` while the intention was to build `WHERE (filter1 AND filter2 AND (cursor_part1 OR cursor_part2))`.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
