### PR TITLE
NPM: Use env var for OIDC token auth instead of direct npmrc

### DIFF
--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -102,7 +102,8 @@ if (( CHANGES_COUNT > 0 )); then
                         echo "::add-mask::$NPM_AUTH_TOKEN"
                         echo "Configuring npm auth via NPM_TOKEN env var"
                         export NPM_TOKEN="$NPM_AUTH_TOKEN"
-                        # Reference the env var in npmrc (single quotes to prevent shell expansion)
+                        # Reference the env var in npmrc (single quotes intentional - npm expands it at runtime)
+                        # shellcheck disable=SC2016
                         echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
                     else
                         echo "Warning: No token in response, dist-tag operation may fail"

--- a/scripts/publish-npm-packages.sh
+++ b/scripts/publish-npm-packages.sh
@@ -100,8 +100,10 @@ if (( CHANGES_COUNT > 0 )); then
                     if [ -n "$NPM_AUTH_TOKEN" ]; then
                         # Mask the token so it won't appear in logs
                         echo "::add-mask::$NPM_AUTH_TOKEN"
-                        echo "Configuring npm auth token in ~/.npmrc"
-                        echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" >> ~/.npmrc
+                        echo "Configuring npm auth via NPM_TOKEN env var"
+                        export NPM_TOKEN="$NPM_AUTH_TOKEN"
+                        # Reference the env var in npmrc (single quotes to prevent shell expansion)
+                        echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >> ~/.npmrc
                     else
                         echo "Warning: No token in response, dist-tag operation may fail"
                     fi


### PR DESCRIPTION
**What is this feature?**

Change how the OIDC-exchanged npm token is configured: use `NPM_TOKEN` environment variable referenced in `~/.npmrc` instead of writing the token value directly.

**Why do we need this feature?**

Previous approach wrote the token directly to `~/.npmrc` but still failed with 401. This matches how Electron's [npm-trusted-auth-action](https://github.com/electron/npm-trusted-auth-action) handles the token (via env var reference).

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
