### PR TITLE
docs: clarify org admin requirement for team membership management

### DIFF
--- a/docs/sources/administration/team-management/configure-grafana-teams.md
+++ b/docs/sources/administration/team-management/configure-grafana-teams.md
@@ -24,7 +24,7 @@ For a tutorial on working with Teams, refer to [Create users and teams](https://
 
 Before you begin creating and working with Grafana Teams:
 
-- Ensure that you have `Organization Administrator` permissions. Team administrators who are not Organization Administrators cannot add or remove team members or view the team members list.
+- Ensure that you have either the `Organization Administrator` role or `team administrator` permissions.
   Refer to [Organization roles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#organization-roles) and [RBAC permissions, actions, and scopes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#rbac-permissions-actions-and-scopes) for a list of Grafana roles and role-based access control actions.
 - Decide which users belong to which teams and what permissions team members receive.
 - Configure the default basic role for users to join Grafana. This role applies to users where no role is set by the identity provider (IDP).
@@ -66,9 +66,14 @@ To create a Team, complete the following steps:
 
 ## Add a Team member
 
-Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user. This task requires that you have `Organization Administrator` permissions.
+**Note**
+>
+> In Grafana Enterprise or Grafana Cloud with RBAC enforcement enabled, adding or viewing team members requires the `org.users:read` permission, which is typically granted only to Organization Administrators.
+>
+> In Grafana OSS (unlicensed), Team Administrators may still be able to search for users and add team members due to the OSS permission evaluator fallback.
 
-**Note:** Managing team membership requires access to organization-wide user information, which requires the `org.users:read` permission. This permission is only granted to Organization Administrators.
+
+Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user.
 
 To add a team member, complete the following steps:
 

--- a/docs/sources/administration/team-management/configure-grafana-teams.md
+++ b/docs/sources/administration/team-management/configure-grafana-teams.md
@@ -67,11 +67,10 @@ To create a Team, complete the following steps:
 ## Add a Team member
 
 **Note**
->
+
 > In Grafana Enterprise or Grafana Cloud with RBAC enforcement enabled, adding or viewing team members requires the `org.users:read` permission, which is typically granted only to `Organization Administrators`.
 >
 > In Grafana OSS (or unlicensed), `team administrators` can search for and add any user in the organization without requiring additional permission.
-
 
 Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user.
 

--- a/docs/sources/administration/team-management/configure-grafana-teams.md
+++ b/docs/sources/administration/team-management/configure-grafana-teams.md
@@ -24,7 +24,7 @@ For a tutorial on working with Teams, refer to [Create users and teams](https://
 
 Before you begin creating and working with Grafana Teams:
 
-- Ensure that you have either the `Organization Administrator` role or team administrator permissions.
+- Ensure that you have `Organization Administrator` permissions. Team administrators who are not Organization Administrators cannot add or remove team members or view the team members list.
   Refer to [Organization roles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/#organization-roles) and [RBAC permissions, actions, and scopes](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/custom-role-actions-scopes/#rbac-permissions-actions-and-scopes) for a list of Grafana roles and role-based access control actions.
 - Decide which users belong to which teams and what permissions team members receive.
 - Configure the default basic role for users to join Grafana. This role applies to users where no role is set by the identity provider (IDP).
@@ -66,7 +66,9 @@ To create a Team, complete the following steps:
 
 ## Add a Team member
 
-Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user. This task requires that you have `organization administrator` permissions.
+Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user. This task requires that you have `Organization Administrator` permissions.
+
+**Note:** Managing team membership requires access to organization-wide user information, which requires the `org.users:read` permission. This permission is only granted to Organization Administrators.
 
 To add a team member, complete the following steps:
 
@@ -107,7 +109,7 @@ To delete a role, remove the check next to the role name and click **Update**.
 
 ## Delete a team
 
-Delete a team when you no longer need it. This action permanently deletes the team and removes all team permissions from dashboards and folders. This task requires that you have `organization administrator` permissions.
+Delete a team when you no longer need it. This action permanently deletes the team and removes all team permissions from dashboards and folders. This task requires that you have `Organization Administrator` permissions.
 
 1. Sign in to Grafana as an `org administrator` or `team administrator`.
 1. Click the arrow next to **Administration** in the left-side menu, click **Users and access**, and select **Teams**.

--- a/docs/sources/administration/team-management/configure-grafana-teams.md
+++ b/docs/sources/administration/team-management/configure-grafana-teams.md
@@ -68,9 +68,9 @@ To create a Team, complete the following steps:
 
 **Note**
 >
-> In Grafana Enterprise or Grafana Cloud with RBAC enforcement enabled, adding or viewing team members requires the `org.users:read` permission, which is typically granted only to Organization Administrators.
+> In Grafana Enterprise or Grafana Cloud with RBAC enforcement enabled, adding or viewing team members requires the `org.users:read` permission, which is typically granted only to `Organization Administrators`.
 >
-> In Grafana OSS (unlicensed), Team Administrators may still be able to search for users and add team members due to the OSS permission evaluator fallback.
+> In Grafana OSS (or unlicensed), `team administrators` can search for and add any user in the organization without requiring additional permission.
 
 
 Add a member to a new Team or add a team member to an existing Team when you want to provide access to team dashboards and folders to another user.


### PR DESCRIPTION
**What is this feature?**

This PR updates the Grafana documentation to clarify the permissions required to manage team membership. It removes ambiguity by explicitly stating that only **Organization Administrators** can view, add, or remove team members.

**Why do we need this feature?**

The current documentation contains conflicting statements about whether team administrators can manage team membership. In practice, team membership management requires access to organization-wide user data (org.users:read), which is only available to Organization Administrators. This mismatch leads to confusion and permission errors for users following the existing documentation.

Aligning the documentation with actual authorization behavior helps prevent misconfiguration and reduces support overhead.

**Who is this feature for?**

This change is intended for:

Grafana administrators and operators
Platform and SRE teams managing Grafana organizations
Users responsible for configuring teams and access control

**Which issue(s) does this PR fix?**

Fixes #108956

**Special notes for your reviewer:**

Please check that:

- [X] It works as expected from a user's perspective (documentation accurately reflects current behavior)
- [X] This change is documentation-only; no feature toggles are applicable
- [X] The docs are updated and consistent; this is not a notable product change and does not require inclusion in What’s New