### PR TITLE
`grafana-iam`: use apiserver errors

### DIFF
--- a/pkg/registry/apis/iam/authorizer/resource_permissions.go
+++ b/pkg/registry/apis/iam/authorizer/resource_permissions.go
@@ -53,7 +53,10 @@ func (r *ResourcePermissionsAuthorizer) AfterGet(ctx context.Context, obj runtim
 			return err
 		}
 		if !res.Allowed {
-			return storewrapper.ErrUnauthorized
+			return fmt.Errorf(
+				"user cannot set permissions on resource %s/%s/%s: %w",
+				target.ApiGroup, target.Resource, target.Name, storewrapper.ErrUnauthorized,
+			)
 		}
 		return nil
 	default:
@@ -85,7 +88,10 @@ func (r *ResourcePermissionsAuthorizer) beforeWrite(ctx context.Context, obj run
 			return err
 		}
 		if !res.Allowed {
-			return storewrapper.ErrUnauthorized
+			return fmt.Errorf(
+				"user cannot set permissions on resource %s/%s/%s: %w",
+				target.ApiGroup, target.Resource, target.Name, storewrapper.ErrUnauthorized,
+			)
 		}
 		return nil
 	default:

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -4,18 +4,20 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apiserver/rest"
 )
 
 var (
-	ErrUnauthenticated = fmt.Errorf("unauthenticated")
-	ErrUnauthorized    = fmt.Errorf("unauthorized")
-	ErrUnexpectedType  = fmt.Errorf("unexpected object type")
+	ErrUnauthenticated = errors.NewUnauthorized("unauthenticated")
+	ErrUnauthorized    = errors.NewUnauthorized("unauthorized")
+	ErrUnexpectedType  = errors.NewBadRequest("unexpected object type")
 )
 
 // ResourceStorageAuthorizer defines authorization hooks for resource storage operations.


### PR DESCRIPTION
This pull request improves error handling in the authorization logic by providing more descriptive error messages and aligning error types with Kubernetes API conventions.