### PR TITLE
Dashboards: Fix logging for conversions

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_data_loss_detection.go
@@ -488,7 +488,7 @@ func withConversionDataLossDetection(sourceFuncName, targetFuncName string, conv
 
 		// Detect if data was lost
 		if dataLossErr := detectConversionDataLoss(sourceStats, targetStats, sourceFuncName, targetFuncName); dataLossErr != nil {
-			logger.Error("Dashboard conversion data loss detected",
+			getLogger().Error("Dashboard conversion data loss detected",
 				"sourceFunc", sourceFuncName,
 				"targetFunc", targetFuncName,
 				"sourcePanels", sourceStats.panelCount,
@@ -504,7 +504,7 @@ func withConversionDataLossDetection(sourceFuncName, targetFuncName string, conv
 			return dataLossErr
 		}
 
-		logger.Debug("Dashboard conversion completed without data loss",
+		getLogger().Debug("Dashboard conversion completed without data loss",
 			"sourceFunc", sourceFuncName,
 			"targetFunc", targetFuncName,
 			"panels", targetStats.panelCount,

--- a/apps/dashboard/pkg/migration/conversion/metrics.go
+++ b/apps/dashboard/pkg/migration/conversion/metrics.go
@@ -17,7 +17,9 @@ import (
 	"github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 )
 
-var logger = logging.DefaultLogger.With("logger", "dashboard.conversion")
+func getLogger() logging.Logger {
+	return logging.DefaultLogger.With("logger", "dashboard.conversion")
+}
 
 // getErroredSchemaVersionFunc determines the schema version function that errored
 func getErroredSchemaVersionFunc(err error) string {
@@ -197,9 +199,9 @@ func withConversionMetrics(sourceVersionAPI, targetVersionAPI string, conversion
 			)
 
 			if errorType == "schema_minimum_version_error" {
-				logger.Warn("Dashboard conversion failed", logFields...)
+				getLogger().Warn("Dashboard conversion failed", logFields...)
 			} else {
-				logger.Error("Dashboard conversion failed", logFields...)
+				getLogger().Error("Dashboard conversion failed", logFields...)
 			}
 		} else {
 			// Record success metrics
@@ -235,7 +237,7 @@ func withConversionMetrics(sourceVersionAPI, targetVersionAPI string, conversion
 				)
 			}
 
-			logger.Debug("Dashboard conversion succeeded", successLogFields...)
+			getLogger().Debug("Dashboard conversion succeeded", successLogFields...)
 		}
 
 		return nil


### PR DESCRIPTION
At init time, the default logger has not yet been overriden, so it will use the NoOp logger from the app sdk: https://github.com/grafana/grafana-app-sdk/blob/679c43084387d5f9a740fb29f1c1b00c84a23386/logging/logger.go#L9

This PR updates it to use what is initialized later in the app, so we get the logs:
<img width="972" height="76" alt="Screenshot 2025-12-10 at 9 31 35 PM" src="https://github.com/user-attachments/assets/4f35ef09-135a-4d01-b7f2-b552aa776e34" />
