### PR TITLE
V2 -> V1 conversion: include empty properties array when converting overrides

### DIFF
--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.value-mapping-and-overrides.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.value-mapping-and-overrides.json
@@ -1,0 +1,864 @@
+{
+    "kind": "DashboardWithAccessInfo",
+    "apiVersion": "dashboard.grafana.app/v2beta1",
+    "metadata": {
+      "name": "value-mapping-test",
+      "namespace": "default",
+      "uid": "value-mapping-test",
+      "resourceVersion": "1765384157199094",
+      "generation": 2,
+      "creationTimestamp": "2025-11-19T20:09:28Z",
+      "labels": {
+        "grafana.app/deprecatedInternalID": "646372978987008"
+      }
+    },
+    "spec": {
+      "annotations": [
+        {
+          "kind": "AnnotationQuery",
+          "spec": {
+            "query": {
+              "kind": "DataQuery",
+              "group": "grafana",
+              "version": "v0",
+              "datasource": {
+                "name": "-- Grafana --"
+              },
+              "spec": {}
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations \u0026 Alerts",
+            "builtIn": true,
+            "legacyOptions": {
+              "type": "dashboard"
+            }
+          }
+        }
+      ],
+      "cursorSync": "Off",
+      "description": "Test dashboard for all value mapping types and override matcher types",
+      "editable": true,
+      "elements": {
+        "panel-1": {
+          "kind": "Panel",
+          "spec": {
+            "id": 1,
+            "title": "ValueMap Example",
+            "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "up"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "critical": {
+                            "text": "Critical!",
+                            "color": "red",
+                            "index": 0
+                          },
+                          "ok": {
+                            "text": "OK",
+                            "color": "green",
+                            "index": 2
+                          },
+                          "warning": {
+                            "text": "Warning",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "status"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 100
+                        },
+                        {
+                          "id": "custom.align",
+                          "value": "center"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-2": {
+          "kind": "Panel",
+          "spec": {
+            "id": 2,
+            "title": "RangeMap Example",
+            "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "cpu_usage_percent"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "gauge",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 0,
+                          "to": 50,
+                          "result": {
+                            "text": "Low",
+                            "color": "green",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 50,
+                          "to": 80,
+                          "result": {
+                            "text": "Medium",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 80,
+                          "to": 100,
+                          "result": {
+                            "text": "High",
+                            "color": "red",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": "/^cpu_/"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "decimals",
+                          "value": 2
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-3": {
+          "kind": "Panel",
+          "spec": {
+            "id": 3,
+            "title": "RegexMap Example",
+            "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "log_level"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^error.*/",
+                          "result": {
+                            "text": "Error",
+                            "color": "red",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^warn.*/",
+                          "result": {
+                            "text": "Warning",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^info.*/",
+                          "result": {
+                            "text": "Info",
+                            "color": "blue",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byType",
+                        "options": "string"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-text"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-4": {
+          "kind": "Panel",
+          "spec": {
+            "id": 4,
+            "title": "SpecialValueMap Example",
+            "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "some_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "No Data",
+                            "color": "gray",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "nan",
+                          "result": {
+                            "text": "Not a Number",
+                            "color": "gray",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null+nan",
+                          "result": {
+                            "text": "N/A",
+                            "color": "gray",
+                            "index": 2
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "true",
+                          "result": {
+                            "text": "Yes",
+                            "color": "green",
+                            "index": 3
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "false",
+                          "result": {
+                            "text": "No",
+                            "color": "red",
+                            "index": 4
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "empty",
+                          "result": {
+                            "text": "Empty",
+                            "color": "gray",
+                            "index": 5
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "A"
+                      },
+                      "properties": [
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "blue",
+                            "mode": "fixed"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-6": {
+          "kind": "Panel",
+          "spec": {
+            "id": 6,
+            "title": "Empty Properties Override Example",
+            "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "empty_override_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {},
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "field_with_empty_override"
+                      },
+                      "properties": []
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-5": {
+          "kind": "Panel",
+          "spec": {
+            "id": 5,
+            "title": "Combined Mappings and Overrides Example",
+            "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "combined_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  },
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "secondary_metric"
+                        }
+                      },
+                      "refId": "B",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "table",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "failure": {
+                            "text": "Failure",
+                            "color": "red",
+                            "index": 1
+                          },
+                          "success": {
+                            "text": "Success",
+                            "color": "green",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 0,
+                          "to": 100,
+                          "result": {
+                            "text": "In Range",
+                            "color": "blue",
+                            "index": 2
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^[A-Z]{3}-\\d+$/",
+                          "result": {
+                            "text": "ID Format",
+                            "color": "purple",
+                            "index": 3
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "Missing",
+                            "color": "gray",
+                            "index": 4
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "status"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 120
+                        },
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-background"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": "/^value_/"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "short"
+                        },
+                        {
+                          "id": "min",
+                          "value": 0
+                        },
+                        {
+                          "id": "max",
+                          "value": 100
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byType",
+                        "options": "number"
+                      },
+                      "properties": [
+                        {
+                          "id": "decimals",
+                          "value": 2
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "green",
+                                "value": null
+                              },
+                              {
+                                "color": "yellow",
+                                "value": 50
+                              },
+                              {
+                                "color": "red",
+                                "value": 80
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "B"
+                      },
+                      "properties": [
+                        {
+                          "id": "displayName",
+                          "value": "Secondary Query"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byValue",
+                        "options": {
+                          "op": "gte",
+                          "reducer": "allIsNull",
+                          "value": 0
+                        }
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.hidden",
+                          "value": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": [
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-1"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 12,
+                "y": 0,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-2"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 8,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-3"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 12,
+                "y": 8,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-4"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 16,
+                "width": 24,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-5"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 24,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-6"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "links": [],
+      "liveNow": false,
+      "preload": false,
+      "tags": [
+        "value-mapping",
+        "overrides",
+        "test"
+      ],
+      "timeSettings": {
+        "timezone": "browser",
+        "from": "now-6h",
+        "to": "now",
+        "autoRefresh": "",
+        "autoRefreshIntervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "hideTimepicker": false,
+        "fiscalYearStartMonth": 0
+      },
+      "title": "Value Mapping and Overrides Test",
+      "variables": []
+    },
+    "status": {
+      "conversion": {
+        "failed": false,
+        "storedVersion": "v1beta1"
+      }
+    }
+  }

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v0alpha1.json
@@ -1,0 +1,640 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "liveNow": false,
+    "panels": [
+      {
+        "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "critical": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Critical!"
+                  },
+                  "ok": {
+                    "color": "green",
+                    "index": 2,
+                    "text": "OK"
+                  },
+                  "warning": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 100
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "up",
+            "refId": "A"
+          }
+        ],
+        "title": "ValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Low"
+                  },
+                  "to": 50
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 50,
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Medium"
+                  },
+                  "to": 80
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 80,
+                  "result": {
+                    "color": "red",
+                    "index": 2,
+                    "text": "High"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^cpu_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "percent"
+                },
+                {
+                  "id": "decimals",
+                  "value": 2
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "cpu_usage_percent",
+            "refId": "A"
+          }
+        ],
+        "title": "RangeMap Example",
+        "type": "gauge"
+      },
+      {
+        "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "pattern": "/^error.*/",
+                  "result": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Error"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^warn.*/",
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^info.*/",
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "Info"
+                  }
+                },
+                "type": "regex"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "string"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-text"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "log_level",
+            "refId": "A"
+          }
+        ],
+        "title": "RegexMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 0,
+                    "text": "No Data"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 1,
+                    "text": "Not a Number"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "null+nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 2,
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "true",
+                  "result": {
+                    "color": "green",
+                    "index": 3,
+                    "text": "Yes"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "false",
+                  "result": {
+                    "color": "red",
+                    "index": 4,
+                    "text": "No"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "empty",
+                  "result": {
+                    "color": "gray",
+                    "index": 5,
+                    "text": "Empty"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "A"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 4,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "some_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "SpecialValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "failure": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "Failure"
+                  },
+                  "success": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Success"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "In Range"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "pattern": "/^[A-Z]{3}-\\d+$/",
+                  "result": {
+                    "color": "purple",
+                    "index": 3,
+                    "text": "ID Format"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 4,
+                    "text": "Missing"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 120
+                },
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^value_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "short"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 100
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              },
+              "properties": [
+                {
+                  "id": "decimals",
+                  "value": 2
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "B"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Secondary Query"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byValue",
+                "options": {
+                  "op": "gte",
+                  "reducer": "allIsNull",
+                  "value": 0
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hidden",
+                  "value": true
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 5,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "combined_metric",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "secondary_metric",
+            "refId": "B"
+          }
+        ],
+        "title": "Combined Mappings and Overrides Example",
+        "type": "table"
+      },
+      {
+        "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+        "fieldConfig": {
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "field_with_empty_override"
+              },
+              "properties": []
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "empty_override_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "Empty Properties Override Example",
+        "type": "stat"
+      }
+    ],
+    "preload": false,
+    "refresh": "",
+    "schemaVersion": 42,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Value Mapping and Overrides Test"
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v1beta1.json
@@ -1,0 +1,640 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "liveNow": false,
+    "panels": [
+      {
+        "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "critical": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Critical!"
+                  },
+                  "ok": {
+                    "color": "green",
+                    "index": 2,
+                    "text": "OK"
+                  },
+                  "warning": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 100
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "up",
+            "refId": "A"
+          }
+        ],
+        "title": "ValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Low"
+                  },
+                  "to": 50
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 50,
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Medium"
+                  },
+                  "to": 80
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 80,
+                  "result": {
+                    "color": "red",
+                    "index": 2,
+                    "text": "High"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^cpu_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "percent"
+                },
+                {
+                  "id": "decimals",
+                  "value": 2
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "cpu_usage_percent",
+            "refId": "A"
+          }
+        ],
+        "title": "RangeMap Example",
+        "type": "gauge"
+      },
+      {
+        "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "pattern": "/^error.*/",
+                  "result": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Error"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^warn.*/",
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^info.*/",
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "Info"
+                  }
+                },
+                "type": "regex"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "string"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-text"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "log_level",
+            "refId": "A"
+          }
+        ],
+        "title": "RegexMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 0,
+                    "text": "No Data"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 1,
+                    "text": "Not a Number"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "null+nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 2,
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "true",
+                  "result": {
+                    "color": "green",
+                    "index": 3,
+                    "text": "Yes"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "false",
+                  "result": {
+                    "color": "red",
+                    "index": 4,
+                    "text": "No"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "empty",
+                  "result": {
+                    "color": "gray",
+                    "index": 5,
+                    "text": "Empty"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "A"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 4,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "some_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "SpecialValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "failure": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "Failure"
+                  },
+                  "success": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Success"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "In Range"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "pattern": "/^[A-Z]{3}-\\d+$/",
+                  "result": {
+                    "color": "purple",
+                    "index": 3,
+                    "text": "ID Format"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 4,
+                    "text": "Missing"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 120
+                },
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^value_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "short"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 100
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              },
+              "properties": [
+                {
+                  "id": "decimals",
+                  "value": 2
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "B"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Secondary Query"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byValue",
+                "options": {
+                  "op": "gte",
+                  "reducer": "allIsNull",
+                  "value": 0
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hidden",
+                  "value": true
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 5,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "combined_metric",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "secondary_metric",
+            "refId": "B"
+          }
+        ],
+        "title": "Combined Mappings and Overrides Example",
+        "type": "table"
+      },
+      {
+        "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+        "fieldConfig": {
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "field_with_empty_override"
+              },
+              "properties": []
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "empty_override_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "Empty Properties Override Example",
+        "type": "stat"
+      }
+    ],
+    "preload": false,
+    "refresh": "",
+    "schemaVersion": 42,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Value Mapping and Overrides Test"
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v2alpha1.json
@@ -1,0 +1,850 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v2alpha1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "query": {
+            "kind": "grafana",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "ValueMap Example",
+          "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "up"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "critical": {
+                          "text": "Critical!",
+                          "color": "red",
+                          "index": 0
+                        },
+                        "ok": {
+                          "text": "OK",
+                          "color": "green",
+                          "index": 2
+                        },
+                        "warning": {
+                          "text": "Warning",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "RangeMap Example",
+          "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "cpu_usage_percent"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "gauge",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 0,
+                        "to": 50,
+                        "result": {
+                          "text": "Low",
+                          "color": "green",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 50,
+                        "to": 80,
+                        "result": {
+                          "text": "Medium",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 80,
+                        "to": 100,
+                        "result": {
+                          "text": "High",
+                          "color": "red",
+                          "index": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^cpu_/"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "RegexMap Example",
+          "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "log_level"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^error.*/",
+                        "result": {
+                          "text": "Error",
+                          "color": "red",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^warn.*/",
+                        "result": {
+                          "text": "Warning",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^info.*/",
+                        "result": {
+                          "text": "Info",
+                          "color": "blue",
+                          "index": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byType",
+                      "options": "string"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "SpecialValueMap Example",
+          "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "some_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "No Data",
+                          "color": "gray",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "nan",
+                        "result": {
+                          "text": "Not a Number",
+                          "color": "gray",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null+nan",
+                        "result": {
+                          "text": "N/A",
+                          "color": "gray",
+                          "index": 2
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "true",
+                        "result": {
+                          "text": "Yes",
+                          "color": "green",
+                          "index": 3
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "false",
+                        "result": {
+                          "text": "No",
+                          "color": "red",
+                          "index": 4
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "empty",
+                        "result": {
+                          "text": "Empty",
+                          "color": "gray",
+                          "index": 5
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Combined Mappings and Overrides Example",
+          "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "combined_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "secondary_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "table",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "failure": {
+                          "text": "Failure",
+                          "color": "red",
+                          "index": 1
+                        },
+                        "success": {
+                          "text": "Success",
+                          "color": "green",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 0,
+                        "to": 100,
+                        "result": {
+                          "text": "In Range",
+                          "color": "blue",
+                          "index": 2
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^[A-Z]{3}-\\d+$/",
+                        "result": {
+                          "text": "ID Format",
+                          "color": "purple",
+                          "index": 3
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "Missing",
+                          "color": "gray",
+                          "index": 4
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 120
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^value_/"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 100
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byType",
+                      "options": "number"
+                    },
+                    "properties": [
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 50
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Secondary Query"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byValue",
+                      "options": {
+                        "op": "gte",
+                        "reducer": "allIsNull",
+                        "value": 0
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "id": 6,
+          "title": "Empty Properties Override Example",
+          "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "empty_override_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "field_with_empty_override"
+                    },
+                    "properties": []
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 16,
+              "width": 24,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Value Mapping and Overrides Test",
+    "variables": []
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -1983,7 +1983,6 @@ func convertFieldConfigOverridesToV1(overrides []dashv2alpha1.DashboardV2alpha1F
 			}
 		}
 		overrideMap["properties"] = properties
-		
 
 		result = append(result, overrideMap)
 	}

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -1973,16 +1973,17 @@ func convertFieldConfigOverridesToV1(overrides []dashv2alpha1.DashboardV2alpha1F
 			"options": override.Matcher.Options,
 		}
 
+		properties := make([]map[string]interface{}, 0, len(override.Properties))
 		if len(override.Properties) > 0 {
-			properties := make([]map[string]interface{}, 0, len(override.Properties))
 			for _, prop := range override.Properties {
 				properties = append(properties, map[string]interface{}{
 					"id":    prop.Id,
 					"value": prop.Value,
 				})
 			}
-			overrideMap["properties"] = properties
 		}
+		overrideMap["properties"] = properties
+		
 
 		result = append(result, overrideMap)
 	}

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -2074,11 +2074,9 @@ func convertRegexMapToV1(regexMap *dashv2alpha1.DashboardRegexMap) map[string]in
 		return nil
 	}
 
-	options := []map[string]interface{}{
-		{
-			"pattern": regexMap.Options.Pattern,
-			"result":  convertValueMappingResultToV1(regexMap.Options.Result),
-		},
+	options := map[string]interface{}{
+		"pattern": regexMap.Options.Pattern,
+		"result":  convertValueMappingResultToV1(regexMap.Options.Result),
 	}
 
 	return map[string]interface{}{


### PR DESCRIPTION
`properties: []` would be omitted when converting v2 panel with override without properties. This would break the panel when converting to V1. Adding logic to always include `properties: []` when converting override.


Test V2 JSON to reproduce error:
[dashboard-1765979177867.json](https://github.com/user-attachments/files/24214914/dashboard-1765979177867.json)

Fixes https://github.com/grafana/grafana/issues/115493
