### PR TITLE
Alerting: Apply rule_uid filter when fetching state of a single rule

### DIFF
--- a/public/app/features/alerting/unified/api/alertRuleApi.test.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.test.ts
@@ -69,5 +69,19 @@ describe('alertRuleApi', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       expect(request.params?.[PrometheusAPIFilters.LimitAlerts]).toBe('25');
     });
+
+    it('includes rule_uid when provided', async () => {
+      const request = await executePrometheusRuleNamespacesQuery({ ruleUid: 'test-rule-uid-123' });
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(request.params?.[PrometheusAPIFilters.RuleUID]).toBe('test-rule-uid-123');
+    });
+
+    it('omits rule_uid when not provided', async () => {
+      const request = await executePrometheusRuleNamespacesQuery();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(request.params?.[PrometheusAPIFilters.RuleUID]).toBeUndefined();
+    });
   });
 });

--- a/public/app/features/alerting/unified/api/alertRuleApi.ts
+++ b/public/app/features/alerting/unified/api/alertRuleApi.ts
@@ -54,6 +54,7 @@ export enum PrometheusAPIFilters {
   Namespace = 'file',
   NamespaceVanilla = 'file[]',
   FolderUID = 'folder_uid',
+  RuleUID = 'rule_uid',
   LimitAlerts = 'limit_alerts',
   MaxGroups = 'max_groups',
   ExcludeAlerts = 'exclude_alerts',
@@ -169,6 +170,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         namespace?: string;
         groupName?: string;
         ruleName?: string;
+        ruleUid?: string;
         dashboardUid?: string;
         panelId?: number;
         limitAlerts?: number;
@@ -181,6 +183,7 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         namespace,
         groupName,
         ruleName,
+        ruleUid,
         dashboardUid,
         panelId,
         limitAlerts,
@@ -200,6 +203,11 @@ export const alertRuleApi = alertingApi.injectEndpoints({
         if (ruleName) {
           queryParams[PrometheusAPIFilters.RuleName] = ruleName;
           queryParams[PrometheusAPIFilters.RuleNameVanilla] = ruleName;
+        }
+
+        // Supported only by Grafana managed rules
+        if (ruleUid) {
+          queryParams[PrometheusAPIFilters.RuleUID] = ruleUid;
         }
 
         if (namespace) {

--- a/public/app/features/alerting/unified/hooks/useCombinedRule.ts
+++ b/public/app/features/alerting/unified/hooks/useCombinedRule.ts
@@ -122,6 +122,7 @@ export function useCombinedRule({ ruleIdentifier, limitAlerts }: Props): Request
       namespace: ruleLocation?.namespace,
       groupName: ruleLocation?.group,
       ruleName: ruleLocation?.ruleName,
+      ruleUid: isGrafanaRuleIdentifier(ruleIdentifier) ? ruleIdentifier.uid : undefined,
       limitAlerts,
     },
     {


### PR DESCRIPTION
**What is this feature?**

Alert rule view page now passes the new [rule_uid](https://github.com/grafana/grafana/pull/114182) filter to the API when it fetches the status of a single alert rule. This change improves performance of finding the alert rule.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
