### PR TITLE
Alerting: Update createdBy field when silence is being Recreated

### DIFF
--- a/public/app/features/alerting/unified/components/silences/utils.ts
+++ b/public/app/features/alerting/unified/components/silences/utils.ts
@@ -47,7 +47,7 @@ export const getFormFieldsForSilence = (silence: Silence): SilenceFormFields => 
     startsAt: interval.start.toISOString(),
     endsAt: interval.end.toISOString(),
     comment: silence.comment,
-    createdBy: silence.createdBy,
+    createdBy: isExpired ? contextSrv.user.name : silence.createdBy,
     duration: intervalToAbbreviatedDurationString(interval),
     isRegex: false,
     matchers: silence.matchers?.map(matcherToMatcherField) || [],


### PR DESCRIPTION
**What is this feature?**

This ensures the recreated silences are properly assigned to the user who is recreating them and not to the original creator.

This also keeps the original user if someone is trying to edit an active silence.

**Why do we need this feature?**

When recreating an expired silence, the "Created By" field incorrectly retains the original creator's name instead of the current user performing the recreation. This creates misleading audit trails and accountability issues, as the new silence should be attributed to the user who actually created it.

**Who is this feature for?**

All the alerting users.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #115542

**Special notes for your reviewer:**

I tested it locally, and it works as expected. It updates the creator when a silence is being created using the `Recreate` button.

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
