### PR TITLE
Alerting: Fix Alerts page filtering

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
@@ -58,6 +58,8 @@ export const triageScene = new EmbeddedSceneWithContext({
         baseFilters: [],
         layout: 'combobox',
         expressionBuilder: prometheusExpressionBuilder,
+        // Filter out __name__ from options as this is the metric name not a filterable label
+        tagKeyRegexFilter: /^(?!__name__$).*/,
       }),
     ],
   }),

--- a/public/app/features/alerting/unified/triage/scene/dataTransform.ts
+++ b/public/app/features/alerting/unified/triage/scene/dataTransform.ts
@@ -33,7 +33,7 @@ export function convertToWorkbenchRows(series: DataFrame[], groupBy: string[] = 
   const ruleUIDIndex = fieldIndex.get('grafana_rule_uid');
 
   // These should always exist due to validation above, but handle gracefully
-  if (!alertnameIndex || !folderIndex || !ruleUIDIndex) {
+  if (alertnameIndex === undefined || folderIndex === undefined || ruleUIDIndex === undefined) {
     return [];
   }
 

--- a/public/app/features/alerting/unified/triage/scene/expressionBuilder.ts
+++ b/public/app/features/alerting/unified/triage/scene/expressionBuilder.ts
@@ -4,9 +4,12 @@ import { AdHocFilterWithLabels } from '@grafana/scenes';
  * Custom expression builder for Prometheus that properly handles regex operators.
  * Unlike the default builder, this doesn't escape regex metacharacters when using =~ or !~
  * operators, allowing users to enter raw regex patterns.
+ *
+ * Note: __name__ is excluded from filters as it represents the metric name itself,
+ * not a label, and should be handled separately in query construction.
  */
 export function prometheusExpressionBuilder(filters: AdHocFilterWithLabels[]): string {
-  const applicableFilters = filters.filter((f) => !f.nonApplicable && !f.hidden);
+  const applicableFilters = filters.filter((f) => !f.nonApplicable && !f.hidden && f.key !== '__name__');
   return applicableFilters.map(renderFilter).join(',');
 }
 


### PR DESCRIPTION
  Relates to issue: https://github.com/grafana/support-escalations/issues/19889
  
Root Cause:
  - Filtering by __name__=GRAFANA_ALERTS created an invalid PromQL query: GRAFANA_ALERTS{__name__="ALERTS"} because this is a prometheus metric name not a label filter (this is always GRAFANA_ALERTS)
  - This caused a 400 error, which returned no data
  - The error "Cannot read properties of undefined (reading 'values')" was a symptom of the missing data

Fix:
  1. Prevent the invalid query - expressionBuilder filters out __name__
  2. Improve UX - TriageScene hides __name__ from dropdown options