### PR TITLE
fix(dashboard): panic on nil logger on dashboard accessor

### DIFF
--- a/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
+++ b/pkg/registry/apis/dashboard/legacy/sql_dashboards.go
@@ -113,6 +113,7 @@ func ProvideMigratorDashboardAccessor(
 		dashboardPermissionSvc: nil, // not needed for migration
 		libraryPanelSvc:        nil, // not needed for migration
 		accessControl:          accessControl,
+		log:                    log.New("legacy.dashboard.migrator.accessor"),
 	}
 }
 
@@ -136,6 +137,7 @@ func NewDashboardSQLAccess(sql legacysql.LegacyDatabaseProvider,
 		dashboardPermissionSvc: dashboardPermissionSvc,
 		libraryPanelSvc:        libraryPanelSvc,
 		accessControl:          accessControl,
+		log:                    log.New("legacy.dashboard.accessor"),
 	}
 }
 


### PR DESCRIPTION
**What is this feature?**

Sets logger to acessor

**Why do we need this feature?**

We only use the logger on errors, but when used it will panic the binary.

```
grafana logs:
grafana-1  | github.com/grafana/grafana/pkg/storage/unified/migrations.(*UnifiedStorageMigrationServiceImpl).Run(0xc0010cfa90, {0xcd47050, 0x14830c80})
grafana-1  |    /tmp/grafana/pkg/storage/unified/migrations/service.go:59 +0xe9
grafana-1  | github.com/grafana/grafana/pkg/storage/legacysql/dualwrite.ProvideService({0xcd18c10, 0xc001e7ce00}, {0xcd63920, 0xc001c02fa0}, 0xc000037608, {0xcc89e40?, 0xc0010cfa90?})
grafana-1  |    /tmp/grafana/pkg/storage/legacysql/dualwrite/service.go:51 +0x5b
grafana-1  | github.com/grafana/grafana/pkg/server.Initialize({0xcd47050, 0x14830c80}, 0xc000037608, {{0x0, 0x0}, {0x0, 0x0}, {0xcc5cf60, 0xa}, {0xcd18720, ...}, ...}, ...)
```

**Who is this feature for?**

Dashboard accessor users

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
