### PR TITLE
PostgreSQL: Add variable query editor support

### DIFF
--- a/docs/sources/datasources/postgres/query-editor/_index.md
+++ b/docs/sources/datasources/postgres/query-editor/_index.md
@@ -279,7 +279,41 @@ Refer to [Templates](ref:templates) for an introduction to creating template var
 
 If you add a `Query` template variable you can write a PostgreSQL query to retrieve items such as measurement names, key names, or key values, which will be displayed in the drop-down menu.
 
-For example, you can use a variable to retrieve all the values from the `hostname` column in a table by creating the following query in the templating variable _Query_ setting.
+The PostgreSQL variable query editor supports both **Builder** and **Code** modes, similar to the standard query editor.
+
+#### Builder mode for variables
+
+{{< admonition type="note" >}}
+Builder mode for variable queries is currently behind the `postgresVariableQueryEditor` feature toggle.
+{{< /admonition >}}
+
+Builder mode provides a visual interface for creating variable queries. When using Builder mode for variable queries, the **Alias** dropdown includes predefined options `__text` and `__value` to easily create key/value variables.
+
+{{< figure src="/static/img/docs/postgresql-variable-query-editor.png" class="docs-image--no-shadow" caption="PostgreSQL variable query editor in Builder mode" >}}
+
+For example, to create a variable that displays hostnames but uses IDs as values:
+
+1. Select your table from the **Table** dropdown.
+2. Add a column for the display text (for example, `hostname`) and set its **Alias** to `__text`.
+3. Add another column for the value (for example, `id`) and set its **Alias** to `__value`.
+
+This generates a query equivalent to `SELECT hostname AS __text, id AS __value FROM host`.
+
+#### Multiple properties
+
+When you create a key/value variable with `__text` and `__value`, you can also include additional columns to store extra properties. These additional properties can be accessed using dot notation.
+
+For example, if you have a variable named `server` with columns for `hostname` (as `__text`), `id` (as `__value`), and `region`, you can access the region property using `${server.region}`.
+
+To add multiple properties:
+
+1. Set up your `__text` and `__value` columns as described above.
+2. Add additional columns for any extra properties you want to include.
+3. Access the properties in your queries or panels using `${variableName.propertyName}`.
+
+#### Code mode for variables
+
+In Code mode, you can write PostgreSQL queries directly. For example, you can use a variable to retrieve all the values from the `hostname` column in a table by creating the following query in the templating variable _Query_ setting.
 
 ```sql
 SELECT hostname FROM host
@@ -297,7 +331,9 @@ To use time range dependent macros like `$__timeFilter(column)` in your query, y
 SELECT event_name FROM event_log WHERE $__timeFilter(time_column)
 ```
 
-Another option is a query that can create a key/value variable. The query should return two columns that are named `__text` and `__value`. The `__text` column must contain unique values (if not, only the first value is used). This allows the drop-down options to display a text-friendly name as the text while using an ID as the value. For example, a query could use `hostname` as the text and `id` as the value:
+Another option is a query that can create a key/value variable. The query should return two columns that are named `__text` and `__value`. The `__text` column must contain unique values (if not, only the first value is used). This allows the drop-down options to display a text-friendly name as the text while using an ID as the value.
+
+You can create key/value variables using Builder mode by selecting the predefined `__text` and `__value` alias options, or write the query directly in Code mode. For example, a query could use `hostname` as the text and `id` as the value:
 
 ```sql
 SELECT hostname AS __text, id AS __value FROM host

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1161,6 +1161,10 @@ export interface FeatureToggles {
   */
   jaegerEnableGrpcEndpoint?: boolean;
   /**
+  * Enable the new variable query editor for the PostgreSQL data source
+  */
+  postgresVariableQueryEditor?: boolean;
+  /**
   * Load plugins on store service startup instead of wire provider, and call RegisterFixedRoles after all plugins are loaded
   * @default false
   */

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -21,6 +21,7 @@
     "@grafana/i18n": "12.4.0-pre",
     "@grafana/plugin-ui": "^0.11.0",
     "@grafana/runtime": "12.4.0-pre",
+    "@grafana/schema": "12.4.0-pre",
     "@grafana/ui": "12.4.0-pre",
     "@react-awesome-query-builder/ui": "6.6.15",
     "immutable": "5.1.4",

--- a/packages/grafana-sql/src/components/QueryEditor.tsx
+++ b/packages/grafana-sql/src/components/QueryEditor.tsx
@@ -15,7 +15,7 @@ import { RawEditor } from './query-editor-raw/RawEditor';
 import { VisualEditor } from './visual-query-builder/VisualEditor';
 
 export interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
-  queryHeaderProps?: Pick<QueryHeaderProps, 'dialect'>;
+  queryHeaderProps?: Pick<QueryHeaderProps, 'dialect' | 'hideRunButton' | 'hideFormatSelector'>;
 }
 
 export default function SqlQueryEditor({
@@ -99,6 +99,8 @@ export default function SqlQueryEditor({
         query={queryWithDefaults}
         isQueryRunnable={isQueryRunnable}
         dialect={dialect}
+        hideRunButton={queryHeaderProps?.hideRunButton}
+        hideFormatSelector={queryHeaderProps?.hideFormatSelector}
       />
 
       <Space v={0.5} />

--- a/packages/grafana-sql/src/components/QueryEditor.tsx
+++ b/packages/grafana-sql/src/components/QueryEditor.tsx
@@ -16,6 +16,7 @@ import { VisualEditor } from './visual-query-builder/VisualEditor';
 
 export interface SqlQueryEditorProps extends QueryEditorProps<SqlDatasource, SQLQuery, SQLOptions> {
   queryHeaderProps?: Pick<QueryHeaderProps, 'dialect' | 'hideRunButton' | 'hideFormatSelector'>;
+  isVariableQuery?: boolean;
 }
 
 export default function SqlQueryEditor({
@@ -25,6 +26,7 @@ export default function SqlQueryEditor({
   onRunQuery,
   range,
   queryHeaderProps,
+  isVariableQuery = false,
 }: SqlQueryEditorProps) {
   const [isQueryRunnable, setIsQueryRunnable] = useState(true);
   const db = datasource.getDB();
@@ -113,6 +115,7 @@ export default function SqlQueryEditor({
           queryRowFilter={queryRowFilter}
           onValidate={setIsQueryRunnable}
           range={range}
+          isVariableQuery={isVariableQuery}
         />
       )}
 

--- a/packages/grafana-sql/src/components/QueryHeader.tsx
+++ b/packages/grafana-sql/src/components/QueryHeader.tsx
@@ -25,6 +25,8 @@ export interface QueryHeaderProps {
   preconfiguredDataset: string;
   query: QueryWithDefaults;
   queryRowFilter: QueryRowFilter;
+  hideRunButton?: boolean;
+  hideFormatSelector?: boolean;
 }
 
 export function QueryHeader({
@@ -37,6 +39,8 @@ export function QueryHeader({
   preconfiguredDataset,
   query,
   queryRowFilter,
+  hideRunButton,
+  hideFormatSelector,
 }: QueryHeaderProps) {
   const { editorMode } = query;
   const [_, copyToClipboard] = useCopyToClipboard();
@@ -123,14 +127,16 @@ export function QueryHeader({
   return (
     <>
       <EditorHeader>
-        <InlineSelect
-          label={t('grafana-sql.components.query-header.label-format', 'Format')}
-          value={query.format}
-          placeholder={t('grafana-sql.components.query-header.placeholder-select-format', 'Select format')}
-          menuShouldPortal
-          onChange={onFormatChange}
-          options={QUERY_FORMAT_OPTIONS}
-        />
+        {!hideFormatSelector && (
+          <InlineSelect
+            label={t('grafana-sql.components.query-header.label-format', 'Format')}
+            value={query.format}
+            placeholder={t('grafana-sql.components.query-header.placeholder-select-format', 'Select format')}
+            menuShouldPortal
+            onChange={onFormatChange}
+            options={QUERY_FORMAT_OPTIONS}
+          />
+        )}
 
         {editorMode === EditorMode.Builder && (
           <>
@@ -222,26 +228,27 @@ export function QueryHeader({
 
         <FlexItem grow={1} />
 
-        {isQueryRunnable ? (
-          <Button icon="play" variant="primary" size="sm" onClick={() => onRunQuery()}>
-            <Trans i18nKey="grafana-sql.components.query-header.run-query">Run query</Trans>
-          </Button>
-        ) : (
-          <Tooltip
-            theme="error"
-            content={
-              <Trans i18nKey="grafana-sql.components.query-header.content-invalid-query">
-                Your query is invalid. Check below for details. <br />
-                However, you can still run this query.
-              </Trans>
-            }
-            placement="top"
-          >
-            <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
+        {!hideRunButton &&
+          (isQueryRunnable ? (
+            <Button icon="play" variant="primary" size="sm" onClick={() => onRunQuery()}>
               <Trans i18nKey="grafana-sql.components.query-header.run-query">Run query</Trans>
             </Button>
-          </Tooltip>
-        )}
+          ) : (
+            <Tooltip
+              theme="error"
+              content={
+                <Trans i18nKey="grafana-sql.components.query-header.content-invalid-query">
+                  Your query is invalid. Check below for details. <br />
+                  However, you can still run this query.
+                </Trans>
+              }
+              placement="top"
+            >
+              <Button icon="exclamation-triangle" variant="secondary" size="sm" onClick={() => onRunQuery()}>
+                <Trans i18nKey="grafana-sql.components.query-header.run-query">Run query</Trans>
+              </Button>
+            </Tooltip>
+          ))}
 
         <RadioButtonGroup options={editorModes} size="sm" value={editorMode} onChange={onEditorModeChange} />
 

--- a/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/SelectRow.tsx
@@ -20,18 +20,25 @@ interface SelectRowProps {
   onQueryChange: (sql: SQLQuery) => void;
   db: DB;
   columns: Array<SelectableValue<string>>;
+  isVariableQuery?: boolean;
 }
 
-export function SelectRow({ query, onQueryChange, db, columns }: SelectRowProps) {
+export function SelectRow({ query, onQueryChange, db, columns, isVariableQuery }: SelectRowProps) {
   const styles = useStyles2(getStyles);
   const { onSqlChange } = useSqlChange({ query, onQueryChange, db });
-  const timeSeriesAliasOpts: Array<SelectableValue<string>> = [];
+  const aliasOpts: Array<SelectableValue<string>> = [];
 
   // Add necessary alias options for time series format
   // when that format has been selected
   if (query.format === QueryFormat.Timeseries) {
-    timeSeriesAliasOpts.push({ label: t('grafana-sql.components.select-row.label.time', 'time'), value: 'time' });
-    timeSeriesAliasOpts.push({ label: t('grafana-sql.components.select-row.label.value', 'value'), value: 'value' });
+    aliasOpts.push({ label: t('grafana-sql.components.select-row.label.time', 'time'), value: 'time' });
+    aliasOpts.push({ label: t('grafana-sql.components.select-row.label.value', 'value'), value: 'value' });
+  }
+
+  // Add variable query alias options for text and value
+  if (isVariableQuery) {
+    aliasOpts.push({ label: t('grafana-sql.components.select-row.label.__text', '__text'), value: '__text' });
+    aliasOpts.push({ label: t('grafana-sql.components.select-row.label.__value', '__value'), value: '__value' });
   }
 
   const onAggregationChange = useCallback(
@@ -145,7 +152,7 @@ export function SelectRow({ query, onQueryChange, db, columns }: SelectRowProps)
                 value={item.alias ? toOption(item.alias) : null}
                 inputId={`select-alias-${index}-${uniqueId()}`}
                 data-testid={selectors.components.SQLQueryEditor.selectAlias}
-                options={timeSeriesAliasOpts}
+                options={aliasOpts}
                 onChange={onAliasChange(item, index)}
                 isClearable
                 menuShouldPortal

--- a/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/VisualEditor.tsx
@@ -16,9 +16,18 @@ interface VisualEditorProps extends QueryEditorProps {
   db: DB;
   queryRowFilter: QueryRowFilter;
   onValidate: (isValid: boolean) => void;
+  isVariableQuery?: boolean;
 }
 
-export const VisualEditor = ({ query, db, queryRowFilter, onChange, onValidate, range }: VisualEditorProps) => {
+export const VisualEditor = ({
+  query,
+  db,
+  queryRowFilter,
+  onChange,
+  onValidate,
+  range,
+  isVariableQuery,
+}: VisualEditorProps) => {
   const state = useAsync(async () => {
     const fields = await db.fields(query);
     return fields;
@@ -28,7 +37,13 @@ export const VisualEditor = ({ query, db, queryRowFilter, onChange, onValidate, 
     <>
       <EditorRows>
         <EditorRow>
-          <SelectRow columns={state.value || []} query={query} onQueryChange={onChange} db={db} />
+          <SelectRow
+            columns={state.value || []}
+            query={query}
+            onQueryChange={onChange}
+            db={db}
+            isVariableQuery={isVariableQuery}
+          />
         </EditorRow>
         {queryRowFilter.filter && (
           <EditorRow>

--- a/packages/grafana-sql/src/locales/en-US/grafana-sql.json
+++ b/packages/grafana-sql/src/locales/en-US/grafana-sql.json
@@ -107,6 +107,8 @@
           }
         },
         "label": {
+          "__text": "__text",
+          "__value": "__value",
           "time": "time",
           "value": "value"
         },

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1914,6 +1914,13 @@ var (
 			Owner:       grafanaOSSBigTent,
 		},
 		{
+			Name:         "postgresVariableQueryEditor",
+			Description:  "Enable the new variable query editor for the PostgreSQL data source",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaOSSBigTent,
+			FrontendOnly: true,
+		},
+		{
 			Name:         "pluginStoreServiceLoading",
 			Description:  "Load plugins on store service startup instead of wire provider, and call RegisterFixedRoles after all plugins are loaded",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -260,6 +260,7 @@ newVizSuggestions,preview,@grafana/dataviz-squad,false,false,true
 externalVizSuggestions,experimental,@grafana/dataviz-squad,false,false,true
 preventPanelChromeOverflow,preview,@grafana/grafana-frontend-platform,false,false,true
 jaegerEnableGrpcEndpoint,experimental,@grafana/oss-big-tent,false,false,false
+postgresVariableQueryEditor,experimental,@grafana/oss-big-tent,false,false,true
 pluginStoreServiceLoading,experimental,@grafana/plugins-platform-backend,false,false,false
 newPanelPadding,preview,@grafana/dashboards-squad,false,false,true
 onlyStoreActionSets,GA,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2694,6 +2694,19 @@
     },
     {
       "metadata": {
+        "name": "postgresVariableQueryEditor",
+        "resourceVersion": "1765231394616",
+        "creationTimestamp": "2025-12-08T22:03:14Z"
+      },
+      "spec": {
+        "description": "Enable the new variable query editor for the PostgreSQL data source",
+        "stage": "experimental",
+        "codeowner": "@grafana/oss-big-tent",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "preferLibraryPanelTitle",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-06-17T11:21:21Z"

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/VariableQueryEditor.tsx
@@ -15,6 +15,7 @@ export function VariableQueryEditor(props: QueryEditorProps<PostgresDatasource, 
     ...props,
     query: migrateVariableQuery(props.query),
     queryHeaderProps,
+    isVariableQuery: true,
   };
   return <SqlQueryEditorLazy {...newProps} />;
 }

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/VariableQueryEditor.tsx
@@ -1,0 +1,20 @@
+import { QueryEditorProps } from '@grafana/data';
+import { QueryHeaderProps, SQLOptions, SQLQuery, SqlQueryEditorLazy } from '@grafana/sql';
+
+import { PostgresDatasource } from './datasource';
+import { migrateVariableQuery } from './migrations';
+
+const queryHeaderProps: Pick<QueryHeaderProps, 'dialect' | 'hideRunButton' | 'hideFormatSelector'> = {
+  dialect: 'postgres',
+  hideRunButton: true,
+  hideFormatSelector: true,
+};
+
+export function VariableQueryEditor(props: QueryEditorProps<PostgresDatasource, SQLQuery, SQLOptions>) {
+  const newProps = {
+    ...props,
+    query: migrateVariableQuery(props.query),
+    queryHeaderProps,
+  };
+  return <SqlQueryEditorLazy {...newProps} />;
+}

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/migrations.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/migrations.test.ts
@@ -1,0 +1,82 @@
+import { QueryFormat, SQLQuery } from '@grafana/sql';
+
+import { migrateVariableQuery } from './migrations';
+
+describe('migrateVariableQuery', () => {
+  describe('when given a string query (legacy format)', () => {
+    it('should convert to SQLQuery format with rawSql and query fields', () => {
+      const result = migrateVariableQuery('SELECT hostname FROM hosts');
+
+      expect(result.rawSql).toBe('SELECT hostname FROM hosts');
+      expect(result.query).toBe('SELECT hostname FROM hosts');
+      expect(result.refId).toBe('SQLVariableQueryEditor-VariableQuery');
+    });
+
+    it('should handle empty string', () => {
+      const result = migrateVariableQuery('');
+
+      expect(result.rawSql).toBe('');
+      expect(result.query).toBe('');
+    });
+
+    it('should handle complex SQL queries', () => {
+      const complexQuery = `SELECT hostname AS __text, id AS __value FROM hosts WHERE region = 'us-east-1'`;
+      const result = migrateVariableQuery(complexQuery);
+
+      expect(result.rawSql).toBe(complexQuery);
+      expect(result.query).toBe(complexQuery);
+    });
+  });
+
+  describe('when given an SQLQuery object', () => {
+    it('should preserve the rawSql and add query field', () => {
+      const sqlQuery = {
+        refId: 'A',
+        rawSql: 'SELECT id FROM table',
+      };
+      const result = migrateVariableQuery(sqlQuery);
+
+      expect(result.rawSql).toBe('SELECT id FROM table');
+      expect(result.query).toBe('SELECT id FROM table');
+      expect(result.refId).toBe('A');
+    });
+
+    it('should handle SQLQuery with empty rawSql', () => {
+      const sqlQuery = {
+        refId: 'A',
+        rawSql: '',
+      };
+      const result = migrateVariableQuery(sqlQuery);
+
+      expect(result.rawSql).toBe('');
+      expect(result.query).toBe('');
+    });
+
+    it('should handle SQLQuery without rawSql', () => {
+      const sqlQuery = {
+        refId: 'A',
+      };
+      const result = migrateVariableQuery(sqlQuery);
+
+      expect(result.query).toBe('');
+    });
+
+    it('should preserve all existing SQLQuery properties', () => {
+      const sqlQuery: SQLQuery = {
+        refId: 'B',
+        rawSql: 'SELECT * FROM users',
+        format: QueryFormat.Table,
+        table: 'users',
+        dataset: 'mydb',
+      };
+      const result = migrateVariableQuery(sqlQuery);
+
+      expect(result.refId).toBe('B');
+      expect(result.rawSql).toBe('SELECT * FROM users');
+      expect(result.query).toBe('SELECT * FROM users');
+      expect(result.format).toBe(QueryFormat.Table);
+      expect(result.table).toBe('users');
+      expect(result.dataset).toBe('mydb');
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/migrations.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/migrations.ts
@@ -1,0 +1,20 @@
+import { applyQueryDefaults, type SQLQuery } from '@grafana/sql';
+
+import type { VariableQuery } from './types';
+
+export function migrateVariableQuery(rawQuery: string | SQLQuery): VariableQuery {
+  if (typeof rawQuery !== 'string') {
+    return {
+      ...rawQuery,
+      query: rawQuery.rawSql || '',
+    };
+  }
+
+  return {
+    ...applyQueryDefaults({
+      refId: 'SQLVariableQueryEditor-VariableQuery',
+      rawSql: rawQuery,
+    }),
+    query: rawQuery,
+  };
+}

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/responseParser.test.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/responseParser.test.ts
@@ -1,0 +1,177 @@
+import { FieldType, DataFrame } from '@grafana/data';
+
+import { transformMetricFindResponse } from './responseParser';
+
+describe('transformMetricFindResponse function', () => {
+  it('should handle big arrays', () => {
+    const stringValues = new Array(150_000).fill('a');
+    const numberValues = new Array(150_000).fill(1);
+
+    const frame: DataFrame = {
+      fields: [
+        { name: 'name', type: FieldType.string, config: {}, values: stringValues },
+        { name: 'value', type: FieldType.number, config: {}, values: numberValues },
+      ],
+      length: stringValues.length,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    // With the new logic, first field is text/value and additional fields are properties
+    // After deduplication, we get 1 unique item since all 'a' values deduplicate
+    // Fields named 'value' are not added to properties to avoid conflicts
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      text: 'a',
+      value: 'a',
+    });
+  });
+
+  it('should use first field as text and value with additional fields as properties', () => {
+    const frame: DataFrame = {
+      fields: [
+        { name: 'id', type: FieldType.string, config: {}, values: ['user1', 'user2', 'user3'] },
+        {
+          name: 'email',
+          type: FieldType.string,
+          config: {},
+          values: ['user1@test.com', 'user2@test.com', 'user3@test.com'],
+        },
+        { name: 'role', type: FieldType.string, config: {}, values: ['admin', 'user', 'guest'] },
+      ],
+      length: 3,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    expect(result).toHaveLength(3);
+    expect(result[0]).toEqual({
+      text: 'user1',
+      value: 'user1',
+      properties: {
+        email: 'user1@test.com',
+        role: 'admin',
+      },
+    });
+    expect(result[1]).toEqual({
+      text: 'user2',
+      value: 'user2',
+      properties: {
+        email: 'user2@test.com',
+        role: 'user',
+      },
+    });
+    expect(result[2]).toEqual({
+      text: 'user3',
+      value: 'user3',
+      properties: {
+        email: 'user3@test.com',
+        role: 'guest',
+      },
+    });
+  });
+
+  it('should handle single field without properties', () => {
+    const frame: DataFrame = {
+      fields: [{ name: 'name', type: FieldType.string, config: {}, values: ['value1', 'value2'] }],
+      length: 2,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      text: 'value1',
+      value: 'value1',
+    });
+    expect(result[1]).toEqual({
+      text: 'value2',
+      value: 'value2',
+    });
+  });
+
+  it('should still handle __text and __value fields', () => {
+    const frame: DataFrame = {
+      fields: [
+        { name: '__text', type: FieldType.string, config: {}, values: ['Display 1', 'Display 2'] },
+        { name: '__value', type: FieldType.string, config: {}, values: ['val1', 'val2'] },
+      ],
+      length: 2,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      text: 'Display 1',
+      value: 'val1',
+    });
+    expect(result[1]).toEqual({
+      text: 'Display 2',
+      value: 'val2',
+    });
+  });
+
+  it('should not add fields named "text" or "value" to properties', () => {
+    const frame: DataFrame = {
+      fields: [
+        { name: 'id', type: FieldType.string, config: {}, values: ['item1', 'item2'] },
+        { name: 'text', type: FieldType.string, config: {}, values: ['Text 1', 'Text 2'] },
+        { name: 'value', type: FieldType.string, config: {}, values: ['Value 1', 'Value 2'] },
+        { name: 'description', type: FieldType.string, config: {}, values: ['Desc 1', 'Desc 2'] },
+      ],
+      length: 2,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    expect(result).toHaveLength(2);
+    // Fields named 'text' and 'value' should not be in properties
+    expect(result[0]).toEqual({
+      text: 'item1',
+      value: 'item1',
+      properties: {
+        description: 'Desc 1',
+      },
+    });
+    expect(result[1]).toEqual({
+      text: 'item2',
+      value: 'item2',
+      properties: {
+        description: 'Desc 2',
+      },
+    });
+  });
+
+  it('should add additional fields as properties when __text and __value are present', () => {
+    const frame: DataFrame = {
+      fields: [
+        { name: '__text', type: FieldType.string, config: {}, values: ['Display 1', 'Display 2'] },
+        { name: '__value', type: FieldType.string, config: {}, values: ['val1', 'val2'] },
+        { name: 'category', type: FieldType.string, config: {}, values: ['cat1', 'cat2'] },
+        { name: 'priority', type: FieldType.number, config: {}, values: [1, 2] },
+      ],
+      length: 2,
+    };
+
+    const result = transformMetricFindResponse(frame);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({
+      text: 'Display 1',
+      value: 'val1',
+      properties: {
+        category: 'cat1',
+        priority: '1',
+      },
+    });
+    expect(result[1]).toEqual({
+      text: 'Display 2',
+      value: 'val2',
+      properties: {
+        category: 'cat2',
+        priority: '2',
+      },
+    });
+  });
+});

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/responseParser.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/responseParser.ts
@@ -1,0 +1,62 @@
+import { uniqBy } from 'lodash';
+
+import { DataFrame, Field, MetricFindValue } from '@grafana/data';
+
+export function transformMetricFindResponse(frame: DataFrame): MetricFindValue[] {
+  const textField = frame.fields.find((f) => f.name === '__text');
+  const valueField = frame.fields.find((f) => f.name === '__value');
+
+  let values: MetricFindValue[];
+
+  if (textField && valueField) {
+    const additionalFields = frame.fields.filter((f) => f.name !== '__text' && f.name !== '__value');
+    values = buildMetricFindValues(textField, valueField, additionalFields);
+  } else if (frame.fields.length > 0) {
+    // Support multiple fields by first field as text/value and additional fields as properties
+    const firstField = frame.fields[0];
+    const additionalFields = frame.fields.slice(1);
+    values = buildMetricFindValues(firstField, firstField, additionalFields);
+  } else {
+    values = [];
+  }
+
+  return uniqBy(values, 'text');
+}
+
+function buildMetricFindValues(textField: Field, valueField: Field, additionalFields: Field[]): MetricFindValue[] {
+  const values: MetricFindValue[] = [];
+
+  for (let i = 0; i < textField.values.length; i++) {
+    const item: MetricFindValue = {
+      text: '' + textField.values[i],
+      value: '' + valueField.values[i],
+    };
+
+    const properties = buildProperties(additionalFields, i);
+    if (properties) {
+      item.properties = properties;
+    }
+
+    values.push(item);
+  }
+
+  return values;
+}
+
+function buildProperties(fields: Field[], rowIndex: number): Record<string, string> | undefined {
+  if (fields.length === 0) {
+    return undefined;
+  }
+
+  const properties: Record<string, string> = {};
+
+  for (const field of fields) {
+    // Skip fields named 'text' or 'value' to avoid conflicts with top-level fields
+    if (field.name !== 'text' && field.name !== 'value') {
+      properties[field.name] = '' + field.values[rowIndex];
+    }
+  }
+
+  // Only return properties object if there are actual properties
+  return Object.keys(properties).length > 0 ? properties : undefined;
+}

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/types.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/types.ts
@@ -1,4 +1,4 @@
-import { SQLOptions } from '@grafana/sql';
+import { SQLOptions, SQLQuery } from '@grafana/sql';
 
 export enum PostgresTLSModes {
   disable = 'disable',
@@ -24,4 +24,8 @@ export interface PostgresOptions extends SQLOptions {
 
 export interface SecureJsonData {
   password?: string;
+}
+
+export interface VariableQuery extends SQLQuery {
+  query: string;
 }

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/variables.ts
@@ -15,6 +15,10 @@ export class SQLVariableSupport extends CustomVariableSupport<PostgresDatasource
   editor = VariableQueryEditor;
 
   query(request: DataQueryRequest<SQLQuery>): Observable<{ data: MetricFindValue[] }> {
+    if (!request.targets || request.targets.length === 0) {
+      return from(Promise.resolve([])).pipe(map((data) => ({ data })));
+    }
+
     const queryObj = migrateVariableQuery(request.targets[0]);
     const result = this.datasource.metricFindQuery(queryObj, { scopedVars: request.scopedVars, range: request.range });
 

--- a/public/app/plugins/datasource/grafana-postgresql-datasource/variables.ts
+++ b/public/app/plugins/datasource/grafana-postgresql-datasource/variables.ts
@@ -1,0 +1,27 @@
+import { from, map, Observable } from 'rxjs';
+
+import { CustomVariableSupport, DataQueryRequest, MetricFindValue } from '@grafana/data';
+import { applyQueryDefaults, SQLQuery } from '@grafana/sql';
+
+import { VariableQueryEditor } from './VariableQueryEditor';
+import { PostgresDatasource } from './datasource';
+import { migrateVariableQuery } from './migrations';
+
+export class SQLVariableSupport extends CustomVariableSupport<PostgresDatasource, SQLQuery> {
+  constructor(private readonly datasource: PostgresDatasource) {
+    super();
+  }
+
+  editor = VariableQueryEditor;
+
+  query(request: DataQueryRequest<SQLQuery>): Observable<{ data: MetricFindValue[] }> {
+    const queryObj = migrateVariableQuery(request.targets[0]);
+    const result = this.datasource.metricFindQuery(queryObj, { scopedVars: request.scopedVars, range: request.range });
+
+    return from(result).pipe(map((data) => ({ data })));
+  }
+
+  getDefaultQuery(): Partial<SQLQuery> {
+    return applyQueryDefaults({ refId: 'SQLVariableQueryEditor-VariableQuery' });
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3702,6 +3702,7 @@ __metadata:
     "@grafana/i18n": "npm:12.4.0-pre"
     "@grafana/plugin-ui": "npm:^0.11.0"
     "@grafana/runtime": "npm:12.4.0-pre"
+    "@grafana/schema": "npm:12.4.0-pre"
     "@grafana/ui": "npm:12.4.0-pre"
     "@react-awesome-query-builder/ui": "npm:6.6.15"
     "@testing-library/dom": "npm:10.4.1"


### PR DESCRIPTION
**What is this feature?**

![Screenshot 2025-12-09 at 14 53 39](https://github.com/user-attachments/assets/f388a13e-5224-4817-baf1-cf4f7888d4b2)

**Note**: This feature is behind a feature flag `postgresVariableQueryEditor`.

This pull request introduces a new variable query editor for the PostgreSQL data source. It updates the SQL query editor to better support variable queries. The changes are grouped below by theme:

**PostgreSQL Datasource Enhancements**

- Updated the PostgreSQL datasource to use the new variable query editor and variable support class (`SQLVariableSupport`) when the feature toggle is enabled. Also, set up a custom response parser for variable queries.
- **Adds support for multiple properties when `__text` and `__value` fields are selected.**

**SQL Query Editor and Visual Query Builder Improvements**

- Extended the SQL query editor and visual query builder to support variable queries. This includes new props (`isVariableQuery`, `hideRunButton`, `hideFormatSelector`) and logic to show appropriate alias options for variable queries.

**Why do we need this feature?**

Enhance writing query variable experience for PostgreSQL data source users.

**Who is this feature for?**

PostgreSQL data source users who doesn't want to write queries in a single textbox.

**Which issue(s) does this PR fix?**:

Fixes grafana/data-sources#1447

---

## Test plan

### Prerequisites
1. Enable the `postgresVariableQueryEditor` feature toggle in your Grafana configuration:
   ```ini
   [feature_toggles]
   postgresVariableQueryEditor = true
   ```
2. Have a PostgreSQL data source configured with access to a table (for example, a `host` table with columns like `id`, `hostname`, `region`)

### Test Builder mode for variables

1. Go to **Dashboard settings** → **Variables** → **New variable**
2. Select **Query** as the variable type
3. Select your PostgreSQL data source
4. Verify the query editor shows both **Builder** and **Code** mode tabs
5. In Builder mode:
   - Select a table from the **Table** dropdown
   - Add a column and verify the **Alias** dropdown shows `__text` and `__value` options
   - Set one column's alias to `__text` and another to `__value`
   - Verify the preview shows the expected values

### Test multiple properties

1. Create a variable with `__text` and `__value` columns as above
2. Add an additional column (for example, `region`) without an alias
3. Save the variable
4. In a panel query or text panel, use `${variableName.region}` (replace with your variable and column names)
5. Verify the property value is correctly resolved

### Test Code mode

1. Switch to **Code** mode in the variable query editor
2. Write a raw SQL query (for example, `SELECT hostname FROM host`)
3. Verify the variable dropdown populates correctly

### Test backwards compatibility

1. Create a variable using the old raw SQL query format
2. Verify it still works after enabling the feature toggle

---

**Special notes for your reviewer:**

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.