### PR TITLE
Explore: Reset hidden series

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelContext.ts
@@ -35,6 +35,7 @@ export interface PanelContext {
   onSeriesColorChange?: (label: string, color: string) => void;
 
   onToggleSeriesVisibility?: (label: string, mode: SeriesVisibilityChangeMode) => void;
+  onResetAllSeriesVisibility?: () => void;
 
   canAddAnnotations?: () => boolean;
   canEditAnnotations?: (dashboardUID?: string) => boolean;

--- a/packages/grafana-ui/src/components/PanelChrome/types.ts
+++ b/packages/grafana-ui/src/components/PanelChrome/types.ts
@@ -7,6 +7,7 @@
 export enum SeriesVisibilityChangeMode {
   ToggleSelection = 'select',
   AppendToSelection = 'append',
+  Show = 'show',
 }
 
 export type OnSelectRangeCallback = (selections: RangeSelection2D[]) => void;

--- a/packages/grafana-ui/src/components/VizLegend/VizLegend.tsx
+++ b/packages/grafana-ui/src/components/VizLegend/VizLegend.tsx
@@ -1,9 +1,12 @@
+import { css } from '@emotion/css';
 import { useCallback } from 'react';
 import * as React from 'react';
 
 import { DataHoverClearEvent, DataHoverEvent } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
 import { LegendDisplayMode } from '@grafana/schema';
 
+import { Button } from '../Button/Button';
 import { SeriesVisibilityChangeMode, usePanelContext } from '../PanelChrome';
 
 import { VizLegendList } from './VizLegendList';
@@ -32,7 +35,7 @@ export function VizLegend<T>({
   readonly,
   isSortable,
 }: LegendProps<T>) {
-  const { eventBus, onToggleSeriesVisibility, onToggleLegendSort } = usePanelContext();
+  const { eventBus, onResetAllSeriesVisibility, onToggleSeriesVisibility, onToggleLegendSort } = usePanelContext();
 
   const onMouseOver = useCallback(
     (
@@ -104,6 +107,26 @@ export function VizLegend<T>({
     },
     [className, placement, onMouseOver, onMouseOut, onLegendLabelClick, itemRenderer, readonly]
   );
+
+  if (onResetAllSeriesVisibility && items.every((item) => (item.fieldName ?? item.label) && item.disabled)) {
+    return (
+      <div className={css({ paddingTop: '0.5em' })}>
+        <Button
+          size="sm"
+          tooltip={t(
+            'grafana-ui.viz-legend.show-all-series-tooltip',
+            'Currently loaded series are hidden by previous selection. Click to show all series.'
+          )}
+          variant="secondary"
+          onClick={() => {
+            onResetAllSeriesVisibility();
+          }}
+        >
+          <Trans i18nKey="grafana-ui.viz-legend.show-all-series">Show all series</Trans>
+        </Button>
+      </div>
+    );
+  }
 
   switch (displayMode) {
     case LegendDisplayMode.Table:

--- a/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
+++ b/public/app/features/dashboard/dashgrid/PanelStateWrapper.tsx
@@ -53,7 +53,7 @@ import { loadSnapshotData } from '../utils/loadSnapshotData';
 
 import { PanelHeaderMenuWrapper } from './PanelHeader/PanelHeaderMenuWrapper';
 import { PanelLoadTimeMonitor } from './PanelLoadTimeMonitor';
-import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
+import { isHideSeriesOverride, seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
 import { liveTimer } from './liveTimer';
 import { PanelOptionsLogger } from './panelOptionsLogger';
 
@@ -106,6 +106,7 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
         sync: this.getSync,
         onSeriesColorChange: this.onSeriesColorChange,
         onToggleSeriesVisibility: this.onSeriesVisibilityChange,
+        onResetAllSeriesVisibility: this.onSeriesVisibilityReset,
         onAnnotationCreate: this.onAnnotationCreate,
         onAnnotationUpdate: this.onAnnotationUpdate,
         onAnnotationDelete: this.onAnnotationDelete,
@@ -169,6 +170,13 @@ export class PanelStateWrapper extends PureComponent<Props, State> {
     this.onFieldConfigChange(
       seriesVisibilityConfigFactory(label, mode, this.props.panel.fieldConfig, this.state.data.series)
     );
+  };
+
+  onSeriesVisibilityReset = () => {
+    this.onFieldConfigChange({
+      ...this.props.panel.fieldConfig,
+      overrides: this.props.panel.fieldConfig.overrides.filter((rule) => !isHideSeriesOverride(rule)),
+    });
   };
 
   onToggleLegendSort = (sortKey: string) => {

--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
@@ -14,7 +14,7 @@ import {
 import { SeriesVisibilityChangeMode } from '@grafana/ui';
 
 const displayOverrideRef = 'hideSeriesFrom';
-const isHideSeriesOverride = isSystemOverrideWithRef(displayOverrideRef);
+export const isHideSeriesOverride = isSystemOverrideWithRef(displayOverrideRef);
 
 export function seriesVisibilityConfigFactory(
   label: string,

--- a/public/app/features/explore/Graph/ExploreGraph.tsx
+++ b/public/app/features/explore/Graph/ExploreGraph.tsx
@@ -34,7 +34,10 @@ import { defaultGraphConfig, getGraphFieldConfig } from 'app/plugins/panel/times
 import { Options as TimeSeriesOptions } from 'app/plugins/panel/timeseries/panelcfg.gen';
 import { ExploreGraphStyle } from 'app/types/explore';
 
-import { seriesVisibilityConfigFactory } from '../../dashboard/dashgrid/SeriesVisibilityConfigFactory';
+import {
+  isHideSeriesOverride,
+  seriesVisibilityConfigFactory,
+} from '../../dashboard/dashgrid/SeriesVisibilityConfigFactory';
 import { useExploreDataLinkPostProcessor } from '../hooks/useExploreDataLinkPostProcessor';
 
 import { applyGraphStyle, applyThresholdsConfig } from './exploreGraphStyleUtils';
@@ -170,6 +173,12 @@ export function ExploreGraph({
     sync: () => DashboardCursorSync.Off,
     onToggleSeriesVisibility(label: string, mode: SeriesVisibilityChangeMode) {
       setFieldConfig(seriesVisibilityConfigFactory(label, mode, fieldConfig, data));
+    },
+    onResetAllSeriesVisibility: () => {
+      setFieldConfig({
+        ...fieldConfig,
+        overrides: fieldConfig.overrides.filter((rule) => !isHideSeriesOverride(rule)),
+      });
     },
   };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9314,7 +9314,9 @@
       "remove-button": "Remove {{children}}"
     },
     "viz-legend": {
-      "right-axis-indicator": "(right y-axis)"
+      "right-axis-indicator": "(right y-axis)",
+      "show-all-series": "Show all series",
+      "show-all-series-tooltip": "Previously selected series are hidden. Click to show all series."
     },
     "viz-tooltip": {
       "actions-confirmation-input-placeholder": "Are you sure you want to {{ actionTitle }}?",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9316,7 +9316,7 @@
     "viz-legend": {
       "right-axis-indicator": "(right y-axis)",
       "show-all-series": "Show all series",
-      "show-all-series-tooltip": "Previously selected series are hidden. Click to show all series."
+      "show-all-series-tooltip": "Currently loaded series are hidden by previous selection. Click to show all series."
     },
     "viz-tooltip": {
       "actions-confirmation-input-placeholder": "Are you sure you want to {{ actionTitle }}?",


### PR DESCRIPTION
Fixes: #115406

Similar to https://github.com/grafana/grafana/issues/113975 but slightly different approach that if approved we can implement in dashboards as well (requires scenes update to pass new function).

Resetting the legend selection on each query change as in https://github.com/grafana/grafana/issues/113975 could be annoying in Explore. Instead we allow the user to reset the selection when all currently visible series are hidden.


https://github.com/user-attachments/assets/e8bccf4f-b668-4f20-8e31-0bde9c1fdc54

