### PR TITLE
LibraryPanels: Use getFolders legacy

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -691,7 +691,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	libraryElementService := libraryelements.ProvideService(cfg, sqlStore, routeRegisterImpl, folderimplService, featureToggles, accessControl, dashboardService, eventualRestConfigProvider, userService)
+	libraryElementService := libraryelements.ProvideService(cfg, sqlStore, routeRegisterImpl, folderimplService, folderimplService, featureToggles, accessControl, dashboardService, eventualRestConfigProvider, userService)
 	libraryPanelService, err := librarypanels.ProvideService(cfg, sqlStore, routeRegisterImpl, libraryElementService, folderimplService)
 	if err != nil {
 		return nil, err
@@ -1353,7 +1353,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	libraryElementService := libraryelements.ProvideService(cfg, sqlStore, routeRegisterImpl, folderimplService, featureToggles, accessControl, dashboardService, eventualRestConfigProvider, userService)
+	libraryElementService := libraryelements.ProvideService(cfg, sqlStore, routeRegisterImpl, folderimplService, folderimplService, featureToggles, accessControl, dashboardService, eventualRestConfigProvider, userService)
 	libraryPanelService, err := librarypanels.ProvideService(cfg, sqlStore, routeRegisterImpl, libraryElementService, folderimplService)
 	if err != nil {
 		return nil, err

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -483,8 +483,14 @@ func (l *LibraryElementService) getAllLibraryElements(c context.Context, signedI
 
 		metrics.MFolderIDsServiceCount.WithLabelValues(metrics.LibraryElements).Inc()
 		retDTOs := make([]model.LibraryElementDTO, 0)
+
 		// getting all folders a user can see
-		fs, err := l.folderService.GetFolders(c, folder.GetFoldersQuery{OrgID: signedInUser.GetOrgID(), SignedInUser: signedInUser})
+		// TODO: this is a temporary solution to get all folders a user can see. We should refactor this to use the unified folder service but
+		// it requires code changes to improve performance when getting all folders and then filter them by library panels.
+		// It should retrieve only folders a user can see and not all folders.
+		fs, err := l.folderLegacyService.GetFoldersLegacy(c, folder.GetFoldersQuery{OrgID: signedInUser.GetOrgID(), SignedInUser: signedInUser})
+		//fs, err := l.folderService.GetFolders(c, folder.GetFoldersQuery{OrgID: signedInUser.GetOrgID(), SignedInUser: signedInUser})
+
 		if err != nil {
 			return err
 		}

--- a/pkg/services/libraryelements/libraryelements.go
+++ b/pkg/services/libraryelements/libraryelements.go
@@ -18,17 +18,18 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-func ProvideService(cfg *setting.Cfg, sqlStore db.DB, routeRegister routing.RouteRegister, folderService folder.Service, features featuremgmt.FeatureToggles, ac accesscontrol.AccessControl, dashboardsService dashboards.DashboardService, clientConfigProvider grafanaapiserver.DirectRestConfigProvider, userService user.Service) *LibraryElementService {
+func ProvideService(cfg *setting.Cfg, sqlStore db.DB, routeRegister routing.RouteRegister, folderService folder.Service, folderLegacyService folder.LegacyService, features featuremgmt.FeatureToggles, ac accesscontrol.AccessControl, dashboardsService dashboards.DashboardService, clientConfigProvider grafanaapiserver.DirectRestConfigProvider, userService user.Service) *LibraryElementService {
 	l := &LibraryElementService{
-		Cfg:               cfg,
-		SQLStore:          sqlStore,
-		RouteRegister:     routeRegister,
-		folderService:     folderService,
-		dashboardsService: dashboardsService,
-		log:               log.New("library-elements"),
-		features:          features,
-		AccessControl:     ac,
-		k8sHandler:        newLibraryElementsK8sHandler(cfg, clientConfigProvider, folderService, userService, dashboardsService),
+		Cfg:                 cfg,
+		SQLStore:            sqlStore,
+		RouteRegister:       routeRegister,
+		folderService:       folderService,
+		folderLegacyService: folderLegacyService,
+		dashboardsService:   dashboardsService,
+		log:                 log.New("library-elements"),
+		features:            features,
+		AccessControl:       ac,
+		k8sHandler:          newLibraryElementsK8sHandler(cfg, clientConfigProvider, folderService, userService, dashboardsService),
 	}
 
 	l.registerAPIEndpoints()
@@ -52,15 +53,16 @@ type Service interface {
 
 // LibraryElementService is the service for the Library Element feature.
 type LibraryElementService struct {
-	Cfg               *setting.Cfg
-	SQLStore          db.DB
-	RouteRegister     routing.RouteRegister
-	folderService     folder.Service
-	dashboardsService dashboards.DashboardService
-	log               log.Logger
-	features          featuremgmt.FeatureToggles
-	AccessControl     accesscontrol.AccessControl
-	k8sHandler        *libraryElementsK8sHandler
+	Cfg                 *setting.Cfg
+	SQLStore            db.DB
+	RouteRegister       routing.RouteRegister
+	folderService       folder.Service
+	folderLegacyService folder.LegacyService
+	dashboardsService   dashboards.DashboardService
+	log                 log.Logger
+	features            featuremgmt.FeatureToggles
+	AccessControl       accesscontrol.AccessControl
+	k8sHandler          *libraryElementsK8sHandler
 }
 
 var _ Service = (*LibraryElementService)(nil)


### PR DESCRIPTION
**What is this feature?**

Use the legacy getFolders service until we improve the unified getFolders.

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
