### PR TITLE
Alerting: Collate alert_rule.namespace_uid column as binary

### DIFF
--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -165,5 +165,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 
 	ualert.AddStateAnnotationsColumn(mg)
 
+	ualert.CollateBinAlertRuleNamespace(mg)
+
 	ualert.CollateBinAlertRuleGroup(mg)
 }

--- a/pkg/services/sqlstore/migrations/ualert/alert_rule_namespace_collation.go
+++ b/pkg/services/sqlstore/migrations/ualert/alert_rule_namespace_collation.go
@@ -1,0 +1,10 @@
+package ualert
+
+import "github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+
+// CollateBinAlertRuleNamespace ensures that namespace_uid column collates in the same way go sorts strings.
+func CollateBinAlertRuleNamespace(mg *migrator.Migrator) {
+	mg.AddMigration("ensure namespace_uid column sorts the same way as golang", migrator.NewRawSQLMigration("").
+		Mysql("ALTER TABLE alert_rule MODIFY namespace_uid VARCHAR(40) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL;").
+		Postgres(`ALTER TABLE alert_rule ALTER COLUMN namespace_uid SET DATA TYPE varchar(40) COLLATE "C";`))
+}


### PR DESCRIPTION
**What is this feature?**

Follow-up for https://github.com/grafana/grafana/pull/114365. Modify the collation of alert_rule.namespace_uid to use `utf8mb4_bin` or `C` in MySQL and PostgreSQL respectively, which should match the ordering when strings are sorted by Go when it sorts by both rule group and namespace_uid: https://github.com/grafana/grafana/blob/4ab198b201acc42077463518d1697ed79a0ce77e/pkg/services/ngalert/models/alert_rule.go#L654-L659

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
