### PR TITLE
Unified Storage: Retry when we fail to get a db connection due to a transient error

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -3,8 +3,18 @@ package dbimpl
 import (
 	"context"
 	"database/sql"
+	"strings"
+	"time"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
+)
+
+const (
+	// Connection retry settings for transient errors (e.g., Cloud SQL proxy pod churn)
+	defaultConnAttemptTimeout = 3 * time.Second
+	defaultConnMaxRetries     = 3
+	defaultConnRetryBackoff   = 1 * time.Second
 )
 
 // NewDB converts a *sql.DB to a db.DB.
@@ -12,6 +22,7 @@ func NewDB(d *sql.DB, driverName string) db.DB {
 	ret := sqlDB{
 		DB:         d,
 		driverName: driverName,
+		log:        log.New("resource-db"),
 	}
 	ret.WithTxFunc = db.NewWithTxFunc(ret.BeginTx)
 
@@ -22,6 +33,7 @@ type sqlDB struct {
 	*sql.DB
 	db.WithTxFunc
 	driverName string
+	log        log.Logger
 }
 
 func (d sqlDB) DriverName() string {
@@ -37,11 +49,40 @@ func (d sqlDB) QueryRowContext(ctx context.Context, query string, args ...any) d
 }
 
 func (d sqlDB) BeginTx(ctx context.Context, opts *sql.TxOptions) (db.Tx, error) {
-	tx, err := d.DB.BeginTx(ctx, opts)
-	if err != nil {
-		return nil, err
+	var tx *sql.Tx
+	var err error
+	var conn *sql.Conn
+
+	// try to acquire a connection with retries on transient errors
+	for attempt := 1; attempt <= defaultConnMaxRetries; attempt++ {
+		connCtx, cancel := context.WithTimeout(ctx, defaultConnAttemptTimeout)
+		conn, err = d.DB.Conn(connCtx)
+		cancel()
+
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		if !isTransientConnError(err) {
+			return nil, err
+		}
+
+		d.log.Warn("Transient database connection error, retrying", "attempt", attempt, "max_retries", defaultConnMaxRetries, "error", err)
+
+		if attempt < defaultConnMaxRetries {
+			time.Sleep(defaultConnRetryBackoff)
+		}
 	}
-	return sqlTx{tx}, err
+
+	// once we have a connection, begin the transaction
+	if err == nil {
+		tx, err = conn.BeginTx(ctx, opts)
+		if err == nil {
+			return sqlTx{tx}, nil
+		}
+	}
+
+	return nil, err
 }
 
 type sqlTx struct {
@@ -63,4 +104,38 @@ func (tx sqlTx) QueryRowContext(ctx context.Context, query string, args ...any) 
 	// // codeql-suppress go/sql-query-built-from-user-controlled-sources "The query comes from a safe template source
 	// and the parameters are passed as arguments."
 	return tx.Tx.QueryRowContext(ctx, query, args...)
+}
+
+// isTransientConnError checks if an error is a transient connection error that should be retried.
+// This includes TCP timeouts, connection refused, and other network-related errors that can occur
+// during Cloud SQL proxy pod churn or similar infrastructure events.
+func isTransientConnError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	// TCP/network errors
+	if strings.Contains(errStr, "i/o timeout") ||
+		strings.Contains(errStr, "connection refused") ||
+		strings.Contains(errStr, "connection reset") ||
+		strings.Contains(errStr, "broken pipe") ||
+		strings.Contains(errStr, "no such host") ||
+		strings.Contains(errStr, "network is unreachable") {
+		return true
+	}
+
+	// Context deadline exceeded from our attempt timeout
+	if strings.Contains(errStr, "context deadline exceeded") {
+		return true
+	}
+
+	// MySQL specific errors
+	if strings.Contains(errStr, "bad connection") ||
+		strings.Contains(errStr, "invalid connection") {
+		return true
+	}
+
+	return false
 }

--- a/pkg/storage/unified/sql/db/dbimpl/db.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db.go
@@ -11,7 +11,6 @@ import (
 )
 
 const (
-	// Connection retry settings for transient errors (e.g., Cloud SQL proxy pod churn)
 	defaultConnAttemptTimeout = 3 * time.Second
 	defaultConnMaxRetries     = 3
 	defaultConnRetryBackoff   = 1 * time.Second

--- a/pkg/storage/unified/sql/db/dbimpl/db_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/db_test.go
@@ -1,8 +1,13 @@
 package dbimpl
 
 import (
+	"context"
 	"database/sql"
+	"database/sql/driver"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -24,4 +29,164 @@ func TestDB_BeginTx(t *testing.T) {
 	tx, err := d.BeginTx(ctx, nil)
 	require.NoError(t, err)
 	require.NotNil(t, tx)
+}
+
+func TestDB_BeginTx_RetriesOnTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Register a driver that times out on the first two connection attempts
+	driverName := "test-timeout-driver-" + t.Name()
+	timeoutDriver := &timeoutTestDriver{
+		timeoutsRemaining: 2,
+	}
+	sql.Register(driverName, timeoutDriver)
+
+	sqlDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	sqlDB.SetMaxOpenConns(1)
+
+	d := NewDB(sqlDB, driverName)
+
+	// Use a longer timeout context since we expect retries with backoff
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tx, err := d.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	// Should have attempted 3 connections (2 timeouts + 1 success)
+	require.Equal(t, int32(3), timeoutDriver.connAttempts.Load())
+}
+
+func TestDB_BeginTx_ConnectionReleasedAfterCommitAndRollback(t *testing.T) {
+	t.Parallel()
+
+	// Register a driver that tracks open connections
+	driverName := "test-conn-tracking-driver-" + t.Name()
+	trackingDriver := &connTrackingDriver{}
+	sql.Register(driverName, trackingDriver)
+
+	sqlDB, err := sql.Open(driverName, "")
+	require.NoError(t, err)
+	// Setting MaxIdleConns to 0 ensures connections are closed when returned to pool
+	sqlDB.SetMaxIdleConns(0)
+	sqlDB.SetMaxOpenConns(1)
+
+	d := NewDB(sqlDB, driverName)
+	ctx := testutil.NewDefaultTestContext(t)
+
+	// Test Commit releases connection
+	tx1, err := d.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), trackingDriver.openConns.Load(), "should have 1 open connection after BeginTx")
+
+	err = tx1.Commit()
+	require.NoError(t, err)
+	require.Equal(t, int32(0), trackingDriver.openConns.Load(), "should have 0 open connections after Commit")
+
+	// Test Rollback releases connection
+	tx2, err := d.BeginTx(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), trackingDriver.openConns.Load(), "should have 1 open connection after BeginTx")
+
+	err = tx2.Rollback()
+	require.NoError(t, err)
+	require.Equal(t, int32(0), trackingDriver.openConns.Load(), "should have 0 open connections after Rollback")
+}
+
+// timeoutTestDriver simulates connection timeouts for testing retry logic
+type timeoutTestDriver struct {
+	mu                sync.Mutex
+	timeoutsRemaining int
+	connAttempts      atomic.Int32
+}
+
+func (d *timeoutTestDriver) Open(name string) (driver.Conn, error) {
+	return d.connect(context.Background())
+}
+
+func (d *timeoutTestDriver) OpenConnector(name string) (driver.Connector, error) {
+	return &timeoutTestConnector{driver: d}, nil
+}
+
+func (d *timeoutTestDriver) connect(ctx context.Context) (driver.Conn, error) {
+	d.connAttempts.Add(1)
+
+	d.mu.Lock()
+	shouldTimeout := d.timeoutsRemaining > 0
+	if shouldTimeout {
+		d.timeoutsRemaining--
+	}
+	d.mu.Unlock()
+
+	if shouldTimeout {
+		// Block until context is cancelled to simulate a slow connection
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}
+
+	return &timeoutTestConn{}, nil
+}
+
+type timeoutTestConnector struct {
+	driver *timeoutTestDriver
+}
+
+func (c *timeoutTestConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	return c.driver.connect(ctx)
+}
+
+func (c *timeoutTestConnector) Driver() driver.Driver {
+	return c.driver
+}
+
+type timeoutTestConn struct{}
+
+func (c *timeoutTestConn) Prepare(query string) (driver.Stmt, error) { return testStmt{}, nil }
+func (c *timeoutTestConn) Close() error                              { return nil }
+func (c *timeoutTestConn) Begin() (driver.Tx, error)                 { return testTx{}, nil }
+func (c *timeoutTestConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return testTx{}, nil
+}
+
+// connTrackingDriver tracks open connections for testing connection lifecycle
+type connTrackingDriver struct {
+	openConns atomic.Int32
+}
+
+func (d *connTrackingDriver) Open(name string) (driver.Conn, error) {
+	d.openConns.Add(1)
+	return &connTrackingConn{driver: d}, nil
+}
+
+func (d *connTrackingDriver) OpenConnector(name string) (driver.Connector, error) {
+	return &connTrackingConnector{driver: d}, nil
+}
+
+type connTrackingConnector struct {
+	driver *connTrackingDriver
+}
+
+func (c *connTrackingConnector) Connect(ctx context.Context) (driver.Conn, error) {
+	c.driver.openConns.Add(1)
+	return &connTrackingConn{driver: c.driver}, nil
+}
+
+func (c *connTrackingConnector) Driver() driver.Driver {
+	return c.driver
+}
+
+type connTrackingConn struct {
+	driver *connTrackingDriver
+}
+
+func (c *connTrackingConn) Prepare(query string) (driver.Stmt, error) { return testStmt{}, nil }
+func (c *connTrackingConn) Close() error {
+	c.driver.openConns.Add(-1)
+	return nil
+}
+func (c *connTrackingConn) Begin() (driver.Tx, error) { return testTx{}, nil }
+func (c *connTrackingConn) BeginTx(context.Context, driver.TxOptions) (driver.Tx, error) {
+	return testTx{}, nil
 }


### PR DESCRIPTION
This adds a shorter timeout to unified storage when **opening** a db connection. If it takes longer than 3s to open a db connection, then it will retry up to 3 times.