### PR TITLE
VizSuggestions: Error handling

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -120,7 +120,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
       dataObject.subscribeToState(async () => {
         const { data } = dataObject.state;
         if (hasData(data) && panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID) {
-          const suggestions = await getAllSuggestions(data);
+          const { suggestions } = await getAllSuggestions(data);
 
           if (suggestions.length > 0) {
             const defaultFirstSuggestion = suggestions[0];

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -16,7 +16,7 @@ import { UNCONFIGURED_PANEL_PLUGIN_ID } from 'app/features/dashboard-scene/scene
 
 import { getAllPanelPluginMeta } from '../../state/util';
 import { MIN_MULTI_COLUMN_SIZE } from '../../suggestions/constants';
-import { getAllSuggestions, SuggestionsResult } from '../../suggestions/getAllSuggestions';
+import { getAllSuggestions } from '../../suggestions/getAllSuggestions';
 import { hasData } from '../../suggestions/utils';
 
 import { VisualizationSuggestionCard } from './VisualizationSuggestionCard';

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -30,6 +30,7 @@ export interface Props {
 
 export function VisualizationSuggestions({ onChange, data, panel }: Props) {
   const styles = useStyles2(getStyles);
+  const [fetchSuggestionsCounter, setFetchSuggestionsCounter] = useState(0);
   const {
     value: result,
     loading,
@@ -40,7 +41,7 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
     }
 
     return await getAllSuggestions(data);
-  }, [data]);
+  }, [data, fetchSuggestionsCounter]);
   const suggestions = result?.suggestions;
   const hasLoadingErrors = result?.hasErrors ?? false;
   const [suggestionHash, setSuggestionHash] = useState<string | null>(null);
@@ -84,6 +85,10 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
     },
     [onChange]
   );
+
+  const handleRetry = useCallback(() => {
+    setFetchSuggestionsCounter((prev) => prev + 1);
+  }, []);
 
   useEffect(() => {
     if (!isNewVizSuggestionsEnabled || !suggestions || suggestions.length === 0) {
@@ -136,9 +141,16 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
     <>
       {hasLoadingErrors && (
         <Alert severity="warning" title={''}>
-          <Trans i18nKey="panel.visualization-suggestions.error-loading-some-suggestions.message">
-            Some suggestions could not be loaded
-          </Trans>
+          <div className={styles.alertContent}>
+            <Trans i18nKey="panel.visualization-suggestions.error-loading-some-suggestions.message">
+              Some suggestions could not be loaded
+            </Trans>
+            <Button variant="secondary" size="sm" onClick={handleRetry}>
+              <Trans i18nKey="panel.visualization-suggestions.error-loading-suggestions.try-again-button">
+                Try again
+              </Trans>
+            </Button>
+          </div>
         </Alert>
       )}
       <div className={styles.grid}>
@@ -228,6 +240,11 @@ const getStyles = (theme: GrafanaTheme2) => {
       alignItems: 'center',
       width: '100%',
       marginTop: theme.spacing(6),
+    }),
+    alertContent: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
     }),
     filterRow: css({
       display: 'flex',

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -36,10 +36,7 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
     error,
     retry,
   } = useAsyncRetry(async () => {
-    if (!hasData(data)) {
-      return { suggestions: [], hasErrors: false };
-    }
-
+    await new Promise((resolve) => setTimeout(resolve, 75));
     return await getAllSuggestions(data);
   }, [data]);
   const suggestions = result?.suggestions;
@@ -85,10 +82,6 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
     },
     [onChange]
   );
-
-  const handleRetry = useCallback(() => {
-    retry();
-  }, [retry]);
 
   useEffect(() => {
     if (!isNewVizSuggestionsEnabled || !suggestions || suggestions.length === 0) {
@@ -145,7 +138,7 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
             <Trans i18nKey="panel.visualization-suggestions.error-loading-some-suggestions.message">
               Some suggestions could not be loaded
             </Trans>
-            <Button variant="secondary" size="sm" onClick={handleRetry}>
+            <Button variant="secondary" size="sm" onClick={retry}>
               <Trans i18nKey="panel.visualization-suggestions.error-loading-suggestions.try-again-button">
                 Try again
               </Trans>

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -16,7 +16,7 @@ import { UNCONFIGURED_PANEL_PLUGIN_ID } from 'app/features/dashboard-scene/scene
 
 import { getAllPanelPluginMeta } from '../../state/util';
 import { MIN_MULTI_COLUMN_SIZE } from '../../suggestions/constants';
-import { getAllSuggestions } from '../../suggestions/getAllSuggestions';
+import { getAllSuggestions, SuggestionsResult } from '../../suggestions/getAllSuggestions';
 import { hasData } from '../../suggestions/utils';
 
 import { VisualizationSuggestionCard } from './VisualizationSuggestionCard';
@@ -28,17 +28,21 @@ export interface Props {
   panel?: PanelModel;
 }
 
+const useSuggestions = (data: PanelData | undefined) => {
+  const [hasFetched, setHasFetched] = useState(false);
+  const { value, loading, error, retry } = useAsyncRetry(async () => {
+    await new Promise((resolve) => setTimeout(resolve, hasFetched ? 75 : 0));
+    setHasFetched(true);
+    return await getAllSuggestions(data);
+  }, [hasFetched, data]);
+  return { value, loading, error, retry };
+};
+
 export function VisualizationSuggestions({ onChange, data, panel }: Props) {
   const styles = useStyles2(getStyles);
-  const {
-    value: result,
-    loading,
-    error,
-    retry,
-  } = useAsyncRetry(async () => {
-    await new Promise((resolve) => setTimeout(resolve, 75));
-    return await getAllSuggestions(data);
-  }, [data]);
+
+  const { value: result, loading, error, retry } = useSuggestions(data);
+
   const suggestions = result?.suggestions;
   const hasLoadingErrors = result?.hasErrors ?? false;
   const [suggestionHash, setSuggestionHash] = useState<string | null>(null);

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestions.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { Fragment, useState, useEffect, useCallback, useMemo } from 'react';
-import { useAsync, useMeasure } from 'react-use';
+import { useAsyncRetry, useMeasure } from 'react-use';
 
 import {
   GrafanaTheme2,
@@ -30,18 +30,18 @@ export interface Props {
 
 export function VisualizationSuggestions({ onChange, data, panel }: Props) {
   const styles = useStyles2(getStyles);
-  const [fetchSuggestionsCounter, setFetchSuggestionsCounter] = useState(0);
   const {
     value: result,
     loading,
     error,
-  } = useAsync(async () => {
+    retry,
+  } = useAsyncRetry(async () => {
     if (!hasData(data)) {
       return { suggestions: [], hasErrors: false };
     }
 
     return await getAllSuggestions(data);
-  }, [data, fetchSuggestionsCounter]);
+  }, [data]);
   const suggestions = result?.suggestions;
   const hasLoadingErrors = result?.hasErrors ?? false;
   const [suggestionHash, setSuggestionHash] = useState<string | null>(null);
@@ -87,8 +87,8 @@ export function VisualizationSuggestions({ onChange, data, panel }: Props) {
   );
 
   const handleRetry = useCallback(() => {
-    setFetchSuggestionsCounter((prev) => prev + 1);
-  }, []);
+    retry();
+  }, [retry]);
 
   useEffect(() => {
     if (!isNewVizSuggestionsEnabled || !suggestions || suggestions.length === 0) {

--- a/public/app/features/panel/suggestions/consts.ts
+++ b/public/app/features/panel/suggestions/consts.ts
@@ -16,4 +16,5 @@ export const panelsToCheckFirst = [
   'heatmap',
   'histogram',
   'geomap',
+  'text',
 ];

--- a/public/app/features/panel/suggestions/getAllSuggestions.test.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.test.ts
@@ -555,6 +555,27 @@ describe('sortSuggestions', () => {
   });
 });
 
+describe('Visualization suggestions error handling', () => {
+  it('returns result with hasErrors flag', async () => {
+    const result = await getAllSuggestions({
+      series: [
+        toDataFrame({
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [1, 2] },
+            { name: 'Max', type: FieldType.number, values: [1, 10] },
+          ],
+        }),
+      ],
+      state: LoadingState.Done,
+      timeRange: getDefaultTimeRange(),
+    });
+
+    expect(result).toHaveProperty('suggestions');
+    expect(result).toHaveProperty('hasErrors');
+    expect(result.hasErrors).toBe(false);
+  });
+});
+
 function repeatFrame(count: number, frame: DataFrame): DataFrame[] {
   const frames: DataFrame[] = [];
   for (let i = 0; i < count; i++) {

--- a/public/app/features/panel/suggestions/getAllSuggestions.test.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.test.ts
@@ -52,28 +52,6 @@ for (const pluginId of panelsToCheckFirst) {
   };
 }
 
-config.panels.text = {
-  id: 'text',
-  module: 'core:plugin/text',
-  sort: idx++,
-  name: 'Text',
-  type: PluginType.panel,
-  baseUrl: 'public/app/plugins/panel',
-  skipDataQuery: true,
-  suggestions: false,
-  info: {
-    version: '1.0.0',
-    updated: '2025-01-01',
-    links: [],
-    screenshots: [],
-    author: {
-      name: 'Grafana Labs',
-    },
-    description: 'Text panel',
-    logos: { small: 'small/logo', large: 'large/logo' },
-  },
-};
-
 jest.mock('../state/util', () => {
   const originalModule = jest.requireActual('../state/util');
   return {

--- a/public/app/features/panel/suggestions/getAllSuggestions.test.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.test.ts
@@ -103,7 +103,8 @@ class ScenarioContext {
       timeRange: getDefaultTimeRange(),
     };
 
-    this.suggestions = await getAllSuggestions(panelData);
+    const result = await getAllSuggestions(panelData);
+    this.suggestions = result.suggestions;
   }
 
   names() {

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -128,25 +128,6 @@ export async function getAllSuggestions(data?: PanelData): Promise<SuggestionsRe
 
   let pluginSuggestionsError = false;
   for (const plugin of plugins) {
-    // only for legacy suggestions, we should push empty cards into suggestions in the "no data" case.
-    if (
-      dataSummary.fieldCount === 0 &&
-      !config.featureToggles.newVizSuggestions &&
-      !plugin.meta.skipDataQuery &&
-      !plugin.meta.hideFromList
-    ) {
-      list.push({
-        name: plugin.meta.name,
-        pluginId: plugin.meta.id,
-        description: plugin.meta.info.description,
-        hash: 'plugin-empty-' + plugin.meta.id,
-        cardOptions: {
-          imgSrc: plugin.meta.info.logos.small,
-        },
-      });
-      continue;
-    }
-
     try {
       const suggestions = plugin.getSuggestions(dataSummary);
       if (suggestions) {

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -8,6 +8,7 @@ import {
   PreferredVisualisationType,
   VisualizationSuggestionScore,
 } from '@grafana/data';
+import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { importPanelPlugin, isBuiltInPlugin } from 'app/features/plugins/importPanelPlugin';
@@ -49,7 +50,16 @@ async function getPanelsWithSuggestions(): Promise<PluginLoadResult> {
         hasErrors = true;
         console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
       } else {
-        appEvents.emit(AppEvents.alertError, [`Failed to load panel plugin: ${pluginId}.`]);
+        appEvents.publish({
+          type: AppEvents.alertError.name,
+          payload: [
+            t(
+              'panel.visualization-suggestions.error-loading-suggestions.plugin-failed',
+              'Failed to load panel plugin: {{ pluginId }}.',
+              { pluginId }
+            ),
+          ],
+        });
       }
     }
   }

--- a/public/app/features/panel/suggestions/getAllSuggestions.ts
+++ b/public/app/features/panel/suggestions/getAllSuggestions.ts
@@ -44,9 +44,11 @@ async function getPanelsWithSuggestions(): Promise<PluginLoadResult> {
       plugins.push(settled.value);
     } else {
       const pluginId = pluginIds[i];
+
+      console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
+
       if (isBuiltInPlugin(pluginId)) {
         hasErrors = true;
-        console.error(`Failed to load ${pluginId} for visualization suggestions:`, settled.reason);
       } else {
         appEvents.publish({
           type: AppEvents.alertError.name,

--- a/public/app/features/plugins/importPanelPlugin.ts
+++ b/public/app/features/plugins/importPanelPlugin.ts
@@ -62,3 +62,9 @@ export function syncGetPanelPlugin(id: string): PanelPlugin | undefined {
 function getPanelPlugin(meta: PanelPluginMeta): Promise<PanelPlugin> {
   return pluginImporter.importPanel(meta);
 }
+
+export function clearPanelPluginCache(): void {
+  for (const key of Object.keys(promiseCache)) {
+    delete promiseCache[key];
+  }
+}

--- a/public/app/plugins/panel/table/suggestions.ts
+++ b/public/app/plugins/panel/table/suggestions.ts
@@ -1,4 +1,5 @@
 import { PanelDataSummary, VisualizationSuggestionScore, VisualizationSuggestionsSupplier } from '@grafana/data';
+import { config } from 'app/core/config';
 import icnTablePanelSvg from 'app/plugins/panel/table/img/icn-table-panel.svg';
 
 import { Options, FieldConfig } from './panelcfg.gen';
@@ -29,7 +30,7 @@ export const tableSuggestionsSupplier: VisualizationSuggestionsSupplier<Options,
       },
       // If there is no data, suggest table anyway, but use icon instead of real preview
       // TODO: delete this in once "new" suggestions are fully rolled out
-      imgSrc: dataSummary.fieldCount === 0 ? icnTablePanelSvg : undefined,
+      imgSrc: dataSummary.fieldCount === 0 && !config.featureToggles.newVizSuggestions ? icnTablePanelSvg : undefined,
     },
   },
 ];

--- a/public/app/plugins/panel/text/module.tsx
+++ b/public/app/plugins/panel/text/module.tsx
@@ -1,8 +1,10 @@
 import { PanelPlugin } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from 'app/core/config';
 
 import { TextPanel } from './TextPanel';
 import { TextPanelEditor } from './TextPanelEditor';
+import icnTextPanelSvg from './img/icn-text-panel.svg';
 import { CodeLanguage, defaultCodeOptions, defaultOptions, Options, TextMode } from './panelcfg.gen';
 import { textPanelMigrationHandler } from './textPanelMigrationHandler';
 
@@ -59,4 +61,9 @@ export const plugin = new PanelPlugin<Options>(TextPanel)
         defaultValue: defaultOptions.content,
       });
   })
-  .setMigrationHandler(textPanelMigrationHandler);
+  .setMigrationHandler(textPanelMigrationHandler)
+  .setSuggestionsSupplier((ds) =>
+    ds.fieldCount === 0 && !config.featureToggles.newVizSuggestions
+      ? [{ cardOptions: { imgSrc: icnTextPanelSvg } }]
+      : []
+  );

--- a/public/app/plugins/panel/text/plugin.json
+++ b/public/app/plugins/panel/text/plugin.json
@@ -2,7 +2,7 @@
   "type": "panel",
   "name": "Text",
   "id": "text",
-
+  "suggestions": true,
   "skipDataQuery": true,
 
   "info": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11199,6 +11199,7 @@
       },
       "error-loading-suggestions": {
         "message": "An error occurred when loading visualization suggestions.",
+        "plugin-failed": "Failed to load panel plugin: {{ pluginId }}.",
         "title": "Error",
         "try-again-button": "Try again"
       },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11194,6 +11194,9 @@
     },
     "visualization-suggestions": {
       "apply-suggestion-aria-label": "Apply {{suggestionName}} visualization",
+      "error-loading-some-suggestions": {
+        "message": "Some suggestions could not be loaded"
+      },
       "error-loading-suggestions": {
         "message": "An error occurred when loading visualization suggestions.",
         "title": "Error"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11199,7 +11199,8 @@
       },
       "error-loading-suggestions": {
         "message": "An error occurred when loading visualization suggestions.",
-        "title": "Error"
+        "title": "Error",
+        "try-again-button": "Try again"
       },
       "unknown-viz-type": "Unknown visualization type",
       "use-this-suggestion": "Use this suggestion"


### PR DESCRIPTION
This PR add more error handling to suggestions, preventing complete failure when individual plugins fail to load.
For:
- Core plugins: shows warning in the UI and "Try again" button, which retries to fetch suggestions
- Non-core plugins: shows the rest of the suggestions and an error toaster

Core plugins:

https://github.com/user-attachments/assets/fb2070e4-32a1-4e4c-ad61-dd4b2deeefa6

To test:
- add the following to `importPanelPlugin.ts#importPanelPlugin` L#15

> if (id === 'histogram') { throw new Error(`Plugin ${id} not found`); }



Non-core plugins:

https://github.com/user-attachments/assets/034f6243-8fe6-4bc9-99e2-cbaf4a2f0571



To test the plugins error (toast):
- add `pluginIds.push('fake_plugin_id');` to `getAllSuggestions.ts#getPanelsWithSuggestions` L#35



Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
