### PR TITLE
SQL Expressions: Add schemas to LLM prompt

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/GenAI/sqlPromptConfig.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/GenAI/sqlPromptConfig.test.ts
@@ -1,0 +1,52 @@
+import { getSQLSuggestionSystemPrompt, QueryUsageContext } from './sqlPromptConfig';
+
+describe('getSQLSuggestionSystemPrompt', () => {
+  it('includes all context fields in generated prompt', () => {
+    const queryContext: QueryUsageContext = {
+      panelId: 'timeseries',
+      alerting: false,
+      dashboardContext: {
+        dashboardTitle: 'Production Metrics',
+        panelName: 'CPU Usage',
+      },
+      datasources: ['prometheus', 'postgres'],
+      totalRows: 5000,
+      requestTime: 250,
+      numberOfQueries: 3,
+    };
+
+    const result = getSQLSuggestionSystemPrompt({
+      refIds: 'A, B',
+      currentQuery: 'SELECT * FROM A',
+      queryInstruction: 'Focus on fixing the current query',
+      formattedSchemas: 'RefID A:\n  - time (TIMESTAMP, not null)\n  - value (FLOAT, nullable)',
+      errorContext: ['Syntax error near WHERE'],
+      queryContext,
+    });
+
+    expect(result).toContain('A, B');
+    expect(result).toContain('SELECT * FROM A');
+    expect(result).toContain('Focus on fixing the current query');
+    expect(result).toContain('time (TIMESTAMP, not null)');
+    expect(result).toContain('Syntax error near WHERE');
+    expect(result).toContain('Panel Type: timeseries');
+    expect(result).toContain('Dashboard: Production Metrics, Panel: CPU Usage');
+    expect(result).toContain('Datasources: prometheus, postgres');
+    expect(result).toContain('Total rows in the query: 5000');
+    expect(result).toContain('Request time: 250');
+    expect(result).toContain('Number of queries: 3');
+  });
+
+  it('formats multiple errors with newlines', () => {
+    const result = getSQLSuggestionSystemPrompt({
+      refIds: 'A',
+      currentQuery: 'SELECT * FROM A',
+      queryInstruction: 'Fix errors',
+      errorContext: ['Error 1: Syntax error', 'Error 2: Column not found'],
+    });
+
+    expect(result).toContain('Error 1: Syntax error');
+    expect(result).toContain('Error 2: Column not found');
+    expect(result).toContain('Error 1: Syntax error\nError 2: Column not found');
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/GenAI/utils/formatSchemas.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/GenAI/utils/formatSchemas.test.ts
@@ -1,0 +1,90 @@
+import { SQLSchemasResponse } from '../../hooks/useSQLSchemas';
+
+import { formatSchemasForPrompt } from './formatSchemas';
+
+describe('formatSchemasForPrompt', () => {
+  const createSchemaResponse = (sqlSchemas: SQLSchemasResponse['sqlSchemas']): SQLSchemasResponse => ({
+    kind: 'SQLSchemaResponse',
+    apiVersion: 'query.grafana.app/v0alpha1',
+    sqlSchemas,
+  });
+
+  it('returns fallback message for null/undefined/empty schemas', () => {
+    expect(formatSchemasForPrompt(null)).toBe('No schema information available.');
+    expect(formatSchemasForPrompt(undefined)).toBe('No schema information available.');
+    expect(formatSchemasForPrompt(createSchemaResponse({}))).toBe('No schema information available.');
+  });
+
+  it('includes schema errors instead of silently failing', () => {
+    const schemas = createSchemaResponse({
+      A: {
+        columns: null,
+        sampleRows: null,
+        error: 'Connection timeout',
+      },
+    });
+
+    const result = formatSchemasForPrompt(schemas);
+
+    expect(result).toBe('RefID A: Error - Connection timeout');
+  });
+
+  it('truncates columns beyond default limit to prevent token overflow', () => {
+    const maxColumns = 10; // Default limit
+    const totalColumns = 15;
+    const columns = Array.from({ length: totalColumns }, (_, i) => ({
+      name: `column_${i + 1}`,
+      mysqlType: 'VARCHAR',
+      dataFrameFieldType: 'string',
+      nullable: false,
+    }));
+
+    const schemas = createSchemaResponse({
+      A: {
+        columns,
+        sampleRows: null,
+        error: undefined,
+      },
+    });
+
+    const result = formatSchemasForPrompt(schemas);
+
+    // Should include columns up to limit
+    expect(result).toContain('column_1 (VARCHAR, not null)');
+    expect(result).toContain(`column_${maxColumns} (VARCHAR, not null)`);
+
+    // Should truncate columns beyond limit
+    expect(result).not.toContain(`column_${maxColumns + 1}`);
+    expect(result).toContain(`... and ${totalColumns - maxColumns} more columns`);
+  });
+
+  it('formats multiple RefIDs with proper separation', () => {
+    const schemas = createSchemaResponse({
+      A: {
+        columns: [{ name: 'time', mysqlType: 'TIMESTAMP', dataFrameFieldType: 'time', nullable: false }],
+        sampleRows: [[1234567890]],
+        error: undefined,
+      },
+      B: {
+        columns: [{ name: 'value', mysqlType: 'FLOAT', dataFrameFieldType: 'number', nullable: true }],
+        sampleRows: [[42.5]],
+        error: undefined,
+      },
+      C: {
+        columns: [{ name: 'label', mysqlType: 'VARCHAR', dataFrameFieldType: 'string', nullable: false }],
+        sampleRows: [['production']],
+        error: undefined,
+      },
+    });
+
+    const result = formatSchemasForPrompt(schemas);
+
+    expect(result).toContain('RefID A:');
+    expect(result).toContain('time (TIMESTAMP, not null)');
+    expect(result).toContain('RefID B:');
+    expect(result).toContain('value (FLOAT, nullable)');
+    expect(result).toContain('RefID C:');
+    expect(result).toContain('label (VARCHAR, not null)');
+    expect(result.split('\n\n').length).toBe(3);
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/GenAI/utils/formatSchemas.ts
+++ b/public/app/features/expressions/components/SqlExpressions/GenAI/utils/formatSchemas.ts
@@ -1,0 +1,70 @@
+import { SQLSchemasResponse, SQLSchemaField } from '../../hooks/useSQLSchemas';
+
+const DEFAULT_MAX_COLUMNS = 10;
+
+/**
+ * Format schemas into a readable string for LLM context with token budget management
+ *
+ * This function converts SQL schema information into a human-readable format suitable
+ * for LLM prompts. It includes column names, types, nullability, and sample data.
+ *
+ * Token budget management:
+ * - Limits columns per RefID to prevent excessive token usage
+ * - Respects original column order from schema
+ * - Provides summary for truncated columns
+ *
+ * @param schemas - The SQL schemas response from the API
+ * @param maxColumnsPerRefId - Maximum number of columns to include per RefID (default: 10)
+ * @returns A formatted string representation of the schemas
+ */
+export const formatSchemasForPrompt = (
+  schemas?: SQLSchemasResponse | null,
+  maxColumnsPerRefId = DEFAULT_MAX_COLUMNS
+): string => {
+  if (!schemas?.sqlSchemas || Object.keys(schemas.sqlSchemas).length === 0) {
+    return 'No schema information available.';
+  }
+
+  const schemaParts: string[] = [];
+
+  for (const [refId, schemaData] of Object.entries(schemas.sqlSchemas)) {
+    if (schemaData.error) {
+      schemaParts.push(`RefID ${refId}: Error - ${schemaData.error}`);
+      continue;
+    }
+
+    if (!schemaData.columns || schemaData.columns.length === 0) {
+      schemaParts.push(`RefID ${refId}: No columns available`);
+      continue;
+    }
+
+    const columnsToShow = schemaData.columns.slice(0, maxColumnsPerRefId);
+    const remainingCount = schemaData.columns.length - columnsToShow.length;
+
+    const columnDescriptions = columnsToShow.map(({ nullable, name, mysqlType }: SQLSchemaField) => {
+      const isNullable = nullable ? 'nullable' : 'not null';
+      return `  - ${name} (${mysqlType}, ${isNullable})`;
+    });
+
+    // Add truncation notice if we hit the limit
+    if (remainingCount > 0) {
+      columnDescriptions.push(`  ... and ${remainingCount} more column${remainingCount > 1 ? 's' : ''}`);
+    }
+
+    // Build schema text parts
+    const textParts = [`RefID ${refId}:`, columnDescriptions.join('\n')];
+
+    // Add sample data if available (first row only)
+    if (schemaData.sampleRows && schemaData.sampleRows.length > 0) {
+      const sampleRow = schemaData.sampleRows[0];
+      const sampleValues = columnsToShow
+        .map(({ name }: SQLSchemaField, idx: number) => `${name}=${JSON.stringify(sampleRow[idx])}`)
+        .join(', ');
+      textParts.push(`  Sample: ${sampleValues}`);
+    }
+
+    schemaParts.push(textParts.join('\n'));
+  }
+
+  return schemaParts.join('\n\n');
+};

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -121,7 +121,6 @@ LIMIT
     refetch: refetchSchemas,
   } = useSQLSchemas({
     queries,
-    enabled: isSchemaInspectorOpen,
     timeRange: metadata?.range,
   });
 
@@ -129,7 +128,6 @@ LIMIT
     () => ({
       alerting,
       panelId: metadata?.data?.request?.panelPluginId,
-      queries: metadata?.queries,
       dashboardContext: {
         dashboardTitle: metadata?.data?.request?.dashboardTitle ?? '',
         panelName: metadata?.data?.request?.panelName ?? '',
@@ -140,7 +138,6 @@ LIMIT
         ? metadata?.data?.request?.endTime - metadata?.data?.request?.startTime
         : -1,
       numberOfQueries: metadata?.data?.request?.targets?.length ?? 0,
-      seriesData: metadata?.data?.series,
     }),
     [alerting, metadata]
   );
@@ -276,7 +273,7 @@ LIMIT
               onExplain={handleExplain}
               queryContext={queryContext}
               refIds={vars}
-              // schemas={schemas} // Will be added when schema extraction is implemented
+              schemas={schemas}
             />
           )}
         </Suspense>
@@ -288,8 +285,8 @@ LIMIT
             onHistoryUpdate={handleHistoryUpdate}
             queryContext={queryContext}
             refIds={vars}
-            errorContext={errorContext} // Will be added when error tracking is implemented
-            // schemas={schemas} // Will be added when schema extraction is implemented
+            errorContext={errorContext}
+            schemas={schemas}
           />
         </Suspense>
       </Stack>

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { testWithFeatureToggles } from 'test/test-utils';
+
+import { useSQLSchemas, SQLSchemasResponse } from './useSQLSchemas';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
+
+jest.mock('@grafana/api-clients', () => ({
+  getAPINamespace: jest.fn(() => 'default'),
+}));
+
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  getDefaultTimeRange: jest.fn(() => ({
+    from: { toISOString: () => '2024-01-01T00:00:00.000Z' },
+    to: { toISOString: () => '2024-01-01T23:59:59.999Z' },
+  })),
+}));
+
+describe('useSQLSchemas', () => {
+  testWithFeatureToggles({ enable: ['queryService'] });
+
+  beforeEach(() => jest.clearAllMocks());
+
+  const mockQueries = [
+    {
+      refId: 'A',
+      datasource: { type: 'prometheus', uid: 'prom-uid' },
+    },
+  ];
+
+  const mockSchemasResponse: SQLSchemasResponse = {
+    kind: 'SQLSchemaResponse',
+    apiVersion: 'query.grafana.app/v0alpha1',
+    sqlSchemas: {
+      A: {
+        columns: [
+          { name: 'time', mysqlType: 'TIMESTAMP', dataFrameFieldType: 'time', nullable: false },
+          { name: 'value', mysqlType: 'FLOAT', dataFrameFieldType: 'number', nullable: true },
+        ],
+        sampleRows: [[1234567890, 42.5]],
+        error: undefined,
+      },
+    },
+  };
+
+  const setupMockBackendSrv = (mockImplementation: jest.Mock) => {
+    const { getBackendSrv } = require('@grafana/runtime');
+    getBackendSrv.mockReturnValue({ post: mockImplementation });
+    return mockImplementation;
+  };
+
+  it('fetches schemas successfully and updates state', async () => {
+    // Arrange
+    const mockPost = setupMockBackendSrv(jest.fn().mockResolvedValue(mockSchemasResponse));
+
+    // Act - Render the hook
+    const { result } = renderHook(() => useSQLSchemas({ queries: mockQueries }));
+
+    // Assert - Initial state
+    expect(result.current.loading).toBe(true);
+    expect(result.current.schemas).toBe(null);
+    expect(result.current.error).toBe(null);
+
+    // Wait for async fetch to complete
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Assert - Final state
+    expect(result.current.schemas).toEqual(mockSchemasResponse);
+    expect(result.current.schemas?.sqlSchemas.A.columns).toHaveLength(2);
+    expect(result.current.schemas?.sqlSchemas.A.columns?.[0].name).toBe('time');
+    expect(result.current.error).toBe(null);
+
+    // Verify API was called correctly
+    expect(mockPost).toHaveBeenCalledWith(
+      '/apis/query.grafana.app/v0alpha1/namespaces/default/sqlschemas/name',
+      expect.objectContaining({
+        queries: mockQueries,
+        from: '2024-01-01T00:00:00.000Z',
+        to: '2024-01-01T23:59:59.999Z',
+      })
+    );
+  });
+
+  it('handles API errors gracefully without crashing', async () => {
+    // Arrange
+    const mockError = new Error('Network error');
+    setupMockBackendSrv(jest.fn().mockRejectedValue(mockError));
+
+    // Act
+    const { result } = renderHook(() => useSQLSchemas({ queries: mockQueries }));
+
+    // Wait for error to be set
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Assert - Error state is set, no crash
+    expect(result.current.error).toEqual(mockError);
+    expect(result.current.schemas).toBe(null);
+    expect(result.current.loading).toBe(false);
+  });
+
+  describe('when feature flag is disabled', () => {
+    testWithFeatureToggles({ disable: ['queryService', 'grafanaAPIServerWithExperimentalAPIs'] });
+
+    it('does not fetch schemas', async () => {
+      // Arrange
+      setupMockBackendSrv(jest.fn());
+
+      // Act
+      const { result } = renderHook(() => useSQLSchemas({ queries: mockQueries }));
+
+      // Assert - No API call, feature disabled
+      expect(result.current.isFeatureEnabled).toBe(false);
+      expect(result.current.loading).toBe(false);
+      expect(result.current.schemas).toBe(null);
+    });
+  });
+
+  it('returns empty schemas for empty queries array without calling API', async () => {
+    // Arrange
+    const mockPost = setupMockBackendSrv(jest.fn());
+
+    // Act - Empty queries array
+    const { result } = renderHook(() => useSQLSchemas({ queries: [] }));
+
+    // Wait for state to settle
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Assert - Returns empty schemas, no API call
+    expect(result.current.schemas).toEqual({
+      kind: 'SQLSchemaResponse',
+      apiVersion: 'query.grafana.app/v0alpha1',
+      sqlSchemas: {},
+    });
+    expect(result.current.error).toBe(null);
+    expect(mockPost).not.toHaveBeenCalled(); // No API call for empty queries
+  });
+});

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
@@ -28,11 +28,10 @@ export interface SQLSchemasResponse {
 
 interface UseSQLSchemasOptions {
   queries?: DataQuery[];
-  enabled: boolean;
   timeRange?: TimeRange;
 }
 
-export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOptions) {
+export function useSQLSchemas({ queries, timeRange }: UseSQLSchemasOptions) {
   const isFeatureEnabled = useMemo(
     () => config.featureToggles.queryService || config.featureToggles.grafanaAPIServerWithExperimentalAPIs || false,
     []
@@ -40,7 +39,7 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
 
   // Start with loading=true if we're going to fetch on mount
   const [schemas, setSchemas] = useState<SQLSchemasResponse | null>(null);
-  const [loading, setLoading] = useState(enabled && isFeatureEnabled && Boolean(queries));
+  const [loading, setLoading] = useState(isFeatureEnabled && Boolean(queries));
   const [error, setError] = useState<Error | null>(null);
 
   // Store queries in ref so we can access current value without triggering effect
@@ -48,7 +47,7 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
   queriesRef.current = queries;
 
   const fetchSchemas = useCallback(async () => {
-    if (!enabled || !isFeatureEnabled) {
+    if (!isFeatureEnabled) {
       return;
     }
 
@@ -85,7 +84,7 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
     } finally {
       setLoading(false);
     }
-  }, [enabled, isFeatureEnabled, timeRange]);
+  }, [isFeatureEnabled, timeRange]);
 
   useEffect(() => {
     fetchSchemas();


### PR DESCRIPTION
## What does this PR do? 📓 

Integrated SQL schema information into the LLM prompts for both the "Explain" and "Suggestions" features in SQL expressions.

**Key improvements:**

- SQL schemas are now fetched and passed to LLM for context-aware suggestions and explanations. Previously they were only fetched for the schema inspector feature.
- Implemented token budget management to prevent excessive LLM costs
- Cleaned up LLM prompting to improve speed and add token optimization

### Why

Without schema information, the LLM generates generic SQL suggestions that may reference non-existent columns or use incorrect types. With schemas, the LLM can:

- Suggest queries using actual column names and types from the data
- Provide accurate explanations of what columns represent
- Avoid syntax errors related to column availability

### Token optimization

Implemented several optimizations to keep LLM costs under control:

- 10-column limit per RefID with truncation notices (prevents token bombs on wide tables)
- Removed `seriesData` serialization (99.5% token reduction - was sending entire data frames)
- Removed `queries` serialization (was sending full DataQuery objects)
- Memoized schema formatting to avoid unnecessary re-computation
- Removed JSON pretty-printing from context generation

### Testing

Added comprehensive test coverage:
- `formatSchemas.test.ts` - Schema formatting and truncation logic
- `sqlPromptConfig.test.ts` - Prompt generation with all context fields
- `useSQLSchemas.test.ts` - Data fetching hook behavior and error handling