### PR TITLE
DynamicDashboards: Hide variables from outline in view mode

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditableElement.tsx
@@ -59,9 +59,9 @@ export class DashboardEditableElement implements EditableDashboardElement {
     };
   }
 
-  public getOutlineChildren(): SceneObject[] {
+  public getOutlineChildren(isEditing: boolean): SceneObject[] {
     const { $variables, body } = this.dashboard.state;
-    return [$variables!, ...body.getOutlineChildren()];
+    return isEditing ? [$variables!, ...body.getOutlineChildren()] : body.getOutlineChildren();
   }
 
   public useEditPaneOptions = useEditPaneOptions.bind(this, this.dashboard);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { SceneObject } from '@grafana/scenes';
+import { SceneObject, SceneVariableSet } from '@grafana/scenes';
 import { Box, Icon, Sidebar, Text, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { isRepeatCloneOrChildOf } from '../utils/clone';
@@ -48,10 +48,15 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
   const { isSelected, onSelect } = useElementSelection(key);
   const isCloned = useMemo(() => isRepeatCloneOrChildOf(sceneObject), [sceneObject]);
   const editableElement = useMemo(() => getEditableElementFor(sceneObject)!, [sceneObject]);
-
   const noTitleText = t('dashboard.outline.tree-item.no-title', '<no title>');
 
-  const children = editableElement.getOutlineChildren?.() ?? [];
+  const children = useMemo(() => {
+    let children = editableElement.getOutlineChildren?.() ?? [];
+    if (!isEditing) {
+      children = children.filter((c) => !(c instanceof SceneVariableSet));
+    }
+    return children;
+  }, [editableElement, isEditing]);
   const elementInfo = editableElement.getEditableElementInfo();
   const instanceName = elementInfo.instanceName === '' ? noTitleText : elementInfo.instanceName;
   const outlineRename = useOutlineRename(editableElement, isEditing);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { SceneObject, SceneVariableSet } from '@grafana/scenes';
+import { SceneObject } from '@grafana/scenes';
 import { Box, Icon, Sidebar, Text, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { isRepeatCloneOrChildOf } from '../utils/clone';
@@ -48,15 +48,10 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
   const { isSelected, onSelect } = useElementSelection(key);
   const isCloned = useMemo(() => isRepeatCloneOrChildOf(sceneObject), [sceneObject]);
   const editableElement = useMemo(() => getEditableElementFor(sceneObject)!, [sceneObject]);
+
   const noTitleText = t('dashboard.outline.tree-item.no-title', '<no title>');
 
-  const children = useMemo(() => {
-    let children = editableElement.getOutlineChildren?.() ?? [];
-    if (!isEditing) {
-      children = children.filter((c) => !(c instanceof SceneVariableSet));
-    }
-    return children;
-  }, [editableElement, isEditing]);
+  const children = editableElement.getOutlineChildren?.(isEditing) ?? [];
   const elementInfo = editableElement.getEditableElementInfo();
   const instanceName = elementInfo.instanceName === '' ? noTitleText : elementInfo.instanceName;
   const outlineRename = useOutlineRename(editableElement, isEditing);

--- a/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
+++ b/public/app/features/dashboard-scene/scene/types/EditableDashboardElement.ts
@@ -74,7 +74,7 @@ export interface EditableDashboardElement {
   /**
    * Container objects can have children
    */
-  getOutlineChildren?(): SceneObject[];
+  getOutlineChildren?(isEditing?: boolean): SceneObject[];
 }
 
 export interface EditableDashboardElementInfo {


### PR DESCRIPTION
**What is this feature?**

| Before | After |
|  ---   |  ---  |
| <img width="342" height="294" alt="image" src="https://github.com/user-attachments/assets/eab4e134-acad-4cfc-83fc-8dec82681c38" /> | <img width="346" height="219" alt="image" src="https://github.com/user-attachments/assets/bc79d837-ecc6-4bdd-b390-0bf6bad8b42a" /> |

**Why do we need this feature?**

Because variables are always visible at the top, showing/clicking on them doesn't offer much to the user

**Who is this feature for?**

Dynamic dashboards users

**Which issue(s) does this PR fix?**:

`-`

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
