### PR TITLE
Dynamic Dashboards: Decrease min height of first grid child

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -695,7 +695,7 @@ function getStyles(theme: GrafanaTheme2) {
       // disable flex grow on the SceneGridLayouts first div
       '> div:first-child': {
         flexGrow: `0 !important`,
-        minHeight: '1px',
+        minHeight: 1,
       },
       ...dashboardCanvasAddButtonHoverStyles,
     }),

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -695,7 +695,7 @@ function getStyles(theme: GrafanaTheme2) {
       // disable flex grow on the SceneGridLayouts first div
       '> div:first-child': {
         flexGrow: `0 !important`,
-        minHeight: '250px',
+        minHeight: '1px',
       },
       ...dashboardCanvasAddButtonHoverStyles,
     }),


### PR DESCRIPTION
Min height being 250 causes a gap when the panel is shorter than 250px: https://github.com/grafana/grafana/issues/115319

If I remove the height, the panel isn't rendered at all when switching auto -> custom layout (because of `useMeasure` in SceneGridLayoutRenderer maybe?), so 1px should work: 

Before: 

https://github.com/user-attachments/assets/397fb0e9-112c-4aa8-bc41-6472cb0546f1

After:

https://github.com/user-attachments/assets/d4f8d57b-785b-4e6b-ae6a-e4bedba9b1a1

