### PR TITLE
Plugins: Sync channel close for app installer readiness

### DIFF
--- a/apps/plugins/pkg/app/app.go
+++ b/apps/plugins/pkg/app/app.go
@@ -3,7 +3,9 @@ package app
 import (
 	"context"
 	"fmt"
+	"sync"
 
+	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/app"
 	"github.com/grafana/grafana-app-sdk/k8s"
 	appsdkapiserver "github.com/grafana/grafana-app-sdk/k8s/apiserver"
@@ -16,7 +18,6 @@ import (
 	restclient "k8s.io/client-go/rest"
 	"k8s.io/klog/v2"
 
-	authlib "github.com/grafana/authlib/types"
 	pluginsappapis "github.com/grafana/grafana/apps/plugins/pkg/apis"
 	pluginsv0alpha1 "github.com/grafana/grafana/apps/plugins/pkg/apis/plugins/v0alpha1"
 	"github.com/grafana/grafana/apps/plugins/pkg/app/meta"
@@ -106,12 +107,15 @@ type PluginAppInstaller struct {
 	// restConfig is set during InitializeApp and used by the client factory
 	restConfig *restclient.Config
 	ready      chan struct{}
+	readyOnce  sync.Once
 }
 
 func (p *PluginAppInstaller) InitializeApp(restConfig restclient.Config) error {
 	if p.restConfig == nil {
 		p.restConfig = &restConfig
-		close(p.ready)
+		p.readyOnce.Do(func() {
+			close(p.ready)
+		})
 	}
 	return p.AppInstaller.InitializeApp(restConfig)
 }


### PR DESCRIPTION
Fixes issue in CI:

```
panic: close of closed channel

goroutine 1076 [running]:
github.com/grafana/grafana/apps/plugins/pkg/app.(*PluginAppInstaller).InitializeApp(...)
	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/apps/plugins/pkg/app/app.go:114
github.com/grafana/grafana/pkg/services/apiserver.(*service).start(0xc00121bc20, {0xde52c68, 0xc002e7e460})
	/opt/actions-runner/_work/grafana-enterprise/grafana-enterprise/grafana/pkg/services/apiserver/service.go:491 +0x1a55
github.com/grafana/dskit/services.(*BasicService).main(0xc0018c4f00)
	/home/ubuntu/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20250908063411-6b6da59b5cc4/services/basic_service.go:160 +0x59
created by github.com/grafana/dskit/services.(*BasicService).StartAsync.func1 in goroutine 1046
	/home/ubuntu/go/pkg/mod/github.com/grafana/dskit@v0.0.0-20250908063411-6b6da59b5cc4/services/basic_service.go:122 +0x105
FAIL	github.com/grafana/grafana/pkg/tests/apis/dashboard	2.099s
```