### PR TITLE
RecentlyViewedDashboards: Set up container on browsing dashboards page

### DIFF
--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -27,6 +27,7 @@ import { BrowseFilters } from './components/BrowseFilters';
 import { BrowseView } from './components/BrowseView';
 import CreateNewButton from './components/CreateNewButton';
 import { FolderActionsButton } from './components/FolderActionsButton';
+import { RecentlyViewedDashboards } from './components/RecentlyViewedDashboards';
 import { SearchView } from './components/SearchView';
 import { getFolderPermissions } from './permissions';
 import { useHasSelection } from './state/hooks';
@@ -177,6 +178,8 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
       }
     >
       <Page.Contents className={styles.pageContents}>
+        {/* only show recently viewed dashboards when in root */}
+        {!folderUID && <RecentlyViewedDashboards />}
         <ProvisionedFolderPreviewBanner queryParams={queryParams} />
         <div>
           <FilterInput

--- a/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
+++ b/public/app/features/browse-dashboards/BrowseDashboardsPage.tsx
@@ -178,9 +178,9 @@ const BrowseDashboardsPage = memo(({ queryParams }: { queryParams: Record<string
       }
     >
       <Page.Contents className={styles.pageContents}>
+        <ProvisionedFolderPreviewBanner queryParams={queryParams} />
         {/* only show recently viewed dashboards when in root */}
         {!folderUID && <RecentlyViewedDashboards />}
-        <ProvisionedFolderPreviewBanner queryParams={queryParams} />
         <div>
           <FilterInput
             placeholder={getSearchPlaceholder(searchState.includePanels)}

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -15,6 +15,8 @@ export function RecentlyViewedDashboards() {
   // state
   const [recentDashboards, setRecentDashboards] = useState<DashboardQueryResult[]>([]);
   const [loading, setLoading] = useState(false);
+
+  // hook
   const styles = useStyles2(getStyles);
 
   const getRecentlyViewedDashboardsList = async () => {
@@ -42,7 +44,7 @@ export function RecentlyViewedDashboards() {
     <CollapsableSection
       headerDataTestId="browseDashboardsRecentlyViewedTitle"
       label={
-        <Text variant="h4" element="h3">
+        <Text variant="h5" element="h3">
           {t('browse-dashboards.recently-viewed.title', 'Recently Viewed')}
         </Text>
       }
@@ -76,8 +78,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 
   return {
     title: css({
-      background: `linear-gradient(90deg, ${accent} 0%, #d961ebff 100%)`,
-      WebkitBackgroundClip: 'text',
+      background: `linear-gradient(90deg, ${accent} 0%, #e478eaff 100%)`,
       WebkitTextFillColor: 'transparent',
       backgroundClip: 'text',
       color: 'transparent',

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -1,39 +1,23 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useAsync } from 'react-use';
 
 import { GrafanaTheme2 } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { t, Trans } from '@grafana/i18n';
 import { evaluateBooleanFlag } from '@grafana/runtime/internal';
 import { CollapsableSection, Link, Spinner, Text, useStyles2 } from '@grafana/ui';
-import { DashboardQueryResult } from 'app/features/search/service/types';
 
 import { getRecentlyViewedDashboards } from './utils';
 
 const MAX_RECENT = 5;
 
 export function RecentlyViewedDashboards() {
-  // state
-  const [recentDashboards, setRecentDashboards] = useState<DashboardQueryResult[]>([]);
-  const [loading, setLoading] = useState(false);
-
-  // hook
   const styles = useStyles2(getStyles);
 
-  const getRecentlyViewedDashboardsList = async () => {
-    setLoading(true);
-    try {
-      const data = await getRecentlyViewedDashboards(MAX_RECENT);
-      setRecentDashboards(data);
-    } catch (err) {
-      // TODO: handle error properly, include user retry option
-      console.error(t('browse-dashboards.recently-viewed.error', 'Error loading recently viewed dashboards'), err);
-    } finally {
-      setLoading(false);
+  const { value: recentDashboards = [], loading } = useAsync(async () => {
+    if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
+      return [];
     }
-  };
-
-  useEffect(() => {
-    getRecentlyViewedDashboardsList();
+    return getRecentlyViewedDashboards(MAX_RECENT);
   }, []);
 
   if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
@@ -45,7 +29,7 @@ export function RecentlyViewedDashboards() {
       headerDataTestId="browseDashboardsRecentlyViewedTitle"
       label={
         <Text variant="h5" element="h3">
-          {t('browse-dashboards.recently-viewed.title', 'Recently Viewed')}
+          <Trans i18nKey="browse-dashboards.recently-viewed.title">Recently viewed</Trans>
         </Text>
       }
       isOpen={true}

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -1,0 +1,94 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { evaluateBooleanFlag } from '@grafana/runtime/internal';
+import { CollapsableSection, Link, Text, useStyles2 } from '@grafana/ui';
+import { DashboardQueryResult } from 'app/features/search/service/types';
+
+import { getRecentlyViewedDashboards } from './utils';
+
+const MAX_RECENT = 5;
+
+export function RecentlyViewedDashboards() {
+  // state
+  const [recentDashboards, setRecentDashboards] = useState<DashboardQueryResult[]>([]);
+  const [loading, setLoading] = useState(false);
+  const styles = useStyles2(getStyles);
+
+  const getRecentlyViewedDashboardsList = async () => {
+    setLoading(true);
+    try {
+      const data = await getRecentlyViewedDashboards(MAX_RECENT);
+      setRecentDashboards(data);
+    } catch (err) {
+      // TODO: handle error properly, include user retry option
+      console.error(t('browse-dashboards.recently-viewed.error', 'Error loading recently viewed dashboards'), err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    getRecentlyViewedDashboardsList();
+  }, []);
+
+  if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
+    return null;
+  }
+
+  return (
+    <div>
+      <CollapsableSection
+        headerDataTestId="browseDashboardsRecentlyViewedTitle"
+        label={
+          <Text variant="h4" element="h3">
+            {t('browse-dashboards.recently-viewed.title', 'Recently Viewed')}
+          </Text>
+        }
+        isOpen={true}
+        className={styles.title}
+        contentClassName={styles.content}
+      >
+        {/* placeholder */}
+        {loading && <Text>{t('browse-dashboards.recently-viewed.loading', 'Loading…')}</Text>}
+        {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
+        {!loading && recentDashboards.length === 0 && (
+          <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>
+        )}
+
+        {/* TODO: implement actual card content */}
+        {!loading && recentDashboards.length > 0 && (
+          <>
+            {recentDashboards.map((dash) => (
+              <div key={dash.uid}>
+                <Link href={dash.url}>{dash.name}</Link>
+              </div>
+            ))}
+          </>
+        )}
+      </CollapsableSection>
+    </div>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => {
+  const accent = theme.visualization.getColorByName('purple'); // or your own hex
+
+  return {
+    title: css({
+      background: `linear-gradient(90deg, ${accent} 0%, #d961ebff 100%)`,
+      WebkitBackgroundClip: 'text',
+      WebkitTextFillColor: 'transparent',
+      backgroundClip: 'text',
+      color: 'transparent',
+      '& button svg': {
+        color: accent,
+      },
+    }),
+    content: css({
+      paddingTop: theme.spacing(0),
+    }),
+  };
+};

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { evaluateBooleanFlag } from '@grafana/runtime/internal';
-import { CollapsableSection, Link, Text, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, Link, Spinner, Text, useStyles2 } from '@grafana/ui';
 import { DashboardQueryResult } from 'app/features/search/service/types';
 
 import { getRecentlyViewedDashboards } from './utils';
@@ -53,7 +53,7 @@ export function RecentlyViewedDashboards() {
       contentClassName={styles.content}
     >
       {/* placeholder */}
-      {loading && <Text>{t('browse-dashboards.recently-viewed.loading', 'Loading…')}</Text>}
+      {loading && <Spinner />}
       {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
       {!loading && recentDashboards.length === 0 && (
         <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -39,37 +39,35 @@ export function RecentlyViewedDashboards() {
   }
 
   return (
-    <div>
-      <CollapsableSection
-        headerDataTestId="browseDashboardsRecentlyViewedTitle"
-        label={
-          <Text variant="h4" element="h3">
-            {t('browse-dashboards.recently-viewed.title', 'Recently Viewed')}
-          </Text>
-        }
-        isOpen={true}
-        className={styles.title}
-        contentClassName={styles.content}
-      >
-        {/* placeholder */}
-        {loading && <Text>{t('browse-dashboards.recently-viewed.loading', 'Loading…')}</Text>}
-        {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
-        {!loading && recentDashboards.length === 0 && (
-          <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>
-        )}
+    <CollapsableSection
+      headerDataTestId="browseDashboardsRecentlyViewedTitle"
+      label={
+        <Text variant="h4" element="h3">
+          {t('browse-dashboards.recently-viewed.title', 'Recently Viewed')}
+        </Text>
+      }
+      isOpen={true}
+      className={styles.title}
+      contentClassName={styles.content}
+    >
+      {/* placeholder */}
+      {loading && <Text>{t('browse-dashboards.recently-viewed.loading', 'Loading…')}</Text>}
+      {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
+      {!loading && recentDashboards.length === 0 && (
+        <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>
+      )}
 
-        {/* TODO: implement actual card content */}
-        {!loading && recentDashboards.length > 0 && (
-          <>
-            {recentDashboards.map((dash) => (
-              <div key={dash.uid}>
-                <Link href={dash.url}>{dash.name}</Link>
-              </div>
-            ))}
-          </>
-        )}
-      </CollapsableSection>
-    </div>
+      {/* TODO: implement actual card content */}
+      {!loading && recentDashboards.length > 0 && (
+        <>
+          {recentDashboards.map((dash) => (
+            <div key={dash.uid}>
+              <Link href={dash.url}>{dash.name}</Link>
+            </div>
+          ))}
+        </>
+      )}
+    </CollapsableSection>
   );
 }
 

--- a/public/app/features/commandPalette/actions/dashboardActions.ts
+++ b/public/app/features/commandPalette/actions/dashboardActions.ts
@@ -4,7 +4,7 @@ import { useEffect, useRef, useState } from 'react';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import impressionSrv from 'app/core/services/impression_srv';
+import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/components/utils';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
 import { CommandPaletteAction } from '../types';
@@ -20,20 +20,7 @@ export async function getRecentDashboardActions(): Promise<CommandPaletteAction[
     return [];
   }
 
-  const recentUids = (await impressionSrv.getDashboardOpened()).slice(0, MAX_RECENT_DASHBOARDS);
-  const resultsDataFrame = await getGrafanaSearcher().search({
-    kind: ['dashboard'],
-    limit: MAX_RECENT_DASHBOARDS,
-    uid: recentUids,
-  });
-
-  // Search results are alphabetical, so reorder them according to recently viewed
-  const recentResults = resultsDataFrame.view.toArray();
-  recentResults.sort((resultA, resultB) => {
-    const orderA = recentUids.indexOf(resultA.uid);
-    const orderB = recentUids.indexOf(resultB.uid);
-    return orderA - orderB;
-  });
+  const recentResults = await getRecentlyViewedDashboards(MAX_RECENT_DASHBOARDS);
 
   const recentDashboardActions: CommandPaletteAction[] = recentResults.map((item) => {
     const { url, name } = item; // items are backed by DataFrameView, so must hold the url in a closure

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3708,7 +3708,6 @@
     "recently-viewed": {
       "empty": "Nothing viewed yet",
       "error": "Error loading recently viewed dashboards",
-      "loading": "Loading…",
       "title": "Recently Viewed"
     },
     "restore": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3705,6 +3705,12 @@
       "clear": "Clear search and filters",
       "text": "No results found for your query"
     },
+    "recently-viewed": {
+      "empty": "Nothing viewed yet",
+      "error": "Error loading recently viewed dashboards",
+      "loading": "Loading…",
+      "title": "Recently Viewed"
+    },
     "restore": {
       "all-failed_one": "Failed to restore {{count}} dashboard",
       "all-failed_other": "Failed to restore {{count}} dashboards",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3707,8 +3707,7 @@
     },
     "recently-viewed": {
       "empty": "Nothing viewed yet",
-      "error": "Error loading recently viewed dashboards",
-      "title": "Recently Viewed"
+      "title": "Recently viewed"
     },
     "restore": {
       "all-failed_one": "Failed to restore {{count}} dashboard",


### PR DESCRIPTION
**What is this feature?**

`RecentlyViewedDashboards`: Add a recently view dashboard section to browsing dashboards page, its just a container yet, each dashboard card display will be a separate PR. (behind FF)

<img width="1426" height="707" alt="image" src="https://github.com/user-attachments/assets/3f207a10-f13d-418b-904b-e18778555b7b" />


**Why do we need this feature?**

Improve user experience on browsing dashboards page

**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114793

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
