### PR TITLE
E2E Selectors: Fix test title typo

### DIFF
--- a/packages/grafana-e2e-selectors/src/resolver.test.ts
+++ b/packages/grafana-e2e-selectors/src/resolver.test.ts
@@ -51,7 +51,7 @@ describe('Resolver', () => {
     expect(pages.Alerting.AddAlertRule.url).toBe('/alerting/new');
   });
 
-  it('should throw error if an invalid semver range is used in versioned selector', () => {
+  it('should throw an error if an invalid semver range is used in versioned selector', () => {
     expect(() =>
       resolveSelectors({
         Alerting: {


### PR DESCRIPTION
**What is this feature?**

This PR is fixing a typo in a test. 

**Why do we need this feature?**

This is a bit of a dummie change to test whether [this fix](https://github.com/grafana/grafana/pull/115218) solved the issue we're having with NPM dist-tags for the e2e-selectors package.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514