### PR TITLE
Dashboards: Fix links not wrapping

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardLinkRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinkRenderer.tsx
@@ -63,7 +63,6 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'inline-flex',
       alignItems: 'center',
       verticalAlign: 'middle',
-      marginBottom: theme.spacing(1),
     }),
   };
 }

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.tsx
@@ -39,6 +39,8 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'inline-flex',
       gap: theme.spacing(1),
       marginRight: theme.spacing(1),
+      marginBottom: theme.spacing(1),
+      flexWrap: 'wrap',
     }),
   };
 }

--- a/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
+++ b/public/app/features/dashboard/components/SubMenu/DashboardLinksDashboard.tsx
@@ -181,7 +181,6 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'inline-flex',
       alignItems: 'center',
       verticalAlign: 'middle',
-      marginBottom: theme.spacing(1),
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Makes links wrap again.

The flex element containing the links was not set to wrap so the links would extend outside of the viewport. Making them wrap made the empty space between the links in the vertical direction a bit too big, so removed the marginBottom to instead rely on the gap from the wrapping element.

Because we removed the margin from the link elements, the spacing to the panels would not be correct if we only had links. Moved the marginBottom: 8 from the links to the element wrapping the links.
