### PR TITLE
Alerting: Fix alert instances count display

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -44,20 +44,21 @@ interface ShowMoreInstancesProps {
 
 function ShowMoreInstances({ stats, onClick, href }: ShowMoreInstancesProps) {
   const styles = useStyles2(getStyles);
+  const { visibleItemsCount, totalItemsCount } = stats;
 
   return (
     <div className={styles.footerRow}>
       <div>
         <Trans
           i18nKey="alerting.rule-details-matching-instances.showing-count"
-          values={{ visibleItems: stats.visibleItemsCount, totalItems: stats.totalItemsCount }}
+          values={{ visibleItemsCount, totalItemsCount }}
         >
-          Showing {'{{visibleItems}}'} out of {'{{totalItems}}'} instances
+          Showing {{ visibleItemsCount }} out of {{ totalItemsCount }} instances
         </Trans>
       </div>
       <LinkButton size="sm" variant="secondary" data-testid="show-all" onClick={onClick} href={href}>
-        <Trans i18nKey="alerting.rule-details-matching-instances.button-show-all" count={stats.totalItemsCount}>
-          Show all {'{{totalItems}}'} alert instances
+        <Trans i18nKey="alerting.rule-details-matching-instances.button-show-all" values={{ totalItemsCount }}>
+          Show all {{ totalItemsCount }} alert instances
         </Trans>
       </LinkButton>
     </div>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2334,9 +2334,8 @@
       "label-tenant-sources": "Tenant sources"
     },
     "rule-details-matching-instances": {
-      "button-show-all_one": "Show all {{totalItems}} alert instances",
-      "button-show-all_other": "Show all {{totalItems}} alert instances",
-      "showing-count": "Showing {{visibleItems}} out of {{totalItems}} instances"
+      "button-show-all": "Show all {{totalItemsCount}} alert instances",
+      "showing-count": "Showing {{visibleItemsCount}} out of {{totalItemsCount}} instances"
     },
     "rule-editor": {
       "get-content": {


### PR DESCRIPTION
Relates to escalation: https://github.com/grafana/support-escalations/issues/19812

**Root Cause:**
Placeholders `{{totalItems}}` and `{{visibleItems}}` are wrapped in JS string literals so can't be properly interpreted by the Trans translation component

**Fix:**
Add the instances counts as values props to Trans component

Before:
<img width="1502" height="720" alt="Screenshot 2025-12-08 at 12 20 47" src="https://github.com/user-attachments/assets/0fc063f8-26ca-442b-97e9-81e9eb9444b3" />

After:
<img width="1503" height="730" alt="Screenshot 2025-12-08 at 12 34 50" src="https://github.com/user-attachments/assets/4907cacf-4049-4dfb-8fc8-1b4d2928eaee" />
