### PR TITLE
AppChrome: Use canvas bg for topnav

### DIFF
--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -231,7 +231,7 @@ const getStyles = (theme: GrafanaTheme2, headerLevels: number, headerHeight: num
       zIndex: theme.zIndex.navbarFixed,
       left: 0,
       right: 0,
-      background: theme.colors.background.primary,
+      background: theme.colors.background.canvas,
       flexDirection: 'column',
     }),
     topNavMenuDocked: css({

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -69,6 +69,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   header: css({
     alignItems: 'center',
     borderBottom: `1px solid ${theme.colors.border.weak}`,
+    background: theme.colors.background.canvas,
     display: 'flex',
     gap: theme.spacing(1),
     justifyContent: 'space-between',

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -122,7 +122,7 @@ const getStyles = (theme: GrafanaTheme2, menuDockedAndOpen: boolean) => ({
     gap: theme.spacing(2),
     alignItems: 'center',
     padding: theme.spacing(0, 1),
-    paddingLeft: menuDockedAndOpen ? theme.spacing(3.5) : theme.spacing(0.75),
+    paddingLeft: menuDockedAndOpen ? theme.spacing(2) : theme.spacing(0.75),
     borderBottom: `1px solid ${theme.colors.border.weak}`,
     justifyContent: 'space-between',
   }),


### PR DESCRIPTION
* [x] Switch from primary to canvas bg for top nav and mega menu header
* [x] Reduced breadcrumb left padding to align breadcrumbs with pages like dashboards, explore, drilldown apps 

<img width="1679" height="1058" alt="Screenshot 2025-12-10 at 16 34 24" src="https://github.com/user-attachments/assets/58c8438c-44bb-4be0-941d-7e936d9846b7" />

<img width="1351" height="937" alt="Screenshot 2025-12-10 at 16 36 54" src="https://github.com/user-attachments/assets/365d4f71-eb60-4e9b-ac9d-f6fce54ba4df" />
<img width="1353" height="792" alt="Screenshot 2025-12-10 at 16 35 57" src="https://github.com/user-attachments/assets/2e059851-379b-4fdf-a0e3-92eea7acf649" />
<img width="1194" height="779" alt="Screenshot 2025-12-10 at 16 35 23" src="https://github.com/user-attachments/assets/77925e3d-ea26-43cf-8624-cb4b78a35b99" />

