### PR TITLE
Tooltip: Y-axis aware auto decimals in Tooltip to better show small c…

### DIFF
--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -352,6 +352,8 @@ export {
   getValueFormat,
   getValueFormatterIndex,
   getValueFormats,
+  setYAxisRangeContext,
+  clearYAxisRangeContext,
 } from './valueFormats/valueFormats';
 
 // datetime


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This feature add Y-axis aware auto decimals. Current implementation is not aware of the current scale, creating issues with rounding data too much for certain types of charts.
One could just set specific decimals value but for panels that use variables and can have different data ranges(one variable has data in values of 11000 - 10000, second one of 0.099950 - 0.099900) it's impossible to use specific decimals value. Auto decimals unfortunately can't handle certain data ranges well which is explained in issue https://github.com/grafana/grafana/issues/113576

The auto-decimals with that change work similarly to how pre-7.4.

v12.3.0 without the fix:
<img width="469" height="308" alt="Screenshot 2025-12-03 at 08 06 57" src="https://github.com/user-attachments/assets/6ae15307-a5ce-484a-bdbb-743726aa2f27" />
<img width="498" height="308" alt="Screenshot 2025-12-03 at 08 08 35" src="https://github.com/user-attachments/assets/0141fe0d-9c5e-4b50-beed-d9753b5780e3" />


v7.3.10:
<img width="461" height="348" alt="Screenshot 2025-12-03 at 08 27 31" src="https://github.com/user-attachments/assets/ecd4fbba-137c-4647-8ca3-5d919d6da588" />
<img width="480" height="345" alt="Screenshot 2025-12-03 at 08 34 38" src="https://github.com/user-attachments/assets/dd9a79ad-e9fd-4921-9e42-cccafff91d82" />


v12.3.0 after the fix:
<img width="471" height="306" alt="Screenshot 2025-12-03 at 08 11 20" src="https://github.com/user-attachments/assets/05940c4a-74d2-4aee-967a-11c5fd59680f" />
<img width="496" height="304" alt="Screenshot 2025-12-03 at 08 11 40" src="https://github.com/user-attachments/assets/b0777937-8f63-43fd-b29f-9472316ac620" />

With different values(smaller, bigger) it works similarly.

**Why do we need this feature?**

Calculating auto decimals is complex here but makes auto decimals much more useful.

**Who is this feature for?**

Anyone who is has specific data that has very small changes for big values(a good one is that 0.099950 - 0.099900 example) and want to use auto decimals, either because of wanting to avoid setting specific decimals or because using variables for changing what type of data is being shown at panel.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113576
Relates to https://github.com/grafana/grafana/pull/30519 
Relates to https://github.com/grafana/grafana/pull/30262

**Special notes for your reviewer:**
When implementing the feature the goal was to make as little changes as possible. When having Y-axis range data the new way of calculating auto-decimals is used, otherwise the current one is used.
Also, there was issue with units (K, Mil etc.) in a way that for range 10Mil - 20Mil and value of 15Mil, the range was being received as 10000000 - 20000000 and value as 15, so the calculation of the unit change is being done to determine how to handle auto decimals. I don't know if it's the best solution. It works however.

After migrating from pre-7.4 Grafana our teams use this fix to keep the dashboards work the same as before because post-7.4 auto decimals scaling was unusable for us.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
