### PR TITLE
Alerting: Fix writing recording rules with query offset

### DIFF
--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -849,6 +849,25 @@ func (alertRule *AlertRule) Type() RuleType {
 	return RuleTypeAlerting
 }
 
+// GetRecordingRuleEvaluationOffset returns the evaluation offset for a recording rule
+// derived from the source query's RelativeTimeRange.To.
+func (alertRule *AlertRule) GetRecordingRuleEvaluationOffset() time.Duration {
+	if alertRule.Record == nil {
+		return 0
+	}
+
+	for _, query := range alertRule.Data {
+		if query.RefID == alertRule.Record.From {
+			if isExpr, _ := query.IsExpression(); isExpr {
+				return 0
+			}
+			return time.Duration(query.RelativeTimeRange.To)
+		}
+	}
+
+	return 0
+}
+
 // Copy creates and returns a deep copy of the AlertRule instance, duplicating all fields and nested data structures.
 func (alertRule *AlertRule) Copy() *AlertRule {
 	if alertRule == nil {


### PR DESCRIPTION
**What is this feature?**

This fix ensures that Grafana-managed recording rules apply the query evaluation offset to the write timestamp when recording metrics. Previously, recording rules would query data at `scheduledAt - offset` but write metrics with timestamp `scheduledAt`, creating a mismatch. Now they write metrics with timestamp `scheduledAt - offset`, matching Prometheus behavior.

**Which issue(s) does this PR fix?**:

Fixes #110037

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
