### PR TITLE
Dashboards: Fix accessible color palettes not being saved in v2 schema

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -119,6 +119,16 @@ export function colorIdEnumToColorIdV2(colorId: FieldColorModeIdV1 | string): Fi
       return 'continuous-greens';
     case FieldColorModeIdV1.ContinuousPurples:
       return 'continuous-purples';
+    case FieldColorModeIdV1.ContinuousViridis:
+      return 'continuous-viridis';
+    case FieldColorModeIdV1.ContinuousMagma:
+      return 'continuous-magma';
+    case FieldColorModeIdV1.ContinuousPlasma:
+      return 'continuous-plasma';
+    case FieldColorModeIdV1.ContinuousInferno:
+      return 'continuous-inferno';
+    case FieldColorModeIdV1.ContinuousCividis:
+      return 'continuous-cividis';
     case FieldColorModeIdV1.Fixed:
       return 'fixed';
     case FieldColorModeIdV1.Shades:

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -1268,6 +1268,16 @@ function colorIdToEnumv1(colorId: FieldColorModeId): FieldColorModeIdV1 {
       return FieldColorModeIdV1.ContinuousGreens;
     case 'continuous-purples':
       return FieldColorModeIdV1.ContinuousPurples;
+    case 'continuous-viridis':
+      return FieldColorModeIdV1.ContinuousViridis;
+    case 'continuous-magma':
+      return FieldColorModeIdV1.ContinuousMagma;
+    case 'continuous-plasma':
+      return FieldColorModeIdV1.ContinuousPlasma;
+    case 'continuous-inferno':
+      return FieldColorModeIdV1.ContinuousInferno;
+    case 'continuous-cividis':
+      return FieldColorModeIdV1.ContinuousCividis;
     case 'fixed':
       return FieldColorModeIdV1.Fixed;
     case 'shades':


### PR DESCRIPTION
**What is this feature?**

Adds missing accessible color palette modes to the v1→v2 schema conversion function. The following palettes are now properly preserved when saving dashboards:
- `continuous-viridis`
- `continuous-magma`
- `continuous-plasma`
- `continuous-inferno`
- `continuous-cividis`

**Why do we need this feature?**

When saving a dashboard using the v2 schema, the `colorIdEnumToColorIdV2` function was missing cases for the accessible color palettes. 

**Which issue(s) does this PR fix?**:

Fixes #115228

