### PR TITLE
Zanzana: Fix resource translation for dashboards

### DIFF
--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -4,8 +4,12 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	authzv1 "github.com/grafana/authlib/authz/proto/v1"
+
+	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 )
 
@@ -44,7 +48,8 @@ func getTypeInfo(group, resource string) (typeInfo, bool) {
 
 func NewResourceInfoFromCheck(r *authzv1.CheckRequest) ResourceInfo {
 	typ, relations := getTypeAndRelations(r.GetGroup(), r.GetResource())
-	return newResource(
+
+	resource := newResource(
 		typ,
 		r.GetGroup(),
 		r.GetResource(),
@@ -53,6 +58,17 @@ func NewResourceInfoFromCheck(r *authzv1.CheckRequest) ResourceInfo {
 		r.GetSubresource(),
 		relations,
 	)
+
+	// Special case for creating folders and resources in the root folder
+	if r.GetVerb() == utils.VerbCreate {
+		if resource.IsFolderResource() {
+			resource.name = accesscontrol.GeneralFolderUID
+		} else if resource.HasFolderSupport() {
+			resource.folder = accesscontrol.GeneralFolderUID
+		}
+	}
+
+	return resource
 }
 
 func NewResourceInfoFromBatchItem(i *authzextv1.BatchCheckItem) ResourceInfo {
@@ -163,4 +179,16 @@ func (r ResourceInfo) IsValidRelation(relation string) bool {
 
 func (r ResourceInfo) HasSubresource() bool {
 	return r.subresource != ""
+}
+
+var resourcesWithFolderSupport = map[string]bool{
+	dashboardV1.DashboardResourceInfo.GroupResource().Group: true,
+}
+
+func (r ResourceInfo) HasFolderSupport() bool {
+	return resourcesWithFolderSupport[r.group]
+}
+
+func (r ResourceInfo) IsFolderResource() bool {
+	return r.group == folders.FolderResourceInfo.GroupResource().Group
 }

--- a/pkg/services/authz/zanzana/common/info.go
+++ b/pkg/services/authz/zanzana/common/info.go
@@ -61,11 +61,13 @@ func NewResourceInfoFromCheck(r *authzv1.CheckRequest) ResourceInfo {
 
 	// Special case for creating folders and resources in the root folder
 	if r.GetVerb() == utils.VerbCreate {
-		if resource.IsFolderResource() {
+		if resource.IsFolderResource() && resource.name == "" {
 			resource.name = accesscontrol.GeneralFolderUID
-		} else if resource.HasFolderSupport() {
+		} else if resource.HasFolderSupport() && resource.folder == "" {
 			resource.folder = accesscontrol.GeneralFolderUID
 		}
+
+		return resource
 	}
 
 	return resource

--- a/pkg/services/authz/zanzana/common/tuple.go
+++ b/pkg/services/authz/zanzana/common/tuple.go
@@ -228,6 +228,9 @@ func TranslateToResourceTuple(subject string, action, kind, name string) (*openf
 	}
 
 	if name == "*" {
+		if m.group != "" && m.resource != "" {
+			return NewGroupResourceTuple(subject, m.relation, m.group, m.resource, m.subresource), true
+		}
 		return NewGroupResourceTuple(subject, m.relation, translation.group, translation.resource, m.subresource), true
 	}
 

--- a/pkg/services/authz/zanzana/common/tuple_test.go
+++ b/pkg/services/authz/zanzana/common/tuple_test.go
@@ -1,0 +1,89 @@
+package common
+
+import (
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type translationTestCase struct {
+	testName string
+	subject  string
+	action   string
+	kind     string
+	name     string
+	expected *openfgav1.TupleKey
+}
+
+func TestTranslateToResourceTuple(t *testing.T) {
+	tests := []translationTestCase{
+		{
+			testName: "dashboards:read in folders",
+			subject:  "user:1",
+			action:   "dashboards:read",
+			kind:     "folders",
+			name:     "*",
+			expected: &openfgav1.TupleKey{
+				User:     "user:1",
+				Relation: "get",
+				Object:   "group_resource:dashboard.grafana.app/dashboards",
+			},
+		},
+		{
+			testName: "dashboards:read for all dashboards",
+			subject:  "user:1",
+			action:   "dashboards:read",
+			kind:     "dashboards",
+			name:     "*",
+			expected: &openfgav1.TupleKey{
+				User:     "user:1",
+				Relation: "get",
+				Object:   "group_resource:dashboard.grafana.app/dashboards",
+			},
+		},
+		{
+			testName: "dashboards:read for general folder",
+			subject:  "user:1",
+			action:   "dashboards:read",
+			kind:     "folders",
+			name:     "general",
+			expected: &openfgav1.TupleKey{
+				User:     "user:1",
+				Relation: "resource_get",
+				Object:   "folder:general",
+				Condition: &openfgav1.RelationshipCondition{
+					Name: "subresource_filter",
+					Context: &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"subresources": structpb.NewListValue(&structpb.ListValue{
+								Values: []*structpb.Value{structpb.NewStringValue("dashboard.grafana.app/dashboards")},
+							}),
+						},
+					},
+				},
+			},
+		},
+		{
+			testName: "folders:read",
+			subject:  "user:1",
+			action:   "folders:read",
+			kind:     "folders",
+			name:     "*",
+			expected: &openfgav1.TupleKey{
+				User:     "user:1",
+				Relation: "get",
+				Object:   "group_resource:folder.grafana.app/folders",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			tuple, ok := TranslateToResourceTuple(test.subject, test.action, test.kind, test.name)
+			require.True(t, ok)
+			require.EqualExportedValues(t, test.expected, tuple)
+		})
+	}
+}

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -213,14 +213,14 @@ func testCheck(t *testing.T, server *Server) {
 		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
 	})
 
-	t.Run("user:1 should be able to create folder in root folder", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, folderGroup, folderResource, "", "", ""))
+	t.Run("user:18 should be able to create folder in root folder", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:18", utils.VerbCreate, folderGroup, folderResource, "", "", ""))
 		require.NoError(t, err)
 		assert.Equal(t, true, res.GetAllowed())
 	})
 
-	t.Run("user:1 should be able to create dashboard in root folder", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, dashboardGroup, dashboardResource, "", "", ""))
+	t.Run("user:18 should be able to create dashboard in root folder", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:18", utils.VerbCreate, dashboardGroup, dashboardResource, "", "", ""))
 		require.NoError(t, err)
 		assert.Equal(t, true, res.GetAllowed())
 	})

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -24,194 +24,194 @@ func testCheck(t *testing.T, server *Server) {
 		}
 	}
 
-	// t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	// sanity check
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
+		// sanity check
+		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
 
-	// 	// sanity check no access to subresource
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		// sanity check no access to subresource
+		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through group_resource", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through group_resource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	// sanity check
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		// sanity check
+		res, err = server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	// sanity check
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		// sanity check
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:6 should be able to read folder 1 ", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:6 should be able to read folder 1 ", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:7 should be able to read folder one through group_resource access", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:7 should be able to read folder one through group_resource access", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:9 should be able to create dashboards in folder 5", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:9 should be able to create dashboards in folder 5", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:10 should be able to read dashboard status for dashboard 10", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:10 should be able to read dashboard status for dashboard 10", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:11 should be able to read dashboard status for dashboard 10 through group_resource", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:11 should be able to read dashboard status for dashboard 10 through group_resource", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:12 should be able to read dashboard status for all dashboards in folder 5", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:12 should be able to read dashboard status for all dashboards in folder 5", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	// inherited from folder 5
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		// inherited from folder 5
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:13 should be able to read folder status for all subfolders of folder 5", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "5"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:13 should be able to read folder status for all subfolders of folder 5", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "5"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "6"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "6"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "4"))
-	// 	require.NoError(t, err)
-	// 	assert.False(t, res.GetAllowed())
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "4"))
+		require.NoError(t, err)
+		assert.False(t, res.GetAllowed())
+	})
 
-	// t.Run("user:14 should be able to read team subresources for team 1", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:14", utils.VerbGet, "iam.grafana.app", "teams", statusSubresource, "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:14 should be able to read team subresources for team 1", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:14", utils.VerbGet, "iam.grafana.app", "teams", statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:15 should be able to read user subresources for user 1", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:15", utils.VerbGet, "iam.grafana.app", "users", statusSubresource, "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:15 should be able to read user subresources for user 1", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:15", utils.VerbGet, "iam.grafana.app", "users", statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:16 should be able to read serviceaccount subresources for serviceaccount 1", func(t *testing.T) {
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:16", utils.VerbGet, "iam.grafana.app", "serviceaccounts", statusSubresource, "", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
-	// })
+	t.Run("user:16 should be able to read serviceaccount subresources for serviceaccount 1", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:16", utils.VerbGet, "iam.grafana.app", "serviceaccounts", statusSubresource, "", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
+	})
 
-	// t.Run("user:17 should be able to view dashboards in folder 4 and all subfolders", func(t *testing.T) {
-	// 	// Check for folders
-	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "4"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+	t.Run("user:17 should be able to view dashboards in folder 4 and all subfolders", func(t *testing.T) {
+		// Check for folders
+		res, err := server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "4"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "5"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "5"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "6"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed())
+		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "6"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed())
 
-	// 	// Check for dashboards
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "4", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 4")
+		// Check for dashboards
+		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "4", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 4")
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 5")
+		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 5")
 
-	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "1"))
-	// 	require.NoError(t, err)
-	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
-	// })
+		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "1"))
+		require.NoError(t, err)
+		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
+	})
 
 	t.Run("user:1 should be able to create folder in root folder", func(t *testing.T) {
 		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, folderGroup, folderResource, "", "", ""))

--- a/pkg/services/authz/zanzana/server/server_check_test.go
+++ b/pkg/services/authz/zanzana/server/server_check_test.go
@@ -24,192 +24,204 @@ func testCheck(t *testing.T, server *Server) {
 		}
 	}
 
-	t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
+	// t.Run("user:1 should only be able to read resource:dashboard.grafana.app/dashboards/1", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
 
-		// sanity check
-		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
+	// 	// sanity check
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
 
-		// sanity check no access to subresource
-		res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
+	// 	// sanity check no access to subresource
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through group_resource", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	// sanity check
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	// sanity check
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:6 should be able to read folder 1 ", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:7 should be able to read folder one through group_resource access", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:9 should be able to create dashboards in folder 5", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:10 should be able to read dashboard status for dashboard 10", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:11 should be able to read dashboard status for dashboard 10 through group_resource", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:12 should be able to read dashboard status for all dashboards in folder 5", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	// inherited from folder 5
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:13 should be able to read folder status for all subfolders of folder 5", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "5"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "6"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "4"))
+	// 	require.NoError(t, err)
+	// 	assert.False(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:14 should be able to read team subresources for team 1", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:14", utils.VerbGet, "iam.grafana.app", "teams", statusSubresource, "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:15 should be able to read user subresources for user 1", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:15", utils.VerbGet, "iam.grafana.app", "users", statusSubresource, "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:16 should be able to read serviceaccount subresources for serviceaccount 1", func(t *testing.T) {
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:16", utils.VerbGet, "iam.grafana.app", "serviceaccounts", statusSubresource, "", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+	// })
+
+	// t.Run("user:17 should be able to view dashboards in folder 4 and all subfolders", func(t *testing.T) {
+	// 	// Check for folders
+	// 	res, err := server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "4"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "5"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "6"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed())
+
+	// 	// Check for dashboards
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "4", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 4")
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 5")
+
+	// 	res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "1"))
+	// 	require.NoError(t, err)
+	// 	assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
+	// })
+
+	t.Run("user:1 should be able to create folder in root folder", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, folderGroup, folderResource, "", "", ""))
 		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
+		assert.Equal(t, true, res.GetAllowed())
 	})
 
-	t.Run("user:2 should be able to read resource:dashboard.grafana.app/dashboards/1 through group_resource", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:2", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
+	t.Run("user:1 should be able to create dashboard in root folder", func(t *testing.T) {
+		res, err := server.Check(newContextWithNamespace(), newReq("user:1", utils.VerbCreate, dashboardGroup, dashboardResource, "", "", ""))
 		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:3 should be able to read resource:dashboard.grafana.app/dashboards/1 with set relation", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		// sanity check
-		res, err = server.Check(newContextWithNamespace(), newReq("user:3", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:4 should be able to read all dashboard.grafana.app/dashboards in folder 1 and 3", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "3", "2"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		// sanity check
-		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "2"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:4", utils.VerbGet, dashboardGroup, dashboardResource, "", "2", "2"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:5 should be able to read resource:dashboard.grafana.app/dashboards/1 through folder with set relation", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:5", utils.VerbGet, dashboardGroup, dashboardResource, "", "1", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:6 should be able to read folder 1 ", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:6", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:7 should be able to read folder one through group_resource access", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:7", utils.VerbGet, folderGroup, folderResource, "", "", "10"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:8 should be able to read all resoruce:dashboard.grafana.app/dashboar in folder 6 through folder 5", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "10"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "11"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:8", utils.VerbGet, folderGroup, folderResource, "", "4", "12"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:9 should be able to create dashboards in folder 5", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:9", utils.VerbCreate, dashboardGroup, dashboardResource, "", "5", ""))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:10 should be able to read dashboard status for dashboard 10", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:10", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "1"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:11 should be able to read dashboard status for dashboard 10 through group_resource", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:11", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "", "10"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:12 should be able to read dashboard status for all dashboards in folder 5", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "10"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "5", "11"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		// inherited from folder 5
-		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "6", "12"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:12", utils.VerbGet, dashboardGroup, dashboardResource, statusSubresource, "1", "13"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:13 should be able to read folder status for all subfolders of folder 5", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "5"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "6"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:13", utils.VerbGet, folderGroup, folderResource, statusSubresource, "", "4"))
-		require.NoError(t, err)
-		assert.False(t, res.GetAllowed())
-	})
-
-	t.Run("user:14 should be able to read team subresources for team 1", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:14", utils.VerbGet, "iam.grafana.app", "teams", statusSubresource, "", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:15 should be able to read user subresources for user 1", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:15", utils.VerbGet, "iam.grafana.app", "users", statusSubresource, "", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:16 should be able to read serviceaccount subresources for serviceaccount 1", func(t *testing.T) {
-		res, err := server.Check(newContextWithNamespace(), newReq("user:16", utils.VerbGet, "iam.grafana.app", "serviceaccounts", statusSubresource, "", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-	})
-
-	t.Run("user:17 should be able to view dashboards in folder 4 and all subfolders", func(t *testing.T) {
-		// Check for folders
-		res, err := server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "4"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "5"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, folderGroup, folderResource, "", "", "6"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed())
-
-		// Check for dashboards
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "4", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 4")
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "5", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 5")
-
-		res, err = server.Check(newContextWithNamespace(), newReq("user:17", utils.VerbGet, dashboardGroup, dashboardResource, "", "6", "1"))
-		require.NoError(t, err)
-		assert.True(t, res.GetAllowed(), "user should be able to view dashboards in folder 6")
+		assert.Equal(t, true, res.GetAllowed())
 	})
 }

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -49,6 +49,8 @@ func setup(t *testing.T, srv *Server) *Server {
 	tuples := []*openfgav1.TupleKey{
 		common.NewResourceTuple("user:1", common.RelationGet, dashboardGroup, dashboardResource, "", "1"),
 		common.NewResourceTuple("user:1", common.RelationUpdate, dashboardGroup, dashboardResource, "", "1"),
+		common.NewFolderTuple("user:1", common.RelationCreate, "general"),
+		common.NewFolderResourceTuple("user:1", common.RelationCreate, dashboardGroup, dashboardResource, "", "general"),
 		common.NewGroupResourceTuple("user:2", common.RelationGet, dashboardGroup, dashboardResource, ""),
 		common.NewGroupResourceTuple("user:2", common.RelationUpdate, dashboardGroup, dashboardResource, ""),
 		common.NewResourceTuple("user:3", common.RelationSetView, dashboardGroup, dashboardResource, "", "1"),

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -49,8 +49,6 @@ func setup(t *testing.T, srv *Server) *Server {
 	tuples := []*openfgav1.TupleKey{
 		common.NewResourceTuple("user:1", common.RelationGet, dashboardGroup, dashboardResource, "", "1"),
 		common.NewResourceTuple("user:1", common.RelationUpdate, dashboardGroup, dashboardResource, "", "1"),
-		common.NewFolderTuple("user:1", common.RelationCreate, "general"),
-		common.NewFolderResourceTuple("user:1", common.RelationCreate, dashboardGroup, dashboardResource, "", "general"),
 		common.NewGroupResourceTuple("user:2", common.RelationGet, dashboardGroup, dashboardResource, ""),
 		common.NewGroupResourceTuple("user:2", common.RelationUpdate, dashboardGroup, dashboardResource, ""),
 		common.NewResourceTuple("user:3", common.RelationSetView, dashboardGroup, dashboardResource, "", "1"),
@@ -73,6 +71,8 @@ func setup(t *testing.T, srv *Server) *Server {
 		common.NewTypedResourceTuple("user:15", common.RelationGet, common.TypeUser, userGroup, userResource, statusSubresource, "1"),
 		common.NewTypedResourceTuple("user:16", common.RelationGet, common.TypeServiceAccount, serviceAccountGroup, serviceAccountResource, statusSubresource, "1"),
 		common.NewFolderTuple("user:17", common.RelationSetView, "4"),
+		common.NewFolderTuple("user:18", common.RelationCreate, "general"),
+		common.NewFolderResourceTuple("user:18", common.RelationCreate, dashboardGroup, dashboardResource, "", "general"),
 	}
 
 	return setupOpenFGADatabase(t, srv, tuples)


### PR DESCRIPTION
**What is this feature?**

Fix resource translation for dashboards.

`dashboards:create folder:*` should be translated to `create group_resource dashboard.grafana.app/dashboards`, not to 
`create group_resource folder.grafana.app/folders`.

**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
