### PR TITLE
Alerting: Fix creating a new alert rule vesion when only keep_firing_for changes

### DIFF
--- a/pkg/services/ngalert/store/models.go
+++ b/pkg/services/ngalert/store/models.go
@@ -88,6 +88,7 @@ func (a alertRuleVersion) EqualSpec(b alertRuleVersion) bool {
 		a.NoDataState == b.NoDataState &&
 		a.ExecErrState == b.ExecErrState &&
 		a.For == b.For &&
+		a.KeepFiringFor == b.KeepFiringFor &&
 		a.Annotations == b.Annotations &&
 		a.Labels == b.Labels &&
 		a.IsPaused == b.IsPaused &&

--- a/pkg/services/ngalert/store/models_test.go
+++ b/pkg/services/ngalert/store/models_test.go
@@ -21,6 +21,7 @@ func TestAlertRuleVersion_EqualSpec(t *testing.T) {
 		NoDataState:                 "state1",
 		ExecErrState:                "state2",
 		For:                         time.Minute,
+		KeepFiringFor:               2 * time.Minute,
 		Annotations:                 `{ "test": "annotation" }`,
 		Labels:                      `{ "test": "label" }`,
 		IsPaused:                    true,
@@ -117,6 +118,12 @@ func TestAlertRuleVersion_EqualSpec(t *testing.T) {
 			name:   "different For durations",
 			a:      baseVersion,
 			b:      func() alertRuleVersion { v := baseVersion; v.For = 2 * time.Minute; return v }(),
+			expect: false,
+		},
+		{
+			name:   "different KeepFiringFor durations",
+			a:      baseVersion,
+			b:      func() alertRuleVersion { v := baseVersion; v.KeepFiringFor = 5 * time.Minute; return v }(),
 			expect: false,
 		},
 		{


### PR DESCRIPTION
**What is this feature?**

Add the `KeepFiringFor` field to the `EqualSpec` comparison function in alert rule versions.

**Why do we need this feature?**

When alert rule is updated, if only the `KeepFiringFor` field is changed, no new version is created in the versions table, so the update is not visible in the UI in the "Versions" tab.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
