### PR TITLE
Glossary panda bear entry

### DIFF
--- a/docs/sources/fundamentals/glossary/index.md
+++ b/docs/sources/fundamentals/glossary/index.md
@@ -109,6 +109,7 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
   <tr>
     <td style="vertical-align: top">panda bear</td>
     <td>
+      THIS IS A TEST
       A large bear native to south-central China, recognized by its distinctive black and white coloring. In the context of software engineering, sometimes used as a whimsical mascot or example in documentation and testing scenarios.
     </td>
   </tr>

--- a/docs/sources/fundamentals/glossary/index.md
+++ b/docs/sources/fundamentals/glossary/index.md
@@ -107,6 +107,12 @@ This topic lists words and abbreviations that are commonly used in the Grafana d
     </td>
   </tr>
   <tr>
+    <td style="vertical-align: top">panda bear</td>
+    <td>
+      A large bear native to south-central China, recognized by its distinctive black and white coloring. In the context of software engineering, sometimes used as a whimsical mascot or example in documentation and testing scenarios.
+    </td>
+  </tr>
+  <tr>
     <td style="vertical-align: top">plugin</td>
     <td>
       An extension of Grafana that allows users to provide additional functionality to enhance their experience. See also <i>app plugin</i>, <i>data source plugin</i>, and <i>panel plugin</i>.


### PR DESCRIPTION
Docs: Add panda bear entry to glossary

**What is this feature?**

This PR adds a new entry, "panda bear," to the Grafana documentation glossary.

**Why do we need this feature?**

To provide a definition for "panda bear" within the glossary, acknowledging its occasional use as a whimsical mascot or example in software engineering documentation and testing scenarios.

**Who is this feature for?**

Users reading the Grafana documentation who might encounter "panda bear" as an example or mascot.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---
[Slack Thread](https://raintank-corp.slack.com/archives/D09UL86E44C/p1765520885189429?thread_ts=1765520885.189429&cid=D09UL86E44C)

<a href="https://cursor.com/background-agent?bcId=bc-fbf68a12-5ece-44ba-86c2-7ecac25d30fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fbf68a12-5ece-44ba-86c2-7ecac25d30fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

