### PR TITLE
CI: Remove the default alpine & ubuntu versions so that the ones in Dockerfile

### DIFF
--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -84,11 +84,11 @@ inputs:
     required: false
   ubuntu-base:
     type: string
-    default: ''
+    default: 'ubuntu'
     required: false
   alpine-base:
     type: string
-    default: ''
+    default: 'alpine'
     required: false
 outputs:
   dist-dir:

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -84,11 +84,11 @@ inputs:
     required: false
   ubuntu-base:
     type: string
-    default: 'ubuntu:22.04'
+    default: ''
     required: false
   alpine-base:
     type: string
-    default: 'alpine:3.22'
+    default: ''
     required: false
 outputs:
   dist-dir:

--- a/.github/actions/build-package/action.yml
+++ b/.github/actions/build-package/action.yml
@@ -82,14 +82,6 @@ inputs:
     description: Docker registry of produced images
     default: docker.io
     required: false
-  ubuntu-base:
-    type: string
-    default: 'ubuntu'
-    required: false
-  alpine-base:
-    type: string
-    default: 'alpine'
-    required: false
 outputs:
   dist-dir:
     description: Directory where artifacts are placed
@@ -134,13 +126,11 @@ runs:
         UBUNTU_TAG_FORMAT: ${{ inputs.docker-tag-format-ubuntu }}
         CHECKSUM: ${{ inputs.checksum }}
         VERIFY: ${{ inputs.verify }}
-        ALPINE_BASE: ${{ inputs.alpine-base }}
-        UBUNTU_BASE: ${{ inputs.ubuntu-base }}
       with:
         verb: run
         dagger-flags: --verbose=0
         version: 0.18.8
-        args: go run -C ${GRAFANA_PATH} ./pkg/build/cmd artifacts --artifacts ${ARTIFACTS} --grafana-dir=${GRAFANA_PATH} --alpine-base=${ALPINE_BASE} --ubuntu-base=${UBUNTU_BASE} --enterprise-dir=${ENTERPRISE_PATH} --version=${VERSION} --patches-repo=${PATCHES_REPO} --patches-ref=${PATCHES_REF} --patches-path=${PATCHES_PATH} --build-id=${BUILD_ID} --tag-format="${TAG_FORMAT}" --ubuntu-tag-format="${UBUNTU_TAG_FORMAT}" --org=${DOCKER_ORG} --registry=${DOCKER_REGISTRY} --checksum=${CHECKSUM} --verify=${VERIFY} > $OUTFILE
+        args: go run -C ${GRAFANA_PATH} ./pkg/build/cmd artifacts --artifacts ${ARTIFACTS} --grafana-dir=${GRAFANA_PATH} --enterprise-dir=${ENTERPRISE_PATH} --version=${VERSION} --patches-repo=${PATCHES_REPO} --patches-ref=${PATCHES_REF} --patches-path=${PATCHES_PATH} --build-id=${BUILD_ID} --tag-format="${TAG_FORMAT}" --ubuntu-tag-format="${UBUNTU_TAG_FORMAT}" --org=${DOCKER_ORG} --registry=${DOCKER_REGISTRY} --checksum=${CHECKSUM} --verify=${VERIFY} > $OUTFILE
     - id: output
       shell: bash
       env:


### PR DESCRIPTION
The Dockerfile sets alpine-base and ubuntu-base, and those values are automatically updated by dependabot / renovate. We now should be using those, but there was a mistakenly set default which was setting alpine-base to 3.22 :(