### PR TITLE
DashboardLibrary: Force v1 dashboard scene page manager when loading template dashboards

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -1082,6 +1082,12 @@ export class UnifiedDashboardScenePageStateManager extends DashboardScenePageSta
       const newDashboardVersion = shouldForceV2API() ? 'v2' : 'v1';
       this.setActiveManager(newDashboardVersion);
     }
+
+    // Template dashboards are currently in v1 schema format.
+    if (options.route === DashboardRoutes.Template) {
+      this.setActiveManager('v1');
+    }
+
     return this.withVersionHandling((manager) => manager.loadDashboard.call(this, options));
   }
 


### PR DESCRIPTION
Alternative to https://github.com/grafana/grafana/pull/115118

**Problem**

After merging this [PR](https://github.com/grafana/grafana/pull/113548) we are now forcing v2 dashboard API and the corresponding `DashboardScenePageStateManagerV2` manager when the `dashboardNewLayouts` feature flag is enabled. This was needed because v1-to-v2 dashboard conversions now happens in the backend.

However, this change broke the template dashboard loading flow (**dashboard library/suggested dashboards/community** dashboards). 

**Error when loading the feature with FF  `dashboardNewLayouts`  enabled:** 

> Error: Dashboard uid or slug required


https://github.com/user-attachments/assets/ee020d1e-9999-4ba6-8ec0-5a34d28ffb1b


**Root Cause**
  Template dashboards are loaded via the `/dashboard/template `route with query parameters like:
`  /dashboard/template?gnetId=969&datasource=xpyRJd9Mz&mappings=[]
`
  **The flow with the bug:**

  1. `UnifiedDashboardScenePageStateManager` defaults to V2 manager when `shouldForceV2API`() returns true
  2. V2 manager's `fetchDashboard()` is called with route: `DashboardRoutes.Template`
  3. V2 manager has no case handler for `DashboardRoutes.Template` in its switch statement
  4. Falls through to default case which calls t`his.dashboardLoader.loadDashboard('db', '', '')` with an empty uid
  5. `DashboardLoaderSrvV2` throws "Dashboard uid or slug required" because template URLs don't have uids

  **Why Template Dashboards Are Special**

  Template dashboards from grafana.com are:
  - Always in v1 schema format (they haven't been migrated to v2)
  - Don't have UIDs (they're starting points, not saved dashboards)
  - Meant to be loaded, customized, and then saved as new dashboards
  - Only handled by the V1 manager, which has the `loadDashboardLibrary() `method

**My approach**

This PR forces the use of the V1 manager specifically for the` DashboardRoutes.Template `route, regardless of the `dashboardNewLayouts` feature flag setting. This in an alternative to avoid using the `ensureV2Response` in the frontend. The PR[ ](https://github.com/grafana/grafana/pull/115118)that juani was implementing.

**Flow After This PR**

  1. User loads template dashboard: `/dashboard/template?gnetId=969&...`
  2. `UnifiedDashboardScenePageStateManager` detects Template route → forces V1 manager
  3. V1 manager's `fetchDashboard()` calls `loadDashboardLibrary()`
  4. `loadDashboardLibrary()` fetches dashboard from grafana.com → interpolates variables → returns v1 DashboardDTO
  5. Dashboard transforms to scene and loads successfully ✅
  6. When user saves, conversion to v2 happens lazily at save time (if `shouldForceV2API()` is true)


Fixes https://github.com/grafana/grafana/issues/114193