### PR TITLE
[release-12.1.5] Add missing runs-on arg

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -212,6 +212,7 @@ jobs:
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
+      runs-on: ubuntu-x64-small
 
   publish-dockerhub:
     if: github.ref_name == 'main'


### PR DESCRIPTION
This fixes an issue where the runner runs out of space when uploading artifacts to GCS. :(