### PR TITLE
fix(unified-storage): check auth before getting value

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1084,10 +1084,6 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 				return err
 			}
 
-			item := &resourcepb.ResourceWrapper{
-				ResourceVersion: iter.ResourceVersion(),
-				Value:           iter.Value(),
-			}
 			// Trash is only accessible to admins or the user who deleted the object
 			if req.Source == resourcepb.ListRequest_TRASH {
 				if !s.isTrashItemAuthorized(ctx, iter, trashChecker) {
@@ -1095,6 +1091,11 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 				}
 			} else if !checker(iter.Name(), iter.Folder()) {
 				continue
+			}
+
+			item := &resourcepb.ResourceWrapper{
+				ResourceVersion: iter.ResourceVersion(),
+				Value:           iter.Value(),
 			}
 
 			pageBytes += len(item.Value)


### PR DESCRIPTION
When we do a List, right now we first call `Value` ([which might call Marshal](https://github.com/grafana/grafana/blob/39b7d866603d9e59cf6d0198e307767eb5e7ef70/pkg/registry/apis/dashboard/legacy/sql_dashboards.go#L689-L694)) on the item and then check if we really need it for that request. This PR changes it, so we first check if the user can access the item, and only if they can we call `Value` and append it.