### PR TITLE
fix(unified): key_path column default

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -186,7 +186,7 @@ func initResourceTables(mg *migrator.Migrator) string {
 	}))
 
 	mg.AddMigration("Add key_path column to resource_history", migrator.NewAddColumnMigration(resource_history_table, &migrator.Column{
-		Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, Default: "", IsLatin: true,
+		Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, Default: "''", IsLatin: true,
 	}))
 
 	resource_events_table := migrator.Table{


### PR DESCRIPTION
```
logger=resource-migrator t=2025-12-04T18:01:11.1384+01:00 level=error msg="Exec failed" error="Cannot add a NOT NULL column with default value NULL" sql="alter table `resource_history` ADD COLUMN `key_path` TEXT NOT NULL "
```