### PR TITLE
Alerting: Highlight dashboard alert button when rules are firing

### DIFF
--- a/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
+++ b/public/app/features/alerting/unified/integration/AlertRulesToolbarButton.tsx
@@ -2,6 +2,7 @@ import { useContext } from 'react';
 
 import { t } from '@grafana/i18n';
 import { ModalsContext, ToolbarButton } from '@grafana/ui';
+import { PromAlertingRuleState, PromRuleType } from 'app/types/unified-alerting-dto';
 
 import { alertRuleApi } from '../api/alertRuleApi';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
@@ -24,6 +25,14 @@ export default function AlertRulesToolbarButton({ dashboardUid }: AlertRulesTool
     return null;
   }
 
+  const hasFiringRules = namespaces.some((namespace) =>
+    namespace.groups.some((group) =>
+      group.rules.some(
+        (rule) => rule.type === PromRuleType.Alerting && rule.state === PromAlertingRuleState.Firing
+      )
+    )
+  );
+
   const onShowDrawer = () => {
     showModal(AlertRulesDrawer, {
       dashboardUid: dashboardUid,
@@ -37,6 +46,7 @@ export default function AlertRulesToolbarButton({ dashboardUid }: AlertRulesTool
       icon="bell"
       onClick={onShowDrawer}
       key="button-alerting"
+      variant={hasFiringRules ? 'destructive' : 'default'}
     />
   );
 }


### PR DESCRIPTION
**What this PR does**

The current `AlertRulesToolbarButton` in the dashboard toolbar does not visually reflect the state of the alert rules associated with the dashboard. As a result, users may overlook critical firing alerts unless they manually open the alert rules panel.

This PR enhances the `AlertRulesToolbarButton` by updating its visual state when any linked alert rules are in a **Firing** state. When firing alerts are detected, the button variant is changed to a *destructive* (red) style, providing an immediate and clear visual indication of active issues. This style changes with dashboard auto-refresh.

**Design considerations**

The implementation intentionally excludes the *Pending* state. Pending alerts can be transient, and frequently switching the button's appearance could create unnecessary visual noise, diminishing its usefulness. Additionally, since the destructive (red) variant also includes a shape change, it provides a more accessible cue for color-blind users, while distinguishing between Firing and Pending would not offer meaningful additional clarity.

**Testing**

This change was validated manually through the following steps:

- Created a dashboard with an alert rule in a Firing state and confirmed that the toolbar button updated to the destructive (red) variant as expected.
- Created a dashboard with no firing alert rules to ensure the default button style remained unaffected.
- Verified that the button style updates automatically on refresh, confirming that no manual interaction is required for the state to be reflected.
- Full test suit ran:

```text
Test Suites: 1 skipped, 1552 passed, 1552 of 1553 total
Tests:       55 skipped, 5 todo, 16070 passed, 16130 total
Snapshots:   454 passed, 454 total
Time:        511.622 s
Ran all test suites.
```

After further checking I think no tests are done for individual visual components. If so, I will add corresponding tests with no problem.

---

Example when an alert linked to any panel in the dashboard is firing:

<img width="994" height="444" alt="alerting-toolbar-highlight" src="https://github.com/user-attachments/assets/ef280afc-3f51-491b-85fe-326c660917e6" />

 
