### PR TITLE
Logs: Cell format value on inspect should use Code view for arrays, objects, and JSON strings

### DIFF
--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -1,3 +1,4 @@
+import { isPlainObject } from 'lodash';
 import { useCallback } from 'react';
 import * as React from 'react';
 
@@ -9,7 +10,6 @@ import { Stack } from '../Layout/Stack/Stack';
 import { TooltipPlacement } from '../Tooltip/types';
 
 import { TableCellInspectorMode } from './TableCellInspector';
-import { buildInspectValue } from './TableNG/utils';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, TableCellProps } from './types';
 import { getTextAlign } from './utils';
 
@@ -64,7 +64,17 @@ export function CellActions({
             tooltip={t('grafana-ui.table.cell-inspect', 'Inspect value')}
             onClick={() => {
               if (setInspectCell) {
-                const [inspectValue, mode] = buildInspectValue(cell.value, field);
+                let mode = TableCellInspectorMode.text;
+                let inspectValue = cell.value;
+                try {
+                  const parsed = typeof inspectValue === 'string' ? JSON.parse(inspectValue) : inspectValue;
+                  if (Array.isArray(parsed) || isPlainObject(parsed)) {
+                    inspectValue = JSON.stringify(parsed, null, 2);
+                    mode = TableCellInspectorMode.code;
+                  }
+                } catch {
+                  // do nothing
+                }
                 setInspectCell({ value: inspectValue, mode });
               }
             }}

--- a/packages/grafana-ui/src/components/Table/CellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/CellActions.tsx
@@ -9,6 +9,7 @@ import { Stack } from '../Layout/Stack/Stack';
 import { TooltipPlacement } from '../Tooltip/types';
 
 import { TableCellInspectorMode } from './TableCellInspector';
+import { buildInspectValue } from './TableNG/utils';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR, TableCellProps } from './types';
 import { getTextAlign } from './utils';
 
@@ -63,7 +64,8 @@ export function CellActions({
             tooltip={t('grafana-ui.table.cell-inspect', 'Inspect value')}
             onClick={() => {
               if (setInspectCell) {
-                setInspectCell({ value: cell.value, mode: previewMode });
+                const [inspectValue, mode] = buildInspectValue(cell.value, field);
+                setInspectCell({ value: inspectValue, mode });
               }
             }}
             {...commonButtonProps}

--- a/public/app/features/explore/Logs/LogsTableActionButtons.tsx
+++ b/public/app/features/explore/Logs/LogsTableActionButtons.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { isArray, isPlainObject } from 'lodash';
 import { useCallback, useState } from 'react';
 
 import {

--- a/public/app/features/explore/Logs/LogsTableActionButtons.tsx
+++ b/public/app/features/explore/Logs/LogsTableActionButtons.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { isArray, isPlainObject } from 'lodash';
 import { useCallback, useState } from 'react';
 
 import {


### PR DESCRIPTION

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes the old logs table to prettify JSON once a user clicks inspect.
@grafana/dataviz-squad I'm not sure this is 💯 , let me know if there is a better way. 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
