### PR TITLE
plugin(experiment): make sure component is registered to show side bar

### DIFF
--- a/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
@@ -28,7 +28,18 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
 
   const interactiveLearningPluginId = getInteractiveLearningPluginId(availableComponents);
 
-  if (isSmallScreen || !enrichedHelpNode.hideFromTabs || interactiveLearningPluginId === undefined) {
+  // Check if the component is actually registered, not just if the plugin exists
+  // This allows plugins to conditionally register their sidebar component (e.g., for A/B testing)
+  const componentId = interactiveLearningPluginId
+    ? getComponentIdFromComponentMeta(interactiveLearningPluginId, 'Interactive learning')
+    : undefined;
+
+  // Show native help dropdown if:
+  // - Screen is small (mobile/responsive), OR
+  // - hideFromTabs is false, OR
+  // - Interactive learning plugin is not installed, OR
+  // - Interactive learning component is not registered (plugin may exist but chose not to register)
+  if (isSmallScreen || !enrichedHelpNode.hideFromTabs || interactiveLearningPluginId === undefined || componentId === undefined) {
     return (
       <Dropdown overlay={() => <TopNavBarMenu node={enrichedHelpNode} />} placement="bottom-end">
         <ToolbarButton
@@ -41,7 +52,6 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
     );
   }
 
-  const componentId = getComponentIdFromComponentMeta(interactiveLearningPluginId, 'Interactive learning');
   const isOpen = dockedComponentId === componentId;
 
   return (

--- a/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/HelpTopBarButton.tsx
@@ -39,7 +39,12 @@ export const HelpTopBarButton = memo(function HelpTopBarButton({ isSmallScreen }
   // - hideFromTabs is false, OR
   // - Interactive learning plugin is not installed, OR
   // - Interactive learning component is not registered (plugin may exist but chose not to register)
-  if (isSmallScreen || !enrichedHelpNode.hideFromTabs || interactiveLearningPluginId === undefined || componentId === undefined) {
+  if (
+    isSmallScreen ||
+    !enrichedHelpNode.hideFromTabs ||
+    interactiveLearningPluginId === undefined ||
+    componentId === undefined
+  ) {
     return (
       <Dropdown overlay={() => <TopNavBarMenu node={enrichedHelpNode} />} placement="bottom-end">
         <ToolbarButton


### PR DESCRIPTION
We are in the process of building an experiment for Grafana Pathfinder (Interactive learning). We want to have a control group that, when you open the help bar, even though the interactive learning plugin is installed, we show the current dropdown menu. My implementation thoughts are here is: if a user enters the control, we set the sidebar as unmounted
```
if (experimentVariant !== 'control') {
  plugin.addComponent({
    targets: `grafana/extension-sidebar/v0-alpha`,
    title: 'Interactive learning',
    description: 'Opens Interactive learning',
    component: function ContextSidebar() {
      // Get plugin configuration
      const pluginContext = usePluginContext();
      const config = useMemo(() => {
        const rawJsonData = pluginContext?.meta?.jsonData || {};
        const configWithDefaults = getConfigWithDefaults(rawJsonData);

        return configWithDefaults;
      }, [pluginContext?.meta?.jsonData]);

      // Set global config for utility functions (including auto-open logic)
      useEffect(() => {
        (window as any).__pathfinderPluginConfig = config;
      }, [config]);

```
Which triggers the conditional flag to revert back to the dropdown. Happy to have other thoughts on this, but trying to do this in the realm of the plugin being installed, but using OpenFeature to drive the experience 