### PR TITLE
`grafana-iam`: Use the K8sStorage interface

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -405,7 +405,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateResourcePermissionsAPIGroup(
 	}
 
 	// Not ideal, the alternative is to wrap both stores that dualwrite uses
-	regStoreDW, ok := dw.(*registry.Store)
+	regStoreDW, ok := dw.(storewrapper.K8sStorage)
 	if !ok {
 		return fmt.Errorf("expected RegistryStoreDualWrite, got %T", dw)
 	}


### PR DESCRIPTION
Fix to https://github.com/grafana/grafana/pull/114498, I should have used the interface not the type as the dualwrite store is not a `registry.Store`.