### PR TITLE
Alerting: Improve errors from failed requests in historian app.

### DIFF
--- a/apps/alerting/historian/pkg/app/notification/notification.go
+++ b/apps/alerting/historian/pkg/app/notification/notification.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 
 	"github.com/grafana/grafana-app-sdk/app"
@@ -49,7 +50,7 @@ func (n *Notification) QueryHandler(ctx context.Context, writer app.CustomRouteR
 			ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusBadRequest,
-				Message: err.Error(),
+				Message: fmt.Sprintf("parse request: %s", err.Error()),
 			}}
 	}
 
@@ -67,7 +68,7 @@ func (n *Notification) QueryHandler(ctx context.Context, writer app.CustomRouteR
 			ErrStatus: metav1.Status{
 				Status:  metav1.StatusFailure,
 				Code:    http.StatusInternalServerError,
-				Message: err.Error(),
+				Message: fmt.Sprintf("notification query: %s", err.Error()),
 			}}
 	}
 


### PR DESCRIPTION
Passing an empty body to the query handler would result in the rather unhelpful
response of "EOF", so add some prefixes to errors in useful places.
