### PR TITLE
Provisioning: Block Library Panel creation in provisioned folders

### DIFF
--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -424,6 +424,9 @@ func (l *LibraryElementService) toLibraryElementError(err error, message string)
 	if errors.Is(err, model.ErrLibraryElementUIDTooLong) {
 		return response.Error(http.StatusBadRequest, model.ErrLibraryElementUIDTooLong.Error(), err)
 	}
+	if errors.Is(err, model.ErrLibraryElementProvisionedFolder) {
+		return response.Error(http.StatusConflict, model.ErrLibraryElementProvisionedFolder.Error(), err)
+	}
 	if err != nil && strings.Contains(err.Error(), "insufficient permissions") {
 		return response.Error(http.StatusForbidden, err.Error(), err)
 	}

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/dtos"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -122,6 +123,20 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 			return model.LibraryElementDTO{}, model.ErrLibraryElementInvalidUID
 		} else if util.IsShortUIDTooLong(createUID) {
 			return model.LibraryElementDTO{}, model.ErrLibraryElementUIDTooLong
+		}
+	}
+
+	if cmd.FolderUID != nil {
+		f, err := l.folderService.Get(c, &folder.GetFolderQuery{
+			OrgID:        signedInUser.GetOrgID(),
+			UID:          cmd.FolderUID,
+			SignedInUser: signedInUser,
+		})
+		if err != nil {
+			return model.LibraryElementDTO{}, err
+		}
+		if f.ManagedBy == utils.ManagerKindRepo {
+			return model.LibraryElementDTO{}, model.ErrLibraryElementProvisionedFolder
 		}
 	}
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -616,6 +616,21 @@ func (l *LibraryElementService) PatchLibraryElement(c context.Context, signedInU
 	if err := l.requireSupportedElementKind(cmd.Kind); err != nil {
 		return model.LibraryElementDTO{}, err
 	}
+
+	if cmd.FolderUID != nil {
+		f, err := l.folderService.Get(c, &folder.GetFolderQuery{
+			OrgID:        signedInUser.GetOrgID(),
+			UID:          cmd.FolderUID,
+			SignedInUser: signedInUser,
+		})
+		if err != nil {
+			return model.LibraryElementDTO{}, err
+		}
+		if f.ManagedBy == utils.ManagerKindRepo {
+			return model.LibraryElementDTO{}, model.ErrLibraryElementProvisionedFolder
+		}
+	}
+
 	err := l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		elementInDB, err := l.GetLibraryElement(c, signedInUser, session, uid)
 		if err != nil {

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -161,6 +161,8 @@ var (
 	ErrLibraryElementInvalidUID = errors.New("uid contains illegal characters")
 	// errLibraryElementUIDTooLong is an error for when the uid of a library element is invalid
 	ErrLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
+	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
+	ErrLibraryElementProvisionedFolder = errors.New("cannot create a library element on a provisioned folder")
 )
 
 // Commands

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -162,7 +162,7 @@ var (
 	// errLibraryElementUIDTooLong is an error for when the uid of a library element is invalid
 	ErrLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
 	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
-	ErrLibraryElementProvisionedFolder = errors.New("cannot create or move a library element on a provisioned folder")
+	ErrLibraryElementProvisionedFolder = errors.New("resource type not supported in repository-managed folders")
 )
 
 // Commands

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -162,7 +162,7 @@ var (
 	// errLibraryElementUIDTooLong is an error for when the uid of a library element is invalid
 	ErrLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
 	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
-	ErrLibraryElementProvisionedFolder = errors.New("cannot create a library element on a provisioned folder")
+	ErrLibraryElementProvisionedFolder = errors.New("cannot create or move a library element on a provisioned folder")
 )
 
 // Commands

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -4,17 +4,22 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
+	"time"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // We currently block the creation of library panels in provisioned folders.
-func TestIntegrationLibraryPanels(t *testing.T) {
+func TestIntegrationLibraryPanels_ProvisionedFolders(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	helper := runGrafana(t)
@@ -44,7 +49,7 @@ func TestIntegrationLibraryPanels(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, http.StatusConflict, code)
 		require.NotNil(t, libraryElementData)
-		require.Equal(t, "cannot create or move a library element on a provisioned folder", libraryElementData["message"])
+		require.Equal(t, "resource type not supported in repository-managed folders", libraryElementData["message"])
 	})
 
 	t.Run("should fail to patch library element, moving it in a provisioned folder", func(t *testing.T) {
@@ -106,6 +111,65 @@ func TestIntegrationLibraryPanels(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, http.StatusConflict, code)
 		require.NotNil(t, newLibraryElement)
-		require.Equal(t, "cannot create or move a library element on a provisioned folder", newLibraryElement["message"])
+		require.Equal(t, "resource type not supported in repository-managed folders", newLibraryElement["message"])
+	})
+}
+
+func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
+	const repo = "test-repo"
+	helper := runGrafana(t)
+	helper.CreateRepo(t, TestRepo{
+		Name:            repo,
+		Target:          "folder",
+		ExpectedFolders: 1,
+	})
+
+	t.Run("should create library element when folder is released", func(t *testing.T) {
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, folders.Items, 1)
+		managedFolderName := folders.Items[0].GetName()
+		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerKind, "folder should be managed")
+		require.Contains(t, folders.Items[0].GetAnnotations(), utils.AnnoKeyManagerIdentity, "folder should be managed")
+
+		_, err = helper.Repositories.Resource.Patch(t.Context(), repo, types.JSONPatchType, []byte(`[
+		{
+			"op": "replace",
+			"path": "/metadata/finalizers",
+			"value": ["cleanup", "release-orphan-resources"]
+		}
+		]`), metav1.PatchOptions{})
+		require.NoError(t, err, "should successfully patch finalizers")
+
+		require.NoError(t, helper.Repositories.Resource.Delete(t.Context(), repo, metav1.DeleteOptions{}))
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
+			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
+		}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+			require.NoError(t, err, "can list values")
+			for _, v := range foundFolders.Items {
+				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerKind)
+				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeyManagerIdentity)
+				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
+				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
+			}
+		}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+
+		libraryElement := map[string]interface{}{
+			"kind":      1,
+			"name":      "Library Panel",
+			"folderUid": managedFolderName,
+			"model": map[string]interface{}{
+				"type":  "text",
+				"title": "Library Panel",
+			},
+		}
+		libraryElementURL := "/api/library-elements"
+		libraryElementData, code, err := postHelper(t, *helper.K8sTestHelper, libraryElementURL, libraryElement, helper.Org1.Admin)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
+		require.NotNil(t, libraryElementData)
 	})
 }

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -82,6 +82,7 @@ func TestIntegrationLibraryPanels(t *testing.T) {
 		libraryElementURL := "/api/library-elements"
 		libraryElementData, code, err := postHelper(t, *helper.K8sTestHelper, libraryElementURL, libraryElement, helper.Org1.Admin)
 		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, code)
 		require.NotNil(t, libraryElementData)
 
 		res := libraryElementData["result"].(map[string]interface{})

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -1,0 +1,110 @@
+package provisioning
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/util/testutil"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// We currently block the creation of library panels in provisioned folders.
+func TestIntegrationLibraryPanels(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	helper.CreateRepo(t, TestRepo{
+		Name:            "test-repo",
+		Target:          "folder",
+		ExpectedFolders: 1,
+	})
+
+	t.Run("should fail to create library element in provisioned folder", func(t *testing.T) {
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, folders.Items, 1)
+
+		managedFolderName := folders.Items[0].GetName()
+		libraryElement := map[string]interface{}{
+			"kind":      1,
+			"name":      "Library Panel",
+			"folderUid": managedFolderName,
+			"model": map[string]interface{}{
+				"type":  "text",
+				"title": "Library Panel",
+			},
+		}
+		libraryElementURL := "/api/library-elements"
+		libraryElementData, code, err := postHelper(t, *helper.K8sTestHelper, libraryElementURL, libraryElement, helper.Org1.Admin)
+		require.Error(t, err)
+		require.Equal(t, http.StatusConflict, code)
+		require.NotNil(t, libraryElementData)
+		require.Equal(t, "cannot create or move a library element on a provisioned folder", libraryElementData["message"])
+	})
+
+	t.Run("should fail to patch library element, moving it in a provisioned folder", func(t *testing.T) {
+		// Getting managed folder
+		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		require.NoError(t, err)
+		require.Len(t, folders.Items, 1)
+		managedFolderName := folders.Items[0].GetName()
+
+		unmanagedFolder := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": foldersV1.FolderResourceInfo.GroupVersion().String(),
+				"kind":       foldersV1.FolderResourceInfo.GroupVersionKind().Kind,
+				"metadata": map[string]interface{}{
+					"generateName": "test-folder-",
+				},
+				"spec": map[string]interface{}{
+					"title": "Library Panel",
+				},
+			},
+		}
+		createdFolder, err := helper.Folders.Resource.Create(t.Context(), unmanagedFolder, metav1.CreateOptions{})
+		require.NoError(t, err)
+		require.NotNil(t, createdFolder)
+
+		libraryElement := map[string]interface{}{
+			"kind":      1,
+			"name":      "Moved Library Panel",
+			"folderUid": createdFolder.GetName(),
+			"model": map[string]interface{}{
+				"type":  "text",
+				"title": "Moved Library Panel",
+			},
+		}
+		libraryElementURL := "/api/library-elements"
+		libraryElementData, code, err := postHelper(t, *helper.K8sTestHelper, libraryElementURL, libraryElement, helper.Org1.Admin)
+		require.NoError(t, err)
+		require.NotNil(t, libraryElementData)
+
+		res := libraryElementData["result"].(map[string]interface{})
+		helper.SetPermissions(helper.Org1.Admin, []resourcepermissions.SetResourcePermissionCommand{
+			{
+				Actions:           []string{"library.panels:write"},
+				Resource:          "library.panels",
+				ResourceAttribute: "uid",
+				ResourceID:        "*",
+			},
+		})
+
+		// Patching libraryElement - changing folder to a managed one
+		updatedLibraryElement := map[string]interface{}{
+			"kind":      1,
+			"version":   res["version"],
+			"folderUid": managedFolderName,
+		}
+		patchLibraryElementURL := fmt.Sprintf("/api/library-elements/%f", +res["id"].(float64))
+		newLibraryElement, code, err := patchHelper(t, *helper.K8sTestHelper, patchLibraryElementURL, updatedLibraryElement, helper.Org1.Admin)
+		require.Error(t, err)
+		require.Equal(t, http.StatusConflict, code)
+		require.NotNil(t, newLibraryElement)
+		require.Equal(t, "cannot create or move a library element on a provisioned folder", newLibraryElement["message"])
+	})
+}


### PR DESCRIPTION
**What is this feature?**

This PR blocks Library Panel creation in provisioned folders.

**Why do we need this feature?**

As mentioned in https://github.com/grafana/git-ui-sync-project/issues/618 -in case unmanaged resources are present into a folder managed by a `Repository`, the deletion of said folder will cause the unmanaged res to be orphaned. 

Due to that, we decided to stop the creation of Library Panel (which is among the unmanaged resources) into managed folders. 

**Who is this feature for?**

Users of GitSync.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/618

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
