### PR TITLE
Provisioning: Update provisioning docs to reflect kubernetesDashboards defaults to true

### DIFF
--- a/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
+++ b/docs/sources/as-code/observability-as-code/provision-resources/file-path-setup.md
@@ -54,7 +54,7 @@ For production systems, use the `folderFromFilesStructure` capability instead of
 ## Before you begin
 
 {{< admonition type="note" >}}
-Enable the `provisioning` and `kubernetesDashboards` feature toggles in Grafana to use this feature.
+Enable the `provisioning` feature toggle in Grafana to use this feature.
 {{< /admonition >}}
 
 To set up file provisioning, you need:
@@ -67,7 +67,7 @@ To set up file provisioning, you need:
 
 ## Enable required feature toggles and configure permitted paths
 
-To activate local file provisioning in Grafana, you need to enable the `provisioning` and `kubernetesDashboards` feature toggles.
+To activate local file provisioning in Grafana, you need to enable the `provisioning` feature toggle.
 For additional information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles).
 
 The local setting must be a relative path and its relative path must be configured in the `permitted_provisioned_paths` configuration option.
@@ -82,12 +82,11 @@ Any subdirectories are automatically included.
 The values that you enter for the `permitted_provisioning_paths` become the base paths for those entered when you enter a local path in the **Connect to local storage** wizard.
 
 1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
-1. Locate or add a `[feature_toggles]` section. Add these values:
+1. Locate or add a `[feature_toggles]` section. Add this value:
 
    ```ini
    [feature_toggles]
    provisioning = true
-   kubernetesDashboards = true ; use k8s from browser
    ```
 
 1. Locate or add a `[paths]` section. To add more than one location, use the pipe character (`|`) to separate the paths. The list should not include empty paths or trailing pipes. Add these values:

--- a/docs/sources/as-code/observability-as-code/provision-resources/git-sync-setup.md
+++ b/docs/sources/as-code/observability-as-code/provision-resources/git-sync-setup.md
@@ -74,17 +74,16 @@ Alternatively, you can configure a local file system instead of using GitHub. Re
 
 ## Enable required feature toggles
 
-To activate Git Sync in Grafana, you need to enable the `provisioning` and `kubernetesDashboards` feature toggles. For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
+To activate Git Sync in Grafana, you need to enable the `provisioning` feature toggle. For more information about feature toggles, refer to [Configure feature toggles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
 
-To enable the required feature toggles:
+To enable the required feature toggle:
 
 1. Open your Grafana configuration file, either `grafana.ini` or `custom.ini`. For file location based on operating system, refer to [Configuration file location](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/#experimental-feature-toggles).
-1. Locate or add a `[feature_toggles]` section. Add these values:
+1. Locate or add a `[feature_toggles]` section. Add this value:
 
    ```ini
    [feature_toggles]
    provisioning = true
-   kubernetesDashboards = true ; use k8s from browser
    ```
 
 1. Save the changes to the file and restart Grafana.

--- a/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStarted.tsx
@@ -22,7 +22,6 @@ const featureIni = `# In your custom.ini file
 
 [feature_toggles]
 provisioning = true
-kubernetesDashboards = true ; use k8s from browser
 `;
 
 const ngrokExample = `ngrok http 3000
@@ -103,7 +102,7 @@ const getModalContent = (setupType: SetupType) => {
             ),
             description: t(
               'provisioning.getting-started.step-description-enable-feature-toggles',
-              'Add these settings to your custom.ini file to enable necessary features:'
+              'Add the provisioning feature toggle to your custom.ini file. Note: kubernetesDashboards is enabled by default, but if you have explicitly disabled it, you will need to enable it in your Grafana settings or remove the override from your configuration.'
             ),
             code: featureIni,
           },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11838,7 +11838,7 @@
       "modal-title-set-up-public-access": "Set up public access",
       "modal-title-set-up-required-features": "Set up required features",
       "step-description-copy-url": "From the ngrok output, copy the https:// forwarding URL that looks like this:",
-      "step-description-enable-feature-toggles": "Add these settings to your custom.ini file to enable necessary features:",
+      "step-description-enable-feature-toggles": "Add the provisioning feature toggle to your custom.ini file. Note: kubernetesDashboards is enabled by default, but if you have explicitly disabled it, you will need to enable it in your Grafana settings or remove the override from your configuration.",
       "step-description-start-ngrok": "Run this command to create a secure tunnel to your local Grafana:",
       "step-description-update-grafana-config": "Add this to your custom.ini file, replacing the URL with your actual ngrok URL:",
       "step-title-copy-url": "Copy your public URL",


### PR DESCRIPTION
## Summary

The `kubernetesDashboards` feature toggle now defaults to `true`. This PR updates the documentation and UI to reflect this change so users aren't instructed to add unnecessary configuration.

Slack: https://raintank-corp.slack.com/archives/C07QVGH37D4/p1765449135002609

## Changes

- **Removed `kubernetesDashboards = true` from configuration examples** - Users no longer need to add this to their config files since it defaults to true
- **Updated UI modal text** - Clarified that only `provisioning` needs to be configured, with a note about `kubernetesDashboards` defaulting to true
- **Kept validation checks** - Still validates both feature toggles are enabled to catch cases where users explicitly disabled `kubernetesDashboards`
