### PR TITLE
Panel Menu: Allow using icons for link extensions

### DIFF
--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -202,6 +202,47 @@ describe('panelMenuBehavior', () => {
       );
     });
 
+    it('should show icons for link extensions (if they provide it)', async () => {
+      getPluginExtensionsMock.mockReturnValue({
+        extensions: [
+          {
+            id: '1',
+            pluginId: '...',
+            type: PluginExtensionTypes.link,
+            title: 'Declare incident when pressing this amazing menu item',
+            description: 'Declaring an incident in the app',
+            path: '/a/grafana-basic-app/declare-incident',
+            icon: 'external-link-alt',
+          },
+        ],
+      });
+
+      const { menu, panel } = await buildTestScene({});
+
+      panel.getPlugin = () => getPanelPlugin({ skipDataQuery: false });
+
+      mocks.contextSrv.hasAccessToExplore.mockReturnValue(true);
+      mocks.getExploreUrl.mockReturnValue(Promise.resolve('/explore'));
+
+      menu.activate();
+
+      await new Promise((r) => setTimeout(r, 1));
+
+      expect(menu.state.items?.length).toBe(7);
+
+      const extensionsSubMenu = menu.state.items?.find((i) => i.text === 'Extensions')?.subMenu;
+
+      expect(extensionsSubMenu).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            text: 'Declare incident when...',
+            href: '/a/grafana-basic-app/declare-incident',
+            iconClassName: 'external-link-alt',
+          }),
+        ])
+      );
+    });
+
     it('should pass onClick from plugin extension link to menu item', async () => {
       const expectedOnClick = jest.fn();
 

--- a/public/app/features/plugins/extensions/utils.tsx
+++ b/public/app/features/plugins/extensions/utils.tsx
@@ -419,6 +419,7 @@ export function createExtensionSubMenu(extensions: PluginExtensionLink[]): Panel
         text: truncateTitle(extension.title, 25),
         href: extension.path,
         onClick: extension.onClick,
+        iconClassName: extension.icon,
       });
       continue;
     }
@@ -431,6 +432,7 @@ export function createExtensionSubMenu(extensions: PluginExtensionLink[]): Panel
       text: truncateTitle(extension.title, 25),
       href: extension.path,
       onClick: extension.onClick,
+      iconClassName: extension.icon,
     });
   }
 


### PR DESCRIPTION
### What changed?

This PR makes it possible for link extensions that extend the panel menu to define icons that are rendered next to the link.

<img width="1036" height="437" alt="Screenshot 2025-12-04 at 13 30 35" src="https://github.com/user-attachments/assets/f9c39d8c-59fa-4a53-9760-65322e4914ae" />

**Example:**
```ts
// Provider (module.tsx)
.addLink({
    title: 'Link',
    description: '...',
    targets: PluginExtensionPoints.DashboardPanelMenu,
    icon: 'external-link-alt',
    path: '...'
  })
```
