### PR TITLE
[release-12.1.5] Chore: Run annotation data migration in batches

### DIFF
--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -645,6 +646,144 @@ func TestIntegrationAnnotations(t *testing.T) {
 			require.NoError(t, err)
 			require.Len(t, result.Tags, 0)
 		})
+	})
+}
+
+func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
+	tutil.SkipIntegrationTestInShortMode(t)
+
+	sql := db.InitTestDB(t)
+	cfg := setting.NewCfg()
+	cfg.AnnotationMaximumTagsLength = 60
+
+	t.Run("NewXormStore should call triggerAlwaysOnMigrations and skip migrations", func(t *testing.T) {
+		cfg.Raw.Section("database").Key("skip_dashboard_uid_migration_on_startup").SetValue("true")
+
+		l := log.New("annotation.test")
+
+		dashboard := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+			UserID: 1,
+			OrgID:  1,
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"title": "Test Skip Dashboard",
+				"uid":   "test-skip-uid",
+			}),
+		})
+
+		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), nil)
+		annotation := &annotations.Item{
+			OrgID:        1,
+			UserID:       1,
+			DashboardID:  dashboard.ID, // nolint: staticcheck
+			DashboardUID: dashboard.UID,
+			Text:         "test migration skip",
+			Type:         "alert",
+			Epoch:        100,
+		}
+		err := tempStore.Add(context.Background(), annotation)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			err := tempStore.Delete(context.Background(), &annotations.DeleteParams{ID: annotation.ID, OrgID: 1})
+			assert.NoError(t, err)
+		})
+
+		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			_, err := sess.Exec("UPDATE annotation SET dashboard_uid = NULL WHERE id = ?", annotation.ID)
+			return err
+		})
+		require.NoError(t, err)
+
+		xormMigrationTrigger = sync.Once{}
+		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), prometheus.NewRegistry())
+
+		require.NotNil(t, store)
+		assert.Equal(t, "sql", store.Type())
+
+		var result struct {
+			DashboardUID *string `xorm:"dashboard_uid"`
+		}
+		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			has, err := sess.Table("annotation").
+				Where("id = ?", annotation.ID).
+				Get(&result)
+			if err != nil {
+				return err
+			}
+			if !has {
+				return fmt.Errorf("annotation not found")
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Nil(t, result.DashboardUID, "dashboard_uid should still be NULL when migration is skipped")
+	})
+
+	t.Run("NewXormStore should call triggerAlwaysOnMigrations and run migrations", func(t *testing.T) {
+		cfg.Raw.Section("database").Key("skip_dashboard_uid_migration_on_startup").SetValue("false")
+		l := log.New("annotation.test")
+
+		dashboard := testutil.CreateDashboard(t, sql, cfg, featuremgmt.WithFeatures(), dashboards.SaveDashboardCommand{
+			UserID: 1,
+			OrgID:  1,
+			Dashboard: simplejson.NewFromAny(map[string]any{
+				"title": "Test Run Dashboard",
+				"uid":   "test-run-uid",
+			}),
+		})
+
+		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), nil)
+		annotation := &annotations.Item{
+			OrgID:        1,
+			UserID:       1,
+			DashboardID:  dashboard.ID, // nolint: staticcheck
+			DashboardUID: dashboard.UID,
+			Text:         "test migration run",
+			Type:         "alert",
+			Epoch:        100,
+		}
+		err := tempStore.Add(context.Background(), annotation)
+		require.NoError(t, err)
+
+		t.Cleanup(func() {
+			err := tempStore.Delete(context.Background(), &annotations.DeleteParams{ID: annotation.ID, OrgID: 1})
+			assert.NoError(t, err)
+		})
+
+		err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+			_, err := sess.Exec("UPDATE annotation SET dashboard_uid = NULL WHERE id = ?", annotation.ID)
+			return err
+		})
+		require.NoError(t, err)
+
+		xormMigrationTrigger = sync.Once{}
+		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), prometheus.NewRegistry())
+
+		require.NotNil(t, store)
+		assert.Equal(t, "sql", store.Type())
+
+		// Wait for the async migration to complete (runs in background goroutine)
+		var result struct {
+			DashboardUID *string `xorm:"dashboard_uid"`
+		}
+		require.Eventually(t, func() bool {
+			err = sql.WithDbSession(context.Background(), func(sess *db.Session) error {
+				has, err := sess.Table("annotation").
+					Where("id = ?", annotation.ID).
+					Get(&result)
+				if err != nil {
+					return err
+				}
+				if !has {
+					return fmt.Errorf("annotation not found")
+				}
+				return nil
+			})
+			if err != nil {
+				return false
+			}
+			return result.DashboardUID != nil && *result.DashboardUID == "test-run-uid"
+		}, 5*time.Second, 100*time.Millisecond, "dashboard_uid should be populated when migration runs")
 	})
 }
 

--- a/pkg/services/annotations/annotationsimpl/xorm_store_test.go
+++ b/pkg/services/annotations/annotationsimpl/xorm_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -27,9 +28,6 @@ import (
 )
 
 func TestIntegrationAnnotations(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping integration test")
-	}
 	sql := db.InitTestDB(t)
 
 	cfg := setting.NewCfg()
@@ -650,7 +648,9 @@ func TestIntegrationAnnotations(t *testing.T) {
 }
 
 func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
-	tutil.SkipIntegrationTestInShortMode(t)
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
 
 	sql := db.InitTestDB(t)
 	cfg := setting.NewCfg()
@@ -670,7 +670,7 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 			}),
 		})
 
-		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), nil)
+		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql))
 		annotation := &annotations.Item{
 			OrgID:        1,
 			UserID:       1,
@@ -695,7 +695,7 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 		require.NoError(t, err)
 
 		xormMigrationTrigger = sync.Once{}
-		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), prometheus.NewRegistry())
+		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql))
 
 		require.NotNil(t, store)
 		assert.Equal(t, "sql", store.Type())
@@ -732,7 +732,7 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 			}),
 		})
 
-		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), nil)
+		tempStore := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql))
 		annotation := &annotations.Item{
 			OrgID:        1,
 			UserID:       1,
@@ -757,7 +757,7 @@ func TestIntegrationAnnotationsAlwaysOnMigrations(t *testing.T) {
 		require.NoError(t, err)
 
 		xormMigrationTrigger = sync.Once{}
-		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql), prometheus.NewRegistry())
+		store := NewXormStore(cfg, l, sql, tagimpl.ProvideService(sql))
 
 		require.NotNil(t, store)
 		assert.Equal(t, "sql", store.Type())


### PR DESCRIPTION
Backport 95e65e258878545856688c57d24a609d5db46734 from #113589

---

This PR modified annotation migration that updates dashboard UIDs, so that it would run in batches. Also it starts from the end of the table, i.e. newest annotations would be migrated first and users shouldn't notice the delay.

Confirmed it on manually upgrading grafana from v12.0.0 to this version with 1M annotations in the database, there is no blocking when the migration runs, latest annotations show up on dashboards immediately.
