### PR TITLE
E2E Selectors: Add missing comma

### DIFF
--- a/packages/grafana-e2e-selectors/src/selectors/index.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/index.ts
@@ -9,7 +9,7 @@ const Components = resolveSelectors(versionedComponents);
 const selectors = { pages: Pages, components: Components };
 
 /**
- * Exposes Pages, Component selectors and E2ESelectors type in package for easy use in e2e tests and in production code
+ * Exposes Pages, Component selectors, and E2ESelectors type in package for easy use in e2e tests and in production code.
  */
 export {
   Pages,


### PR DESCRIPTION
**What is this feature?**

This PR is adding a missing comma in a comment. 

**Why do we need this feature?**

This is a bit of a dummie change to test whether [this fix](https://github.com/grafana/plugin-tools/pull/2353) solved the id-token issue in plugin-tools. 

**Who is this feature for?**

Plugin devs

**Which issue(s) does this PR fix?**:

Related to https://github.com/grafana/grafana/issues/114514