### PR TITLE
Dashboards: update manifest to avoid useoldmanifestkinds

### DIFF
--- a/apps/dashboard/Makefile
+++ b/apps/dashboard/Makefile
@@ -12,8 +12,7 @@ do-generate: install-app-sdk update-app-sdk ## Run Grafana App SDK code generati
 		--grouping=group \
 		--defencoding=none \
 		--genoperatorstate=false \
-		--noschemasinmanifest \
-		--useoldmanifestkinds
+		--noschemasinmanifest 
 
 .PHONY: post-generate-cleanup
 post-generate-cleanup: ## Clean up the generated code

--- a/apps/dashboard/kinds/dashboard.cue
+++ b/apps/dashboard/kinds/dashboard.cue
@@ -1,12 +1,5 @@
 package kinds
 
-import (
-	v0 "github.com/grafana/grafana/sdkkinds/dashboard/v0alpha1"
-	v1 "github.com/grafana/grafana/sdkkinds/dashboard/v1beta1"
-	v2alpha1 "github.com/grafana/grafana/sdkkinds/dashboard/v2alpha1"
-	v2beta1 "github.com/grafana/grafana/sdkkinds/dashboard/v2beta1"
-)
-
 // Status is the shared status of all dashboard versions.
 DashboardStatus: {
 	// Optional conversion status.
@@ -30,51 +23,4 @@ ConversionStatus: {
 
   // The original value map[string]any
 	source?: _
-}
-
-dashboard: {
-	kind:       "Dashboard"
-	pluralName: "Dashboards"
-	current:    "v1beta1"
-	codegen: {
-		ts: {
-			enabled: true
-			config: {
-				enumsAsUnionTypes: true
-			}
-		}
-		go: {
-			enabled: true
-			config: {
-				allowMarshalEmptyDisjunctions: true
-			}
-		}
-	}
-
-	versions: {
-		"v0alpha1": {
-			schema: {
-				spec:   v0.DashboardSpec
-				status: DashboardStatus
-			}
-		}
-		"v1beta1": {
-			schema: {
-				spec:   v1.DashboardSpec
-				status: DashboardStatus
-			}
-		}
-		"v2alpha1": {
-			schema: {
-				spec:   v2alpha1.DashboardSpec
-				status: DashboardStatus
-			}
-		}
-		"v2beta1": {
-			schema: {
-				spec:   v2beta1.DashboardSpec
-				status: DashboardStatus
-			}
-		}
-	}
 }

--- a/apps/dashboard/kinds/manifest.cue
+++ b/apps/dashboard/kinds/manifest.cue
@@ -1,10 +1,82 @@
 package kinds
 
+import (
+	v0 "github.com/grafana/grafana/sdkkinds/dashboard/v0alpha1"
+	v1 "github.com/grafana/grafana/sdkkinds/dashboard/v1beta1"
+	v2alpha1 "github.com/grafana/grafana/sdkkinds/dashboard/v2alpha1"
+	v2beta1 "github.com/grafana/grafana/sdkkinds/dashboard/v2beta1"
+)
+
 manifest: {
-	appName:       "dashboard"
-	groupOverride: "dashboard.grafana.app"
-	kinds: [
-		dashboard,
-		snapshot,
-	]
+	appName:          "dashboard"
+	groupOverride:    "dashboard.grafana.app"
+	preferredVersion: "v1beta1"
+
+	versions: {
+		"v0alpha1": {
+			codegen: {
+				ts: {enabled: false}
+				go: {enabled: true}
+			}
+			kinds: [
+				{
+					kind:       "Dashboard"
+					pluralName: "Dashboards"
+					schema: {
+						spec:   v0.DashboardSpec
+						status: DashboardStatus
+					}
+				},
+				snapshotV0alpha1, // Only exists in v0alpha (for now)
+			]
+		}
+		"v1beta1": {
+			codegen: {
+				ts: {enabled: false}
+				go: {enabled: true}
+			}
+			kinds: [
+				{
+					kind:       "Dashboard"
+					pluralName: "Dashboards"
+					schema: {
+						spec:   v1.DashboardSpec
+						status: DashboardStatus
+					}
+				}
+			]
+		}
+		"v2alpha1": {
+			codegen: {
+				ts: {enabled: false}
+				go: {enabled: true}
+			}
+			kinds: [
+				{
+					kind:       "Dashboard"
+					pluralName: "Dashboards"
+					schema: {
+						spec:   v2alpha1.DashboardSpec
+						status: DashboardStatus
+					}
+				}
+			]
+		}
+		"v2beta1": {
+			codegen: {
+				ts: {enabled: false}
+				go: {enabled: true}
+			}
+			kinds: [
+				{
+					kind:       "Dashboard"
+					pluralName: "Dashboards"
+					schema: {
+						spec:   v2beta1.DashboardSpec
+						status: DashboardStatus
+					}
+				}
+			]
+		}
+	}
 }

--- a/apps/dashboard/kinds/snapshot.cue
+++ b/apps/dashboard/kinds/snapshot.cue
@@ -1,46 +1,30 @@
 package kinds
 
-snapshot: {
+snapshotV0alpha1: {
 	kind:       "Snapshot"
 	pluralName: "Snapshots"
-	scope:      "Namespaced"
-	current:    "v0alpha1"
-	
-	codegen: {
-		ts: {
-			enabled: true
-		}
-		go: {
-			enabled: true
-		}
-	}
-	
-	versions: {
-		"v0alpha1": {
-			schema: {
-				spec: {
-					// Snapshot title
-					title?: string
-					
-					// Optionally auto-remove the snapshot at a future date (Unix timestamp in seconds)
-					expires?: int64 | *0
-					
-					// When set to true, the snapshot exists in a remote server
-					external?: bool | *false
-					
-					// The external URL where the snapshot can be seen
-					externalUrl?: string
-					
-					// The URL that created the dashboard originally
-					originalUrl?: string
-					
-					// Snapshot creation timestamp
-					timestamp?: string
+	schema: {
+		spec: {
+			// Snapshot title
+			title?: string
+			
+			// Optionally auto-remove the snapshot at a future date (Unix timestamp in seconds)
+			expires?: int64 | *0
+			
+			// When set to true, the snapshot exists in a remote server
+			external?: bool | *false
+			
+			// The external URL where the snapshot can be seen
+			externalUrl?: string
+			
+			// The URL that created the dashboard originally
+			originalUrl?: string
+			
+			// Snapshot creation timestamp
+			timestamp?: string
 
-					// The raw dashboard (unstructured for now)
-	        dashboard?: [string]: _
-				}
-			}
+			// The raw dashboard (unstructured for now)
+			dashboard?: [string]: _
 		}
 	}
 }

--- a/apps/dashboard/pkg/apis/dashboard/utils.go
+++ b/apps/dashboard/pkg/apis/dashboard/utils.go
@@ -6,6 +6,8 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
+const GrafanaDatasourceUID = "grafana"
+
 // SetPluginIDMeta sets the repo name to "plugin" and the path to the plugin ID
 func SetPluginIDMeta(obj *unstructured.Unstructured, pluginID string) {
 	if pluginID == "" {

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -12,11 +12,11 @@ import (
 	"k8s.io/apiserver/pkg/endpoints/request"
 
 	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	schemaversion "github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
-	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 )
 
 // getDefaultDatasourceType gets the default datasource type using the datasource provider
@@ -58,7 +58,7 @@ func getDatasourceTypeByUID(ctx context.Context, uid string, provider schemavers
 // datasource: { type: "datasource" } with no UID, it should resolve to uid: "grafana".
 func resolveGrafanaDatasourceUID(dsType, dsUID string) string {
 	if dsType == "datasource" && dsUID == "" {
-		return grafanads.DatasourceUID
+		return dashboard.GrafanaDatasourceUID
 	}
 	return dsUID
 }

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1_test.go
@@ -7,11 +7,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration"
 	migrationtestutil "github.com/grafana/grafana/apps/dashboard/pkg/migration/testutil"
-	"github.com/grafana/grafana/pkg/tsdb/grafanads"
 )
 
 // TestV1beta1ToV2alpha1 tests conversion from v1beta1 to v2alpha1 with various datasource scenarios
@@ -77,7 +77,7 @@ func TestV1beta1ToV2alpha1(t *testing.T) {
 
 				// Verify datasource UID is resolved to "grafana"
 				assert.NotNil(t, query.Spec.Datasource.Uid)
-				assert.Equal(t, grafanads.DatasourceUID, *query.Spec.Datasource.Uid, "type: 'datasource' with no UID should resolve to uid: 'grafana'")
+				assert.Equal(t, dashboard.GrafanaDatasourceUID, *query.Spec.Datasource.Uid, "type: 'datasource' with no UID should resolve to uid: 'grafana'")
 
 				// Verify query kind matches datasource type
 				assert.Equal(t, "datasource", query.Spec.Query.Kind)

--- a/pkg/tsdb/grafanads/grafana.go
+++ b/pkg/tsdb/grafanads/grafana.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	"github.com/grafana/grafana/pkg/components/simplejson"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -31,7 +32,7 @@ const DatasourceID = -1
 
 // DatasourceUID is the fake datasource uid used in requests to identify it as a
 // Grafana DS command.
-const DatasourceUID = "grafana"
+const DatasourceUID = dashboard.GrafanaDatasourceUID
 
 // Make sure Service implements required interfaces.
 // This is important to do since otherwise we will only get a


### PR DESCRIPTION
This updates the dashboards manifest so that versions is the top level rather than the bottom level.
