### PR TITLE
Dropdown: Don't pass getFloatingProps to content function 

### DIFF
--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -111,7 +111,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
                 timeout={{ appear: animationDuration, exit: 0, enter: 0 }}
                 classNames={animationStyles}
               >
-                <div ref={transitionRef}>{renderOrCallToRender(overlay)}</div>
+                <div ref={transitionRef}>{renderOrCallToRender(overlay, {})}</div>
               </CSSTransition>
             </div>
           </FloatingFocusManager>

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -83,8 +83,6 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
     }
   };
 
-  console.log(getFloatingProps());
-
   return (
     <>
       {React.cloneElement(children, {
@@ -99,7 +97,13 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
               see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events
             */}
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-            <div ref={refs.setFloating} style={floatingStyles} onClick={onOverlayClicked} onKeyDown={handleKeys}>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              onClick={onOverlayClicked}
+              onKeyDown={handleKeys}
+              {...getFloatingProps()}
+            >
               <CSSTransition
                 nodeRef={transitionRef}
                 appear={true}
@@ -107,7 +111,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
                 timeout={{ appear: animationDuration, exit: 0, enter: 0 }}
                 classNames={animationStyles}
               >
-                <div ref={transitionRef}>{renderOrCallToRender(overlay, { ...getFloatingProps() })}</div>
+                <div ref={transitionRef}>{renderOrCallToRender(overlay)}</div>
               </CSSTransition>
             </div>
           </FloatingFocusManager>

--- a/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/grafana-ui/src/components/Dropdown/Dropdown.tsx
@@ -83,6 +83,8 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
     }
   };
 
+  console.log(getFloatingProps());
+
   return (
     <>
       {React.cloneElement(children, {
@@ -97,13 +99,7 @@ export const Dropdown = React.memo(({ children, overlay, placement, offset, root
               see https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-static-element-interactions.md#case-the-event-handler-is-only-being-used-to-capture-bubbled-events
             */}
             {/* eslint-disable-next-line jsx-a11y/no-static-element-interactions, jsx-a11y/click-events-have-key-events */}
-            <div
-              ref={refs.setFloating}
-              style={floatingStyles}
-              onClick={onOverlayClicked}
-              onKeyDown={handleKeys}
-              {...getFloatingProps()}
-            >
+            <div ref={refs.setFloating} style={floatingStyles} onClick={onOverlayClicked} onKeyDown={handleKeys}>
               <CSSTransition
                 nodeRef={transitionRef}
                 appear={true}


### PR DESCRIPTION
While investigating why Toggletip does support Select components (where you can select a value without it closing) but Dropdown did not I discovered the only difference is that for Dropdown we never set getFloatingProps on any div, we just pass it to content function (but so far not found a case where we actually use these props) 

So I think this change should probably remain, but opening this PR to discuss it 