### PR TITLE
TimeRange: Additional keyboard shortcut `t =` to complement `t +` for zoom in

### DIFF
--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -236,6 +236,10 @@ export class KeybindingSrv {
         appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
       });
 
+      this.bind('t =', () => {
+        appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
+      });
+
       this.bind('t -', () => {
         appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
       });

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -269,6 +269,13 @@ describe('setupKeyboardShortcuts', () => {
         expect(tPlusBinding).toBeDefined();
       });
 
+      it('should setup t = zoom in shortcut', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tEqualsBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't =');
+        expect(tEqualsBinding).toBeDefined();
+      });
+
       it('should setup t - zoom out shortcut with keypress type', () => {
         setupKeyboardShortcuts(mockScene);
 
@@ -302,9 +309,11 @@ describe('setupKeyboardShortcuts', () => {
         setupKeyboardShortcuts(mockScene);
 
         const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
+        const tEqualsBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't =');
         const tMinusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't -');
 
         expect(tPlusBinding).toBeUndefined();
+        expect(tEqualsBinding).toBeUndefined();
         expect(tMinusBinding).toBeUndefined();
       });
     });
@@ -347,6 +356,28 @@ describe('setupKeyboardShortcuts', () => {
 
         const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
         const handler = tPlusBinding![0].onTrigger;
+
+        handler();
+
+        // Scale 0.5 should result in 3 hour span (half of 6)
+        expect(mockTimeRange.onTimeRangeChange).toHaveBeenCalledWith(
+          expect.objectContaining({
+            from: expect.any(Object),
+            to: expect.any(Object),
+            raw: expect.any(Object),
+          })
+        );
+
+        const call = mockTimeRange.onTimeRangeChange.mock.calls[0][0];
+        const newSpan = call.to.valueOf() - call.from.valueOf();
+        expect(newSpan).toBe(3 * 60 * 60 * 1000); // 3 hours in milliseconds
+      });
+
+      it('should zoom in (scale 0.5) when t = is pressed', () => {
+        setupKeyboardShortcuts(mockScene);
+
+        const tEqualsBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't =');
+        const handler = tEqualsBinding![0].onTrigger;
 
         handler();
 

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -139,6 +139,13 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     });
 
     keybindings.addBinding({
+      key: 't =',
+      onTrigger: () => {
+        handleZoom(scene, 0.5);
+      },
+    });
+
+    keybindings.addBinding({
       key: 't -',
       type: 'keypress', // NOTE: Because some browsers/OS identify minus symbol differently.
       onTrigger: () => {


### PR DESCRIPTION
**What is this feature?**

This change adds an overloaded keyboard shortcut `t =` for time range zoom in.

**Why do we need this feature?**

We're adding `t =` for the convenience of users who miss the `Shift` key when typing in `t +`.

This also makes the time range zoom in keyboard shortcut more consistent with similar browser zoom in/out shortcuts.

**Who is this feature for?**

All users of Grafana with the experiment `newTimeRangeZoomShortcuts` flag toggled on, for now.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114484

**Special notes for your reviewer:**

🎏 `newTimeRangeZoomShortcuts = true`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
