### PR TITLE
Docs: Add caution regarding storing images in `public/img` directory

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/canvas/index.md
@@ -119,8 +119,8 @@ You can add a custom icon by referencing an SVG file. To add a custom icon, foll
 
    {{< admonition type="caution" >}}
    Using the `public/img` directory as a server for custom images is not supported.
-   This type of usage was possible prior to Grafana v12.1, but it was never supported.
-   If you did this before Grafana v12.1, your image file paths will no longer work and you'll need to move your images to an accessible URL as indicated in this step.
+   It was possible to do so before Grafana v12.1.1, but this was not a supported behavior.
+   If you stored images at this directory prior to Grafana v12.1.1, those image paths will no longer function, and you'll need to move them an accessible URL.
    {{< /admonition >}}
 
 1. Click **Select**.
@@ -178,6 +178,12 @@ To upload a custom image, follow these steps:
 1. Enter the URL in the field below the **URL** tab.
 
    {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-canvas-custom-image-v11.3.png" max-width="250px" alt="Add a custom image URL" >}}
+
+   {{< admonition type="caution" >}}
+   Using the `public/img` directory as a server for custom images is not supported.
+   It was possible to do so before Grafana v12.1.1, but this was not a supported behavior.
+   If you stored images at this directory prior to Grafana v12.1.1, those image paths will no longer function, and you'll need to move them an accessible URL.
+   {{< /admonition >}}
 
 1. Click **Select**.
 

--- a/docs/sources/visualizations/panels-visualizations/visualizations/canvas/index.md
+++ b/docs/sources/visualizations/panels-visualizations/visualizations/canvas/index.md
@@ -117,6 +117,12 @@ You can add a custom icon by referencing an SVG file. To add a custom icon, foll
 
    {{< figure src="/media/docs/grafana/panels-visualizations/screenshot-canvas-custom-image-v11.3.png" max-width="250px" alt="Add a custom image URL" >}}
 
+   {{< admonition type="caution" >}}
+   Using the `public/img` directory as a server for custom images is not supported.
+   This type of usage was possible prior to Grafana v12.1, but it was never supported.
+   If you did this before Grafana v12.1, your image file paths will no longer work and you'll need to move your images to an accessible URL as indicated in this step.
+   {{< /admonition >}}
+
 1. Click **Select**.
 1. (Optional) Add a background image to your icon with the **Background (icon)** option by following the steps to [add a custom image](#add-custom-images-to-elements).
 


### PR DESCRIPTION
Added caution about the fact that storing images in `public/img` directory is not and has never been supported behaviour and those image paths will no longer function after Grafana 12.1.1. 
