### PR TITLE
VizSuggestions: Update selected suggestion styling

### DIFF
--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -58,19 +58,6 @@ export function VisualizationSuggestionCard({
       suggestion.cardOptions.previewModifier(preview);
     }
 
-    // const eventHandlers = ([
-    //   'onClick',
-    //   'onDoubleClick',
-    //   'onMouseMove',
-    //   'onMouseEnter',
-    //   'onMouseLeave',
-    //   'onFocus',
-    //   'onBlur',
-    // ] as const).reduce((handlers: HTMLAttributes<HTMLDivElement>, eventName) => {
-    //   handlers[eventName] = (ev) => ev.stopPropagation();
-    //   return handlers;
-    // }, {});
-
     content = (
       <button {...commonButtonProps}>
         {/* to use inert in React 18, we have to do this hacky object spread thing. https://stackoverflow.com/questions/72720469/error-when-using-inert-attribute-with-typescript */}

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { cloneDeep } from 'lodash';
 import { CSSProperties, HTMLAttributes, ReactNode } from 'react';
 
-import { colorManipulator, GrafanaTheme2, PanelData, PanelPluginVisualizationSuggestion } from '@grafana/data';
+import { GrafanaTheme2, PanelData, PanelPluginVisualizationSuggestion } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { config } from '@grafana/runtime';
 import { Tooltip, useStyles2 } from '@grafana/ui';
@@ -31,7 +31,11 @@ export function VisualizationSuggestionCard({
 
   const commonButtonProps = {
     'aria-label': suggestion.name,
-    className: cx(className, styles.vizBox),
+    className: cx(
+      className,
+      styles.vizBox,
+      config.featureToggles.newVizSuggestions && isSelected && styles.selectedBox
+    ),
     'data-testid': selectors.components.VisualizationPreview.card(suggestion.name),
     style: outerStyles,
     tabIndex: -1, // selection is handled by parent container
@@ -56,7 +60,7 @@ export function VisualizationSuggestionCard({
 
     content = (
       <button {...commonButtonProps}>
-        <div style={innerStyles} className={styles.renderContainer}>
+        <div style={innerStyles} className={cx(styles.renderContainer, isSelected && styles.selectedSuggestion)}>
           <PanelRenderer
             title=""
             data={data}
@@ -66,8 +70,6 @@ export function VisualizationSuggestionCard({
             options={preview.options}
             fieldConfig={preview.fieldConfig}
           />
-          {/* this prevents interaction with the underlying panel. */}
-          <div className={cx(styles.hoverPane, isSelected && styles.hoverPaneSelected)} />
         </div>
       </button>
     );
@@ -82,22 +84,8 @@ export function VisualizationSuggestionCard({
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {
-    hoverPane: css({
-      position: 'absolute',
-      top: -4,
-      left: -4,
-      right: -2,
-      bottom: -2,
-      borderRadius: theme.spacing(0.5),
-      background: 'transparent',
-      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
-        transition: theme.transitions.create(['background'], {
-          duration: theme.transitions.duration.short,
-        }),
-      },
-    }),
-    hoverPaneSelected: css({
-      background: colorManipulator.alpha(theme.colors.text.primary, 0.1),
+    selectedSuggestion: css({
+      filter: 'blur(1px) brightness(0.5)',
     }),
     vizBox: css({
       position: 'relative',
@@ -148,6 +136,10 @@ const getStyles = (theme: GrafanaTheme2) => {
       transformOrigin: 'left top',
       top: '6px',
       left: '6px',
+    }),
+    selectedBox: css({
+      border: `1px solid ${theme.colors.primary.border}`,
+      background: theme.colors.action.selected,
     }),
   };
 };

--- a/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
+++ b/public/app/features/panel/components/VizTypePicker/VisualizationSuggestionCard.tsx
@@ -58,9 +58,27 @@ export function VisualizationSuggestionCard({
       suggestion.cardOptions.previewModifier(preview);
     }
 
+    // const eventHandlers = ([
+    //   'onClick',
+    //   'onDoubleClick',
+    //   'onMouseMove',
+    //   'onMouseEnter',
+    //   'onMouseLeave',
+    //   'onFocus',
+    //   'onBlur',
+    // ] as const).reduce((handlers: HTMLAttributes<HTMLDivElement>, eventName) => {
+    //   handlers[eventName] = (ev) => ev.stopPropagation();
+    //   return handlers;
+    // }, {});
+
     content = (
       <button {...commonButtonProps}>
-        <div style={innerStyles} className={cx(styles.renderContainer, isSelected && styles.selectedSuggestion)}>
+        {/* to use inert in React 18, we have to do this hacky object spread thing. https://stackoverflow.com/questions/72720469/error-when-using-inert-attribute-with-typescript */}
+        <div
+          style={innerStyles}
+          className={cx(styles.renderContainer, isSelected && styles.selectedSuggestion)}
+          {...{ inert: '' }}
+        >
           <PanelRenderer
             title=""
             data={data}
@@ -85,7 +103,7 @@ export function VisualizationSuggestionCard({
 const getStyles = (theme: GrafanaTheme2) => {
   return {
     selectedSuggestion: css({
-      filter: 'blur(1px) brightness(0.5)',
+      filter: `blur(1px) ${theme.isDark ? 'brightness(0.5)' : 'opacity(0.3)'}`,
     }),
     vizBox: css({
       position: 'relative',


### PR DESCRIPTION
This PR updates the stying for the selected suggestion card:

- adds a blue border to match the selected visualization
- add a blur filter


https://github.com/user-attachments/assets/aabfc491-888c-46d1-b382-0ec59f955a16




Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
