### PR TITLE
NPM: Attempt to fix e2e-selectors dist-tag after OIDC migration

### DIFF
--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -69,18 +69,43 @@ if (( CHANGES_COUNT > 0 )); then
     if [[ $TAGS =~ $regex_pattern ]]; then
         echo "$CHANGES_COUNT file(s) in packages/grafana-e2e-selectors were changed. Adding 'modified' tag to @grafana/e2e-selectors@${BASH_REMATCH[1]}"
         
-        # If using OIDC, fetch the token for dist-tag operation (npm publish handles OIDC internally,
+        # If using OIDC, exchange token for npm auth (npm publish handles OIDC internally,
         # but dist-tag requires explicit authentication)
+        # Reference: https://github.com/electron/npm-trusted-auth-action
         if [ -n "$ACTIONS_ID_TOKEN_REQUEST_URL" ] && [ -n "$ACTIONS_ID_TOKEN_REQUEST_TOKEN" ]; then
-            echo "Fetching OIDC token for dist-tag operation..."
+            echo "Fetching GitHub OIDC token..."
             OIDC_TOKEN=$(curl -sS -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm" | jq -r '.value')
+                "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -r '.value // empty')
             
-            if [ -n "$OIDC_TOKEN" ] && [ "$OIDC_TOKEN" != "null" ]; then
-                echo "Configuring OIDC token in ~/.npmrc"
-                echo "//registry.npmjs.org/:_authToken=${OIDC_TOKEN}" >> ~/.npmrc
-            else
+            if [ -z "$OIDC_TOKEN" ]; then
                 echo "Warning: Failed to fetch OIDC token, dist-tag operation may fail"
+            else
+                # Mask the OIDC token so it won't appear in logs
+                echo "::add-mask::$OIDC_TOKEN"
+                echo "Exchanging OIDC token for npm auth token..."
+                ENCODED_PACKAGE=$(printf "%s" "@grafana/e2e-selectors" | jq -Rr @uri)
+                RESPONSE=$(curl -sS -X POST \
+                    -H "Authorization: Bearer $OIDC_TOKEN" \
+                    -H "Accept: application/json" \
+                    -w "\n%{http_code}" \
+                    "https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/$ENCODED_PACKAGE")
+                
+                HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
+                BODY=$(echo "$RESPONSE" | sed '$d')
+                
+                if [ "$HTTP_CODE" != "201" ]; then
+                    echo "Warning: Failed to exchange token. Status: $HTTP_CODE"
+                else
+                    NPM_AUTH_TOKEN=$(echo "$BODY" | jq -r '.token // empty')
+                    if [ -n "$NPM_AUTH_TOKEN" ]; then
+                        # Mask the token so it won't appear in logs
+                        echo "::add-mask::$NPM_AUTH_TOKEN"
+                        echo "Configuring npm auth token in ~/.npmrc"
+                        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
+                    else
+                        echo "Warning: No token in response, dist-tag operation may fail"
+                    fi
+                fi
             fi
         fi
         


### PR DESCRIPTION
**What is this feature?**

Exchange GitHub OIDC token for a package-scoped npm auth token to authenticate `npm dist-tag add` for `@grafana/e2e-selectors`. 

This is a workaround for [npm/cli#8547](https://github.com/npm/cli/issues/8547), which confirms Trusted Publishers only support `npm publish`. We're trying the approach suggested by Electron in [this comment](https://github.com/npm/cli/issues/8547#issuecomment-3353607158), using their [npm-trusted-auth-action](https://github.com/electron/npm-trusted-auth-action) as reference.

See related issue https://github.com/grafana/grafana/issues/114514

**Why do we need this feature?**

After migrating to NPM OIDC Trusted Publishing, the `modified` dist-tag fails with 401. OIDC tokens only authenticate `npm publish` internally - other npm commands need explicit credentials. This performs the same token exchange that `npm publish` does internally.

**Security:**
- Tokens are masked with `::add-mask::` to prevent log exposure
- npm auth token is scoped only to `@grafana/e2e-selectors`
- Both tokens are short-lived (minutes)
- Runner is ephemeral. `~/.npmrc` is destroyed after the job

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

Since this is an experimental workaround, I'm not entirely sure it will solve https://github.com/grafana/grafana/issues/114514. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
