### PR TITLE
Infinite scroll: Fix interaction with client-side filter

### DIFF
--- a/public/app/features/logs/components/panel/InfiniteScroll.tsx
+++ b/public/app/features/logs/components/panel/InfiniteScroll.tsx
@@ -256,7 +256,11 @@ export const InfiniteScroll = ({
       if (props.visibleStartIndex === 0) {
         noScrollRef.current = scrollElement.scrollHeight <= scrollElement.clientHeight;
       }
-      if (noScrollRef.current || infiniteLoaderState === 'loading' || infiniteLoaderState === 'out-of-bounds') {
+      if (noScrollRef.current) {
+        setInfiniteLoaderState('idle');
+        return;
+      }
+      if (infiniteLoaderState === 'loading' || infiniteLoaderState === 'out-of-bounds') {
         return;
       }
       const lastLogIndex = logs.length - 1;
@@ -267,7 +271,7 @@ export const InfiniteScroll = ({
         setInfiniteLoaderState('idle');
       }
     },
-    [infiniteLoaderState, logs.length, scrollElement]
+    [infiniteLoaderState, logs, scrollElement]
   );
 
   const getItemKey = useCallback((index: number) => (logs[index] ? logs[index].uid : index.toString()), [logs]);


### PR DESCRIPTION
This PR fixes a bad interaction between the client-side filters and infinite scroll, where by focusing on matching logs, it triggered infinite scrolling requests.

Broken:

https://github.com/user-attachments/assets/4e5301f0-c59b-46ce-81dd-b4bdf228988f

Fixed:

https://github.com/user-attachments/assets/668a24f5-b991-4d9e-bf7f-7a975645feb1

