### PR TITLE
[IGNORE] Testing fork CI

### DIFF
--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -18,11 +18,11 @@ permissions:
 # target branch onto the source branch, to verify compatibility before merging.
 jobs:
   dispatch-job:
-    uses: grafana/grafana/.github/workflows/pr-patch-check.yml@main
+    uses: kminehart/grafana/.github/workflows/pr-patch-check.yml@main
     with:
       head_ref: ${{ github.head_ref }}
       base_ref: ${{ github.base_ref }}
-      repo: ${{ github.repository }}
+      repo: ${{ github.event.pull_request.head.repo }}
       sender_login: ${{ github.event.sender.login }}
       sha: ${{ github.sha }}
       pr_commit_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       head_ref: ${{ github.head_ref }}
       base_ref: ${{ github.base_ref }}
-      repo: ${{ github.event.pull_request.head.repo }}
+      repo: ${{ github.event.pull_request.head.repo.full_name }}
       sender_login: ${{ github.event.sender.login }}
       sha: ${{ github.sha }}
       pr_commit_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-patch-check-event.yml
+++ b/.github/workflows/pr-patch-check-event.yml
@@ -22,7 +22,7 @@ jobs:
     with:
       head_ref: ${{ github.head_ref }}
       base_ref: ${{ github.base_ref }}
-      repo: ${{ github.event.pull_request.head.repo.full_name }}
+      repo: ${{ github.repository }}
       sender_login: ${{ github.event.sender.login }}
       sha: ${{ github.sha }}
       pr_commit_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/pr-patch-check.yml
+++ b/.github/workflows/pr-patch-check.yml
@@ -97,3 +97,4 @@ jobs:
           status: success
           context: "Test Patches (event)"
           description: "Test Patches (event) on a fork"
+          allowForks: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Test Fork
+
 ![Grafana Logo (Light)](docs/logo-horizontal.png#gh-light-mode-only)
 ![Grafana Logo (Dark)](docs/logo-horizontal-dark.png#gh-dark-mode-only)
 


### PR DESCRIPTION
Testing out whether forks can write GItHub statuses to try to get around a CI process that will not run on forks.

Unfortunately I just discovered that the GITHUB_TOKEN generated by workflows in forks are read-only. :\ 