### PR TITLE
Dashboard V1 -> V2 conversion: Rows with hidden header should never be collapsed

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v30.value_mappings_and_tooltip_options.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v30.value_mappings_and_tooltip_options.v42.v2alpha1.json
@@ -530,7 +530,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v30.value_mappings_and_tooltip_options.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v30.value_mappings_and_tooltip_options.v42.v2beta1.json
@@ -546,7 +546,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2alpha1.json
@@ -548,7 +548,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v33.panel_ds_name_to_ref.v42.v2beta1.json
@@ -574,7 +574,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2alpha1.json
@@ -1663,7 +1663,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v34.multiple_stats_cloudwatch.v42.v2beta1.json
@@ -1727,7 +1727,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v42.hidefrom_tooltip.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v42.hidefrom_tooltip.v42.v2alpha1.json
@@ -328,7 +328,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v42.hidefrom_tooltip.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v42.hidefrom_tooltip.v42.v2beta1.json
@@ -335,7 +335,7 @@
             "kind": "RowsLayoutRow",
             "spec": {
               "title": "",
-              "collapse": true,
+              "collapse": false,
               "hideHeader": true,
               "layout": {
                 "kind": "GridLayout",

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -501,11 +501,9 @@ func convertToRowsLayout(ctx context.Context, panels []interface{}, dsIndexProvi
 
 			if currentRow != nil {
 				// If currentRow is a hidden-header row (panels before first explicit row),
-				// set its collapse to match the first explicit row's collapsed value
-				// This matches frontend behavior: collapse: panel.collapsed
+				// it should not be collapsed because it will disappear and be visible only in edit mode
 				if currentRow.Spec.HideHeader != nil && *currentRow.Spec.HideHeader {
-					rowCollapsed := getBoolField(panelMap, "collapsed", false)
-					currentRow.Spec.Collapse = &rowCollapsed
+					currentRow.Spec.Collapse = &[]bool{false}[0]
 				}
 				// Flush current row to layout
 				rows = append(rows, *currentRow)

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_new.v42.json
@@ -75,9 +75,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": true,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -154,9 +154,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -233,9 +233,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -312,9 +312,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -391,9 +391,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -470,9 +470,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": false,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -549,9 +549,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": false,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -641,9 +641,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -720,9 +720,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -799,9 +799,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -878,9 +878,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": false,
           "rounded": true,
-          "spotlight": true,
-          "gradient": false
+          "spotlight": true
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -974,9 +974,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": false,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1053,9 +1053,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": false,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1132,9 +1132,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": true,
           "rounded": false,
-          "spotlight": false,
-          "gradient": true
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1211,9 +1211,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": false,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1290,9 +1290,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": false,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1386,9 +1386,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": true,
           "rounded": false,
-          "spotlight": false,
-          "gradient": true
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1469,9 +1469,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": true,
           "rounded": false,
-          "spotlight": false,
-          "gradient": true
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1552,9 +1552,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": true,
           "rounded": false,
-          "spotlight": false,
-          "gradient": true
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {
@@ -1643,9 +1643,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -1727,9 +1727,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -1825,9 +1825,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -1910,9 +1910,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -1994,9 +1994,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -2078,9 +2078,9 @@
         "effects": {
           "barGlow": true,
           "centerGlow": true,
+          "gradient": true,
           "rounded": true,
-          "spotlight": true,
-          "gradient": true
+          "spotlight": true
         },
         "glow": "both",
         "orientation": "auto",
@@ -2172,7 +2172,9 @@
         },
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },
@@ -2238,7 +2240,9 @@
         },
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": ["lastNotNull"],
+          "calcs": [
+            "lastNotNull"
+          ],
           "fields": "",
           "values": false
         },

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/panel-gauge/gauge_tests_old_to_new.v42.json
@@ -955,9 +955,9 @@
         "effects": {
           "barGlow": false,
           "centerGlow": false,
+          "gradient": false,
           "rounded": false,
-          "spotlight": false,
-          "gradient": false
+          "spotlight": false
         },
         "orientation": "auto",
         "reduceOptions": {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -108,7 +108,9 @@ export function createRowsFromPanels(oldPanels: PanelModel[]): RowsLayoutManager
         rowItems.push(
           new RowItem({
             title: '',
-            collapse: panel.collapsed,
+            // Hidden header rows must stay expanded; collapsing them would hide the panels entirely.
+            // Keep aligned with backend conversion that forces hidden headers to Collapse=false.
+            collapse: false,
             layout: new DefaultGridLayoutManager({
               grid: new SceneGridLayout({
                 children: currentRowPanels,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelToScene.ts
@@ -109,7 +109,6 @@ export function createRowsFromPanels(oldPanels: PanelModel[]): RowsLayoutManager
           new RowItem({
             title: '',
             // Hidden header rows must stay expanded; collapsing them would hide the panels entirely.
-            // Keep aligned with backend conversion that forces hidden headers to Collapse=false.
             collapse: false,
             layout: new DefaultGridLayoutManager({
               grid: new SceneGridLayout({

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelV1ToV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelV1ToV2.test.ts
@@ -313,23 +313,8 @@ describe('V1 to V2 Dashboard Transformation Comparison', () => {
         inputPanels
       );
 
-      const normalizedFrontendOutput = normalizeFrontendOutputRowLayout(frontendOutput);
       // Compare only the spec structures - this is the core transformation
-      expect(normalizedBackendOutput).toEqual(normalizedFrontendOutput);
+      expect(normalizedBackendOutput).toEqual(frontendOutput);
     });
   });
 });
-
-// Rows that are collapsed and have hideHeader set to true are invalid in V2
-// because they will disappear and be visible only in edit mode
-// So during the conversion from v1 to v2, we need to normalize the output to set collapse to false
-const normalizeFrontendOutputRowLayout = (dashboard: Spec): Spec => {
-  if (dashboard.layout.kind === 'RowsLayout') {
-    dashboard.layout.spec.rows.forEach((row) => {
-      if (row.spec.collapse && row.spec.hideHeader) {
-        row.spec.collapse = false;
-      }
-    });
-  }
-  return dashboard;
-};

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelV1ToV2.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelV1ToV2.test.ts
@@ -1,8 +1,6 @@
 import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
 
-import { Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-
 import { normalizeBackendOutputForFrontendComparison } from './serialization-test-utils';
 import { transformSaveModelSchemaV2ToScene } from './transformSaveModelSchemaV2ToScene';
 import { transformSaveModelToScene } from './transformSaveModelToScene';


### PR DESCRIPTION
When converting from v1 to v2, sometimes the first row is created for panels that were positioned outside the first explicit row in V1. If the header was hidden, we were incorrectly using panel's collapsed state. Instead, we need to always set `collapse` as`false`, otherwise the row will only be visible in edit mode.

Related to https://github.com/grafana/grafana/pull/115284

Fixes: https://github.com/grafana/grafana/issues/115287

Please check that:
- [ ] It works as expected from a user's perspective.

