### PR TITLE
fix: use dsIndexProvider cache on schema migrations

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -12,13 +12,6 @@ import (
 )
 
 func RegisterConversions(s *runtime.Scheme, dsIndexProvider schemaversion.DataSourceIndexProvider, leIndexProvider schemaversion.LibraryElementIndexProvider) error {
-	// Wrap the provider once with 10s caching for all conversions.
-	// This prevents repeated DB queries across multiple conversion calls while allowing
-	// the cache to refresh periodically, making it suitable for long-lived singleton usage.
-	dsIndexProvider = schemaversion.WrapIndexProviderWithCache(dsIndexProvider)
-	// Wrap library element provider with caching as well
-	leIndexProvider = schemaversion.WrapLibraryElementProviderWithCache(leIndexProvider)
-
 	// v0 conversions
 	if err := s.AddConversionFunc((*dashv0.Dashboard)(nil), (*dashv1.Dashboard)(nil),
 		withConversionMetrics(dashv0.APIVERSION, dashv1.APIVERSION, func(a, b interface{}, scope conversion.Scope) error {

--- a/apps/dashboard/pkg/migration/migrate.go
+++ b/apps/dashboard/pkg/migration/migrate.go
@@ -61,10 +61,11 @@ type migrator struct {
 
 func (m *migrator) init(dsIndexProvider schemaversion.DataSourceIndexProvider, leIndexProvider schemaversion.LibraryElementIndexProvider) {
 	initOnce.Do(func() {
-		// Wrap the provider with configurable caching.
+		// Wrap the provider once with 10s caching for all conversions.
 		// This prevents repeated DB queries across multiple conversion calls while allowing
 		// the cache to refresh periodically, making it suitable for long-lived singleton usage.
 		m.dsIndexProvider = schemaversion.WrapIndexProviderWithCache(dsIndexProvider)
+		// Wrap library element provider with caching as well
 		m.leIndexProvider = schemaversion.WrapLibraryElementProviderWithCache(leIndexProvider)
 		m.migrations = schemaversion.GetMigrations(m.dsIndexProvider, m.leIndexProvider)
 		close(m.ready)


### PR DESCRIPTION
**What is this feature?**

Re-use wrapped cache provider on migrate functions.

**Why do we need this feature?**

The cache was not used on V33 and V36 migrations.

**Who is this feature for?**

Dashboard Listing API users

**Which issue(s) does this PR fix?**:

Ticket: https://github.com/grafana/support-escalations/issues/18721

**Special notes for your reviewer:**

A org-aware cache will be added on a follow-up PR.

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
