### PR TITLE
CustomVariable: Remove dead code and incorrect label

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/CustomVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/CustomVariableEditor.tsx
@@ -1,12 +1,8 @@
 import { FormEvent, useCallback } from 'react';
 
-import { t } from '@grafana/i18n';
-import { CustomVariable, SceneVariable } from '@grafana/scenes';
+import { CustomVariable } from '@grafana/scenes';
 
-import { OptionsPaneItemDescriptor } from '../../../../../dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 import { CustomVariableForm } from '../../components/CustomVariableForm';
-
-import { PaneItem } from './PaneItem';
 
 interface CustomVariableEditorProps {
   variable: CustomVariable;
@@ -66,18 +62,4 @@ export function CustomVariableEditor({ variable, onRunQuery }: CustomVariableEdi
       onAllowCustomValueChange={onAllowCustomValueChange}
     />
   );
-}
-
-export function getCustomVariableOptions(variable: SceneVariable): OptionsPaneItemDescriptor[] {
-  if (!(variable instanceof CustomVariable)) {
-    return [];
-  }
-
-  return [
-    new OptionsPaneItemDescriptor({
-      title: t('dashboard.edit-pane.variable.custom-options.values', 'Values separated by comma'),
-      id: 'custom-variable-values',
-      render: ({ props }) => <PaneItem id={props.id} variable={variable} />,
-    }),
-  ];
 }

--- a/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/getCustomVariableOptions.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/CustomVariableEditor/getCustomVariableOptions.tsx
@@ -1,4 +1,3 @@
-import { t } from '@grafana/i18n';
 import { CustomVariable, SceneVariable } from '@grafana/scenes';
 
 import { OptionsPaneItemDescriptor } from '../../../../../dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
@@ -12,7 +11,6 @@ export function getCustomVariableOptions(variable: SceneVariable): OptionsPaneIt
 
   return [
     new OptionsPaneItemDescriptor({
-      title: t('dashboard.edit-pane.variable.custom-options.values', 'Values separated by comma'),
       id: 'custom-variable-values',
       render: ({ props }) => <PaneItem id={props.id} variable={variable} />,
     }),

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4821,8 +4821,7 @@
           "apply": "Apply",
           "change-value": "Change variable value",
           "discard": "Discard",
-          "modal-title": "Custom Variable",
-          "values": "Values separated by comma"
+          "modal-title": "Custom Variable"
         },
         "datasource-options": {
           "name-filter": "Name filter",


### PR DESCRIPTION
When testing i've noticed some useless and incorrect label being rendered for custom variable editor:

<img width="377" height="371" alt="Screenshot 2025-12-15 at 13 45 15" src="https://github.com/user-attachments/assets/97786f7a-0b99-4018-b1f3-5cfa25aeb13e" />


This also removes redundand, dead code.