### PR TITLE
Wire up data source config metrics correctly

### DIFF
--- a/pkg/registry/apis/datasource/legacy_store.go
+++ b/pkg/registry/apis/datasource/legacy_store.go
@@ -57,6 +57,11 @@ func (s *legacyStorage) ConvertToTable(ctx context.Context, object runtime.Objec
 }
 
 func (s *legacyStorage) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	start := time.Now()
+	defer func() {
+		metricutil.ObserveWithExemplar(ctx, s.dsConfigHandlerRequestsDuration.WithLabelValues("new", "List"), time.Since(start).Seconds())
+	}()
+
 	return s.datasources.ListDataSources(ctx)
 }
 


### PR DESCRIPTION
Fix metrics for data source configuration CRUD.

Make sure to only create one histogram and only register it with prometheus once.
