### PR TITLE
Table: Add title attribute to make truncated headings legible

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.test.tsx
@@ -451,6 +451,19 @@ describe('TableNG', () => {
       expect(screen.getByText('A1')).toBeInTheDocument();
       expect(screen.getByText('1')).toBeInTheDocument();
     });
+
+    it('shows full column name in title attribute for truncated headers', () => {
+      const { container } = render(
+        <TableNG enableVirtualization={false} data={createBasicDataFrame()} width={800} height={600} />
+      );
+
+      const headers = container.querySelectorAll('[role="columnheader"]');
+      const firstHeaderSpan = headers[0].querySelector('span');
+      const secondHeaderSpan = headers[1].querySelector('span');
+
+      expect(firstHeaderSpan).toHaveAttribute('title', 'Column A');
+      expect(secondHeaderSpan).toHaveAttribute('title', 'Column B');
+    });
   });
 
   describe('Footer options', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -56,7 +56,7 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
         <Icon className={styles.headerCellIcon} name={getFieldTypeIcon(field)} title={field?.type} size="sm" />
       )}
       <span className={styles.headerCellLabel} title={displayName}>
-        {getDisplayName(field)}
+        {displayName}
       </span>
       {direction && (
         <Icon

--- a/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/HeaderCell.tsx
@@ -55,7 +55,9 @@ const HeaderCell: React.FC<HeaderCellProps> = ({
       {showTypeIcons && (
         <Icon className={styles.headerCellIcon} name={getFieldTypeIcon(field)} title={field?.type} size="sm" />
       )}
-      <span className={styles.headerCellLabel}>{getDisplayName(field)}</span>
+      <span className={styles.headerCellLabel} title={displayName}>
+        {getDisplayName(field)}
+      </span>
       {direction && (
         <Icon
           className={cx(styles.headerCellIcon, styles.headerSortIcon)}


### PR DESCRIPTION
**What is this feature?**

This change adds the `title` attribute to all heading cells in the new table panel.

Before:

https://github.com/user-attachments/assets/11e6aecc-9cb6-49d4-b82e-380db5876487

After:

https://github.com/user-attachments/assets/e28a6c88-f8c1-49b5-b401-51b9a1f4f189


**Why do we need this feature?**

Because long heading cells often get truncated, sometimes making them illegible, or indiscernible from other headings with the same prefix.
 
**Who is this feature for?**

All users of the new table (AKA TableNG) in Grafana.

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/grafana/issues/115165

**Special notes for your reviewer:**

🕊️ 🌈 ✨ Be true to yourself, and follow your dreams.

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` ~If this is a pre-GA feature, it is behind a feature toggle.~
- `N/A` ~The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.~
