### PR TITLE
QueryEditor: Expose `aria-labelledby` prop, reenable storybook a11y tests

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -710,11 +710,6 @@
       "count": 1
     }
   },
-  "packages/grafana-ui/src/components/QueryField/QueryField.story.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "packages/grafana-ui/src/components/QueryField/QueryField.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -1,6 +1,9 @@
 import { Meta, StoryFn } from '@storybook/react';
+import { useId } from 'react';
 
 import { TypeaheadInput } from '../../types/completion';
+import { Field } from '../Forms/Field';
+import { Label } from '../Forms/Label';
 
 import { QueryField, QueryFieldProps } from './QueryField';
 
@@ -32,7 +35,16 @@ const meta: Meta<typeof QueryField> = {
   },
 };
 
-export const Basic: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => <QueryField {...args} />;
+export const Basic: StoryFn<typeof QueryField> = (args: Omit<QueryFieldProps, 'theme'>) => {
+  const id = useId();
+  // have to manually set an id on the label
+  // can't use htmlFor as QueryField is a contenteditable div, not an input
+  return (
+    <Field label={<Label id={id}>Query field</Label>}>
+      <QueryField {...args} aria-labelledby={id} />
+    </Field>
+  );
+};
 
 Basic.args = {
   onTypeahead: async (_input: TypeaheadInput) => ({

--- a/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.story.tsx
@@ -24,8 +24,6 @@ const meta: Meta<typeof QueryField> = {
         'syntaxLoaded',
       ],
     },
-    // TODO fix a11y issue in story and remove this
-    a11y: { test: 'off' },
   },
   argTypes: {
     query: {

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -9,6 +9,7 @@ import { Editor, EventHook, Plugin } from 'slate-react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { t } from '@grafana/i18n';
 
 import { ClearPlugin } from '../../slate-plugins/clear';
 import { ClipboardPlugin } from '../../slate-plugins/clipboard';
@@ -25,6 +26,7 @@ import { makeValue, SCHEMA } from '../../utils/slate';
 
 export interface QueryFieldProps extends Themeable2 {
   additionalPlugins?: Plugin[];
+  ['aria-label']?: string;
   cleanText?: (text: string) => string;
   disabled?: boolean;
   // We have both value and local state. This is usually an antipattern but we need to keep local state
@@ -201,7 +203,7 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
   }
 
   render() {
-    const { disabled, theme } = this.props;
+    const { disabled, theme, ['aria-label']: ariaLabel } = this.props;
     const wrapperClassName = classnames('slate-query-field__wrapper', {
       'slate-query-field__wrapper--disabled': disabled,
     });
@@ -214,6 +216,7 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
             ref={(editor) => {
               this.editor = editor;
             }}
+            aria-label={ariaLabel ?? t('grafana-ui.components.queryField.ariaLabel', 'Query input field')}
             schema={SCHEMA}
             autoCorrect={false}
             readOnly={this.props.disabled}

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -216,7 +216,7 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
             ref={(editor) => {
               this.editor = editor;
             }}
-            aria-label={ariaLabel ?? t('grafana-ui.components.queryField.ariaLabel', 'Query input field')}
+            aria-label={ariaLabel ?? t('grafana-ui.query-field.aria-label', 'Query input field')}
             schema={SCHEMA}
             autoCorrect={false}
             readOnly={this.props.disabled}

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -9,7 +9,6 @@ import { Editor, EventHook, Plugin } from 'slate-react';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { t } from '@grafana/i18n';
 
 import { ClearPlugin } from '../../slate-plugins/clear';
 import { ClipboardPlugin } from '../../slate-plugins/clipboard';
@@ -26,7 +25,7 @@ import { makeValue, SCHEMA } from '../../utils/slate';
 
 export interface QueryFieldProps extends Themeable2 {
   additionalPlugins?: Plugin[];
-  ['aria-label']?: string;
+  ['aria-labelledby']?: string;
   cleanText?: (text: string) => string;
   disabled?: boolean;
   // We have both value and local state. This is usually an antipattern but we need to keep local state
@@ -203,7 +202,7 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
   }
 
   render() {
-    const { disabled, theme, ['aria-label']: ariaLabel } = this.props;
+    const { disabled, theme, ['aria-labelledby']: ariaLabelledby } = this.props;
     const wrapperClassName = classnames('slate-query-field__wrapper', {
       'slate-query-field__wrapper--disabled': disabled,
     });
@@ -216,7 +215,7 @@ export class UnThemedQueryField extends PureComponent<QueryFieldProps, QueryFiel
             ref={(editor) => {
               this.editor = editor;
             }}
-            aria-label={ariaLabel ?? t('grafana-ui.query-field.aria-label', 'Query input field')}
+            aria-labelledby={ariaLabelledby}
             schema={SCHEMA}
             autoCorrect={false}
             readOnly={this.props.disabled}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9070,9 +9070,6 @@
       "tooltip-hide": "Hide password",
       "tooltip-show": "Show password"
     },
-    "query-field": {
-      "aria-label": "Query input field"
-    },
     "range-slider": {
       "drag-handle-aria-label": "Use arrow keys to change the value"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9070,6 +9070,9 @@
       "tooltip-hide": "Hide password",
       "tooltip-show": "Show password"
     },
+    "query-field": {
+      "aria-label": "Query input field"
+    },
     "range-slider": {
       "drag-handle-aria-label": "Use arrow keys to change the value"
     },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- exposes an `aria-labelledby` prop on `QueryEditor` and attaches it to the underlying `Editor` element
- normally we would expose e.g. an `id` prop, and use that to connect the editor to a field label (see e.g. `Input` stories for examples)
- however, slate renders it's editor as a contenteditable div, and it's not possible to connect the label this way
- instead we can use a custom label with an id set and pass that id via `aria-labelledby`

**Why do we need this feature?**

- so consumers can set an accessible label for the query field

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/109450

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
