### PR TITLE
Fix: Ensure stat panel labels render above sparkline

### DIFF
--- a/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
+++ b/packages/grafana-ui/src/components/BigValue/BigValueLayout.tsx
@@ -68,6 +68,8 @@ export abstract class BigValueLayout {
     const styles: CSSProperties = {
       fontSize: `${this.titleFontSize}px`,
       lineHeight: LINE_HEIGHT,
+      position: 'relative',
+      zIndex: 1,
     };
 
     if (
@@ -283,6 +285,7 @@ export abstract class BigValueLayout {
       position: 'absolute',
       right: 0,
       bottom: 0,
+      zIndex: 0,
     };
   }
 }


### PR DESCRIPTION
Fixes #114741

Add z-index layering to BigValue component to prevent sparkline from drawing over text elements when both are enabled.

## Changes
- Set chart/sparkline container z-index to 0 (behind)
- Set title/label z-index to 1 (in front)  
- Value and percent change already had z-index: 1

## Testing
When both sparkline and label are enabled in a stat panel, the label text now appears clearly above the sparkline visualization instead of being obscured by it.