### PR TITLE
K8s: discourage nil authorizer return for APIBuilder as well

### DIFF
--- a/pkg/services/apiserver/service.go
+++ b/pkg/services/apiserver/service.go
@@ -275,6 +275,8 @@ func (s *service) start(ctx context.Context) error {
 				auth := a.GetAuthorizer()
 				if auth != nil {
 					s.authorizer.Register(gv, auth)
+				} else {
+					panic("authorizer can not be nil for api group=" + gv.String())
 				}
 			}
 		}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In https://github.com/grafana/grafana/pull/114982, all currently existing K8s style APIs were updated to provide an explicit authorizer. This is in the hopes that we can get rid of RoleAuthorizer when we are able to use [Mixed Version Proxy](https://kubernetes.io/docs/concepts/architecture/mixed-version-proxy/) in front of Kube-Aggregator in cloud.

However, that PR forgot to throw a panic for the API Builder nil authorizer case (it did handle the AppInstaller use case). This completes it.

**Why do we need this feature?**

Explicit authorizer implementation when specified by app developers reduce unexpected outcomes when deployed to cloud.

**Who is this feature for?**

Grafana App Platform

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
