### PR TITLE
Provisioning: Fix duplicated breadcrumb

### DIFF
--- a/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
+++ b/public/app/features/provisioning/GettingStarted/GettingStartedPage.tsx
@@ -15,13 +15,10 @@ export default function GettingStartedPage({ items }: Props) {
   return (
     <Page
       navId="provisioning"
-      pageNav={{
-        text: t('provisioning.getting-started-page.header', 'Provisioning'),
-        subTitle: t(
-          'provisioning.getting-started-page.subtitle-provisioning-feature',
-          'View and manage your provisioning connections'
-        ),
-      }}
+      subTitle={t(
+        'provisioning.getting-started-page.subtitle-provisioning-feature',
+        'View and manage your provisioning connections'
+      )}
     >
       <Page.Contents>
         <Stack direction="column" gap={3}>

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11867,7 +11867,6 @@
       "title-setting-connection-could-cause-temporary-outage": "Setting up this connection could cause a temporary outage"
     },
     "getting-started-page": {
-      "header": "Provisioning",
       "subtitle-provisioning-feature": "View and manage your provisioning connections"
     },
     "git": {


### PR DESCRIPTION
 **What is this feature?**
  This fix removes the duplicate "Provisioning" breadcrumb that appeared when navigating to /admin/provisioning with no repository configured.

  **Why do we need this feature?**
  The breadcrumb displayed "Provisioning" twice because the component was using both `navId="provisioning"` (which provides "Provisioning" from server-side navigation) and a redundant `pageNav` prop with `text: 'Provisioning'`.


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/712

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
