### PR TITLE
Alerting: Fix saving result_fingerprint in async alert state persister

### DIFF
--- a/pkg/services/ngalert/models/testing.go
+++ b/pkg/services/ngalert/models/testing.go
@@ -973,6 +973,12 @@ func (a AlertInstanceMutators) WithAnnotations(annotations InstanceAnnotations) 
 	}
 }
 
+func (a AlertInstanceMutators) WithResultFingerprint(fp string) AlertInstanceMutator {
+	return func(i *AlertInstance) {
+		i.ResultFingerprint = fp
+	}
+}
+
 type Mutator[T any] func(*T)
 
 // CopyNotificationSettings creates a deep copy of NotificationSettings.

--- a/pkg/services/ngalert/store/instance_database.go
+++ b/pkg/services/ngalert/store/instance_database.go
@@ -364,10 +364,10 @@ func (st InstanceDBStore) insertInstancesBatch(sess *sqlstore.DBSession, batch [
 
 	query := strings.Builder{}
 	placeholders := make([]string, 0, len(batch))
-	args := make([]any, 0, len(batch)*13)
+	args := make([]any, 0, len(batch)*14)
 
 	query.WriteString("INSERT INTO alert_instance ")
-	query.WriteString("(rule_org_id, rule_uid, labels, labels_hash, current_state, current_reason, current_state_since, current_state_end, last_eval_time, fired_at, resolved_at, last_sent_at, annotations) VALUES ")
+	query.WriteString("(rule_org_id, rule_uid, labels, labels_hash, current_state, current_reason, current_state_since, current_state_end, last_eval_time, fired_at, resolved_at, last_sent_at, result_fingerprint, annotations) VALUES ")
 
 	for _, instance := range batch {
 		if err := models.ValidateAlertInstance(instance); err != nil {
@@ -387,7 +387,7 @@ func (st InstanceDBStore) insertInstancesBatch(sess *sqlstore.DBSession, batch [
 			continue
 		}
 
-		placeholders = append(placeholders, "(?,?,?,?,?,?,?,?,?,?,?,?,?)")
+		placeholders = append(placeholders, "(?,?,?,?,?,?,?,?,?,?,?,?,?,?)")
 		args = append(args,
 			instance.RuleOrgID,
 			instance.RuleUID,
@@ -401,6 +401,7 @@ func (st InstanceDBStore) insertInstancesBatch(sess *sqlstore.DBSession, batch [
 			nullableTimeToUnix(instance.FiredAt),
 			nullableTimeToUnix(instance.ResolvedAt),
 			nullableTimeToUnix(instance.LastSentAt),
+			instance.ResultFingerprint,
 			annotationsJSON,
 		)
 	}


### PR DESCRIPTION
**What is this feature?**

When the `alertingSaveStatePeriodic` flag is enabled and `alertingSaveStateCompressed` is disabled, we do not currently save `result_fingerprint` of the alert instances as we do in the sync state save:

https://github.com/grafana/grafana/blob/6a95fb6af5d839280f6c8fa1de405a9972f117df/pkg/services/ngalert/store/instance_database.go#L126