### PR TITLE
Docs: Clarify section title for repeating rows and tabs

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/index.md
@@ -245,11 +245,12 @@ To configure repeats, follow these steps:
 1. Click **Save**.
 1. Toggle off the edit mode switch.
 
-### Repeating rows and the Dashboard special data source
+### Repeating rows and tabs and the Dashboard special data source
 
 <!-- is this next section still true? -->
 
 If a row includes panels using the special [Dashboard data source](ref:built-in-special-data-sources)&mdash;the data source that uses a result set from another panel in the same dashboard&mdash;then corresponding panels in repeated rows will reference the panel in the original row, not the ones in the repeated rows.
+The same behavior applies to tabs.
 
 For example, in a dashboard:
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -135,7 +135,7 @@ function TabRepeatSelect({ tab, id }: { tab: TabItem; id?: string }) {
           <TextLink
             external
             href={
-              'https://grafana.com/docs/grafana/latest/dashboards/build-dashboards/create-dashboard/#configure-repeating-tabs'
+              'https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/create-dynamic-dashboard/#repeating-rows-and-tabs-and-the-dashboard-special-data-source'
             }
           >
             <Trans i18nKey="dashboard.tabs-layout.tab.repeat.learn-more">Learn more</Trans>


### PR DESCRIPTION
Updated section title to clarify content regarding repeating rows and tabs.

**Note**: Only backport docs, not code changes


