### PR TITLE
Modal: Fix modal button row

### DIFF
--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -91,7 +91,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
     modalButtonRow: css({
       background: theme.colors.background.primary,
       position: 'sticky',
-      bottom: -1,
+      bottom: 0,
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(0.5),
       zIndex: 1,

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -79,7 +79,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
     modalContent: css({
       overflow: 'auto',
       padding: theme.spacing(3, 3, 0, 3),
-      marginBottom: theme.spacing(3),
+      marginBottom: theme.spacing(2.5),
       scrollbarWidth: 'thin',
       width: '100%',
 
@@ -91,7 +91,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
     modalButtonRow: css({
       background: theme.colors.background.primary,
       position: 'sticky',
-      bottom: 0,
+      bottom: 1,
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(0.5),
       zIndex: 1,

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -91,7 +91,7 @@ export const getModalStyles = (theme: GrafanaTheme2) => {
     modalButtonRow: css({
       background: theme.colors.background.primary,
       position: 'sticky',
-      bottom: 1,
+      bottom: -1,
       paddingTop: theme.spacing(2),
       paddingBottom: theme.spacing(0.5),
       zIndex: 1,


### PR DESCRIPTION
Noticed un-even spacing in modals where the bottom spacing (from buttons to edge) was different vs other directions. 

This was due to 4px extra padding added to button row for focus ring to not be clipped (when scrolling was added to modal content and button row was made sticky).

This fixes the uneven spacing as well as a strange issue where the button row is not fully at the bottom, when scrolling you can see through the sticky row 

<img width="855" height="206" alt="Screenshot 2025-12-17 at 12 48 10" src="https://github.com/user-attachments/assets/2e7d0790-ee3c-458d-853b-64e6fedb4687" />
