### PR TITLE
Alerting: Add a feature toggle to fetch rules with compact=true

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -828,6 +828,10 @@ export interface FeatureToggles {
   */
   fetchRulesUsingPost?: boolean;
   /**
+  * Add compact=true when fetching rules
+  */
+  fetchRulesInCompactMode?: boolean;
+  /**
   * Enables the new logs panel
   * @default true
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1361,6 +1361,13 @@ var (
 			HideFromDocs: true,
 		},
 		{
+			Name:         "fetchRulesInCompactMode",
+			Description:  "Add compact=true when fetching rules",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+		},
+		{
 			Name:         "newLogsPanel",
 			Description:  "Enables the new logs panel",
 			Stage:        FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -188,6 +188,7 @@ grafanaAdvisor,privatePreview,@grafana/plugins-platform-backend,false,false,fals
 elasticsearchImprovedParsing,experimental,@grafana/partner-datasources,false,false,false
 datasourceConnectionsTab,privatePreview,@grafana/plugins-platform-backend,false,false,true
 fetchRulesUsingPost,experimental,@grafana/alerting-squad,false,false,false
+fetchRulesInCompactMode,experimental,@grafana/alerting-squad,false,false,false
 newLogsPanel,GA,@grafana/observability-logs,false,false,true
 grafanaconThemes,GA,@grafana/grafana-frontend-platform,false,true,false
 alertingJiraIntegration,experimental,@grafana/alerting-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -571,6 +571,10 @@ const (
 	// Use a POST request to list rules by passing down the namespaces user has access to
 	FlagFetchRulesUsingPost = "fetchRulesUsingPost"
 
+	// FlagFetchRulesInCompactMode
+	// Add compact=true when fetching rules
+	FlagFetchRulesInCompactMode = "fetchRulesInCompactMode"
+
 	// FlagGrafanaconThemes
 	// Enables the temporary themes for GrafanaCon
 	FlagGrafanaconThemes = "grafanaconThemes"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1459,6 +1459,19 @@
     },
     {
       "metadata": {
+        "name": "fetchRulesInCompactMode",
+        "resourceVersion": "1766045288124",
+        "creationTimestamp": "2025-12-18T08:08:08Z"
+      },
+      "spec": {
+        "description": "Add compact=true when fetching rules",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "fetchRulesUsingPost",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2025-01-29T12:17:44Z"


### PR DESCRIPTION
**What is this feature?**

Adding a new feature toggle to add compact=true when fetching alert rules.

Part of https://github.com/grafana/alerting-squad/issues/1270