### PR TITLE
Folders: Fix error handling for zanzana

### DIFF
--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -125,7 +125,7 @@ func TestToFolderErrorResponse(t *testing.T) {
 		},
 		// --- Kubernetes status errors ---
 		{
-			name: "kubernetes status error",
+			name: "kubernetes status error with message",
 			input: &k8sErrors.StatusError{
 				ErrStatus: metav1.Status{
 					Code:    412,
@@ -136,6 +136,66 @@ func TestToFolderErrorResponse(t *testing.T) {
 				ErrStatus: metav1.Status{
 					Code:    412,
 					Message: "the folder has been changed by someone else",
+				},
+			}),
+		},
+		{
+			name: "kubernetes status error with empty message - 403 forbidden",
+			input: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusForbidden,
+					Message: "",
+				},
+			},
+			want: response.Error(http.StatusForbidden, "Access denied", &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusForbidden,
+					Message: "",
+				},
+			}),
+		},
+		{
+			name: "kubernetes status error with empty message - 404 not found",
+			input: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusNotFound,
+					Message: "",
+				},
+			},
+			want: response.Error(http.StatusNotFound, "Folder not found", &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusNotFound,
+					Message: "",
+				},
+			}),
+		},
+		{
+			name: "kubernetes status error with empty message - 400 bad request",
+			input: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusBadRequest,
+					Message: "",
+				},
+			},
+			want: response.Error(http.StatusBadRequest, "Invalid request", &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusBadRequest,
+					Message: "",
+				},
+			}),
+		},
+		{
+			name: "kubernetes status error with empty message - default fallback",
+			input: &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "",
+				},
+			},
+			want: response.Error(http.StatusInternalServerError, "Folder API error", &k8sErrors.StatusError{
+				ErrStatus: metav1.Status{
+					Code:    http.StatusInternalServerError,
+					Message: "",
 				},
 			}),
 		},


### PR DESCRIPTION
Zanzana returns the error:

```
{ErrStatus: k8s.io/apimachinery/pkg/apis/meta/v1.Status {TypeMeta: (*"k8s.io/apimachinery/pkg/apis/meta/v1.TypeMeta")(0x14003910d20), ListMeta: (*"k8s.io/apimachinery/pkg/apis/meta/v1.ListMeta")(0x14003910d40), Status: "Failure", Message: "", Reason: "", Details: *k8s.io/apimachinery/pkg/apis/meta/v1.StatusDetails nil, Code: 403}}
```

which was resulting in a 500 from the folders api. This PR updates the error handling in folders to correctly return an access denied

Before:
<img width="375" height="136" alt="Screenshot 2025-12-09 at 6 20 40 PM" src="https://github.com/user-attachments/assets/6e331dae-bfde-4304-959c-0cd1efd337fe" />
<img width="499" height="100" alt="Screenshot 2025-12-09 at 6 20 50 PM" src="https://github.com/user-attachments/assets/2f45d623-2667-4161-9a9d-c4bce18156f9" />

After:
<img width="486" height="153" alt="Screenshot 2025-12-09 at 6 21 00 PM" src="https://github.com/user-attachments/assets/634dbb62-da3f-43c0-82ea-1324c7cc0a6c" />
<img width="501" height="78" alt="Screenshot 2025-12-09 at 6 21 05 PM" src="https://github.com/user-attachments/assets/f30dc431-ea72-459b-94d8-5e99a66b5422" />
