### PR TITLE
Elasticsearch: Make code editor look more like prometheus

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
@@ -1,29 +1,22 @@
 import { SelectableValue } from '@grafana/data';
 import { RadioButtonGroup } from '@grafana/ui';
 
-import { useDispatch } from '../../hooks/useStatelessReducer';
 import { EditorType } from '../../types';
-
-import { useQuery } from './ElasticsearchQueryContext';
-import { changeEditorTypeAndResetQuery } from './state';
 
 const BASE_OPTIONS: Array<SelectableValue<EditorType>> = [
   { value: 'builder', label: 'Builder' },
   { value: 'code', label: 'Code' },
 ];
 
-export const EditorTypeSelector = () => {
-  const query = useQuery();
-  const dispatch = useDispatch();
+interface Props {
+  value: EditorType;
+  onChange: (editorType: EditorType) => void;
+}
 
-  // Default to 'builder' if editorType is empty
-  const editorType: EditorType = query.editorType === 'code' ? 'code' : 'builder';
-
-  const onChange = (newEditorType: EditorType) => {
-    dispatch(changeEditorTypeAndResetQuery(newEditorType));
-  };
-
+export const EditorTypeSelector = ({ value, onChange }: Props) => {
   return (
-      <RadioButtonGroup<EditorType> size="sm" options={BASE_OPTIONS} value={editorType} onChange={onChange} />
+    <div data-testid="ElasticsearchEditorTypeToggle">
+      <RadioButtonGroup<EditorType> size="sm" options={BASE_OPTIONS} value={value} onChange={onChange} />
+    </div>
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
@@ -15,6 +15,12 @@ interface Props {
 
 export const EditorTypeSelector = ({ value, onChange }: Props) => {
   return (
-      <RadioButtonGroup<EditorType> data-testid="elasticsearch-editor-type-toggle" size="sm" options={BASE_OPTIONS} value={value} onChange={onChange} />
+    <RadioButtonGroup<EditorType>
+      data-testid="elasticsearch-editor-type-toggle"
+      size="sm"
+      options={BASE_OPTIONS}
+      value={value}
+      onChange={onChange}
+    />
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
@@ -24,6 +24,6 @@ export const EditorTypeSelector = () => {
   };
 
   return (
-    <RadioButtonGroup<EditorType> fullWidth={false} options={BASE_OPTIONS} value={editorType} onChange={onChange} />
+      <RadioButtonGroup<EditorType> size="sm" options={BASE_OPTIONS} value={editorType} onChange={onChange} />
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/EditorTypeSelector.tsx
@@ -15,8 +15,6 @@ interface Props {
 
 export const EditorTypeSelector = ({ value, onChange }: Props) => {
   return (
-    <div data-testid="ElasticsearchEditorTypeToggle">
-      <RadioButtonGroup<EditorType> size="sm" options={BASE_OPTIONS} value={value} onChange={onChange} />
-    </div>
+      <RadioButtonGroup<EditorType> data-testid="elasticsearch-editor-type-toggle" size="sm" options={BASE_OPTIONS} value={value} onChange={onChange} />
   );
 };

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/RawQueryEditor.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/RawQueryEditor.tsx
@@ -28,6 +28,8 @@ export function RawQueryEditor({ value, onChange, onRunQuery }: Props) {
       });
 
       // Make the editor resize itself so that the content fits (grows taller when necessary)
+      // this code comes from the Prometheus query editor.
+      // We may wish to consider abstracting it into the grafana/ui repo in the future
       const updateElementHeight = () => {
         const containerDiv = containerRef.current;
         if (containerDiv !== null) {

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -1,16 +1,16 @@
 import { css } from '@emotion/css';
-import { useEffect, useId, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { SemVer } from 'semver';
 
 import { getDefaultTimeRange, GrafanaTheme2, QueryEditorProps } from '@grafana/data';
 import { config } from '@grafana/runtime';
-import { Alert, InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
+import { Alert, ConfirmModal, InlineField, InlineLabel, Input, QueryField, useStyles2 } from '@grafana/ui';
 
 import { ElasticsearchDataQuery } from '../../dataquery.gen';
 import { ElasticDatasource } from '../../datasource';
 import { useNextId } from '../../hooks/useNextId';
 import { useDispatch } from '../../hooks/useStatelessReducer';
-import { ElasticsearchOptions } from '../../types';
+import { EditorType, ElasticsearchOptions } from '../../types';
 import { isSupportedVersion, isTimeSeriesQuery, unsupportedVersionMessage } from '../../utils';
 
 import { BucketAggregationsEditor } from './BucketAggregationsEditor';
@@ -20,7 +20,7 @@ import { MetricAggregationsEditor } from './MetricAggregationsEditor';
 import { metricAggregationConfig } from './MetricAggregationsEditor/utils';
 import { QueryTypeSelector } from './QueryTypeSelector';
 import { RawQueryEditor } from './RawQueryEditor';
-import { changeAliasPattern, changeQuery, changeRawDSLQuery } from './state';
+import { changeAliasPattern, changeEditorTypeAndResetQuery, changeQuery, changeRawDSLQuery } from './state';
 
 export type ElasticQueryEditorProps = QueryEditorProps<ElasticDatasource, ElasticsearchDataQuery, ElasticsearchOptions>;
 
@@ -97,17 +97,50 @@ const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void
   const inputId = useId();
   const styles = useStyles2(getStyles);
 
+  const [switchModalOpen, setSwitchModalOpen] = useState(false);
+  const [pendingEditorType, setPendingEditorType] = useState<EditorType | null>(null);
+
   const isTimeSeries = isTimeSeriesQuery(value);
 
   const isCodeEditor = value.editorType === 'code';
   const rawDSLFeatureEnabled = config.featureToggles.elasticsearchRawDSLQuery;
 
+  // Default to 'builder' if editorType is empty
+  const currentEditorType: EditorType = value.editorType === 'code' ? 'code' : 'builder';
+
   const showBucketAggregationsEditor = value.metrics?.every(
     (metric) => metricAggregationConfig[metric.type].impliedQueryType === 'metrics'
   );
 
+  const onEditorTypeChange = useCallback((newEditorType: EditorType) => {
+    // Show warning modal when switching modes
+    setPendingEditorType(newEditorType);
+    setSwitchModalOpen(true);
+  }, []);
+
+  const confirmEditorTypeChange = useCallback(() => {
+    if (pendingEditorType) {
+      dispatch(changeEditorTypeAndResetQuery(pendingEditorType));
+    }
+    setSwitchModalOpen(false);
+    setPendingEditorType(null);
+  }, [dispatch, pendingEditorType]);
+
+  const cancelEditorTypeChange = useCallback(() => {
+    setSwitchModalOpen(false);
+    setPendingEditorType(null);
+  }, []);
+
   return (
     <>
+      <ConfirmModal
+        isOpen={switchModalOpen}
+        title="Switch editor"
+        body="Switching between editors will reset your query. Are you sure you want to continue?"
+        confirmText="Continue"
+        onConfirm={confirmEditorTypeChange}
+        onDismiss={cancelEditorTypeChange}
+      />
       <div className={styles.root}>
         <InlineLabel width={17}>Query type</InlineLabel>
         <div className={styles.queryItem}>
@@ -115,7 +148,7 @@ const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void
         </div>
         {rawDSLFeatureEnabled && (
           <div style={{ marginLeft: 'auto' }}>
-            <EditorTypeSelector />
+            <EditorTypeSelector value={currentEditorType} onChange={onEditorTypeChange} />
           </div>
         )}
       </div>

--- a/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
+++ b/public/app/plugins/datasource/elasticsearch/components/QueryEditor/index.tsx
@@ -113,15 +113,12 @@ const QueryEditorForm = ({ value, onRunQuery }: Props & { onRunQuery: () => void
         <div className={styles.queryItem}>
           <QueryTypeSelector />
         </div>
-      </div>
-      {rawDSLFeatureEnabled && (
-        <div className={styles.root}>
-          <InlineLabel width={17}>Editor type</InlineLabel>
-          <div className={styles.queryItem}>
+        {rawDSLFeatureEnabled && (
+          <div style={{ marginLeft: 'auto' }}>
             <EditorTypeSelector />
           </div>
-        </div>
-      )}
+        )}
+      </div>
 
       {isCodeEditor && rawDSLFeatureEnabled && (
         <RawQueryEditor


### PR DESCRIPTION
- Removed the run query button.
- Moved the editor type (builder/code) to the right. In line with the query type
- The code editor grows like prometheus' when new lines are added
- Moved the format button under the code editor
- When switch builder/code, the user will be prompted if they want to continue because the query will be cleared

<img width="1332" height="558" alt="image" src="https://github.com/user-attachments/assets/2296d962-f4e7-4226-8830-2f443ef7fa95" />
