### PR TITLE
E2E Selectors: Fix comment typo

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -3,7 +3,7 @@
 // (a <button> with clear text, for example, does not need an aria-label as it's already labeled)
 // but you still might need to select it for testing,
 // in that case please add the attribute data-testid={selector} in the component and
-// prefix your selector string with 'data-testid' so that when create the selectors we know to search for it on the right attribute
+// prefix your selector string with 'data-testid' so that when we create the selectors we know to search for it on the right attribute
 
 import { VersionedSelectorGroup } from '../types';
 


### PR DESCRIPTION
**What is this feature?**

This PR is fixing a code comment typo. 

**Why do we need this feature?**

This is a bit of a dummie change to test whether [this fix](https://github.com/grafana/grafana/pull/115153) solved the issue we're having with NPM dist-tags for the e2e-selectors package.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514