### PR TITLE
Provisioning: Add resource-level warning support.

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/jobs.go
@@ -198,6 +198,7 @@ type JobStatus struct {
 	Finished int64    `json:"finished,omitempty"`
 	Message  string   `json:"message,omitempty"`
 	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 
 	// Optional value 0-100 that can be set while running
 	Progress float64 `json:"progress,omitempty"`
@@ -225,18 +226,20 @@ type JobResourceSummary struct {
 	Kind  string `json:"kind,omitempty"`
 	Total int64  `json:"total,omitempty"` // the count (if known)
 
-	Create int64 `json:"create,omitempty"`
-	Update int64 `json:"update,omitempty"`
-	Delete int64 `json:"delete,omitempty"`
-	Write  int64 `json:"write,omitempty"` // Create or update (export)
-	Error  int64 `json:"error,omitempty"` // The error count
+	Create  int64 `json:"create,omitempty"`
+	Update  int64 `json:"update,omitempty"`
+	Delete  int64 `json:"delete,omitempty"`
+	Write   int64 `json:"write,omitempty"`   // Create or update (export)
+	Error   int64 `json:"error,omitempty"`   // The error count
+	Warning int64 `json:"warning,omitempty"` // The warning count
 
 	// No action required (useful for sync)
 	Noop int64 `json:"noop,omitempty"`
 
-	// Report errors for this resource type
+	// Report errors/warnings for this resource type
 	// This may not be an exhaustive list and recommend looking at the logs for more info
-	Errors []string `json:"errors,omitempty"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // HistoricJob is an append only log, saving all jobs that have been processed.

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.deepcopy.go
@@ -401,6 +401,11 @@ func (in *JobResourceSummary) DeepCopyInto(out *JobResourceSummary) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Warnings != nil {
+		in, out := &in.Warnings, &out.Warnings
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -465,6 +470,11 @@ func (in *JobStatus) DeepCopyInto(out *JobStatus) {
 	*out = *in
 	if in.Errors != nil {
 		in, out := &in.Errors, &out.Errors
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.Warnings != nil {
+		in, out := &in.Warnings, &out.Warnings
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi.go
@@ -889,6 +889,13 @@ func schema_pkg_apis_provisioning_v0alpha1_JobResourceSummary(ref common.Referen
 							Format:      "int64",
 						},
 					},
+					"warning": {
+						SchemaProps: spec.SchemaProps{
+							Description: "The error count",
+							Type:        []string{"integer"},
+							Format:      "int64",
+						},
+					},
 					"noop": {
 						SchemaProps: spec.SchemaProps{
 							Description: "No action required (useful for sync)",
@@ -898,8 +905,22 @@ func schema_pkg_apis_provisioning_v0alpha1_JobResourceSummary(ref common.Referen
 					},
 					"errors": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Report errors for this resource type This may not be an exhaustive list and recommend looking at the logs for more info",
+							Description: "Report errors/warnings for this resource type This may not be an exhaustive list and recommend looking at the logs for more info",
 							Type:        []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"warnings": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
@@ -1016,6 +1037,20 @@ func schema_pkg_apis_provisioning_v0alpha1_JobStatus(ref common.ReferenceCallbac
 						},
 					},
 					"errors": {
+						SchemaProps: spec.SchemaProps{
+							Type: []string{"array"},
+							Items: &spec.SchemaOrArray{
+								Schema: &spec.Schema{
+									SchemaProps: spec.SchemaProps{
+										Default: "",
+										Type:    []string{"string"},
+										Format:  "",
+									},
+								},
+							},
+						},
+					},
+					"warnings": {
 						SchemaProps: spec.SchemaProps{
 							Type: []string{"array"},
 							Items: &spec.SchemaOrArray{

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/zz_generated.openapi_violation_exceptions.list
@@ -3,8 +3,10 @@ API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioni
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,FileList,Items
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,HistoryList,Items
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,JobResourceSummary,Errors
+API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,JobResourceSummary,Warnings
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,JobStatus,Errors
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,JobStatus,Summary
+API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,JobStatus,Warnings
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,ManagerStats,Stats
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,MoveJobOptions,Paths
 API rule violation: list_type_missing,github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1,MoveJobOptions,Resources

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobresourcesummary.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobresourcesummary.go
@@ -7,16 +7,18 @@ package v0alpha1
 // JobResourceSummaryApplyConfiguration represents a declarative configuration of the JobResourceSummary type for use
 // with apply.
 type JobResourceSummaryApplyConfiguration struct {
-	Group  *string  `json:"group,omitempty"`
-	Kind   *string  `json:"kind,omitempty"`
-	Total  *int64   `json:"total,omitempty"`
-	Create *int64   `json:"create,omitempty"`
-	Update *int64   `json:"update,omitempty"`
-	Delete *int64   `json:"delete,omitempty"`
-	Write  *int64   `json:"write,omitempty"`
-	Error  *int64   `json:"error,omitempty"`
-	Noop   *int64   `json:"noop,omitempty"`
-	Errors []string `json:"errors,omitempty"`
+	Group    *string  `json:"group,omitempty"`
+	Kind     *string  `json:"kind,omitempty"`
+	Total    *int64   `json:"total,omitempty"`
+	Create   *int64   `json:"create,omitempty"`
+	Update   *int64   `json:"update,omitempty"`
+	Delete   *int64   `json:"delete,omitempty"`
+	Write    *int64   `json:"write,omitempty"`
+	Error    *int64   `json:"error,omitempty"`
+	Warning  *int64   `json:"warning,omitempty"`
+	Noop     *int64   `json:"noop,omitempty"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
 }
 
 // JobResourceSummaryApplyConfiguration constructs a declarative configuration of the JobResourceSummary type for use with
@@ -89,6 +91,14 @@ func (b *JobResourceSummaryApplyConfiguration) WithError(value int64) *JobResour
 	return b
 }
 
+// WithWarning sets the Warning field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the Warning field is set to the value of the last call.
+func (b *JobResourceSummaryApplyConfiguration) WithWarning(value int64) *JobResourceSummaryApplyConfiguration {
+	b.Warning = &value
+	return b
+}
+
 // WithNoop sets the Noop field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Noop field is set to the value of the last call.
@@ -103,6 +113,16 @@ func (b *JobResourceSummaryApplyConfiguration) WithNoop(value int64) *JobResourc
 func (b *JobResourceSummaryApplyConfiguration) WithErrors(values ...string) *JobResourceSummaryApplyConfiguration {
 	for i := range values {
 		b.Errors = append(b.Errors, values[i])
+	}
+	return b
+}
+
+// WithWarnings adds the given value to the Warnings field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Warnings field.
+func (b *JobResourceSummaryApplyConfiguration) WithWarnings(values ...string) *JobResourceSummaryApplyConfiguration {
+	for i := range values {
+		b.Warnings = append(b.Warnings, values[i])
 	}
 	return b
 }

--- a/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobstatus.go
+++ b/apps/provisioning/pkg/generated/applyconfiguration/provisioning/v0alpha1/jobstatus.go
@@ -16,6 +16,7 @@ type JobStatusApplyConfiguration struct {
 	Finished *int64                                     `json:"finished,omitempty"`
 	Message  *string                                    `json:"message,omitempty"`
 	Errors   []string                                   `json:"errors,omitempty"`
+	Warnings []string                                   `json:"warnings,omitempty"`
 	Progress *float64                                   `json:"progress,omitempty"`
 	Summary  []*provisioningv0alpha1.JobResourceSummary `json:"summary,omitempty"`
 	URLs     *RepositoryURLsApplyConfiguration          `json:"url,omitempty"`
@@ -65,6 +66,16 @@ func (b *JobStatusApplyConfiguration) WithMessage(value string) *JobStatusApplyC
 func (b *JobStatusApplyConfiguration) WithErrors(values ...string) *JobStatusApplyConfiguration {
 	for i := range values {
 		b.Errors = append(b.Errors, values[i])
+	}
+	return b
+}
+
+// WithWarnings adds the given value to the Warnings field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Warnings field.
+func (b *JobStatusApplyConfiguration) WithWarnings(values ...string) *JobStatusApplyConfiguration {
+	for i := range values {
+		b.Warnings = append(b.Warnings, values[i])
 	}
 	return b
 }

--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -1138,7 +1138,7 @@ export type JobResourceSummary = {
   delete?: number;
   /** Create or update (export) */
   error?: number;
-  /** Report errors for this resource type This may not be an exhaustive list and recommend looking at the logs for more info */
+  /** Report errors/warnings for this resource type This may not be an exhaustive list and recommend looking at the logs for more info */
   errors?: string[];
   group?: string;
   kind?: string;
@@ -1146,6 +1146,9 @@ export type JobResourceSummary = {
   noop?: number;
   total?: number;
   update?: number;
+  /** The error count */
+  warning?: number;
+  warnings?: string[];
   write?: number;
 };
 export type RepositoryUrLs = {
@@ -1176,6 +1179,7 @@ export type JobStatus = {
   summary?: JobResourceSummary[];
   /** URLs contains URLs for the reference branch or commit if applicable. */
   url?: RepositoryUrLs;
+  warnings?: string[];
 };
 export type Job = {
   /** APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources */

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -2,9 +2,11 @@ package jobs
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -82,4 +84,168 @@ func TestJobProgressRecorderCompleteIncludesRefURLs(t *testing.T) {
 	assert.Equal(t, refURLs.SourceURL, finalStatus.URLs.SourceURL)
 	assert.Equal(t, provisioning.JobStateSuccess, finalStatus.State)
 	assert.Equal(t, "completed successfully", finalStatus.Message)
+}
+
+func TestJobProgressRecorderWarningStatus(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a progress recorder
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn).(*jobProgressRecorder)
+
+	// Record a result with a warning
+	warningErr := errors.New("deprecated API used")
+	result := JobResourceResult{
+		Name:    "test-resource",
+		Group:   "test.grafana.app",
+		Kind:    "Dashboard",
+		Path:    "dashboards/test.json",
+		Action:  repository.FileActionUpdated,
+		Warning: warningErr,
+	}
+	recorder.Record(ctx, result)
+
+	// Record another result with a different warning
+	warningErr2 := errors.New("missing optional field")
+	result2 := JobResourceResult{
+		Name:    "test-resource-2",
+		Group:   "test.grafana.app",
+		Kind:    "Dashboard",
+		Path:    "dashboards/test2.json",
+		Action:  repository.FileActionCreated,
+		Warning: warningErr2,
+	}
+	recorder.Record(ctx, result2)
+
+	// Record a result with a warning from a different resource type
+	warningErr3 := errors.New("validation warning")
+	result3 := JobResourceResult{
+		Name:    "test-resource-3",
+		Group:   "test.grafana.app",
+		Kind:    "DataSource",
+		Path:    "datasources/test.yaml",
+		Action:  repository.FileActionCreated,
+		Warning: warningErr3,
+	}
+	recorder.Record(ctx, result3)
+
+	// Verify warnings are stored in summaries
+	recorder.mu.RLock()
+	require.Len(t, recorder.summaries, 2) // Dashboard and DataSource
+	dashboardSummary := recorder.summaries["test.grafana.app:Dashboard"]
+	require.NotNil(t, dashboardSummary)
+	assert.Equal(t, int64(2), dashboardSummary.Warning)
+	assert.Len(t, dashboardSummary.Warnings, 2)
+	assert.Contains(t, dashboardSummary.Warnings[0], "deprecated API used")
+	assert.Contains(t, dashboardSummary.Warnings[1], "missing optional field")
+
+	datasourceSummary := recorder.summaries["test.grafana.app:DataSource"]
+	require.NotNil(t, datasourceSummary)
+	assert.Equal(t, int64(1), datasourceSummary.Warning)
+	assert.Len(t, datasourceSummary.Warnings, 1)
+	assert.Contains(t, datasourceSummary.Warnings[0], "validation warning")
+	recorder.mu.RUnlock()
+
+	// Complete the job
+	finalStatus := recorder.Complete(ctx, nil)
+
+	// Verify the final status includes warnings
+	require.NotNil(t, finalStatus.Warnings)
+	assert.Len(t, finalStatus.Warnings, 3)
+	assert.Contains(t, finalStatus.Warnings[0], "deprecated API used")
+	assert.Contains(t, finalStatus.Warnings[1], "missing optional field")
+	assert.Contains(t, finalStatus.Warnings[2], "validation warning")
+
+	// Verify the state is set to Warning
+	assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)
+	assert.Equal(t, "completed with warnings", finalStatus.Message)
+
+	// Verify summaries are included
+	require.Len(t, finalStatus.Summary, 2)
+
+	// Verify no errors were recorded
+	assert.Empty(t, finalStatus.Errors)
+}
+
+func TestJobProgressRecorderWarningWithErrors(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a progress recorder
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn).(*jobProgressRecorder)
+
+	// Record a result with an error (errors take precedence)
+	errorErr := errors.New("failed to process")
+	result := JobResourceResult{
+		Name:   "test-resource",
+		Group:  "test.grafana.app",
+		Kind:   "Dashboard",
+		Path:   "dashboards/test.json",
+		Action: repository.FileActionUpdated,
+		Error:  errorErr,
+	}
+	recorder.Record(ctx, result)
+
+	// Record a result with only a warning
+	warningErr := errors.New("deprecated API used")
+	result2 := JobResourceResult{
+		Name:    "test-resource-2",
+		Group:   "test.grafana.app",
+		Kind:    "Dashboard",
+		Path:    "dashboards/test2.json",
+		Action:  repository.FileActionCreated,
+		Warning: warningErr,
+	}
+	recorder.Record(ctx, result2)
+
+	// Complete the job
+	finalStatus := recorder.Complete(ctx, nil)
+
+	// When there are errors, the state should be Warning (not Error unless too many)
+	// and warnings should still be included
+	assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)
+	assert.Equal(t, "completed with errors", finalStatus.Message)
+	assert.Len(t, finalStatus.Errors, 1)
+	assert.Contains(t, finalStatus.Errors[0], "failed to process")
+
+	// Warnings should still be extracted from summaries
+	require.NotNil(t, finalStatus.Warnings)
+	assert.Len(t, finalStatus.Warnings, 1)
+	assert.Contains(t, finalStatus.Warnings[0], "deprecated API used")
+}
+
+func TestJobProgressRecorderWarningOnlyNoErrors(t *testing.T) {
+	ctx := context.Background()
+
+	// Create a progress recorder
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn).(*jobProgressRecorder)
+
+	// Record only warnings, no errors
+	warningErr := errors.New("deprecated API used")
+	result := JobResourceResult{
+		Name:    "test-resource",
+		Group:   "test.grafana.app",
+		Kind:    "Dashboard",
+		Path:    "dashboards/test.json",
+		Action:  repository.FileActionUpdated,
+		Warning: warningErr,
+	}
+	recorder.Record(ctx, result)
+
+	// Complete the job
+	finalStatus := recorder.Complete(ctx, nil)
+
+	// Verify the state is Warning (not Error) when only warnings exist
+	assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)
+	assert.Equal(t, "completed with warnings", finalStatus.Message)
+	assert.Empty(t, finalStatus.Errors)
+	require.NotNil(t, finalStatus.Warnings)
+	assert.Len(t, finalStatus.Warnings, 1)
 }

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -3696,7 +3696,7 @@
             "format": "int64"
           },
           "errors": {
-            "description": "Report errors for this resource type This may not be an exhaustive list and recommend looking at the logs for more info",
+            "description": "Report errors/warnings for this resource type This may not be an exhaustive list and recommend looking at the logs for more info",
             "type": "array",
             "items": {
               "type": "string",
@@ -3721,6 +3721,18 @@
           "update": {
             "type": "integer",
             "format": "int64"
+          },
+          "warning": {
+            "description": "The error count",
+            "type": "integer",
+            "format": "int64"
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
           },
           "write": {
             "type": "integer",
@@ -3849,6 +3861,13 @@
                 "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.RepositoryURLs"
               }
             ]
+          },
+          "warnings": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "default": ""
+            }
           }
         }
       },


### PR DESCRIPTION
**What is this feature?**

Provisioning allows for Warning status on resource sync.

**Why do we need this feature?**

Before this change, only non-successful status is Error. This gives the same treatment to Git Sync errors and user errors (e.g. malformed dashboards), which may lead to sync operations to stop.

Part of https://github.com/grafana/git-ui-sync-project/issues/683

