### PR TITLE
Provisioning: update progress warning test cause it depended on a non…

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -154,9 +154,12 @@ func TestJobProgressRecorderWarningStatus(t *testing.T) {
 	// Verify the final status includes warnings
 	require.NotNil(t, finalStatus.Warnings)
 	assert.Len(t, finalStatus.Warnings, 3)
-	assert.Contains(t, finalStatus.Warnings[0], "deprecated API used")
-	assert.Contains(t, finalStatus.Warnings[1], "missing optional field")
-	assert.Contains(t, finalStatus.Warnings[2], "validation warning")
+	expectedWarnings := []string{
+		"deprecated API used (file: dashboards/test.json, name: test-resource, action: updated)",
+		"missing optional field (file: dashboards/test2.json, name: test-resource-2, action: created)",
+		"validation warning (file: datasources/test.yaml, name: test-resource-3, action: created)",
+	}
+	assert.ElementsMatch(t, finalStatus.Warnings, expectedWarnings)
 
 	// Verify the state is set to Warning
 	assert.Equal(t, provisioning.JobStateWarning, finalStatus.State)


### PR DESCRIPTION
Quick fix for a flaky test that is causing noise.

The test is flaky because the summaries goes to a map before being converted to a list, making their order non-deterministic. Updating the test so it checks the string independently of the order.

Test is passing:

```
ok      github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs  0.620s
❯ /usr/local/go/bin/go test -count=1 -timeout 30s -run ^TestJobProgressRecorderWarningStatus$ github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs
ok      github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs  0.593s
```

Fixes https://github.com/grafana/git-ui-sync-project/issues/713