### PR TITLE
VizSuggestions: Fix unique key warning

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -520,7 +520,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /e2e-playwright/various-suite/solo-route.spec.ts @grafana/dashboards-squad
 /e2e-playwright/various-suite/trace-view-scrolling.spec.ts @grafana/observability-traces-and-profiling
 /e2e-playwright/various-suite/verify-i18n.spec.ts @grafana/grafana-frontend-platform
-/e2e-playwright/various-suite/visualization-suggestions.spec.ts @grafana/dashboards-squad
+/e2e-playwright/various-suite/visualization-suggestions.spec.ts @grafana/dataviz-squad
 /e2e-playwright/various-suite/perf-test.spec.ts @grafana/grafana-frontend-platform
 
 # Packages
@@ -956,6 +956,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/notifications/ @grafana/grafana-search-navigate-organise
 /public/app/features/org/ @grafana/grafana-search-navigate-organise
 /public/app/features/panel/ @grafana/dashboards-squad
+/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx @grafana/dataviz-squad
 /public/app/features/panel/suggestions/ @grafana/dataviz-squad
 /public/app/features/playlist/ @grafana/dashboards-squad
 /public/app/features/plugins/ @grafana/plugins-platform-frontend

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { Fragment, useState, useEffect, useCallback, useMemo } from 'react';
 import { useAsync, useMeasure } from 'react-use';
 
 import {
@@ -127,9 +127,9 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
   return (
     <div className={styles.grid}>
       {isNewVizSuggestionsEnabled
-        ? suggestionsByVizType.map(([vizType, vizTypeSuggestions]) => (
-            <>
-              <div className={styles.vizTypeHeader} key={vizType?.id || 'unknown-viz-type'}>
+        ? suggestionsByVizType.map(([vizType, vizTypeSuggestions], groupIndex) => (
+            <Fragment key={vizType?.id || `unknown-viz-type-${groupIndex}`}>
+              <div className={styles.vizTypeHeader}>
                 <Text variant="body" weight="medium">
                   {vizType?.info && <img className={styles.vizTypeLogo} src={vizType.info.logos.small} alt="" />}
                   {vizType?.name || t('panel.visualization-suggestions.unknown-viz-type', 'Unknown visualization type')}
@@ -174,7 +174,7 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
                   </div>
                 );
               })}
-            </>
+            </Fragment>
           ))
         : suggestions?.map((suggestion, index) => (
             <div key={suggestion.hash} className={styles.cardContainer} ref={index === 0 ? firstCardRef : undefined}>


### PR DESCRIPTION
Added fragment with unique key to fix "Each child in a list should have a unique key prop" error

<img width="1051" height="398" alt="Screenshot 2025-12-09 at 10 11 45" src="https://github.com/user-attachments/assets/3acc2027-9982-41e0-9b4f-46c3c924752a" />


Also updated code owners to @grafana/dataviz-squad for:

- /e2e-playwright/various-suite/visualization-suggestions.spec.ts
- /public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
