### PR TITLE
DynamicDashboards: Fix to allow panels with empty titles to be dragged

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/HoverWidget.tsx
@@ -16,17 +16,22 @@ interface Props {
   title?: string;
   offset?: number;
   dragClass?: string;
+  onDragStart?: (event: React.PointerEvent<HTMLDivElement>) => void;
   onOpenMenu?: () => void;
 }
 
-export function HoverWidget({ menu, title, dragClass, children, offset = -32, onOpenMenu }: Props) {
+export function HoverWidget({ menu, title, dragClass, children, offset = -32, onOpenMenu, onDragStart }: Props) {
   const styles = useStyles2(getStyles);
   const draggableRef = useRef<HTMLDivElement>(null);
   const selectors = e2eSelectors.components.Panels.Panel.HoverWidget;
   // Capture the pointer to keep the widget visible while dragging
-  const onPointerDown = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    draggableRef.current?.setPointerCapture(e.pointerId);
-  }, []);
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      draggableRef.current?.setPointerCapture(e.pointerId);
+      onDragStart?.(e);
+    },
+    [onDragStart]
+  );
 
   const onPointerUp = useCallback((e: React.PointerEvent<HTMLDivElement>) => {
     draggableRef.current?.releasePointerCapture(e.pointerId);

--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -384,6 +384,7 @@ export function PanelChrome({
                 menu={menu}
                 title={typeof title === 'string' ? title : undefined}
                 dragClass={dragClass}
+                onDragStart={onDragStart}
                 offset={hoverHeaderOffset}
                 onOpenMenu={onOpenMenu}
               >


### PR DESCRIPTION
**What is this feature?**

With auto grid layout, dragging a panel with an empty title does not work. This PR fixes it.

**Why do we need this feature?**

Bug fix

**Who is this feature for?**

Dynamic dashboard users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115268

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
