### PR TITLE
ServiceAccounts: Fix token expiration display & show date on hover

### DIFF
--- a/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
+++ b/public/app/features/serviceaccounts/components/ServiceAccountTokensTable.tsx
@@ -1,7 +1,7 @@
 import { css, cx } from '@emotion/css';
 import type { JSX } from 'react';
 
-import { dateTimeFormat, GrafanaTheme2, TimeZone } from '@grafana/data';
+import { dateTimeFormat, GrafanaTheme2, TimeZone, dateTimeFormatTimeAgo } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { DeleteButton, Icon, Tooltip, useStyles2, useTheme2 } from '@grafana/ui';
 import { ApiKey } from 'app/types/apiKeys';
@@ -84,9 +84,9 @@ function formatDate(timeZone: TimeZone, expiration?: string): string {
 }
 
 function formatSecondsLeftUntilExpiration(secondsUntilExpiration: number): string {
-  const days = Math.ceil(secondsUntilExpiration / (3600 * 24));
-  const daysFormat = days > 1 ? `${days} days` : `${days} day`;
-  return `Expires in ${daysFormat}`;
+  const expirationTime = Date.now() + secondsUntilExpiration * 1000;
+  const daysFormat = dateTimeFormatTimeAgo(expirationTime, { timeZone: 'browser' });
+  return `Expires ${daysFormat}`;
 }
 
 const TokenRevoked = () => {
@@ -126,14 +126,14 @@ const TokenExpiration = ({ timeZone, token }: TokenExpirationProps) => {
   }
   if (token.secondsUntilExpiration) {
     return (
-      <span className={styles.secondsUntilExpiration}>
+      <span className={styles.secondsUntilExpiration} title={formatDate(timeZone, token.expiration)}>
         {formatSecondsLeftUntilExpiration(token.secondsUntilExpiration)}
       </span>
     );
   }
   if (token.hasExpired) {
     return (
-      <span className={styles.hasExpired}>
+      <span className={styles.hasExpired} title={formatDate(timeZone, token.expiration)}>
         <Trans i18nKey="serviceaccounts.token-expiration.expired-label">Expired</Trans>
         <span className={styles.tooltipContainer}>
           <Tooltip


### PR DESCRIPTION
**What is this feature?**

This PR fixes the token expiration time calculation and adds hover tooltips to show the exact expiration date. The expiration display now correctly handles tokens with expirations shorter than a day, showing more granular and precise time remaining (e.g., "Expires in 2 hours" instead of incorrect day-based calculations).

**Why do we need this feature?**

The previous implementation displayed the expiration time incorrectly for tokens with expiration shorter than 24 hours. This change is useful to prevent any further confusion.

**Which issue(s) does this PR fix?**:

Fixes  https://github.com/grafana/support-escalations/issues/19950.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.