### PR TITLE
Docs: Add a "DO NOT MODIFY" warning to the `public/img/*` source code directory

### DIFF
--- a/public/img/DO_NOT_MODIFY.md
+++ b/public/img/DO_NOT_MODIFY.md
@@ -1,6 +1,6 @@
 # WARNING: Do NOT modify the contents of this directory!
 
-User modifications in this directory to change the runtime behaviour or appearance of Grafana are NOT supported. Doing so could result in undefined behaviour including: bugs, security vulnerabilities, or critical failures.
+User modifications in this directory to change the runtime behavior or appearance of Grafana are NOT supported. Doing so could result in undefined behaviour including: bugs, security vulnerabilities, or critical failures.
 
 Grafana is an open source project. Please feel free to contribute changes for review if you have specific bug fix or feature that you think might be useful to the rest of the community.
 

--- a/public/img/DO_NOT_MODIFY.md
+++ b/public/img/DO_NOT_MODIFY.md
@@ -1,0 +1,7 @@
+# WARNING: Do NOT modify the contents of this directory!
+
+User modifications in this directory to change the runtime behaviour or appearance of Grafana are NOT supported. Doing so could result in undefined behaviour including: bugs, security vulnerabilities, or critical failures.
+
+Grafana is an open source project. Please feel free to contribute changes for review if you have specific bug fix or feature that you think might be useful to the rest of the community.
+
+- SEE: https://github.com/grafana/plugin-tools/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
**What is this feature?**

We're adding a simple Markdown file to warn users and set clear expectations around the practice of source code modification in Grafana's `public/img/*` directory that we _do not_ support.

**Why do we need this feature?**

It turns out some users have been modifying the contents of `public/img/*` to customize the runtime behaviour and/or appearance of Grafana. Some of these customizations can become brittle and break Grafana when they upgrade later. 

Unfortunately this can cause frustration for users.

While we're an open source software product, and the user is totally free to do these modifications, we haven't explicitly warned them that we don't support the infinite number of ways they could break Grafana for themselves in so doing.

**Who is this feature for?**

All users of Grafana.

**Which issue(s) does this PR fix?**:

Fixes: https://github.com/grafana/support-escalations/issues/19541, https://github.com/grafana/grafana/issues/113135, https://github.com/grafana/grafana/issues/113447, https://github.com/grafana/grafana/issues/111701 

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
