### PR TITLE
Sparkline: Set axis show to false

### DIFF
--- a/packages/grafana-ui/src/components/Sparkline/utils.ts
+++ b/packages/grafana-ui/src/components/Sparkline/utils.ts
@@ -175,6 +175,7 @@ export const prepareConfig = (
   builder.addAxis({
     scaleKey: 'x',
     theme,
+    show: false,
     placement: AxisPlacement.Hidden,
   });
 
@@ -201,6 +202,7 @@ export const prepareConfig = (
     builder.addAxis({
       scaleKey,
       theme,
+      show: false,
       placement: AxisPlacement.Hidden,
     });
 


### PR DESCRIPTION
Another min/max issue with Sparkline, this time related to the axis. Since we want to just hide the axis rather than try to provide it with min/max values, we should have always been providing `show` as false rather than only setting `placement: AxisPlacement.Hidden`. The issue here would be an uncaught thrown error when rendering sparklines, preventing the sparkline from appearing, related to the min and max.

There are many places in the code which do this same thing (setting `show` to false conditionally on the `placement` value being `AxisPlacement.Hidden`), such that it probably makes sense to explore whether that can be the default (something like https://github.com/grafana/grafana/pull/115355). But, I don't want to pull that thread immediately since we can just fix this atomically. 

**To test:**

This can randomly manifest in Sparkline Table, but is consistently an issue on the new Gauge at the moment, so the new gauge gdev is the best place to test whether this is working or not. It's worth looking at both.

This PR doesn't contain a test currently because the best way to test this is going to be to write an e2e against the new Gauge which checks for successful renders of uPlot. I'm planning to write the e2es for Gauge this week, so I would like to avoid scaffolding this today to make sure this issue gets resolved in prod in case anyone is seeing this in Table.