### PR TITLE
Pass the feature flag instead of false to RegisterAPIService

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -85,7 +85,8 @@ func RegisterAPIService(
 			accessControl,
 			//nolint:staticcheck // not yet migrated to OpenFeature
 			features.IsEnabledGlobally(featuremgmt.FlagDatasourceQueryTypes),
-			false,
+			//nolint:staticcheck // not yet migrated to OpenFeature
+			features.IsEnabledGlobally(featuremgmt.FlagQueryServiceWithConnections),
 		)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Doh. The feature flag was not actually being used to enable the new DS config CRUD APIs. This PR fixes that, hashtag facepalm.

https://github.com/grafana/grafana-enterprise/issues/8977
