### PR TITLE
Chore: Switch annotations app from old feature toggle mechanism to runtime config

### DIFF
--- a/apps/annotation/kinds/manifest.cue
+++ b/apps/annotation/kinds/manifest.cue
@@ -10,7 +10,7 @@ manifest: {
 
 v0alpha1: {
     kinds: [annotationv0alpha1]
-	served: false
+    served: false
     routes: {
         namespaced: {
             "/tags": {

--- a/apps/annotation/kinds/manifest.cue
+++ b/apps/annotation/kinds/manifest.cue
@@ -10,6 +10,7 @@ manifest: {
 
 v0alpha1: {
     kinds: [annotationv0alpha1]
+		served: false
     routes: {
         namespaced: {
             "/tags": {

--- a/apps/annotation/kinds/manifest.cue
+++ b/apps/annotation/kinds/manifest.cue
@@ -10,7 +10,7 @@ manifest: {
 
 v0alpha1: {
     kinds: [annotationv0alpha1]
-		served: false
+	served: false
     routes: {
         namespaced: {
             "/tags": {

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_object_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_object_gen.go
@@ -25,6 +25,13 @@ type Annotation struct {
 	Status AnnotationStatus `json:"status" yaml:"status"`
 }
 
+func NewAnnotation() *Annotation {
+	return &Annotation{
+		Spec:   *NewAnnotationSpec(),
+		Status: *NewAnnotationStatus(),
+	}
+}
+
 func (o *Annotation) GetSpec() any {
 	return o.Spec
 }

--- a/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_schema_gen.go
+++ b/apps/annotation/pkg/apis/annotation/v0alpha1/annotation_schema_gen.go
@@ -10,7 +10,7 @@ import (
 
 // schema is unexported to prevent accidental overwrites
 var (
-	schemaAnnotation = resource.NewSimpleSchema("annotation.grafana.app", "v0alpha1", &Annotation{}, &AnnotationList{}, resource.WithKind("Annotation"),
+	schemaAnnotation = resource.NewSimpleSchema("annotation.grafana.app", "v0alpha1", NewAnnotation(), &AnnotationList{}, resource.WithKind("Annotation"),
 		resource.WithPlural("annotations"), resource.WithScope(resource.NamespacedScope))
 	kindAnnotation = resource.Kind{
 		Schema: schemaAnnotation,

--- a/apps/annotation/pkg/apis/annotation_manifest.go
+++ b/apps/annotation/pkg/apis/annotation_manifest.go
@@ -32,7 +32,7 @@ var appManifestData = app.ManifestData{
 	Versions: []app.ManifestVersion{
 		{
 			Name:   "v0alpha1",
-			Served: true,
+			Served: false,
 			Kinds: []app.ManifestVersionKind{
 				{
 					Kind:       "Annotation",

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apiserver/pkg/authorization/authorizer"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	restclient "k8s.io/client-go/rest"
@@ -113,6 +114,15 @@ func (a *AnnotationAppInstaller) GetLegacyStorage(requested schema.GroupVersionR
 	)
 
 	return a.legacy
+}
+
+// GetAuthorizer Returns a dummy authorizer
+func (a *AnnotationAppInstaller) GetAuthorizer() authorizer.Authorizer {
+	return authorizer.AuthorizerFunc(
+		func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		},
+	)
 }
 
 var (

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -76,10 +76,6 @@ func ProvideAppInstallers(
 	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesLogsDrilldown) {
 		installers = append(installers, logsdrilldownAppInstaller)
 	}
-	//nolint:staticcheck
-	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotations) {
-		installers = append(installers, annotationAppInstaller)
-	}
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if features.IsEnabledGlobally(featuremgmt.FlagGrafanaAdvisor) {
 		installers = append(installers, advisorAppInstaller)
@@ -88,6 +84,10 @@ func ProvideAppInstallers(
 	if features.IsEnabledGlobally(featuremgmt.FlagKubernetesAlertingHistorian) && alertingHistorianAppInstaller != nil {
 		installers = append(installers, alertingHistorianAppInstaller)
 	}
+	// Applications under active development should be disabled by default
+	// and explicitly enabled by specifying it in `runtime_config`
+	// under the `[grafana-apiserver]` section in settings.ini (see docs apps/example/README.md).
+	installers = append(installers, annotationAppInstaller)
 
 	return installers
 }


### PR DESCRIPTION
App platform has a mechanism to enable apps using runtime config, so instead of using deprecated feature toggles, we can change sthe state of the app to disabled by settign the `served` param to `false` and enable it specific environments using settings.ini.

Prerequisite for a merge: https://github.com/grafana/grafana-app-sdk/pull/1154 