### PR TITLE
NPM: Dispatch to plugin-tools on e2e-selectors changes

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           persist-credentials: false
           ref: ${{ inputs.grafana_commit }}
+          fetch-depth: 2  # Need HEAD~1 for e2e-selectors change detection
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
@@ -127,3 +128,43 @@ jobs:
         env:
           NPM_TAG: ${{ steps.npm-tag.outputs.NPM_TAG }}
         run: ./scripts/publish-npm-packages.sh --dist-tag "$NPM_TAG" --registry 'https://registry.npmjs.org/'
+
+      # Notify plugin-tools when e2e-selectors changes so it can update its bundled version
+      - name: Check for e2e-selectors changes
+        id: check-e2e-changes
+        run: |
+          CHANGES=$(git diff --name-only HEAD~1 HEAD -- packages/grafana-e2e-selectors | wc -l)
+          echo "changes=$CHANGES" >> "$GITHUB_OUTPUT"
+          if [ "$CHANGES" -gt 0 ]; then
+            echo "Detected $CHANGES file(s) changed in packages/grafana-e2e-selectors"
+          fi
+
+      - name: Get Vault secrets
+        if: steps.check-e2e-changes.outputs.changes > 0
+        id: vault-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            GRAFANA_DELIVERY_BOT_APP_PEM=delivery-bot-app:PRIVATE_KEY
+
+      - name: Generate token for plugin-tools
+        if: steps.check-e2e-changes.outputs.changes > 0
+        id: generate_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a
+        with:
+          app_id: ${{ vars.DELIVERY_BOT_APP_ID }}
+          private_key: ${{ env.GRAFANA_DELIVERY_BOT_APP_PEM }}
+          repositories: '["plugin-tools"]'
+          permissions: '{"actions": "write"}'
+
+      - name: Dispatch to plugin-tools
+        if: steps.check-e2e-changes.outputs.changes > 0
+        env:
+          VERSION: ${{ inputs.version }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        run: |
+          echo "Dispatching bump-e2e-selectors workflow to grafana/plugin-tools with version $VERSION"
+          gh workflow run bump-e2e-selectors.yml \
+            --repo grafana/plugin-tools \
+            --ref main \
+            --field version="$VERSION"


### PR DESCRIPTION
**What is this feature?**

When changes are detected in the e2e-selectors package after npm publish, dispatch a workflow to grafana/plugin-tools to update the bundled dependency in plugin-e2e.

**Why do we need this feature?**

After migrating to NPM OIDC Trusted Publishing, the `modified` dist-tag approach stopped working (OIDC only supports `npm publish`, not `npm dist-tag`). This replaces that mechanism by directly notifying plugin-tools when e2e-selectors changes, so plugin-e2e can stay in sync.

Corresponding PR in plugin tools: https://github.com/grafana/plugin-tools/pull/2342

**Who is this feature for?**

Plugin developers

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
