### PR TITLE
Alerting: Add compact model for alert rules

### DIFF
--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -1201,7 +1201,7 @@ func extractDatasourceUIDs(rule *ngmodels.AlertRule) []string {
 }
 
 // ruleToQuery attempts to extract the datasource queries from the alert query model.
-// Returns the whole JSON model as a string if it fails to extract a minimum of 1 query.
+// Returns an empty string if it fails to extract a minimum of 1 query.
 func ruleToQuery(logger log.Logger, rule *ngmodels.AlertRule) string {
 	var queryErr error
 
@@ -1229,17 +1229,8 @@ func ruleToQuery(logger log.Logger, rule *ngmodels.AlertRule) string {
 		return strings.Join(queries, " | ")
 	}
 
-	return encodedQueriesOrError(rule.Data)
-}
-
-// encodedQueriesOrError tries to encode rule query data into JSON if it fails returns the encoding error as a string.
-func encodedQueriesOrError(rules []ngmodels.AlertQuery) string {
-	encodedQueries, err := json.Marshal(rules)
-	if err == nil {
-		return string(encodedQueries)
-	}
-
-	return err.Error()
+	// No queries extracted, return an empty string.
+	return ""
 }
 
 func errorOrEmpty(err error) string {

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -110,6 +110,12 @@ func (aq *AlertQuery) String() string {
 }
 
 func (aq *AlertQuery) setModelProps() error {
+	if aq.Model == nil {
+		// No data to extract, use an empty map.
+		aq.modelProps = map[string]any{}
+		return nil
+	}
+
 	aq.modelProps = make(map[string]any)
 	err := json.Unmarshal(aq.Model, &aq.modelProps)
 	if err != nil {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -1007,6 +1007,7 @@ type ListAlertRulesExtendedQuery struct {
 	Limit         int64
 	RuleLimit     int64
 	ContinueToken string
+	Compact       bool
 }
 
 // CountAlertRulesQuery is the query for counting alert rules

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -631,7 +631,13 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 				continue
 			}
 
-			converted, err := alertRuleToModelsAlertRule(*rule, st.Logger)
+			var converted ngmodels.AlertRule
+			if query.Compact {
+				converted, err = alertRuleToModelsAlertRuleCompact(*rule, st.Logger)
+			} else {
+				converted, err = alertRuleToModelsAlertRule(*rule, st.Logger)
+			}
+
 			if err != nil {
 				st.Logger.Error("Invalid rule found in DB store, cannot convert, ignoring it", "func", "ListAlertRulesByGroup", "error", err)
 				continue

--- a/pkg/services/ngalert/store/compat.go
+++ b/pkg/services/ngalert/store/compat.go
@@ -10,11 +10,38 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
+// We only care about the data source UIDs.
+type compactQuery struct {
+	DatasourceUID string `json:"datasourceUid"`
+}
+
 func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, error) {
+	return transformRule(ar, l, false)
+}
+
+// alertRuleToModelsAlertRuleCompact transforms an alertRule to a models.AlertRule
+// ignoring alert queries (except for data source UIDs), notification settings, and metadata.
+func alertRuleToModelsAlertRuleCompact(ar alertRule, l log.Logger) (models.AlertRule, error) {
+	return transformRule(ar, l, true)
+}
+
+// transformRule creates a models.AlertRule from an alertRule.
+// When 'compact' is set to 'true', it skips parsing the alert queries (except for the data source UID), notification
+// settings, and metadata, thus reducing the number of JSON serializations needed.
+func transformRule(ar alertRule, l log.Logger, compact bool) (models.AlertRule, error) {
 	var data []models.AlertQuery
-	err := json.Unmarshal([]byte(ar.Data), &data)
-	if err != nil {
-		return models.AlertRule{}, fmt.Errorf("failed to parse data: %w", err)
+	if compact {
+		var cqs []compactQuery
+		if err := json.Unmarshal([]byte(ar.Data), &cqs); err != nil {
+			return models.AlertRule{}, fmt.Errorf("failed to parse data: %w", err)
+		}
+		for _, cq := range cqs {
+			data = append(data, models.AlertQuery{DatasourceUID: cq.DatasourceUID})
+		}
+	} else {
+		if err := json.Unmarshal([]byte(ar.Data), &data); err != nil {
+			return models.AlertRule{}, fmt.Errorf("failed to parse data: %w", err)
+		}
 	}
 
 	result := models.AlertRule{
@@ -52,6 +79,7 @@ func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, e
 		result.UpdatedBy = util.Pointer(models.UserUID(*ar.UpdatedBy))
 	}
 
+	var err error
 	if ar.NoDataState != "" {
 		result.NoDataState, err = models.NoDataStateFromString(ar.NoDataState)
 		if err != nil {
@@ -90,7 +118,7 @@ func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, e
 		}
 	}
 
-	if ar.NotificationSettings != "" {
+	if !compact && ar.NotificationSettings != "" {
 		ns, err := parseNotificationSettings(ar.NotificationSettings)
 		if err != nil {
 			return models.AlertRule{}, fmt.Errorf("failed to parse notification settings: %w", err)
@@ -98,7 +126,7 @@ func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, e
 		result.NotificationSettings = ns
 	}
 
-	if ar.Metadata != "" {
+	if !compact && ar.Metadata != "" {
 		err = json.Unmarshal([]byte(ar.Metadata), &result.Metadata)
 		if err != nil {
 			return models.AlertRule{}, fmt.Errorf("failed to metadata: %w", err)

--- a/pkg/services/ngalert/store/compat.go
+++ b/pkg/services/ngalert/store/compat.go
@@ -16,19 +16,19 @@ type compactQuery struct {
 }
 
 func alertRuleToModelsAlertRule(ar alertRule, l log.Logger) (models.AlertRule, error) {
-	return transformRule(ar, l, false)
+	return convertAlertRuleToModel(ar, l, false)
 }
 
 // alertRuleToModelsAlertRuleCompact transforms an alertRule to a models.AlertRule
 // ignoring alert queries (except for data source UIDs), notification settings, and metadata.
 func alertRuleToModelsAlertRuleCompact(ar alertRule, l log.Logger) (models.AlertRule, error) {
-	return transformRule(ar, l, true)
+	return convertAlertRuleToModel(ar, l, true)
 }
 
-// transformRule creates a models.AlertRule from an alertRule.
+// convertAlertRuleToModel creates a models.AlertRule from an alertRule.
 // When 'compact' is set to 'true', it skips parsing the alert queries (except for the data source UID), notification
 // settings, and metadata, thus reducing the number of JSON serializations needed.
-func transformRule(ar alertRule, l log.Logger, compact bool) (models.AlertRule, error) {
+func convertAlertRuleToModel(ar alertRule, l log.Logger, compact bool) (models.AlertRule, error) {
 	var data []models.AlertQuery
 	if compact {
 		var cqs []compactQuery

--- a/pkg/services/ngalert/store/compat_test.go
+++ b/pkg/services/ngalert/store/compat_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
@@ -80,4 +81,15 @@ func TestAlertRuleVersionToAlertRule(t *testing.T) {
 			require.Equal(t, r, r2)
 		}
 	})
+}
+
+func BenchmarkAlertRuleToModelsAlertRule(b *testing.B) {
+	r := ngmodels.RuleGen.Generate()
+	ar, err := alertRuleFromModelsAlertRule(r)
+	require.NoError(b, err)
+	l := log.NewNopLogger()
+
+	for range b.N {
+		alertRuleToModelsAlertRuleCompact(ar, l)
+	}
 }

--- a/pkg/services/ngalert/store/compat_test.go
+++ b/pkg/services/ngalert/store/compat_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
@@ -81,15 +80,4 @@ func TestAlertRuleVersionToAlertRule(t *testing.T) {
 			require.Equal(t, r, r2)
 		}
 	})
-}
-
-func BenchmarkAlertRuleToModelsAlertRule(b *testing.B) {
-	r := ngmodels.RuleGen.Generate()
-	ar, err := alertRuleFromModelsAlertRule(r)
-	require.NoError(b, err)
-	l := log.NewNopLogger()
-
-	for range b.N {
-		alertRuleToModelsAlertRuleCompact(ar, l)
-	}
 }


### PR DESCRIPTION
### Description

This PR introduces a `compact` (bool) query parameter to the `/rules` endpoint. When this parameter is set to `true`, we omit the following fields in the alerts in our response:
- `query`
- `metadata`
- `notificationSettings`

These fields are not needed by the FE to render the list of alerts. By omitting them, we reduce the payload size and avoid unnecessary JSON serializations (check [here](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/store/compat.go#L13)).

### Results

<details>
<summary>Example payload with <code>compact=false</code></summary>

```json
{
  "status": "success",
  "data": {
    "groups": [
      {
        "name": "test",
        "file": "test",
        "folderUid": "ff75obdtx2ltsd",
        "rules": [
          {
            "state": "firing",
            "name": "Test",
            "query": "up",
            "queriedDatasourceUIDs": [
              "ff75o9mvsosu8a"
            ],
            "duration": 60,
            "activeAt": "2025-12-15T09:18:00Z",
            "totals": {
              "alerting": 5,
              "normal": 3
            },
            "totalsFiltered": {
              "alerting": 5,
              "normal": 3
            },
            "uid": "ef75obq6f04xsb",
            "folderUid": "ff75obdtx2ltsd",
            "health": "ok",
            "type": "alerting",
            "lastEvaluation": "2025-12-15T12:16:00+01:00",
            "evaluationTime": 0.003037103,
            "isPaused": false,
            "notificationSettings": {
              "receiver": "grafana-default-email"
            }
          }
        ],
        "totals": {
          "firing": 1
        },
        "interval": 60,
        "lastEvaluation": "2025-12-15T12:16:00+01:00",
        "evaluationTime": 0.003037103
      }
    ]
  }
}
```
</details>
<details>
<summary>Example payload with <code>compact=true</code></summary>

```json
{
  "status": "success",
  "data": {
    "groups": [
      {
        "name": "test",
        "file": "test",
        "folderUid": "ff75obdtx2ltsd",
        "rules": [
          {
            "state": "firing",
            "name": "Test",
            "queriedDatasourceUIDs": [
              "ff75o9mvsosu8a"
            ],
            "duration": 60,
            "activeAt": "2025-12-15T09:18:00Z",
            "totals": {
              "alerting": 5,
              "normal": 3
            },
            "totalsFiltered": {
              "alerting": 5,
              "normal": 3
            },
            "uid": "ef75obq6f04xsb",
            "folderUid": "ff75obdtx2ltsd",
            "health": "ok",
            "type": "alerting",
            "lastEvaluation": "2025-12-15T12:02:00+01:00",
            "evaluationTime": 0.016697888,
            "isPaused": false
          }
        ],
        "totals": {
          "firing": 1
        },
        "interval": 60,
        "lastEvaluation": "2025-12-15T12:02:00+01:00",
        "evaluationTime": 0.016697888
      }
    ]
  }
}
```
</details>


The biggest benefit here is skipping serializations for [notificationSettings](https://github.com/grafana/grafana/blob/172f1fb974546c6c20d03c0799357e8e9eff9a6e/pkg/services/ngalert/store/compat.go#L93-L99) and [metadata](https://github.com/grafana/grafana/blob/172f1fb974546c6c20d03c0799357e8e9eff9a6e/pkg/services/ngalert/store/compat.go#L101-L106), and reducing the time and allocations needed to serialize the [data](https://github.com/grafana/grafana/blob/172f1fb974546c6c20d03c0799357e8e9eff9a6e/pkg/services/ngalert/store/compat.go#L15-L18) field.

I ran benchmarks comparing non-compact vs. compact. I used one test alert rule with only one query.

```
goos: linux
goarch: amd64
cpu: Intel i9-14900HX (32) @ 5.600GHz 
memory: 96290MiB

                              │   old.txt   │               new.txt                │
                              │   sec/op    │    sec/op     vs base                │
AlertRuleToModelsAlertRule-32   6.716µ ± 9%   2.439µ ± 13%  -63.69% (p=0.000 n=30)

                              │    old.txt    │               new.txt                │
                              │     B/op      │     B/op      vs base                │
AlertRuleToModelsAlertRule-32   3.977Ki ± 16%   1.750Ki ± 7%  -55.99% (p=0.000 n=30)

                              │   old.txt   │               new.txt               │
                              │  allocs/op  │  allocs/op   vs base                │
AlertRuleToModelsAlertRule-32   75.50 ± 11%   25.00 ± 16%  -66.89% (p=0.000 n=30)
```

### Testing

You can pull the [FE PR](https://github.com/grafana/grafana/pull/115339) and test this locally. Fetching alert groups should work as before, but payloads should be smaller.