### PR TITLE
Gauge: Update labelling to include new gauge

### DIFF
--- a/.github/pr-commands.json
+++ b/.github/pr-commands.json
@@ -365,7 +365,9 @@
     "type": "changedfiles",
     "matches": [
       "public/app/plugins/panel/gauge/**/*",
-      "/packages/grafana-ui/src/components/Gauge/**/*"
+      "public/app/plugins/panel/radialbar/**/*",
+      "/packages/grafana-ui/src/components/Gauge/**/*",
+      "/packages/grafana-ui/src/components/RadialGauge/**/*"
     ],
     "action": "updateLabel",
     "addLabel": "area/panel/gauge"


### PR DESCRIPTION
This will ensure that PRs related to the "new gauge" also get the gauge label.