### PR TITLE
fix(unit): stop milli-scaling logarithmic dBm values (show dBm decimals)

### DIFF
--- a/packages/grafana-data/src/valueFormats/categories.ts
+++ b/packages/grafana-data/src/valueFormats/categories.ts
@@ -894,7 +894,7 @@ export const getCategories = (): ValueFormatCategory[] => [
           'Decibel-milliwatt (dBm)'
         ),
         id: 'dBm',
-        fn: SIPrefix('dBm'),
+        fn: toFixedUnit('dbm'),
       },
       {
         name: t('grafana-data.valueFormats.categories.energy.formats.name-milliohm', 'Milliohm (mΩ)'),


### PR DESCRIPTION
**What is this feature?**

dBm is a logarithmic unit and must not be scaled with SI prefixes. Display decimal dBm values directly instead of converting to “mdbm”.

**Why do we need this feature?**

dBm is a logarithmic unit and must not be scaled with SI prefixes. Display decimal dBm values directly instead of converting to “mdbm”.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
