### PR TITLE
docs: use clearly invalid tokens

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
@@ -162,7 +162,7 @@ The following request creates a custom role that includes permissions to access 
 
 ```
 curl --location --request POST '<grafana_url>/api/access-control/roles/' \
---header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+--header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "version": 1,
@@ -208,13 +208,13 @@ By default, only a Grafana Server Admin can create and manage custom roles. If y
 
   ```bash
   # Fetch the role, modify it to add the desired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
     -X GET '<grafana_url>/api/access-control/roles/basic_editor' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq '.permissions += [{"action": "roles:read", "scope": "roles:*"}, {"action": "roles:write", "scope": "permissions:type:delegate"}, {"action": "roles:delete", "scope": "permissions:type:delegate"}]' > /tmp/basic_editor.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_editor.json '<grafana_url>/api/access-control/roles/basic_editor'
   ```
 
@@ -253,13 +253,13 @@ If you want your `Viewers` to create reports, [update the `Viewer` basic role pe
 
   ```bash
   # Fetch the role, modify it to add the desired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq '.permissions += [{"action": "reports:create"}, {"action": "reports:read", "scope": "reports:*"}, {"action": "reports:write", "scope": "reports:*"}, {"action": "reports:send", "scope": "reports:*"}]' > /tmp/basic_viewer.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 
@@ -299,13 +299,13 @@ There are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove the undesired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
     -X GET '<grafana_url>/api/access-control/roles/basic_grafana_admin' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "users:create")) | del(.permissions[] | select (.action == "org.users:add" and .scope == "users:*"))' > /tmp/basic_grafana_admin.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_grafana_admin.json '<grafana_url>/api/access-control/roles/basic_grafana_admin'
   ```
 
@@ -361,14 +361,14 @@ Here are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove the undesired permissions, add the new permission and increment its version
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "plugins.app:access" and .scope == "plugins:*"))' | \
     jq '.permissions += [{"action": "plugins.app:access", "scope": "plugins:id:kentik-connect-app"}]' > /tmp/basic_viewer.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' -H 'Content-Type: application/json' \
     -X PUT -d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 
@@ -400,13 +400,13 @@ Here are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove permissions to kentik-connect-app and increment role version
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "plugins.app:access" and .scope == "plugins:id:kentik-connect-app"))'
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697' -H 'Content-Type: application/json' \
     -X PUT -d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 

--- a/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plan-rbac-rollout-strategy/index.md
@@ -162,7 +162,7 @@ The following request creates a custom role that includes permissions to access 
 
 ```
 curl --location --request POST '<grafana_url>/api/access-control/roles/' \
---header 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+--header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
 --header 'Content-Type: application/json' \
 --data-raw '{
     "version": 1,
@@ -208,13 +208,13 @@ By default, only a Grafana Server Admin can create and manage custom roles. If y
 
   ```bash
   # Fetch the role, modify it to add the desired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
     -X GET '<grafana_url>/api/access-control/roles/basic_editor' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq '.permissions += [{"action": "roles:read", "scope": "roles:*"}, {"action": "roles:write", "scope": "permissions:type:delegate"}, {"action": "roles:delete", "scope": "permissions:type:delegate"}]' > /tmp/basic_editor.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_editor.json '<grafana_url>/api/access-control/roles/basic_editor'
   ```
 
@@ -253,13 +253,13 @@ If you want your `Viewers` to create reports, [update the `Viewer` basic role pe
 
   ```bash
   # Fetch the role, modify it to add the desired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq '.permissions += [{"action": "reports:create"}, {"action": "reports:read", "scope": "reports:*"}, {"action": "reports:write", "scope": "reports:*"}, {"action": "reports:send", "scope": "reports:*"}]' > /tmp/basic_viewer.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 
@@ -299,13 +299,13 @@ There are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove the undesired permissions and increment its version
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
     -X GET '<grafana_url>/api/access-control/roles/basic_grafana_admin' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "users:create")) | del(.permissions[] | select (.action == "org.users:add" and .scope == "users:*"))' > /tmp/basic_grafana_admin.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
     -X PUT-d @/tmp/basic_grafana_admin.json '<grafana_url>/api/access-control/roles/basic_grafana_admin'
   ```
 
@@ -361,14 +361,14 @@ Here are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove the undesired permissions, add the new permission and increment its version
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "plugins.app:access" and .scope == "plugins:*"))' | \
     jq '.permissions += [{"action": "plugins.app:access", "scope": "plugins:id:kentik-connect-app"}]' > /tmp/basic_viewer.json
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
     -X PUT -d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 
@@ -400,13 +400,13 @@ Here are two ways to achieve this:
 
   ```bash
   # Fetch the role, modify it to remove permissions to kentik-connect-app and increment role version
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' \
     -X GET '<grafana_url>/api/access-control/roles/basic_viewer' | \
     jq 'del(.created)| del(.updated) | del(.permissions[].created) | del(.permissions[].updated) | .version += 1' | \
     jq 'del(.permissions[] | select (.action == "plugins.app:access" and .scope == "plugins:id:kentik-connect-app"))'
 
   # Update the role
-  curl -H 'Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt' -H 'Content-Type: application/json' \
+  curl -H 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal' -H 'Content-Type: application/json' \
     -X PUT -d @/tmp/basic_viewer.json '<grafana_url>/api/access-control/roles/basic_viewer'
   ```
 

--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -243,7 +243,7 @@ Authorize your request with the token whose permissions you want to check.
 {{< /admonition >}}
 
 ```bash
-curl -H "Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7FDsNSLAa_54e2f8be" -X GET '<grafana_url>/api/access-control/user/permissions' | jq
+curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal" -X GET '<grafana_url>/api/access-control/user/permissions' | jq
 ```
 
 The output lists the token's permissions:
@@ -268,7 +268,7 @@ To list which dashboards a token can view, you can filter the `/api/access-contr
 #### Example
 
 ```bash
-curl -H "Authorization: Bearer glsa_HOruNAb7SOiCdshU9algkrq7FDsNSLAa_54e2f8be" -X GET '<grafana_url>/api/access-control/user/permissions' | jq '."dashboards:read"'
+curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal" -X GET '<grafana_url>/api/access-control/user/permissions' | jq '."dashboards:read"'
 ```
 
 The output lists the dashboards a token can view and the folders a token can view dashboards from,

--- a/docs/sources/administration/service-accounts/_index.md
+++ b/docs/sources/administration/service-accounts/_index.md
@@ -243,7 +243,7 @@ Authorize your request with the token whose permissions you want to check.
 {{< /admonition >}}
 
 ```bash
-curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal" -X GET '<grafana_url>/api/access-control/user/permissions' | jq
+curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697" -X GET '<grafana_url>/api/access-control/user/permissions' | jq
 ```
 
 The output lists the token's permissions:
@@ -268,7 +268,7 @@ To list which dashboards a token can view, you can filter the `/api/access-contr
 #### Example
 
 ```bash
-curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal" -X GET '<grafana_url>/api/access-control/user/permissions' | jq '."dashboards:read"'
+curl -H "Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697" -X GET '<grafana_url>/api/access-control/user/permissions' | jq '."dashboards:read"'
 ```
 
 The output lists the dashboards a token can view and the folders a token can view dashboards from,

--- a/docs/sources/administration/service-accounts/migrate-api-keys.md
+++ b/docs/sources/administration/service-accounts/migrate-api-keys.md
@@ -136,10 +136,10 @@ curl -X POST -H "Content-Type: application/json" -d '{"name": "my-service-accoun
 curl -X POST -H "Content-Type: application/json" -d '{"name": "my-service-account-token"}' http://admin:admin@localhost:3000/api/serviceaccounts/1/tokens
 
 # response with the created SAT id,name and key.
-{"id":2,"name":"my-service-account-token","key":"glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"}%
+{"id":2,"name":"my-service-account-token","key":"glsa_iNValIdinValiDinvalidinvalidinva_5b582697"}%
 
 # now you can authenticate the same way as you did with the API key
-curl --request GET --url http://localhost:3000/api/folders --header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal'
+curl --request GET --url http://localhost:3000/api/folders --header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697'
 
 # response
 [{"id":1,"uid":"a5261a84-eebc-4733-83a9-61f4713561d1","title":"gdev dashboards"}]%

--- a/docs/sources/administration/service-accounts/migrate-api-keys.md
+++ b/docs/sources/administration/service-accounts/migrate-api-keys.md
@@ -136,10 +136,10 @@ curl -X POST -H "Content-Type: application/json" -d '{"name": "my-service-accoun
 curl -X POST -H "Content-Type: application/json" -d '{"name": "my-service-account-token"}' http://admin:admin@localhost:3000/api/serviceaccounts/1/tokens
 
 # response with the created SAT id,name and key.
-{"id":2,"name":"my-service-account-token","key":"glsa_9244xlVFZK0j8Lh4fU8Cz6Z5tO664zIi_7a762939"}%
+{"id":2,"name":"my-service-account-token","key":"glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"}%
 
 # now you can authenticate the same way as you did with the API key
-curl --request GET --url http://localhost:3000/api/folders --header 'Authorization: Bearer glsa_9244xlVFZK0j8Lh4fU8Cz6Z5tO664zIi_7a762939'
+curl --request GET --url http://localhost:3000/api/folders --header 'Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal'
 
 # response
 [{"id":1,"uid":"a5261a84-eebc-4733-83a9-61f4713561d1","title":"gdev dashboards"}]%

--- a/docs/sources/developer-resources/api-reference/http-api/team.md
+++ b/docs/sources/developer-resources/api-reference/http-api/team.md
@@ -53,7 +53,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/search?perpage=10&page=1&query=mytestteam HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -119,7 +119,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -165,7 +165,7 @@ See note in the [introduction](#team-api) for an explanation.
 POST /api/teams HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 
 {
   "name": "MyTestTeam",
@@ -209,7 +209,7 @@ See note in the [introduction](#team-api) for an explanation.
 PUT /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 
 {
   "name": "MyTestTeam",
@@ -252,7 +252,7 @@ See note in the [introduction](#team-api) for an explanation.
 DELETE /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -289,7 +289,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -342,7 +342,7 @@ See note in the [introduction](#team-api) for an explanation.
 POST /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 
 {
   "userId": 2
@@ -384,7 +384,7 @@ See note in the [introduction](#team-api) for an explanation.
 DELETE /api/teams/2/members/3 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -424,7 +424,7 @@ See note in the [introduction](#team-api) for an explanation.
 PUT /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 
 {
   "members": ["user1@email.com", "user2@email.com"]

--- a/docs/sources/developer-resources/api-reference/http-api/team.md
+++ b/docs/sources/developer-resources/api-reference/http-api/team.md
@@ -53,7 +53,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/search?perpage=10&page=1&query=mytestteam HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -119,7 +119,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/1 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -165,7 +165,7 @@ See note in the [introduction](#team-api) for an explanation.
 POST /api/teams HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 
 {
   "name": "MyTestTeam",
@@ -209,7 +209,7 @@ See note in the [introduction](#team-api) for an explanation.
 PUT /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 
 {
   "name": "MyTestTeam",
@@ -252,7 +252,7 @@ See note in the [introduction](#team-api) for an explanation.
 DELETE /api/teams/2 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -289,7 +289,7 @@ See note in the [introduction](#team-api) for an explanation.
 GET /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -342,7 +342,7 @@ See note in the [introduction](#team-api) for an explanation.
 POST /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 
 {
   "userId": 2
@@ -384,7 +384,7 @@ See note in the [introduction](#team-api) for an explanation.
 DELETE /api/teams/2/members/3 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -424,7 +424,7 @@ See note in the [introduction](#team-api) for an explanation.
 PUT /api/teams/1/members HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 
 {
   "members": ["user1@email.com", "user2@email.com"]

--- a/docs/sources/developer-resources/api-reference/http-api/team_sync.md
+++ b/docs/sources/developer-resources/api-reference/http-api/team_sync.md
@@ -47,7 +47,7 @@ See note in the [introduction](#external-group-synchronization-api) for an expla
 GET /api/teams/1/groups HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -131,7 +131,7 @@ See note in the [introduction](#external-group-synchronization-api) for an expla
 DELETE /api/teams/1/groups?groupId=cn%3Deditors%2Cou%3Dgroups%2Cdc%3Dgrafana%2Cdc%3Dorg HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:
@@ -168,7 +168,7 @@ Search for team groups with pagination support.
 GET /api/teams/1/groups/search?name=editors&query=group&page=1&perpage=10 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_kcVxDhZtu5ISOZIEt
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 ```
 
 **Example Response**:

--- a/docs/sources/developer-resources/api-reference/http-api/team_sync.md
+++ b/docs/sources/developer-resources/api-reference/http-api/team_sync.md
@@ -47,7 +47,7 @@ See note in the [introduction](#external-group-synchronization-api) for an expla
 GET /api/teams/1/groups HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -131,7 +131,7 @@ See note in the [introduction](#external-group-synchronization-api) for an expla
 DELETE /api/teams/1/groups?groupId=cn%3Deditors%2Cou%3Dgroups%2Cdc%3Dgrafana%2Cdc%3Dorg HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:
@@ -168,7 +168,7 @@ Search for team groups with pagination support.
 GET /api/teams/1/groups/search?name=editors&query=group&page=1&perpage=10 HTTP/1.1
 Accept: application/json
 Content-Type: application/json
-Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+Authorization: Bearer glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 ```
 
 **Example Response**:

--- a/pkg/api/dtos/apikey.go
+++ b/pkg/api/dtos/apikey.go
@@ -5,6 +5,6 @@ type NewApiKeyResult struct {
 	ID int64 `json:"id"`
 	// example: grafana
 	Name string `json:"name"`
-	// example: glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
+	// example: glsa_iNValIdinValiDinvalidinvalidinva_5b582697
 	Key string `json:"key"`
 }

--- a/pkg/api/dtos/apikey.go
+++ b/pkg/api/dtos/apikey.go
@@ -5,6 +5,6 @@ type NewApiKeyResult struct {
 	ID int64 `json:"id"`
 	// example: grafana
 	Name string `json:"name"`
-	// example: glsa_yscW25imSKJIuav8zF37RZmnbiDvB05G_fcaaf58a
+	// example: glsa_iNValIdinValiDinvalidinvalidinva_lidinVal
 	Key string `json:"key"`
 }

--- a/pkg/components/satokengen/tokengen_test.go
+++ b/pkg/components/satokengen/tokengen_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestApiKeyValidation(t *testing.T) {
 	result := KeyGenResult{
-		ClientSecret: "glsa_yscW25imSKJIuav8zF37RZmnbiDvB05G_fcaaf58a",
+		ClientSecret: "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal",
 		HashedKey:    "26cd2524985150529dc5f32109f544860512b999766e11bc8f3d5711bf0ba6e7020099f9f21538b5df94d577782f7431dd27",
 	}
 

--- a/pkg/components/satokengen/tokengen_test.go
+++ b/pkg/components/satokengen/tokengen_test.go
@@ -9,15 +9,15 @@ import (
 
 func TestApiKeyValidation(t *testing.T) {
 	result := KeyGenResult{
-		ClientSecret: "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal",
-		HashedKey:    "26cd2524985150529dc5f32109f544860512b999766e11bc8f3d5711bf0ba6e7020099f9f21538b5df94d577782f7431dd27",
+		ClientSecret: "glsa_iNValIdinValiDinvalidinvalidinva_5b582697",
+		HashedKey:    "c59a6e547944ef768df51d1fc8b2a9810bc777a0bd2e5daa9ef8590f300c884e0ab9470c22c6f789414fdb6485b531166ded",
 	}
 
 	keyInfo, err := Decode(result.ClientSecret)
 	require.NoError(t, err)
 	require.Equal(t, "sa", keyInfo.ServiceID)
-	require.Equal(t, "yscW25imSKJIuav8zF37RZmnbiDvB05G", keyInfo.Secret)
-	require.Equal(t, "fcaaf58a", keyInfo.Checksum)
+	require.Equal(t, "iNValIdinValiDinvalidinvalidinva", keyInfo.Secret)
+	require.Equal(t, "5b582697", keyInfo.Checksum)
 
 	hash, err := keyInfo.Hash()
 	require.NoError(t, err)

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -5905,7 +5905,7 @@
         },
         "key": {
           "type": "string",
-          "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"
+          "example": "glsa_iNValIdinValiDinvalidinvalidinva_5b582697"
         },
         "name": {
           "type": "string",

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -5905,7 +5905,7 @@
         },
         "key": {
           "type": "string",
-          "example": "glsa_yscW25imSKJIuav8zF37RZmnbiDvB05G_fcaaf58a"
+          "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"
         },
         "name": {
           "type": "string",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18080,7 +18080,7 @@
         },
         "key": {
           "type": "string",
-          "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"
+          "example": "glsa_iNValIdinValiDinvalidinvalidinva_5b582697"
         },
         "name": {
           "type": "string",

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -18080,7 +18080,7 @@
         },
         "key": {
           "type": "string",
-          "example": "glsa_yscW25imSKJIuav8zF37RZmnbiDvB05G_fcaaf58a"
+          "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal"
         },
         "name": {
           "type": "string",

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7612,7 +7612,7 @@
             "type": "integer"
           },
           "key": {
-            "example": "glsa_yscW25imSKJIuav8zF37RZmnbiDvB05G_fcaaf58a",
+            "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal",
             "type": "string"
           },
           "name": {

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -7612,7 +7612,7 @@
             "type": "integer"
           },
           "key": {
-            "example": "glsa_iNValIdinValiDinvalidinvalidinva_lidinVal",
+            "example": "glsa_iNValIdinValiDinvalidinvalidinva_5b582697",
             "type": "string"
           },
           "name": {


### PR DESCRIPTION
We keep chasing our own tails when forks of this repository happen and we start worrying about the tokens being valid. This changes the tokens to values that are clearly invalid, and intended only for documentation and testing purposes.