### PR TITLE
Zanzana: Fix duplicated writes in one request

### DIFF
--- a/pkg/services/authz/zanzana/server/server_mutate_folder.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_folder.go
@@ -52,24 +52,7 @@ func (s *Server) mutateFolders(ctx context.Context, store *storeInfo, operations
 		return nil
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write folder tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_org_role.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_org_role.go
@@ -50,24 +50,7 @@ func (s *Server) mutateOrgRoles(ctx context.Context, store *storeInfo, operation
 		return nil
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write user org role tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_resourcepermissions.go
@@ -47,24 +47,7 @@ func (s *Server) mutateResourcePermissions(ctx context.Context, store *storeInfo
 		}
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write resource permission tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_rolebindings.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_rolebindings.go
@@ -44,24 +44,7 @@ func (s *Server) mutateRoleBindings(ctx context.Context, store *storeInfo, opera
 		}
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write resource role binding tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_roles.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_roles.go
@@ -41,24 +41,7 @@ func (s *Server) mutateRoles(ctx context.Context, store *storeInfo, operations [
 		}
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write resource role binding tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_teambindings.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_teambindings.go
@@ -43,24 +43,7 @@ func (s *Server) mutateTeamBindings(ctx context.Context, store *storeInfo, opera
 		}
 	}
 
-	writeReq := &openfgav1.WriteRequest{
-		StoreId:              store.ID,
-		AuthorizationModelId: store.ModelID,
-	}
-	if len(writeTuples) > 0 {
-		writeReq.Writes = &openfgav1.WriteRequestWrites{
-			TupleKeys:   writeTuples,
-			OnDuplicate: "ignore",
-		}
-	}
-	if len(deleteTuples) > 0 {
-		writeReq.Deletes = &openfgav1.WriteRequestDeletes{
-			TupleKeys: deleteTuples,
-			OnMissing: "ignore",
-		}
-	}
-
-	_, err := s.openfga.Write(ctx, writeReq)
+	err := s.writeTuples(ctx, store, writeTuples, deleteTuples)
 	if err != nil {
 		s.logger.Error("failed to write resource role binding tuples", "error", err)
 		return err

--- a/pkg/services/authz/zanzana/server/server_mutate_test.go
+++ b/pkg/services/authz/zanzana/server/server_mutate_test.go
@@ -5,6 +5,7 @@ import (
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	v1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
@@ -131,5 +132,68 @@ func testMutate(t *testing.T, srv *Server) {
 		})
 		require.NoError(t, err)
 		require.Len(t, res.Tuples, 0)
+	})
+}
+
+func TestDeduplicateTupleKeys(t *testing.T) {
+	t.Run("should deduplicate write tuples", func(t *testing.T) {
+		writeTuples := []*openfgav1.TupleKey{
+			{User: "user:1", Relation: "get", Object: "object:1"},
+			{User: "user:1", Relation: "get", Object: "object:2"},
+		}
+		deleteTuples := []*openfgav1.TupleKeyWithoutCondition{
+			{User: "user:1", Relation: "get", Object: "object:1"},
+			{User: "user:2", Relation: "get", Object: "object:2"},
+		}
+
+		deduplicatedWriteTuples, deduplicatedDeleteTuples := deduplicateTupleKeys(writeTuples, deleteTuples)
+		require.Len(t, deduplicatedWriteTuples, 2)
+		require.ElementsMatch(t, deduplicatedWriteTuples, []*openfgav1.TupleKey{
+			{User: "user:1", Relation: "get", Object: "object:1"},
+			{User: "user:1", Relation: "get", Object: "object:2"},
+		})
+
+		require.Len(t, deduplicatedDeleteTuples, 1)
+		require.ElementsMatch(t, deduplicatedDeleteTuples, []*openfgav1.TupleKeyWithoutCondition{
+			{User: "user:2", Relation: "get", Object: "object:2"},
+		})
+	})
+
+	t.Run("should deduplicate write tuples with conditions", func(t *testing.T) {
+		writeTuples := []*openfgav1.TupleKey{
+			{User: "user:1", Relation: "get", Object: "object:1", Condition: &openfgav1.RelationshipCondition{Name: "condition:1", Context: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"field:1": structpb.NewStringValue("value:1"),
+			}}}},
+			{User: "user:1", Relation: "get", Object: "object:2"},
+		}
+		deleteTuples := []*openfgav1.TupleKeyWithoutCondition{
+			{User: "user:1", Relation: "get", Object: "object:1"},
+		}
+
+		deduplicatedWriteTuples, deduplicatedDeleteTuples := deduplicateTupleKeys(writeTuples, deleteTuples)
+		require.Len(t, deduplicatedWriteTuples, 2)
+		require.ElementsMatch(t, deduplicatedWriteTuples, []*openfgav1.TupleKey{
+			{User: "user:1", Relation: "get", Object: "object:1", Condition: &openfgav1.RelationshipCondition{Name: "condition:1", Context: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"field:1": structpb.NewStringValue("value:1"),
+			}}}},
+			{User: "user:1", Relation: "get", Object: "object:2"},
+		})
+
+		require.Len(t, deduplicatedDeleteTuples, 0)
+	})
+
+	t.Run("should do nothing for no duplicates", func(t *testing.T) {
+		writeTuples := []*openfgav1.TupleKey{
+			{User: "user:1", Relation: "get", Object: "object:1"},
+		}
+		deleteTuples := []*openfgav1.TupleKeyWithoutCondition{
+			{User: "user:2", Relation: "get", Object: "object:2"},
+		}
+
+		deduplicatedWriteTuples, deduplicatedDeleteTuples := deduplicateTupleKeys(writeTuples, deleteTuples)
+		require.Len(t, deduplicatedWriteTuples, 1)
+		require.ElementsMatch(t, deduplicatedWriteTuples, writeTuples)
+		require.Len(t, deduplicatedDeleteTuples, 1)
+		require.ElementsMatch(t, deduplicatedDeleteTuples, deleteTuples)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

This PR fixes issue with writing and deleting same tuples in one transaction.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
