### PR TITLE
Dashboard: Default dashboard folder to current folder when importing

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2067,9 +2067,6 @@
     },
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    },
-    "no-restricted-syntax": {
-      "count": 3
     }
   },
   "public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx": {

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
@@ -41,7 +41,6 @@ export const ImportDashboardFormV2 = ({
   useEffect(() => {
     if (isSubmitted && (errors.dashboard?.title || errors.k8s?.name)) {
       const formValues = getValues();
-      console.log(formValues);
       onSubmit({
         ...formValues,
         dashboard: {
@@ -51,6 +50,7 @@ export const ImportDashboardFormV2 = ({
       });
     }
   }, [errors, getValues, isSubmitted, onSubmit]);
+
   return (
     <Stack direction="column" gap={2}>
       <Field

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardFormV2.tsx
@@ -17,10 +17,8 @@ interface Props
     'register' | 'control' | 'getValues' | 'watch'
   > {
   inputs: DashboardInputs;
-  uidReset: boolean;
   errors: FieldErrors<SaveDashboardCommand<DashboardV2Spec> & { [key: `datasource-${string}`]: string }>;
   onCancel: () => void;
-  onUidReset: () => void;
   onSubmit: FormsOnSubmit<SaveDashboardCommand<DashboardV2Spec> & { [key: `datasource-${string}`]: string }>;
 }
 
@@ -30,8 +28,6 @@ export const ImportDashboardFormV2 = ({
   control,
   inputs,
   getValues,
-  uidReset,
-  onUidReset,
   onCancel,
   onSubmit,
   watch,
@@ -45,6 +41,7 @@ export const ImportDashboardFormV2 = ({
   useEffect(() => {
     if (isSubmitted && (errors.dashboard?.title || errors.k8s?.name)) {
       const formValues = getValues();
+      console.log(formValues);
       onSubmit({
         ...formValues,
         dashboard: {
@@ -54,14 +51,13 @@ export const ImportDashboardFormV2 = ({
       });
     }
   }, [errors, getValues, isSubmitted, onSubmit]);
-
   return (
-    <>
-      <Trans i18nKey="manage-dashboards.import-dashboard-form.options">Options</Trans>
+    <Stack direction="column" gap={2}>
       <Field
         label={t('manage-dashboards.import-dashboard-form.label-name', 'Name')}
         invalid={!!errors.dashboard?.title}
         error={errors.dashboard?.title && errors.dashboard?.title.message}
+        noMargin
       >
         <Input
           {...(register as any)('dashboard.title', {
@@ -72,7 +68,8 @@ export const ImportDashboardFormV2 = ({
           data-testid={selectors.components.ImportDashboardForm.name}
         />
       </Field>
-      <Field label={t('dashboard-scene.import-dashboard-form-v2.label-folder', 'Folder')}>
+
+      <Field label={t('dashboard-scene.import-dashboard-form-v2.label-folder', 'Folder')} noMargin>
         <Controller<any>
           render={({ field: { ref, value, onChange, ...field } }) => (
             <FolderPicker
@@ -87,6 +84,7 @@ export const ImportDashboardFormV2 = ({
           control={control}
         />
       </Field>
+
       {inputs.dataSources &&
         inputs.dataSources.map((input: DataSourceInput) => {
           if (input.pluginId === ExpressionDatasourceRef.type) {
@@ -102,6 +100,7 @@ export const ImportDashboardFormV2 = ({
               key={input.pluginId}
               invalid={!!errors[dataSourceOption]}
               error={errors[dataSourceOption] ? 'Please select a data source' : undefined}
+              noMargin
             >
               <Controller<any>
                 name={dataSourceOption}
@@ -133,7 +132,7 @@ export const ImportDashboardFormV2 = ({
           );
         })}
 
-      <Stack>
+      <Stack direction="row" gap={2}>
         <Button
           type="submit"
           data-testid={selectors.components.ImportDashboardForm.submit}
@@ -148,7 +147,7 @@ export const ImportDashboardFormV2 = ({
           <Trans i18nKey="dashboard-scene.import-dashboard-form-v2.cancel">Cancel</Trans>
         </Button>
       </Stack>
-    </>
+    </Stack>
   );
 };
 

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -20,7 +20,6 @@ const IMPORT_FINISHED_EVENT_NAME = 'dashboard_import_imported';
 type FormData = SaveDashboardCommand<DashboardV2Spec> & { [key: `datasource-${string}`]: string };
 
 export function ImportDashboardOverviewV2() {
-  const [uidReset, setUidReset] = useState(false);
   const dispatch = useDispatch();
 
   // Get state from Redux store
@@ -28,10 +27,6 @@ export function ImportDashboardOverviewV2() {
   const dashboard = useSelector((state: StoreState) => state.importDashboard.dashboard as DashboardV2Spec);
   const inputs = useSelector((state: StoreState) => state.importDashboard.inputs);
   const folder = searchObj.folderUid ? { uid: String(searchObj.folderUid) } : { uid: '' };
-
-  function onUidReset() {
-    setUidReset(true);
-  }
 
   function onCancel() {
     dispatch(clearLoadedDashboard());
@@ -180,7 +175,7 @@ export function ImportDashboardOverviewV2() {
     <>
       <Form<FormData>
         onSubmit={onSubmit}
-        defaultValues={{ dashboard, k8s: { annotations: { 'grafana.app/folder': folder.uid } } }}
+        defaultValues={{ dashboard, folderUid: folder.uid, k8s: { annotations: { 'grafana.app/folder': folder.uid } } }}
         validateOnMount
         validateOn="onChange"
       >
@@ -191,9 +186,7 @@ export function ImportDashboardOverviewV2() {
             errors={errors}
             control={control}
             getValues={getValues}
-            uidReset={uidReset}
             onCancel={onCancel}
-            onUidReset={onUidReset}
             onSubmit={onSubmit}
             watch={watch}
           />

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { locationUtil } from '@grafana/data';
 import { locationService, reportInteraction } from '@grafana/runtime';
 import {


### PR DESCRIPTION
**What is this feature?**

This update ensures that when a user imports a dashboard from a file or JSON, the new dashboard will automatically be placed in the folder they are currently in.

**Why do we need this feature?**

This change makes the behaviour consistent with the regular “create dashboard” flow.


**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114867
