### PR TITLE
Rudderstack: Update init logic to automatically use new url when new config is set

### DIFF
--- a/public/app/core/services/echo/init.ts
+++ b/public/app/core/services/echo/init.ts
@@ -146,7 +146,19 @@ async function initRudderstackBackend() {
     return;
   }
 
-  const modulePromise = config.featureToggles.rudderstackUpgrade
+  // this will need to be updated when rudderstackSdkV3Url is added
+  // Desired logic: if only one of the sdk urls is provided, use respective code
+  // otherwise defer to the feature toggle.
+  const fakeConfigRudderstackSdkV3Url: string | undefined = undefined;
+
+  const hasOldSdkUrl = Boolean(config.rudderstackSdkUrl);
+  const hasNewSdkUrl = Boolean(fakeConfigRudderstackSdkV3Url);
+  const onlyOneConfigURLSet = hasOldSdkUrl !== hasNewSdkUrl;
+  const useNewRudderstack = onlyOneConfigURLSet ? hasNewSdkUrl : config.featureToggles.rudderstackUpgrade;
+
+  const configUrl = useNewRudderstack ? fakeConfigRudderstackSdkV3Url : config.rudderstackSdkUrl;
+
+  const modulePromise = useNewRudderstack
     ? import('./backends/analytics/RudderstackV3Backend')
     : import('./backends/analytics/RudderstackBackend');
 
@@ -157,7 +169,7 @@ async function initRudderstackBackend() {
       dataPlaneUrl: config.rudderstackDataPlaneUrl,
       user: contextSrv.user,
       sdkUrl: config.rudderstackSdkUrl,
-      configUrl: config.rudderstackConfigUrl,
+      configUrl: configUrl,
       integrationsUrl: config.rudderstackIntegrationsUrl,
       buildInfo: config.buildInfo,
     })


### PR DESCRIPTION
**What is this feature?**

Updates rudderstack init logic to rely on existence of old or new sdk config option being set and only defer to feature toggle if both or neither is set.

Note: The new config option doesn't actually exist yet, but we need this change in ASAP to get it rolled out so the feature toggle is safe to enable.

**Why do we need this feature?**

Need to get RS up to date and stop annoying people with console messages about it being out of date.

**Who is this feature for?**

Devs touching rudderstack, people who look in the console.

**Which issue(s) does this PR fix?**: 

Fixes https://github.com/grafana/grafana-frontend-platform/issues/99

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
