### PR TITLE
Tracing: Fix excluding paths from tracing 

### DIFF
--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -638,7 +638,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 	m := hs.web
 
 	m.Use(requestmeta.SetupRequestMetadata())
-	m.Use(middleware.RequestTracing(hs.tracer, middleware.SkipTracingPaths))
+	m.Use(middleware.RequestTracing(hs.tracer, middleware.ShouldTraceWithExceptions))
 	m.Use(middleware.RequestMetrics(hs.Features, hs.Cfg, hs.promRegister))
 
 	m.UseMiddleware(hs.LoggerMiddleware.Middleware())

--- a/pkg/middleware/request_tracing.go
+++ b/pkg/middleware/request_tracing.go
@@ -73,16 +73,20 @@ func RouteOperationName(req *http.Request) (string, bool) {
 	return "", false
 }
 
-// Paths that don't need tracing spans applied to them because of the
-// little value that would provide us
-func SkipTracingPaths(req *http.Request) bool {
-	return strings.HasPrefix(req.URL.Path, "/public/") ||
+func ShouldTraceWithExceptions(req *http.Request) bool {
+	// Paths that don't need tracing spans applied to them because of the
+	// little value that would provide us
+	if strings.HasPrefix(req.URL.Path, "/public/") ||
 		req.URL.Path == "/robots.txt" ||
 		req.URL.Path == "/favicon.ico" ||
-		req.URL.Path == "/api/health"
+		req.URL.Path == "/api/health" {
+		return false
+	}
+
+	return true
 }
 
-func TraceAllPaths(req *http.Request) bool {
+func ShouldTraceAllPaths(req *http.Request) bool {
 	return true
 }
 

--- a/pkg/services/frontend/frontend_service.go
+++ b/pkg/services/frontend/frontend_service.go
@@ -134,7 +134,7 @@ func (s *frontendService) addMiddlewares(m *web.Mux) {
 	loggermiddleware := loggermw.Provide(s.cfg, s.features)
 
 	m.Use(requestmeta.SetupRequestMetadata())
-	m.Use(middleware.RequestTracing(s.tracer, middleware.TraceAllPaths))
+	m.Use(middleware.RequestTracing(s.tracer, middleware.ShouldTraceAllPaths))
 	m.Use(middleware.RequestMetrics(s.features, s.cfg, s.promRegister))
 
 	m.UseMiddleware(s.contextMiddleware())


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/113878.

### What changed?
Updates the `ShouldTraceWithExceptions` function to return `false` when the path should be skipped from tracing, and `true` if it should be traced.