### PR TITLE
Sparkline: Export a class component for now

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -16,7 +16,7 @@ export interface SparklineProps extends Themeable2 {
   sparkline: FieldSparkline;
 }
 
-export const Sparkline: React.FC<SparklineProps> = memo((props) => {
+const SparklineFn: React.FC<SparklineProps> = memo((props) => {
   const { sparkline, config: fieldConfig, theme, width, height } = props;
 
   const { frame: alignedDataFrame, warning } = prepareSeries(sparkline, fieldConfig);
@@ -30,4 +30,14 @@ export const Sparkline: React.FC<SparklineProps> = memo((props) => {
   return <UPlotChart data={data} config={configBuilder} width={width} height={height} />;
 });
 
-Sparkline.displayName = 'Sparkline';
+SparklineFn.displayName = 'Sparkline';
+
+// we converted to function component above, but some apps extend Sparkline, so we need
+// to keep exporting a class component until those apps are all rolled out.
+// see https://github.com/grafana/app-observability-plugin/pull/2079
+// eslint-disable-next-line react-prefer-function-component/react-prefer-function-component
+export class Sparkline extends React.PureComponent<SparklineProps> {
+  render() {
+    return <SparklineFn {...this.props} />;
+  }
+}


### PR DESCRIPTION
This should prevent errors in Grafana Cloud until https://github.com/grafana/app-observability-plugin/pull/2079 can be released.