### PR TITLE
OpenTSDB: Migrate frontend requests to data source backend

### DIFF
--- a/pkg/tsdb/opentsdb/callresource.go
+++ b/pkg/tsdb/opentsdb/callresource.go
@@ -1,10 +1,13 @@
 package opentsdb
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"path"
+	"sort"
+	"strings"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
@@ -61,6 +64,389 @@ func (s *Service) HandleSuggestQuery(rw http.ResponseWriter, req *http.Request) 
 
 	rw.WriteHeader(res.StatusCode)
 	if _, err := rw.Write(responseBody); err != nil {
+		logger.Error("Failed to write response", "error", err)
+		return
+	}
+}
+
+func (s *Service) HandleAggregatorsQuery(rw http.ResponseWriter, req *http.Request) {
+	logger := logger.FromContext(req.Context())
+
+	dsInfo, err := s.getDSInfo(req.Context(), backend.PluginConfigFromContext(req.Context()))
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to get datasource info: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u, err := url.Parse(dsInfo.URL)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to parse datasource URL: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u.Path = path.Join(u.Path, "api/aggregators")
+	httpReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := dsInfo.HTTPClient.Do(httpReq)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to execute request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Error("Failed to close response body", "error", err)
+		}
+	}()
+
+	responseBody, err := DecodeResponseBody(res, logger)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to decode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	var aggregators []string
+	if err := json.Unmarshal(responseBody, &aggregators); err != nil {
+		logger.Warn("Failed to unmarshal aggregators response, returning empty array", "error", err)
+		aggregators = []string{}
+	}
+
+	sort.Strings(aggregators)
+	sortedResponse, err := json.Marshal(aggregators)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	for name, values := range res.Header {
+		if name == "Content-Encoding" || name == "Content-Length" {
+			continue
+		}
+		for _, value := range values {
+			rw.Header().Add(name, value)
+		}
+	}
+
+	rw.WriteHeader(res.StatusCode)
+	if _, err := rw.Write(sortedResponse); err != nil {
+		logger.Error("Failed to write response", "error", err)
+		return
+	}
+}
+
+func (s *Service) HandleFiltersQuery(rw http.ResponseWriter, req *http.Request) {
+	logger := logger.FromContext(req.Context())
+
+	dsInfo, err := s.getDSInfo(req.Context(), backend.PluginConfigFromContext(req.Context()))
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to get datasource info: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u, err := url.Parse(dsInfo.URL)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to parse datasource URL: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u.Path = path.Join(u.Path, "/api/config/filters")
+	httpReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := dsInfo.HTTPClient.Do(httpReq)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to execute request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Error("Failed to close response body", "error", err)
+		}
+	}()
+
+	responseBody, err := DecodeResponseBody(res, logger)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to decode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	var filters map[string]json.RawMessage
+	if err := json.Unmarshal(responseBody, &filters); err != nil {
+		logger.Warn("Failed to unmarshal filters response, returning empty array", "error", err)
+		filters = make(map[string]json.RawMessage)
+	}
+
+	keys := make([]string, 0, len(filters))
+	for key := range filters {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+	sortedResponse, err := json.Marshal(keys)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	for name, values := range res.Header {
+		if name == "Content-Encoding" || name == "Content-Length" {
+			continue
+		}
+		for _, value := range values {
+			rw.Header().Add(name, value)
+		}
+	}
+
+	rw.WriteHeader(res.StatusCode)
+	if _, err := rw.Write(sortedResponse); err != nil {
+		logger.Error("Failed to write response", "error", err)
+		return
+	}
+}
+
+func (s *Service) HandleLookupQuery(rw http.ResponseWriter, req *http.Request) {
+	queryParams := req.URL.Query()
+	typeParam := queryParams.Get("type")
+	if typeParam == "" {
+		http.Error(rw, "missing 'type' parameter", http.StatusBadRequest)
+		return
+	}
+
+	switch typeParam {
+	case "key":
+		s.HandleKeyLookup(rw, req, queryParams)
+	case "keyvalue":
+		s.HandleKeyValueLookup(rw, req, queryParams)
+	default:
+		http.Error(rw, fmt.Sprintf("unsupported type: %s", typeParam), http.StatusBadRequest)
+		return
+	}
+}
+
+func (s *Service) HandleKeyLookup(rw http.ResponseWriter, req *http.Request, queryParams url.Values) {
+	logger := logger.FromContext(req.Context())
+
+	dsInfo, err := s.getDSInfo(req.Context(), backend.PluginConfigFromContext(req.Context()))
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to get datasource info: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	metric := queryParams.Get("metric")
+	if metric == "" {
+		http.Error(rw, "missing 'metric' parameter", http.StatusBadRequest)
+		return
+	}
+
+	u, err := url.Parse(dsInfo.URL)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to parse datasource URL: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u.Path = path.Join(u.Path, "api/search/lookup")
+	lookupQueryParams := u.Query()
+	lookupQueryParams.Set("m", metric)
+	lookupQueryParams.Set("limit", "1000")
+	u.RawQuery = lookupQueryParams.Encode()
+
+	httpReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := dsInfo.HTTPClient.Do(httpReq)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to execute request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Error("Failed to close response body", "error", err)
+		}
+	}()
+
+	responseBody, err := DecodeResponseBody(res, logger)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to decode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	var lookupResponse struct {
+		Results []struct {
+			Tags map[string]string `json:"tags"`
+		} `json:"results"`
+	}
+
+	if err := json.Unmarshal(responseBody, &lookupResponse); err != nil {
+		http.Error(rw, fmt.Sprintf("failed to unmarshal lookup response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	tagKeysMap := make(map[string]bool)
+	for _, result := range lookupResponse.Results {
+		for tagKey := range result.Tags {
+			tagKeysMap[tagKey] = true
+		}
+	}
+
+	tagKeys := make([]string, 0, len(tagKeysMap))
+	for tagKey := range tagKeysMap {
+		tagKeys = append(tagKeys, tagKey)
+	}
+
+	sort.Strings(tagKeys)
+	sortedResponse, err := json.Marshal(tagKeys)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	for name, values := range res.Header {
+		if name == "Content-Encoding" || name == "Content-Length" {
+			continue
+		}
+		for _, value := range values {
+			rw.Header().Add(name, value)
+		}
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(res.StatusCode)
+	if _, err := rw.Write(sortedResponse); err != nil {
+		logger.Error("Failed to write response", "error", err)
+		return
+	}
+}
+
+func (s *Service) HandleKeyValueLookup(rw http.ResponseWriter, req *http.Request, queryParams url.Values) {
+	logger := logger.FromContext(req.Context())
+
+	dsInfo, err := s.getDSInfo(req.Context(), backend.PluginConfigFromContext(req.Context()))
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to get datasource info: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	metric := queryParams.Get("metric")
+	if metric == "" {
+		http.Error(rw, "missing 'metric' parameter", http.StatusBadRequest)
+		return
+	}
+
+	keys := queryParams.Get("keys")
+	if keys == "" {
+		http.Error(rw, "missing 'keys' parameter", http.StatusBadRequest)
+		return
+	}
+
+	keysArray := strings.Split(keys, ",")
+	for i := range keysArray {
+		keysArray[i] = strings.TrimSpace(keysArray[i])
+	}
+
+	if len(keysArray) == 0 {
+		http.Error(rw, "keys parameter cannot be empty", http.StatusBadRequest)
+		return
+	}
+
+	key := keysArray[0]
+	keysQuery := key + "=*"
+
+	if len(keysArray) > 1 {
+		keysQuery += "," + strings.Join(keysArray[1:], ",")
+	}
+
+	m := metric + "{" + keysQuery + "}"
+
+	u, err := url.Parse(dsInfo.URL)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to parse datasource URL: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	u.Path = path.Join(u.Path, "api/search/lookup")
+	lookupQueryParams := u.Query()
+	lookupQueryParams.Set("m", m)
+	lookupQueryParams.Set("limit", fmt.Sprintf("%d", dsInfo.LookupLimit))
+	u.RawQuery = lookupQueryParams.Encode()
+
+	httpReq, err := http.NewRequestWithContext(req.Context(), http.MethodGet, u.String(), nil)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to create request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	res, err := dsInfo.HTTPClient.Do(httpReq)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to execute request: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	defer func() {
+		if err := res.Body.Close(); err != nil {
+			logger.Error("Failed to close response body", "error", err)
+		}
+	}()
+
+	responseBody, err := DecodeResponseBody(res, logger)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to decode response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	var lookupResponse struct {
+		Results []struct {
+			Tags map[string]string `json:"tags"`
+		} `json:"results"`
+	}
+
+	if err := json.Unmarshal(responseBody, &lookupResponse); err != nil {
+		http.Error(rw, fmt.Sprintf("failed to unmarshal lookup response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	tagValuesMap := make(map[string]bool)
+	for _, result := range lookupResponse.Results {
+		if tagValue, exists := result.Tags[key]; exists {
+			tagValuesMap[tagValue] = true
+		}
+	}
+
+	tagValues := make([]string, 0, len(tagValuesMap))
+	for tagValue := range tagValuesMap {
+		tagValues = append(tagValues, tagValue)
+	}
+
+	sort.Strings(tagValues)
+	sortedResponse, err := json.Marshal(tagValues)
+	if err != nil {
+		http.Error(rw, fmt.Sprintf("failed to marshal response: %v", err), http.StatusInternalServerError)
+		return
+	}
+
+	for name, values := range res.Header {
+		if name == "Content-Encoding" || name == "Content-Length" {
+			continue
+		}
+		for _, value := range values {
+			rw.Header().Add(name, value)
+		}
+	}
+
+	rw.Header().Set("Content-Type", "application/json")
+	rw.WriteHeader(res.StatusCode)
+	if _, err := rw.Write(sortedResponse); err != nil {
 		logger.Error("Failed to write response", "error", err)
 		return
 	}

--- a/pkg/tsdb/opentsdb/callresource.go
+++ b/pkg/tsdb/opentsdb/callresource.go
@@ -111,8 +111,8 @@ func (s *Service) HandleAggregatorsQuery(rw http.ResponseWriter, req *http.Reque
 
 	var aggregators []string
 	if err := json.Unmarshal(responseBody, &aggregators); err != nil {
-		logger.Warn("Failed to unmarshal aggregators response, returning empty array", "error", err)
-		aggregators = []string{}
+		http.Error(rw, fmt.Sprintf("failed to unmarshal aggregators response: %v", err), http.StatusInternalServerError)
+		return
 	}
 
 	sort.Strings(aggregators)
@@ -180,8 +180,8 @@ func (s *Service) HandleFiltersQuery(rw http.ResponseWriter, req *http.Request) 
 
 	var filters map[string]json.RawMessage
 	if err := json.Unmarshal(responseBody, &filters); err != nil {
-		logger.Warn("Failed to unmarshal filters response, returning empty array", "error", err)
-		filters = make(map[string]json.RawMessage)
+		http.Error(rw, fmt.Sprintf("failed to unmarshal filters response: %v", err), http.StatusInternalServerError)
+		return
 	}
 
 	keys := make([]string, 0, len(filters))

--- a/pkg/tsdb/opentsdb/opentsdb.go
+++ b/pkg/tsdb/opentsdb/opentsdb.go
@@ -152,6 +152,9 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/suggest", s.HandleSuggestQuery)
+	mux.HandleFunc("/api/aggregators", s.HandleAggregatorsQuery)
+	mux.HandleFunc("/api/config/filters", s.HandleFiltersQuery)
+	mux.HandleFunc("/api/search/lookup", s.HandleLookupQuery)
 
 	handler := httpadapter.New(mux)
 	return handler.CallResource(ctx, req, sender)

--- a/pkg/tsdb/opentsdb/types.go
+++ b/pkg/tsdb/opentsdb/types.go
@@ -7,9 +7,16 @@ type OpenTsdbQuery struct {
 }
 
 type OpenTsdbCommon struct {
-	Metric        string            `json:"metric"`
-	Tags          map[string]string `json:"tags"`
-	AggregateTags []string          `json:"aggregateTags"`
+	Metric            string               `json:"metric"`
+	Tags              map[string]string    `json:"tags"`
+	AggregateTags     []string             `json:"aggregateTags"`
+	Annotations       []OpenTsdbAnnotation `json:"annotations,omitempty"`
+	GlobalAnnotations []OpenTsdbAnnotation `json:"globalAnnotations,omitempty"`
+}
+
+type OpenTsdbAnnotation struct {
+	Description string  `json:"description"`
+	StartTime   float64 `json:"startTime"`
 }
 
 type OpenTsdbResponse struct {

--- a/pkg/tsdb/opentsdb/utils.go
+++ b/pkg/tsdb/opentsdb/utils.go
@@ -198,11 +198,21 @@ func CreateDataFrame(val OpenTsdbCommon, length int, refID string) *data.Frame {
 	sort.Strings(tagKeys)
 	tagKeys = append(tagKeys, val.AggregateTags...)
 
+	custom := map[string]any{
+		"tagKeys": tagKeys,
+	}
+	if len(val.Annotations) > 0 {
+		custom["annotations"] = val.Annotations
+	}
+	if len(val.GlobalAnnotations) > 0 {
+		custom["globalAnnotations"] = val.GlobalAnnotations
+	}
+
 	frame := data.NewFrameOfFieldTypes(val.Metric, length, data.FieldTypeTime, data.FieldTypeFloat64)
 	frame.Meta = &data.FrameMeta{
 		Type:        data.FrameTypeTimeSeriesMulti,
 		TypeVersion: data.FrameTypeVersion{0, 1},
-		Custom:      map[string]any{"tagKeys": tagKeys},
+		Custom:      custom,
 	}
 	frame.RefID = refID
 	timeField := frame.Fields[0]

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -306,6 +306,10 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
       return of([]);
     }
 
+    if (config.featureToggles.opentsdbBackendMigration) {
+      return from(this.getResource('/api/search/lookup', { type: 'keyvalue', metric, keys }));
+    }
+
     const keysArray = keys.split(',').map((key) => {
       return key.trim();
     });
@@ -335,6 +339,10 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
   _performMetricKeyLookup(metric: string) {
     if (!metric) {
       return of([]);
+    }
+
+    if (config.featureToggles.opentsdbBackendMigration) {
+      return from(this.getResource('/api/search/lookup', { type: 'key', metric }));
     }
 
     return this._get('/api/search/lookup', { m: metric, limit: 1000 }).pipe(
@@ -450,6 +458,11 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
       return this.aggregatorsPromise;
     }
 
+    if (config.featureToggles.opentsdbBackendMigration) {
+      this.aggregatorsPromise = this.getResource('/api/aggregators');
+      return this.aggregatorsPromise;
+    }
+
     this.aggregatorsPromise = lastValueFrom(
       this._get('/api/aggregators').pipe(
         map((result) => {
@@ -465,6 +478,11 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
 
   getFilterTypes() {
     if (this.filterTypesPromise) {
+      return this.filterTypesPromise;
+    }
+
+    if (config.featureToggles.opentsdbBackendMigration) {
+      this.filterTypesPromise = this.getResource('/api/config/filters');
       return this.filterTypesPromise;
     }
 

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -354,7 +354,7 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
     }
 
     if (config.featureToggles.opentsdbBackendMigration) {
-      return from(this.getResource('/api/search/lookup', { type: 'keyvalue', metric, keys }));
+      return from(this.getResource('api/search/lookup', { type: 'keyvalue', metric, keys }));
     }
 
     const keysArray = keys.split(',').map((key) => {
@@ -389,7 +389,8 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
     }
 
     if (config.featureToggles.opentsdbBackendMigration) {
-      return from(this.getResource('/api/search/lookup', { type: 'key', metric }));
+      console.log('_performMetricKeyValueLookup', 'key');
+      return from(this.getResource('api/search/lookup', { type: 'key', metric }));
     }
 
     return this._get('/api/search/lookup', { m: metric, limit: 1000 }).pipe(
@@ -506,7 +507,7 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
     }
 
     if (config.featureToggles.opentsdbBackendMigration) {
-      this.aggregatorsPromise = this.getResource('/api/aggregators');
+      this.aggregatorsPromise = this.getResource('api/aggregators');
       return this.aggregatorsPromise;
     }
 
@@ -529,7 +530,7 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
     }
 
     if (config.featureToggles.opentsdbBackendMigration) {
-      this.filterTypesPromise = this.getResource('/api/config/filters');
+      this.filterTypesPromise = this.getResource('api/config/filters');
       return this.filterTypesPromise;
     }
 

--- a/public/app/plugins/datasource/opentsdb/datasource.ts
+++ b/public/app/plugins/datasource/opentsdb/datasource.ts
@@ -197,16 +197,9 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
             const eventList: AnnotationEvent[] = [];
 
             for (const frame of response.data) {
-              // const annotations = frame.meta?.custom?.annotations;
-              // const globalAnnotations = frame.meta?.custom?.globalAnnotations;
               const annotationObject = annotation.isGlobal
                 ? frame.meta?.custom?.globalAnnotations
                 : frame.meta?.custom?.annotations;
-
-              // let annotationObject = annotations;
-              // if (annotation.isGlobal && globalAnnotations) {
-              //   annotationObject = globalAnnotations;
-              // }
 
               if (annotationObject && isArray(annotationObject)) {
                 annotationObject.forEach((ann) => {
@@ -221,7 +214,6 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
               }
             }
 
-            console.log('be eventList', eventList);
             return eventList;
           })
         )
@@ -389,7 +381,6 @@ export default class OpenTsDatasource extends DataSourceWithBackend<OpenTsdbQuer
     }
 
     if (config.featureToggles.opentsdbBackendMigration) {
-      console.log('_performMetricKeyValueLookup', 'key');
       return from(this.getResource('api/search/lookup', { type: 'key', metric }));
     }
 


### PR DESCRIPTION
Migrates the remaining metadata requests to the data source backend if `opentsdbBackendMigration` feature toggle has been enabled.

these methods include `_performMetricKeyLookup`, `_performMetricKeyValueLookup`, `getAggregators`, `getFilterTypes`.

---

### How to test these functions:
make sure to enable `opentsdbBackendMigration`

**_performMetricKeyLookup**:
- go to dashboard settings → variables → add variable
- set variable type: query
- data source: opentsdb
- query: tag_names(<METRIC_NAME>)
- click update

**_performMetricKeyValueLookup**:
- go to dashboard settings → variables → add variable
- set variable type: query
- data source: opentsdb
- query: tag_values(<METRIC_NAME>)
- click update

**getAggregators**:
- go to explore → select opentsdb data source
- check the request to `/api/datasources/proxy/uid/<ds_uid>/api/aggregators` was successful

**getFilterTypes**:
- go to explore → select opentsdb data source
- verify the request to `http://localhost:3000/api/datasources/proxy/uid/<ds_uid>/api/config/filters` was successful