### PR TITLE
Assistant streaming feature toggle

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -96,6 +96,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `azureMonitorLogsBuilderEditor`   | Enables the logs builder mode for the Azure Monitor data source                                        |
 | `localeFormatPreference`          | Specifies the locale so the correct format for numbers and dates can be shown                          |
 | `logsPanelControls`               | Enables a control component for the logs panel in Explore                                              |
+| `assistantStreaming`              | Enables streaming functionality for Grafana Assistant                                                  |
 | `interactiveLearning`             | Enables the interactive learning app                                                                   |
 | `newVizSuggestions`               | Enable new visualization suggestions                                                                   |
 | `preventPanelChromeOverflow`      | Restrict PanelChrome contents with overflow: hidden;                                                   |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -937,6 +937,11 @@ export interface FeatureToggles {
   */
   grafanaAssistantInProfilesDrilldown?: boolean;
   /**
+  * Enables streaming functionality for Grafana Assistant
+  * @default true
+  */
+  assistantStreaming?: boolean;
+  /**
   * Enables creating alerts from Tempo data source
   */
   tempoAlerting?: boolean;

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1547,6 +1547,13 @@ var (
 			Expression:   "true",
 		},
 		{
+			Name:        "assistantStreaming",
+			Description: "Enables streaming functionality for Grafana Assistant",
+			Stage:       FeatureStagePublicPreview,
+			Owner:       grafanaAppPlatformSquad,
+			Expression:  "true", // enabled by default
+		},
+		{
 			Name:        "tempoAlerting",
 			Description: "Enables creating alerts from Tempo data source",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -212,6 +212,7 @@ unifiedNavbars,GA,@grafana/plugins-platform-backend,false,false,true
 logsPanelControls,preview,@grafana/observability-logs,false,false,true
 metricsFromProfiles,experimental,@grafana/observability-traces-and-profiling,false,false,true
 grafanaAssistantInProfilesDrilldown,GA,@grafana/observability-traces-and-profiling,false,false,true
+assistantStreaming,preview,@grafana/grafana-app-platform-squad,false,false,false
 tempoAlerting,experimental,@grafana/observability-traces-and-profiling,false,false,false
 pluginsAutoUpdate,experimental,@grafana/plugins-platform-backend,false,false,false
 alertingListViewV2PreviewToggle,privatePreview,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -614,6 +614,10 @@ const (
 	// use multi-tenant path for awsTempCredentials
 	FlagMultiTenantTempCredentials = "multiTenantTempCredentials"
 
+	// FlagAssistantStreaming
+	// Enables streaming functionality for Grafana Assistant
+	FlagAssistantStreaming = "assistantStreaming"
+
 	// FlagTempoAlerting
 	// Enables creating alerts from Tempo data source
 	FlagTempoAlerting = "tempoAlerting"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -647,6 +647,19 @@
     },
     {
       "metadata": {
+        "name": "assistantStreaming",
+        "resourceVersion": "1765555492103",
+        "creationTimestamp": "2025-12-12T16:04:52Z"
+      },
+      "spec": {
+        "description": "Enables streaming functionality for Grafana Assistant",
+        "stage": "preview",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "authZGRPCServer",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2024-06-13T09:41:35Z"


### PR DESCRIPTION
**What is this feature?**

This PR enables the `assistantStreaming` feature toggle, which provides streaming functionality for Grafana Assistant.

**Why do we need this feature?**

To make the `assistantStreaming` feature available by default and promote it to a Public Preview stage, allowing for broader testing and adoption of real-time streaming capabilities in Grafana Assistant.

**Who is this feature for?**

Users interacting with Grafana Assistant who will experience improved responsiveness and real-time updates.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

---
[Slack Thread](https://raintank-corp.slack.com/archives/C08JKQKQ448/p1765536617592809?thread_ts=1765536617.592809&cid=C08JKQKQ448)

<a href="https://cursor.com/background-agent?bcId=bc-ad769370-1547-4e4d-abe5-9bb9e0bbe9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ad769370-1547-4e4d-abe5-9bb9e0bbe9f0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

