### PR TITLE
Elasticsearch: Builder queries no longer execute in code mode

### DIFF
--- a/pkg/tsdb/elasticsearch/data_query_processor.go
+++ b/pkg/tsdb/elasticsearch/data_query_processor.go
@@ -24,7 +24,7 @@ func (e *elasticsearchDataQuery) processQuery(q *Query, ms *es.MultiSearchReques
 	filters.AddDateRangeFilter(defaultTimeField, to, from, es.DateFormatEpochMS)
 	filters.AddQueryStringFilter(q.RawQuery, true)
 
-	if q.EditorType != nil && *q.EditorType == "code" && q.RawDSLQuery != "" {
+	if q.EditorType != nil && *q.EditorType == "code" {
 		cfg := backend.GrafanaConfigFromContext(e.ctx)
 		if !cfg.FeatureToggles().IsEnabled("elasticsearchRawDSLQuery") {
 			return backend.DownstreamError(fmt.Errorf("raw DSL query feature is disabled. Enable the elasticsearchRawDSLQuery feature toggle to use this query type"))

--- a/pkg/tsdb/elasticsearch/data_query_validator.go
+++ b/pkg/tsdb/elasticsearch/data_query_validator.go
@@ -7,7 +7,7 @@ import (
 // isQueryWithError validates the query and returns an error if invalid
 func isQueryWithError(query *Query) error {
 	// Skip validation for raw DSL queries because no easy way to see it is valid without just running it
-	if query.EditorType != nil && *query.EditorType == "code" && query.RawDSLQuery != "" {
+	if query.EditorType != nil && *query.EditorType == "code" {
 		return nil
 	}
 	if len(query.BucketAggs) == 0 {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.test.ts
@@ -7,7 +7,7 @@ import {
 import { defaultBucketAgg } from '../../../../queryDef';
 import { reducerTester } from '../../../reducerTester';
 import { changeMetricType } from '../../MetricAggregationsEditor/state/actions';
-import { initQuery } from '../../state';
+import { changeEditorTypeAndResetQuery, initQuery } from '../../state';
 import { bucketAggregationConfig } from '../utils';
 
 import {
@@ -178,6 +178,29 @@ describe('Bucket Aggregations Reducer', () => {
         .givenReducer(createReducer('@timestamp'), [bucketAgg])
         .whenActionIsDispatched(initQuery())
         .thenStateShouldEqual([bucketAgg]);
+    });
+  });
+
+  describe('When switching editor type', () => {
+    it('Should reset bucket aggregations to default when switching editor types', () => {
+      const defaultTimeField = '@timestamp';
+      const initialState: BucketAggregation[] = [
+        {
+          id: '1',
+          type: 'date_histogram',
+          field: '@timestamp',
+        },
+        {
+          id: '2',
+          type: 'terms',
+          field: 'status',
+        },
+      ];
+
+      reducerTester<ElasticsearchDataQuery['bucketAggs']>()
+        .givenReducer(createReducer(defaultTimeField), initialState)
+        .whenActionIsDispatched(changeEditorTypeAndResetQuery('code'))
+        .thenStateShouldEqual([{ ...defaultBucketAgg('2'), field: defaultTimeField }]);
     });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -88,7 +88,7 @@ export const createReducer =
     }
 
     if (changeEditorTypeAndResetQuery.match(action)) {
-      // Returns the default bugcket agg. We will always want to set the default when switching types
+      // Returns the default bucket agg. We will always want to set the default when switching types
       return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
     }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -89,7 +89,7 @@ export const createReducer =
 
     if (changeEditorTypeAndResetQuery.match(action)) {
       // Returns the default bugcket agg. We will always want to set the default when switching types
-        return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
+      return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
     }
 
     if (changeBucketAggregationSetting.match(action)) {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -6,7 +6,7 @@ import { defaultBucketAgg } from '../../../../queryDef';
 import { removeEmpty } from '../../../../utils';
 import { changeMetricType } from '../../MetricAggregationsEditor/state/actions';
 import { metricAggregationConfig } from '../../MetricAggregationsEditor/utils';
-import { initQuery } from '../../state';
+import { changeEditorTypeAndResetQuery, initQuery } from '../../state';
 import { bucketAggregationConfig } from '../utils';
 
 import {
@@ -85,6 +85,10 @@ export const createReducer =
         return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
       }
       return state;
+    }
+
+    if (changeEditorTypeAndResetQuery.match(action)) {
+        return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
     }
 
     if (changeBucketAggregationSetting.match(action)) {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/BucketAggregationsEditor/state/reducer.ts
@@ -88,6 +88,7 @@ export const createReducer =
     }
 
     if (changeEditorTypeAndResetQuery.match(action)) {
+      // Returns the default bugcket agg. We will always want to set the default when switching types
         return [{ ...defaultBucketAgg('2'), field: defaultTimeField }];
     }
 

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.test.ts
@@ -7,7 +7,7 @@ import {
 
 import { defaultMetricAgg } from '../../../../queryDef';
 import { reducerTester } from '../../../reducerTester';
-import { initQuery } from '../../state';
+import { changeEditorTypeAndResetQuery, initQuery } from '../../state';
 import { metricAggregationConfig } from '../utils';
 
 import {
@@ -247,5 +247,27 @@ describe('Metric Aggregations Reducer', () => {
       .givenReducer(reducer, [])
       .whenActionIsDispatched(initQuery())
       .thenStateShouldEqual([defaultMetricAgg('1')]);
+  });
+
+  describe('When switching editor type', () => {
+    it('Should reset to single default metric when switching to code editor', () => {
+      const initialState: MetricAggregation[] = [
+        {
+          id: '1',
+          type: 'avg',
+          field: 'value',
+        },
+        {
+          id: '2',
+          type: 'max',
+          field: 'value',
+        },
+      ];
+
+      reducerTester<ElasticsearchDataQuery['metrics']>()
+        .givenReducer(reducer, initialState)
+        .whenActionIsDispatched(changeEditorTypeAndResetQuery('code'))
+        .thenStateShouldEqual([defaultMetricAgg('1')]);
+    });
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/MetricAggregationsEditor/state/reducer.ts
@@ -4,7 +4,7 @@ import { ElasticsearchDataQuery, MetricAggregation } from 'app/plugins/datasourc
 
 import { defaultMetricAgg, queryTypeToMetricType } from '../../../../queryDef';
 import { removeEmpty } from '../../../../utils';
-import { initQuery } from '../../state';
+import { changeEditorTypeAndResetQuery, initQuery } from '../../state';
 import { isMetricAggregationWithMeta, isMetricAggregationWithSettings, isPipelineAggregation } from '../aggregations';
 import { getChildren, metricAggregationConfig } from '../utils';
 
@@ -63,6 +63,11 @@ export const reducer = (
           ...metricAggregationConfig[action.payload.type].defaults,
         } as MetricAggregation;
       });
+  }
+
+  if (changeEditorTypeAndResetQuery.match(action)) {
+    // Reset to default metric when switching to editor types
+    return [defaultMetricAgg('1')];
   }
 
   if (changeMetricField.match(action)) {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.test.ts
@@ -1,7 +1,15 @@
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
 import { reducerTester } from '../reducerTester';
 
-import { aliasPatternReducer, changeAliasPattern, changeQuery, initQuery, queryReducer } from './state';
+import {
+  aliasPatternReducer,
+  changeAliasPattern,
+  changeEditorTypeAndResetQuery,
+  changeQuery,
+  initQuery,
+  queryReducer,
+  rawDSLQueryReducer,
+} from './state';
 
 describe('Query Reducer', () => {
   describe('On Init', () => {
@@ -42,6 +50,17 @@ describe('Query Reducer', () => {
       .whenActionIsDispatched({ type: 'THIS ACTION SHOULD NOT HAVE ANY EFFECT IN THIS REDUCER' })
       .thenStateShouldEqual(initialState);
   });
+
+  describe('When switching editor type', () => {
+    it('Should clear query when switching editor types', () => {
+      const initialQuery: ElasticsearchDataQuery['query'] = 'Some lucene query';
+
+      reducerTester<ElasticsearchDataQuery['query']>()
+        .givenReducer(queryReducer, initialQuery)
+        .whenActionIsDispatched(changeEditorTypeAndResetQuery('code'))
+        .thenStateShouldEqual('');
+    });
+  });
 });
 
 describe('Alias Pattern Reducer', () => {
@@ -61,5 +80,27 @@ describe('Alias Pattern Reducer', () => {
       .givenReducer(aliasPatternReducer, initialState)
       .whenActionIsDispatched({ type: 'THIS ACTION SHOULD NOT HAVE ANY EFFECT IN THIS REDUCER' })
       .thenStateShouldEqual(initialState);
+  });
+
+  describe('When switching editor type', () => {
+    it('Should clear alias when switching editor types', () => {
+      const initialAlias: ElasticsearchDataQuery['alias'] = 'Some alias pattern';
+
+      reducerTester<ElasticsearchDataQuery['alias']>()
+        .givenReducer(aliasPatternReducer, initialAlias)
+        .whenActionIsDispatched(changeEditorTypeAndResetQuery('code'))
+        .thenStateShouldEqual('');
+    });
+  });
+});
+
+describe('Raw DSL Query Reducer', () => {
+  it('Should clear raw DSL query when switching editor types', () => {
+    const initialRawQuery: ElasticsearchDataQuery['rawDSLQuery'] = '{"query": {"match_all": {}}}';
+
+    reducerTester<ElasticsearchDataQuery['rawDSLQuery']>()
+      .givenReducer(rawDSLQueryReducer, initialRawQuery)
+      .whenActionIsDispatched(changeEditorTypeAndResetQuery('builder'))
+      .thenStateShouldEqual('');
   });
 });

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/state.ts
@@ -58,6 +58,10 @@ export const aliasPatternReducer = (prevAliasPattern: ElasticsearchDataQuery['al
     return action.payload;
   }
 
+  if (changeEditorTypeAndResetQuery.match(action)) {
+    return '';
+  }
+
   if (initQuery.match(action)) {
     return prevAliasPattern || '';
   }


### PR DESCRIPTION
The builder query no longer runs if DSL raw query is empty. 
The frontend removes the builder query when switching to code mode.