### PR TITLE
AppChrome: Increase header height from 40-48

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
+++ b/public/app/core/components/AppChrome/TopBar/useChromeHeaderHeight.ts
@@ -94,6 +94,5 @@ export function useChromeHeaderHeight() {
  **/
 export function getChromeHeaderLevelHeight() {
   // Waiting with switch to 48 until we have a story for scopes
-  // return config.featureToggles.unifiedNavbars ? 48 : 40;
-  return 40;
+  return config.featureToggles.unifiedNavbars || config.featureToggles.dashboardNewLayouts ? 48 : 40;
 }


### PR DESCRIPTION
Change is only active right now when dashboardNewLayouts or unifiedNavbars ie enabled (without those feature toggles enabled dashboards always use 2 navbar levels). 

<img width="1512" height="855" alt="Screenshot 2025-12-08 at 17 23 42" src="https://github.com/user-attachments/assets/8329f459-5d3c-475c-aa5c-359d57124a60" />
