### PR TITLE
Panel visualizations: Focus on search input when changing visualizations

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useId, useMemo, useState } from 'react';
 import { useMedia, useSessionStorage } from 'react-use';
 
 import { GrafanaTheme2, PanelData } from '@grafana/data';
@@ -48,15 +48,8 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
   const theme = useTheme2();
   const panelModel = useMemo(() => new PanelModelCompatibilityWrapper(panel), [panel]);
   const filterId = useId();
-  const [searchInputRef, setSearchInputRef] = useState<HTMLInputElement | null>(null);
 
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
-
-  useEffect(() => {
-    if (searchInputRef && !isMobile) {
-      searchInputRef.focus();
-    }
-  }, [searchInputRef, isMobile]);
 
   /** SEARCH */
   const [searchQuery, setSearchQuery] = useState('');
@@ -142,6 +135,7 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
                 )}
                 <FilterInput
                   id={filterId}
+                  autoFocus={!isMobile}
                   className={styles.filter}
                   value={searchQuery}
                   onChange={setSearchQuery}

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -1,14 +1,14 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
 import { useCallback, useEffect, useId, useMemo, useState } from 'react';
-import { useSessionStorage } from 'react-use';
+import { useMedia, useSessionStorage } from 'react-use';
 
 import { GrafanaTheme2, PanelData } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
-import { Button, Field, FilterInput, ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { Button, Field, FilterInput, ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2, useTheme2 } from '@grafana/ui';
 import { LS_VISUALIZATION_SELECT_TAB_KEY } from 'app/core/constants';
 import { VisualizationSelectPaneTab } from 'app/features/dashboard/components/PanelEditor/types';
 import { VisualizationSuggestions } from 'app/features/panel/components/VizTypePicker/VisualizationSuggestions';
@@ -45,15 +45,18 @@ const getTabs = (): Array<{ label: string; value: VisualizationSelectPaneTab }> 
 
 export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose, showBackButton, isNewPanel }: Props) {
   const styles = useStyles2(getStyles);
+  const theme = useTheme2();
   const panelModel = useMemo(() => new PanelModelCompatibilityWrapper(panel), [panel]);
   const filterId = useId();
   const [searchInputRef, setSearchInputRef] = useState<HTMLInputElement | null>(null);
 
+  const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
+
   useEffect(() => {
-    if (searchInputRef) {
+    if (searchInputRef && !isMobile) {
       searchInputRef.focus();
     }
-  }, [searchInputRef]);
+  }, [searchInputRef, isMobile]);
 
   /** SEARCH */
   const [searchQuery, setSearchQuery] = useState('');

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -8,7 +8,18 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { VizPanel } from '@grafana/scenes';
-import { Button, Field, FilterInput, ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2, useTheme2 } from '@grafana/ui';
+import {
+  Button,
+  Field,
+  FilterInput,
+  ScrollContainer,
+  Stack,
+  Tab,
+  TabContent,
+  TabsBar,
+  useStyles2,
+  useTheme2,
+} from '@grafana/ui';
 import { LS_VISUALIZATION_SELECT_TAB_KEY } from 'app/core/constants';
 import { VisualizationSelectPaneTab } from 'app/features/dashboard/components/PanelEditor/types';
 import { VisualizationSuggestions } from 'app/features/panel/components/VizTypePicker/VisualizationSuggestions';

--- a/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelVizTypePicker.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { debounce } from 'lodash';
-import { useCallback, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
 import { useSessionStorage } from 'react-use';
 
 import { GrafanaTheme2, PanelData } from '@grafana/data';
@@ -47,6 +47,13 @@ export function PanelVizTypePicker({ panel, editPreview, data, onChange, onClose
   const styles = useStyles2(getStyles);
   const panelModel = useMemo(() => new PanelModelCompatibilityWrapper(panel), [panel]);
   const filterId = useId();
+  const [searchInputRef, setSearchInputRef] = useState<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    if (searchInputRef) {
+      searchInputRef.focus();
+    }
+  }, [searchInputRef]);
 
   /** SEARCH */
   const [searchQuery, setSearchQuery] = useState('');


### PR DESCRIPTION
This has been bothering me for a while - If I want to change visualizations and I already have in mind which new viz I want, it's frustrating that I have to have one additional click to actually search for it. So this is just a suggestion to solve this paper cut, but not sure if there are other considerations I'm missing

After: 
https://github.com/user-attachments/assets/3509e21e-7715-411c-ab5a-0016adfd18c9

~~Not sure if it should also happen when using mobile 🤔~~ I decided to not do it while on mobile, seems a bit disruptive to focus and open the keyboard