### PR TITLE
Folders: Prevent circular dependencies on apis level

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -58,6 +58,12 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return fmt.Errorf("unable to create folder inside parent: %w", err)
 	}
 
+	for _, parent := range parents.Items {
+		if parent.Name == f.Name {
+			return folder.ErrCircularReference.Errorf("circular reference detected")
+		}
+	}
+
 	// Can not create a folder that will be too deep.
 	// We need to add +1 as we also have the root folder as part of the parents.
 	if len(parents.Items) > maxDepth+1 {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -53,12 +53,17 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return folder.ErrFolderCannotBeParentOfItself
 	}
 
+	// note: `parents` will include itself as the last item
 	parents, err := getter(ctx, f)
 	if err != nil {
 		return fmt.Errorf("unable to create folder inside parent: %w", err)
 	}
 
-	for _, parent := range parents.Items {
+	for i, parent := range parents.Items {
+		// skip the last item, which is itself
+		if i == len(parents.Items)-1 {
+			continue
+		}
 		if parent.Name == f.Name {
 			return folder.ErrCircularReference.Errorf("circular reference detected")
 		}

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -127,6 +127,27 @@ func TestValidateCreate(t *testing.T) {
 			},
 			maxDepth: folder.MaxNestedFolderDepth,
 		},
+		{
+			name: "cannot create a circular reference",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "3",
+					Annotations: map[string]string{"grafana.app/folder": "2"},
+				},
+				Spec: folders.FolderSpec{
+					Title: "some title",
+				},
+			},
+			expectedErr: "circular reference detected",
+			getter: &folders.FolderInfoList{
+				Items: []folders.FolderInfo{
+					{Name: "2", Parent: "1"},
+					{Name: "1", Parent: "3"},
+					{Name: "3", Parent: folder.GeneralFolderUID},
+					{Name: folder.GeneralFolderUID},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Currently, we have a check in /apis for circular dependencies on folder move ([here](https://github.com/grafana/grafana/blob/main/pkg/registry/apis/folders/validate.go#L127)), but we do not have that on create. We do have a check within the folder service on create, but going forward, we want to be able to rely solely on /apis to do this validation.

This PR adds the validation to the /apis validation hook for folder creation