### PR TITLE
Logs: Improved flexibility of `hasSupplementaryQuerySupport`

### DIFF
--- a/packages/grafana-data/src/types/logs.ts
+++ b/packages/grafana-data/src/types/logs.ts
@@ -273,7 +273,7 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
   /**
    * Returns supplementary query types that data source supports.
    */
-  getSupportedSupplementaryQueryTypes(): SupplementaryQueryType[];
+  getSupportedSupplementaryQueryTypes(dsRequest?: DataQueryRequest<DataQuery>): SupplementaryQueryType[];
   /**
    * Returns a supplementary query to be used to fetch supplementary data based on the provided type and original query.
    * If the provided query is not suitable for the provided supplementary query type, undefined should be returned.
@@ -283,7 +283,8 @@ export interface DataSourceWithSupplementaryQueriesSupport<TQuery extends DataQu
 
 export const hasSupplementaryQuerySupport = <TQuery extends DataQuery>(
   datasource: DataSourceApi | (DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery>),
-  type: SupplementaryQueryType
+  type: SupplementaryQueryType,
+  dsRequest?: DataQueryRequest<DataQuery>
 ): datasource is DataSourceApi & DataSourceWithSupplementaryQueriesSupport<TQuery> => {
   if (!datasource) {
     return false;
@@ -293,7 +294,7 @@ export const hasSupplementaryQuerySupport = <TQuery extends DataQuery>(
     ('getDataProvider' in datasource || 'getSupplementaryRequest' in datasource) &&
     'getSupplementaryQuery' in datasource &&
     'getSupportedSupplementaryQueryTypes' in datasource &&
-    datasource.getSupportedSupplementaryQueryTypes().includes(type)
+    datasource.getSupportedSupplementaryQueryTypes(dsRequest).includes(type)
   );
 };
 

--- a/public/app/features/explore/utils/supplementaryQueries.ts
+++ b/public/app/features/explore/utils/supplementaryQueries.ts
@@ -129,7 +129,7 @@ export const getSupplementaryQueryProvider = (
     dsRequest.requestId = `${dsRequest.requestId || ''}_${i}`;
     dsRequest.targets = targets;
 
-    if (hasSupplementaryQuerySupport(datasource, type)) {
+    if (hasSupplementaryQuerySupport(datasource, type, dsRequest)) {
       if (datasource.getDataProvider) {
         return datasource.getDataProvider(type, dsRequest);
       } else if (datasource.getSupplementaryRequest) {


### PR DESCRIPTION
The `hasSupplementaryQuerySupport` evaluates if a data source supports supplementary queries by evaluating the following condition:

```
  'getDataProvider' in datasource || 'getSupplementaryRequest' in datasource) &&
    'getSupplementaryQuery' in datasource &&
    'getSupportedSupplementaryQueryTypes' in datasource &&
    datasource.getSupportedSupplementaryQueryTypes(dsRequest).includes(type)
```

This is insufficient in cases where data sources support supplementary queries for certain specific query conditions but not others.

In the case of logs volume queries and ClickHouse, the logs volume query can be correctly executed when using the builder mode but not when using the SQL editor. When the editor is in use, it's not straightforward to discern the appropriate columns for a volume query. In this case, the fallback query is more appropriate.

This change will supply the request to the data source when evaluating if supplementary queries are supported. The data source can then improve how it handles various queries.

Relevant Clickhouse issue: grafana/clickhouse-datasource#1364