### PR TITLE
Authorization: panic when specific authorizer returns nil

### DIFF
--- a/pkg/registry/apis/service/register.go
+++ b/pkg/registry/apis/service/register.go
@@ -12,6 +12,7 @@ import (
 
 	service "github.com/grafana/grafana/pkg/apis/service/v0alpha1"
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
+	roleauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
@@ -37,7 +38,7 @@ func RegisterAPIService(features featuremgmt.FeatureToggles, apiregistration bui
 }
 
 func (b *ServiceAPIBuilder) GetAuthorizer() authorizer.Authorizer {
-	return nil // default authorizer is fine
+	return roleauthorizer.NewRoleAuthorizer()
 }
 
 func (b *ServiceAPIBuilder) GetGroupVersion() schema.GroupVersion {

--- a/pkg/services/apiserver/appinstaller/installer.go
+++ b/pkg/services/apiserver/appinstaller/installer.go
@@ -108,6 +108,9 @@ func RegisterAuthorizers(
 		if authorizerProvider, ok := installer.(AuthorizerProvider); ok {
 			authorizer := authorizerProvider.GetAuthorizer()
 			for _, gv := range installer.GroupVersions() {
+				if authorizer == nil {
+					panic("authorizer cannot be nil for api group: " + gv.String())
+				}
 				registrar.Register(gv, authorizer)
 				logger.Debug("Registered authorizer", "group", gv.Group, "version", gv.Version, "app")
 			}

--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -42,6 +42,8 @@ func NewGrafanaBuiltInSTAuthorizer(cfg *setting.Cfg) *GrafanaAuthorizer {
 
 	// org role is last -- and will return allow for verbs that match expectations
 	// The apiVersion flavors will run first and can return early when FGAC has appropriate rules
+	// NOTE: role authorizer is now used by some api groups as their specific authorizer
+	// but there are still some apis not directly registered in the embedded delegate that benefit from including it here
 	authorizers = append(authorizers, NewRoleAuthorizer())
 	return &GrafanaAuthorizer{
 		apis: apis,

--- a/pkg/services/apiserver/auth/authorizer/authorizer.go
+++ b/pkg/services/apiserver/auth/authorizer/authorizer.go
@@ -42,7 +42,7 @@ func NewGrafanaBuiltInSTAuthorizer(cfg *setting.Cfg) *GrafanaAuthorizer {
 
 	// org role is last -- and will return allow for verbs that match expectations
 	// The apiVersion flavors will run first and can return early when FGAC has appropriate rules
-	authorizers = append(authorizers, newRoleAuthorizer())
+	authorizers = append(authorizers, NewRoleAuthorizer())
 	return &GrafanaAuthorizer{
 		apis: apis,
 		auth: union.New(authorizers...),

--- a/pkg/services/apiserver/auth/authorizer/role.go
+++ b/pkg/services/apiserver/auth/authorizer/role.go
@@ -19,7 +19,7 @@ var orgRoleNoneAsViewerAPIGroups = []string{
 
 type roleAuthorizer struct{}
 
-func newRoleAuthorizer() *roleAuthorizer {
+func NewRoleAuthorizer() *roleAuthorizer {
 	return &roleAuthorizer{}
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Panic when missing specific authorizer implementation for an app installer

**Why do we need this feature?**

Default to fail in local development might be useful than finding problems later in deployments.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
