### PR TITLE
Folders: Add max depth check with descendant to /apis

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -29,7 +29,8 @@ func ToFolderErrorResponse(err error) response.Response {
 		errors.Is(err, dashboards.ErrDashboardTypeMismatch) ||
 		errors.Is(err, dashboards.ErrDashboardInvalidUid) ||
 		errors.Is(err, dashboards.ErrDashboardUidTooLong) ||
-		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) {
+		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
+		errors.Is(err, folder.ErrMaximumDepthReached) {
 		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -30,7 +30,7 @@ func TestToFolderErrorResponse(t *testing.T) {
 		{
 			name:  "maximum depth reached",
 			input: folder.ErrMaximumDepthReached.Errorf("Maximum nested folder depth reached"),
-			want:  response.Err(folder.ErrMaximumDepthReached.Errorf("Maximum nested folder depth reached")),
+			want:  response.Error(http.StatusBadRequest, "[folder.maximum-depth-reached] Maximum nested folder depth reached", nil),
 		},
 		{
 			name:  "bad request errors",

--- a/pkg/api/folder.go
+++ b/pkg/api/folder.go
@@ -214,7 +214,7 @@ func (hs *HTTPServer) MoveFolder(c *contextmodel.ReqContext) response.Response {
 	cmd.SignedInUser = c.SignedInUser
 	theFolder, err := hs.folderService.Move(c.Req.Context(), &cmd)
 	if err != nil {
-		return response.ErrOrFallback(http.StatusInternalServerError, "move folder failed", err)
+		return apierrors.ToFolderErrorResponse(err)
 	}
 
 	folderDTO, err := hs.newToFolderDto(c, theFolder)

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -356,7 +356,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if !ok {
 			return fmt.Errorf("obj is not folders.Folder")
 		}
-		return validateOnUpdate(ctx, f, old, b.storage, b.parents, folder.MaxNestedFolderDepth)
+		return validateOnUpdate(ctx, f, old, b.storage, b.parents, b.searcher, folder.MaxNestedFolderDepth)
 	default:
 		return nil
 	}

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -376,6 +376,10 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 				m.On("Get", mock.Anything, "new-parent", mock.Anything).Return(
 					&folders.Folder{},
 					nil).Once()
+				// also retrieves old parent for depth difference calculation
+				m.On("Get", mock.Anything, "valid-parent", mock.Anything).Return(
+					&folders.Folder{},
+					nil).Once()
 			},
 		},
 		{

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -206,9 +206,16 @@ func checkSubtreeDepthBatched(ctx context.Context, searcher resourcepb.ResourceI
 
 	const pageSize int64 = 1000
 	var offset int64
+	totalPages := 0
+	hasMore := true
 
-	for {
-		children, hasMore, err := getChildrenBatch(ctx, searcher, namespace, parentUIDs, pageSize, offset)
+	// Using an upper limit to ensure no infinite loops can happen
+	for hasMore && totalPages < 1000 {
+		totalPages++
+
+		var err error
+		var children []string
+		children, hasMore, err = getChildrenBatch(ctx, searcher, namespace, parentUIDs, pageSize, offset)
 		if err != nil {
 			return fmt.Errorf("failed to get children: %w", err)
 		}
@@ -232,6 +239,8 @@ func checkSubtreeDepthBatched(ctx context.Context, searcher resourcepb.ResourceI
 
 		offset += pageSize
 	}
+
+	return nil
 }
 
 // getChildrenBatch fetches children for multiple parents

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
@@ -13,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -73,6 +75,7 @@ func validateOnUpdate(ctx context.Context,
 	old *folders.Folder,
 	getter rest.Getter,
 	parents parentsGetter,
+	searcher resourcepb.ResourceIndexClient,
 	maxDepth int,
 ) error {
 	folderObj, err := utils.MetaAccessor(obj)
@@ -95,7 +98,10 @@ func validateOnUpdate(ctx context.Context,
 	// Validate the move operation
 	newParent := folderObj.GetFolder()
 
-	// If we move to root, we don't need to validate the depth.
+	// If we move to root, we don't need to validate the depth, because the folder already existed
+	// before and wasn't too deep. This move will make it more shallow.
+	//
+	// We also don't need to validate circular references because the root folder cannot have a parent.
 	if newParent == folder.RootFolderUID {
 		return nil
 	}
@@ -113,9 +119,6 @@ func validateOnUpdate(ctx context.Context,
 	if !ok {
 		return fmt.Errorf("expected folder, found %T", parentObj)
 	}
-
-	//FIXME: until we have a way to represent the tree, we can only
-	// look at folder parents to check how deep the new folder tree will be
 	info, err := parents(ctx, parent)
 	if err != nil {
 		return err
@@ -129,11 +132,105 @@ func validateOnUpdate(ctx context.Context,
 		}
 	}
 
-	// if by moving a folder we exceed the max depth, return an error
+	// if by moving a folder we exceed the max depth just from its parents + itself, return an error
 	if len(info.Items) > maxDepth+1 {
 		return folder.ErrMaximumDepthReached.Errorf("maximum folder depth reached")
 	}
+	// To try to save some computation, get the parents of the old parent (this is typically cheaper
+	// than looking at the children of the folder). If the old parent has more parents or the same
+	// number of parents as the new parent, we can return early, because we know the folder had to be
+	// safe from the creation validation.
+	oldParentDepth := 0
+	if oldFolder.GetFolder() != folder.RootFolderUID {
+		oldParentObj, err := getter.Get(ctx, oldFolder.GetFolder(), &metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("old parent not found %w", err)
+		}
+		oldParent, ok := oldParentObj.(*folders.Folder)
+		if !ok {
+			return fmt.Errorf("expected folder, found %T", oldParentObj)
+		}
+		oldInfo, err := parents(ctx, oldParent)
+		if err != nil {
+			return err
+		}
+		oldParentDepth = len(oldInfo.Items)
+	}
+	levelDifference := len(info.Items) - oldParentDepth
+	if levelDifference <= 0 {
+		return nil
+	}
+
+	// Now comes the more expensive part: we need to check if moving this folder will cause
+	// any descendant folders to exceed the max depth.
+	//
+	// Calculate the maximum allowed subtree depth after the move.
+	// We only need to search one level beyond this to detect violations.
+	depthToCheck := (maxDepth + 1) - len(info.Items)
+	currentLevel := []string{obj.Name}
+	for depth := 1; depth <= depthToCheck; depth++ {
+		children, err := searchChildrenOfFolders(ctx, searcher, obj.Namespace, currentLevel)
+		if err != nil {
+			return fmt.Errorf("failed to get children for depth validation: %w", err)
+		}
+
+		if len(children) == 0 {
+			break
+		}
+
+		// if descendants exist beyond the allowed depth, error
+		if depth == depthToCheck {
+			return folder.ErrMaximumDepthReached.Errorf("maximum folder depth %d would be exceeded after move", maxDepth)
+		}
+
+		currentLevel = children
+	}
+
 	return nil
+}
+
+// searchChildrenOfFolders returns all folder UIDs that have a parent in the given list.
+func searchChildrenOfFolders(ctx context.Context, searcher resourcepb.ResourceIndexClient, namespace string, parentUIDs []string) ([]string, error) {
+	if len(parentUIDs) == 0 {
+		return nil, nil
+	}
+	resp, err := searcher.Search(ctx, &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: namespace,
+				Group:     folders.FolderResourceInfo.GroupVersionResource().Group,
+				Resource:  folders.FolderResourceInfo.GroupVersionResource().Resource,
+			},
+			Fields: []*resourcepb.Requirement{{
+				Key:      resource.SEARCH_FIELD_FOLDER,
+				Operator: string(selection.In),
+				Values:   parentUIDs,
+			}},
+		},
+		Limit: 10000,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to search folders: %w", err)
+	}
+
+	if resp.Error != nil {
+		return nil, fmt.Errorf("search error: %s", resp.Error.Message)
+	}
+
+	if resp.Results == nil || len(resp.Results.Rows) == 0 {
+		return nil, nil
+	}
+
+	children := make([]string, 0, len(resp.Results.Rows))
+	for _, row := range resp.Results.Rows {
+		if row.Key != nil {
+			children = append(children, row.Key.Name)
+		}
+	}
+
+	// TODO: handle continue tokens...
+
+	return children, nil
 }
 
 func validateOnDelete(ctx context.Context,

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -282,6 +282,7 @@ func TestValidateUpdate(t *testing.T) {
 		old          *folders.Folder
 		parents      *folders.FolderInfoList
 		parentsError error
+		allFolders   []folders.Folder
 		expectedErr  string
 		maxDepth     int // defaults to 5 unless set
 	}{
@@ -454,6 +455,74 @@ func TestValidateUpdate(t *testing.T) {
 			},
 			expectedErr: "cannot move folder under its own descendant",
 		},
+		{
+			name: "error when moving folder from root to level2 with children exceeds max depth",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "folderWithChildren",
+					Annotations: map[string]string{
+						utils.AnnoKeyFolder: "level2",
+					},
+				},
+				Spec: folders.FolderSpec{
+					Title: "folder with children",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "folderWithChildren",
+				},
+				Spec: folders.FolderSpec{
+					Title: "folder with children",
+				},
+			},
+			parents: &folders.FolderInfoList{
+				Items: []folders.FolderInfo{
+					{Name: "level2", Parent: "level1"},
+					{Name: "level1", Parent: folder.GeneralFolderUID},
+					{Name: folder.GeneralFolderUID},
+				},
+			},
+			allFolders: []folders.Folder{
+				{ObjectMeta: metav1.ObjectMeta{Name: "child1", Annotations: map[string]string{utils.AnnoKeyFolder: "folderWithChildren"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "grandchild1", Annotations: map[string]string{utils.AnnoKeyFolder: "child1"}}},
+			},
+			maxDepth:    4,
+			expectedErr: "[folder.maximum-depth-reached]",
+		},
+		{
+			name: "can move folder from root level to level1 with children when within max depth",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "folderWithChildren",
+					Annotations: map[string]string{
+						utils.AnnoKeyFolder: "level1",
+					},
+				},
+				Spec: folders.FolderSpec{
+					Title: "folder with children",
+				},
+			},
+			old: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "folderWithChildren",
+				},
+				Spec: folders.FolderSpec{
+					Title: "folder with children",
+				},
+			},
+			parents: &folders.FolderInfoList{
+				Items: []folders.FolderInfo{
+					{Name: "level1", Parent: folder.GeneralFolderUID},
+					{Name: folder.GeneralFolderUID},
+				},
+			},
+			allFolders: []folders.Folder{
+				{ObjectMeta: metav1.ObjectMeta{Name: "child1", Annotations: map[string]string{utils.AnnoKeyFolder: "folderWithChildren"}}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "grandchild1", Annotations: map[string]string{utils.AnnoKeyFolder: "child1"}}},
+			},
+			maxDepth: 4,
+		},
 	}
 
 	for _, tt := range tests {
@@ -474,11 +543,17 @@ func TestValidateUpdate(t *testing.T) {
 					}, nil).Maybe()
 				}
 			}
+			for i := range tt.allFolders {
+				f := tt.allFolders[i]
+				m.On("Get", context.Background(), f.Name, &metav1.GetOptions{}).Return(&f, nil).Maybe()
+			}
 
 			err := validateOnUpdate(context.Background(), tt.folder, tt.old, m,
 				func(ctx context.Context, folder *folders.Folder) (*folders.FolderInfoList, error) {
 					return tt.parents, tt.parentsError
-				}, maxDepth)
+				},
+				&mockSearchClient{folders: tt.allFolders},
+				maxDepth)
 
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
@@ -693,8 +768,7 @@ type mockSearchClient struct {
 	stats    *resourcepb.ResourceStatsResponse
 	statsErr error
 
-	search    *resourcepb.ResourceSearchResponse
-	searchErr error
+	folders []folders.Folder
 }
 
 // GetStats implements resourcepb.ResourceIndexClient.
@@ -703,8 +777,37 @@ func (m *mockSearchClient) GetStats(ctx context.Context, in *resourcepb.Resource
 }
 
 // Search implements resourcepb.ResourceIndexClient.
-func (m *mockSearchClient) Search(ctx context.Context, in *resourcepb.ResourceSearchRequest, opts ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
-	return m.search, m.searchErr
+func (m *mockSearchClient) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest, opts ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	// get the list of parents from the search request
+	parentSet := make(map[string]bool)
+	if req.Options != nil && req.Options.Fields != nil {
+		for _, field := range req.Options.Fields {
+			if field.Key == "folder" && field.Operator == "in" {
+				for _, v := range field.Values {
+					parentSet[v] = true
+				}
+			}
+		}
+	}
+
+	// find children that match the parent filter
+	var rows []*resourcepb.ResourceTableRow
+	for i := range m.folders {
+		meta, err := utils.MetaAccessor(&m.folders[i])
+		if err != nil {
+			continue
+		}
+		parentUID := meta.GetFolder()
+		if parentSet[parentUID] {
+			rows = append(rows, &resourcepb.ResourceTableRow{
+				Key: &resourcepb.ResourceKey{Name: m.folders[i].Name},
+			})
+		}
+	}
+
+	return &resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{Rows: rows},
+	}, nil
 }
 
 // RebuildIndexes implements resourcepb.ResourceIndexClient.

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -726,15 +726,6 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 		return nil, folder.ErrBadRequest.Errorf("k6 project may not be moved")
 	}
 
-	f, err := s.unifiedStore.Get(ctx, folder.GetFolderQuery{
-		UID:          &cmd.UID,
-		OrgID:        cmd.OrgID,
-		SignedInUser: cmd.SignedInUser,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	// Check that the user is allowed to move the folder to the destination folder
 	hasAccess, evalErr := s.canMoveViaApiServer(ctx, cmd)
 	if evalErr != nil {
@@ -744,7 +735,7 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 		return nil, dashboards.ErrFolderAccessDenied
 	}
 
-	f, err = s.unifiedStore.Update(ctx, folder.UpdateFolderCommand{
+	f, err := s.unifiedStore.Update(ctx, folder.UpdateFolderCommand{
 		UID:          cmd.UID,
 		OrgID:        cmd.OrgID,
 		NewParentUID: &cmd.NewParentUID,

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -721,6 +721,11 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 		return nil, folder.ErrBadRequest.Errorf("missing signed in user")
 	}
 
+	// k6-specific check to prevent folder move for a k6-app folder and its children
+	if cmd.UID == accesscontrol.K6FolderUID {
+		return nil, folder.ErrBadRequest.Errorf("k6 project may not be moved")
+	}
+
 	f, err := s.unifiedStore.Get(ctx, folder.GetFolderQuery{
 		UID:          &cmd.UID,
 		OrgID:        cmd.OrgID,
@@ -728,10 +733,6 @@ func (s *Service) moveOnApiServer(ctx context.Context, cmd *folder.MoveFolderCom
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	if f != nil && f.ParentUID == accesscontrol.K6FolderUID {
-		return nil, folder.ErrBadRequest.Errorf("k6 project may not be moved")
 	}
 
 	// Check that the user is allowed to move the folder to the destination folder


### PR DESCRIPTION
**What is this feature?**

This PR:
- Adds a check to the `/apis` Validation Hook to prevent moving a folder when it contains children folders that would exceed the max depth (right now this is only in the unified storage code in the folders service, which is only hit in `/api`).
- Removes redundant checks that are being run now or were already being run in the validation hook. They need to be in the validation hook, so that they are run for both `/api` and `/apis`.
- Optimizes the original check written in the folder service (note: the code `GetHeight` cannot be removed because of the interface dependencies, but the unistore implementation is no longer used)

Optimization notes:
This is an expensive check if the folder has a lot of children within it (or if its children do, etc). To try to reduce the scenarios in which we compute the children, I grab the depth of the folder before the move, and if it is less than or equal to the new depth, I do not run this check (with the assumption that the folder, on create, and any children folders on create, have ensured the current folder structure is within the maxDepth. Due to this bug, that may not be the case, however, since the UI is not using `/apis` yet, this should hopefully be a small amount of users that have run into this).

If the folder is being moved deeper into the folder tree, then we have to search for all the children folders, then search for their children folders, etc. This will check levels up to `(maxDepth + 1) - newDepth`. Worst case scenario this would be 4 levels (root folder -> folder one deep: (4+1) - 1). However, if that one search request cannot return all the data, the number of search queries will grow. To try to optimize this further, we explore one batch depth first, so we can fail earlier, than getting all the children on one level, before moving on to the next batch. The original unified storage check for /api, would [retrieve the children of each child folder one at a time](https://github.com/grafana/grafana/blob/c5345498b16c0082c3d78d71b6c6547998667d49/pkg/services/folder/folderimpl/unifiedstore.go#L303), so this will reduce the number of calls.