### PR TITLE
ElasticSearch: Update annotation time-range properties

### DIFF
--- a/public/app/plugins/datasource/elasticsearch/datasource.test.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.test.ts
@@ -1000,7 +1000,7 @@ describe('ElasticDatasource', () => {
         });
         expect(postResourceRequestMock).toHaveBeenCalledWith(
           '_msearch',
-          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@test_time":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}},{"range":{"@time_end_field":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}},{"query_string":{"query":"abc"}}]}},"size":10000}\n'
+          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@test_time":{"gte":1683291160012,"lte":1683291460012,"format":"epoch_millis"}}},{"range":{"@time_end_field":{"gte":1683291160012,"lte":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}},{"query_string":{"query":"abc"}}]}},"size":10000}\n'
         );
       });
 
@@ -1030,7 +1030,7 @@ describe('ElasticDatasource', () => {
         });
         expect(postResourceRequestMock).toHaveBeenCalledWith(
           '_msearch',
-          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@timestamp":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}}]}},"size":10000}\n'
+          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@timestamp":{"gte":1683291160012,"lte":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}}]}},"size":10000}\n'
         );
       });
 
@@ -1087,7 +1087,7 @@ describe('ElasticDatasource', () => {
         });
         expect(postResourceRequestMock).toHaveBeenCalledWith(
           '_msearch',
-          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@test_time":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}},{"range":{"@time_end_field":{"from":1683291160012,"to":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}},{"query_string":{"query":"abc AND abc_key:\\"abc_value\\""}}]}},"size":10000}\n'
+          '{"search_type":"query_then_fetch","ignore_unavailable":true,"index":"[test-]YYYY.MM.DD"}\n{"query":{"bool":{"filter":[{"bool":{"should":[{"range":{"@test_time":{"gte":1683291160012,"lte":1683291460012,"format":"epoch_millis"}}},{"range":{"@time_end_field":{"gte":1683291160012,"lte":1683291460012,"format":"epoch_millis"}}}],"minimum_should_match":1}},{"query_string":{"query":"abc AND abc_key:\\"abc_value\\""}}]}},"size":10000}\n'
         );
       });
     });

--- a/public/app/plugins/datasource/elasticsearch/datasource.ts
+++ b/public/app/plugins/datasource/elasticsearch/datasource.ts
@@ -294,8 +294,8 @@ export class ElasticDatasource
     const dateRanges = [];
     const rangeStart: RangeMap = {};
     rangeStart[timeField] = {
-      from: options.range.from.valueOf(),
-      to: options.range.to.valueOf(),
+      gte: options.range.from.valueOf(),
+      lte: options.range.to.valueOf(),
       format: 'epoch_millis',
     };
     dateRanges.push({ range: rangeStart });
@@ -303,8 +303,8 @@ export class ElasticDatasource
     if (timeEndField) {
       const rangeEnd: RangeMap = {};
       rangeEnd[timeEndField] = {
-        from: options.range.from.valueOf(),
-        to: options.range.to.valueOf(),
+        gte: options.range.from.valueOf(),
+        lte: options.range.to.valueOf(),
         format: 'epoch_millis',
       };
       dateRanges.push({ range: rangeEnd });

--- a/public/app/plugins/datasource/elasticsearch/types.ts
+++ b/public/app/plugins/datasource/elasticsearch/types.ts
@@ -137,7 +137,7 @@ export interface ElasticsearchAnnotationQuery {
   index?: string;
 }
 
-export type RangeMap = Record<string, { from: number; to: number; format: string }>;
+export type RangeMap = Record<string, { gte: number; lte: number; format: string }>;
 
 export type ElasticsearchResponse = ElasticsearchResponseWithHits | ElasticsearchResponseWithAggregations;
 


### PR DESCRIPTION
ElasticSearch [deprecated](https://www.elastic.co/docs/release-notes/elasticsearch/breaking-changes#elasticsearch-900-breaking-changes) support for the `from` and `to` properties in search queries as of v9.0.0.

The query endpoint was appropriately updated but the annotation query path was not. This change switches the `from` and `to` properties to `gte` and `lte` respectively which allows the time-range to be correctly passed as a filter.

I've tested this across v7.17.x, v8.19.x, and v9.x.x and it works as expected for all versions.

Fixes #113723