### PR TITLE
Troubleshooting why deletion of old resource import times doesn't work 

### DIFF
--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -983,7 +983,7 @@ func (b *backend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[reso
 		now := time.Now()
 		threshold := now.Add(-b.lastImportTimeMaxAge)
 
-		b.log.Debug("Deleting old last import times", "threshold", threshold)
+		b.log.Debug("Deleting last import times older or equal than threshold", "threshold", threshold, "maxAge", b.lastImportTimeMaxAge)
 
 		res, err := dbutil.Exec(ctx, b.db, sqlResourceLastImportTimeDelete, &sqlResourceLastImportTimeDeleteRequest{
 			SQLTemplate: sqltemplate.New(b.dialect),

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -86,7 +86,7 @@ func NewBackend(opts BackendOptions) (Backend, error) {
 		opts.WatchBufferSize = defaultWatchBufferSize
 	}
 	l := logging.DefaultLogger.With("logger", "sql-resource-server")
-	l.Debug("initializing unifie storge sql backend", "lastImportTimeMaxAge", opts.LastImportTimeMaxAge)
+	l.Debug("initializing unified storage sql backend", "lastImportTimeMaxAge", opts.LastImportTimeMaxAge)
 	return &backend{
 		isHA:                    opts.IsHA,
 		done:                    ctx.Done(),


### PR DESCRIPTION
Log lastImportTimeMaxAge when initializing backend, and when deleting old import entries.