### PR TITLE
Doc: Add docs for displaying links in the dashboard-controls menu

### DIFF
--- a/docs/sources/as-code/observability-as-code/schema-v2/links-schema.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/links-schema.md
@@ -62,6 +62,6 @@ The table includes default and other fields:
 | targetBlank | bool. If true, the link will be opened in a new tab. Default is `false`. |
 | includeVars | bool. If true, includes current template variables values in the link as query params. Default is `false`. |
 | keepTime    | bool. If true, includes current time range in the link as query params. Default is `false`. |
-| placement?  | string. Placement can be used to display the link somewhere else on the dashboard other than above the visualizations. Accepted value: `inControlsMenu` - renders the link in the dashboard controls dropdown menu. |
+| placement?  | string. Use placement to display the link somewhere else on the dashboard other than above the visualizations. Use  the `inControlsMenu` parameter to render the link in the dashboard controls dropdown menu. |
 
 <!-- prettier-ignore-end -->

--- a/docs/sources/as-code/observability-as-code/schema-v2/links-schema.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/links-schema.md
@@ -62,5 +62,6 @@ The table includes default and other fields:
 | targetBlank | bool. If true, the link will be opened in a new tab. Default is `false`. |
 | includeVars | bool. If true, includes current template variables values in the link as query params. Default is `false`. |
 | keepTime    | bool. If true, includes current time range in the link as query params. Default is `false`. |
+| placement?  | string. Placement can be used to display the link somewhere else on the dashboard other than above the visualizations. Accepted value: `inControlsMenu` - renders the link in the dashboard controls dropdown menu. |
 
 <!-- prettier-ignore-end -->

--- a/docs/sources/visualizations/dashboards/build-dashboards/manage-dashboard-links/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/manage-dashboard-links/index.md
@@ -99,6 +99,7 @@ Add links to other dashboards at the top of your current dashboard.
    - **Include current time range** – Select this option to include the dashboard time range in the link. When the user clicks the link, the linked dashboard opens with the indicated time range already set. **Example:** https://play.grafana.org/d/000000010/annotations?orgId=1&from=now-3h&to=now
    - **Include current template variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link. For more information, see [Dashboard URL variables](ref:dashboard-url-variables).
    - **Open link in new tab** – Select this option if you want the dashboard link to open in a new tab or window.
+   - **Show in controls menu** – Select this option to display the link in the dashboard controls menu instead of at the top of the dashboard. The dashboard controls menu appears as a button in the dashboard toolbar.
 
 1. Click **Save dashboard** in the top-right corner.
 1. Click **Back to dashboard** and then **Exit edit**.
@@ -121,6 +122,7 @@ Add a link to a URL at the top of your current dashboard. You can link to any av
    - **Include current time range** – Select this option to include the dashboard time range in the link. When the user clicks the link, the linked dashboard opens with the indicated time range already set. **Example:** https://play.grafana.org/d/000000010/annotations?orgId=1&from=now-3h&to=now
    - **Include current template variable values** – Select this option to include template variables currently used as query parameters in the link. When the user clicks the link, any matching templates in the linked dashboard are set to the values from the link.
    - **Open link in new tab** – Select this option if you want the dashboard link to open in a new tab or window.
+   - **Show in controls menu** – Select this option to display the link in the dashboard controls menu instead of at the top of the dashboard. The dashboard controls menu appears as a button in the dashboard toolbar.
 
 1. Click **Save dashboard** in the top-right corner.
 1. Click **Back to dashboard** and then **Exit edit**.


### PR DESCRIPTION
([Related PR for template variables](https://github.com/grafana/grafana/pull/115205))

### What changed?

Updates the dashboard links documentation to include the "Show in controls menu" option.

<img width="1617" height="1093" alt="Screenshot 2025-12-12 at 10 19 21" src="https://github.com/user-attachments/assets/ca77a635-9872-47a8-a183-93807e2908a4" />
