### PR TITLE
Icon: Use empty `<svg>` as fallback to prevent layout shift

### DIFF
--- a/packages/grafana-ui/src/components/Icon/Icon.tsx
+++ b/packages/grafana-ui/src/components/Icon/Icon.tsx
@@ -93,7 +93,7 @@ export const Icon = React.memo(
           // this prevents content layout shift whilst the icon asynchronously loads
           // which happens even if the icon is in the cache(!)
           loader={
-            <span
+            <svg
               className={cx(
                 css({
                   width: svgWid,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- getting icons from the cache is an async process
- whilst that process is resolving, we show a fallback
- currently this fallback is an empty span element with the same dimensions as the icon
- some places (e.g. `Tab`) set custom margin on child `svg` elements
- because the fallback is currently a `span`, these custom styles don't get applied to the fallback, but do get applied to the actual icon
- this causes a layout shift which looks really bad 🤮 
- let's make the fallback an empty `svg` to better match the real icon

**Why do we need this feature?**

- prevent layout shift when changing tabs (and maybe in other places)

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

See https://raintank-corp.slack.com/archives/CHKLEJ668/p1764922335718219 for context

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
