### PR TITLE
fix(setting): Add default scheme to handle k8s api errors

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 	"gopkg.in/ini.v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -397,6 +398,9 @@ func getRestClient(config Config, log logging.Logger) (*rest.RESTClient, error) 
 		burst = config.Burst
 	}
 
+	// Add a default scheme to handle K8s API error responses
+	scheme := runtime.NewScheme()
+
 	restConfig := &rest.Config{
 		Host:            config.URL,
 		TLSClientConfig: config.TLSClientConfig,
@@ -407,7 +411,7 @@ func getRestClient(config Config, log logging.Logger) (*rest.RESTClient, error) 
 		APIPath: "/apis",
 		ContentConfig: rest.ContentConfig{
 			GroupVersion:         &settingGroupVersion,
-			NegotiatedSerializer: serializer.NewCodecFactory(nil).WithoutConversion(),
+			NegotiatedSerializer: serializer.NewCodecFactory(scheme).WithoutConversion(),
 		},
 	}
 


### PR DESCRIPTION
**What is this feature?**

k8s Rest client would fail to handle api errors if a default scheme is not defined in the codec factory.
This should address the issue and prevent panics on api errors 

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
