### PR TITLE
FeatureToggles: Add multiPropsVariables

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1220,4 +1220,8 @@ export interface FeatureToggles {
   * @default false
   */
   useMTPlugins?: boolean;
+  /**
+  * Enables support for variables whose values can have multiple properties
+  */
+  multiPropsVariables?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2015,6 +2015,13 @@ var (
 			FrontendOnly: true,
 			Expression:   "false",
 		},
+		{
+			Name:         "multiPropsVariables",
+			Description:  "Enables support for variables whose values can have multiple properties",
+			Stage:        FeatureStageExperimental,
+			FrontendOnly: true,
+			Owner:        grafanaDashboardsSquad,
+		},
 	}
 )
 

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -273,3 +273,4 @@ lokiQueryLimitsContext,experimental,@grafana/observability-logs,false,false,true
 rudderstackUpgrade,experimental,@grafana/grafana-frontend-platform,false,false,true
 kubernetesAlertingHistorian,experimental,@grafana/alerting-squad,false,true,false
 useMTPlugins,experimental,@grafana/plugins-platform-backend,false,false,true
+multiPropsVariables,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2261,6 +2261,19 @@
     },
     {
       "metadata": {
+        "name": "multiPropsVariables",
+        "resourceVersion": "1765293230587",
+        "creationTimestamp": "2025-12-09T15:13:50Z"
+      },
+      "spec": {
+        "description": "Enables support for variables whose values can have multiple properties",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true
+      }
+    },
+    {
+      "metadata": {
         "name": "multiTenantTempCredentials",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-04-02T20:25:50Z"


### PR DESCRIPTION
**What is this feature?**

Adding a feature toggle to enable/disable support for variables whose values can have multiple properties 

**Why do we need this feature?**

See our [delivery plan](https://docs.google.com/document/d/14--NsIxOQ401Gi15b8PYnlEIEudu3B_qizr2c0r1lfw/edit?tab=t.0#heading=h.kc3lr1d17hte)

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/grafana-org/issues/555

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
