### PR TITLE
Remote Alertmanager: Remove X-Remote-Alertmanager header

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -153,7 +153,6 @@ func TestGetRemoteState(t *testing.T) {
 	getOkHandler := func(state string) http.HandlerFunc {
 		return func(w http.ResponseWriter, r *http.Request) {
 			require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-			require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 
 			res := map[string]any{
 				"status": "success",
@@ -268,7 +267,6 @@ func TestIntegrationApplyConfig(t *testing.T) {
 
 	errorHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 		w.Header().Add("content-type", "application/json")
 		w.WriteHeader(http.StatusInternalServerError)
 		require.NoError(t, json.NewEncoder(w).Encode(map[string]string{"status": "error"}))
@@ -278,7 +276,6 @@ func TestIntegrationApplyConfig(t *testing.T) {
 	var configSyncs, stateSyncs int
 	okHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 		res := map[string]any{"status": "success"}
 
 		if r.Method == http.MethodPost {
@@ -432,7 +429,6 @@ func TestCompareAndSendConfiguration(t *testing.T) {
 	var got string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 		w.Header().Add("content-type", "application/json")
 
 		b, err := io.ReadAll(r.Body)
@@ -639,7 +635,6 @@ func Test_TestReceiversDecryptsSecureSettings(t *testing.T) {
 	var got apimodels.TestReceiversConfigBodyParams
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 		w.Header().Add("Content-Type", "application/json")
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&got))
 		require.NoError(t, r.Body.Close())
@@ -746,7 +741,6 @@ func TestApplyConfigWithExtraConfigs(t *testing.T) {
 	var configSent client.UserGrafanaConfig
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/config") {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&configSent))
@@ -828,7 +822,6 @@ func TestCompareAndSendConfigurationWithExtraConfigs(t *testing.T) {
 	var configSent client.UserGrafanaConfig
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		require.Equal(t, tenantID, r.Header.Get(client.MimirTenantHeader))
-		require.Equal(t, "true", r.Header.Get(client.RemoteAlertmanagerHeader))
 
 		if r.Method == http.MethodPost && strings.Contains(r.URL.Path, "/config") {
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&configSent))

--- a/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
+++ b/pkg/services/ngalert/remote/client/mimir_auth_round_tripper.go
@@ -5,8 +5,7 @@ import (
 )
 
 const (
-	MimirTenantHeader        = "X-Scope-OrgID"
-	RemoteAlertmanagerHeader = "X-Remote-Alertmanager"
+	MimirTenantHeader = "X-Scope-OrgID"
 )
 
 type MimirAuthRoundTripper struct {
@@ -19,7 +18,6 @@ type MimirAuthRoundTripper struct {
 // It adds an `X-Scope-OrgID` header with the TenantID if only provided with a tenantID or sets HTTP Basic Authentication if both
 // a tenantID and a password are provided.
 func (r *MimirAuthRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	req.Header.Set(RemoteAlertmanagerHeader, "true")
 	if r.TenantID != "" && r.Password == "" {
 		req.Header.Set(MimirTenantHeader, r.TenantID)
 	}


### PR DESCRIPTION
We added this before changing approaches (second tenant). We never used it, and don't need it.