### PR TITLE
Comment out schema editor button in dashboard edit pane

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -76,12 +76,12 @@ export function DashboardEditPaneRenderer({ editPane, dashboard, isDocked }: Pro
               data-testid={selectors.pages.Dashboard.Sidebar.optionsButton}
               active={selectedObject === dashboard ? true : false}
             />
-            <Sidebar.Button
+            {/* <Sidebar.Button
               tooltip={t('dashboard.sidebar.edit-schema.tooltip', 'Edit as code')}
               title={t('dashboard.sidebar.edit-schema.title', 'Code')}
               icon="brackets-curly"
               onClick={() => dashboard.openV2SchemaEditor()}
-            />
+            /> */}
             <Sidebar.Divider />
           </>
         )}


### PR DESCRIPTION
Comments out Edit as code option as it's useless currently. Will soon open a PR that makes it usable, but this ain't high prio.