### PR TITLE
datasources: querier: log the statuscode not the pointer

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -156,7 +156,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 						}
 					}
 				}
-				connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
+				connectLogger.Debug("responder sending status code", "statusCode", *statusCode, "caller", getCaller(ctx))
 			},
 
 			func(err error) {


### PR DESCRIPTION
we log the `statusCode` variable, which is a `*int`, a pointer to an int.

this causes the logs to have something like`statusCode=0x123adsadsf`.

with this change you get the `statusCode=200`.