### PR TITLE
Dashboards: Prevent memory leak in CUE validation by reusing context only for 100 validations

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"cuelang.org/go/cue"
+	"cuelang.org/go/cue/cuecontext"
 	cuejson "cuelang.org/go/encoding/json"
 )
 
@@ -11,19 +12,38 @@ import (
 //
 // CUE is not safe for concurrent use: https://github.com/cue-lang/cue/discussions/1205#discussioncomment-1189238
 // This validator uses a mutex to protect concurrent access to the underlying CUE validation.
+//
+// To prevent memory leaks from CUE's internal caching, we store the schema source string
+// and compile it in a fresh context for each validation. This allows the context and its
+// internal caches to be garbage collected after each validation.
 type Validator struct {
-	schema cue.Value
-	mu     sync.Mutex
+	schemaSource string
+	schemaPath   cue.Path
+	mu           sync.Mutex
 }
 
-func NewValidator(schema cue.Value) *Validator {
+// NewValidatorFromSource creates a new validator from a schema source string and path.
+// This prevents memory leaks by allowing each validation to use a fresh CUE context.
+func NewValidatorFromSource(schemaSource string, schemaPath cue.Path) *Validator {
 	return &Validator{
-		schema: schema,
+		schemaSource: schemaSource,
+		schemaPath:   schemaPath,
 	}
 }
 
 func (v *Validator) Validate(data []byte) error {
 	v.mu.Lock()
 	defer v.mu.Unlock()
-	return cuejson.Validate(data, v.schema)
+
+	// Create a fresh CUE context for each validation to prevent memory leaks.
+	// CUE contexts cache intermediate computation results (disjunctions, unifications, etc.),
+	// and reusing the same context causes these caches to grow unboundedly.
+	//
+	// We compile the schema in a fresh context for each validation. While this means
+	// recompiling the schema each time, it's necessary to prevent memory leaks. The schema
+	// compilation is relatively fast compared to the validation itself, and the memory
+	// leak would be much worse without this approach.
+	cueCtx := cuecontext.New()
+	compiledSchema := cueCtx.CompileString(v.schemaSource).LookupPath(v.schemaPath)
+	return cuejson.Validate(data, compiledSchema)
 }

--- a/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
+++ b/apps/dashboard/pkg/apis/dashboard/cuevalidator/validator.go
@@ -2,48 +2,73 @@ package cuevalidator
 
 import (
 	"sync"
+	"sync/atomic"
 
 	"cuelang.org/go/cue"
 	"cuelang.org/go/cue/cuecontext"
 	cuejson "cuelang.org/go/encoding/json"
 )
 
-// Validator provides thread-safe CUE schema validation.
+const (
+	// maxValidations limits how many validations can use the same context before it's recreated.
+	// This prevents unbounded memory growth while still allowing schema reuse for performance.
+	// After this many validations, the context is discarded and a new one is created.
+	maxValidations = 100
+)
+
+// Validator provides thread-safe CUE schema validation with periodic context recreation.
 //
 // CUE is not safe for concurrent use: https://github.com/cue-lang/cue/discussions/1205#discussioncomment-1189238
 // This validator uses a mutex to protect concurrent access to the underlying CUE validation.
 //
-// To prevent memory leaks from CUE's internal caching, we store the schema source string
-// and compile it in a fresh context for each validation. This allows the context and its
-// internal caches to be garbage collected after each validation.
+// To prevent memory leaks from CUE's internal caching, we reuse a context for up to maxValidations
+// validations, then recreate it. This balances performance (schema reuse) with memory safety
+// (periodic garbage collection of cached values).
+//
+// See https://github.com/grafana/grafana/issues/114344#issuecomment-3605562491 for details
+// about the memory leak issue and this fix.
 type Validator struct {
-	schemaSource string
-	schemaPath   cue.Path
-	mu           sync.Mutex
+	schemaSource    string
+	schemaPath      cue.Path
+	mu              sync.Mutex
+	ctx             *cue.Context
+	compiledSchema  cue.Value
+	validationCount atomic.Uint64
 }
 
 // NewValidatorFromSource creates a new validator from a schema source string and path.
-// This prevents memory leaks by allowing each validation to use a fresh CUE context.
+// This prevents memory leaks by periodically recreating the CUE context after maxValidations uses.
 func NewValidatorFromSource(schemaSource string, schemaPath cue.Path) *Validator {
+	cueCtx := cuecontext.New()
+	compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(schemaPath)
 	return &Validator{
-		schemaSource: schemaSource,
-		schemaPath:   schemaPath,
+		schemaSource:   schemaSource,
+		schemaPath:     schemaPath,
+		ctx:            cueCtx,
+		compiledSchema: compiledSchema,
 	}
 }
 
 func (v *Validator) Validate(data []byte) error {
-	v.mu.Lock()
-	defer v.mu.Unlock()
+	count := v.validationCount.Add(1)
 
-	// Create a fresh CUE context for each validation to prevent memory leaks.
-	// CUE contexts cache intermediate computation results (disjunctions, unifications, etc.),
-	// and reusing the same context causes these caches to grow unboundedly.
-	//
-	// We compile the schema in a fresh context for each validation. While this means
-	// recompiling the schema each time, it's necessary to prevent memory leaks. The schema
-	// compilation is relatively fast compared to the validation itself, and the memory
-	// leak would be much worse without this approach.
-	cueCtx := cuecontext.New()
-	compiledSchema := cueCtx.CompileString(v.schemaSource).LookupPath(v.schemaPath)
-	return cuejson.Validate(data, compiledSchema)
+	// If we've reached the maximum number of validations, recreate the context
+	if count >= maxValidations {
+		v.mu.Lock()
+		// Double-check after acquiring lock (another goroutine might have already recreated)
+		if v.validationCount.Load() >= maxValidations {
+			// Recreate context to allow GC to reclaim cached values
+			v.ctx = cuecontext.New()
+			v.compiledSchema = v.ctx.CompileString(v.schemaSource).LookupPath(v.schemaPath)
+			v.validationCount.Store(0)
+		}
+		v.mu.Unlock()
+	}
+
+	// Acquire lock to safely read the compiled schema
+	v.mu.Lock()
+	schema := v.compiledSchema
+	v.mu.Unlock()
+
+	return cuejson.Validate(data, schema)
 }

--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/validation.go
@@ -82,9 +82,9 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
-		// Each validation will create a fresh CUE context, allowing the context and its
-		// internal caches to be garbage collected after validation completes.
+		// The validator uses periodic context recreation to prevent memory leaks.
+		// The context is reused for up to 100 validations, then recreated to allow
+		// garbage collection of cached values while maintaining good performance.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("lineage.schemas[0].schema.spec"),

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
@@ -83,9 +83,9 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
-		// Each validation will create a fresh CUE context, allowing the context and its
-		// internal caches to be garbage collected after validation completes.
+		// The validator uses periodic context recreation to prevent memory leaks.
+		// The context is reused for up to 100 validations, then recreated to allow
+		// garbage collection of cached values while maintaining good performance.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("lineage.schemas[0].schema.spec"),

--- a/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1beta1/validation.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
@@ -84,11 +83,13 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		cueCtx := cuecontext.New()
-		compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(
+		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
+		// Each validation will create a fresh CUE context, allowing the context and its
+		// internal caches to be garbage collected after validation completes.
+		validator = cuevalidator.NewValidatorFromSource(
+			schemaSource,
 			cue.ParsePath("lineage.schemas[0].schema.spec"),
 		)
-		validator = cuevalidator.NewValidator(compiledSchema)
 	})
 
 	return validator

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
@@ -132,9 +132,9 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
-		// Each validation will create a fresh CUE context, allowing the context and its
-		// internal caches to be garbage collected after validation completes.
+		// The validator uses periodic context recreation to prevent memory leaks.
+		// The context is reused for up to 100 validations, then recreated to allow
+		// garbage collection of cached values while maintaining good performance.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("DashboardSpec"),

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/validation.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
@@ -133,11 +132,13 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		cueCtx := cuecontext.New()
-		compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(
+		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
+		// Each validation will create a fresh CUE context, allowing the context and its
+		// internal caches to be garbage collected after validation completes.
+		validator = cuevalidator.NewValidatorFromSource(
+			schemaSource,
 			cue.ParsePath("DashboardSpec"),
 		)
-		validator = cuevalidator.NewValidator(compiledSchema)
 	})
 
 	return validator

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
@@ -132,9 +132,9 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
-		// Each validation will create a fresh CUE context, allowing the context and its
-		// internal caches to be garbage collected after validation completes.
+		// The validator uses periodic context recreation to prevent memory leaks.
+		// The context is reused for up to 100 validations, then recreated to allow
+		// garbage collection of cached values while maintaining good performance.
 		validator = cuevalidator.NewValidatorFromSource(
 			schemaSource,
 			cue.ParsePath("DashboardSpec"),

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/validation.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"cuelang.org/go/cue"
-	"cuelang.org/go/cue/cuecontext"
 	"cuelang.org/go/cue/errors"
 
 	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/cuevalidator"
@@ -133,11 +132,13 @@ var schemaSource string
 
 func getValidator() *cuevalidator.Validator {
 	getSchemaOnce.Do(func() {
-		cueCtx := cuecontext.New()
-		compiledSchema := cueCtx.CompileString(schemaSource).LookupPath(
+		// Store the schema source string instead of a compiled cue.Value to prevent memory leaks.
+		// Each validation will create a fresh CUE context, allowing the context and its
+		// internal caches to be garbage collected after validation completes.
+		validator = cuevalidator.NewValidatorFromSource(
+			schemaSource,
 			cue.ParsePath("DashboardSpec"),
 		)
-		validator = cuevalidator.NewValidator(compiledSchema)
 	})
 
 	return validator


### PR DESCRIPTION
## Description

Fixes #114344

This PR fixes a memory leak in the CUE validation code for Dashboards v2 that was causing unbounded memory growth over time, especially when using Git sync.

(pooled means 100 usages)

<img width="4164" height="2364" alt="image" src="https://github.com/user-attachments/assets/9ca16e7c-d50c-4337-8ac2-67753dbb4b0a" />


## Root Cause

The CUE validation was reusing a single `cue.Context` across all validations via `getValidator()`. CUE contexts cache intermediate computation results (disjunctions, unifications, etc.), and reusing the same context causes these caches to grow unboundedly:

- Each validation adds entries to the context's internal caches
- These caches accumulate over time
- Memory cannot be garbage collected because the context holds references
- Result: Memory grows from ~100 MB to 2,000+ MB over 50k validations

## Solution

We implement **periodic context recreation** to balance performance with memory safety:

1. Store the schema source string (not a compiled `cue.Value`)
2. Reuse a `cue.Context` for up to 100 validations
3. After 100 validations, recreate the context to allow GC of cached values
4. This prevents unbounded memory growth while maintaining good performance

## Changes

- Modified `cuevalidator.Validator` to use periodic context recreation (every 100 validations)
- Updated all dashboard API versions (v0alpha1, v1beta1, v2alpha1, v2beta1) to use the new approach
- Added thread-safe atomic counters and mutex locks for concurrent access

## Performance Impact

- **19% slower** than the leaky approach (vs 13.3x slower with fresh context each time)
- **Acceptable trade-off** to prevent memory leaks
- Memory usage stays **bounded** (~5 MB peak) instead of growing unboundedly (2,000+ MB)

## Testing

We verified the fix with comprehensive testing comparing multiple approaches:

### Memory Growth Results (50,000 iterations)

**Old Validator (Reused Context - Leaky):**
- Initial: ~100 MB
- Final: ~2,000 MB
- Growth: **~1,900 MB** (unbounded leak)

**Periodic Context Recreation (Fixed):**
- Initial: ~4 MB
- Final: ~5 MB
- Growth: **~1 MB** (stable, bounded)

**Fresh Context Each Time:**
- Initial: ~2 MB
- Final: ~3 MB
- Growth: **~1 MB** (stable, but 13.3x slower)

**Result:** Periodic recreation provides the best balance - prevents leaks while maintaining good performance (only 19% slower than leaky approach).

## Other Resource Types Analysis

We analyzed the codebase to check if other resource types are affected by similar CUE validation memory leaks:

### ✅ Dashboard Validation (Fixed)
- **Only place** using CUE validation for repeated request validation
- Fixed in this PR

### ✅ Registry Schemas (`pkg/registry/schemas`)
- Used for **one-time schema loading**, not repeated validation
- `GetCoreKinds()` creates one context but called at startup/generation
- `loadCueFileWithCommon()` creates fresh contexts each time
- **Low risk** - not used for repeated validation

### ✅ Other Resource Types
- Alerting rules, recording rules, example app, etc.
- All use `simple.Validator` with Go code validation
- **No CUE validation** - no memory leak risk

**Conclusion:** Dashboard validation is the only production code path using CUE validation repeatedly. Other uses are either one-time schema loading or don't use CUE validation at all.

## References

- Issue: #114344
- CUE Thread Safety: https://github.com/cue-lang/cue/discussions/1205#discussioncomment-1189238
- CUE Context Documentation: https://pkg.go.dev/cuelang.org/go/cue/cuecontext