### PR TITLE
E2E Selectors: Fix package description

### DIFF
--- a/packages/grafana-e2e-selectors/src/index.ts
+++ b/packages/grafana-e2e-selectors/src/index.ts
@@ -1,5 +1,5 @@
 /**
- * A library containing the different design components of the Grafana ecosystem.
+ * A library containing e2e selectors for the Grafana ecosystem.
  *
  * @packageDocumentation
  */


### PR DESCRIPTION
**What is this feature?**

This PR is fixing an incorrect package description comment. 

**Why do we need this feature?**

This is a bit of a dummie change to test whether [this fix](https://github.com/grafana/grafana/pull/115012) solved the issue we're having with NPM dist-tags for the e2e-selectors package.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514