### PR TITLE
Chore: cherry-pick npm valdiation fix into `release-12.0.9` branch

### DIFF
--- a/scripts/prepare-npm-package.js
+++ b/scripts/prepare-npm-package.js
@@ -86,7 +86,7 @@ async function createAliasPackageJsonFiles(packageJsonContent, aliasName) {
     const pkgJson = await PackageJson.create(pkgJsonPath, {
       data: {
         name: pkgName,
-        types: `../dist/types/${aliasName}.d.ts`,
+        types: `../dist/cjs/${aliasName}.d.cts`,
         main: `../dist/cjs/${aliasName}.cjs`,
         module: `../dist/esm/${aliasName}.mjs`,
       },


### PR DESCRIPTION
Chore: cherry-pick npm valdiation fix into `release-12.0.9` branch