### PR TITLE
DashListItem: Added DashListItem shared component

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -70,15 +70,18 @@ export function RecentlyViewedDashboards() {
 
 const getStyles = (theme: GrafanaTheme2) => {
   const accent = theme.visualization.getColorByName('purple');
+  const blue = theme.visualization.getColorByName('blue');
 
   return {
     title: css({
-      background: `linear-gradient(90deg, ${accent} 0%, #e478eaff 100%)`,
-      WebkitTextFillColor: 'transparent',
-      backgroundClip: 'text',
-      color: 'transparent',
       '& button svg': {
         color: accent,
+      },
+      h3: {
+        background: `linear-gradient(90deg, ${accent} 0%, ${blue} 100%)`,
+        WebkitTextFillColor: 'transparent',
+        backgroundClip: 'text',
+        color: 'transparent',
       },
     }),
     content: css({

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -69,16 +69,13 @@ export function RecentlyViewedDashboards() {
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
-  const accent = theme.visualization.getColorByName('purple');
-  const blue = theme.visualization.getColorByName('blue');
-
   return {
     title: css({
       '& button svg': {
-        color: accent,
+        color: theme.colors.primary.text,
       },
       h3: {
-        background: `linear-gradient(90deg, ${accent} 0%, ${blue} 100%)`,
+        background: `linear-gradient(90deg, ${theme.colors.primary.text} 0%, ${theme.colors.secondary.text} 100%)`,
         WebkitTextFillColor: 'transparent',
         backgroundClip: 'text',
         color: 'transparent',

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -4,7 +4,9 @@ import { useAsync } from 'react-use';
 import { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { evaluateBooleanFlag } from '@grafana/runtime/internal';
-import { CollapsableSection, Link, Spinner, Text, useStyles2 } from '@grafana/ui';
+import { CollapsableSection, Grid, Spinner, Text, useStyles2 } from '@grafana/ui';
+import { useDashboardLocationInfo } from 'app/features/search/hooks/useDashboardLocationInfo';
+import { DashListItem } from 'app/plugins/panel/dashlist/DashListItem';
 
 import { getRecentlyViewedDashboards } from './utils';
 
@@ -19,6 +21,7 @@ export function RecentlyViewedDashboards() {
     }
     return getRecentlyViewedDashboards(MAX_RECENT);
   }, []);
+  const { foldersByUid } = useDashboardLocationInfo(recentDashboards.length > 0);
 
   if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
     return null;
@@ -43,22 +46,26 @@ export function RecentlyViewedDashboards() {
         <Text>{t('browse-dashboards.recently-viewed.empty', 'Nothing viewed yet')}</Text>
       )}
 
-      {/* TODO: implement actual card content */}
       {!loading && recentDashboards.length > 0 && (
-        <>
+        <Grid columns={{ xs: 1, sm: 2, md: 3, lg: 5 }} gap={2}>
           {recentDashboards.map((dash) => (
-            <div key={dash.uid}>
-              <Link href={dash.url}>{dash.name}</Link>
-            </div>
+            <DashListItem
+              key={dash.uid}
+              dashboard={dash}
+              url={dash.url}
+              showFolderNames={true}
+              locationInfo={foldersByUid[dash.location]}
+              layoutMode="card"
+            />
           ))}
-        </>
+        </Grid>
       )}
     </CollapsableSection>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => {
-  const accent = theme.visualization.getColorByName('purple'); // or your own hex
+  const accent = theme.visualization.getColorByName('purple');
 
   return {
     title: css({

--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -47,18 +47,22 @@ export function RecentlyViewedDashboards() {
       )}
 
       {!loading && recentDashboards.length > 0 && (
-        <Grid columns={{ xs: 1, sm: 2, md: 3, lg: 5 }} gap={2}>
-          {recentDashboards.map((dash) => (
-            <DashListItem
-              key={dash.uid}
-              dashboard={dash}
-              url={dash.url}
-              showFolderNames={true}
-              locationInfo={foldersByUid[dash.location]}
-              layoutMode="card"
-            />
-          ))}
-        </Grid>
+        <ul className={styles.list}>
+          <Grid columns={{ xs: 1, sm: 2, md: 3, lg: 5 }} gap={2}>
+            {recentDashboards.map((dash) => (
+              <li key={dash.uid} className={styles.listItem}>
+                <DashListItem
+                  key={dash.uid}
+                  dashboard={dash}
+                  url={dash.url}
+                  showFolderNames={true}
+                  locationInfo={foldersByUid[dash.location]}
+                  layoutMode="card"
+                />
+              </li>
+            ))}
+          </Grid>
+        </ul>
       )}
     </CollapsableSection>
   );
@@ -79,6 +83,16 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     content: css({
       paddingTop: theme.spacing(0),
+    }),
+    list: css({
+      listStyle: 'none',
+      margin: 0,
+      padding: 0,
+      display: 'grid',
+      gap: theme.spacing(2),
+    }),
+    listItem: css({
+      margin: 0,
     }),
   };
 };

--- a/public/app/features/search/hooks/useDashboardLocationInfo.tsx
+++ b/public/app/features/search/hooks/useDashboardLocationInfo.tsx
@@ -3,6 +3,11 @@ import { useAsync } from 'react-use';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { LocationInfo } from 'app/features/search/service/types';
 
+/**
+ *
+ * @description Hook to fetch dashboard location info (folders).
+ * @returns An object containing a mapping of folder UIDs to LocationInfo, loading state, and error state.
+ */
 export function useDashboardLocationInfo(enabled: boolean) {
   const searcher = getGrafanaSearcher();
   const {

--- a/public/app/features/search/hooks/useDashboardLocationInfo.tsx
+++ b/public/app/features/search/hooks/useDashboardLocationInfo.tsx
@@ -1,0 +1,25 @@
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
+
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { LocationInfo } from 'app/features/search/service/types';
+
+export function useDashboardLocationInfo(enabled: boolean) {
+  const searcher = useMemo(() => getGrafanaSearcher(), []);
+  const {
+    value: folders,
+    loading,
+    error,
+  } = useAsync(async (): Promise<Record<string, LocationInfo>> => {
+    if (!enabled) {
+      return {};
+    }
+    return searcher.getLocationInfo();
+  }, [enabled, searcher]);
+
+  return {
+    foldersByUid: folders ?? {},
+    loading,
+    error,
+  };
+}

--- a/public/app/features/search/hooks/useDashboardLocationInfo.tsx
+++ b/public/app/features/search/hooks/useDashboardLocationInfo.tsx
@@ -1,13 +1,12 @@
-import { useMemo } from 'react';
 import { useAsync } from 'react-use';
 
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { LocationInfo } from 'app/features/search/service/types';
 
 export function useDashboardLocationInfo(enabled: boolean) {
-  const searcher = useMemo(() => getGrafanaSearcher(), []);
+  const searcher = getGrafanaSearcher();
   const {
-    value: folders,
+    value: foldersByUid,
     loading,
     error,
   } = useAsync(async (): Promise<Record<string, LocationInfo>> => {
@@ -18,7 +17,7 @@ export function useDashboardLocationInfo(enabled: boolean) {
   }, [enabled, searcher]);
 
   return {
-    foldersByUid: folders ?? {},
+    foldersByUid: foldersByUid ?? {},
     loading,
     error,
   };

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -4,18 +4,18 @@ import { useThrottle } from 'react-use';
 
 import { InterpolateFunction, PanelProps, textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { useStyles2, ScrollContainer, Box, Text, EmptyState, Link } from '@grafana/ui';
+import { ScrollContainer, Box, Text, EmptyState } from '@grafana/ui';
 import { getConfig } from 'app/core/config';
 import impressionSrv from 'app/core/services/impression_srv';
+import { useDashboardLocationInfo } from 'app/features/search/hooks/useDashboardLocationInfo';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
-import { DashboardQueryResult, LocationInfo, QueryResponse, SearchQuery } from 'app/features/search/service/types';
-import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
+import { DashboardQueryResult, QueryResponse, SearchQuery } from 'app/features/search/service/types';
 
+import { DashListItem } from './DashListItem';
 import { Options } from './panelcfg.gen';
-import { getStyles } from './styles';
 import { useDashListUrlParams } from './utils';
 
-type Dashboard = DashboardQueryResult & {
+export type Dashboard = DashboardQueryResult & {
   isSearchResult?: boolean;
   isRecent?: boolean;
   isStarred?: boolean;
@@ -107,15 +107,10 @@ async function fetchDashboards(options: Options, replaceVars: InterpolateFunctio
   return dashMap;
 }
 
-async function fetchDashboardFolders() {
-  return getGrafanaSearcher().getLocationInfo();
-}
-
 const collator = new Intl.Collator();
 
 export function DashList(props: PanelProps<Options>) {
   const [dashboards, setDashboards] = useState(new Map<string, Dashboard>());
-  const [foldersTitleMap, setFoldersTitleMap] = useState<Record<string, LocationInfo>>({});
 
   const throttledRenderCount = useThrottle(props.renderCounter, 5000);
 
@@ -125,13 +120,7 @@ export function DashList(props: PanelProps<Options>) {
     });
   }, [props.options, props.replaceVariables, throttledRenderCount]);
 
-  useEffect(() => {
-    if (props.options.showFolderNames && dashboards.size > 0) {
-      fetchDashboardFolders().then((locationInfo) => {
-        setFoldersTitleMap(locationInfo);
-      });
-    }
-  }, [props.options.showFolderNames, dashboards]);
+  const { foldersByUid } = useDashboardLocationInfo(props.options.showFolderNames && dashboards.size > 0);
 
   const [starredDashboards, recentDashboards, searchedDashboards] = useMemo(() => {
     const dashboardList = [...dashboards.values()];
@@ -185,7 +174,7 @@ export function DashList(props: PanelProps<Options>) {
     setDashboards(updatedDashboards);
   };
 
-  const css = useStyles2(getStyles);
+  // const css = useStyles2(getStyles);
   const urlParams = useDashListUrlParams(props);
 
   const renderList = (dashboards: Dashboard[]) => (
@@ -194,10 +183,10 @@ export function DashList(props: PanelProps<Options>) {
         let url = dash.url + urlParams;
         url = getConfig().disableSanitizeHtml ? url : textUtil.sanitizeUrl(url);
 
-        const locationInfo = showFolderNames && dash.location ? foldersTitleMap[dash.location] : undefined;
+        const locationInfo = showFolderNames && dash.location ? foldersByUid[dash.location] : undefined;
         return (
           <li key={`dash-${dash.uid}`}>
-            <div className={css.dashlistLink}>
+            {/* <div className={css.dashlistLink}>
               <Box flex={1}>
                 <Link href={url}>{dash.name}</Link>
                 {showFolderNames && locationInfo && (
@@ -213,7 +202,15 @@ export function DashList(props: PanelProps<Options>) {
                 id={dash.uid}
                 onStarChange={handleStarChange}
               />
-            </div>
+            </div> */}
+            <DashListItem
+              dashboard={dash}
+              url={url}
+              showFolderNames={showFolderNames}
+              locationInfo={locationInfo}
+              layoutMode="list"
+              onStarChange={handleStarChange}
+            />
           </li>
         );
       })}

--- a/public/app/plugins/panel/dashlist/DashList.tsx
+++ b/public/app/plugins/panel/dashlist/DashList.tsx
@@ -174,7 +174,6 @@ export function DashList(props: PanelProps<Options>) {
     setDashboards(updatedDashboards);
   };
 
-  // const css = useStyles2(getStyles);
   const urlParams = useDashListUrlParams(props);
 
   const renderList = (dashboards: Dashboard[]) => (
@@ -186,23 +185,6 @@ export function DashList(props: PanelProps<Options>) {
         const locationInfo = showFolderNames && dash.location ? foldersByUid[dash.location] : undefined;
         return (
           <li key={`dash-${dash.uid}`}>
-            {/* <div className={css.dashlistLink}>
-              <Box flex={1}>
-                <Link href={url}>{dash.name}</Link>
-                {showFolderNames && locationInfo && (
-                  <Text color="secondary" variant="bodySmall" element="p">
-                    {locationInfo?.name}
-                  </Text>
-                )}
-              </Box>
-              <StarToolbarButton
-                title={dash.name}
-                group="dashboard.grafana.app"
-                kind="Dashboard"
-                id={dash.uid}
-                onStarChange={handleStarChange}
-              />
-            </div> */}
             <DashListItem
               dashboard={dash}
               url={url}

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -19,7 +19,6 @@ export function DashListItem({ dashboard, url, showFolderNames, locationInfo, la
   return (
     <>
       {layoutMode === 'list' ? (
-        // list mode
         <div className={css.dashlistLink}>
           <Box flex={1}>
             <Link href={url}>{dashboard.name}</Link>
@@ -38,7 +37,6 @@ export function DashListItem({ dashboard, url, showFolderNames, locationInfo, la
           />
         </div>
       ) : (
-        // card mode
         <Card className={css.dashlistCard} noMargin>
           <Stack justifyContent="space-between" alignItems="center">
             <Link href={url}>{dashboard.name}</Link>

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -5,21 +5,15 @@ import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
 import { Dashboard } from './DashList';
 import { getStyles } from './styles';
 
-export function DashListItem({
-  dashboard,
-  url,
-  showFolderNames,
-  locationInfo,
-  layoutMode,
-  onStarChange,
-}: {
+interface Props {
   dashboard: Dashboard;
   url: string;
   showFolderNames: boolean;
   locationInfo?: LocationInfo;
   layoutMode: 'list' | 'card';
   onStarChange?: (id: string, isStarred: boolean) => void;
-}) {
+}
+export function DashListItem({ dashboard, url, showFolderNames, locationInfo, layoutMode, onStarChange }: Props) {
   const css = useStyles2(getStyles);
 
   return (
@@ -59,7 +53,7 @@ export function DashListItem({
 
           {showFolderNames && locationInfo && (
             <Stack alignItems="center" direction="row" gap={0}>
-              <Icon name="folder" size="sm" className={css.dashlistCardIcon} />
+              <Icon name="folder" size="sm" className={css.dashlistCardIcon} aria-hidden="true" />
               <Text color="secondary" variant="bodySmall" element="p">
                 {locationInfo?.name}
               </Text>

--- a/public/app/plugins/panel/dashlist/DashListItem.tsx
+++ b/public/app/plugins/panel/dashlist/DashListItem.tsx
@@ -1,0 +1,72 @@
+import { Box, Card, Icon, Link, Stack, Text, useStyles2 } from '@grafana/ui';
+import { LocationInfo } from 'app/features/search/service/types';
+import { StarToolbarButton } from 'app/features/stars/StarToolbarButton';
+
+import { Dashboard } from './DashList';
+import { getStyles } from './styles';
+
+export function DashListItem({
+  dashboard,
+  url,
+  showFolderNames,
+  locationInfo,
+  layoutMode,
+  onStarChange,
+}: {
+  dashboard: Dashboard;
+  url: string;
+  showFolderNames: boolean;
+  locationInfo?: LocationInfo;
+  layoutMode: 'list' | 'card';
+  onStarChange?: (id: string, isStarred: boolean) => void;
+}) {
+  const css = useStyles2(getStyles);
+
+  return (
+    <>
+      {layoutMode === 'list' ? (
+        // list mode
+        <div className={css.dashlistLink}>
+          <Box flex={1}>
+            <Link href={url}>{dashboard.name}</Link>
+            {showFolderNames && locationInfo && (
+              <Text color="secondary" variant="bodySmall" element="p">
+                {locationInfo?.name}
+              </Text>
+            )}
+          </Box>
+          <StarToolbarButton
+            title={dashboard.name}
+            group="dashboard.grafana.app"
+            kind="Dashboard"
+            id={dashboard.uid}
+            onStarChange={onStarChange}
+          />
+        </div>
+      ) : (
+        // card mode
+        <Card className={css.dashlistCard} noMargin>
+          <Stack justifyContent="space-between" alignItems="center">
+            <Link href={url}>{dashboard.name}</Link>
+            <StarToolbarButton
+              title={dashboard.name}
+              group="dashboard.grafana.app"
+              kind="Dashboard"
+              id={dashboard.uid}
+              onStarChange={onStarChange}
+            />
+          </Stack>
+
+          {showFolderNames && locationInfo && (
+            <Stack alignItems="center" direction="row" gap={0}>
+              <Icon name="folder" size="sm" className={css.dashlistCardIcon} />
+              <Text color="secondary" variant="bodySmall" element="p">
+                {locationInfo?.name}
+              </Text>
+            </Stack>
+          )}
+        </Card>
+      )}
+    </>
+  );
+}

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -33,6 +33,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
         color: theme.colors.text.link,
         textDecoration: 'underline',
       },
+      height: '100%',
 
       '&:hover': {
         backgroundImage: gradient,

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -1,15 +1,14 @@
 import { css } from '@emotion/css';
 
-import { GrafanaTheme2 } from '@grafana/data';
-
-import { alpha } from '../../../../../packages/grafana-data/src/themes/colorManipulator';
+import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 
 export const getStyles = (theme: GrafanaTheme2) => {
   const accent = theme.visualization.getColorByName('purple');
+  const blue = theme.visualization.getColorByName('blue');
   const gradient = `linear-gradient(
     90deg,
-    ${alpha(accent, 0.28)} 0%,
-    ${alpha('#9578eaff', 0.28)} 100%
+    ${colorManipulator.alpha(accent, 0.28)} 0%,
+    ${colorManipulator.alpha(blue, 0.28)} 100%
   )`;
   return {
     dashlistLink: css({

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -3,12 +3,10 @@ import { css } from '@emotion/css';
 import { GrafanaTheme2, colorManipulator } from '@grafana/data';
 
 export const getStyles = (theme: GrafanaTheme2) => {
-  const accent = theme.visualization.getColorByName('purple');
-  const blue = theme.visualization.getColorByName('blue');
   const gradient = `linear-gradient(
     90deg,
-    ${colorManipulator.alpha(accent, 0.28)} 0%,
-    ${colorManipulator.alpha(blue, 0.28)} 100%
+    ${colorManipulator.alpha(theme.colors.primary.text, 0.1)} 0%,
+    ${colorManipulator.alpha(theme.colors.secondary.text, 0.1)} 100%
   )`;
   return {
     dashlistLink: css({

--- a/public/app/plugins/panel/dashlist/styles.ts
+++ b/public/app/plugins/panel/dashlist/styles.ts
@@ -2,7 +2,15 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
+import { alpha } from '../../../../../packages/grafana-data/src/themes/colorManipulator';
+
 export const getStyles = (theme: GrafanaTheme2) => {
+  const accent = theme.visualization.getColorByName('purple');
+  const gradient = `linear-gradient(
+    90deg,
+    ${alpha(accent, 0.28)} 0%,
+    ${alpha('#9578eaff', 0.28)} 100%
+  )`;
   return {
     dashlistLink: css({
       display: 'flex',
@@ -18,6 +26,22 @@ export const getStyles = (theme: GrafanaTheme2) => {
           textDecoration: 'underline',
         },
       },
+    }),
+    dashlistCard: css({
+      display: 'flex',
+      flexDirection: 'column',
+      '&:hover a': {
+        color: theme.colors.text.link,
+        textDecoration: 'underline',
+      },
+
+      '&:hover': {
+        backgroundImage: gradient,
+        color: theme.colors.text.primary,
+      },
+    }),
+    dashlistCardIcon: css({
+      marginRight: theme.spacing(0.5),
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**
- add `DashListItem` shared component 
- add `useDashboardLocationInfo` hook to share folder metadata lookups with consistent async handling
- wire the hook into `DashList` and `RecentlyViewedDashboards` so both surfaces show folder names when available
- refresh `DashListItem` styling for card layout (use in new recently viewed section). 
<img width="1171" height="666" alt="image" src="https://github.com/user-attachments/assets/46380216-f269-4e67-904b-22cd246ccaf0" />


**Who is this feature for?**

All users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/114794
Fixes https://github.com/grafana/grafana/issues/114795

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
