### PR TITLE
unified-storage: add index on resource_history key_path column

### DIFF
--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -198,5 +198,11 @@ func initResourceTables(mg *migrator.Migrator) string {
 	}
 	mg.AddMigration("create table "+resource_events_table.Name, migrator.NewAddTableMigration(resource_events_table))
 
+	mg.AddMigration("Add IDX_resource_history_key_path index", migrator.NewAddIndexMigration(resource_history_table, &migrator.Index{
+		Cols: []string{"key_path"},
+		Type: migrator.IndexType,
+		Name: "IDX_resource_history_key_path",
+	}))
+
 	return marker
 }


### PR DESCRIPTION
for https://github.com/grafana/hyperion-planning/issues/462

At first I was going to introduce this after [the back-fill](https://github.com/grafana/grafana/pull/115033), so the back-fill could finish faster. But with 3M records it takes almost two minutes to add the index in my local database, during which we can't have any writes to `resource_history`.

I tried adding `ALGORITHM=INPLACE LOCK=NONE` but there's still locking. I tested the back-fill with this index and the running time went from 14 to 20 mins. This is acceptable specially given that the back-fill doesn't lock the database. 