### PR TITLE
Packaging: Upgrade alpine to 3.23.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ARG JS_SRC=js-builder
 
 # Dependabot cannot update dependencies listed in ARGs
 # By using FROM instructions we can delegate dependency updates to dependabot
-FROM alpine:3.22.2 AS alpine-base
+FROM alpine:3.23.0 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
 FROM golang:1.25.5-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base


### PR DESCRIPTION
Alpine 3.23.0 was released last week which includes a number of dependency updates. Most notably is BusyBox.

```
$ docker run --rm -it alpine:3.23.0 /bin/sh -c 'apk list -v | grep busybox'
busybox-1.37.0-r29 aarch64 {busybox} (GPL-2.0-only) [installed]
busybox-binsh-1.37.0-r29 aarch64 {busybox} (GPL-2.0-only) [installed]
  busybox ash /bin/sh
ssl_client-1.37.0-r29 aarch64 {busybox} (GPL-2.0-only) [installed]
  External ssl_client for busybox wget
  ```

Release notes here: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.23.0