### PR TITLE
Dashboards: Prevent row selection when clicking canvas add actions

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelChrome.tsx
@@ -248,15 +248,17 @@ export function PanelChrome({
 
   const onContentPointerDown = React.useCallback(
     (evt: React.PointerEvent) => {
-      // Ignore clicks inside buttons, links, canvas and svg elments
+      // When selected, ignore clicks inside buttons, links, canvas and svg elments
       // This does prevent a clicks inside a graphs from selecting panel as there is normal div above the canvas element that intercepts the click
-      if (evt.target instanceof Element && evt.target.closest('button,a,canvas,svg')) {
+      if (isSelected && evt.target instanceof Element && evt.target.closest('button,a,canvas,svg')) {
+        // Stop propagation otherwise row config editor will get selected
+        evt.stopPropagation();
         return;
       }
 
       onSelect?.(evt);
     },
-    [onSelect]
+    [isSelected, onSelect]
   );
 
   const headerContent = (

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -61,9 +61,8 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
   return (
     <div
       className={cx(styles.addAction, 'dashboard-canvas-add-button')}
-      onPointerDown={(evt) => {
-        evt.stopPropagation();
-      }}
+      onPointerUp={(evt) => evt.stopPropagation()}
+      onPointerDown={(evt) => evt.stopPropagation()}
     >
       <Button
         variant="primary"

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -59,7 +59,12 @@ export function CanvasGridAddActions({ layoutManager }: Props) {
   }, [layoutManager]);
 
   return (
-    <div className={cx(styles.addAction, 'dashboard-canvas-add-button')}>
+    <div
+      className={cx(styles.addAction, 'dashboard-canvas-add-button')}
+      onPointerDown={(evt) => {
+        evt.stopPropagation();
+      }}
+    >
       <Button
         variant="primary"
         fill="text"

--- a/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/CanvasGridAddActions.tsx
@@ -194,7 +194,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     height: theme.spacing(5),
     bottom: 0,
     left: 0,
-    right: 0,
     opacity: 0,
     [theme.transitions.handleMotion('no-preference', 'reduce')]: {
       transition: theme.transitions.create('opacity'),


### PR DESCRIPTION
**What is this feature?**

Stops event propagation on canvas grid add actions to prevent row selection when clicking action buttons.

before:

https://github.com/user-attachments/assets/8bf415ba-ee81-4464-a7fd-51b05452db24


after:

https://github.com/user-attachments/assets/7ddf003e-4b86-4967-a7b5-86d6b37c8eb3


**Why do we need this feature?**

Clicking "Add panel" or "Group panels" buttons inside a row was unintentionally selecting the row.

**Which issue(s) does this PR fix?**:

Fixes #115349

