### PR TITLE
Provisioning: Add Git Sync limitations warning and migrate resources checkbox

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -117,14 +117,9 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
   const [repoName = '', repoType, syncTarget] = watch(['repositoryName', 'repository.type', 'repository.sync.target']);
   const [submitData] = useCreateOrUpdateRepository(repoName);
   const [deleteRepository] = useDeleteRepositoryMutation();
-  const {
-    shouldSkipSync,
-    requiresMigration,
-    isLoading: isResourceStatsLoading,
-  } = useResourceStats(repoName, syncTarget);
+  const { shouldSkipSync, isLoading: isResourceStatsLoading } = useResourceStats(repoName, syncTarget);
   const { createSyncJob, isLoading: isCreatingSkipJob } = useCreateSyncJob({
     repoName: repoName,
-    requiresMigration,
     setStepStatusInfo,
   });
 
@@ -275,7 +270,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
         nextStepIndex = currentStepIndex + 2; // Skip to finish step
 
         // Create a pull job to initialize the repository
-        const job = await createSyncJob();
+        const job = await createSyncJob(false);
         if (!job) {
           return; // Don't proceed if job creation fails
         }

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -269,7 +269,7 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
       if (activeStep === 'bootstrap' && canSkipSync) {
         nextStepIndex = currentStepIndex + 2; // Skip to finish step
 
-        // Create a pull job to initialize the repository
+        // No migration needed when skipping sync
         const job = await createSyncJob(false);
         if (!job) {
           return; // Don't proceed if job creation fails

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -1,5 +1,5 @@
 import { skipToken } from '@reduxjs/toolkit/query';
-import { memo, useEffect, useMemo, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
@@ -20,29 +20,14 @@ export interface SynchronizeStepProps {
 }
 
 export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCancelling }: SynchronizeStepProps) {
-  const { watch, register } = useFormContext<WizardFormData>();
+  const { watch, register, getValues } = useFormContext<WizardFormData>();
   const { setStepStatusInfo } = useStepStatus();
   const repoName = watch('repositoryName') ?? '';
   const syncTarget = watch('repository.sync.target');
-  const migrateResources = watch('migrate.migrateResources');
   const { requiresMigration: baseRequiresMigration } = useResourceStats(repoName, syncTarget);
-
-  // Calculate final requiresMigration based on sync target and user selection
-  // For instance sync: use the base requiresMigration
-  // For folder sync: only migrate if user explicitly opts in via checkbox
-  const requiresMigration = useMemo(() => {
-    if (syncTarget === 'instance') {
-      return baseRequiresMigration;
-    }
-    if (syncTarget === 'folder') {
-      return migrateResources ?? false;
-    }
-    return baseRequiresMigration;
-  }, [syncTarget, baseRequiresMigration, migrateResources]);
 
   const { createSyncJob } = useCreateSyncJob({
     repoName,
-    requiresMigration,
     setStepStatusInfo,
   });
   const [job, setJob] = useState<Job>();
@@ -79,7 +64,15 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
   const isButtonDisabled = hasError || (checked !== undefined && isRepositoryHealthy === false) || healthStatusNotReady;
 
   const startSynchronization = async () => {
-    const response = await createSyncJob();
+    // Calculate final requiresMigration based on sync target and user selection
+    // For instance sync: use the base requiresMigration
+    // For folder sync: only migrate if user explicitly opts in via checkbox
+    let finalRequiresMigration = baseRequiresMigration;
+    if (syncTarget === 'folder') {
+      finalRequiresMigration = getValues('migrate.migrateResources') ?? false;
+    }
+
+    const response = await createSyncJob(finalRequiresMigration);
     if (response) {
       setJob(response);
     }

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -12,7 +12,7 @@ import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useStepStatus } from './StepStatusContext';
 import { useCreateSyncJob } from './hooks/useCreateSyncJob';
 import { useResourceStats } from './hooks/useResourceStats';
-import { Target, WizardFormData } from './types';
+import { WizardFormData } from './types';
 
 export interface SynchronizeStepProps {
   onCancel?: (repoName: string) => void;

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -20,19 +20,14 @@ export interface SynchronizeStepProps {
 }
 
 export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCancelling }: SynchronizeStepProps) {
-  const { watch, register, setValue } = useFormContext<WizardFormData>();
+  const { watch, register } = useFormContext<WizardFormData>();
   const { setStepStatusInfo } = useStepStatus();
-  const repoName = watch('repositoryName') ?? '';
-  const syncTarget = watch('repository.sync.target');
-  const migrateResources = watch('migrate.migrateResources');
+  const [repoName = '', syncTarget, migrateResources] = watch([
+    'repositoryName',
+    'repository.sync.target',
+    'migrate.migrateResources',
+  ]);
   const { requiresMigration } = useResourceStats(repoName, syncTarget, migrateResources);
-
-  // For instance sync, always set migrateResources to true
-  useEffect(() => {
-    if (syncTarget === 'instance') {
-      setValue('migrate.migrateResources', true);
-    }
-  }, [syncTarget, setValue]);
 
   const { createSyncJob } = useCreateSyncJob({
     repoName,
@@ -157,18 +152,11 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
                 </Trans>
               </li>
               {syncTarget === 'instance' && (
-                <>
-                  <li>
-                    <Trans i18nKey="provisioning.wizard.alert-point-instance-permissions">
-                      Fine-grained folder permissions will be lost and cannot be recovered.
-                    </Trans>
-                  </li>
-                  <li>
-                    <Trans i18nKey="provisioning.wizard.alert-point-instance-alerts">
-                      Existing alerts and library panels will be lost and will not be usable after migration.
-                    </Trans>
-                  </li>
-                </>
+                <li>
+                  <Trans i18nKey="provisioning.wizard.alert-point-instance-alerts">
+                    Existing alerts and library panels will be lost and will not be usable after migration.
+                  </Trans>
+                </li>
               )}
               {syncTarget === 'folder' && (
                 <>
@@ -203,30 +191,29 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
           </Stack>
         </Alert>
       )}
-      <>
-        <Text element="h3">
-          <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
-        </Text>
-        <Field noMargin>
-          <Checkbox
-            {...register('migrate.migrateResources')}
-            id="migrate-resources"
-            label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
-            disabled={syncTarget === 'instance'}
-            description={
-              syncTarget === 'instance' ? (
-                <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
-                  Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
-                </Trans>
-              ) : (
-                <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
-                  Import existing dashboards from all folders into the new provisioned folder
-                </Trans>
-              )
-            }
-          />
-        </Field>
-      </>
+      <Text element="h3">
+        <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
+      </Text>
+      <Field noMargin>
+        <Checkbox
+          {...register('migrate.migrateResources')}
+          id="migrate-resources"
+          label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
+          checked={syncTarget === 'instance' ? true : undefined}
+          disabled={syncTarget === 'instance'}
+          description={
+            syncTarget === 'instance' ? (
+              <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
+                Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
+              </Trans>
+            ) : (
+              <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
+                Import existing dashboards from all folders into the new provisioned folder
+              </Trans>
+            )
+          }
+        />
+      </Field>
       {healthStatusNotReady ? (
         <>
           <Stack>

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -201,7 +201,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
               <Trans i18nKey="provisioning.wizard.alert-point-4">
                 Enterprise instance administrators can display an announcement banner to notify users that migration is
                 in progress. See{' '}
-                <TextLink external href="https://grafana.com/docs/grafana/latest/administration/announcement-banner/">
+                <TextLink external variant="bodySmall" href="https://grafana.com/docs/grafana/latest/administration/announcement-banner/">
                   this guide
                 </TextLink>{' '}
                 for step-by-step instructions.

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -210,33 +210,30 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
           </Stack>
         </Alert>
       )}
-      {(syncTarget === 'folder' || syncTarget === 'instance') && (
-        <>
-          <Text element="h3">
-            <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
-          </Text>
-          <Field noMargin>
-            <Checkbox
-              {...register('migrate.migrateResources')}
-              id="migrate-resources"
-              label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
-              disabled={syncTarget === 'instance'}
-              description={
-                syncTarget === 'instance' ? (
-                  <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
-                    Instance sync requires all resources to be managed. Existing resources will be migrated
-                    automatically.
-                  </Trans>
-                ) : (
-                  <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
-                    Import existing dashboards from all folders into the new provisioned folder
-                  </Trans>
-                )
-              }
-            />
-          </Field>
-        </>
-      )}
+      <>
+        <Text element="h3">
+          <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
+        </Text>
+        <Field noMargin>
+          <Checkbox
+            {...register('migrate.migrateResources')}
+            id="migrate-resources"
+            label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
+            disabled={syncTarget === 'instance'}
+            description={
+              syncTarget === 'instance' ? (
+                <Trans i18nKey="provisioning.synchronize-step.instance-migrate-resources-description">
+                  Instance sync requires all resources to be managed. Existing resources will be migrated automatically.
+                </Trans>
+              ) : (
+                <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
+                  Import existing dashboards from all folders into the new provisioned folder
+                </Trans>
+              )
+            }
+          />
+        </Field>
+      </>
       {healthStatusNotReady ? (
         <>
           <Stack>

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -3,7 +3,7 @@ import { memo, useEffect, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
 import { Trans, t } from '@grafana/i18n';
-import { Alert, Button, Field, Spinner, Stack, Text, TextLink } from '@grafana/ui';
+import { Alert, Button, Checkbox, Field, Spinner, Stack, Text, TextLink } from '@grafana/ui';
 import { Job, useGetRepositoryStatusQuery } from 'app/api/clients/provisioning/v0alpha1';
 
 import { JobStatus } from '../Job/JobStatus';
@@ -12,7 +12,7 @@ import { ProvisioningAlert } from '../Shared/ProvisioningAlert';
 import { useStepStatus } from './StepStatusContext';
 import { useCreateSyncJob } from './hooks/useCreateSyncJob';
 import { useResourceStats } from './hooks/useResourceStats';
-import { WizardFormData } from './types';
+import { Target, WizardFormData } from './types';
 
 export interface SynchronizeStepProps {
   onCancel?: (repoName: string) => void;
@@ -20,13 +20,15 @@ export interface SynchronizeStepProps {
 }
 
 export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCancelling }: SynchronizeStepProps) {
-  const { watch } = useFormContext<WizardFormData>();
+  const { watch, register, getValues } = useFormContext<WizardFormData>();
   const { setStepStatusInfo } = useStepStatus();
-  const [repoName = '', syncTarget] = watch(['repositoryName', 'repository.sync.target']);
+  const repoName = watch('repositoryName') ?? '';
+  const syncTarget = watch('repository.sync.target');
   const { requiresMigration } = useResourceStats(repoName, syncTarget);
   const { createSyncJob } = useCreateSyncJob({
     repoName,
     requiresMigration,
+    syncTarget,
     setStepStatusInfo,
   });
   const [job, setJob] = useState<Job>();
@@ -63,7 +65,8 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
   const isButtonDisabled = hasError || (checked !== undefined && isRepositoryHealthy === false) || healthStatusNotReady;
 
   const startSynchronization = async () => {
-    const response = await createSyncJob();
+    const migrateResources = getValues('migrate.migrateResources');
+    const response = await createSyncJob({ migrateResources });
     if (response) {
       setJob(response);
     }
@@ -108,29 +111,76 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
       )}
       {isRepositoryHealthy && (
         <Alert
-          title={t(
-            'provisioning.wizard.alert-title',
-            'Important: No data or configuration will be lost. Dashboards remain accessible during migration, but changes made during this process may not be exported.'
-          )}
-          severity={'info'}
+          title={t('provisioning.wizard.alert-title', 'Important: Review Git Sync limitations before proceeding')}
+          severity={'warning'}
         >
-          <ul style={{ marginLeft: '16px' }}>
-            <li>
-              <Trans i18nKey="provisioning.wizard.alert-point-1">
-                Resources can still be created, edited, or deleted during this process, but changes may not be exported.
+          <Stack direction="column" gap={2}>
+            <Text>
+              <Trans i18nKey="provisioning.wizard.alert-intro">
+                Please be aware of the following limitations. For more details, see the{' '}
+                <TextLink
+                  external
+                  href="https://grafana.com/docs/grafana/latest/as-code/observability-as-code/provision-resources/intro-git-sync/"
+                >
+                  Git Sync documentation
+                </TextLink>
+                .
               </Trans>
-            </li>
-            <li>
-              <Trans i18nKey="provisioning.wizard.alert-point-2">
-                Once provisioning is complete, resources will be marked as managed through external storage.
-              </Trans>
-            </li>
-            <li>
-              <Trans i18nKey="provisioning.wizard.alert-point-3">
-                The duration of this process depends on the number of resources involved.
-              </Trans>
-            </li>
-            <li>
+            </Text>
+            <ul style={{ marginLeft: '16px', marginTop: 0, marginBottom: 0 }}>
+              <li>
+                <Trans i18nKey="provisioning.wizard.alert-point-1">
+                  Resources can still be created, edited, or deleted during this process, but changes may not be
+                  exported.
+                </Trans>
+              </li>
+              <li>
+                <Trans i18nKey="provisioning.wizard.alert-point-unsupported">
+                  Alerts and library panels are not supported in provisioned folders.
+                </Trans>
+              </li>
+              <li>
+                <Trans i18nKey="provisioning.wizard.alert-point-permissions">
+                  Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer roles
+                  are preserved with their standard access levels.
+                </Trans>
+              </li>
+              <li>
+                <Trans i18nKey="provisioning.wizard.alert-point-3">
+                  The duration of this process depends on the number of resources involved.
+                </Trans>
+              </li>
+              {syncTarget === 'instance' && (
+                <>
+                  <li>
+                    <Trans i18nKey="provisioning.wizard.alert-point-instance-permissions">
+                      Fine-grained folder permissions will be lost and cannot be recovered.
+                    </Trans>
+                  </li>
+                  <li>
+                    <Trans i18nKey="provisioning.wizard.alert-point-instance-alerts">
+                      Existing alerts and library panels will be lost and will not be usable after migration.
+                    </Trans>
+                  </li>
+                </>
+              )}
+              {syncTarget === 'folder' && (
+                <>
+                  <li>
+                    <Trans i18nKey="provisioning.wizard.alert-point-folder-structure">
+                      When migrating existing dashboards, the folder structure will be replicated in the repository.
+                      Original folders will be emptied of dashboards but may still contain alerts or library panels.
+                    </Trans>
+                  </li>
+                  <li>
+                    <Trans i18nKey="provisioning.wizard.alert-point-folder-cleanup">
+                      You may need to manually remove or manage original folders after migration.
+                    </Trans>
+                  </li>
+                </>
+              )}
+            </ul>
+            <Text color="secondary" variant="bodySmall">
               <Trans i18nKey="provisioning.wizard.alert-point-4">
                 Enterprise instance administrators can display an announcement banner to notify users that migration is
                 in progress. See{' '}
@@ -139,9 +189,28 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
                 </TextLink>{' '}
                 for step-by-step instructions.
               </Trans>
-            </li>
-          </ul>
+            </Text>
+          </Stack>
         </Alert>
+      )}
+      {syncTarget === 'folder' && (
+        <>
+          <Text element="h3">
+            <Trans i18nKey="provisioning.synchronize-step.synchronization-options">Synchronization options</Trans>
+          </Text>
+          <Field noMargin>
+            <Checkbox
+              {...register('migrate.migrateResources')}
+              id="migrate-resources"
+              label={t('provisioning.wizard.sync-option-migrate-resources', 'Migrate existing resources')}
+              description={
+                <Trans i18nKey="provisioning.synchronize-step.migrate-resources-description">
+                  Import existing dashboards from all folders into the new provisioned folder
+                </Trans>
+              }
+            />
+          </Field>
+        </>
       )}
       {healthStatusNotReady ? (
         <>

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -213,7 +213,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({ onCancel, isCance
       {(syncTarget === 'folder' || syncTarget === 'instance') && (
         <>
           <Text element="h3">
-            <Trans i18nKey="provisioning.synchronize-step.synchronization-options">Synchronization options</Trans>
+            <Trans i18nKey="provisioning.synchronize-step.options">Options</Trans>
           </Text>
           <Field noMargin>
             <Checkbox

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -5,13 +5,14 @@ import { StepStatusInfo } from '../types';
 
 export interface UseCreateSyncJobParams {
   repoName: string;
+  requiresMigration: boolean;
   setStepStatusInfo?: (info: StepStatusInfo) => void;
 }
 
-export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJobParams) {
+export function useCreateSyncJob({ repoName, requiresMigration, setStepStatusInfo }: UseCreateSyncJobParams) {
   const [createJob, { isLoading }] = useCreateRepositoryJobsMutation();
 
-  const createSyncJob = async (requiresMigration: boolean) => {
+  const createSyncJob = async () => {
     if (!repoName) {
       setStepStatusInfo?.({
         status: 'error',

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -1,28 +1,17 @@
 import { t } from '@grafana/i18n';
 import { useCreateRepositoryJobsMutation } from 'app/api/clients/provisioning/v0alpha1';
 
-import { StepStatusInfo, Target } from '../types';
+import { StepStatusInfo } from '../types';
 
 export interface UseCreateSyncJobParams {
   repoName: string;
-  requiresMigration: boolean;
-  syncTarget?: Target;
   setStepStatusInfo?: (info: StepStatusInfo) => void;
 }
 
-export interface CreateSyncJobOptions {
-  migrateResources?: boolean;
-}
-
-export function useCreateSyncJob({
-  repoName,
-  requiresMigration,
-  syncTarget,
-  setStepStatusInfo,
-}: UseCreateSyncJobParams) {
+export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJobParams) {
   const [createJob, { isLoading }] = useCreateRepositoryJobsMutation();
 
-  const createSyncJob = async (options?: CreateSyncJobOptions) => {
+  const createSyncJob = async (requiresMigration: boolean) => {
     if (!repoName) {
       setStepStatusInfo?.({
         status: 'error',
@@ -34,13 +23,7 @@ export function useCreateSyncJob({
     try {
       setStepStatusInfo?.({ status: 'running' });
 
-      // Determine if we should run a migration job:
-      // - For instance sync: always migrate if there are resources
-      // - For folder sync: migrate only if user explicitly opted in via checkbox
-      const shouldMigrate =
-        syncTarget === 'instance' ? requiresMigration : syncTarget === 'folder' && options?.migrateResources;
-
-      const jobSpec = shouldMigrate
+      const jobSpec = requiresMigration
         ? {
             migrate: {},
           }

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -5,14 +5,13 @@ import { StepStatusInfo } from '../types';
 
 export interface UseCreateSyncJobParams {
   repoName: string;
-  requiresMigration: boolean;
   setStepStatusInfo?: (info: StepStatusInfo) => void;
 }
 
-export function useCreateSyncJob({ repoName, requiresMigration, setStepStatusInfo }: UseCreateSyncJobParams) {
+export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJobParams) {
   const [createJob, { isLoading }] = useCreateRepositoryJobsMutation();
 
-  const createSyncJob = async () => {
+  const createSyncJob = async (requiresMigration: boolean) => {
     if (!repoName) {
       setStepStatusInfo?.({
         status: 'error',

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
@@ -100,7 +100,7 @@ function getResourceStats(files?: GetRepositoryFilesApiResponse, stats?: GetReso
 /**
  * Hook that provides resource statistics and sync logic
  */
-export function useResourceStats(repoName?: string, syncTarget?: RepositoryView['target']) {
+export function useResourceStats(repoName?: string, syncTarget?: RepositoryView['target'], migrateResources?: boolean) {
   const resourceStatsQuery = useGetResourceStatsQuery(repoName ? undefined : skipToken);
   const filesQuery = useGetRepositoryFilesQuery(repoName ? { name: repoName } : skipToken);
 
@@ -121,7 +121,22 @@ export function useResourceStats(repoName?: string, syncTarget?: RepositoryView[
     };
   }, [resourceStatsQuery.data]);
 
-  const requiresMigration = resourceCount > 0 && syncTarget === 'instance';
+  // Calculate base requiresMigration: true if there are resources to migrate
+  const baseRequiresMigration = resourceCount > 0;
+
+  // Calculate final requiresMigration based on sync target and user selection
+  // For instance sync: always use baseRequiresMigration (checkbox is disabled and always true)
+  // For folder sync: only migrate if user explicitly opts in via checkbox
+  const requiresMigration = useMemo(() => {
+    if (syncTarget === 'instance') {
+      return baseRequiresMigration;
+    }
+    if (syncTarget === 'folder') {
+      return migrateResources ?? false;
+    }
+    return baseRequiresMigration;
+  }, [syncTarget, baseRequiresMigration, migrateResources]);
+
   const shouldSkipSync = (resourceCount === 0 || syncTarget === 'folder') && fileCount === 0;
 
   // Format display strings

--- a/public/app/features/provisioning/Wizard/types.ts
+++ b/public/app/features/provisioning/Wizard/types.ts
@@ -9,6 +9,7 @@ export type RepoType = RepositorySpec['type'];
 export interface MigrateFormData {
   history: boolean;
   identifier: boolean;
+  migrateResources?: boolean;
 }
 
 export interface WizardFormData {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12182,9 +12182,11 @@
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"
     },
     "synchronize-step": {
+      "migrate-resources-description": "Import existing dashboards from all folders into the new provisioned folder",
       "repository-error": "Repository error",
       "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",
-      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below."
+      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below.",
+      "synchronization-options": "Synchronization options"
     },
     "token-permissions-info": {
       "and-click": "and click",
@@ -12201,11 +12203,17 @@
     },
     "warning-title-default": "Warning",
     "wizard": {
+      "alert-intro": "Please be aware of the following limitations. For more details, see the <2>Git Sync documentation</2>.",
       "alert-point-1": "Resources can still be created, edited, or deleted during this process, but changes may not be exported.",
-      "alert-point-2": "Once provisioning is complete, resources will be marked as managed through external storage.",
       "alert-point-3": "The duration of this process depends on the number of resources involved.",
       "alert-point-4": "Enterprise instance administrators can display an announcement banner to notify users that migration is in progress. See <2>this guide</2> for step-by-step instructions.",
-      "alert-title": "Important: No data or configuration will be lost. Dashboards remain accessible during migration, but changes made during this process may not be exported.",
+      "alert-point-folder-cleanup": "You may need to manually remove or manage original folders after migration.",
+      "alert-point-folder-structure": "When migrating existing dashboards, the folder structure will be replicated in the repository. Original folders will be emptied of dashboards but may still contain alerts or library panels.",
+      "alert-point-instance-alerts": "Existing alerts and library panels will be lost and will not be usable after migration.",
+      "alert-point-instance-permissions": "Fine-grained folder permissions will be lost and cannot be recovered.",
+      "alert-point-permissions": "Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer roles are preserved with their standard access levels.",
+      "alert-point-unsupported": "Alerts and library panels are not supported in provisioned folders.",
+      "alert-title": "Important: Review Git Sync limitations before proceeding",
       "button-cancel": "Cancel",
       "button-cancelling": "Cancelling...",
       "button-next": "Finish",
@@ -12223,6 +12231,7 @@
       "step-finish": "Choose additional settings",
       "step-synchronize": "Synchronize with external storage",
       "sync-description": "Sync resources with external storage. After this one-time step, all future updates will be automatically saved to the repository and provisioned back into the instance.",
+      "sync-option-migrate-resources": "Migrate existing resources",
       "title-bootstrap": "Choose what to synchronize",
       "title-connect": "Connect to external storage",
       "title-finish": "Choose additional settings",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12182,6 +12182,7 @@
       "tooltip-unhealthy-repository": "Unable to pull an unhealthy repository"
     },
     "synchronize-step": {
+      "instance-migrate-resources-description": "Instance sync requires all resources to be managed. Existing resources will be migrated automatically.",
       "migrate-resources-description": "Import existing dashboards from all folders into the new provisioned folder",
       "repository-error": "Repository error",
       "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12211,7 +12211,6 @@
       "alert-point-folder-cleanup": "You may need to manually remove or manage original folders after migration.",
       "alert-point-folder-structure": "When migrating existing dashboards, the folder structure will be replicated in the repository. Original folders will be emptied of dashboards but may still contain alerts or library panels.",
       "alert-point-instance-alerts": "Existing alerts and library panels will be lost and will not be usable after migration.",
-      "alert-point-instance-permissions": "Fine-grained folder permissions will be lost and cannot be recovered.",
       "alert-point-permissions": "Fine-grained permissions are not supported. Default permissions apply: Admin, Editor, and Viewer roles are preserved with their standard access levels.",
       "alert-point-unsupported": "Alerts and library panels are not supported in provisioned folders.",
       "alert-title": "Important: Review Git Sync limitations before proceeding",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -12184,10 +12184,10 @@
     "synchronize-step": {
       "instance-migrate-resources-description": "Instance sync requires all resources to be managed. Existing resources will be migrated automatically.",
       "migrate-resources-description": "Import existing dashboards from all folders into the new provisioned folder",
+      "options": "Options",
       "repository-error": "Repository error",
       "repository-error-message": "Unable to check repository status. Please verify the repository configuration and try again.",
-      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below.",
-      "synchronization-options": "Synchronization options"
+      "repository-unhealthy": "The repository cannot be synchronized. Cancel provisioning and try again once the issue has been resolved. See details below."
     },
     "token-permissions-info": {
       "and-click": "and click",


### PR DESCRIPTION
## Summary
- Update the SynchronizeStep alert to use warning severity with comprehensive Git Sync limitations
- Add conditional warnings based on sync target:
  - **Instance sync**: Fine-grained folder permissions will be lost, alerts and library panels will be lost
  - **Folder sync**: Folder structure changes, manual cleanup may be needed for original folders
- Add "Migrate existing resources" checkbox for folder sync mode to allow users to opt-in to migrating existing dashboards
- Update `useCreateSyncJob` hook to handle the `migrateResources` option

Instance sync: 
<img width="720" height="444" alt="image" src="https://github.com/user-attachments/assets/5906fae7-f120-494e-9c88-df52fc5a5036" />

Folder sync:
<img width="1059" height="826" alt="image" src="https://github.com/user-attachments/assets/a1aabb51-5e9d-409f-83f5-30f27b418150" />

## Related Issues

https://github.com/grafana/git-ui-sync-project/issues/606
https://github.com/grafana/git-ui-sync-project/issues/604
https://github.com/grafana/grafana/issues/109870
