### PR TITLE
MSSQL: Remove the need for `azure_auth_enabled`

### DIFF
--- a/docs/sources/datasources/mssql/configure/index.md
+++ b/docs/sources/datasources/mssql/configure/index.md
@@ -153,10 +153,6 @@ If you're using an older version of Microsoft SQL Server like 2008 and 2008R2, y
 
 **Authentication:**
 
-{{< admonition type="note" >}}
-In order to use Azure AD Authentication the toggle `auth.azure_auth_enabled` must be set to `true` in the Grafana configuration file.
-{{< /admonition >}}
-
 | Authentication Type                                   | Description                                                                                                                     | Credentials / Fields                                                                                                                                                                      |
 | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **SQL Server Authentication**                         | Default method to connect to MSSQL. Use a SQL Server or Windows login in `DOMAIN\User` format.                                  | - **Username**: SQL Server username<br>- **Password**: SQL Server password                                                                                                                |

--- a/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
+++ b/public/app/plugins/datasource/mssql/configuration/ConfigurationEditor.tsx
@@ -49,10 +49,8 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
 
   const styles = useStyles2(getStyles);
   const jsonData = dsSettings.jsonData;
-  const azureAuthIsSupported = config.azureAuthEnabled;
 
   const azureAuthSettings: AzureAuthConfigType = {
-    azureAuthIsSupported,
     azureAuthSettingsUI: AzureAuthSettings,
   };
 
@@ -108,14 +106,8 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
       { value: MSSQLAuthenticationType.kerberosKeytab, label: 'Windows AD: Keytab file' },
       { value: MSSQLAuthenticationType.kerberosCredentialCache, label: 'Windows AD: Credential cache' },
       { value: MSSQLAuthenticationType.kerberosCredentialCacheLookupFile, label: 'Windows AD: Credential cache file' },
+      { value: MSSQLAuthenticationType.azureAuth, label: MSSQLAuthenticationType.azureAuth },
     ];
-
-    if (azureAuthIsSupported) {
-      return [
-        ...basicAuthenticationOptions,
-        { value: MSSQLAuthenticationType.azureAuth, label: MSSQLAuthenticationType.azureAuth },
-      ];
-    }
 
     return basicAuthenticationOptions;
   };
@@ -303,14 +295,12 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
                   logged onto Windows and have enabled this option for MS SQL Server.
                 </Trans>
               </li>
-              {azureAuthIsSupported && (
-                <li>
-                  <Trans i18nKey="configuration.configuration-editor.description-auth-type-azure-auth">
-                    <i>Azure Authentication</i> Securely authenticate and access Azure resources and applications using
-                    Azure AD credentials - Managed Service Identity and Client Secret Credentials are supported.
-                  </Trans>
-                </li>
-              )}
+              <li>
+                <Trans i18nKey="configuration.configuration-editor.description-auth-type-azure-auth">
+                  <i>Azure Authentication</i> Securely authenticate and access Azure resources and applications using
+                  Azure AD credentials - Managed Service Identity and Client Secret Credentials are supported.
+                </Trans>
+              </li>
               <li>
                 <Trans i18nKey="configuration.configuration-editor.description-auth-type-username-password">
                   <i>Windows AD: Username + password</i> Windows Active Directory - Sign on for domain user via
@@ -393,7 +383,7 @@ export const ConfigurationEditor = (props: DataSourcePluginOptionsEditorProps<Ms
           </>
         )}
 
-        {azureAuthIsSupported && jsonData.authenticationType === MSSQLAuthenticationType.azureAuth && (
+        {jsonData.authenticationType === MSSQLAuthenticationType.azureAuth && (
           <FieldSet
             label={t('configuration.configuration-editor.label-auth-settings', 'Azure Authentication Settings')}
           >

--- a/public/app/plugins/datasource/mssql/types.ts
+++ b/public/app/plugins/datasource/mssql/types.ts
@@ -39,6 +39,5 @@ export interface MssqlSecureOptions {
 }
 
 export type AzureAuthConfigType = {
-  azureAuthIsSupported: boolean;
   azureAuthSettingsUI: (props: HttpSettingsBaseProps) => JSX.Element;
 };


### PR DESCRIPTION
The configuration property `azure_auth_enabled` is currently required to display Azure authentication methods in the MSSQL data source.

There is no real benefit to hiding these mechanisms, and it may be confusing to users to have to modify the Grafana config in order to use Azure auth.