### PR TITLE
V2 Schema: Restore inspect panel json editing workflow, for v2

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1835,11 +1835,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/pages/DashboardScenePage.tsx": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 2

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.test.tsx
@@ -190,7 +190,7 @@ describe('InspectJsonTab', () => {
     expect(obj.kind).toEqual('Panel');
     expect(obj.spec.id).toEqual(12);
     expect(obj.spec.data.kind).toEqual('QueryGroup');
-    expect(tab.isEditable()).toBe(false);
+    expect(tab.isEditable()).toBe(true);
   });
 });
 

--- a/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
+++ b/public/app/features/dashboard-scene/inspect/InspectJsonTab.tsx
@@ -136,6 +136,18 @@ export class InspectJsonTab extends SceneObjectBase<InspectJsonTabState> {
         return;
       }
       const vizPanel = buildVizPanel(jsonObj, jsonObj.spec.id);
+
+      if (!dashboard.state.isEditing) {
+        dashboard.onEnterEditMode();
+      }
+
+      reportPanelInspectInteraction(InspectTab.JSON, 'apply', {
+        panel_type_changed: panel.state.pluginId !== jsonObj.spec.vizConfig.group,
+        panel_id_changed: getPanelIdForVizPanel(panel) !== jsonObj.spec.id,
+        panel_grid_pos_changed: false, // Grid cant be edited from inspect in v2 panels.
+        panel_targets_changed: hasQueriesChanged(getQueryRunnerFor(panel), getQueryRunnerFor(vizPanel.state.$data)),
+      });
+
       panel.setState(vizPanel.state);
       this.state.onClose();
     } else {

--- a/public/app/features/dashboard-scene/v2schema/validation.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.test.ts
@@ -1,0 +1,60 @@
+import {
+  defaultPanelKind,
+  defaultQueryGroupKind,
+  defaultPanelQueryKind,
+  defaultVizConfigKind,
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import { isPanelKindV2 } from './validation';
+
+describe('v2schema validation', () => {
+  it('isPanelKindV2 returns true for a minimal valid PanelKind', () => {
+    const panel = defaultPanelKind();
+    // Ensure minimal required properties exist (defaults should be fine)
+    panel.spec.vizConfig = defaultVizConfigKind();
+    panel.spec.data = defaultQueryGroupKind();
+
+    expect(isPanelKindV2(panel)).toBe(true);
+  });
+
+  it('returns false when kind is not "Panel"', () => {
+    const panel = defaultPanelKind();
+    // @ts-expect-error intentional invalid kind for test
+    panel.kind = 'NotAPanel';
+    expect(isPanelKindV2(panel)).toBe(false);
+  });
+
+  it('returns false when data kind is wrong', () => {
+    const panel = defaultPanelKind();
+    // @ts-expect-error intentional invalid kind for test
+    panel.spec.data = { kind: 'Wrong', spec: {} };
+    expect(isPanelKindV2(panel)).toBe(false);
+  });
+
+  it('returns false when queries contain invalid entries', () => {
+    const panel = defaultPanelKind();
+    panel.spec.data = defaultQueryGroupKind();
+    // @ts-expect-error push an invalid query shape
+    panel.spec.data.spec.queries = [{}];
+    expect(isPanelKindV2(panel)).toBe(false);
+
+    // Ensure a valid query shape passes
+    panel.spec.data.spec.queries = [defaultPanelQueryKind()];
+    expect(isPanelKindV2(panel)).toBe(true);
+  });
+
+  it('returns false when vizConfig.group is not a string', () => {
+    const panel = defaultPanelKind();
+    panel.spec.vizConfig = defaultVizConfigKind();
+    // @ts-expect-error force wrong type
+    panel.spec.vizConfig.group = 42;
+    expect(isPanelKindV2(panel)).toBe(false);
+  });
+
+  it('returns false when transparent is not a boolean', () => {
+    const panel = defaultPanelKind();
+    // @ts-expect-error wrong type
+    panel.spec.transparent = 'yes';
+    expect(isPanelKindV2(panel)).toBe(false);
+  });
+});

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -1,0 +1,137 @@
+import {
+  PanelKind,
+  QueryGroupKind,
+  VizConfigKind,
+  PanelQueryKind,
+  TransformationKind,
+} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isPanelQueryKind(value: unknown): value is PanelQueryKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.kind !== 'PanelQuery' || !isObject(value.spec)) {
+    return false;
+  }
+  // Minimal checks for query spec; accept additional properties
+  if (typeof value.spec.refId !== 'string') {
+    return false;
+  }
+  if (typeof value.spec.hidden !== 'boolean') {
+    return false;
+  }
+  // value.spec.query is an opaque "DataQueryKind" which is { kind: string, spec: Record<string, any> }
+  const q = value.spec.query;
+  if (!isObject(q) || typeof q.kind !== 'string' || !isObject(q.spec)) {
+    return false;
+  }
+  return true;
+}
+
+function isTransformationKind(value: unknown): value is TransformationKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (typeof value.kind !== 'string') {
+    return false;
+  }
+  if (!isObject(value.spec)) {
+    return false;
+  }
+  return true;
+}
+
+function isQueryGroupKind(value: unknown): value is QueryGroupKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.kind !== 'QueryGroup' || !isObject(value.spec)) {
+    return false;
+  }
+  const spec = value.spec;
+  if (!Array.isArray(spec.queries) || !spec.queries.every(isPanelQueryKind)) {
+    return false;
+  }
+  if (!Array.isArray(spec.transformations) || !spec.transformations.every(isTransformationKind)) {
+    return false;
+  }
+  if (!isObject(spec.queryOptions)) {
+    return false;
+  }
+  return true;
+}
+
+function isVizConfigKind(value: unknown): value is VizConfigKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.kind !== 'VizConfig') {
+    return false;
+  }
+  if (typeof value.group !== 'string') {
+    return false;
+  }
+  if (typeof value.version !== 'string') {
+    return false;
+  }
+  if (!isObject(value.spec)) {
+    return false;
+  }
+  const spec = value.spec;
+  if (!isObject(spec.options)) {
+    return false;
+  }
+  if (!isObject(spec.fieldConfig)) {
+    return false;
+  }
+  // Minimal fieldConfig shape (defaults/overrides may be empty)
+  if (!isObject(spec.fieldConfig)) {
+    return false;
+  }
+  return true;
+}
+
+export function isPanelKindV2(value: unknown): value is PanelKind {
+  if (!isObject(value)) {
+    return false;
+  }
+  if (value.kind !== 'Panel') {
+    return false;
+  }
+  if (!isObject(value.spec)) {
+    return false;
+  }
+  const spec = value.spec;
+  if (typeof spec.id !== 'number') {
+    return false;
+  }
+  if (typeof spec.title !== 'string') {
+    return false;
+  }
+  if (typeof spec.description !== 'string') {
+    return false;
+  }
+  if (!Array.isArray(spec.links)) {
+    return false;
+  }
+  if (!isQueryGroupKind(spec.data)) {
+    return false;
+  }
+  if (!isVizConfigKind(spec.vizConfig)) {
+    return false;
+  }
+  if (spec.transparent !== undefined && typeof spec.transparent !== 'boolean') {
+    return false;
+  }
+  return true;
+}
+
+export function validatePanelKindV2(value: unknown): asserts value is PanelKind {
+  if (!isPanelKindV2(value)) {
+    throw new Error('Provided JSON is not a valid v2 Panel spec');
+  }
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6141,7 +6141,10 @@
       "no-data-found": "No data found"
     },
     "inspect-json-tab": {
-      "apply": "Apply"
+      "apply": "Apply",
+      "error-invalid-json": "Invalid JSON",
+      "error-invalid-v2-panel": "Panel JSON did not pass validation. Please check the JSON and try again.",
+      "validation-error": "Validation error"
     },
     "interval-variable-form": {
       "description-auto-option": "Dynamically calculates interval by dividing time range by the count specified",


### PR DESCRIPTION
**What is this feature?**

When implementing the v2 schema, we never implemented the mechanism to change panels by altering the panel json in the inspect panel json UI.

This implements that functionality by using the panel deserialization for v2 schema and a basic validator for the json.

However, it is no longer possible to edit the size of a panel by editing the panel json, as in V2 that is not part of the panel, but of the grid item.

<img width="1332" height="765" alt="image" src="https://github.com/user-attachments/assets/a6cf19a1-9f3c-43dc-8a0a-7f64ee44677f" />


Fixes #115238