### PR TITLE
SchemaV2: Always set ad hoc filters to empty array when converting to v2

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-elasticsearch/v0alpha1.elasticsearch_complex.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-elasticsearch/v0alpha1.elasticsearch_complex.v42.v2alpha1.json
@@ -7234,9 +7234,9 @@
             "type": "elasticsearch",
             "uid": "gdev-elasticsearch"
           },
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-elasticsearch/v0alpha1.elasticsearch_complex.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-elasticsearch/v0alpha1.elasticsearch_complex.v42.v2beta1.json
@@ -7335,9 +7335,9 @@
         },
         "spec": {
           "name": "adhoc",
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-influxdb/v0alpha1.influxdb-templated.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-influxdb/v0alpha1.influxdb-templated.v42.v2alpha1.json
@@ -307,9 +307,9 @@
         "kind": "AdhocVariable",
         "spec": {
           "name": "adhoc",
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-influxdb/v0alpha1.influxdb-templated.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-influxdb/v0alpha1.influxdb-templated.v42.v2beta1.json
@@ -317,9 +317,9 @@
         "datasource": {},
         "spec": {
           "name": "adhoc",
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-loki/v0alpha1.loki_fakedata.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-loki/v0alpha1.loki_fakedata.v42.v2alpha1.json
@@ -604,9 +604,9 @@
             "type": "loki",
             "uid": "PDDA8E780A17E7EF1"
           },
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "label": "Ad-hoc",
           "hide": "dontHide",
           "skipUrlSync": false,

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-loki/v0alpha1.loki_fakedata.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/datasource-loki/v0alpha1.loki_fakedata.v42.v2beta1.json
@@ -616,9 +616,9 @@
         },
         "spec": {
           "name": "adhoc",
-          "baseFilters": null,
+          "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "label": "Ad-hoc",
           "hide": "dontHide",
           "skipUrlSync": false,

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_footer.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_footer.v42.v2alpha1.json
@@ -1885,7 +1885,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_footer.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_footer.v42.v2beta1.json
@@ -1931,7 +1931,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_kitchen_sink.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_kitchen_sink.v42.v2alpha1.json
@@ -2184,7 +2184,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_kitchen_sink.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_kitchen_sink.v42.v2beta1.json
@@ -2219,7 +2219,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_v12_2_migrations.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_v12_2_migrations.v42.v2alpha1.json
@@ -2499,7 +2499,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_v12_2_migrations.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-table/v0alpha1.table_v12_2_migrations.v42.v2beta1.json
@@ -2542,7 +2542,7 @@
           "name": "Filters",
           "baseFilters": [],
           "filters": [],
-          "defaultKeys": null,
+          "defaultKeys": [],
           "hide": "dontHide",
           "skipUrlSync": false,
           "allowCustomValue": true

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -1539,25 +1539,37 @@ func buildAdhocVariable(ctx context.Context, varMap map[string]interface{}, comm
 		},
 	}
 
-	// Transform baseFilters if they exist
+	// Transform baseFilters if they exist, otherwise default to empty array
 	if baseFilters, exists := varMap["baseFilters"]; exists {
 		if baseFiltersArray, ok := baseFilters.([]interface{}); ok {
 			adhocVar.Spec.BaseFilters = transformAdHocFilters(baseFiltersArray)
 		}
 	}
+	// Ensure baseFilters is always set (default to empty array if not present or invalid)
+	if adhocVar.Spec.BaseFilters == nil {
+		adhocVar.Spec.BaseFilters = []dashv2alpha1.DashboardAdHocFilterWithLabels{}
+	}
 
-	// Transform filters if they exist
+	// Transform filters if they exist, otherwise default to empty array
 	if filters, exists := varMap["filters"]; exists {
 		if filtersArray, ok := filters.([]interface{}); ok {
 			adhocVar.Spec.Filters = transformAdHocFilters(filtersArray)
 		}
 	}
+	// Ensure filters is always set (default to empty array if not present or invalid)
+	if adhocVar.Spec.Filters == nil {
+		adhocVar.Spec.Filters = []dashv2alpha1.DashboardAdHocFilterWithLabels{}
+	}
 
-	// Transform defaultKeys if they exist
+	// Transform defaultKeys if they exist, otherwise default to empty array
 	if defaultKeys, exists := varMap["defaultKeys"]; exists {
 		if defaultKeysArray, ok := defaultKeys.([]interface{}); ok {
 			adhocVar.Spec.DefaultKeys = transformMetricFindValues(defaultKeysArray)
 		}
+	}
+	// Ensure defaultKeys is always set (default to empty array if not present or invalid)
+	if adhocVar.Spec.DefaultKeys == nil {
+		adhocVar.Spec.DefaultKeys = []dashv2alpha1.DashboardMetricFindValue{}
 	}
 
 	// Only include datasource if datasourceUID exists (matching frontend behavior)


### PR DESCRIPTION
**What is this feature?**

When converting adhoc filters to V2 we were not setting the filters property that is required. This causes the filter property to be null in the frontend. When we then try to save the dashboard we will get a validation error from that null.