### PR TITLE
Dashboards: Prevent query for ID 0; improve logging

### DIFF
--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1305,6 +1305,11 @@ func (dr *DashboardServiceImpl) GetDashboardUIDByID(ctx context.Context, query *
 	if err != nil {
 		return nil, err
 	}
+
+	if query.ID <= 0 {
+		return nil, dashboards.ErrDashboardNotFound
+	}
+
 	result, err := dr.searchDashboardsThroughK8s(ctx, &dashboards.FindPersistedDashboardsQuery{
 		OrgId:        requester.GetOrgID(),
 		DashboardIds: []int64{query.ID},
@@ -1316,7 +1321,7 @@ func (dr *DashboardServiceImpl) GetDashboardUIDByID(ctx context.Context, query *
 	if len(result) == 0 {
 		return nil, dashboards.ErrDashboardNotFound
 	} else if len(result) > 1 {
-		return nil, fmt.Errorf("unexpected number of dashboards found: %d. desired: 1", len(result))
+		return nil, fmt.Errorf("unexpected number of dashboards for id %d. found: %d. desired: 1", query.ID, len(result))
 	}
 
 	return &dashboards.DashboardRef{UID: result[0].UID, Slug: result[0].Slug, FolderUID: result[0].FolderUID}, nil

--- a/pkg/services/dashboards/service/dashboard_service_test.go
+++ b/pkg/services/dashboards/service/dashboard_service_test.go
@@ -1663,6 +1663,13 @@ func TestGetDashboardUIDByID(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, expectedResult, result)
 	k8sCliMock.AssertExpectations(t)
+
+	// 0 should return error
+	_, err = service.GetDashboardUIDByID(ctx, &dashboards.GetDashboardRefByIDQuery{
+		ID: 0,
+	})
+	require.Error(t, err)
+	require.Equal(t, dashboards.ErrDashboardNotFound, err)
 }
 
 func TestUnstructuredToLegacyDashboard(t *testing.T) {


### PR DESCRIPTION
Prevents trying to get a dashboard id of 0 or less, and adds better logging if we get an unexpected result