### PR TITLE
Dashboards: Fix dashboard controls margin

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -246,6 +246,7 @@ function getStyles(theme: GrafanaTheme2) {
       position: 'relative',
       width: '100%',
       marginLeft: 'auto',
+      display: 'inline-block',
       [theme.breakpoints.down('sm')]: {
         flexDirection: 'column-reverse',
         alignItems: 'stretch',


### PR DESCRIPTION
**What is this feature?**

The margin between time controls and the panels on the dashboard is not correct

Before:
<img width="1172" height="227" alt="image" src="https://github.com/user-attachments/assets/d5d87467-8dd8-405b-bb6e-e4d8e226705b" />

setting display to inline-block fixes the height calculation so margin is there:
<img width="1172" height="227" alt="image" src="https://github.com/user-attachments/assets/c2cf9c0d-f181-46a0-9081-284349da3fc2" />
