### PR TITLE
TableRT: fix bug preventing users from selecting filter operators

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterList.tsx
@@ -23,6 +23,7 @@ interface Props {
   setSearchFilter: (value: string) => void;
   operator: SelectableValue<string>;
   setOperator: (item: SelectableValue<string>) => void;
+  referenceElement: HTMLElement;
 }
 
 const ITEM_HEIGHT = 28;
@@ -81,6 +82,7 @@ export const FilterList = ({
   setSearchFilter,
   operator,
   setOperator,
+  referenceElement,
 }: Props) => {
   const regex = useMemo(() => new RegExp(searchFilter, caseSensitive ? undefined : 'i'), [searchFilter, caseSensitive]);
   const items = useMemo(
@@ -186,6 +188,7 @@ export const FilterList = ({
       {showOperators && (
         <Stack direction="row" gap={0}>
           <ButtonSelect
+            root={referenceElement}
             variant="canvas"
             options={OPERATORS}
             onChange={setOperator}

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import * as React from 'react';
 
 import { Field, GrafanaTheme2, SelectableValue } from '@grafana/data';
@@ -42,8 +42,12 @@ export const FilterPopup = ({
   const filteredOptions = useMemo(() => getFilteredOptions(options, filterValue), [options, filterValue]);
   const [values, setValues] = useState<SelectableValue[]>(filteredOptions);
   const [matchCase, setMatchCase] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
-  const onCancel = useCallback((event?: React.MouseEvent) => onClose(), [onClose]);
+  const onCancel = useCallback(() => {
+    console.log('onCancel');
+    onClose();
+  }, [onClose]);
 
   const onFilter = useCallback(
     (event: React.MouseEvent) => {
@@ -70,7 +74,7 @@ export const FilterPopup = ({
     <ClickOutsideWrapper onClick={onCancel} useCapture={true}>
       {/* This is just blocking click events from bubbeling and should not have a keyboard interaction. */}
       {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-      <div className={cx(styles.filterContainer)} onClick={stopPropagation}>
+      <div ref={ref} className={cx(styles.filterContainer)} onClick={stopPropagation}>
         <Stack direction="column" gap={3}>
           <Stack direction="column" gap={0.5}>
             <Stack justifyContent="space-between" alignItems="center">
@@ -87,17 +91,20 @@ export const FilterPopup = ({
               />
             </Stack>
             <div className={cx(styles.listDivider)} />
-            <FilterList
-              onChange={setValues}
-              values={values}
-              options={options}
-              caseSensitive={matchCase}
-              showOperators={true}
-              searchFilter={searchFilter}
-              setSearchFilter={setSearchFilter}
-              operator={operator}
-              setOperator={setOperator}
-            />
+            {ref.current && (
+              <FilterList
+                referenceElement={ref.current}
+                onChange={setValues}
+                values={values}
+                options={options}
+                caseSensitive={matchCase}
+                showOperators={true}
+                searchFilter={searchFilter}
+                setSearchFilter={setSearchFilter}
+                operator={operator}
+                setOperator={setOperator}
+              />
+            )}
           </Stack>
           <Stack gap={3}>
             <Stack>
@@ -147,5 +154,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 const stopPropagation = (event: React.MouseEvent) => {
+  console.log('stop prop', event);
   event.stopPropagation();
 };

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
@@ -151,6 +151,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
 });
 
 const stopPropagation = (event: React.MouseEvent) => {
-  console.log('stop prop', event);
   event.stopPropagation();
 };

--- a/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
+++ b/packages/grafana-ui/src/components/Table/TableRT/FilterPopup.tsx
@@ -44,10 +44,7 @@ export const FilterPopup = ({
   const [matchCase, setMatchCase] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
-  const onCancel = useCallback(() => {
-    console.log('onCancel');
-    onClose();
-  }, [onClose]);
+  const onCancel = useCallback(() => onClose(), [onClose]);
 
   const onFilter = useCallback(
     (event: React.MouseEvent) => {


### PR DESCRIPTION
**What is this fix?**
Fixing bug in tableRT which prevents users from selecting filter operators besides default "contains":
<img width="379" height="405" alt="image" src="https://github.com/user-attachments/assets/6b74ec40-9932-483a-ac27-1fb991c192a0" />

Before this fix is applied, selecting any operator in that dropdown causes the filter component to close.

https://github.com/user-attachments/assets/cc85f5eb-06ae-462b-a4d6-2c3543e8899e

After the fix is applied:

https://github.com/user-attachments/assets/c3f90e2d-db28-47a6-8fd9-fc33a9550fa8

**Special notes for your reviewer:**
Can be reproduced on play in explore: https://play.grafana.org/goto/df63mathk01kwe?orgId=1

This bug happens because the `stopPropagation` method in the div within the `ClickOutsideWrapper` can't work for portaled elements that are not contained by that div.

The fix was to pass a reference of that div to the `ButtonSelect` component so elements are portaled within the referenced div instead of at the root.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
