### PR TITLE
Docs: Update export as JSON task

### DIFF
--- a/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
@@ -223,9 +223,7 @@ To export a dashboard in its current state as a PDF, follow these steps:
 
 1. Click the **X** at the top-right corner to close the share drawer.
 
-### Export a dashboard as JSON
-
-<!-- ### Export a dashboard as code -->
+### Export a dashboard as code
 
 Export a Grafana JSON file that contains everything you need, including layout, variables, styles, data sources, queries, and so on, so that you can later import the dashboard. To export a JSON file, follow these steps:
 
@@ -237,11 +235,15 @@ Export a Grafana JSON file that contains everything you need, including layout, 
 
 1. Select the dashboard JSON model that you to export:
 
-   - **Classic** - For dashboards created using [current dashboard schema] 
-   - V1 Resource
-   - V2 Resource
+   - **Classic** - Export dashboards created using the [current dashboard schema](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/).
+   - **V1 Resource** - Export dashboards created using the [current dashboard schema](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/) wrapped in the `spec` property of the [V1 Kubernetes-style resource](https://play.grafana.org/swagger?api=dashboard.grafana.app-v2alpha1). Choose between **JSON** and **YAML** format.
+   - **V2 Resource** - Export dashboards created using the [V2 Resource schema](https://play.grafana.org/swagger?api=dashboard.grafana.app-v2beta1). Choose between **JSON** and **YAML** format.
 
-1. Toggle the **Export the dashboard to use in another instance** switch to generate the JSON with a different data source UID.
+1. Do one of the following:
+
+   - Toggle the **Export for sharing externally** switch to generate the JSON with a different data source UID.
+   - Toggle the **Remove deployment details** switch to make the dashboard externally shareable.
+
 1. Click **Download file** or **Copy to clipboard**.
 1. Click the **X** at the top-right corner to close the share drawer.
 

--- a/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
@@ -225,13 +225,21 @@ To export a dashboard in its current state as a PDF, follow these steps:
 
 ### Export a dashboard as JSON
 
+<!-- ### Export a dashboard as code -->
+
 Export a Grafana JSON file that contains everything you need, including layout, variables, styles, data sources, queries, and so on, so that you can later import the dashboard. To export a JSON file, follow these steps:
 
 1. Click **Dashboards** in the main menu.
 1. Open the dashboard you want to export.
-1. Click the **Export** drop-down list in the top-right corner and select **Export as JSON**.
+1. Click the **Export** drop-down list in the top-right corner and select **Export as code**.
 
-   The **Export dashboard JSON** drawer opens.
+   The **Export dashboard** drawer opens.
+
+1. Select the dashboard JSON model that you to export:
+
+   - **Classic** - For dashboards created using [current dashboard schema] 
+   - V1 Resource
+   - V2 Resource
 
 1. Toggle the **Export the dashboard to use in another instance** switch to generate the JSON with a different data source UID.
 1. Click **Download file** or **Copy to clipboard**.

--- a/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
+++ b/docs/sources/visualizations/dashboards/share-dashboards-panels/_index.md
@@ -234,13 +234,11 @@ Export a Grafana JSON file that contains everything you need, including layout, 
    The **Export dashboard** drawer opens.
 
 1. Select the dashboard JSON model that you to export:
-
    - **Classic** - Export dashboards created using the [current dashboard schema](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/).
    - **V1 Resource** - Export dashboards created using the [current dashboard schema](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/view-dashboard-json-model/) wrapped in the `spec` property of the [V1 Kubernetes-style resource](https://play.grafana.org/swagger?api=dashboard.grafana.app-v2alpha1). Choose between **JSON** and **YAML** format.
    - **V2 Resource** - Export dashboards created using the [V2 Resource schema](https://play.grafana.org/swagger?api=dashboard.grafana.app-v2beta1). Choose between **JSON** and **YAML** format.
 
 1. Do one of the following:
-
    - Toggle the **Export for sharing externally** switch to generate the JSON with a different data source UID.
    - Toggle the **Remove deployment details** switch to make the dashboard externally shareable.
 


### PR DESCRIPTION
- Updated the Export a dashboard as JSON task to reflect the updated menu and the new JSON model options.
- Renamed task Export a dashboard as code to match UI. I considered leaving the task name as is but I think this will be confusing down the road if a user is trying to find the UI element.

I'm working on updates to the JSON model page that will explain in more detail the differences between the three JSON models and I'll eventually update this page to link to that more in-depth explanation. For now I just want to quickly resolve the docs/UI mismatch.

I am aware of [this PR](https://github.com/grafana/grafana/pull/114376) that updates these options further and will update this page again when those changes are visible to Cloud users (assuming they're not hidden behind a feature flag).


