### PR TITLE
Provisioning: delegate authorization to access checker in dualwriter

### DIFF
--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -643,7 +643,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
-		resp.Body.Close()
+		require.NoError(t, resp.Body.Close())
 	}
 
 	// Grant view permission to viewer and editor roles, and edit permission to editor role

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1,7 +1,9 @@
 package provisioning
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -588,5 +590,380 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 		dashboard2, err := helper.DashboardsV1.Resource.Get(ctx, timelineUID, metav1.GetOptions{})
 		require.NoError(t, err, "repo2's dashboard should still exist")
 		require.Equal(t, repo2, dashboard2.GetAnnotations()[utils.AnnoKeyManagerIdentity], "repo2's dashboard should still be owned by repo2")
+	})
+}
+
+func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := runGrafana(t)
+	ctx := context.Background()
+
+	const repo = "auth-test-repo"
+	helper.CreateRepo(t, TestRepo{
+		Name:   repo,
+		Path:   helper.ProvisioningPath,
+		Target: "instance",
+		Copies: map[string]string{
+			"testdata/all-panels.json": "dashboard1.json",
+		},
+		ExpectedDashboards: 1,
+		ExpectedFolders:    0,
+	})
+
+	// Wait for initial sync to complete
+	var dashboardUID string
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+		if err != nil {
+			collect.Errorf("could not list dashboards error: %s", err.Error())
+			return
+		}
+		if len(dashboards.Items) != 1 {
+			collect.Errorf("should have the expected dashboards after sync. got: %d. expected: %d", len(dashboards.Items), 1)
+			return
+		}
+		assert.Len(collect, dashboards.Items, 1)
+		dashboardUID = dashboards.Items[0].GetName()
+	}, waitTimeoutDefault, waitIntervalDefault, "should have the expected dashboards after sync")
+
+	// Grant permissions to test users for the dashboard
+	// The access checker checks resource-level permissions, so we need to grant them
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+	setDashboardPermissions := func(permissions []map[string]interface{}) {
+		payload := map[string]interface{}{
+			"items": permissions,
+		}
+		payloadBytes, err := json.Marshal(payload)
+		require.NoError(t, err)
+		url := fmt.Sprintf("http://admin:admin@%s/api/dashboards/uid/%s/permissions", addr, dashboardUID)
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(payloadBytes))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		resp.Body.Close()
+	}
+
+	// Grant view permission to viewer and editor roles, and edit permission to editor role
+	setDashboardPermissions([]map[string]interface{}{
+		{"role": "Viewer", "permission": 1}, // View permission
+		{"role": "Editor", "permission": 2},  // Edit permission
+	})
+
+	t.Run("GET operations", func(t *testing.T) {
+		t.Run("viewer can GET files", func(t *testing.T) {
+			var statusCode int
+			result := helper.ViewerREST.Get().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "dashboard1.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "viewer should be able to GET files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+		})
+
+		t.Run("editor can GET files", func(t *testing.T) {
+			var statusCode int
+			result := helper.EditorREST.Get().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "dashboard1.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "editor should be able to GET files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+		})
+
+		t.Run("admin can GET files", func(t *testing.T) {
+			var statusCode int
+			result := helper.AdminREST.Get().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "dashboard1.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "admin should be able to GET files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+		})
+	})
+
+	t.Run("POST operations", func(t *testing.T) {
+		t.Run("viewer cannot POST files", func(t *testing.T) {
+			var statusCode int
+			result := helper.ViewerREST.Post().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "viewer-test.json").
+				Body(helper.LoadFile("testdata/text-options.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.Error(t, result.Error(), "viewer should not be able to POST files")
+			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+			require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+		})
+
+		t.Run("editor can POST files", func(t *testing.T) {
+			var statusCode int
+			result := helper.EditorREST.Post().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "editor-test.json").
+				Body(helper.LoadFile("testdata/text-options.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "editor should be able to POST files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+
+			// Clean up
+			helper.AdminREST.Delete().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "editor-test.json").
+				Do(ctx)
+		})
+
+		t.Run("admin can POST files", func(t *testing.T) {
+			var statusCode int
+			result := helper.AdminREST.Post().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "admin-test.json").
+				Body(helper.LoadFile("testdata/text-options.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "admin should be able to POST files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+
+			// Clean up
+			helper.AdminREST.Delete().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "admin-test.json").
+				Do(ctx)
+		})
+	})
+
+	t.Run("PUT operations", func(t *testing.T) {
+		// Create a test file first using admin
+		helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "update-test.json").
+			Body(helper.LoadFile("testdata/text-options.json")).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		t.Run("viewer cannot PUT files", func(t *testing.T) {
+			var statusCode int
+			result := helper.ViewerREST.Put().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "update-test.json").
+				Body(helper.LoadFile("testdata/timeline-demo.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.Error(t, result.Error(), "viewer should not be able to PUT files")
+			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+			require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+		})
+
+		t.Run("editor can PUT files", func(t *testing.T) {
+			var statusCode int
+			result := helper.EditorREST.Put().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "update-test.json").
+				Body(helper.LoadFile("testdata/timeline-demo.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "editor should be able to PUT files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+		})
+
+		t.Run("admin can PUT files", func(t *testing.T) {
+			var statusCode int
+			result := helper.AdminREST.Put().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "update-test.json").
+				Body(helper.LoadFile("testdata/text-options.json")).
+				SetHeader("Content-Type", "application/json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "admin should be able to PUT files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+		})
+
+		// Clean up
+		helper.AdminREST.Delete().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "update-test.json").
+			Do(ctx)
+	})
+
+	t.Run("DELETE operations", func(t *testing.T) {
+		// Create test files for deletion tests
+		helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "delete-viewer-test.json").
+			Body(helper.LoadFile("testdata/text-options.json")).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "delete-editor-test.json").
+			Body(helper.LoadFile("testdata/text-options.json")).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("files", "delete-admin-test.json").
+			Body(helper.LoadFile("testdata/text-options.json")).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		t.Run("viewer cannot DELETE files", func(t *testing.T) {
+			var statusCode int
+			result := helper.ViewerREST.Delete().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "delete-viewer-test.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.Error(t, result.Error(), "viewer should not be able to DELETE files")
+			require.Equal(t, http.StatusForbidden, statusCode, "should return 403 Forbidden")
+			require.True(t, apierrors.IsForbidden(result.Error()), "error should be forbidden")
+
+			// Verify file still exists
+			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-viewer-test.json")
+			require.NoError(t, err, "file should still exist after failed delete")
+		})
+
+		t.Run("editor can DELETE files", func(t *testing.T) {
+			var statusCode int
+			result := helper.EditorREST.Delete().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "delete-editor-test.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "editor should be able to DELETE files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+
+			// Verify file was deleted
+			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-editor-test.json")
+			require.Error(t, err, "file should be deleted")
+			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
+		})
+
+		t.Run("admin can DELETE files", func(t *testing.T) {
+			var statusCode int
+			result := helper.AdminREST.Delete().
+				Namespace("default").
+				Resource("repositories").
+				Name(repo).
+				SubResource("files", "delete-admin-test.json").
+				Do(ctx).StatusCode(&statusCode)
+
+			require.NoError(t, result.Error(), "admin should be able to DELETE files")
+			require.Equal(t, http.StatusOK, statusCode, "should return 200 OK")
+
+			// Verify file was deleted
+			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "delete-admin-test.json")
+			require.Error(t, err, "file should be deleted")
+			require.True(t, apierrors.IsNotFound(err), "should return NotFound for deleted file")
+		})
+	})
+
+	t.Run("folder operations", func(t *testing.T) {
+		t.Run("viewer cannot create folders", func(t *testing.T) {
+			// Create a folder by POSTing to a directory path
+			addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+			url := fmt.Sprintf("http://viewer:viewer@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/test-folder/", addr, repo)
+			req, err := http.NewRequest(http.MethodPost, url, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusForbidden, resp.StatusCode, "viewer should not be able to create folders")
+		})
+
+		t.Run("editor can create folders", func(t *testing.T) {
+			addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+			url := fmt.Sprintf("http://editor:editor@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/editor-folder/", addr, repo)
+			req, err := http.NewRequest(http.MethodPost, url, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "editor should be able to create folders")
+
+			// Clean up - delete folder
+			deleteURL := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/editor-folder/", addr, repo)
+			deleteReq, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+			require.NoError(t, err)
+			deleteResp, err := http.DefaultClient.Do(deleteReq)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer deleteResp.Body.Close()
+		})
+
+		t.Run("admin can create folders", func(t *testing.T) {
+			addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+			url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/admin-folder/", addr, repo)
+			req, err := http.NewRequest(http.MethodPost, url, nil)
+			require.NoError(t, err)
+			resp, err := http.DefaultClient.Do(req)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer resp.Body.Close()
+
+			require.Equal(t, http.StatusOK, resp.StatusCode, "admin should be able to create folders")
+
+			// Clean up - delete folder
+			deleteURL := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/admin-folder/", addr, repo)
+			deleteReq, err := http.NewRequest(http.MethodDelete, deleteURL, nil)
+			require.NoError(t, err)
+			deleteResp, err := http.DefaultClient.Do(deleteReq)
+			require.NoError(t, err)
+			// nolint:errcheck
+			defer deleteResp.Body.Close()
+		})
 	})
 }

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -649,7 +649,7 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 	// Grant view permission to viewer and editor roles, and edit permission to editor role
 	setDashboardPermissions([]map[string]interface{}{
 		{"role": "Viewer", "permission": 1}, // View permission
-		{"role": "Editor", "permission": 2},  // Edit permission
+		{"role": "Editor", "permission": 2}, // Edit permission
 	})
 
 	t.Run("GET operations", func(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR refactors the authorization logic in `dualwriter.go` to delegate all authorization checks to the access checker, removing role-based authorization checks that bypassed resource-level permissions.

To avoid the following error in multi-tenant: 

<img width="1005" height="731" alt="image" src="https://github.com/user-attachments/assets/8a27ddb0-ad02-45f7-9ccc-f598c2039cdb" />




## Changes

- **Removed role-based authorization checks**: 
  - Removed `authlib.ParseTypeID` and `id.GetOrgRole().Includes(identity.RoleEditor)` checks from `authorize` function
  - Removed fallback logic that allowed editors/admins based on organization role
  - All authorization now goes through the access checker which checks resource-level permissions

- **Updated `authorizeCreateFolder`**:
  - Changed from simple role-based check (`id.GetOrgRole().Includes(identity.RoleEditor)`) to using the access checker
  - Now determines parent folder from path and checks permissions using `access.Check` with proper folder context

- **Added comprehensive authorization tests**:
  - Tests for viewer, editor, and admin roles covering GET, POST, PUT, DELETE operations
  - Tests for folder creation permissions
  - Uses wildcard permissions via `SetPermissions` to ensure all dashboards created during tests have proper permissions


## Testing

All integration tests pass:
- `TestIntegrationProvisioning_FilesAuthorization` ✓ (covers viewer, editor, admin roles)
- `TestIntegrationProvisioning_PullJobOwnershipProtection` ✓
- All other provisioning integration tests ✓


## Fixes

Fixes https://github.com/grafana/git-ui-sync-project/issues/668