### PR TITLE
Dashboards: Fix adhoc filter click when panel has no panel-level datasource

### DIFF
--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -126,7 +126,7 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
     context.eventBus.publish(new AnnotationChangeEvent({ id }));
   };
 
-  context.onAddAdHocFilter = (newFilter: AdHocFilterItem) => {
+  context.onAddAdHocFilter = async (newFilter: AdHocFilterItem) => {
     const dashboard = getDashboardSceneFor(vizPanel);
 
     const queryRunner = getQueryRunnerFor(vizPanel);
@@ -134,7 +134,18 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       return;
     }
 
-    const datasource = getDatasourceFromQueryRunner(queryRunner);
+    let datasource = getDatasourceFromQueryRunner(queryRunner);
+
+    // If the datasource is type-only (e.g. it's possible that only group is set in V2 schema queries)
+    // we need to resolve it to a full datasource
+    if (datasource && !datasource.uid) {
+      const datasourceToLoad = await getDataSourceSrv().get(datasource);
+      datasource = {
+        uid: datasourceToLoad.uid,
+        type: datasourceToLoad.type,
+      };
+    }
+
     const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
     updateAdHocFilterVariable(filterVar, newFilter);
   };
@@ -165,7 +176,7 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       .filter((item) => item !== undefined);
   };
 
-  context.onAddAdHocFilters = (items: AdHocFilterItem[]) => {
+  context.onAddAdHocFilters = async (items: AdHocFilterItem[]) => {
     const dashboard = getDashboardSceneFor(vizPanel);
 
     const queryRunner = getQueryRunnerFor(vizPanel);
@@ -173,7 +184,17 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       return;
     }
 
-    const datasource = getDatasourceFromQueryRunner(queryRunner);
+    let datasource = getDatasourceFromQueryRunner(queryRunner);
+
+    // If the datasource is type-only (e.g. it's possible that only group is set in V2 schema queries)
+    // we need to resolve it to a full datasource
+    if (datasource && !datasource.uid) {
+      const datasourceToLoad = await getDataSourceSrv().get(datasource);
+      datasource = {
+        uid: datasourceToLoad.uid,
+        type: datasourceToLoad.type,
+      };
+    }
     const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
     bulkUpdateAdHocFiltersVariable(filterVar, items);
   };

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -6,7 +6,12 @@ import { AdHocFilterItem, PanelContext } from '@grafana/ui';
 import { annotationServer } from 'app/features/annotations/api';
 
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
-import { getDashboardSceneFor, getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
+import {
+  getDashboardSceneFor,
+  getDatasourceFromQueryRunner,
+  getPanelIdForVizPanel,
+  getQueryRunnerFor,
+} from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
 
@@ -129,7 +134,8 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       return;
     }
 
-    const filterVar = getAdHocFilterVariableFor(dashboard, queryRunner.state.datasource);
+    const datasource = getDatasourceFromQueryRunner(queryRunner);
+    const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
     updateAdHocFilterVariable(filterVar, newFilter);
   };
 
@@ -141,7 +147,8 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       return [];
     }
 
-    const groupByVar = getGroupByVariableFor(dashboard, queryRunner.state.datasource);
+    const datasource = getDatasourceFromQueryRunner(queryRunner);
+    const groupByVar = getGroupByVariableFor(dashboard, datasource);
 
     if (!groupByVar) {
       return [];
@@ -166,7 +173,8 @@ export function setDashboardPanelContext(vizPanel: VizPanel, context: PanelConte
       return;
     }
 
-    const filterVar = getAdHocFilterVariableFor(dashboard, queryRunner.state.datasource);
+    const datasource = getDatasourceFromQueryRunner(queryRunner);
+    const filterVar = getAdHocFilterVariableFor(dashboard, datasource);
     bulkUpdateAdHocFiltersVariable(filterVar, items);
   };
 

--- a/public/app/features/dashboard-scene/utils/drilldownUtils.ts
+++ b/public/app/features/dashboard-scene/utils/drilldownUtils.ts
@@ -3,6 +3,8 @@ import { getDataSourceSrv } from '@grafana/runtime';
 import { AdHocFiltersVariable, GroupByVariable, sceneGraph, SceneObject, SceneQueryRunner } from '@grafana/scenes';
 import { DataSourceRef } from '@grafana/schema';
 
+import { getDatasourceFromQueryRunner } from './utils';
+
 export function verifyDrilldownApplicability(
   sourceObject: SceneObject,
   queriesDataSource: DataSourceRef | undefined,
@@ -26,7 +28,7 @@ export async function getDrilldownApplicability(
     return;
   }
 
-  const datasource = queryRunner.state.datasource;
+  const datasource = getDatasourceFromQueryRunner(queryRunner);
   const queries = queryRunner.state.data?.request?.targets;
 
   const ds = await getDataSourceSrv().get(datasource?.uid);

--- a/public/app/features/dashboard-scene/utils/urlBuilders.ts
+++ b/public/app/features/dashboard-scene/utils/urlBuilders.ts
@@ -4,7 +4,7 @@ import { sceneGraph, VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getExploreUrl } from 'app/core/utils/explore';
 
-import { getQueryRunnerFor } from './utils';
+import { getDatasourceFromQueryRunner, getQueryRunnerFor } from './utils';
 
 export function getViewPanelUrl(vizPanel: VizPanel) {
   return locationUtil.getUrlForPartial(locationService.getLocation(), {
@@ -27,10 +27,11 @@ export function tryGetExploreUrlForPanel(vizPanel: VizPanel): Promise<string | u
   }
 
   const timeRange = sceneGraph.getTimeRange(vizPanel);
+  const datasource = getDatasourceFromQueryRunner(queryRunner);
 
   return getExploreUrl({
     queries: queryRunner.state.queries,
-    dsRef: queryRunner.state.datasource,
+    dsRef: datasource,
     timeRange: timeRange.state.value,
     scopedVars: { __sceneObject: { value: vizPanel } },
     adhocFilters: queryRunner.state.data?.request?.filters,

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -1,4 +1,4 @@
-import { getDataSourceRef, IntervalVariableModel } from '@grafana/data';
+import { DataSourceRef, getDataSourceRef, IntervalVariableModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getDataSourceSrv } from '@grafana/runtime';
 import {
@@ -232,6 +232,26 @@ export function getQueryRunnerFor(sceneObject: SceneObject | undefined): SceneQu
 
   if (dataProvider instanceof SceneDataTransformer) {
     return getQueryRunnerFor(dataProvider);
+  }
+
+  return undefined;
+}
+
+/**
+ * Gets the datasource from a query runner.
+ * When no panel-level datasource is set, it means all queries use the same datasource,
+ * so we extract the datasource from the first query.
+ */
+export function getDatasourceFromQueryRunner(queryRunner: SceneQueryRunner): DataSourceRef | null | undefined {
+  // Panel-level datasource is set for mixed datasource panels
+  if (queryRunner.state.datasource) {
+    return queryRunner.state.datasource;
+  }
+
+  // No panel-level datasource means all queries share the same datasource
+  const firstQuery = queryRunner.state.queries?.[0];
+  if (firstQuery?.datasource) {
+    return firstQuery.datasource;
   }
 
   return undefined;


### PR DESCRIPTION
*Problem*

When clicking on a series value to add an adhoc filter, if the panel has no panel-level datasource set (because all queries use the same datasource), the filter was not applied to the existing adhoc filter variable. Instead, a new adhoc variable was created.

This happened because `queryRunner.state.datasource` is undefined when all queries share the same datasource (non-mixed mode), causing the adhoc filter lookup to fail.

In v1, the panel ds was the ds from the queries when the queries were the same. In v2 we delegated the ds to the queries, so that ds is undefined unless the queries ds are different between them...

*Solution*

Add a helper function `getDatasourceFromQueryRunner` that extracts the datasource from the query runner. When no panel-level datasource is set, it falls back to the first query's datasource since all queries share the same one.

Updated the following consumers to use this helper:
- `setDashboardPanelContext.ts` - adhoc filter and group by variable lookup
- `urlBuilders.ts` - Explore URL building
- `drilldownUtils.ts` - drilldown applicability checks

*How to test*

1. Create a dashboard with a panel that has queries using the same datasource
2. Add an adhoc filter variable for that datasource
3. Click on a series value in the panel to filter
4. Verify the filter is added to the existing adhoc variable (not a new one)

**Question to be answered**
- Should we set the query runner ds at the scene creation time instead? 
- Is this showing an architecture limitation that should be resolved in any other way?