### PR TITLE
grafana/schema: Expose v0 and v2beta1 dashboard schemas

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -67,6 +67,8 @@ module.exports = {
     // near-membrane-dom won't work in a nodejs environment.
     '@locker/near-membrane-dom': '<rootDir>/public/test/mocks/nearMembraneDom.ts',
     '^@grafana/schema/dist/esm/(.*)$': '<rootDir>/packages/grafana-schema/src/$1',
+    '^@grafana/schema/dashboard/v0$': '<rootDir>/packages/grafana-schema/src/schema/dashboard/v0/index',
+    '^@grafana/schema/dashboard/v2beta1$': '<rootDir>/packages/grafana-schema/src/schema/dashboard/v2beta1/index',
     // prevent systemjs amd extra from breaking tests.
     'systemjs/dist/extras/amd': '<rootDir>/public/test/mocks/systemjsAMDExtra.ts',
     '@bsull/augurs': '<rootDir>/public/test/mocks/augurs.ts',

--- a/packages/grafana-schema/rollup.config.ts
+++ b/packages/grafana-schema/rollup.config.ts
@@ -48,4 +48,44 @@ export default [
     },
     treeshake: false,
   },
+  // Build sub-path exports for dashboard v0
+  {
+    input: {
+      'schema/dashboard/v0': fileURLToPath(new URL('src/schema/dashboard/v0/index.ts', import.meta.url)),
+    },
+    plugins: [noderesolve, esbuild],
+    output: [
+      {
+        format: 'esm',
+        dir: path.dirname(pkg.publishConfig.module),
+        entryFileNames: '[name].mjs',
+      },
+      {
+        format: 'cjs',
+        dir: path.dirname(pkg.publishConfig.main),
+        entryFileNames: '[name].cjs',
+      },
+    ],
+    treeshake: false,
+  },
+  // Build sub-path exports for dashboard v2beta1
+  {
+    input: {
+      'schema/dashboard/v2beta1': fileURLToPath(new URL('src/schema/dashboard/v2beta1/index.ts', import.meta.url)),
+    },
+    plugins: [noderesolve, esbuild],
+    output: [
+      {
+        format: 'esm',
+        dir: path.dirname(pkg.publishConfig.module),
+        entryFileNames: '[name].mjs',
+      },
+      {
+        format: 'cjs',
+        dir: path.dirname(pkg.publishConfig.main),
+        entryFileNames: '[name].cjs',
+      },
+    ],
+    treeshake: false,
+  },
 ];

--- a/packages/grafana-schema/src/schema/dashboard/v0/index.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v0/index.ts
@@ -1,0 +1,3 @@
+// Re-export raw dashboard types for v0 (legacy) dashboard schema
+// This allows imports like: import { AnnotationPanelFilter, DashboardLink } from '@grafana/schema/dashboard/v0'
+export * from '../../../raw/dashboard/x/dashboard_types.gen';

--- a/packages/grafana-schema/src/schema/dashboard/v2beta1/index.ts
+++ b/packages/grafana-schema/src/schema/dashboard/v2beta1/index.ts
@@ -1,0 +1,4 @@
+// Re-export all types and values from types.spec.gen and types.status.gen for sub-path imports
+// This allows imports like: import { Spec, Status } from '@grafana/schema/dashboard/v2beta1'
+export * from './types.spec.gen';
+export * from './types.status.gen';

--- a/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardPicker.tsx
@@ -7,7 +7,7 @@ import { FixedSizeList } from 'react-window';
 
 import { GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import {
   Alert,
   Button,

--- a/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/useDashboardQuery.ts
@@ -1,7 +1,7 @@
 import memoizeOne from 'memoize-one';
 import { useEffect, useState } from 'react';
 
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { isDashboardV2Resource } from 'app/features/dashboard/api/utils';

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -7,7 +7,7 @@ import { AppEvents, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { isProvisionedFolderCheck } from 'app/api/clients/folder/v1beta1/utils';
 import { appEvents } from 'app/core/app_events';
 import { setStarred } from 'app/core/reducers/navBarTree';

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingData.tsx
@@ -11,7 +11,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { ConditionalRenderingDataKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { ConditionalRenderingDataKind } from '@grafana/schema/dashboard/v2beta1';
 import { Combobox, ComboboxOption } from '@grafana/ui';
 
 import { dashboardEditActions } from '../../edit-pane/shared';

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingTimeRangeSize.tsx
@@ -3,7 +3,7 @@ import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
 import { rangeUtil, SelectableValue } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectState } from '@grafana/scenes';
-import { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { ConditionalRenderingTimeRangeSizeKind } from '@grafana/schema/dashboard/v2beta1';
 import { Field, Select } from '@grafana/ui';
 
 import { dashboardEditActions } from '../../edit-pane/shared';

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/ConditionalRenderingVariable.tsx
@@ -8,10 +8,10 @@ import {
   SceneObjectState,
   VariableDependencyConfig,
 } from '@grafana/scenes';
-import {
+import type {
   ConditionalRenderingVariableKind,
   ConditionalRenderingVariableSpec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 import { Box, Combobox, ComboboxOption, Field, Input, Stack } from '@grafana/ui';
 
 import { dashboardEditActions } from '../../edit-pane/shared';

--- a/public/app/features/dashboard-scene/conditional-rendering/conditions/serializers.ts
+++ b/public/app/features/dashboard-scene/conditional-rendering/conditions/serializers.ts
@@ -1,9 +1,9 @@
 import { Registry, RegistryItem } from '@grafana/data';
-import {
+import type {
   ConditionalRenderingDataKind,
   ConditionalRenderingTimeRangeSizeKind,
   ConditionalRenderingVariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 import { ConditionalRenderingData } from './ConditionalRenderingData';
 import { ConditionalRenderingTimeRangeSize } from './ConditionalRenderingTimeRangeSize';

--- a/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
+++ b/public/app/features/dashboard-scene/conditional-rendering/group/ConditionalRenderingGroup.tsx
@@ -10,7 +10,7 @@ import {
   SceneObjectRef,
   SceneObjectState,
 } from '@grafana/scenes';
-import { ConditionalRenderingGroupKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { ConditionalRenderingGroupKind } from '@grafana/schema/dashboard/v2beta1';
 import { Stack } from '@grafana/ui';
 
 import { ConditionalRenderingChangedEvent, dashboardEditActions } from '../../edit-pane/shared';

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -2,7 +2,7 @@ import { locationUtil, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getBackendSrv, getDataSourceSrv, isFetchError, locationService } from '@grafana/runtime';
 import { sceneGraph } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { GetRepositoryFilesWithPathApiResponse, provisioningAPIv0alpha1 } from 'app/api/clients/provisioning/v0alpha1';
 import { StateManagerBase } from 'app/core/services/StateManagerBase';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
+++ b/public/app/features/dashboard-scene/saving/DashboardPrompt.tsx
@@ -5,7 +5,7 @@ import { memo, useContext, useEffect, useMemo } from 'react';
 import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { ModalsContext, Modal, Button, useStyles2 } from '@grafana/ui';
 import { Prompt } from 'app/core/components/FormPrompt/Prompt';
 import { contextSrv } from 'app/core/services/context_srv';

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -2,13 +2,13 @@
 
 import type { AdHocVariableModel, TextBoxVariableModel, TypedVariableModel } from '@grafana/data';
 import { Dashboard, Panel, VariableOption } from '@grafana/schema';
-import {
+import type {
   AdHocFilterWithLabels,
   AdhocVariableSpec,
   Spec as DashboardV2Spec,
   TextVariableSpec,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 import { ResponseTransformers } from 'app/features/dashboard/api/ResponseTransformers';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard-scene/saving/shared.tsx
+++ b/public/app/features/dashboard-scene/saving/shared.tsx
@@ -4,7 +4,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, isFetchError } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { Alert, Box, Button, Stack } from '@grafana/ui';
 
 import { Diffs } from '../settings/version-history/utils';

--- a/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
+++ b/public/app/features/dashboard-scene/saving/useSaveDashboard.ts
@@ -4,7 +4,7 @@ import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { appEvents } from 'app/core/app_events';
 import { useAppNotification } from 'app/core/copy/appNotification';
 import { updateDashboardName } from 'app/core/reducers/navBarTree';

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -16,7 +16,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { Dashboard, DashboardLink, LibraryPanel } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { appEvents } from 'app/core/app_events';
 import { ScrollRefElement } from 'app/core/components/NativeScrollbar';
 import { LS_PANEL_COPY_KEY } from 'app/core/constants';

--- a/public/app/features/dashboard-scene/scene/export/exporters.ts
+++ b/public/app/features/dashboard-scene/scene/export/exporters.ts
@@ -3,15 +3,15 @@ import { defaults, each, sortBy } from 'lodash';
 import { DataSourceRef, PanelPluginMeta, VariableOption, VariableRefresh } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { Panel } from '@grafana/schema';
-import {
-  Spec as DashboardV2Spec,
+import type {
   PanelKind,
   PanelQueryKind,
   AnnotationQueryKind,
   QueryVariableKind,
   LibraryPanelRef,
   LibraryPanelKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+  Spec as DashboardV2Spec,
+} from '@grafana/schema/dashboard/v2beta1';
 import { notifyApp } from 'app/core/actions';
 import config from 'app/core/config';
 import { createErrorNotification } from 'app/core/copy/appNotification';

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -8,7 +8,7 @@ import {
   VizPanel,
   SceneGridItemLike,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { GRID_CELL_VMARGIN } from 'app/core/constants';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -17,7 +17,7 @@ import {
   SceneGridLayoutDragStartEvent,
   SceneObject,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { useStyles2 } from '@grafana/ui';
 import { GRID_COLUMN_COUNT } from 'app/core/constants';
 import DashboardEmpty from 'app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmpty';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -11,7 +11,7 @@ import {
   SceneGridItemLike,
   SceneGridLayout,
 } from '@grafana/scenes';
-import { RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { RowsLayoutRowKind } from '@grafana/schema/dashboard/v2beta1';
 import { appEvents } from 'app/core/app_events';
 import { LS_ROW_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -8,7 +8,7 @@ import {
   SceneObjectState,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeRowsLayout } from '../../serialization/layoutSerializers/RowsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -11,7 +11,7 @@ import {
   SceneGridItemLike,
   SceneGridLayout,
 } from '@grafana/scenes';
-import { TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { TabsLayoutTabKind } from '@grafana/schema/dashboard/v2beta1';
 import { appEvents } from 'app/core/app_events';
 import { LS_TAB_COPY_KEY } from 'app/core/constants';
 import store from 'app/core/store';

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -8,7 +8,7 @@ import {
   SceneObjectUrlValues,
   VizPanel,
 } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 
 import { dashboardEditActions, ObjectsReorderedOnCanvasEvent } from '../../edit-pane/shared';
 import { serializeTabsLayout } from '../../serialization/layoutSerializers/TabsLayoutSerializer';

--- a/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
+++ b/public/app/features/dashboard-scene/scene/types/DashboardLayoutManager.ts
@@ -1,5 +1,5 @@
 import { SceneObject, VizPanel } from '@grafana/scenes';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
 
 import { LayoutRegistryItem } from './LayoutRegistryItem';

--- a/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/DashboardSceneSerializer.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { AnnoKeyDashboardSnapshotOriginalUrl, ObjectMeta } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';

--- a/public/app/features/dashboard-scene/serialization/annotations.ts
+++ b/public/app/features/dashboard-scene/serialization/annotations.ts
@@ -1,9 +1,9 @@
 import { AnnotationQuery } from '@grafana/data';
 import {
-  AnnotationQueryKind,
+  type AnnotationQueryKind,
   defaultAnnotationQuerySpec,
   defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 import { getRuntimePanelDataSource } from './layoutSerializers/utils';
 

--- a/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
+++ b/public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts
@@ -2,14 +2,14 @@ import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { VariableModel, defaultDashboard } from '@grafana/schema';
 import {
-  AdhocVariableKind,
+  type AdhocVariableKind,
+  type GroupByVariableKind,
+  type Spec as DashboardV2Spec,
   defaultAdhocVariableSpec,
   defaultSpec as defaultDashboardV2Spec,
   defaultGroupByVariableSpec,
   defaultTimeSettingsSpec,
-  GroupByVariableKind,
-  Spec as DashboardV2Spec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
 import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
 import { getDatasourceSrv } from 'app/features/plugins/datasource_srv';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/AutoGridLayoutSerializer.ts
@@ -1,8 +1,8 @@
 import {
-  Spec as DashboardV2Spec,
+  type AutoGridLayoutItemKind,
+  type Spec as DashboardV2Spec,
   defaultAutoGridLayoutSpec,
-  AutoGridLayoutItemKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayout } from '../../scene/layout-auto-grid/AutoGridLayout';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/DefaultGridLayoutSerializer.ts
@@ -1,6 +1,5 @@
 import { SceneGridItemLike, SceneGridLayout, VizPanel } from '@grafana/scenes';
-import {
-  Spec as DashboardV2Spec,
+import type {
   GridLayoutItemKind,
   GridLayoutKind,
   RepeatOptions,
@@ -8,7 +7,8 @@ import {
   GridLayoutItemSpec,
   PanelKind,
   LibraryPanelKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+  Spec as DashboardV2Spec,
+} from '@grafana/schema/dashboard/v2beta1';
 
 import { DashboardGridItem } from '../../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/RowsLayoutSerializer.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec, RowsLayoutRowKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { RowsLayoutRowKind, Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 
 import { RowItem } from '../../scene/layout-rows/RowItem';
 import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/TabsLayoutSerializer.ts
@@ -1,4 +1,4 @@
-import { Spec as DashboardV2Spec, TabsLayoutTabKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { TabsLayoutTabKind, Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 
 import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../../scene/layout-tabs/TabsLayoutManager';

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/layoutSerializerRegistry.ts
@@ -1,5 +1,5 @@
 import { Registry, RegistryItem } from '@grafana/data';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 
 import { DashboardLayoutManager } from '../../scene/types/DashboardLayoutManager';
 

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -9,19 +9,19 @@ import {
   VizPanelMenu,
   VizPanelState,
 } from '@grafana/scenes';
-import { DataSourceRef } from '@grafana/schema/dist/esm/index.gen';
 import {
-  Spec as DashboardV2Spec,
-  AutoGridLayoutItemKind,
-  RowsLayoutRowKind,
-  LibraryPanelKind,
-  PanelKind,
-  PanelQueryKind,
-  QueryVariableKind,
-  TabsLayoutTabKind,
-  DataQueryKind,
+  type Spec as DashboardV2Spec,
+  type AutoGridLayoutItemKind,
+  type RowsLayoutRowKind,
+  type LibraryPanelKind,
+  type PanelKind,
+  type PanelQueryKind,
+  type QueryVariableKind,
+  type TabsLayoutTabKind,
+  type DataQueryKind,
   defaultPanelQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
+import { DataSourceRef } from '@grafana/schema/dist/esm/index.gen';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -13,22 +13,22 @@ import {
   VariableSort as OldVariableSort,
 } from '@grafana/schema';
 import {
-  AdhocVariableKind,
-  ConstantVariableKind,
-  CustomVariableKind,
-  DataQueryKind,
-  DatasourceVariableKind,
-  IntervalVariableKind,
-  QueryVariableKind,
-  TextVariableKind,
-  GroupByVariableKind,
+  type AdhocVariableKind,
+  type ConstantVariableKind,
+  type CustomVariableKind,
+  type DataQueryKind,
+  type DatasourceVariableKind,
+  type IntervalVariableKind,
+  type QueryVariableKind,
+  type TextVariableKind,
+  type GroupByVariableKind,
+  type VariableOption,
+  type AdHocFilterWithLabels,
+  type SwitchVariableKind,
   defaultVariableHide,
-  VariableOption,
   defaultDataQueryKind,
-  AdHocFilterWithLabels,
-  SwitchVariableKind,
   defaultIntervalVariableSpec,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 import { getDefaultDatasource } from 'app/features/dashboard/api/ResponseTransformers';
 
 import { getIntervalsQueryFromNewIntervalModel } from '../utils/utils';

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -20,11 +20,19 @@ import {
   TextBoxVariable,
 } from '@grafana/scenes';
 import {
-  AdhocVariableKind,
-  ConstantVariableKind,
-  CustomVariableKind,
-  Spec as DashboardV2Spec,
-  DatasourceVariableKind,
+  type AdhocVariableKind,
+  type ConstantVariableKind,
+  type CustomVariableKind,
+  type Spec as DashboardV2Spec,
+  type DatasourceVariableKind,
+  type GroupByVariableKind,
+  type IntervalVariableKind,
+  type LibraryPanelKind,
+  type PanelKind,
+  type QueryVariableKind,
+  type SwitchVariableKind,
+  type TextVariableKind,
+  type AnnotationQueryKind,
   defaultAdhocVariableKind,
   defaultConstantVariableKind,
   defaultCustomVariableKind,
@@ -35,16 +43,8 @@ import {
   defaultTextVariableKind,
   defaultSwitchVariableKind,
   defaultTimeSettingsSpec,
-  GroupByVariableKind,
-  IntervalVariableKind,
-  LibraryPanelKind,
-  PanelKind,
-  QueryVariableKind,
-  SwitchVariableKind,
-  TextVariableKind,
   defaultDataQueryKind,
-  AnnotationQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import {
   AnnoKeyCreatedBy,

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -14,41 +14,41 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 import { DataSourceRef, VariableRefresh } from '@grafana/schema';
-import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
-
 import {
-  Spec as DashboardV2Spec,
+  type Spec as DashboardV2Spec,
+  type PanelKind,
+  type PanelQueryKind,
+  type TransformationKind,
+  type FieldConfigSource,
+  type DataTransformerConfig,
+  type PanelQuerySpec,
+  type DataQueryKind,
+  type QueryOptionsSpec,
+  type QueryVariableKind,
+  type TextVariableKind,
+  type IntervalVariableKind,
+  type DatasourceVariableKind,
+  type CustomVariableKind,
+  type ConstantVariableKind,
+  type GroupByVariableKind,
+  type AdhocVariableKind,
+  type AnnotationQueryKind,
+  type DataLink,
+  type LibraryPanelKind,
+  type Element,
+  type DashboardCursorSync,
+  type FieldColor,
+  type SwitchVariableKind,
   defaultSpec as defaultDashboardV2Spec,
   defaultFieldConfigSource,
-  PanelKind,
-  PanelQueryKind,
-  TransformationKind,
-  FieldConfigSource,
-  DataTransformerConfig,
-  PanelQuerySpec,
-  DataQueryKind,
-  QueryOptionsSpec,
-  QueryVariableKind,
-  TextVariableKind,
-  IntervalVariableKind,
-  DatasourceVariableKind,
-  CustomVariableKind,
-  ConstantVariableKind,
-  GroupByVariableKind,
-  AdhocVariableKind,
-  AnnotationQueryKind,
-  DataLink,
-  LibraryPanelKind,
-  Element,
-  DashboardCursorSync,
-  FieldColor,
   defaultFieldConfig,
   defaultDataQueryKind,
-  SwitchVariableKind,
   defaultTimeSettingsSpec,
   defaultDashboardLinkType,
   defaultDashboardLink,
-} from '../../../../../packages/grafana-schema/src/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
+import { sortedDeepCloneWithoutNulls } from 'app/core/utils/object';
+
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene, DashboardSceneState } from '../scene/DashboardScene';
 import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';

--- a/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV1TypesUtils.ts
@@ -7,7 +7,7 @@ import {
   MappingType as MappingTypeV1,
   ThresholdsMode as ThresholdsModeV1,
 } from '@grafana/schema';
-import {
+import type {
   DashboardCursorSync,
   VariableHide,
   VariableRefresh,
@@ -15,7 +15,7 @@ import {
   FieldConfigSource,
   SpecialValueMatch,
   ThresholdsMode,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 export function transformVariableRefreshToEnumV1(refresh?: VariableRefresh): VariableRefreshV1 {
   switch (refresh) {

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -6,18 +6,18 @@ import {
   FieldColorModeId as FieldColorModeIdV1,
   DataTopic,
 } from '@grafana/schema';
-import { DataTransformerConfig } from '@grafana/schema/dist/esm/raw/dashboard/x/dashboard_types.gen';
 import {
-  DashboardCursorSync,
+  type DashboardCursorSync,
+  type VariableHide,
+  type VariableRefresh,
+  type VariableSort,
+  type FieldColorModeId as FieldColorModeIdV2,
   defaultSpec as defaultDashboardV2Spec,
   defaultVariableHide,
   defaultVariableRefresh,
   defaultVariableSort,
-  VariableHide,
-  VariableRefresh,
-  VariableSort,
-  FieldColorModeId as FieldColorModeIdV2,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
+import { DataTransformerConfig } from '@grafana/schema/dist/esm/raw/dashboard/x/dashboard_types.gen';
 
 // used for QueryVariableKind's query prop - in schema V2 we've deprecated string type and support only DataQuery
 export const LEGACY_STRING_VALUE_KEY = '__legacyStringValue';

--- a/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/JsonModelEditView.tsx
@@ -5,7 +5,7 @@ import { GrafanaTheme2, PageLayoutType } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { SceneComponentProps, SceneObjectBase, sceneUtils } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { Alert, Box, Button, CodeEditor, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';

--- a/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard-scene/settings/annotations/AnnotationSettingsEdit.tsx
@@ -14,7 +14,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
-import { AnnotationPanelFilter } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
+import { AnnotationPanelFilter } from '@grafana/schema/dashboard/v0';
 import {
   Button,
   Checkbox,

--- a/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/ResourceExport.tsx
@@ -3,7 +3,7 @@ import { AsyncState } from 'react-use/lib/useAsync';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { Alert, Label, RadioButtonGroup, Stack, Switch } from '@grafana/ui';
 import { DashboardJson } from 'app/features/manage-dashboards/types';
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -8,7 +8,7 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { SceneComponentProps, SceneObjectBase } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { Button, ClipboardButton, CodeEditor, Field, Modal, Stack, Switch } from '@grafana/ui';
 import { ObjectMeta } from 'app/features/apiserver/types';
 import { transformDashboardV2SpecToV1 } from 'app/features/dashboard/api/ResponseTransformers';

--- a/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareSnapshotTab.tsx
@@ -5,6 +5,7 @@ import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { SceneComponentProps, sceneGraph, SceneObjectBase, SceneObjectRef, VizPanel } from '@grafana/scenes';
 import { Dashboard } from '@grafana/schema';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { Button, ClipboardButton, Field, Input, Modal, RadioButtonGroup, Stack } from '@grafana/ui';
 import { notifyApp } from 'app/core/actions';
 import { createSuccessNotification } from 'app/core/copy/appNotification';
@@ -12,7 +13,6 @@ import { getTrackingSource, shareDashboardType } from 'app/features/dashboard/co
 import { getDashboardSnapshotSrv, SnapshotSharingOptions } from 'app/features/dashboard/services/SnapshotSrv';
 import { dispatch } from 'app/store/store';
 
-import { Spec as DashboardV2Spec } from '../../../../../packages/grafana-schema/src/schema/dashboard/v2';
 import { DashboardScene } from '../scene/DashboardScene';
 import { transformSceneToSaveModel, trimDashboardForSnapshot } from '../serialization/transformSceneToSaveModel';
 import {

--- a/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
+++ b/public/app/features/dashboard-scene/v2schema/ImportDashboardOverviewV2.tsx
@@ -1,10 +1,6 @@
 import { locationUtil } from '@grafana/data';
 import { locationService, reportInteraction } from '@grafana/runtime';
-import {
-  AnnotationQueryKind,
-  Spec as DashboardV2Spec,
-  defaultDataQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { AnnotationQueryKind, Spec as DashboardV2Spec, defaultDataQueryKind } from '@grafana/schema/dashboard/v2beta1';
 import { Form } from 'app/core/components/Form/Form';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';

--- a/public/app/features/dashboard-scene/v2schema/validation.test.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.test.ts
@@ -3,7 +3,7 @@ import {
   defaultQueryGroupKind,
   defaultPanelQueryKind,
   defaultVizConfigKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 import { isPanelKindV2 } from './validation';
 

--- a/public/app/features/dashboard-scene/v2schema/validation.ts
+++ b/public/app/features/dashboard-scene/v2schema/validation.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   PanelKind,
   QueryGroupKind,
   VizConfigKind,
   PanelQueryKind,
   TransformationKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -13,13 +13,11 @@ import {
   MappingType as MappingTypeV1,
   SpecialValueMatch as SpecialValueMatchV1,
 } from '@grafana/schema';
+import { DashboardLink, DataTransformerConfig } from '@grafana/schema/dashboard/v0';
 import {
   AnnotationQueryKind,
-  Spec as DashboardV2Spec,
   DataLink,
   DatasourceVariableKind,
-  defaultSpec as defaultDashboardV2Spec,
-  defaultTimeSettingsSpec,
   PanelQueryKind,
   QueryVariableKind,
   TransformationKind,
@@ -37,15 +35,17 @@ import {
   LibraryPanelKind,
   PanelKind,
   GridLayoutItemKind,
-  defaultDataQueryKind,
   RowsLayoutRowKind,
   GridLayoutKind,
+  Spec as DashboardV2Spec,
+  defaultSpec as defaultDashboardV2Spec,
+  defaultTimeSettingsSpec,
+  defaultDataQueryKind,
   defaultDashboardLinkType,
   defaultDashboardLink,
   defaultFieldConfigSource,
   defaultPanelQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
-import { DashboardLink, DataTransformerConfig } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
+} from '@grafana/schema/dashboard/v2beta1';
 import { isWeekStart, WeekStart } from '@grafana/ui';
 import {
   AnnoKeyCreatedBy,

--- a/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
+++ b/public/app/features/dashboard/api/UnifiedDashboardAPI.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { isResource } from 'app/features/apiserver/guards';
 import { Resource, ResourceList } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard/api/dashboard_api.ts
+++ b/public/app/features/dashboard/api/dashboard_api.ts
@@ -1,5 +1,5 @@
 import { Dashboard } from '@grafana/schema';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { DashboardDTO } from 'app/types/dashboard';
 
 import { UnifiedDashboardAPI } from './UnifiedDashboardAPI';

--- a/public/app/features/dashboard/api/types.ts
+++ b/public/app/features/dashboard/api/types.ts
@@ -1,5 +1,5 @@
 import { UrlQueryMap } from '@grafana/data';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import type { Status } from '@grafana/schema/dashboard/v2beta1';
 import { ListOptions, Resource, ResourceList } from 'app/features/apiserver/types';
 import { DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
 import { AnnotationsPermissions, SaveDashboardResponseDTO } from 'app/types/dashboard';

--- a/public/app/features/dashboard/api/utils.ts
+++ b/public/app/features/dashboard/api/utils.ts
@@ -1,7 +1,6 @@
 import { config, locationService } from '@grafana/runtime';
-import { Dashboard } from '@grafana/schema/dist/esm/index.gen';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import { Dashboard } from '@grafana/schema';
+import type { Spec as DashboardV2Spec, Status } from '@grafana/schema/dashboard/v2beta1';
 import { Resource } from 'app/features/apiserver/types';
 import { DashboardDataDTO, DashboardDTO } from 'app/types/dashboard';
 

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -1,7 +1,7 @@
 import { locationUtil, UrlQueryMap } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Dashboard } from '@grafana/schema';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import type { Status } from '@grafana/schema/dashboard/v2beta1';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';
 import { ScopedResourceClient } from 'app/features/apiserver/client';

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -1,7 +1,6 @@
 import { locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec, Status } from '@grafana/schema/dashboard/v2beta1';
 import { getFolderByUidFacade } from 'app/api/clients/folder/v1beta1/hooks';
 import { getMessageFromError, getStatusFromError } from 'app/core/utils/errors';
 import { ScopedResourceClient } from 'app/features/apiserver/client';

--- a/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
+++ b/public/app/features/dashboard/components/AnnotationSettings/AnnotationSettingsEdit.tsx
@@ -13,7 +13,7 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { getDataSourceSrv, locationService } from '@grafana/runtime';
-import { AnnotationPanelFilter } from '@grafana/schema/src/raw/dashboard/x/dashboard_types.gen';
+import { AnnotationPanelFilter } from '@grafana/schema/dashboard/v0';
 import { Button, Checkbox, Field, FieldSet, Input, MultiSelect, Select, useStyles2, Stack, Alert } from '@grafana/ui';
 import { ColorValueEditor } from 'app/core/components/OptionsUI/color';
 import config from 'app/core/config';

--- a/public/app/features/dashboard/containers/PublicDashboardPage.test.tsx
+++ b/public/app/features/dashboard/containers/PublicDashboardPage.test.tsx
@@ -6,7 +6,7 @@ import { Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { render } from 'test/test-utils';
 
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors/src';
-import { Dashboard, DashboardCursorSync, FieldConfigSource, Panel, ThresholdsMode } from '@grafana/schema/src';
+import { Dashboard, DashboardCursorSync, FieldConfigSource, Panel, ThresholdsMode } from '@grafana/schema';
 import { getRouteComponentProps } from 'app/core/navigation/mocks/routeProps';
 import { DashboardInitPhase, DashboardMeta, DashboardRoutes } from 'app/types/dashboard';
 import { StoreState } from 'app/types/store';

--- a/public/app/features/dashboard/services/DashboardLoaderSrv.ts
+++ b/public/app/features/dashboard/services/DashboardLoaderSrv.ts
@@ -4,7 +4,7 @@ import moment from 'moment'; // eslint-disable-line no-restricted-imports
 
 import { AppEvents, dateMath, UrlQueryMap, UrlQueryValue } from '@grafana/data';
 import { getBackendSrv, isFetchError, locationService } from '@grafana/runtime';
-import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import type { Spec as DashboardV2Spec } from '@grafana/schema/dashboard/v2beta1';
 import { backendSrv } from 'app/core/services/backend_srv';
 import impressionSrv from 'app/core/services/impression_srv';
 import kbn from 'app/core/utils/kbn';

--- a/public/app/features/dashboard/utils/panelMerge.test.ts
+++ b/public/app/features/dashboard/utils/panelMerge.test.ts
@@ -1,5 +1,5 @@
 import { PanelModel } from '@grafana/data';
-import { FieldColorModeId, ThresholdsMode } from '@grafana/schema/src';
+import { FieldColorModeId, ThresholdsMode } from '@grafana/schema/dashboard/v0';
 
 import { DashboardModel } from '../state/DashboardModel';
 import { createDashboardModelFixture, createPanelSaveModel } from '../state/__fixtures__/dashboardFixtures';

--- a/public/app/features/dashboard/utils/tracking.ts
+++ b/public/app/features/dashboard/utils/tracking.ts
@@ -1,10 +1,10 @@
-import { VariableModel } from '@grafana/schema/dist/esm/index';
-import {
+import type {
   AdhocVariableKind,
   DatasourceVariableKind,
   QueryVariableKind,
   VariableKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+} from '@grafana/schema/dashboard/v2beta1';
+import { VariableModel } from '@grafana/schema/dist/esm/index';
 import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 import { DashboardModel } from '../state/DashboardModel';

--- a/public/app/features/manage-dashboards/state/actions.ts
+++ b/public/app/features/manage-dashboards/state/actions.ts
@@ -1,11 +1,11 @@
 import { DataSourceInstanceSettings } from '@grafana/data';
 import { getBackendSrv, getDataSourceSrv, isFetchError } from '@grafana/runtime';
-import {
-  Spec as DashboardV2Spec,
+import type {
   QueryVariableKind,
   PanelQueryKind,
   AnnotationQueryKind,
-} from '@grafana/schema/dist/esm/schema/dashboard/v2';
+  Spec as DashboardV2Spec,
+} from '@grafana/schema/dashboard/v2beta1';
 import { notifyApp } from 'app/core/actions';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { browseDashboardsAPI, ImportInputs } from 'app/features/browse-dashboards/api/browseDashboardsAPI';

--- a/public/app/features/manage-dashboards/types.ts
+++ b/public/app/features/manage-dashboards/types.ts
@@ -1,4 +1,4 @@
-import { Dashboard } from '@grafana/schema/src/veneer/dashboard.types';
+import { Dashboard } from '@grafana/schema';
 
 import { ExternalDashboard } from '../dashboard/components/DashExportModal/DashboardExporter';
 

--- a/scripts/prepare-npm-package.js
+++ b/scripts/prepare-npm-package.js
@@ -29,6 +29,46 @@ try {
       types: './dist/*',
       default: './dist/*',
     };
+    // Support @grafana/scenes that imports from dist/esm paths which webpack transforms to src paths
+    // (see webpack.common.js NormalModuleReplacementPlugin that replaces @grafana/schema/dist/esm with @grafana/schema/src)
+    exports['./src/*'] = {
+      types: './src/*',
+      default: './src/*',
+    };
+    // Add sub-path exports for dashboard v0
+    exports['./dashboard/v0'] = {
+      import: {
+        types: './dist/types/schema/dashboard/v0/index.d.ts',
+        default: './dist/esm/schema/dashboard/v0.mjs',
+      },
+      require: {
+        types: './dist/types/schema/dashboard/v0/index.d.ts',
+        default: './dist/cjs/schema/dashboard/v0.cjs',
+      },
+    };
+    // Add sub-path exports for dashboard v2beta1
+    exports['./dashboard/v2beta1'] = {
+      import: {
+        types: './dist/types/schema/dashboard/v2beta1/index.d.ts',
+        default: './dist/esm/schema/dashboard/v2beta1.mjs',
+      },
+      require: {
+        types: './dist/types/schema/dashboard/v2beta1/index.d.ts',
+        default: './dist/cjs/schema/dashboard/v2beta1.cjs',
+      },
+    };
+
+    // Add typesVersions for backwards compatibility with moduleResolution: "node"
+    // This allows TypeScript to resolve types for sub-path imports even without
+    // modern moduleResolution settings (bundler/node16/nodenext)
+    pkgJson.update({
+      typesVersions: {
+        '*': {
+          'dashboard/v0': ['./dist/types/schema/dashboard/v0/index.d.ts'],
+          'dashboard/v2beta1': ['./dist/types/schema/dashboard/v2beta1/index.d.ts'],
+        },
+      },
+    });
   }
 
   // Fix for @grafana/i18n so eslint-plugin can be imported by consumers

--- a/scripts/webpack/webpack.common.js
+++ b/scripts/webpack/webpack.common.js
@@ -65,6 +65,12 @@ module.exports = {
     new webpack.NormalModuleReplacementPlugin(/^@grafana\/schema\/dist\/esm\/(.*)$/, (resource) => {
       resource.request = resource.request.replace('@grafana/schema/dist/esm', '@grafana/schema/src');
     }),
+    new webpack.NormalModuleReplacementPlugin(/^@grafana\/schema\/dashboard\/v0$/, (resource) => {
+      resource.request = '@grafana/schema/src/schema/dashboard/v0/index';
+    }),
+    new webpack.NormalModuleReplacementPlugin(/^@grafana\/schema\/dashboard\/v2beta1$/, (resource) => {
+      resource.request = '@grafana/schema/src/schema/dashboard/v2beta1/index';
+    }),
     new CorsWorkerPlugin(),
     new webpack.ProvidePlugin({
       Buffer: ['buffer', 'Buffer'],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,9 @@
     "moduleResolution": "bundler",
     "tsBuildInfoFile": "./tsconfig.tsbuildinfo",
     "paths": {
-      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"]
+      "@grafana/schema/dist/esm/*": ["../packages/grafana-schema/src/*"],
+      "@grafana/schema/dashboard/v0": ["../packages/grafana-schema/src/schema/dashboard/v0/index"],
+      "@grafana/schema/dashboard/v2beta1": ["../packages/grafana-schema/src/schema/dashboard/v2beta1/index"]
     }
   },
   "ts-node": {


### PR DESCRIPTION
This PR exposes v0 (legacy dashboard JSON), and v2beta1 (schema v2) specs from @grafana/schema package under a namespaced import paths. Instead of allowing importing from @grafana/schema, it adds possibility to import respective models like:

```
import type { Spec } from '@grafana/schema/dashboard/v2beta1';
import type { Dashboard } from '@grafana/schema/dashboard/v0';
```

Mind the above are not aligned name-wise (Spec vs Dashboard) but i don't want to introduce k8s specific concepts (spec) int v0(legacy) models.

This work includes some changes to enable subpath imports, which I'm not super comfortable introducing, so i'd appreaciate @grafana/plugins-platform-frontend eyes on this work. Those include:
- rollup build configuration for separate sub-path bundles.
- package.json exports and typesVersions for proper module resolution
- webpack, TS, and jest configuration for development builds

I've tested grafana build - worked OK.
I've tested building packages and using them in create plugin templates, and it worked well. 


I guess we will also epxpose v1 versions, buit for now lets focus on what's imediately needed and asses the infrastructure for it.