### PR TITLE
Docs: Update docs for annotation controls placement

### DIFF
--- a/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
@@ -39,8 +39,7 @@ The configuration for the list of annotations that are associated with the dashb
         "enable": false,
         "hide": false,
         "iconColor": "",
-        "name": "",
-        "placement": null
+        "name": ""
       }
     }
   ],
@@ -53,18 +52,17 @@ The configuration for the list of annotations that are associated with the dashb
 
 ## `AnnotationQuerySpec`
 
-| Name       | Type/Definition                                                                                                                                                                                                                         |
-| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| datasource | [`DataSourceRef`](#datasourceref)                                                                                                                                                                                                       |
-| query      | [`DataQueryKind`](#dataquerykind)                                                                                                                                                                                                       |
-| enable     | bool                                                                                                                                                                                                                                    |
-| hide       | bool                                                                                                                                                                                                                                    |
-| iconColor  | string                                                                                                                                                                                                                                  |
-| name       | string                                                                                                                                                                                                                                  |
-| builtIn    | bool. Default is `false`.                                                                                                                                                                                                               |
-| filter     | [`AnnotationPanelFilter`](#annotationpanelfilter)                                                                                                                                                                                       |
-| placement? | string. Placement can be used to display the annotation query somewhere else on the dashboard other than the default location. Accepted value: `inControlsMenu` - renders the annotation query in the dashboard controls dropdown menu. |
-| options    | `[string]`: A catch-all field for datasource-specific properties.                                                                                                                                                                       |
+| Name       | Type/Definition                                                   |
+| ---------- | ----------------------------------------------------------------- |
+| datasource | [`DataSourceRef`](#datasourceref)                                 |
+| query      | [`DataQueryKind`](#dataquerykind)                                 |
+| enable     | bool                                                              |
+| hide       | bool                                                              |
+| iconColor  | string                                                            |
+| name       | string                                                            |
+| builtIn    | bool. Default is `false`.                                         |
+| filter     | [`AnnotationPanelFilter`](#annotationpanelfilter)                 |
+| options    | `[string]`: A catch-all field for datasource-specific properties. |
 
 ### `DataSourceRef`
 

--- a/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
@@ -53,18 +53,18 @@ The configuration for the list of annotations that are associated with the dashb
 
 ## `AnnotationQuerySpec`
 
-| Name       | Type/Definition                                                   |
-| ---------- | ----------------------------------------------------------------- |
-| datasource | [`DataSourceRef`](#datasourceref)                                 |
-| query      | [`DataQueryKind`](#dataquerykind)                                 |
-| enable     | bool                                                              |
-| hide       | bool                                                              |
-| iconColor  | string                                                            |
-| name       | string                                                            |
-| builtIn    | bool. Default is `false`.                                         |
-| filter     | [`AnnotationPanelFilter`](#annotationpanelfilter)                 |
+| Name       | Type/Definition                                                                                                                                                                                                                         |
+| ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| datasource | [`DataSourceRef`](#datasourceref)                                                                                                                                                                                                       |
+| query      | [`DataQueryKind`](#dataquerykind)                                                                                                                                                                                                       |
+| enable     | bool                                                                                                                                                                                                                                    |
+| hide       | bool                                                                                                                                                                                                                                    |
+| iconColor  | string                                                                                                                                                                                                                                  |
+| name       | string                                                                                                                                                                                                                                  |
+| builtIn    | bool. Default is `false`.                                                                                                                                                                                                               |
+| filter     | [`AnnotationPanelFilter`](#annotationpanelfilter)                                                                                                                                                                                       |
 | placement? | string. Placement can be used to display the annotation query somewhere else on the dashboard other than the default location. Accepted value: `inControlsMenu` - renders the annotation query in the dashboard controls dropdown menu. |
-| options    | `[string]`: A catch-all field for datasource-specific properties. |
+| options    | `[string]`: A catch-all field for datasource-specific properties.                                                                                                                                                                       |
 
 ### `DataSourceRef`
 

--- a/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
+++ b/docs/sources/as-code/observability-as-code/schema-v2/annotations-schema.md
@@ -39,7 +39,8 @@ The configuration for the list of annotations that are associated with the dashb
         "enable": false,
         "hide": false,
         "iconColor": "",
-        "name": ""
+        "name": "",
+        "placement": null
       }
     }
   ],
@@ -62,6 +63,7 @@ The configuration for the list of annotations that are associated with the dashb
 | name       | string                                                            |
 | builtIn    | bool. Default is `false`.                                         |
 | filter     | [`AnnotationPanelFilter`](#annotationpanelfilter)                 |
+| placement? | string. Placement can be used to display the annotation query somewhere else on the dashboard other than the default location. Accepted value: `inControlsMenu` - renders the annotation query in the dashboard controls dropdown menu. |
 | options    | `[string]`: A catch-all field for datasource-specific properties. |
 
 ### `DataSourceRef`

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -149,7 +149,10 @@ To add a new annotation query to a dashboard, follow these steps:
    You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
 
 1. If you don't want to use the annotation query right away, clear the **Enabled** checkbox.
-1. If you don't want the annotation query toggle to be displayed in the dashboard, select the **Hidden** checkbox.
+1. Choose a **Control display** option:
+   - **Above dashboard** - The annotation toggle is displayed above the dashboard. This is the default.
+   - **Controls menu** - The annotation toggle is displayed in the dashboard controls menu instead of above the dashboard. The dashboard controls menu appears as a button in the dashboard toolbar.
+   - **Hidden** - The annotation toggle is not displayed on the dashboard.
 1. Select a color for the event markers.
 1. In the **Show in** drop-down, choose one of the following options:
    - **All panels** - The annotations are displayed on all panels that support annotations.

--- a/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/annotate-visualizations/index.md
@@ -149,7 +149,7 @@ To add a new annotation query to a dashboard, follow these steps:
    You can also click **Open advanced data source picker** to see more options, including adding a data source (Admins only).
 
 1. If you don't want to use the annotation query right away, clear the **Enabled** checkbox.
-1. Choose a **Control display** option:
+1. Select one of the following options in the **Show annotation controls in** drop-down list to control where annotations are displayed:
    - **Above dashboard** - The annotation toggle is displayed above the dashboard. This is the default.
    - **Controls menu** - The annotation toggle is displayed in the dashboard controls menu instead of above the dashboard. The dashboard controls menu appears as a button in the dashboard toolbar.
    - **Hidden** - The annotation toggle is not displayed on the dashboard.


### PR DESCRIPTION
### What changed?
Updates the annotations documentation to include the "Control display" option with three choices: "Above dashboard", "Controls menu", and "Hidden", and adds the placement field to the annotations schema reference.

<img width="1617" height="1093" alt="Screenshot 2025-12-12 at 10 18 54" src="https://github.com/user-attachments/assets/33bb3dec-5be0-4fda-9a16-1b9da383c066" />
