### PR TITLE
Alerting: Initialize rule routine with initial alert rule fingerprint

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -334,7 +334,7 @@ func TestAlertRuleAfterEval(t *testing.T) {
 		ruleStore.PutRule(context.Background(), rule)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 
 		return &testContext{
 			rule:         rule,
@@ -503,7 +503,14 @@ func blankRuleForTests(ctx context.Context, key models.AlertRuleKeyWithGroup) *a
 		Log:       log.NewNopLogger(),
 	}
 	st := state.NewManager(managerCfg, state.NewNoopPersister())
-	return newAlertRule(ctx, key, nil, false, RetryConfig{}, nil, st, nil, nil, nil, log.NewNopLogger(), nil, featuremgmt.WithFeatures(), nil, nil)
+	// Create a minimal rule from the key
+	rule := &models.AlertRule{
+		OrgID:     key.OrgID,
+		UID:       key.UID,
+		RuleGroup: key.RuleGroup,
+	}
+	rf := ruleWithFolder{rule: rule, folderTitle: ""}
+	return newAlertRule(ctx, rf, nil, false, RetryConfig{}, nil, st, nil, nil, nil, log.NewNopLogger(), nil, featuremgmt.WithFeatures(), nil, nil)
 }
 
 func TestRuleRoutine(t *testing.T) {
@@ -540,7 +547,7 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			ruleInfo := factory.new(ctx, rule)
+			ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
 			go func() {
 				_ = ruleInfo.Run()
 			}()
@@ -728,7 +735,8 @@ func TestRuleRoutine(t *testing.T) {
 
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
-			ruleInfo := factory.new(ctx, rule)
+			folderTitle := ""
+			ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
 			go func() {
 				err := ruleInfo.Run()
 				stoppedChan <- err
@@ -750,7 +758,7 @@ func TestRuleRoutine(t *testing.T) {
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID))
 
 			factory := ruleFactoryFromScheduler(sch)
-			ruleInfo := factory.new(context.Background(), rule)
+			ruleInfo := factory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 			go func() {
 				err := ruleInfo.Run()
 				stoppedChan <- err
@@ -774,7 +782,7 @@ func TestRuleRoutine(t *testing.T) {
 			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID))
 
 			factory := ruleFactoryFromScheduler(sch)
-			ruleInfo := factory.new(context.Background(), rule)
+			ruleInfo := factory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 			go func() {
 				err := ruleInfo.Run()
 				stoppedChan <- err
@@ -804,7 +812,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx, rule)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
 
 		go func() {
 			_ = ruleInfo.Run()
@@ -871,6 +879,140 @@ func TestRuleRoutine(t *testing.T) {
 		})
 	})
 
+	t.Run("when update is sent before first evaluation", func(t *testing.T) {
+		rule := gen.With(withQueryForState(t, eval.Normal)).GenerateRef()
+		folderTitle := "folderName"
+
+		evalAppliedChan := make(chan time.Time)
+
+		sender := NewSyncAlertsSenderMock()
+		sender.EXPECT().Send(mock.Anything, rule.GetKey(), mock.Anything).Return()
+
+		sch, ruleStore, _, _ := createSchedule(evalAppliedChan, sender, clock.NewMock())
+		ruleStore.PutRule(context.Background(), rule)
+		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+
+		// Add state to verify it's not cleared
+		states := []*state.State{
+			{
+				AlertRuleUID: rule.UID,
+				CacheID:      data.Labels(rule.Labels).Fingerprint(),
+				OrgID:        rule.OrgID,
+				State:        eval.Alerting,
+				StartsAt:     sch.clock.Now(),
+				EndsAt:       sch.clock.Now().Add(5 * time.Second),
+				Labels:       rule.Labels,
+			},
+		}
+		sch.stateManager.Put(states)
+
+		t.Run("should not reset state if fingerprint is the same", func(t *testing.T) {
+			factory := ruleFactoryFromScheduler(sch)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
+
+			go func() {
+				_ = ruleInfo.Run()
+			}()
+
+			// Send update before first evaluation - same rule, same fingerprint
+			// This should not reset state since fingerprint is the same
+			ruleInfo.Update(&Evaluation{rule: rule, folderTitle: folderTitle})
+
+			// Give time for update to be processed
+			time.Sleep(100 * time.Millisecond)
+
+			actualStates := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
+			require.NotEmpty(t, actualStates)
+		})
+
+		t.Run("should reset state if fingerprint is different", func(t *testing.T) {
+			// Re-add state for this test
+			sch.stateManager.Put(states)
+
+			sender := NewSyncAlertsSenderMock()
+			sender.EXPECT().Send(mock.Anything, rule.GetKey(), mock.Anything).Return()
+
+			sch2, ruleStore2, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
+			ruleStore2.PutRule(context.Background(), rule)
+			sch2.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+			sch2.stateManager.Put(states)
+
+			factory := ruleFactoryFromScheduler(sch2)
+			ctx, cancel := context.WithCancel(context.Background())
+			t.Cleanup(cancel)
+			ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
+
+			go func() {
+				_ = ruleInfo.Run()
+			}()
+
+			// Send update before first eval, with a changed alert rule title.
+			// This should reset state and send resolved alerts
+			updatedRule := models.CopyRule(rule, gen.WithTitle(util.GenerateShortUID()))
+			ruleInfo.Update(&Evaluation{rule: updatedRule, folderTitle: folderTitle})
+
+			// Wait for sender to be called (which happens when state is cleared and resolved alerts are sent)
+			require.Eventually(t, func() bool {
+				return len(sender.Calls()) > 0
+			}, 5*time.Second, 100*time.Millisecond)
+
+			// State should be cleared because fingerprint changed
+			actualStates := sch2.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
+			require.Empty(t, actualStates)
+		})
+	})
+
+	t.Run("paused rule should reset state on first evaluation", func(t *testing.T) {
+		rule := gen.With(withQueryForState(t, eval.Normal)).GenerateRef()
+		rule.IsPaused = true
+		folderTitle := "folderName"
+
+		sender := NewSyncAlertsSenderMock()
+		sender.EXPECT().Send(mock.Anything, rule.GetKey(), mock.Anything).Return()
+
+		sch, ruleStore, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
+		ruleStore.PutRule(context.Background(), rule)
+		sch.schedulableAlertRules.set([]*models.AlertRule{rule}, map[models.FolderKey]string{rule.GetFolderKey(): folderTitle})
+
+		states := []*state.State{
+			{
+				AlertRuleUID: rule.UID,
+				CacheID:      data.Labels(rule.Labels).Fingerprint(),
+				OrgID:        rule.OrgID,
+				State:        eval.Alerting,
+				StartsAt:     sch.clock.Now(),
+				EndsAt:       sch.clock.Now().Add(5 * time.Second),
+				Labels:       rule.Labels,
+			},
+		}
+		sch.stateManager.Put(states)
+		require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID))
+
+		factory := ruleFactoryFromScheduler(sch)
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: folderTitle})
+
+		go func() {
+			_ = ruleInfo.Run()
+		}()
+
+		ruleInfo.Eval(&Evaluation{
+			scheduledAt: sch.clock.Now(),
+			rule:        rule,
+			folderTitle: folderTitle,
+		})
+
+		require.Eventually(t, func() bool {
+			return len(sender.Calls()) > 0
+		}, 5*time.Second, 100*time.Millisecond)
+
+		actualStates := sch.stateManager.GetStatesForRuleUID(rule.OrgID, rule.UID)
+		require.Empty(t, actualStates)
+	})
+
 	t.Run("when evaluation fails", func(t *testing.T) {
 		rule := gen.With(withQueryForState(t, eval.Error)).GenerateRef()
 		rule.ExecErrState = models.ErrorErrState
@@ -910,7 +1052,7 @@ func TestRuleRoutine(t *testing.T) {
 
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx, rule)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
 
 		go func() {
 			_ = ruleInfo.Run()
@@ -1044,7 +1186,7 @@ func TestRuleRoutine(t *testing.T) {
 			factory := ruleFactoryFromScheduler(sch)
 			ctx, cancel := context.WithCancel(context.Background())
 			t.Cleanup(cancel)
-			ruleInfo := factory.new(ctx, rule)
+			ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
 
 			go func() {
 				_ = ruleInfo.Run()
@@ -1078,7 +1220,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx, rule)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
 
 		go func() {
 			_ = ruleInfo.Run()
@@ -1119,7 +1261,7 @@ func TestRuleRoutine(t *testing.T) {
 		factory := ruleFactoryFromScheduler(sch)
 		ctx, cancel := context.WithCancel(context.Background())
 		t.Cleanup(cancel)
-		ruleInfo := factory.new(ctx, rule)
+		ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
 
 		go func() {
 			_ = ruleInfo.Run()
@@ -1214,7 +1356,7 @@ func TestAlertRuleRetry(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
-	ruleInfo := factory.new(ctx, rule)
+	ruleInfo := factory.new(ctx, ruleWithFolder{rule: rule, folderTitle: ""})
 
 	go func() {
 		_ = ruleInfo.Run()

--- a/pkg/services/ngalert/schedule/recording_rule_test.go
+++ b/pkg/services/ngalert/schedule/recording_rule_test.go
@@ -239,7 +239,7 @@ func TestRecordingRuleAfterEval(t *testing.T) {
 		ruleStore.PutRule(context.Background(), rule)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 
 		evalDoneChan := make(chan time.Time, 1) // Buffer to avoid blocking
 		afterEvalCh := make(chan struct{}, 1)   // Buffer to avoid blocking
@@ -444,7 +444,7 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 		folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 		evalDoneChan := make(chan time.Time)
 		process.(*recordingRule).evalAppliedHook = func(_ models.AlertRuleKey, t time.Time) {
 			evalDoneChan <- t
@@ -583,7 +583,7 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 		folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 		evalDoneChan := make(chan time.Time)
 		process.(*recordingRule).evalAppliedHook = func(_ models.AlertRuleKey, t time.Time) {
 			evalDoneChan <- t
@@ -728,7 +728,7 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 		folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 		evalDoneChan := make(chan time.Time)
 		process.(*recordingRule).evalAppliedHook = func(_ models.AlertRuleKey, t time.Time) {
 			evalDoneChan <- t
@@ -787,7 +787,7 @@ func testRecordingRule_Integration(t *testing.T, writeTarget *writer.TestRemoteW
 		folderTitle := ruleStore.getNamespaceTitle(rule.NamespaceUID)
 		ruleFactory := ruleFactoryFromScheduler(sch)
 
-		process := ruleFactory.new(context.Background(), rule)
+		process := ruleFactory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
 		evalDoneChan := make(chan time.Time)
 		process.(*recordingRule).evalAppliedHook = func(_ models.AlertRuleKey, t time.Time) {
 			evalDoneChan <- t

--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -21,7 +21,7 @@ var (
 )
 
 type ruleFactory interface {
-	new(context.Context, *models.AlertRule) Rule
+	new(context.Context, ruleWithFolder) Rule
 }
 
 type ruleRegistry struct {
@@ -35,14 +35,14 @@ func newRuleRegistry() ruleRegistry {
 
 // getOrCreate gets a rule routine from registry for the provided rule. If it does not exist, it creates a new one.
 // Returns a pointer to the rule routine and a flag that indicates whether it is a new struct or not.
-func (r *ruleRegistry) getOrCreate(context context.Context, item *models.AlertRule, factory ruleFactory) (Rule, bool) {
+func (r *ruleRegistry) getOrCreate(context context.Context, rf ruleWithFolder, factory ruleFactory) (Rule, bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	key := item.GetKey()
+	key := rf.rule.GetKey()
 	rule, ok := r.rules[key]
 	if !ok {
-		rule = factory.new(context, item)
+		rule = factory.new(context, rf)
 		r.rules[key] = rule
 	}
 	return rule, !ok

--- a/pkg/services/ngalert/schedule/schedule_unit_test.go
+++ b/pkg/services/ngalert/schedule/schedule_unit_test.go
@@ -1107,7 +1107,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			rule := models.RuleGen.GenerateRef()
 			ruleStore.PutRule(ctx, rule)
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreate(ctx, rule, ruleFactory)
+			info, _ := sch.registry.getOrCreate(ctx, ruleWithFolder{rule: rule, folderTitle: ""}, ruleFactory)
 
 			sch.deleteAlertRule(ctx, key)
 
@@ -1126,7 +1126,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			rule := models.RuleGen.GenerateRef()
 			ruleStore.PutRule(ctx, rule)
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreate(ctx, rule, ruleFactory)
+			info, _ := sch.registry.getOrCreate(ctx, ruleWithFolder{rule: rule, folderTitle: ""}, ruleFactory)
 
 			_, err := sch.updateSchedulableAlertRules(ctx)
 			require.NoError(t, err)
@@ -1149,7 +1149,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			rule := models.RuleGen.GenerateRef()
 			ruleStore.PutRule(ctx, rule)
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreate(ctx, rule, ruleFactory)
+			info, _ := sch.registry.getOrCreate(ctx, ruleWithFolder{rule: rule, folderTitle: ""}, ruleFactory)
 
 			_, err := sch.updateSchedulableAlertRules(ctx)
 			require.NoError(t, err)
@@ -1172,7 +1172,7 @@ func TestSchedule_deleteAlertRule(t *testing.T) {
 			ruleFactory := ruleFactoryFromScheduler(sch)
 			rule := models.RuleGen.GenerateRef()
 			key := rule.GetKey()
-			info, _ := sch.registry.getOrCreate(ctx, rule, ruleFactory)
+			info, _ := sch.registry.getOrCreate(ctx, ruleWithFolder{rule: rule, folderTitle: ""}, ruleFactory)
 
 			_, err := sch.updateSchedulableAlertRules(ctx)
 			require.NoError(t, err)


### PR DESCRIPTION
If an alert rule routine receives update via `a.updateCh` before the first evaluation happens, it resets the alert rule state because of this check:

https://github.com/grafana/grafana/blob/15c93100abd9358292b2c5d97da2c78e284983b4/pkg/services/ngalert/schedule/alert_rule.go#L254-L264

Initially `currentFingerprint` is 0 and is updated on the first evaluation, so any rule update before that triggers a reset, even when fingerprint does not change:

https://github.com/grafana/grafana/blob/15c93100abd9358292b2c5d97da2c78e284983b4/pkg/services/ngalert/schedule/alert_rule.go#L249

https://github.com/grafana/grafana/blob/15c93100abd9358292b2c5d97da2c78e284983b4/pkg/services/ngalert/schedule/alert_rule.go#L311