### PR TITLE
Dashboards: support undo/redo when grouping panels

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -19,6 +19,7 @@ import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { getDashboardSceneFor } from '../../utils/utils';
@@ -110,7 +111,18 @@ export class RowItem
   }
 
   public switchLayout(layout: DashboardLayoutManager) {
-    this.setState({ layout });
+    const currentLayout = this.state.layout;
+
+    dashboardEditActions.edit({
+      description: t('dashboard.edit-actions.switch-layout-row', 'Switch layout'),
+      source: this,
+      perform: () => {
+        this.setState({ layout });
+      },
+      undo: () => {
+        this.setState({ layout: currentLayout });
+      },
+    });
   }
 
   public useEditPaneOptions = useEditOptions.bind(this);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -19,6 +19,7 @@ import kbn from 'app/core/utils/kbn';
 import { ShowConfirmModalEvent } from 'app/types/events';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
+import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
 import { getDashboardSceneFor } from '../../utils/utils';
@@ -108,7 +109,18 @@ export class TabItem
   }
 
   public switchLayout(layout: DashboardLayoutManager) {
-    this.setState({ layout });
+    const currentLayout = this.state.layout;
+
+    dashboardEditActions.edit({
+      description: t('dashboard.edit-actions.switch-layout-tab', 'Switch layout'),
+      source: this,
+      perform: () => {
+        this.setState({ layout });
+      },
+      undo: () => {
+        this.setState({ layout: currentLayout });
+      },
+    });
   }
 
   public useEditPaneOptions = useEditOptions.bind(this);

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4782,6 +4782,8 @@
       "remove": "Remove {{typeName}}",
       "row-title": "Change row title",
       "switch-layout": "Switch layout",
+      "switch-layout-row": "Switch layout",
+      "switch-layout-tab": "Switch layout",
       "tab-title": "Change tab title"
     },
     "edit-pane": {


### PR DESCRIPTION
**What is this feature?**

Before this PR, when the user grouped panels into rows, _then_ into tabs, then clicked on the "Undo" button, both groupings were lost. The same happened when grouping panels into tabs and then into rows.

| Before | After |
|  ---   |  ---  |
| <video src="https://github.com/user-attachments/assets/f4a03e89-4f0e-4875-8361-2297e4b5055b" /> | <video src="https://github.com/user-attachments/assets/b9189988-db49-4f18-9139-c10230f160a0" /> |

**Why do we need this feature?**

To have undo/redo on every major user action

**Who is this feature for?**

Dynamic dashboards users

**Which issue(s) does this PR fix?**:

`-`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
