### PR TITLE
Docs: remove software-properties-common; it is unused and not available in debian:13

### DIFF
--- a/docs/sources/setup-grafana/installation/debian/index.md
+++ b/docs/sources/setup-grafana/installation/debian/index.md
@@ -46,7 +46,7 @@ Complete the following steps to install Grafana from the APT repository:
 1. Install the prerequisite packages:
 
    ```bash
-   sudo apt-get install -y apt-transport-https software-properties-common wget
+   sudo apt-get install -y apt-transport-https wget
    ```
 
 1. Import the GPG key:


### PR DESCRIPTION
Resolves https://github.com/grafana/grafana/issues/110198

Apparently a new version of Debian (debian 13) ships without a software package that we instruct folks to install. (issue here: https://github.com/grafana/grafana/issues/110198)

You can verify this quickly by running this command:

```
docker run --rm -it -p 3000:3000 debian:13 /bin/sh -c 'apt-get update && apt-get install -yq apt-transport-https software-properties-common wget'
E: Unable to locate package software-properties-common
```

Some of the commenters are right to point out that this package is actually unnecessary given the remaining instructions. Here's a docker run that basically follows our instructions without `software-properties-common`.

``` bash
docker run --rm -i -p 3000:3000 debian:13 bash <<'EOF'
set -euo pipefail

apt-get update -yq
apt-get install -yq apt-transport-https wget gnupg

mkdir -p /etc/apt/keyrings

wget -q -O - https://apt.grafana.com/gpg.key \
  | gpg --dearmor \
  | tee /etc/apt/keyrings/grafana.gpg > /dev/null

echo "deb [signed-by=/etc/apt/keyrings/grafana.gpg] https://apt.grafana.com stable main" \
  > /etc/apt/sources.list.d/grafana.list

apt-get update
apt-get install -y grafana

cd /usr/share/grafana
./bin/grafana server
EOF
```

and it starts up just fine without that dependency. So I suppose we can remove it.