### PR TITLE
Prometheus: Fallback to fetch metric names when metadata returns nothing

### DIFF
--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.test.tsx
@@ -48,7 +48,7 @@ describe('MetricsModal', () => {
       operations: [],
     };
 
-    setup(query, ['with-labels'], true);
+    setup(query, ['with-labels']);
     await waitFor(() => {
       expect(screen.getByText('with-labels')).toBeInTheDocument();
     });
@@ -220,6 +220,10 @@ function createDatasource(withLabels?: boolean) {
   // display different results if their labels are selected in the PromVisualQuery
   if (withLabels) {
     languageProvider.queryMetricsMetadata = jest.fn().mockResolvedValue({
+      ALERTS: {
+        type: 'gauge',
+        help: 'alerts help text',
+      },
       'with-labels': {
         type: 'with-labels-type',
         help: 'with-labels-help',
@@ -297,7 +301,7 @@ function createProps(query: PromVisualQuery, datasource: PrometheusDatasource, m
   };
 }
 
-function setup(query: PromVisualQuery, metrics: string[], withlabels?: boolean) {
+function setup(query: PromVisualQuery, metrics: string[]) {
   const withLabels: boolean = query.labels.length > 0;
   const datasource = createDatasource(withLabels);
   const props = createProps(query, datasource, metrics);

--- a/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
+++ b/packages/grafana-prometheus/src/querybuilder/components/metrics-modal/MetricsModal.tsx
@@ -138,7 +138,7 @@ const MetricsModalContent = (props: MetricsModalProps) => {
 
 export const MetricsModal = (props: MetricsModalProps) => {
   return (
-    <MetricsModalContextProvider languageProvider={props.datasource.languageProvider}>
+    <MetricsModalContextProvider languageProvider={props.datasource.languageProvider} timeRange={props.timeRange}>
       <MetricsModalContent {...props} />
     </MetricsModalContextProvider>
   );


### PR DESCRIPTION
**What is this feature?**

For metrics modal we rely on `api/v1/metadata` enpoint. But sometimes that might not available. In the past we had a silent fallback when there is no metadata for metrics modal. During improvements that was removed. This PR brings back the functionality. 

So in case there is no metadata we fetch the metric names and show them in the modal without help and description information as they are coming from metadata endpoint. 

**Why do we need this feature?**

Bringing back old fallback logic in metrics modal.

**Who is this feature for?**

Prometheus users who has a prometheus version that doesn't have metadata endpoint support.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115359

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
