### PR TITLE
Search: Fix field selector parsing

### DIFF
--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -124,7 +124,7 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 			if r.Value != "" {
 				requirement.Values = append(requirement.Values, r.Value)
 			}
-			req.Options.Labels = append(req.Options.Labels, requirement)
+			req.Options.Fields = append(req.Options.Fields, requirement)
 		}
 	}
 

--- a/pkg/storage/unified/apistore/util_test.go
+++ b/pkg/storage/unified/apistore/util_test.go
@@ -118,6 +118,49 @@ func TestToListRequest(t *testing.T) {
 			wantErr: nil,
 		},
 		{
+			name: "with field selector",
+			key: &resourcepb.ResourceKey{
+				Group:     "test",
+				Resource:  "test",
+				Namespace: "default",
+			},
+			opts: storage.ListOptions{
+				Predicate: storage.SelectionPredicate{
+					Label: labels.SelectorFromSet(labels.Set{"label": "A"}),
+					Field: fields.SelectorFromSet(fields.Set{"field": "B"}),
+				},
+			},
+			want: &resourcepb.ListRequest{
+				VersionMatchV2: 1,
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:     "test",
+						Resource:  "test",
+						Namespace: "default",
+					},
+					Labels: []*resourcepb.Requirement{
+						{
+							Key:      "label",
+							Operator: string(selection.Equals),
+							Values:   []string{"A"},
+						},
+					},
+					Fields: []*resourcepb.Requirement{
+						{
+							Key:      "field",
+							Operator: string(selection.Equals),
+							Values:   []string{"B"},
+						},
+					},
+				},
+			},
+			wantPredicate: storage.SelectionPredicate{
+				Label: labels.SelectorFromSet(labels.Set{"label": "A"}),
+				Field: fields.SelectorFromSet(fields.Set{"field": "B"}),
+			},
+			wantErr: nil,
+		},
+		{
 			name: "with trash label",
 			key: &resourcepb.ResourceKey{
 				Group:     "test",


### PR DESCRIPTION
When parsing field+label selectors from the k8s request, we are currently appending both the the label selector element.