### PR TITLE
Dashboards: Do not show alert rules button for new dashboads

### DIFF
--- a/public/app/features/alerting/unified/initAlerting.tsx
+++ b/public/app/features/alerting/unified/initAlerting.tsx
@@ -22,7 +22,7 @@ export function initAlerting() {
       component: ({ dashboard }) =>
         alertingEnabled ? (
           <Suspense fallback={null} key="alert-rules-button">
-            {dashboard && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
+            {dashboard && dashboard.uid && <AlertRulesToolbarButton dashboardUid={dashboard.uid} />}
           </Suspense>
         ) : null,
       index: -2,

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -76,12 +76,6 @@ export function DashboardEditPaneRenderer({ editPane, dashboard, isDocked }: Pro
               data-testid={selectors.pages.Dashboard.Sidebar.optionsButton}
               active={selectedObject === dashboard ? true : false}
             />
-            {/* <Sidebar.Button
-              tooltip={t('dashboard.sidebar.edit-schema.tooltip', 'Edit as code')}
-              title={t('dashboard.sidebar.edit-schema.title', 'Code')}
-              icon="brackets-curly"
-              onClick={() => dashboard.openV2SchemaEditor()}
-            /> */}
             <Sidebar.Divider />
           </>
         )}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5392,10 +5392,6 @@
         "title": "Options",
         "tooltip": "Dashboard options"
       },
-      "edit-schema": {
-        "title": "Code",
-        "tooltip": "Edit as code"
-      },
       "export": {
         "title": "Export",
         "unsaved-modal": {


### PR DESCRIPTION
The previous logic was not show show these extensions buttons (Alert rules and usage insights) in edit mode but I am not sure that makes sense anymore, with the sidebar I think they should be shown in edit mode as well. 

But alert rules button should not be shown for new dashboards, this check seems to be already present for usage insights - 