### PR TITLE
VariablesEditableElement: Set margin correctly

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -150,7 +150,12 @@ function VariableNameInput({ variable, isNewElement }: { variable: SceneVariable
   const oldName = useRef(name);
 
   return (
-    <Field label={t('dashboard.edit-pane.variable.name', 'Name')} invalid={!!nameError} error={nameError} noMargin>
+    <Field
+      label={t('dashboard.edit-pane.variable.name', 'Name')}
+      invalid={!!nameError}
+      error={nameError}
+      noMargin={false}
+    >
       <Input
         id={id}
         ref={ref}


### PR DESCRIPTION
I've blindly accepted this eslint fix by Cursor, sorry about that!

```
Add noMargin prop to Field components to remove built-in margins. Use layout components like Stack or Grid with the gap prop instead for consistent spacing.
```