### PR TITLE
Dashboard: change export dropdown placement in sidebar

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardExportButton.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardExportButton.tsx
@@ -18,7 +18,7 @@ const newExportButtonSelector = selectors.pages.Dashboard.DashNav.NewExportButto
 
 export function ShareExportDashboardButton({ dashboard }: Props) {
   return (
-    <Dropdown overlay={<ExportMenu dashboard={dashboard} />} placement="left-end">
+    <Dropdown overlay={<ExportMenu dashboard={dashboard} />} placement="left-start">
       <Sidebar.Button
         icon="download-alt"
         data-testid={newExportButtonSelector.Menu.container}


### PR DESCRIPTION
**What is this feature?**

Changes the export dropdown menu placement from `left-end` to `left-start` in the dashboard sidebar.

<img width="870" height="391" alt="image" src="https://github.com/user-attachments/assets/f628b8ad-fb86-4c39-9348-0c7832cadbda" />

<img width="870" height="391" alt="image" src="https://github.com/user-attachments/assets/bbe9898d-ca1c-4665-80fb-bd23e2b32c69" />

https://github.com/user-attachments/assets/0f8b91e3-1e0c-4d39-9860-23d1cf369884



**Which issue(s) does this PR fix?**:

Fixes #115328