### PR TITLE
Heatmap: Fix off-by-one error in tooltip for data with numeric X-axis

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -355,7 +355,7 @@ const HeatmapHoverCell = ({
 
   const headerItem: VizTooltipItem = {
     label: '',
-    value: xDisp(xBucketMax!)!,
+    value: xField?.type === FieldType.time ? xDisp(xBucketMax!)! : xDisp(xBucketMin!)!,
   };
 
   let customContent: ReactElement[] = [];


### PR DESCRIPTION

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Currently, the value shown in a tooltip header in Heatmap is the upper bound of the hovered-over cell's X range.

When providing tabular data with ordinal rather than temporal X indexes, this manifests as an off-by-one error. In this example, the X axis corresponds to the port number on a particular device:

<img width="297" height="542" alt="image" src="https://github.com/user-attachments/assets/78bdda00-55a7-4467-b481-9fb5559c7706" />

This one-line fix corrects this by using xBucketMin rather than xBucketMax when the X-axis field type is numeric. Tooltips for time-based data continue to use xBucketMax.

**Why do we need this feature?**

Using Heatmap to represent dense, non-time-based data is very useful, but this discrepancy between axis and tooltip creates a confusing user experience.

**Who is this feature for?**

Anybody who wants to use Heatmap to represent non-

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
