### PR TITLE
v2 conversion error: Throw DashboardVersionError correctly to redirec to to v1 API

### DIFF
--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -13,6 +13,10 @@ export function isV2StoredVersion(version: string | undefined): boolean {
   return version === 'v2alpha1' || version === 'v2beta1';
 }
 
+export function isV0V1StoredVersion(version: string | undefined): boolean {
+  return version === 'v0alpha1' || version === 'v1alpha1' || version === 'v1beta1';
+}
+
 export function getDashboardsApiVersion(responseFormat?: 'v1' | 'v2') {
   const isDashboardSceneEnabled = config.featureToggles.dashboardScene;
   const isKubernetesDashboardsEnabled = config.featureToggles.kubernetesDashboards;

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -317,7 +317,7 @@ describe('v2 dashboard API', () => {
   });
 
   describe('version error handling', () => {
-    it('should not throw DashboardVersionError for v0alpha1 conversion error and v2 spec', async () => {
+    it('should throw DashboardVersionError for v0alpha1 conversion error and v2 spec', async () => {
       const mockDashboardWithError = {
         ...mockDashboardDto,
         status: {
@@ -332,7 +332,7 @@ describe('v2 dashboard API', () => {
       mockGet.mockResolvedValueOnce(mockDashboardWithError);
 
       const api = new K8sDashboardV2API();
-      await expect(api.getDashboardDTO('test')).resolves.toBe(mockDashboardWithError);
+      await expect(api.getDashboardDTO('test')).rejects.toThrow('backend conversion not yet implemented');
     });
 
     it('should throw DashboardVersionError for v0alpha1 conversion error and v1 spec', async () => {
@@ -358,7 +358,7 @@ describe('v2 dashboard API', () => {
       await expect(api.getDashboardDTO('test')).rejects.toThrow('backend conversion not yet implemented');
     });
 
-    it('should not throw DashboardVersionError for v1beta1 conversion error and v2 spec', async () => {
+    it('should throw DashboardVersionError for v1beta1 conversion error and v2 spec', async () => {
       const mockDashboardWithError = {
         ...mockDashboardDto,
         status: {
@@ -373,7 +373,7 @@ describe('v2 dashboard API', () => {
       mockGet.mockResolvedValueOnce(mockDashboardWithError);
 
       const api = new K8sDashboardV2API();
-      await expect(api.getDashboardDTO('test')).resolves.toBe(mockDashboardWithError);
+      await expect(api.getDashboardDTO('test')).rejects.toThrow('backend conversion not yet implemented');
     });
 
     it('should throw DashboardVersionError for v1beta1 conversion error and v1 spec', async () => {


### PR DESCRIPTION
When v1-> v2 conversion fails, we didn't redirect to fetch from v1 API.