### PR TITLE
unified-storage: add `BatchGet` support to the sqlkv implementation

### DIFF
--- a/pkg/storage/unified/resource/data/sqlkv_batch_get.sql
+++ b/pkg/storage/unified/resource/data/sqlkv_batch_get.sql
@@ -1,0 +1,12 @@
+SELECT r.{{ .Ident "key_path" }}, r.{{ .Ident "value" }}
+FROM (
+{{ range $id, $key_path := .KeyPaths }}
+    {{ if eq $id 0 }}
+        SELECT {{ $.Arg $id }} AS idx, {{ $.Arg $key_path }} AS key_path
+    {{ else }}
+        UNION ALL SELECT {{ $.Arg $id }}, {{ $.Arg $key_path }}
+    {{ end }}
+{{ end }}
+) AS requested_keys
+JOIN {{ .TableName }} r ON r.{{ .Ident "key_path" }} = requested_keys.{{ .Ident "key_path" }}
+ORDER BY requested_keys.{{ .Ident "idx" }};

--- a/pkg/storage/unified/resource/data/sqlkv_batch_get.sql
+++ b/pkg/storage/unified/resource/data/sqlkv_batch_get.sql
@@ -8,5 +8,5 @@ FROM (
     {{ end }}
 {{ end }}
 ) AS requested_keys
-JOIN {{ .TableName }} r ON r.{{ .Ident "key_path" }} = requested_keys.{{ .Ident "key_path" }}
+INNER JOIN {{ .TableName }} r ON r.{{ .Ident "key_path" }} = requested_keys.{{ .Ident "key_path" }}
 ORDER BY requested_keys.{{ .Ident "idx" }};

--- a/pkg/storage/unified/resource/sqlkv.go
+++ b/pkg/storage/unified/resource/sqlkv.go
@@ -34,9 +34,10 @@ func mustTemplate(filename string) *template.Template {
 
 // Templates.
 var (
-	sqlKVGet    = mustTemplate("sqlkv_get.sql")
-	sqlKVDelete = mustTemplate("sqlkv_delete.sql")
-	sqlKVKeys   = mustTemplate("sqlkv_keys.sql")
+	sqlKVKeys     = mustTemplate("sqlkv_keys.sql")
+	sqlKVGet      = mustTemplate("sqlkv_get.sql")
+	sqlKVBatchGet = mustTemplate("sqlkv_batch_get.sql")
+	sqlKVDelete   = mustTemplate("sqlkv_delete.sql")
 )
 
 // sqlKVSection can be embedded in structs used when rendering query templates
@@ -107,13 +108,23 @@ func (req sqlKVGetRequest) Results() ([]byte, error) {
 	return req.Value, nil
 }
 
-type sqlKVDeleteRequest struct {
+type sqlKVBatchGetRequest struct {
 	sqltemplate.SQLTemplate
-	sqlKVSectionKey
+	sqlKVSection
+	Keys []string
 }
 
-func (req sqlKVDeleteRequest) Validate() error {
-	return req.sqlKVSectionKey.Validate()
+func (req sqlKVBatchGetRequest) Validate() error {
+	return req.sqlKVSection.Validate()
+}
+
+func (req sqlKVBatchGetRequest) KeyPaths() []string {
+	result := make([]string, 0, len(req.Keys))
+	for _, key := range req.Keys {
+		result = append(result, req.Section+"/"+key)
+	}
+
+	return result
 }
 
 type sqlKVKeysRequest struct {
@@ -140,6 +151,15 @@ func (req sqlKVKeysRequest) EndKey() string {
 
 func (req sqlKVKeysRequest) SortAscending() bool {
 	return req.Options.Sort != SortOrderDesc
+}
+
+type sqlKVDeleteRequest struct {
+	sqltemplate.SQLTemplate
+	sqlKVSectionKey
+}
+
+func (req sqlKVDeleteRequest) Validate() error {
+	return req.sqlKVSectionKey.Validate()
 }
 
 var _ KV = &sqlKV{}
@@ -225,7 +245,40 @@ func (k *sqlKV) Get(ctx context.Context, section string, key string) (io.ReadClo
 
 func (k *sqlKV) BatchGet(ctx context.Context, section string, keys []string) iter.Seq2[KeyValue, error] {
 	return func(yield func(KeyValue, error) bool) {
-		panic("not implemented!")
+		if len(keys) == 0 {
+			return
+		}
+
+		rows, err := dbutil.QueryRows(ctx, k.db, sqlKVBatchGet, sqlKVBatchGetRequest{
+			SQLTemplate:  sqltemplate.New(k.dialect),
+			sqlKVSection: sqlKVSection{section},
+			Keys:         keys,
+		})
+		if err != nil {
+			yield(KeyValue{}, err)
+			return
+		}
+
+		for rows.Next() {
+			var key string
+			var value []byte
+			if err := rows.Scan(&key, &value); err != nil {
+				yield(KeyValue{}, fmt.Errorf("error reading row: %w", err))
+				return
+			}
+
+			kv := KeyValue{
+				Key:   strings.TrimPrefix(key, section+"/"),
+				Value: io.NopCloser(bytes.NewReader(value)),
+			}
+			if !yield(kv, nil) {
+				return
+			}
+		}
+
+		if err := rows.Err(); err != nil {
+			yield(KeyValue{}, fmt.Errorf("failed to read rows: %w", err))
+		}
 	}
 }
 

--- a/pkg/storage/unified/resource/sqlkv.go
+++ b/pkg/storage/unified/resource/sqlkv.go
@@ -208,7 +208,7 @@ func (k *sqlKV) Keys(ctx context.Context, section string, opt ListOptions) iter.
 			yield("", err)
 			return
 		}
-		defer rows.Close()
+		defer closeRows(rows, yield)
 
 		for rows.Next() {
 			var key string
@@ -259,7 +259,7 @@ func (k *sqlKV) BatchGet(ctx context.Context, section string, keys []string) ite
 			yield(KeyValue{}, err)
 			return
 		}
-		defer rows.Close()
+		defer closeRows(rows, yield)
 
 		for rows.Next() {
 			var key string
@@ -327,4 +327,11 @@ func (k *sqlKV) BatchDelete(ctx context.Context, section string, keys []string) 
 
 func (k *sqlKV) UnixTimestamp(ctx context.Context) (int64, error) {
 	panic("not implemented!")
+}
+
+func closeRows[T any](rows db.Rows, yield func(T, error) bool) {
+	if err := rows.Close(); err != nil {
+		var zero T
+		yield(zero, fmt.Errorf("error closing rows: %w", err))
+	}
 }

--- a/pkg/storage/unified/resource/sqlkv.go
+++ b/pkg/storage/unified/resource/sqlkv.go
@@ -208,6 +208,7 @@ func (k *sqlKV) Keys(ctx context.Context, section string, opt ListOptions) iter.
 			yield("", err)
 			return
 		}
+		defer rows.Close()
 
 		for rows.Next() {
 			var key string
@@ -258,6 +259,7 @@ func (k *sqlKV) BatchGet(ctx context.Context, section string, keys []string) ite
 			yield(KeyValue{}, err)
 			return
 		}
+		defer rows.Close()
 
 		for rows.Next() {
 			var key string

--- a/pkg/storage/unified/testing/kv_test.go
+++ b/pkg/storage/unified/testing/kv_test.go
@@ -50,7 +50,6 @@ func TestSQLKV(t *testing.T) {
 			TestKVSave:          true,
 			TestKVConcurrent:    true,
 			TestKVUnixTimestamp: true,
-			TestKVBatchGet:      true,
 			TestKVBatchDelete:   true,
 		},
 	})


### PR DESCRIPTION
Part of: https://github.com/grafana/hyperion-planning/issues/463