### PR TITLE
OpenTSDB: Support all query options in the backend

### DIFF
--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -241,6 +241,7 @@ func createInitialFrame(val OpenTsdbCommon, length int, refID string) *data.Fram
 	for tagKey := range val.Tags {
 		tagKeys = append(tagKeys, tagKey)
 	}
+	sort.Strings(tagKeys)
 	tagKeys = append(tagKeys, val.AggregateTags...)
 
 	frame := data.NewFrameOfFieldTypes(val.Metric, length, data.FieldTypeTime, data.FieldTypeFloat64)

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -368,7 +368,7 @@ func (s *Service) buildMetric(query backend.DataQuery) map[string]any {
 		downsampleInterval := model.DownsampleInterval
 		if downsampleInterval == "" {
 			if ms := query.Interval.Milliseconds(); ms > 0 {
-				downsampleInterval = formatDownsampleInterval(ms)
+				downsampleInterval = FormatDownsampleInterval(ms)
 			} else {
 				downsampleInterval = "1m"
 			}
@@ -448,27 +448,4 @@ func (s *Service) getDSInfo(ctx context.Context, pluginCtx backend.PluginContext
 	}
 
 	return instance, nil
-}
-
-func formatDownsampleInterval(ms int64) string {
-	seconds := ms / 1000
-	if seconds < 60 {
-		if seconds < 1 {
-			return strconv.FormatInt(ms, 10) + "ms"
-		}
-		return strconv.FormatInt(seconds, 10) + "s"
-	}
-
-	minutes := seconds / 60
-	if minutes < 60 {
-		return strconv.FormatInt(minutes, 10) + "m"
-	}
-
-	hours := minutes / 60
-	if hours < 24 {
-		return strconv.FormatInt(hours, 10) + "h"
-	}
-
-	days := hours / 24
-	return strconv.FormatInt(days, 10) + "d"
 }

--- a/pkg/tsdb/opentsdb/opentsdb_test.go
+++ b/pkg/tsdb/opentsdb/opentsdb_test.go
@@ -70,6 +70,164 @@ func TestCheckHealth(t *testing.T) {
 	}
 }
 
+func TestBuildMetric(t *testing.T) {
+	service := &Service{}
+
+	t.Run("Metric with no downsampleInterval should use query interval", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "",
+						"downsampleAggregator": "avg",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+			Interval: 30 * time.Second,
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "30s-avg", metric["downsample"], "should use query interval formatted as seconds")
+	})
+
+	t.Run("Metric with downsampleInterval converts decimal seconds to milliseconds", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "0.5s",
+						"downsampleAggregator": "avg",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "500ms-avg", metric["downsample"], "should convert 0.5s to 500ms")
+	})
+
+	t.Run("Metric with no downsampleInterval uses milliseconds for sub-second query interval", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "",
+						"downsampleAggregator": "avg",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+			Interval: 500 * time.Millisecond,
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "500ms-avg", metric["downsample"], "should use query interval formatted as milliseconds")
+	})
+
+	t.Run("Metric with no downsampleInterval uses minutes for longer intervals", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "",
+						"downsampleAggregator": "sum",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+			Interval: 5 * time.Minute,
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "5m-sum", metric["downsample"], "should use query interval formatted as minutes")
+	})
+
+	t.Run("Metric with no downsampleInterval uses hours for multi-hour intervals", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "",
+						"downsampleAggregator": "max",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+			Interval: 2 * time.Hour,
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "2h-max", metric["downsample"], "should use query interval formatted as hours")
+	})
+
+	t.Run("Metric with no downsampleInterval uses days for multi-day intervals", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": false,
+						"downsampleInterval": "",
+						"downsampleAggregator": "min",
+						"downsampleFillPolicy": "none"
+					}`,
+			),
+			Interval: 48 * time.Hour,
+		}
+
+		metric := service.buildMetric(query)
+		require.Equal(t, "2d-min", metric["downsample"], "should use query interval formatted as days")
+	})
+
+	t.Run("Build metric with explicitTags enabled", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": true,
+						"explicitTags": true,
+						"tags": {
+							"host": "server01"
+						}
+					}`,
+			),
+		}
+
+		metric := service.buildMetric(query)
+		require.True(t, metric["explicitTags"].(bool), "explicitTags should be true")
+
+		metricTags := metric["tags"].(map[string]any)
+		require.Equal(t, "server01", metricTags["host"])
+	})
+
+	t.Run("Build metric with explicitTags disabled does not include explicitTags", func(t *testing.T) {
+		query := backend.DataQuery{
+			JSON: []byte(`
+					{
+						"metric": "cpu.average.percent",
+						"aggregator": "avg",
+						"disableDownsampling": true,
+						"explicitTags": false,
+						"tags": {
+							"host": "server01"
+						}
+					}`,
+			),
+		}
+
+		metric := service.buildMetric(query)
+		require.Nil(t, metric["explicitTags"], "explicitTags should not be present when false")
+	})
+}
+
 func TestOpenTsdbExecutor(t *testing.T) {
 	service := &Service{}
 
@@ -119,6 +277,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		testFrame.Meta = &data.FrameMeta{
 			Type:        data.FrameTypeTimeSeriesMulti,
 			TypeVersion: data.FrameTypeVersion{0, 1},
+			Custom:      map[string]any{"tagKeys": []string{"app", "env"}},
 		}
 		testFrame.RefID = "A"
 		tsdbVersion := float32(4)
@@ -160,6 +319,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		testFrame.Meta = &data.FrameMeta{
 			Type:        data.FrameTypeTimeSeriesMulti,
 			TypeVersion: data.FrameTypeVersion{0, 1},
+			Custom:      map[string]any{"tagKeys": []string{"app", "env"}},
 		}
 		testFrame.RefID = "A"
 		tsdbVersion := float32(3)
@@ -232,6 +392,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		testFrame.Meta = &data.FrameMeta{
 			Type:        data.FrameTypeTimeSeriesMulti,
 			TypeVersion: data.FrameTypeVersion{0, 1},
+			Custom:      map[string]any{"tagKeys": []string{"app", "env"}},
 		}
 		testFrame.RefID = "A"
 		tsdbVersion := float32(3)
@@ -275,6 +436,7 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		testFrame.Meta = &data.FrameMeta{
 			Type:        data.FrameTypeTimeSeriesMulti,
 			TypeVersion: data.FrameTypeVersion{0, 1},
+			Custom:      map[string]any{"tagKeys": []string{"app", "env"}},
 		}
 		testFrame.RefID = myRefid
 
@@ -288,6 +450,45 @@ func TestOpenTsdbExecutor(t *testing.T) {
 		if diff := cmp.Diff(testFrame, result.Responses[myRefid].Frames[0], data.FrameTestCompareOptions()...); diff != "" {
 			t.Errorf("Result mismatch (-want +got):\n%s", diff)
 		}
+	})
+
+	t.Run("tagKeys are returned sorted alphabetically in frame metadata", func(t *testing.T) {
+		response := `
+		[
+			{
+				"metric": "cpu.usage",
+				"dps": [
+					[1405544146, 75.5]
+				],
+				"tags" : {
+					"zone": "us-east-1",
+					"host": "server01",
+					"app": "api",
+					"env": "production"
+				}
+			}
+		]`
+
+		tsdbVersion := float32(4)
+
+		resp := http.Response{Body: io.NopCloser(strings.NewReader(response))}
+		resp.StatusCode = 200
+		result, err := service.parseResponse(logger, &resp, "A", tsdbVersion)
+		require.NoError(t, err)
+
+		frame := result.Responses["A"].Frames[0]
+		require.NotNil(t, frame.Meta, "frame metadata should not be nil")
+		require.NotNil(t, frame.Meta.Custom, "frame custom metadata should not be nil")
+
+		customMeta, ok := frame.Meta.Custom.(map[string]any)
+		require.True(t, ok, "custom metadata should be a map")
+
+		tagKeys, ok := customMeta["tagKeys"].([]string)
+		require.True(t, ok, "tagKeys should be present and be a string slice")
+		require.Len(t, tagKeys, 4, "should have 4 tag keys")
+
+		expectedTagKeys := []string{"app", "env", "host", "zone"}
+		require.Equal(t, expectedTagKeys, tagKeys, "tagKeys should be sorted alphabetically")
 	})
 
 	t.Run("Build metric with downsampling enabled", func(t *testing.T) {

--- a/pkg/tsdb/opentsdb/types.go
+++ b/pkg/tsdb/opentsdb/types.go
@@ -7,8 +7,9 @@ type OpenTsdbQuery struct {
 }
 
 type OpenTsdbCommon struct {
-	Metric string            `json:"metric"`
-	Tags   map[string]string `json:"tags"`
+	Metric        string            `json:"metric"`
+	Tags          map[string]string `json:"tags"`
+	AggregateTags []string          `json:"aggregateTags"`
 }
 
 type OpenTsdbResponse struct {

--- a/pkg/tsdb/opentsdb/utils.go
+++ b/pkg/tsdb/opentsdb/utils.go
@@ -1,0 +1,31 @@
+package opentsdb
+
+import (
+	"strconv"
+	"time"
+)
+
+func FormatDownsampleInterval(ms int64) string {
+	duration := time.Duration(ms) * time.Millisecond
+
+	seconds := int64(duration / time.Second)
+	if seconds < 60 {
+		if seconds < 1 {
+			return strconv.FormatInt(ms, 10) + "ms"
+		}
+		return strconv.FormatInt(seconds, 10) + "s"
+	}
+
+	minutes := int64(duration / time.Minute)
+	if minutes < 60 {
+		return strconv.FormatInt(minutes, 10) + "m"
+	}
+
+	hours := int64(duration / time.Hour)
+	if hours < 24 {
+		return strconv.FormatInt(hours, 10) + "h"
+	}
+
+	days := int64(duration / (24 * time.Hour))
+	return strconv.FormatInt(days, 10) + "d"
+}


### PR DESCRIPTION
Run queries through the opentsdb data source backend if the `opentsdbBackendMigration` feature toggle has been enabled.

to make this possible, we needed a few small changes to the current backend query method, such as returning the `tagKeys` which we store in the frontend cache, passing the `explicitTags` query option and updating the downsample interval to match the current frontend logic.