### PR TITLE
`AuthZ`: Remove automatic Admin grant for root folders and dashboards

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -759,11 +759,6 @@ func (b *DashboardsAPIBuilder) afterDelete(obj runtime.Object, _ *metav1.DeleteO
 var defaultDashboardPermissions = []map[string]any{
 	{
 		"kind": "BasicRole",
-		"name": "Admin",
-		"verb": "admin",
-	},
-	{
-		"kind": "BasicRole",
 		"name": "Editor",
 		"verb": "edit",
 	},

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -205,11 +205,6 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 var defaultPermissions = []map[string]any{
 	{
 		"kind": "BasicRole",
-		"name": "Admin",
-		"verb": "admin",
-	},
-	{
-		"kind": "BasicRole",
 		"name": "Editor",
 		"verb": "edit",
 	},


### PR DESCRIPTION
By default, the `basic_admin` role grants admin access to all folders/dashboards, hence there is no need to grant admin access to each folder/dashboard individually.

Aligns with the previous behavior: 
https://github.com/grafana/grafana/blob/ac55fad1baa98e939a10fd731f0434ea8a1e99e3/pkg/services/dashboards/service/dashboard_service.go#L1282-L1283