### PR TITLE
Dashboard: Fix dropping panels in tabs and rows

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -13,6 +13,7 @@ import { isRepeatCloneOrChildOf } from '../../utils/clone';
 import { useDashboardState, useInterpolatedTitle } from '../../utils/utils';
 import { DashboardScene } from '../DashboardScene';
 import { useSoloPanelContext } from '../SoloPanelContext';
+import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 
 import { RowItem } from './RowItem';
 
@@ -83,7 +84,7 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
             dragProvided.innerRef(ref);
             model.containerRef.current = ref;
           }}
-          data-dashboard-drop-target-key={model.state.key}
+          data-dashboard-drop-target-key={isDashboardLayoutGrid(layout) ? model.state.key : undefined}
           className={cx(
             styles.wrapper,
             !isCollapsed && styles.wrapperNotCollapsed,

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -11,6 +11,7 @@ import { useIsConditionallyHidden } from '../../conditional-rendering/hooks/useI
 import { isRepeatCloneOrChildOf } from '../../utils/clone';
 import { useDashboardState } from '../../utils/utils';
 import { useSoloPanelContext } from '../SoloPanelContext';
+import { isDashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 
 import { TabItem } from './TabItem';
 
@@ -91,7 +92,7 @@ export function TabItemRenderer({ model }: SceneComponentProps<TabItem>) {
               onSelect?.(evt);
             }}
             label={titleInterpolated}
-            data-dashboard-drop-target-key={model.state.key}
+            data-dashboard-drop-target-key={isDashboardLayoutGrid(layout) ? model.state.key : undefined}
             {...titleCollisionProps}
           />
         </div>


### PR DESCRIPTION
**What is this feature?**

Don't consider tabs and rows dropping structures if their layout are containers.

**Why do we need this feature?**

Fix bug with disappearing panels.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

-
**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
