### PR TITLE
E2E Selectors: Fix comment typo 

### DIFF
--- a/packages/grafana-e2e-selectors/src/types/selectors.ts
+++ b/packages/grafana-e2e-selectors/src/types/selectors.ts
@@ -15,7 +15,7 @@ export type FunctionSelector = (id: string) => string;
 export type FunctionSelectorTwoArgs = (arg1: string, arg2: string) => string;
 
 /**
- * A function selector without argument
+ * A function selector without arguments
  */
 export type CssSelector = () => string;
 


### PR DESCRIPTION
**What is this feature?**

This PR is fixing a typo in a test. 

**Why do we need this feature?**

This is a bit of a dummie change to test whether [this fix](https://github.com/grafana/grafana/pull/115218) solved the issue we're having with NPM dist-tags for the e2e-selectors package.

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514