### PR TITLE
Dynamic dashboards: Hide hidden elements in outline in view mode

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -51,11 +51,16 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
 
   const noTitleText = t('dashboard.outline.tree-item.no-title', '<no title>');
 
-  const children = editableElement.getOutlineChildren?.(isEditing) ?? [];
   const elementInfo = editableElement.getEditableElementInfo();
   const instanceName = elementInfo.instanceName === '' ? noTitleText : elementInfo.instanceName;
   const outlineRename = useOutlineRename(editableElement, isEditing);
   const isContainer = editableElement.getOutlineChildren ? true : false;
+  const visibleChildren = useMemo(() => {
+    const children = editableElement.getOutlineChildren?.(isEditing) ?? [];
+    return isEditing
+      ? children
+      : children.filter((child) => !getEditableElementFor(child)?.getEditableElementInfo().isHidden);
+  }, [editableElement, isEditing]);
 
   const onNodeClicked = (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -73,6 +78,10 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
     evt.stopPropagation();
     setIsCollapsed(!isCollapsed);
   };
+
+  if (elementInfo.isHidden && !isEditing) {
+    return null;
+  }
 
   return (
     // todo: add proper keyboard navigation
@@ -130,8 +139,8 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
 
       {isContainer && !isCollapsed && (
         <ul className={styles.nodeChildren} role="group">
-          {children.length > 0 ? (
-            children.map((child, i) => (
+          {visibleChildren.length > 0 ? (
+            visibleChildren.map((child, i) => (
               <DashboardOutlineNode
                 key={child.state.key}
                 sceneObject={child}

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -91,10 +91,12 @@ export class RowItem
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
+    const isHidden = !this.state.conditionalRendering?.state.result;
     return {
       typeName: t('dashboard.edit-pane.elements.row', 'Row'),
       instanceName: sceneGraph.interpolate(this, this.state.title, undefined, 'text'),
       icon: 'list-ul',
+      isHidden,
     };
   }
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -89,10 +89,12 @@ export class TabItem
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
+    const isHidden = !this.state.conditionalRendering?.state.result;
     return {
       typeName: t('dashboard.edit-pane.elements.tab', 'Tab'),
       instanceName: sceneGraph.interpolate(this, this.state.title, undefined, 'text'),
       icon: 'layers',
+      isHidden,
     };
   }
 


### PR DESCRIPTION
**What is this feature?**

Hiding hidden elements from the outline when in edit mode. Also displays the "empty" message when all children are hidden.

https://github.com/user-attachments/assets/c8725c70-a9f2-4f04-a665-a01542d57eab

Fixes #115232