### PR TITLE
Auth: Allow service accounts to authenticate to ST Grafana

### DIFF
--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -131,7 +131,8 @@ func (s *ExtendedJWT) authenticateAsUser(
 		return nil, errExtJWTInvalid.Errorf("failed to parse id token subject: %w", err)
 	}
 
-	if !claims.IsIdentityType(t, claims.TypeUser) {
+	// TODO: How to support other identity types like render and anonymous here?
+	if !claims.IsIdentityType(t, claims.TypeUser, claims.TypeServiceAccount) {
 		return nil, errExtJWTInvalidSubject.Errorf("unexpected identity: %s", idTokenClaims.Subject)
 	}
 

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -118,7 +118,7 @@ var (
 	}
 	invalidSubjectIDTokenClaims = idTokenClaims{
 		Claims: jwt.Claims{
-			Subject:  "service-account:2",
+			Subject:  "anonymous:2",
 			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
 			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
 		},

--- a/pkg/services/authn/clients/ext_jwt_test.go
+++ b/pkg/services/authn/clients/ext_jwt_test.go
@@ -53,6 +53,17 @@ var (
 			Namespace:       "default", // org ID of 1 is special and translates to default
 		},
 	}
+	validIDTokenClaimsWithServiceAccount = idTokenClaims{
+		Claims: jwt.Claims{
+			Subject:  "service-account:3",
+			Expiry:   jwt.NewNumericDate(time.Date(2023, 5, 3, 0, 0, 0, 0, time.UTC)),
+			IssuedAt: jwt.NewNumericDate(time.Date(2023, 5, 2, 0, 0, 0, 0, time.UTC)),
+		},
+		Rest: authnlib.IDTokenClaims{
+			AuthenticatedBy: "extended_jwt",
+			Namespace:       "default", // org ID of 1 is special and translates to default
+		},
+	}
 	validIDTokenClaimsWithStackSet = idTokenClaims{
 		Claims: jwt.Claims{
 			Subject:  "user:2",
@@ -274,6 +285,29 @@ func TestExtendedJWT_Authenticate(t *testing.T) {
 				OrgID:             1,
 				AccessTokenClaims: &validAccessTokenClaims,
 				IDTokenClaims:     &validIDTokenClaims,
+				Namespace:         "default",
+				AuthenticatedBy:   "extendedjwt",
+				AuthID:            "access-policy:this-uid",
+				ClientParams: authn.ClientParams{
+					FetchSyncedUser: true,
+					SyncPermissions: true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{
+						RestrictedActions: []string{"dashboards:create", "folders:read", "datasources:explore", "datasources.insights:read"},
+					},
+				},
+			},
+		},
+		{
+			name:        "should authenticate as service account",
+			accessToken: &validAccessTokenClaims,
+			idToken:     &validIDTokenClaimsWithServiceAccount,
+			orgID:       1,
+			want: &authn.Identity{
+				ID:                "3",
+				Type:              claims.TypeServiceAccount,
+				OrgID:             1,
+				AccessTokenClaims: &validAccessTokenClaims,
+				IDTokenClaims:     &validIDTokenClaimsWithServiceAccount,
 				Namespace:         "default",
 				AuthenticatedBy:   "extendedjwt",
 				AuthID:            "access-policy:this-uid",


### PR DESCRIPTION
**What is this feature?**

This pull request updates the authentication logic in the external JWT client to support service account identities in addition to user identities. It also updates related test data to reflect this change.

**Why do we need this feature?**

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #https://github.com/grafana/grafana-enterprise/issues/10444

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
