### PR TITLE
DynamicDashboards: In view mode, hide config button when panel has not been configured

### DIFF
--- a/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
+++ b/public/app/features/dashboard-scene/scene/UnconfiguredPanel.tsx
@@ -5,7 +5,19 @@ import { CoreApp, GrafanaTheme2, PanelPlugin, PanelProps } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, locationService } from '@grafana/runtime';
 import { sceneUtils } from '@grafana/scenes';
-import { Box, Button, ButtonGroup, Dropdown, Icon, Menu, Stack, Text, usePanelContext, useStyles2 } from '@grafana/ui';
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Dropdown,
+  EmptyState,
+  Icon,
+  Menu,
+  Stack,
+  Text,
+  usePanelContext,
+  useStyles2,
+} from '@grafana/ui';
 
 import { NEW_PANEL_TITLE } from '../../dashboard/utils/dashboard';
 import { DashboardInteractions } from '../utils/interactions';
@@ -92,20 +104,30 @@ function UnconfiguredPanelComp(props: PanelProps) {
     );
   }
 
+  const { isEditing } = dashboard.state;
+
   return (
     <Stack direction={'row'} alignItems={'center'} height={'100%'} justifyContent={'center'}>
       <Box paddingBottom={2}>
-        <ButtonGroup>
-          <Button icon="sliders-v-alt" onClick={onConfigure}>
-            <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
-          </Button>
-          <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
-            <Button
-              aria-label={t('dashboard.new-panel.configure-button-menu', 'Toggle menu')}
-              icon={isOpen ? 'angle-up' : 'angle-down'}
-            />
-          </Dropdown>
-        </ButtonGroup>
+        {isEditing ? (
+          <ButtonGroup>
+            <Button icon="sliders-v-alt" onClick={onConfigure}>
+              <Trans i18nKey="dashboard.new-panel.configure-button">Configure</Trans>
+            </Button>
+            <Dropdown overlay={MenuActions} placement="bottom-end" onVisibleChange={onMenuClick}>
+              <Button
+                aria-label={t('dashboard.new-panel.configure-button-menu', 'Toggle menu')}
+                icon={isOpen ? 'angle-up' : 'angle-down'}
+              />
+            </Dropdown>
+          </ButtonGroup>
+        ) : (
+          <EmptyState
+            variant="call-to-action"
+            message={t('dashboard.new-panel.missing-config', 'Missing panel configuration')}
+            hideImage
+          />
+        )}
       </Box>
     </Stack>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5129,6 +5129,7 @@
       "empty-state-message": "Run a query to visualize it here or go to all visualizations to add other panel types",
       "menu-open-panel-editor": "Configure",
       "menu-use-library-panel": "Use library panel",
+      "missing-config": "Missing panel configuration",
       "suggestions": {
         "empty-state-message": "Run a query to start seeing suggested visualizations"
       }


### PR DESCRIPTION
**What is this feature?**

**In View mode:**
<img width="1797" height="440" alt="image" src="https://github.com/user-attachments/assets/b084300a-1f5f-44fb-968a-94efa8a8ac73" />

**In Edit mode (unchanged):**
<img width="1799" height="492" alt="image" src="https://github.com/user-attachments/assets/30aed802-7572-4549-8175-9d0fafd3e521" />


**Why do we need this feature?**

To prevent inconsistent UX

**Who is this feature for?**

Dynamic dashboard users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115233

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
