### PR TITLE
OpenTSDB: Fix metric dropdown autocomplete

### DIFF
--- a/public/app/plugins/datasource/opentsdb/components/MetricSection.tsx
+++ b/public/app/plugins/datasource/opentsdb/components/MetricSection.tsx
@@ -31,7 +31,7 @@ export function MetricSection({ query, onChange, onRunQuery, suggestMetrics, agg
           placeholder="Metric name"
           allowCustomValue
           loadOptions={metricSearch}
-          defaultOptions={[]}
+          defaultOptions={true}
           onChange={({ value }) => {
             if (value) {
               onChange({ ...query, metric: value });


### PR DESCRIPTION
Currently in OpenTSDB we have a really annoying bug in the query builder where the metric options do no show by default. and are only fetched after you start typing. this can be an issue for visibility if you don't know what metrics you currently have.

Fixes: #108288

Before / After:
<img width="1688" height="287" alt="Screenshot 2025-12-04 at 18 44 14" src="https://github.com/user-attachments/assets/acdea0c5-bffa-4a02-b2a3-4123ce59c61f" />

<img width="1690" height="287" alt="Screenshot 2025-12-04 at 18 44 38" src="https://github.com/user-attachments/assets/847acef3-12fe-4661-9a9f-3b836ea66471" />
