### PR TITLE
fix(dashboards): return right token for version api

### DIFF
--- a/pkg/services/dashboardversion/dashverimpl/dashver.go
+++ b/pkg/services/dashboardversion/dashverimpl/dashver.go
@@ -274,6 +274,11 @@ func (s *Service) listDashboardVersionsThroughK8s(
 		continueToken = tempOut.GetContinue()
 	}
 
+	// Update the continue token on the response to reflect the actual position after all fetched items.
+	// Without this, the response would return the token from the first fetch, causing duplicate items
+	// on subsequent pages when multiple fetches were needed to fill the requested limit.
+	out.SetContinue(continueToken)
+
 	return out, nil
 }
 


### PR DESCRIPTION
When fetching from the store multiple pages to satisfy the request, we never updated the token to the last page we fetched. This resulted in duplicated items in the frontend, as we would re-fetch already displayed items.