### PR TITLE
Dashboards: Fix versions tab not showing in dashboard settings after making dashboard editable

### DIFF
--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.test.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.test.tsx
@@ -186,6 +186,17 @@ describe('NavToolbarActions', () => {
         });
       });
     });
+
+    describe('where dashboard is not editable', () => {
+      it('should set dashboard to editable on make editable button press', async () => {
+        const { dashboard } = setup({}, true);
+        await userEvent.click(await screen.findByTestId(selectors.components.NavToolbar.editDashboard.editButton));
+
+        expect(dashboard.state.editable).toBe(true);
+        expect(dashboard.state.meta.canEdit).toBe(true);
+        expect(dashboard.state.meta.canSave).toBe(true);
+      });
+    });
   });
 
   describe('Given new sharing button', () => {
@@ -214,7 +225,7 @@ describe('NavToolbarActions', () => {
   });
 });
 
-function setup(meta?: DashboardMeta) {
+function setup(meta?: DashboardMeta, editable?: boolean) {
   const dashboard = new DashboardScene({
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
     meta: {
@@ -229,6 +240,7 @@ function setup(meta?: DashboardMeta) {
       ...meta,
     },
     title: 'hello',
+    editable: editable || true,
     uid: 'dash-1',
     body: DefaultGridLayoutManager.fromVizPanels([
       new VizPanel({

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -351,7 +351,7 @@ export function ToolbarActions({ dashboard }: Props) {
         onClick={() => {
           trackDashboardSceneEditButtonClicked(dashboard.state.uid);
           dashboard.onEnterEditMode();
-          dashboard.setState({ editable: true, meta: { ...meta, canEdit: true } });
+          dashboard.setState({ editable: true, meta: { ...meta, canEdit: true, canSave: true } });
         }}
         tooltip={t('dashboard.toolbar.enter-edit-mode.tooltip', 'This dashboard was marked as read only')}
         key="edit"

--- a/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
+++ b/public/app/features/dashboard-scene/scene/NavToolbarActions.tsx
@@ -351,7 +351,7 @@ export function ToolbarActions({ dashboard }: Props) {
         onClick={() => {
           trackDashboardSceneEditButtonClicked(dashboard.state.uid);
           dashboard.onEnterEditMode();
-          dashboard.setState({ editable: true, meta: { ...meta, canEdit: true, canSave: true } });
+          dashboard.setState({ meta: { ...meta, canEdit: true, canSave: true } });
         }}
         tooltip={t('dashboard.toolbar.enter-edit-mode.tooltip', 'This dashboard was marked as read only')}
         key="edit"

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.test.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.test.tsx
@@ -34,10 +34,11 @@ setPluginImportUtils({
   getPanelPluginFromCache: (id: string) => undefined,
 });
 
-export function buildTestScene(isEditing = false) {
+export function buildTestScene(isEditing?: boolean, editable?: boolean) {
   const testScene = new DashboardScene({
     $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
-    isEditing: isEditing,
+    isEditing: isEditing || false,
+    editable: editable || true,
     body: new DefaultGridLayoutManager({
       grid: new SceneGridLayout({
         children: [new DashboardGridItem({ body: new VizPanel({ key: 'panel-1', pluginId: 'text' }) })],
@@ -75,5 +76,16 @@ describe('MakeDashboardEditableButton', () => {
       await userEvent.click(await screen.findByTestId(selectors.components.NavToolbar.editDashboard.editButton));
       expect(DashboardInteractions.editButtonClicked).toHaveBeenCalledWith({ outlineExpanded: false });
     });
+  });
+
+  it('should set state correctly', async () => {
+    const scene = buildTestScene(false, false);
+
+    render(<MakeDashboardEditableButton dashboard={scene} />);
+    await userEvent.click(await screen.findByTestId(selectors.components.NavToolbar.editDashboard.editButton));
+
+    expect(scene.state.editable).toBe(true);
+    expect(scene.state.meta.canEdit).toBe(true);
+    expect(scene.state.meta.canSave).toBe(true);
   });
 });

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.tsx
@@ -13,7 +13,7 @@ export const MakeDashboardEditableButton = ({ dashboard }: ToolbarActionProps) =
       onClick={() => {
         trackDashboardSceneEditButtonClicked(dashboard.state.uid);
         dashboard.onEnterEditMode();
-        dashboard.setState({ editable: true, meta: { ...dashboard.state.meta, canEdit: true } });
+        dashboard.setState({ editable: true, meta: { ...dashboard.state.meta, canEdit: true, canSave: true } });
       }}
       tooltip={t('dashboard.toolbar.new.enter-edit-mode.tooltip', 'This dashboard was marked as read only')}
       variant="secondary"

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/MakeDashboardEditableButton.tsx
@@ -13,7 +13,7 @@ export const MakeDashboardEditableButton = ({ dashboard }: ToolbarActionProps) =
       onClick={() => {
         trackDashboardSceneEditButtonClicked(dashboard.state.uid);
         dashboard.onEnterEditMode();
-        dashboard.setState({ editable: true, meta: { ...dashboard.state.meta, canEdit: true, canSave: true } });
+        dashboard.setState({ meta: { ...dashboard.state.meta, canEdit: true, canSave: true } });
       }}
       tooltip={t('dashboard.toolbar.new.enter-edit-mode.tooltip', 'This dashboard was marked as read only')}
       variant="secondary"


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Turning a read-only dashboard editable does not start showing the versions tab, which is incorrect. After a dashboard becomes editable it should be able to revert to previous versions.

**Why do we need this feature?**

Fixes a bug where the versions tab would not show after making dashboard editable

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
