### PR TITLE
Add non-boolean feature flags support to the StaticProvider

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2079,13 +2079,12 @@ enable =
 # To enable features by default, set `Expression:  "true"` in:
 # https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go
 
-# The feature_toggles section now supports feature flags of different types,
+# The feature_toggles section supports feature flags of a number of types,
 # including boolean, string, integer, float, and structured values, following the OpenFeature specification.
-# This feature is experimental and may change in future releases.
 #
 # feature1 = true
 # feature2 = false
-# feature3 = foobar
+# feature3 = "foobar"
 # feature4 = 1.5
 # feature5 = { "foo": "bar" }
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -336,7 +336,7 @@ rudderstack_data_plane_url =
 rudderstack_sdk_url =
 
 # Rudderstack v3 SDK, optional, defaults to false. If set, Rudderstack v3 SDK will be used instead of v1
-rudderstack_v3_sdk_url = 
+rudderstack_v3_sdk_url =
 
 # Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
 rudderstack_config_url =
@@ -2079,8 +2079,15 @@ enable =
 # To enable features by default, set `Expression:  "true"` in:
 # https://github.com/grafana/grafana/blob/main/pkg/services/featuremgmt/registry.go
 
+# The feature_toggles section now supports feature flags of different types,
+# including boolean, string, integer, float, and structured values, following the OpenFeature specification.
+# This feature is experimental and may change in future releases.
+#
 # feature1 = true
 # feature2 = false
+# feature3 = foobar
+# feature4 = 1.5
+# feature5 = { "foo": "bar" }
 
 [feature_toggles.openfeature]
 # This is EXPERIMENTAL. Please, do not use this section

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -323,7 +323,7 @@
 ;rudderstack_sdk_url =
 
 # Rudderstack v3 SDK, optional, defaults to false. If set, Rudderstack v3 SDK will be used instead of v1
-;rudderstack_v3_sdk_url = 
+;rudderstack_v3_sdk_url =
 
 # Rudderstack Config url, optional, used by Rudderstack SDK to fetch source config
 ;rudderstack_config_url =
@@ -1913,7 +1913,7 @@ default_datasource_uid =
 
 # client_queue_max_size is the maximum size in bytes of the client queue
 # for Live connections. Defaults to 4MB.
-;client_queue_max_size = 
+;client_queue_max_size =
 
 #################################### Grafana Image Renderer Plugin ##########################
 [plugin.grafana-image-renderer]
@@ -1996,9 +1996,14 @@ default_datasource_uid =
 
 ;enable = feature1,feature2
 
+# The feature_toggles section supports feature flags of a number of types,
+# including boolean, string, integer, float, and structured values, following the OpenFeature specification.
+
 ;feature1 = true
 ;feature2 = false
-
+;feature3 = "foobar"
+;feature4 = 1.5
+;feature5 = { "foo": "bar" }
 [date_formats]
 # For information on what formatting patterns that are supported https://momentjs.com/docs/#/displaying/
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2836,12 +2836,12 @@ For more information about Grafana Enterprise, refer to [Grafana Enterprise](../
 
 Keys of features to enable, separated by space.
 
-#### `FEATURE_TOGGLE_NAME = <value>` 
+#### `FEATURE_TOGGLE_NAME = <value>`
 
 The feature toggles section supports feature flags of a number of types, including boolean, string, integer, float, and structured values, following the OpenFeature specification.
 
 - **Boolean**: <br/>
-Some feature toggles for stable features are on by default. Use this setting to disable or change an on-by-default feature toggle
+  Some feature toggles for stable features are on by default. Use this setting to disable or change an on-by-default feature toggle
   ```ini
   exploreMixedDatasource = false
   ```
@@ -2857,7 +2857,7 @@ Some feature toggles for stable features are on by default. Use this setting to 
   ```ini
   requestTimeout = 2.5
   ```
-- **Structured values**:  JSON-objects
+- **Structured values**: JSON-objects
   ```json
   featureConfig = {"retries": 3, "mode": "safe"}
   ```

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2836,31 +2836,11 @@ For more information about Grafana Enterprise, refer to [Grafana Enterprise](../
 
 Keys of features to enable, separated by space.
 
-#### `FEATURE_TOGGLE_NAME = <value>`
+#### `FEATURE_NAME = <value>`
 
-The feature toggles section supports feature flags of a number of types, including boolean, string, integer, float, and structured values, following the OpenFeature specification.
+Use a key-value pair to set feature flag values explicitly, overriding any default values. A few different types are supported, following the OpenFeature specification. See the defaults.ini file for more details.
 
-- **Boolean**: <br/>
-  Some feature toggles for stable features are on by default. Use this setting to disable or change an on-by-default feature toggle
-  ```ini
-  exploreMixedDatasource = false
-  ```
-- **String**: any quoted text
-  ```ini
-  welcomeMessage = "Hello, user!"
-  ```
-- **Integer**: whole numbers
-  ```ini
-  maxConnections = 10
-  ```
-- **Float**: decimal numbers
-  ```ini
-  requestTimeout = 2.5
-  ```
-- **Structured values**: JSON-objects
-  ```json
-  featureConfig = {"retries": 3, "mode": "safe"}
-  ```
+For example, to disable an on-by-default feature toggle named `exploreMixedDatasource`, specify `exploreMixedDatasource = false`.
 
 <hr>
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2836,9 +2836,31 @@ For more information about Grafana Enterprise, refer to [Grafana Enterprise](../
 
 Keys of features to enable, separated by space.
 
-#### `FEATURE_TOGGLE_NAME = false`
+#### `FEATURE_TOGGLE_NAME = <value>` 
 
-Some feature toggles for stable features are on by default. Use this setting to disable an on-by-default feature toggle with the name FEATURE_TOGGLE_NAME, for example, `exploreMixedDatasource = false`.
+The feature toggles section supports feature flags of a number of types, including boolean, string, integer, float, and structured values, following the OpenFeature specification.
+
+- **Boolean**: <br/>
+Some feature toggles for stable features are on by default. Use this setting to disable or change an on-by-default feature toggle
+  ```ini
+  exploreMixedDatasource = false
+  ```
+- **String**: any quoted text
+  ```ini
+  welcomeMessage = "Hello, user!"
+  ```
+- **Integer**: whole numbers
+  ```ini
+  maxConnections = 10
+  ```
+- **Float**: decimal numbers
+  ```ini
+  requestTimeout = 2.5
+  ```
+- **Structured values**:  JSON-objects
+  ```json
+  featureConfig = {"retries": 3, "mode": "safe"}
+  ```
 
 <hr>
 

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -2,6 +2,7 @@ package appregistry
 
 import (
 	"context"
+	"github.com/open-feature/go-sdk/openfeature"
 
 	"github.com/grafana/grafana/pkg/registry/apps/quotas"
 	"github.com/open-feature/go-sdk/openfeature"
@@ -76,7 +77,11 @@ func ProvideAppInstallers(
 		installers = append(installers, logsdrilldownAppInstaller)
 	}
 	//nolint:staticcheck
-	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotations) {
+	ctx := context.Background()
+	s := openfeature.NewDefaultClient().String(ctx, featuremgmt.FlagBlueFlag, "red", openfeature.TransactionContext(ctx))
+	println("@@@@@@", s)
+	if s == "blue" {
+		println("@@@@@@", "OH MY IS BLUE")
 		installers = append(installers, annotationAppInstaller)
 	}
 	//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -2,7 +2,6 @@ package appregistry
 
 import (
 	"context"
-	"github.com/open-feature/go-sdk/openfeature"
 
 	"github.com/grafana/grafana/pkg/registry/apps/quotas"
 	"github.com/open-feature/go-sdk/openfeature"
@@ -77,11 +76,7 @@ func ProvideAppInstallers(
 		installers = append(installers, logsdrilldownAppInstaller)
 	}
 	//nolint:staticcheck
-	ctx := context.Background()
-	s := openfeature.NewDefaultClient().String(ctx, featuremgmt.FlagBlueFlag, "red", openfeature.TransactionContext(ctx))
-	println("@@@@@@", s)
-	if s == "blue" {
-		println("@@@@@@", "OH MY IS BLUE")
+	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotations) {
 		installers = append(installers, annotationAppInstaller)
 	}
 	//nolint:staticcheck // not yet migrated to OpenFeature

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -130,10 +130,10 @@ type FeatureFlagType int
 
 const (
 	Boolean FeatureFlagType = iota
+	String
 	Integer
 	Float
-	Object
-	String
+	Structure
 )
 
 func (t FeatureFlagType) String() string {
@@ -144,7 +144,7 @@ func (t FeatureFlagType) String() string {
 		return "number"
 	case Float:
 		return "float"
-	case Object:
+	case Structure:
 		return "object"
 	case String:
 		return "string"
@@ -176,7 +176,7 @@ func (t *FeatureFlagType) UnmarshalJSON(b []byte) error {
 	case "float":
 		*t = Float
 	case "object":
-		*t = Object
+		*t = Structure
 	case "string":
 		*t = String
 	}
@@ -192,6 +192,8 @@ type FeatureFlag struct {
 
 	// CEL-GO expression.  Using the value "true" will mean this is on by default
 	Expression string `json:"expression,omitempty"`
+	// Type of the feature flag (boolean, number, string, structure),
+	Type FeatureFlagType `json:"type,omitempty"`
 
 	// Special behavior properties
 	RequiresDevMode bool `json:"requiresDevMode,omitempty"` // can not be enabled in production
@@ -200,8 +202,6 @@ type FeatureFlag struct {
 
 	// The server must be initialized with the value
 	RequiresRestart bool `json:"requiresRestart,omitempty"`
-
-	Type FeatureFlagType `json:"type,omitempty"`
 }
 
 type FeatureToggleWebhookPayload struct {

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -126,14 +126,62 @@ func (s *FeatureFlagStage) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type FeatureFlagType string
+type FeatureFlagType int
 
 const (
-	Boolean = "boolean"
-	Number  = "number"
-	Object  = "object"
-	String  = "string"
+	Boolean FeatureFlagType = iota
+	Integer
+	Float
+	Object
+	String
 )
+
+func (t FeatureFlagType) String() string {
+	switch t {
+	case Boolean:
+		return "boolean"
+	case Integer:
+		return "number"
+	case Float:
+		return "float"
+	case Object:
+		return "object"
+	case String:
+		return "string"
+	}
+
+	return "unknown"
+}
+
+// MarshalJSON marshals the enum as a quoted json string
+func (t FeatureFlagType) MarshalJSON() ([]byte, error) {
+	buffer := bytes.NewBufferString(`"`)
+	buffer.WriteString(t.String())
+	buffer.WriteString(`"`)
+	return buffer.Bytes(), nil
+}
+
+func (t *FeatureFlagType) UnmarshalJSON(b []byte) error {
+	var j string
+	err := json.Unmarshal(b, &j)
+	if err != nil {
+		return err
+	}
+
+	switch j {
+	case "boolean":
+		*t = Boolean
+	case "number":
+		*t = Integer
+	case "float":
+		*t = Float
+	case "object":
+		*t = Object
+	case "string":
+		*t = String
+	}
+	return nil
+}
 
 // These are properties about the feature, but not the current state or value for it
 type FeatureFlag struct {

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -133,7 +133,11 @@ type FeatureFlag struct {
 	Stage       FeatureFlagStage `json:"stage,omitempty"`
 	Owner       codeowner        `json:"-"` // Owner person or team that owns this feature flag
 
-	// CEL-GO expression.  Using the value "true" will mean this is on by default
+	// Expression defined by the feature_toggles configuration.
+	// Supports multiple types including boolean, string, integer, float,
+	// and structured values following the OpenFeature specification.
+	// Using the value "true" means the feature flag is enabled by default,
+	// Using the value "1.0" means the default value of the feature flag is 1.0
 	Expression string `json:"expression,omitempty"`
 
 	// Special behavior properties

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -129,6 +129,7 @@ func (s *FeatureFlagStage) UnmarshalJSON(b []byte) error {
 type FeatureFlagType int
 
 const (
+	// Boolean -- Type of a flag
 	Boolean FeatureFlagType = iota
 	Integer
 	Float

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -126,64 +126,6 @@ func (s *FeatureFlagStage) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type FeatureFlagType int
-
-const (
-	// Boolean -- Type of a flag
-	Boolean FeatureFlagType = iota
-	Integer
-	Float
-	String
-	Structure
-)
-
-func (t FeatureFlagType) String() string {
-	switch t {
-	case Boolean:
-		return "boolean"
-	case Integer:
-		return "integer"
-	case Float:
-		return "float"
-	case String:
-		return "string"
-	case Structure:
-		return "structure"
-	}
-
-	return "unknown"
-}
-
-// MarshalJSON marshals the enum as a quoted json string
-func (t FeatureFlagType) MarshalJSON() ([]byte, error) {
-	buffer := bytes.NewBufferString(`"`)
-	buffer.WriteString(t.String())
-	buffer.WriteString(`"`)
-	return buffer.Bytes(), nil
-}
-
-func (t *FeatureFlagType) UnmarshalJSON(b []byte) error {
-	var j string
-	err := json.Unmarshal(b, &j)
-	if err != nil {
-		return err
-	}
-
-	switch j {
-	case "boolean":
-		*t = Boolean
-	case "integer":
-		*t = Integer
-	case "float":
-		*t = Float
-	case "string":
-		*t = String
-	case "structure":
-		*t = Structure
-	}
-	return nil
-}
-
 // These are properties about the feature, but not the current state or value for it
 type FeatureFlag struct {
 	Name        string           `json:"name" yaml:"name"` // Unique name
@@ -193,8 +135,6 @@ type FeatureFlag struct {
 
 	// CEL-GO expression.  Using the value "true" will mean this is on by default
 	Expression string `json:"expression,omitempty"`
-	// Type of the feature flag (boolean, number, string, structure),
-	Type FeatureFlagType `json:"type,omitempty"`
 
 	// Special behavior properties
 	RequiresDevMode bool `json:"requiresDevMode,omitempty"` // can not be enabled in production

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -126,6 +126,15 @@ func (s *FeatureFlagStage) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type FeatureFlagType string
+
+const (
+	Boolean = "boolean"
+	Number  = "number"
+	Object  = "object"
+	String  = "string"
+)
+
 // These are properties about the feature, but not the current state or value for it
 type FeatureFlag struct {
 	Name        string           `json:"name" yaml:"name"` // Unique name
@@ -143,6 +152,8 @@ type FeatureFlag struct {
 
 	// The server must be initialized with the value
 	RequiresRestart bool `json:"requiresRestart,omitempty"`
+
+	Type FeatureFlagType `json:"type,omitempty"`
 }
 
 type FeatureToggleWebhookPayload struct {

--- a/pkg/services/featuremgmt/models.go
+++ b/pkg/services/featuremgmt/models.go
@@ -130,9 +130,9 @@ type FeatureFlagType int
 
 const (
 	Boolean FeatureFlagType = iota
-	String
 	Integer
 	Float
+	String
 	Structure
 )
 
@@ -141,13 +141,13 @@ func (t FeatureFlagType) String() string {
 	case Boolean:
 		return "boolean"
 	case Integer:
-		return "number"
+		return "integer"
 	case Float:
 		return "float"
-	case Structure:
-		return "object"
 	case String:
 		return "string"
+	case Structure:
+		return "structure"
 	}
 
 	return "unknown"
@@ -171,14 +171,14 @@ func (t *FeatureFlagType) UnmarshalJSON(b []byte) error {
 	switch j {
 	case "boolean":
 		*t = Boolean
-	case "number":
+	case "integer":
 		*t = Integer
 	case "float":
 		*t = Float
-	case "object":
-		*t = Structure
 	case "string":
 		*t = String
+	case "structure":
+		*t = Structure
 	}
 	return nil
 }

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -100,7 +100,7 @@ func InitOpenFeatureWithCfg(cfg *setting.Cfg) error {
 func createProvider(
 	providerType string,
 	u *url.URL,
-	StaticFlags map[string]setting.FeatureToggle,
+	staticFlags map[string]setting.FeatureToggle,
 	httpClient *http.Client,
 ) (openfeature.FeatureProvider, error) {
 	if providerType == setting.FeaturesServiceProviderType || providerType == setting.OFREPProviderType {

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -26,7 +26,7 @@ type OpenFeatureConfig struct {
 	// HTTPClient is a pre-configured HTTP client (optional, used by features-service + OFREP providers)
 	HTTPClient *http.Client
 	// StaticFlags are the feature flags to use with static provider
-	StaticFlags map[string]bool
+	StaticFlags map[string]setting.FeatureToggle
 	// TargetingKey is used for evaluation context
 	TargetingKey string
 	// ContextAttrs are additional attributes for evaluation context
@@ -100,7 +100,7 @@ func InitOpenFeatureWithCfg(cfg *setting.Cfg) error {
 func createProvider(
 	providerType string,
 	u *url.URL,
-	staticFlags map[string]bool,
+	StaticFlags map[string]setting.FeatureToggle,
 	httpClient *http.Client,
 ) (openfeature.FeatureProvider, error) {
 	if providerType == setting.FeaturesServiceProviderType || providerType == setting.OFREPProviderType {

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -117,7 +117,7 @@ func createProvider(
 		}
 	}
 
-	return newStaticProvider(staticFlags)
+	return newStaticProvider(staticFlags, standardFeatureFlags)
 }
 
 func createHTTPClient(m *clientauthmiddleware.TokenExchangeMiddleware) (*http.Client, error) {

--- a/pkg/services/featuremgmt/openfeature.go
+++ b/pkg/services/featuremgmt/openfeature.go
@@ -8,6 +8,7 @@ import (
 
 	clientauthmiddleware "github.com/grafana/grafana/pkg/clientauth/middleware"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/open-feature/go-sdk/openfeature"
@@ -26,7 +27,7 @@ type OpenFeatureConfig struct {
 	// HTTPClient is a pre-configured HTTP client (optional, used by features-service + OFREP providers)
 	HTTPClient *http.Client
 	// StaticFlags are the feature flags to use with static provider
-	StaticFlags map[string]setting.FeatureToggle
+	StaticFlags map[string]memprovider.InMemoryFlag
 	// TargetingKey is used for evaluation context
 	TargetingKey string
 	// ContextAttrs are additional attributes for evaluation context
@@ -100,7 +101,7 @@ func InitOpenFeatureWithCfg(cfg *setting.Cfg) error {
 func createProvider(
 	providerType string,
 	u *url.URL,
-	staticFlags map[string]setting.FeatureToggle,
+	staticFlags map[string]memprovider.InMemoryFlag,
 	httpClient *http.Client,
 ) (openfeature.FeatureProvider, error) {
 	if providerType == setting.FeaturesServiceProviderType || providerType == setting.OFREPProviderType {

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -47,7 +47,7 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 			}
 			mgmt.warnings[key] = "unknown flag in config"
 		}
-		mgmt.startup[key] = val
+		mgmt.startup[key] = val.Value == true
 	}
 
 	// update the values

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -47,7 +47,7 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 			}
 			mgmt.warnings[key] = "unknown flag in config"
 		}
-		mgmt.startup[key] = val.Value == true
+		mgmt.startup[key] = setting.IsEnabled(val)
 	}
 
 	// update the values

--- a/pkg/services/featuremgmt/service.go
+++ b/pkg/services/featuremgmt/service.go
@@ -47,7 +47,8 @@ func ProvideManagerService(cfg *setting.Cfg) (*FeatureManager, error) {
 			}
 			mgmt.warnings[key] = "unknown flag in config"
 		}
-		mgmt.startup[key] = setting.IsEnabled(val)
+
+		mgmt.startup[key] = val.Variants[val.DefaultVariant] == true
 	}
 
 	// update the values

--- a/pkg/services/featuremgmt/static_evaluator.go
+++ b/pkg/services/featuremgmt/static_evaluator.go
@@ -29,7 +29,7 @@ func CreateStaticEvaluator(cfg *setting.Cfg) (StaticFlagEvaluator, error) {
 		return nil, fmt.Errorf("failed to read feature flags from config: %w", err)
 	}
 
-	staticProvider, err := newStaticProvider(staticFlags)
+	staticProvider, err := newStaticProvider(staticFlags, standardFeatureFlags)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create static provider: %w", err)
 	}

--- a/pkg/services/featuremgmt/static_provider.go
+++ b/pkg/services/featuremgmt/static_provider.go
@@ -3,10 +3,11 @@ package featuremgmt
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
-	"strconv"
 )
 
 // inMemoryBulkProvider is a wrapper around memprovider.InMemoryProvider that

--- a/pkg/services/featuremgmt/static_provider.go
+++ b/pkg/services/featuremgmt/static_provider.go
@@ -1,9 +1,8 @@
 package featuremgmt
 
 import (
-	"encoding/json"
 	"fmt"
-	"strconv"
+	"reflect"
 
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/open-feature/go-sdk/openfeature"
@@ -33,15 +32,12 @@ func (p *inMemoryBulkProvider) ListFlags() ([]string, error) {
 	return keys, nil
 }
 
-func newStaticProvider(confFlags map[string]setting.FeatureToggle, standardFlags []FeatureFlag) (openfeature.FeatureProvider, error) {
+func newStaticProvider(confFlags map[string]memprovider.InMemoryFlag, standardFlags []FeatureFlag) (openfeature.FeatureProvider, error) {
 	flags := make(map[string]memprovider.InMemoryFlag, len(standardFlags))
 	index := make(map[string]FeatureFlag, len(standardFlags))
 	// Add standard flags
 	for _, flag := range standardFlags {
-		inMemFlag, err := createTypedFlag(flag)
-		if err != nil {
-			return nil, err
-		}
+		inMemFlag := setting.ParseFlag(flag.Name, flag.Expression)
 
 		flags[flag.Name] = inMemFlag
 		index[flag.Name] = flag
@@ -49,60 +45,18 @@ func newStaticProvider(confFlags map[string]setting.FeatureToggle, standardFlags
 
 	// Add flags from config.ini file
 	for name, flag := range confFlags {
-		standard, exists := index[flag.Name]
+		standard, exists := flags[flag.Key]
 
 		// Fail fast if a flag is declared with a mismatched type
-		if exists && standard.Type.String() != string(flag.Type) {
-			return nil, fmt.Errorf("type mismatch for flag '%s' detected", flag.Name)
+		standardValue, _ := setting.GetDefaultValue(standard)
+		flagValue, _ := setting.GetDefaultValue(flag)
+
+		if exists && reflect.TypeOf(standardValue) != reflect.TypeOf(flagValue) {
+			return nil, fmt.Errorf("type mismatch for flag '%s' detected", flag.Key)
 		}
 
-		flags[name] = createInMemoryFlag(flag)
+		flags[name] = flag
 	}
 
 	return newInMemoryBulkProvider(flags), nil
-}
-
-func createInMemoryFlag(flag setting.FeatureToggle) memprovider.InMemoryFlag {
-	variant := "default"
-
-	return memprovider.InMemoryFlag{
-		Key:            flag.Name,
-		DefaultVariant: variant,
-		Variants: map[string]any{
-			variant: flag.Value,
-		},
-	}
-}
-
-func createTypedFlag(flag FeatureFlag) (memprovider.InMemoryFlag, error) {
-	defaultVariant := "default"
-
-	var value any
-	var err error
-	switch flag.Type {
-	case Boolean:
-		value = flag.Expression == "true"
-	case Integer:
-		value, err = strconv.Atoi(flag.Expression)
-	case Float:
-		value, err = strconv.ParseFloat(flag.Expression, 64)
-	case String:
-		value = flag.Expression
-	case Structure:
-		err = json.Unmarshal([]byte(flag.Expression), &value)
-	default:
-		return memprovider.InMemoryFlag{}, fmt.Errorf("unsupported flag type %s", flag.Type)
-	}
-
-	if err != nil {
-		return memprovider.InMemoryFlag{}, err
-	}
-
-	return memprovider.InMemoryFlag{
-		Key:            flag.Name,
-		DefaultVariant: defaultVariant,
-		Variants: map[string]any{
-			defaultVariant: value,
-		},
-	}, nil
 }

--- a/pkg/services/featuremgmt/static_provider.go
+++ b/pkg/services/featuremgmt/static_provider.go
@@ -1,6 +1,7 @@
 package featuremgmt
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
@@ -87,8 +88,8 @@ func createFlag(flag FeatureFlag) (memprovider.InMemoryFlag, error) {
 		value, err = strconv.Atoi(flag.Expression)
 	case Float:
 		value, err = strconv.ParseFloat(flag.Expression, 64)
-	case Object:
-		value = value
+	case Structure:
+		err = json.Unmarshal([]byte(flag.Expression), &value)
 	default:
 		return memprovider.InMemoryFlag{}, fmt.Errorf("unsupported flag type %s", flag.Type)
 	}

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -111,7 +111,6 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 		flags         FeatureFlag
 		defaultValue  any
 		expectedValue any
-		test          int
 	}{
 		{
 			flags: FeatureFlag{
@@ -121,7 +120,6 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 			},
 			defaultValue:  false,
 			expectedValue: true,
-			test:          0,
 		},
 		{
 			flags: FeatureFlag{
@@ -131,7 +129,6 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 			},
 			defaultValue:  0.0,
 			expectedValue: 1.0,
-			test:          1,
 		},
 		{
 			flags: FeatureFlag{
@@ -141,7 +138,6 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 			},
 			defaultValue:  "red",
 			expectedValue: "blue",
-			test:          2,
 		},
 		{
 			flags: FeatureFlag{
@@ -151,7 +147,15 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 			},
 			defaultValue:  int64(0),
 			expectedValue: int64(1),
-			test:          3,
+		},
+		{
+			flags: FeatureFlag{
+				Name:       "Flag",
+				Expression: `{ "foo": "bar" }`,
+				Type:       Structure,
+			},
+			defaultValue:  nil,
+			expectedValue: map[string]any{"foo": "bar"},
 		},
 	}
 
@@ -160,17 +164,17 @@ func Test_StaticProvider_DifferentType(t *testing.T) {
 		assert.NoError(t, err)
 
 		var result any
-		switch tt.test {
-		case 0:
+		switch tt.flags.Type {
+		case Boolean:
 			result = provider.BooleanEvaluation(t.Context(), tt.flags.Name, tt.defaultValue.(bool), openfeature.FlattenedContext{}).Value
-		case 1:
+		case Float:
 			result = provider.FloatEvaluation(t.Context(), tt.flags.Name, tt.defaultValue.(float64), openfeature.FlattenedContext{}).Value
-		case 2:
+		case String:
 			result = provider.StringEvaluation(t.Context(), tt.flags.Name, tt.defaultValue.(string), openfeature.FlattenedContext{}).Value
-		case 3:
+		case Integer:
 			result = provider.IntEvaluation(t.Context(), tt.flags.Name, tt.defaultValue.(int64), openfeature.FlattenedContext{}).Value
-		case 4:
-			result = provider.ObjectEvaluation(t.Context(), tt.flags.Name, tt.defaultValue.(map[string]any), openfeature.FlattenedContext{}).Value
+		case Structure:
+			result = provider.ObjectEvaluation(t.Context(), tt.flags.Name, tt.defaultValue, openfeature.FlattenedContext{}).Value
 		}
 
 		assert.Equal(t, tt.expectedValue, result)

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -94,7 +94,7 @@ ABCD = true
 	assert.Equal(t, openFeatureEnabledFlags, enabledFeatureManager)
 }
 
-func Test_StaticProvider_DifferentTypeFlagsNoSilentIgnore(t *testing.T) {
+func Test_StaticProvider_FailfastOnMismatchedType(t *testing.T) {
 	staticFlags := map[string]bool{"oldBooleanFlag": true}
 
 	flag := FeatureFlag{
@@ -106,7 +106,7 @@ func Test_StaticProvider_DifferentTypeFlagsNoSilentIgnore(t *testing.T) {
 	assert.EqualError(t, err, "flag oldBooleanFlag already declared as boolean")
 }
 
-func Test_StaticProvider_DifferentType(t *testing.T) {
+func Test_StaticProvider_TypedFlags(t *testing.T) {
 	tests := []struct {
 		flags         FeatureFlag
 		defaultValue  any

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -267,5 +267,4 @@ func makeFlags(tt struct {
 	}
 
 	return config, []FeatureFlag{orig}
-
 }

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -261,7 +261,7 @@ func makeFlags(tt struct {
 	config := map[string]setting.FeatureToggle{
 		tt.name: {
 			Name:  tt.name,
-			Type:  setting.FeatureToggleType(tt.typ.String()),
+			Type:  setting.FeatureFlagType(tt.typ.String()),
 			Value: tt.configValue,
 		},
 	}

--- a/pkg/services/featuremgmt/static_provider_test.go
+++ b/pkg/services/featuremgmt/static_provider_test.go
@@ -230,10 +230,7 @@ func makeFlags(tt struct {
 	}
 
 	config := map[string]memprovider.InMemoryFlag{
-		tt.name: {
-			Key:      tt.name,
-			Variants: map[string]any{"": tt.configValue},
-		},
+		tt.name: setting.NewInMemoryFlag(tt.name, tt.configValue),
 	}
 
 	return config, []FeatureFlag{orig}

--- a/pkg/services/featuremgmt/toggles_gen_test.go
+++ b/pkg/services/featuremgmt/toggles_gen_test.go
@@ -190,9 +190,6 @@ func verifyFlagsConfiguration(t *testing.T) {
 		if flag.Stage == FeatureStageGeneralAvailability && flag.Expression == "" {
 			t.Errorf("GA features must be explicitly enabled or disabled, please add the `Expression` property for %s", flag.Name)
 		}
-		if flag.Expression != "" && flag.Expression != "true" && flag.Expression != "false" {
-			t.Errorf("the `Expression` property for %s is incorrect. valid values are: `true`, `false` or empty string for default", flag.Name)
-		}
 		// Check camel case names
 		if flag.Name != strcase.ToLowerCamel(flag.Name) && !legacyNames[flag.Name] {
 			invalidNames = append(invalidNames, flag.Name)

--- a/pkg/services/updatemanager/plugins_test.go
+++ b/pkg/services/updatemanager/plugins_test.go
@@ -9,7 +9,9 @@ import (
 	"sync"
 	"testing"
 
+	"cuelang.org/go/pkg/strconv"
 	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -378,8 +380,8 @@ func setupOpenFeatureProvider(t *testing.T, flagValue bool) {
 
 	err := featuremgmt.InitOpenFeature(featuremgmt.OpenFeatureConfig{
 		ProviderType: setting.StaticProviderType,
-		StaticFlags: map[string]setting.FeatureToggle{
-			featuremgmt.FlagPluginsAutoUpdate: {Value: flagValue, Type: setting.Boolean},
+		StaticFlags: map[string]memprovider.InMemoryFlag{
+			featuremgmt.FlagPluginsAutoUpdate: setting.ParseFlag(featuremgmt.FlagPluginsAutoUpdate, strconv.FormatBool(flagValue)),
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/services/updatemanager/plugins_test.go
+++ b/pkg/services/updatemanager/plugins_test.go
@@ -378,8 +378,8 @@ func setupOpenFeatureProvider(t *testing.T, flagValue bool) {
 
 	err := featuremgmt.InitOpenFeature(featuremgmt.OpenFeatureConfig{
 		ProviderType: setting.StaticProviderType,
-		StaticFlags: map[string]bool{
-			featuremgmt.FlagPluginsAutoUpdate: flagValue,
+		StaticFlags: map[string]setting.FeatureToggle{
+			featuremgmt.FlagPluginsAutoUpdate: {Value: flagValue, Type: setting.Boolean},
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/services/updatemanager/plugins_test.go
+++ b/pkg/services/updatemanager/plugins_test.go
@@ -9,7 +9,6 @@ import (
 	"sync"
 	"testing"
 
-	"cuelang.org/go/pkg/strconv"
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"github.com/stretchr/testify/require"
@@ -381,7 +380,9 @@ func setupOpenFeatureProvider(t *testing.T, flagValue bool) {
 	err := featuremgmt.InitOpenFeature(featuremgmt.OpenFeatureConfig{
 		ProviderType: setting.StaticProviderType,
 		StaticFlags: map[string]memprovider.InMemoryFlag{
-			featuremgmt.FlagPluginsAutoUpdate: setting.ParseFlag(featuremgmt.FlagPluginsAutoUpdate, strconv.FormatBool(flagValue)),
+			featuremgmt.FlagPluginsAutoUpdate: {
+				Key: featuremgmt.FlagPluginsAutoUpdate, Variants: map[string]any{"": flagValue},
+			},
 		},
 	})
 	require.NoError(t, err)

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -1,12 +1,28 @@
 package setting
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
 
 	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/util"
 )
+
+type FeatureToggleType string
+
+const Structure FeatureToggleType = "structure"
+const Integer FeatureToggleType = "integer"
+const Float FeatureToggleType = "float"
+const Boolean FeatureToggleType = "boolean"
+const String FeatureToggleType = "string"
+
+type FeatureToggle struct {
+	Type  FeatureToggleType `json:"type"`
+	Name  string            `json:"name"`
+	Value any               `json:"value"`
+}
 
 // Deprecated: should use `featuremgmt.FeatureToggles`
 func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
@@ -15,18 +31,31 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 	if err != nil {
 		return err
 	}
+	// TODO IsFeatureToggleEnabled has been deprecated for 2 years now, we should remove this function completely
 	// nolint:staticcheck
-	cfg.IsFeatureToggleEnabled = func(key string) bool { return toggles[key] }
+	cfg.IsFeatureToggleEnabled = func(key string) bool {
+
+		toggle, ok := toggles[key]
+		if !ok {
+			return false
+		}
+
+		return toggle.Type == Boolean && toggle.Value == true
+	}
 	return nil
 }
 
-func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[string]bool, error) {
-	featureToggles := make(map[string]bool, 10)
+func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[string]FeatureToggle, error) {
+	featureToggles := make(map[string]FeatureToggle, 10)
 
 	// parse the comma separated list in `enable`.
 	featuresTogglesStr := valueAsString(featureTogglesSection, "enable", "")
 	for _, feature := range util.SplitString(featuresTogglesStr) {
-		featureToggles[feature] = true
+		featureToggles[feature] = FeatureToggle{
+			Type:  Boolean,
+			Name:  feature,
+			Value: true,
+		}
 	}
 
 	// read all other settings under [feature_toggles]. If a toggle is
@@ -36,12 +65,35 @@ func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[str
 			continue
 		}
 
-		b, err := strconv.ParseBool(v.Value())
+		b, err := ParseFlag(v.Name(), v.Value())
 		if err != nil {
 			return featureToggles, err
+		}
+
+		flag, exists := featureToggles[v.Name()]
+		if exists && flag.Type != b.Type {
+			return nil, fmt.Errorf("type mismatch during flag declaration '%s': %s, %s", v.Name(), flag.Type, b.Type)
 		}
 
 		featureToggles[v.Name()] = b
 	}
 	return featureToggles, nil
+}
+
+func ParseFlag(name, value string) (FeatureToggle, error) {
+	var structure any
+
+	if boolean, err := strconv.ParseBool(value); err == nil {
+		return FeatureToggle{Type: Boolean, Name: name, Value: boolean}, nil
+	}
+	if integer, err := strconv.Atoi(value); err == nil {
+		return FeatureToggle{Type: Integer, Name: name, Value: integer}, nil
+	}
+	if float, err := strconv.ParseFloat(value, 64); err == nil {
+		return FeatureToggle{Type: Float, Name: name, Value: float}, nil
+	}
+	if err := json.Unmarshal([]byte(value), &structure); err == nil {
+		return FeatureToggle{Type: Structure, Name: name, Value: structure}, nil
+	}
+	return FeatureToggle{Type: String, Name: name, Value: value}, nil
 }

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -2,9 +2,10 @@ package setting
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"strconv"
 
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
 	"gopkg.in/ini.v1"
 
 	"github.com/grafana/grafana/pkg/util"
@@ -20,6 +21,8 @@ const (
 	String    FeatureFlagType = "string"
 )
 
+const DefaultVariantName = ""
+
 type FeatureToggle struct {
 	Type  FeatureFlagType `json:"type"`
 	Name  string          `json:"name"`
@@ -33,6 +36,7 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 	if err != nil {
 		return err
 	}
+
 	// TODO IsFeatureToggleEnabled has been deprecated for 2 years now, we should remove this function completely
 	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = func(key string) bool {
@@ -41,22 +45,19 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 			return false
 		}
 
-		return toggle.Type == Boolean && toggle.Value == true
+		return IsEnabled(toggle)
 	}
+
 	return nil
 }
 
-func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[string]FeatureToggle, error) {
-	featureToggles := make(map[string]FeatureToggle, 10)
+func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[string]memprovider.InMemoryFlag, error) {
+	featureToggles := make(map[string]memprovider.InMemoryFlag, 10)
 
 	// parse the comma separated list in `enable`.
 	featuresTogglesStr := valueAsString(featureTogglesSection, "enable", "")
 	for _, feature := range util.SplitString(featuresTogglesStr) {
-		featureToggles[feature] = FeatureToggle{
-			Type:  Boolean,
-			Name:  feature,
-			Value: true,
-		}
+		featureToggles[feature] = createFlag(feature, true)
 	}
 
 	// read all other settings under [feature_toggles]. If a toggle is
@@ -66,36 +67,71 @@ func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[str
 			continue
 		}
 
-		b, err := ParseFlag(v.Name(), v.Value())
-		if err != nil {
-			return featureToggles, err
-		}
-
-		flag, exists := featureToggles[v.Name()]
-		if exists && flag.Type != b.Type {
-			return nil, fmt.Errorf("type mismatch during flag declaration '%s': %s, %s", v.Name(), flag.Type, b.Type)
-		}
-
+		b := ParseFlag(v.Name(), v.Value())
 		featureToggles[v.Name()] = b
 	}
 	return featureToggles, nil
 }
 
-func ParseFlag(name, value string) (FeatureToggle, error) {
+func ParseFlag(name, value string) memprovider.InMemoryFlag {
 	var structure map[string]any
 
 	if integer, err := strconv.Atoi(value); err == nil {
-		return FeatureToggle{Type: Integer, Name: name, Value: integer}, nil
+		return createFlag(name, integer)
 	}
 	if float, err := strconv.ParseFloat(value, 64); err == nil {
-		return FeatureToggle{Type: Float, Name: name, Value: float}, nil
+		return createFlag(name, float)
 	}
 	if err := json.Unmarshal([]byte(value), &structure); err == nil {
-		return FeatureToggle{Type: Structure, Name: name, Value: structure}, nil
+		return createFlag(name, structure)
 	}
 	if boolean, err := strconv.ParseBool(value); err == nil {
-		return FeatureToggle{Type: Boolean, Name: name, Value: boolean}, nil
+		return createFlag(name, boolean)
 	}
 
-	return FeatureToggle{Type: String, Name: name, Value: value}, nil
+	return createFlag(name, value)
+}
+
+func SerializeFlag(flag memprovider.InMemoryFlag) string {
+	value, _ := flag.Variants[DefaultVariantName]
+
+	switch castedValue := value.(type) {
+	case bool:
+		return strconv.FormatBool(castedValue)
+	case int64:
+		return strconv.FormatInt(castedValue, 10)
+	case float64:
+		return strconv.FormatFloat(castedValue, 'f', -1, 64)
+	case string:
+		return castedValue
+	default:
+		val, _ := json.Marshal(value)
+		return string(val)
+	}
+}
+
+func createFlag(name string, value any) memprovider.InMemoryFlag {
+	return memprovider.InMemoryFlag{
+		Key:            name,
+		DefaultVariant: DefaultVariantName,
+		Variants: map[string]any{
+			DefaultVariantName: value,
+		},
+	}
+}
+
+func GetDefaultValue(flag memprovider.InMemoryFlag) (any, error) {
+	if value, ok := flag.Variants[flag.DefaultVariant]; !ok {
+		return nil, errors.New("no default variant found")
+	} else {
+		return value, nil
+	}
+}
+
+func IsEnabled(flag memprovider.InMemoryFlag) bool {
+	if value, ok := flag.Variants[flag.DefaultVariant]; !ok {
+		return false
+	} else {
+		return value == true
+	}
 }

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -34,7 +34,6 @@ func (cfg *Cfg) readFeatureToggles(iniFile *ini.File) error {
 	// TODO IsFeatureToggleEnabled has been deprecated for 2 years now, we should remove this function completely
 	// nolint:staticcheck
 	cfg.IsFeatureToggleEnabled = func(key string) bool {
-
 		toggle, ok := toggles[key]
 		if !ok {
 			return false

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -94,7 +94,7 @@ func AsStringMap(m map[string]memprovider.InMemoryFlag) map[string]string {
 }
 
 func serializeFlagValue(flag memprovider.InMemoryFlag) string {
-	value, _ := flag.Variants[flag.DefaultVariant]
+	value := flag.Variants[flag.DefaultVariant]
 
 	switch castedValue := value.(type) {
 	case bool:

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -81,11 +81,8 @@ func ReadFeatureTogglesFromInitFile(featureTogglesSection *ini.Section) (map[str
 }
 
 func ParseFlag(name, value string) (FeatureToggle, error) {
-	var structure any
+	var structure map[string]any
 
-	if boolean, err := strconv.ParseBool(value); err == nil {
-		return FeatureToggle{Type: Boolean, Name: name, Value: boolean}, nil
-	}
 	if integer, err := strconv.Atoi(value); err == nil {
 		return FeatureToggle{Type: Integer, Name: name, Value: integer}, nil
 	}
@@ -95,5 +92,9 @@ func ParseFlag(name, value string) (FeatureToggle, error) {
 	if err := json.Unmarshal([]byte(value), &structure); err == nil {
 		return FeatureToggle{Type: Structure, Name: name, Value: structure}, nil
 	}
+	if boolean, err := strconv.ParseBool(value); err == nil {
+		return FeatureToggle{Type: Boolean, Name: name, Value: boolean}, nil
+	}
+
 	return FeatureToggle{Type: String, Name: name, Value: value}, nil
 }

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -81,7 +81,15 @@ func ParseFlag(name, value string) (memprovider.InMemoryFlag, error) {
 	return memprovider.InMemoryFlag{Key: name, Variants: map[string]any{DefaultVariantName: value}}, nil
 }
 
-func SerializeFlagValue(flag memprovider.InMemoryFlag) string {
+func AsStringMap(m map[string]memprovider.InMemoryFlag) map[string]string {
+	var res = map[string]string{}
+	for k, v := range m {
+		res[k] = serializeFlagValue(v)
+	}
+	return res
+}
+
+func serializeFlagValue(flag memprovider.InMemoryFlag) string {
 	value, _ := flag.Variants[DefaultVariantName]
 
 	switch castedValue := value.(type) {
@@ -103,15 +111,3 @@ func SerializeFlagValue(flag memprovider.InMemoryFlag) string {
 		return string(val)
 	}
 }
-
-func createFlag(name string, value any) memprovider.InMemoryFlag {
-	return memprovider.InMemoryFlag{
-		Key:            name,
-		DefaultVariant: DefaultVariantName,
-		Variants: map[string]any{
-			DefaultVariantName: value,
-		},
-	}
-}
-
-//

--- a/pkg/setting/setting_feature_toggles.go
+++ b/pkg/setting/setting_feature_toggles.go
@@ -10,18 +10,20 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-type FeatureToggleType string
+type FeatureFlagType string
 
-const Structure FeatureToggleType = "structure"
-const Integer FeatureToggleType = "integer"
-const Float FeatureToggleType = "float"
-const Boolean FeatureToggleType = "boolean"
-const String FeatureToggleType = "string"
+const (
+	Structure FeatureFlagType = "structure"
+	Integer   FeatureFlagType = "integer"
+	Float     FeatureFlagType = "float"
+	Boolean   FeatureFlagType = "boolean"
+	String    FeatureFlagType = "string"
+)
 
 type FeatureToggle struct {
-	Type  FeatureToggleType `json:"type"`
-	Name  string            `json:"name"`
-	Value any               `json:"value"`
+	Type  FeatureFlagType `json:"type"`
+	Name  string          `json:"name"`
+	Value any             `json:"value"`
 }
 
 // Deprecated: should use `featuremgmt.FeatureToggles`

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -49,13 +49,29 @@ func TestFeatureToggles(t *testing.T) {
 			},
 		},
 		{
-			name: "invalid boolean value should return syntax error",
+			name: "conflict in type declaration is be detected",
 			conf: map[string]string{
 				"enable":   "feature1,feature2",
 				"feature2": "invalid",
 			},
 			expectedToggles: map[string]FeatureToggle{},
 			err:             errors.New("type mismatch during flag declaration 'feature2': boolean, string"),
+		},
+		{
+			name: "type of the feature flag is handled correctly",
+			conf: map[string]string{
+				"feature1": "1", "feature2": "1.0",
+				"feature3": `{"foo":"bar"}`, "feature4": "bar",
+				"feature5": "t", "feature6": "T",
+			},
+			expectedToggles: map[string]FeatureToggle{
+				"feature1": {Name: "feature1", Type: Integer, Value: 1},
+				"feature2": {Name: "feature2", Type: Float, Value: 1.0},
+				"feature3": {Name: "feature3", Type: Structure, Value: map[string]any{"foo": "bar"}},
+				"feature4": {Name: "feature4", Type: String, Value: "bar"},
+				"feature5": {Name: "feature5", Type: Boolean, Value: true},
+				"feature6": {Name: "feature6", Type: Boolean, Value: true},
+			},
 		},
 	}
 

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -91,7 +91,7 @@ func TestFeatureToggles(t *testing.T) {
 
 		if err == nil {
 			for k, v := range featureToggles {
-				toggle, _ := tc.expectedToggles[k]
+				toggle := tc.expectedToggles[k]
 				require.Equal(t, toggle, v, tc.name)
 			}
 		}

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -50,7 +50,7 @@ func TestFeatureToggles(t *testing.T) {
 			},
 		},
 		{
-			name: "type of the feature flag is handled correctly",
+			name: "feature flags of different types are handled correctly",
 			conf: map[string]string{
 				"feature1": "1", "feature2": "1.0",
 				"feature3": `{"foo":"bar"}`, "feature4": "bar",

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -22,8 +22,8 @@ func TestFeatureToggles(t *testing.T) {
 				"enable": "feature1,feature2",
 			},
 			expectedToggles: map[string]memprovider.InMemoryFlag{
-				"feature1": {Key: "feature1", Variants: map[string]any{"": true}},
-				"feature2": {Key: "feature2", Variants: map[string]any{"": true}},
+				"feature1": NewInMemoryFlag("feature1", true),
+				"feature2": NewInMemoryFlag("feature2", true),
 			},
 		},
 		{
@@ -33,9 +33,9 @@ func TestFeatureToggles(t *testing.T) {
 				"feature3": "true",
 			},
 			expectedToggles: map[string]memprovider.InMemoryFlag{
-				"feature1": {Key: "feature1", Variants: map[string]any{"": true}},
-				"feature2": {Key: "feature2", Variants: map[string]any{"": true}},
-				"feature3": {Key: "feature3", Variants: map[string]any{"": true}},
+				"feature1": NewInMemoryFlag("feature1", true),
+				"feature2": NewInMemoryFlag("feature2", true),
+				"feature3": NewInMemoryFlag("feature3", true),
 			},
 		},
 		{
@@ -45,8 +45,8 @@ func TestFeatureToggles(t *testing.T) {
 				"feature2": "false",
 			},
 			expectedToggles: map[string]memprovider.InMemoryFlag{
-				"feature1": {Key: "feature1", Variants: map[string]any{"": true}},
-				"feature2": {Key: "feature2", Variants: map[string]any{"": false}},
+				"feature1": NewInMemoryFlag("feature1", true),
+				"feature2": NewInMemoryFlag("feature2", false),
 			},
 		},
 		{
@@ -57,12 +57,12 @@ func TestFeatureToggles(t *testing.T) {
 				"feature5": "t", "feature6": "T",
 			},
 			expectedToggles: map[string]memprovider.InMemoryFlag{
-				"feature1": {Key: "feature1", Variants: map[string]any{"": 1}},
-				"feature2": {Key: "feature2", Variants: map[string]any{"": 1.0}},
-				"feature3": {Key: "feature3", Variants: map[string]any{"": map[string]any{"foo": "bar"}}},
-				"feature4": {Key: "feature4", Variants: map[string]any{"": "bar"}},
-				"feature5": {Key: "feature5", Variants: map[string]any{"": true}},
-				"feature6": {Key: "feature6", Variants: map[string]any{"": true}},
+				"feature1": NewInMemoryFlag("feature1", 1),
+				"feature2": NewInMemoryFlag("feature2", 1.0),
+				"feature3": NewInMemoryFlag("feature3", map[string]any{"foo": "bar"}),
+				"feature4": NewInMemoryFlag("feature4", "bar"),
+				"feature5": NewInMemoryFlag("feature5", true),
+				"feature6": NewInMemoryFlag("feature6", true),
 			},
 		},
 	}
@@ -88,14 +88,14 @@ func TestFeatureToggles(t *testing.T) {
 
 func TestFlagValueSerialization(t *testing.T) {
 	testCases := []memprovider.InMemoryFlag{
-		{Key: "int", Variants: map[string]any{"": 1}},
-		{Key: "1.0f", Variants: map[string]any{"": 1.0}},
-		{Key: "1.01f", Variants: map[string]any{"": 1.01}},
-		{Key: "1.10f", Variants: map[string]any{"": 1.10}},
-		{Key: "struct", Variants: map[string]any{"": map[string]any{"foo": "bar"}}},
-		{Key: "string", Variants: map[string]any{"": "bar"}},
-		{Key: "true", Variants: map[string]any{"": true}},
-		{Key: "false", Variants: map[string]any{"": false}},
+		NewInMemoryFlag("int", 1),
+		NewInMemoryFlag("1.0f", 1.0),
+		NewInMemoryFlag("1.01f", 1.01),
+		NewInMemoryFlag("1.10f", 1.10),
+		NewInMemoryFlag("struct", map[string]any{"foo": "bar"}),
+		NewInMemoryFlag("string", "bar"),
+		NewInMemoryFlag("true", true),
+		NewInMemoryFlag("false", false),
 	}
 
 	for _, tt := range testCases {

--- a/pkg/setting/setting_feature_toggles_test.go
+++ b/pkg/setting/setting_feature_toggles_test.go
@@ -99,9 +99,11 @@ func TestFlagValueSerialization(t *testing.T) {
 	}
 
 	for _, tt := range testCases {
-		serialized := SerializeFlagValue(tt)
-		deserialized, err := ParseFlag(tt.Key, serialized)
+		asStringMap := AsStringMap(map[string]memprovider.InMemoryFlag{tt.Key: tt})
+
+		deserialized, err := ParseFlag(tt.Key, asStringMap[tt.Key])
 		assert.NoError(t, err)
+
 		if diff := cmp.Diff(tt, deserialized); diff != "" {
 			t.Errorf("(-want, +got) = %v", diff)
 		}

--- a/pkg/tests/apis/features/features_test.go
+++ b/pkg/tests/apis/features/features_test.go
@@ -44,6 +44,6 @@ func TestIntegrationFeatures(t *testing.T) {
 			"value": true,
 			"key":"`+flag+`",
 			"reason":"static provider evaluation result",
-			"variant":"enabled"}`, string(rsp.Body))
+			"variant":"default"}`, string(rsp.Body))
 	})
 }

--- a/pkg/util/testutil/context_test.go
+++ b/pkg/util/testutil/context_test.go
@@ -15,7 +15,10 @@ import (
 func TestMain(m *testing.M) {
 	// make sure we don't leak goroutines after tests in this package have
 	// finished, which means we haven't leaked contexts either
-	goleak.VerifyTestMain(m)
+	// (Except for goroutines running specific functions. If possible we should fix this.)
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
+	)
 }
 
 func TestTestContextFunc(t *testing.T) {


### PR DESCRIPTION
The OpenFeature standard allows feature flags (FFs) of different types. While this works out-of-the-box in cloud setups when an OpenFeature provider is configured for remote evaluation, it is not supported in setups that rely on statically configured flags. This PR addresses this gap by adding support for non-boolean feature flags in the static provider.

Data types defined in the OopenFeature spec
https://openfeature.dev/specification/types