### PR TITLE
Alerting: Add gh in CLAUDE.md

### DIFF
--- a/public/app/features/alerting/unified/CLAUDE.md
+++ b/public/app/features/alerting/unified/CLAUDE.md
@@ -417,6 +417,60 @@ Check https://testing-library.com/docs/queries/about/ for what selectors to pref
 - [ ] Async operations use `await` and `findBy*`
 - [ ] Permissions tested with `grantUserPermissions`
 
+## Using GitHub CLI for Context
+
+When working on issues, PRs, or needing repository context, use the GitHub CLI (`gh`) to fetch information directly:
+
+### Common Commands
+
+```bash
+# View issue details
+gh issue view <issue-number>
+
+# View PR details and diff
+gh pr view <pr-number>
+gh pr diff <pr-number>
+
+# List recent issues
+gh issue list --limit 10
+
+# List PRs with specific labels
+gh pr list --label "alerting"
+
+# Search issues
+gh issue list --search "keyword"
+
+# View PR reviews and comments
+gh pr view <pr-number> --comments
+
+# Check CI status
+gh pr checks <pr-number>
+
+# View repository info
+gh repo view
+```
+
+### When to Use
+
+- **Understanding issue context**: Fetch issue descriptions, comments, and linked PRs
+- **Reviewing PR changes**: Get diffs, review comments, and CI status
+- **Finding related work**: Search for similar issues or existing implementations
+- **Checking project status**: List open issues/PRs for the alerting team
+
+### Example Workflow
+
+```bash
+# Working on issue #12345
+gh issue view 12345
+
+# Check if there's an existing PR
+gh pr list --search "fixes #12345"
+
+# Review a related PR
+gh pr view 67890
+gh pr diff 67890
+```
+
 ## Getting Help
 
 - Check patterns in existing `components/` code
@@ -425,6 +479,7 @@ Check https://testing-library.com/docs/queries/about/ for what selectors to pref
 - See `mocks.ts` for data factories
 - Read [./TESTING.md](./TESTING.md) for testing details
 - Review Grafana style guides (linked at top)
+- Use `gh` CLI to fetch issue/PR context from GitHub
 
 ---
 


### PR DESCRIPTION
**What is this feature?**

Adds a `gh` usage guideline to CLAUDE.md, instructing Claude to use the GitHub CLI when retrieving information from GitHub.

**Why do we need this feature?**

**Who is this feature for?**

Devs in alerting (actually Claude ) 


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
