### PR TITLE
FS: Fix rendering of public dashboards in MT frontend service

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -187,6 +187,14 @@ func (hs *HTTPServer) registerRoutes() {
 			publicdashboardsapi.CountPublicDashboardRequest(),
 			hs.Index,
 		)
+
+		r.Get("/bootdata/:accessToken",
+			reqNoAuth,
+			publicdashboardsapi.SetPublicDashboardAccessToken,
+			publicdashboardsapi.SetPublicDashboardOrgIdOnContext(hs.PublicDashboardsApi.PublicDashboardService),
+			publicdashboardsapi.CountPublicDashboardRequest(),
+			hs.GetBootdata,
+		)
 	}
 
 	r.Get("/explore", authorize(ac.EvalPermission(ac.ActionDatasourcesExplore)), hs.Index)

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -190,6 +190,7 @@ func (hs *HTTPServer) registerRoutes() {
 
 		r.Get("/bootdata/:accessToken",
 			reqNoAuth,
+			hs.PublicDashboardsApi.Middleware.HandleView,
 			publicdashboardsapi.SetPublicDashboardAccessToken,
 			publicdashboardsapi.SetPublicDashboardOrgIdOnContext(hs.PublicDashboardsApi.PublicDashboardService),
 			publicdashboardsapi.CountPublicDashboardRequest(),

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -22,6 +22,7 @@ import (
 	fswebassets "github.com/grafana/grafana/pkg/services/frontend/webassets"
 	"github.com/grafana/grafana/pkg/services/hooks"
 	"github.com/grafana/grafana/pkg/services/licensing"
+	publicdashboardsapi "github.com/grafana/grafana/pkg/services/publicdashboards/api"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -163,6 +164,11 @@ func (s *frontendService) registerRoutes(m *web.Mux) {
 	// GET because all POST requests are passed to the backend, even though POST is more correct. The frontend
 	// uses cache busting to ensure requests aren't cached.
 	s.routeGet(m, "/-/fe-boot-error", s.handleBootError)
+
+	s.routeGet(m, "/public-dashboards/:accessToken",
+		publicdashboardsapi.SetPublicDashboardAccessToken,
+		s.index.HandleRequest,
+	)
 
 	// All other requests return index.html
 	s.routeGet(m, "/*", s.index.HandleRequest)

--- a/pkg/services/frontend/frontend_settings.go
+++ b/pkg/services/frontend/frontend_settings.go
@@ -46,6 +46,4 @@ type FSFrontendSettings struct {
 	CSPReportOnlyEnabled             bool              `json:"cspReportOnlyEnabled,omitempty"`
 	Http2Enabled                     bool              `json:"http2Enabled,omitempty"`
 	ReportingStaticContext           map[string]string `json:"reportingStaticContext,omitempty"`
-
-	PublicDashboardAccessToken string `json:"publicDashboardAccessToken,omitempty"`
 }

--- a/pkg/services/frontend/frontend_settings.go
+++ b/pkg/services/frontend/frontend_settings.go
@@ -46,4 +46,6 @@ type FSFrontendSettings struct {
 	CSPReportOnlyEnabled             bool              `json:"cspReportOnlyEnabled,omitempty"`
 	Http2Enabled                     bool              `json:"http2Enabled,omitempty"`
 	ReportingStaticContext           map[string]string `json:"reportingStaticContext,omitempty"`
+
+	PublicDashboardAccessToken string `json:"publicDashboardAccessToken,omitempty"`
 }

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -138,9 +138,12 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		return
 	}
 
+	reqCtx := contexthandler.FromContext(ctx)
+
 	// TODO -- restructure so the static stuff is under one variable and the rest is dynamic
 	data := p.data // copy everything
 	data.Nonce = nonce
+	data.Settings.PublicDashboardAccessToken = reqCtx.PublicDashboardAccessToken
 
 	if data.CSPEnabled {
 		data.CSPContent = middleware.ReplacePolicyVariables(p.data.CSPContent, p.data.AppSubUrl, data.Nonce)
@@ -150,7 +153,6 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		writer.Header().Set("Content-Security-Policy-Report-Only", policy)
 	}
 
-	reqCtx := contexthandler.FromContext(ctx)
 	p.runIndexDataHooks(reqCtx, &data)
 
 	writer.Header().Set("Content-Type", "text/html; charset=UTF-8")

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -45,6 +45,8 @@ type IndexViewData struct {
 
 	// Nonce is a cryptographic identifier for use with Content Security Policy.
 	Nonce string
+
+	PublicDashboardAccessToken string
 }
 
 // Templates setup.
@@ -143,7 +145,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	// TODO -- restructure so the static stuff is under one variable and the rest is dynamic
 	data := p.data // copy everything
 	data.Nonce = nonce
-	data.Settings.PublicDashboardAccessToken = reqCtx.PublicDashboardAccessToken
+	data.PublicDashboardAccessToken = reqCtx.PublicDashboardAccessToken
 
 	if data.CSPEnabled {
 		data.CSPContent = middleware.ReplacePolicyVariables(p.data.CSPContent, p.data.AppSubUrl, data.Nonce)

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -188,6 +188,7 @@
       // Wrap in an IIFE to avoid polluting the global scope. Intentionally global-scope properties
       // are explicitly assigned to the `window` object.
       (() => {
+        const publicDashboardAccessToken = [[.PublicDashboardAccessToken]]
         // Grafana can only fail to load once
         // However, it can fail to load in multiple different places
         // To avoid double reporting the error, we use this boolean to check if we've already failed
@@ -274,8 +275,8 @@
           let path = '/bootdata';
           // call a special bootdata url with the public access token
           // this is needed to set the access token and correct org for public dashboards on the ST backend
-          if ([[.PublicDashboardAccessToken]]) {
-            path += `/${[[.PublicDashboardAccessToken]]}`;
+          if (publicDashboardAccessToken) {
+            path += `/${publicDashboardAccessToken}`;
           }
           // pass the search params through to the bootdata request
           // this allows for overriding the theme/language etc

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -271,9 +271,15 @@
         async function fetchBootData() {
           const queryParams = new URLSearchParams(window.location.search);
 
+          let path = '/bootdata';
+          // call a special bootdata url with the public access token
+          // this is needed to set the access token and correct org for public dashboards on the ST backend
+          if ([[.Settings.PublicDashboardAccessToken]]) {
+            path += `/${[[.Settings.PublicDashboardAccessToken]]}`;
+          }
           // pass the search params through to the bootdata request
           // this allows for overriding the theme/language etc
-          const bootDataUrl = new URL('/bootdata', window.location.origin);
+          const bootDataUrl = new URL(path, window.location.origin);
           for (const [key, value] of queryParams.entries()) {
             bootDataUrl.searchParams.append(key, value);
           }

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -274,8 +274,8 @@
           let path = '/bootdata';
           // call a special bootdata url with the public access token
           // this is needed to set the access token and correct org for public dashboards on the ST backend
-          if ([[.Settings.PublicDashboardAccessToken]]) {
-            path += `/${[[.Settings.PublicDashboardAccessToken]]}`;
+          if ([[.PublicDashboardAccessToken]]) {
+            path += `/${[[.PublicDashboardAccessToken]]}`;
           }
           // pass the search params through to the bootdata request
           // this allows for overriding the theme/language etc

--- a/public/app/features/dashboard/routes.ts
+++ b/public/app/features/dashboard/routes.ts
@@ -24,6 +24,7 @@ export const getPublicDashboardRoutes = (): RouteDescriptor[] => {
     {
       path: '/public-dashboards/:accessToken',
       pageClass: 'page-dashboard',
+      allowAnonymous: true,
       routeName: DashboardRoutes.Public,
       chromeless: true,
       component: SafeDynamicImport(


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- sets `allowAnonymous` on the `/public-dashboards/:accessToken` route
  - this prevents the MT frontend service rerouting to `/login` (see https://github.com/grafana/grafana/blob/ash/fs-public-dashboards/public/app/core/navigation/GrafanaRoute.tsx#L68-L75)
- adds a new `/bootdata/:accessToken` route on the ST backend
  - this handles the `publicDashboardAccessToken` being passed from the MT frontend and sets it in the ST backend context
  - **should this be a separate subpath, or should we pass it as a query param to the existing `/bootdata` route and modify that to handle the presence of this query param?** 🤔 
- create a new `/public-dashboards/:accessToken` route handler in the MT frontend 
  - **this is the bit i'm most unsure about - feel like my crappy go is letting me down here** 😂 
  - this sets the `publicDashboardAccessToken` on the context
  - this context is then used to pass the `publicDashboardAccessToken` to `IndexViewData`
  - the presence of this then determines whether to call the `/bootdata` or `/bootdata/:accessToken` route in the index.html

**Why do we need this feature?**

- so public dashboards work correctly when running the MT frontend service

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-frontend-platform/issues/102

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
