### PR TITLE
LogLineContext: remove broken permalink prop

### DIFF
--- a/public/app/features/explore/Logs/Logs.tsx
+++ b/public/app/features/explore/Logs/Logs.tsx
@@ -789,7 +789,6 @@ const UnthemedLogs: React.FunctionComponent<Props> = (props: Props) => {
           logOptionsStorageKey={SETTING_KEY_ROOT}
           timeZone={timeZone}
           displayedFields={displayedFields}
-          onPermalinkClick={onPermalinkClick}
           onClickShowField={showField}
           onClickHideField={hideField}
         />

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -566,7 +566,6 @@ export const LogsPanel = ({
           logLineMenuCustomItems={isLogLineMenuCustomItems(logLineMenuCustomItems) ? logLineMenuCustomItems : undefined}
           timeZone={timeZone}
           displayedFields={displayedFields}
-          onPermalinkClick={showPermaLink() ? onPermalinkClick : undefined}
           onClickShowField={showField}
           onClickHideField={hideField}
         />


### PR DESCRIPTION
Permalinks from Logs Context required a special implementation that doesn't yet exist. Using the prop from Explore/Dashboards/Drilldown doesn't work and was never supported.

Created https://github.com/grafana/grafana/issues/115251 for the right implementation.