### PR TITLE
Alerting: Hide DS-managed options when alertingDisableDMAlerts is ena…

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -540,6 +540,10 @@ export interface FeatureToggles {
   */
   alertingDisableSendAlertsExternal?: boolean;
   /**
+  * Disables data source-managed alerts and hides related UI options.
+  */
+  alertingDisableDMAlerts?: boolean;
+  /**
   * Enables possibility to preserve dashboard variables and time range when navigating between dashboards
   */
   preserveDashboardStateWhenNavigating?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -893,6 +893,14 @@ var (
 			HideFromDocs: true,
 		},
 		{
+			Name:         "alertingDisableDMAlerts",
+			Description:  "Disables data source-managed alerts and hides related UI options.",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			FrontendOnly: true,
+			HideFromDocs: true,
+		},
+		{
 			Name:         "preserveDashboardStateWhenNavigating",
 			Description:  "Enables possibility to preserve dashboard variables and time range when navigating between dashboards",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -123,6 +123,7 @@ dashboardTemplates,preview,@grafana/sharing-squad,false,false,false
 logsExploreTableDefaultVisualization,experimental,@grafana/observability-logs,false,false,true
 alertingListViewV2,privatePreview,@grafana/alerting-squad,false,false,true
 alertingDisableSendAlertsExternal,experimental,@grafana/alerting-squad,false,false,false
+alertingDisableDMAlerts,experimental,@grafana/alerting-squad,false,false,true
 preserveDashboardStateWhenNavigating,experimental,@grafana/dashboards-squad,false,false,false
 alertingCentralAlertHistory,experimental,@grafana/alerting-squad,false,false,false
 pluginProxyPreserveTrailingSlash,GA,@grafana/plugins-platform-backend,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -197,6 +197,20 @@
     },
     {
       "metadata": {
+        "name": "alertingDisableDMAlerts",
+        "resourceVersion": "1765342651926",
+        "creationTimestamp": "2025-12-10T04:57:31Z"
+      },
+      "spec": {
+        "description": "Disables data source-managed alerts and hides related UI options.",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingDisableSendAlertsExternal",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2024-05-23T12:29:19Z"

--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/SmartAlertTypeDetector.tsx
@@ -1,6 +1,7 @@
 import { useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { RadioButtonGroup, Stack, Text } from '@grafana/ui';
 import { AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -21,12 +22,18 @@ export function SmartAlertTypeDetector({ editingExistingRule, queries, onClickSw
   const [ruleFormType] = getValues(['type']);
   const canSwitch = useGetCanSwitch({ queries, ruleFormType });
 
+  const dmAlertsDisabled = config.featureToggles.alertingDisableDMAlerts === true;
+
   const options = [
     { label: t('alerting.smart-alert-type-detector.grafana-managed', 'Grafana-managed'), value: RuleFormType.grafana },
-    {
-      label: t('alerting.smart-alert-type-detector.data-source-managed', 'Data source-managed'),
-      value: RuleFormType.cloudAlerting,
-    },
+    ...(!dmAlertsDisabled
+      ? [
+          {
+            label: t('alerting.smart-alert-type-detector.data-source-managed', 'Data source-managed'),
+            value: RuleFormType.cloudAlerting,
+          },
+        ]
+      : []),
   ];
 
   // if we can't switch to data-source managed, disable it

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -41,7 +41,8 @@ export function RuleListActions() {
   const [exportRulesSupported, exportRulesAllowed] = useAlertingAbility(AlertingAction.ExportGrafanaManagedRules);
 
   const canCreateGrafanaRules = createGrafanaRuleSupported && createGrafanaRuleAllowed;
-  const canCreateCloudRules = createCloudRuleSupported && createCloudRuleAllowed;
+  const canCreateCloudRules =
+    createCloudRuleSupported && createCloudRuleAllowed && !config.featureToggles.alertingDisableDMAlerts;
   const canExportRules = exportRulesSupported && exportRulesAllowed;
 
   const canCreateRules = canCreateGrafanaRules || canCreateCloudRules;

--- a/public/app/features/alerting/unified/utils/access-control.ts
+++ b/public/app/features/alerting/unified/utils/access-control.ts
@@ -1,3 +1,4 @@
+import { config } from '@grafana/runtime';
 import { getConfig } from 'app/core/config';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -129,11 +130,14 @@ export function evaluateAccess(actions: AccessControlAction[]) {
 }
 
 export function getRulesAccess() {
+  const dmAlertsDisabled = config.featureToggles.alertingDisableDMAlerts === true;
+
   return {
     canCreateGrafanaRules:
       contextSrv.hasPermission(AccessControlAction.FoldersRead) &&
       contextSrv.hasPermission(rulesPermissions.create.grafana),
     canCreateCloudRules:
+      !dmAlertsDisabled &&
       contextSrv.hasPermission(AccessControlAction.DataSourcesRead) &&
       contextSrv.hasPermission(rulesPermissions.create.external),
     canEditRules: (rulesSourceName: string) => {


### PR DESCRIPTION
**What is this feature?**
When the `alertingDisableDMAlerts` feature toggle is enabled:
- Hide "New Data source recording rule" from the More dropdown
- Hide "Data source-managed" option from rule type selector
- Disable canCreateCloudRules in access control

**Why do we need this feature?**
Allows admins to disable data source-managed alerting UI when they don't want users to create DS-managed rules.

**Who is this feature for?**
Grafana administrators who want to restrict alerting to Grafana-managed rules only.

**Which issue(s) does this PR fix?**
Fixes #115015

**Special notes for your reviewer:**
Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.


```
With `alertingDisableDMAlerts = true`
"New Data source recording rule" is hidden
```
<img width="3248" height="2120" alt="CleanShot 2025-12-09 at 21 43 16@2x" src="https://github.com/user-attachments/assets/71601330-9985-4069-8d36-01558a0e83e3" />

```
With `alertingDisableDMAlerts = false` 
```
<img width="3248" height="2120" alt="CleanShot 2025-12-09 at 21 47 55@2x" src="https://github.com/user-attachments/assets/a83eff62-afe6-49f3-81bd-3305574667b4" />
(default): "New Data source recording rule" is visible