### PR TITLE
DynamicDashboards: Add background

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -237,6 +237,7 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     dragging: css({
       cursor: 'move',
+      backgroundColor: theme.colors.background.canvas,
     }),
     wrapperGrow: css({
       flexGrow: 1,


### PR DESCRIPTION
**What is this feature?**

Just adding a canvas background color to the row being dragged:

<img width="3595" height="2008" alt="image" src="https://github.com/user-attachments/assets/b884775b-47ca-42a3-ad1e-17400b289c1f" />

**Why do we need this feature?**

Prevent confusion when dragging rows

**Who is this feature for?**

Dynamic dashboard users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/115262

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
