### PR TITLE
Dashboards: Fix autogrid selection / drag and drop

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -123,16 +123,19 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({ width: '100%', height: '100%', position: 'relative' }),
   draggedWrapper: css({
-    // Unfortunately, we need to enforce position absolute here. Otherwise, the position will be overwritten with
-    //  a relative position by .dashboard-visible-hidden-element
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    position: 'absolute !important' as 'absolute',
+    position: 'absolute',
     zIndex: 1000,
     top: `var(${DRAGGED_ITEM_TOP})`,
     left: `var(${DRAGGED_ITEM_LEFT})`,
     width: `var(${DRAGGED_ITEM_WIDTH})`,
     height: `var(${DRAGGED_ITEM_HEIGHT})`,
     opacity: 0.8,
+
+    // Unfortunately, we need to re-enforce the absolute position here. Otherwise, the position will be overwritten with
+    //  a relative position by .dashboard-visible-hidden-element
+    '&.dashboard-visible-hidden-element': {
+      position: 'absolute',
+    },
   }),
   draggedRepeatWrapper: css({
     visibility: 'hidden',

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridItemRenderer.tsx
@@ -123,7 +123,10 @@ export function AutoGridItemRenderer({ model }: SceneComponentProps<AutoGridItem
 const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({ width: '100%', height: '100%', position: 'relative' }),
   draggedWrapper: css({
-    position: 'absolute',
+    // Unfortunately, we need to enforce position absolute here. Otherwise, the position will be overwritten with
+    //  a relative position by .dashboard-visible-hidden-element
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+    position: 'absolute !important' as 'absolute',
     zIndex: 1000,
     top: `var(${DRAGGED_ITEM_TOP})`,
     left: `var(${DRAGGED_ITEM_LEFT})`,

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayout.tsx
@@ -65,6 +65,7 @@ export class AutoGridLayout extends SceneObjectBase<AutoGridLayoutState> impleme
     top: number;
     left: number;
   } | null = null;
+  private _lastDropTargetGridItemKey: string | null = null;
 
   public constructor(state: Partial<AutoGridLayoutState>) {
     super({
@@ -145,6 +146,7 @@ export class AutoGridLayout extends SceneObjectBase<AutoGridLayoutState> impleme
     }
 
     this._draggedGridItem = gridItem;
+    this._lastDropTargetGridItemKey = gridItem.state.key!;
 
     const { top, left, width, height } = this._draggedGridItem.getBoundingBox();
     this._initialGridItemPosition = { pageX: evt.pageX, pageY: evt.pageY, top, left: left };
@@ -166,6 +168,7 @@ export class AutoGridLayout extends SceneObjectBase<AutoGridLayoutState> impleme
 
     this._draggedGridItem = null;
     this._initialGridItemPosition = null;
+    this._lastDropTargetGridItemKey = null;
     this._resetPanelPositionAndSize();
 
     this.setState({ draggingKey: undefined });
@@ -196,7 +199,7 @@ export class AutoGridLayout extends SceneObjectBase<AutoGridLayoutState> impleme
       })
       ?.getAttribute('data-auto-grid-item-drop-target');
 
-    if (dropTargetGridItemKey) {
+    if (dropTargetGridItemKey && dropTargetGridItemKey !== this._lastDropTargetGridItemKey) {
       this._onDragOverItem(dropTargetGridItemKey);
     }
   }
@@ -207,12 +210,14 @@ export class AutoGridLayout extends SceneObjectBase<AutoGridLayoutState> impleme
     const draggedIdx = children.findIndex((child) => child === this._draggedGridItem);
     const draggedOverIdx = children.findIndex((child) => child.state.key === key);
 
-    if (draggedIdx === -1 || draggedOverIdx === -1) {
+    if (draggedIdx === -1 || draggedOverIdx === -1 || draggedIdx === draggedOverIdx) {
+      this._lastDropTargetGridItemKey = key;
       return;
     }
 
     children.splice(draggedIdx, 1);
     children.splice(draggedOverIdx, 0, this._draggedGridItem!);
+    this._lastDropTargetGridItemKey = this._draggedGridItem!.state.key!;
 
     this.setState({ children });
   }


### PR DESCRIPTION
**What is this feature?**

This PR brings two changes to drag and drop in the autogrid:
1. Fix selecting a panel that contains the conditional rendering overlay. This was caused by the `position: relative` CSS property brought by the conditional rendering CSS class.
2. Prevent re-calculating the order of the children when dragging a panel over the same panel.

**Why do we need this feature?**

Prepare for private preview.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #113491 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
