### PR TITLE
Alerting: Improve instance count display

### DIFF
--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -54,16 +54,16 @@ function ShowMoreInstances({ stats, onClick, href, enableFiltering, alertState }
         {enableFiltering && alertState ? (
           <Trans
             i18nKey="alerting.rule-details-matching-instances.showing-count-with-state"
-            values={{ visibleItemsCount, state: alertState, totalItemsCount }}
+            values={{ visibleItemsCount, alertState, totalItemsCount }}
           >
-            Showing {'{{ visibleItemsCount }}'} {'{{ state }}'} out of {'{{ totalItemsCount }}'} instances
+            Showing {{ visibleItemsCount }} {{ alertState }} out of {{ totalItemsCount }} instances
           </Trans>
         ) : (
           <Trans
             i18nKey="alerting.rule-details-matching-instances.showing-count"
             values={{ visibleItemsCount, totalItemsCount }}
           >
-            Showing {'{{ visibleItemsCount }}'} out of {'{{ totalItemsCount }}'} instances
+            Showing {{ visibleItemsCount }} out of {{ totalItemsCount }} instances
           </Trans>
         )}
       </div>

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -40,9 +40,10 @@ interface ShowMoreInstancesProps {
   stats: ShowMoreStats;
   onClick?: React.ComponentProps<typeof LinkButton>['onClick'];
   href?: React.ComponentProps<typeof LinkButton>['href'];
+  enableFiltering?: boolean;
 }
 
-function ShowMoreInstances({ stats, onClick, href }: ShowMoreInstancesProps) {
+function ShowMoreInstances({ stats, onClick, href, enableFiltering }: ShowMoreInstancesProps) {
   const styles = useStyles2(getStyles);
   const { visibleItemsCount, totalItemsCount } = stats;
 
@@ -57,9 +58,16 @@ function ShowMoreInstances({ stats, onClick, href }: ShowMoreInstancesProps) {
         </Trans>
       </div>
       <LinkButton size="sm" variant="secondary" data-testid="show-all" onClick={onClick} href={href}>
-        <Trans i18nKey="alerting.rule-details-matching-instances.button-show-all" values={{ totalItemsCount }}>
-          Show all {{ totalItemsCount }} alert instances
-        </Trans>
+        {enableFiltering ? (
+          <Trans i18nKey="alerting.rule-details-matching-instances.button-show-all">Show all</Trans>
+        ) : (
+          <Trans
+            i18nKey="alerting.rule-details-matching-instances.button-show-all-instances"
+            values={{ totalItemsCount }}
+          >
+            Show all {{ totalItemsCount }} alert instances
+          </Trans>
+        )}
       </LinkButton>
     </div>
   );
@@ -128,6 +136,7 @@ export function RuleDetailsMatchingInstances(props: Props) {
       stats={stats}
       onClick={enableFiltering ? resetFilter : undefined}
       href={!enableFiltering ? ruleViewPageLink : undefined}
+      enableFiltering={enableFiltering}
     />
   ) : undefined;
 

--- a/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleDetailsMatchingInstances.tsx
@@ -41,21 +41,31 @@ interface ShowMoreInstancesProps {
   onClick?: React.ComponentProps<typeof LinkButton>['onClick'];
   href?: React.ComponentProps<typeof LinkButton>['href'];
   enableFiltering?: boolean;
+  alertState?: InstanceStateFilter;
 }
 
-function ShowMoreInstances({ stats, onClick, href, enableFiltering }: ShowMoreInstancesProps) {
+function ShowMoreInstances({ stats, onClick, href, enableFiltering, alertState }: ShowMoreInstancesProps) {
   const styles = useStyles2(getStyles);
   const { visibleItemsCount, totalItemsCount } = stats;
 
   return (
     <div className={styles.footerRow}>
       <div>
-        <Trans
-          i18nKey="alerting.rule-details-matching-instances.showing-count"
-          values={{ visibleItemsCount, totalItemsCount }}
-        >
-          Showing {{ visibleItemsCount }} out of {{ totalItemsCount }} instances
-        </Trans>
+        {enableFiltering && alertState ? (
+          <Trans
+            i18nKey="alerting.rule-details-matching-instances.showing-count-with-state"
+            values={{ visibleItemsCount, state: alertState, totalItemsCount }}
+          >
+            Showing {'{{ visibleItemsCount }}'} {'{{ state }}'} out of {'{{ totalItemsCount }}'} instances
+          </Trans>
+        ) : (
+          <Trans
+            i18nKey="alerting.rule-details-matching-instances.showing-count"
+            values={{ visibleItemsCount, totalItemsCount }}
+          >
+            Showing {'{{ visibleItemsCount }}'} out of {'{{ totalItemsCount }}'} instances
+          </Trans>
+        )}
       </div>
       <LinkButton size="sm" variant="secondary" data-testid="show-all" onClick={onClick} href={href}>
         {enableFiltering ? (
@@ -137,6 +147,7 @@ export function RuleDetailsMatchingInstances(props: Props) {
       onClick={enableFiltering ? resetFilter : undefined}
       href={!enableFiltering ? ruleViewPageLink : undefined}
       enableFiltering={enableFiltering}
+      alertState={alertState}
     />
   ) : undefined;
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2336,8 +2336,8 @@
     "rule-details-matching-instances": {
       "button-show-all": "Show all",
       "button-show-all-instances": "Show all {{totalItemsCount}} alert instances",
-      "showing-count": "Showing {{ visibleItemsCount }} out of {{ totalItemsCount }} instances",
-      "showing-count-with-state": "Showing {{ visibleItemsCount }} {{ state }} out of {{ totalItemsCount }} instances"
+      "showing-count": "Showing {{visibleItemsCount}} out of {{totalItemsCount}} instances",
+      "showing-count-with-state": "Showing {{visibleItemsCount}} {{alertState}} out of {{totalItemsCount}} instances"
     },
     "rule-editor": {
       "get-content": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2336,7 +2336,8 @@
     "rule-details-matching-instances": {
       "button-show-all": "Show all",
       "button-show-all-instances": "Show all {{totalItemsCount}} alert instances",
-      "showing-count": "Showing {{visibleItemsCount}} out of {{totalItemsCount}} instances"
+      "showing-count": "Showing {{ visibleItemsCount }} out of {{ totalItemsCount }} instances",
+      "showing-count-with-state": "Showing {{ visibleItemsCount }} {{ state }} out of {{ totalItemsCount }} instances"
     },
     "rule-editor": {
       "get-content": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -2334,7 +2334,8 @@
       "label-tenant-sources": "Tenant sources"
     },
     "rule-details-matching-instances": {
-      "button-show-all": "Show all {{totalItemsCount}} alert instances",
+      "button-show-all": "Show all",
+      "button-show-all-instances": "Show all {{totalItemsCount}} alert instances",
       "showing-count": "Showing {{visibleItemsCount}} out of {{totalItemsCount}} instances"
     },
     "rule-editor": {


### PR DESCRIPTION
This PR updates the text in the instances tab of an alert rule when state filters are applied

Before:
<img width="1503" height="730" alt="Screenshot 2025-12-08 at 12 34 50" src="https://github.com/user-attachments/assets/2ace69d8-db03-492e-a26d-540e14b4cec5" />

After:
<img width="948" height="457" alt="image" src="https://github.com/user-attachments/assets/e690c733-41a2-4e38-a1d5-fef12f19d1a4" /> 
