### PR TITLE
`grafana-iam`: Fix missing UID

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/models.go
+++ b/pkg/registry/apis/iam/resourcepermission/models.go
@@ -17,6 +17,7 @@ import (
 	"github.com/grafana/grafana/pkg/registry/apis/iam/common"
 	idStore "github.com/grafana/grafana/pkg/registry/apis/iam/legacy"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 )
 
 var (
@@ -120,6 +121,7 @@ func newV0ResourcePermission(grn *groupResourceName, specs []v0alpha1.ResourcePe
 		},
 	}
 	r.SetUpdateTimestamp(updated.UTC())
+	r.UID = gapiutil.CalculateClusterWideUID(&r)
 	return r
 }
 


### PR DESCRIPTION
Dual Writing to the UniStore seems to fail because we are missing a UID.
This PR attempts to fix the issue.

Error:
```
level=error msg="object is missing UID" key="namespace:\"stacks-XXYY\" group:\"iam.grafana.app\" resource:\"resourcepermissions\" name:\"folder.grafana.app-folders-RRSSTT\""
```