### PR TITLE
Zanzana: Allow resources to derive permissions from folders by default

### DIFF
--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -12,7 +12,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"google.golang.org/protobuf/types/known/structpb"
 
-	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
@@ -149,7 +148,7 @@ func (s *Server) checkGeneric(ctx context.Context, subject, relation string, res
 		folderRelation = common.SubresourceRelation(relation)
 	)
 
-	if isFolderPermissionBasedResource(resource.GroupResource()) {
+	if folderIdent != "" && isFolderPermissionBasedResource(resource.GroupResource()) {
 		// Check if resource inherits permissions from the folder (like dashboards in a folder)
 		res, err := s.openfgaCheck(ctx, store, subject, relation, folderIdent, contextuals, resourceCtx)
 		if err != nil {
@@ -210,11 +209,10 @@ func (s *Server) openfgaCheck(ctx context.Context, store *storeInfo, subject, re
 	return res, nil
 }
 
-var folderPermissionBasedResources = map[string]bool{
-	// dashboard.grafana.app/dashboards
-	common.FormatGroupResource(dashboardV1.DashboardResourceInfo.GroupResource().Group, dashboardV1.DashboardResourceInfo.GroupResource().Resource, ""): true,
+var folderPermissionBasedResourceExceptions = map[string]bool{
+	// allow all resources to inherit permissions from the folder
 }
 
 func isFolderPermissionBasedResource(resource string) bool {
-	return folderPermissionBasedResources[resource]
+	return !folderPermissionBasedResourceExceptions[resource]
 }

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -211,9 +211,5 @@ func testCheck(t *testing.T, server *Server) {
 		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "1"))
 		require.NoError(t, err)
 		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, "foo.grafana.app", "bar", "", "4", "1"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed(), "user should not be able to view other resources in folder 4")
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Follow up on https://github.com/grafana/grafana/pull/114718. Allow resources to derive permissions from folder by default.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
