### PR TITLE
Chore: fix grafana 12 release and support dates

### DIFF
--- a/docs/sources/upgrade-guide/when-to-upgrade/index.md
+++ b/docs/sources/upgrade-guide/when-to-upgrade/index.md
@@ -107,8 +107,8 @@ Here is an overview of version support through 2026:
 | 12.0.x                    | May 5, 2025        | February 5, 2026     | Patch Support      |
 | 12.1.x                    | July 22, 2025      | April 22, 2026       | Patch Support      |
 | 12.2.x                    | September 23, 2025 | June 23, 2026        | Patch Support      |
-| 12.3.x                    | November 18, 2025  | August 18, 2026      | Yet to be released |
-| 12.4.x (Last minor of 12) | February 24, 2026  | November 24, 2026    | Yet to be released |
+| 12.3.x                    | November 19, 2025  | August 19, 2026      | Patch Support      |
+| 12.4.x (Last minor of 12) | February 24, 2026  | May 24, 2027         | Yet to be released |
 | 13.0.0                    | TBD                | TBD                  | Yet to be released |
 
 ## How are these versions supported?


### PR DESCRIPTION
Docs change:

- 12.3.x release date and support end date
- 12.4.x planned support end date 