### PR TITLE
CI: enable branch cleanup workflow

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v5
       - uses: grafana/shared-workflows/actions/cleanup-branches@cleanup-branches/v0.2.1
         with:
-          dry-run: true
+          dry-run: false
           max-date: "1 month ago"


### PR DESCRIPTION
Currently this is only running in dry-run mode. Pretty soon we will reach the max number of branches our repo can have before performance starts taking a hit in the backport process, so we should start cleaning those up.