### PR TITLE
Sparkline: Add point annotations for some common calcs

### DIFF
--- a/packages/grafana-data/src/field/fieldDisplay.test.ts
+++ b/packages/grafana-data/src/field/fieldDisplay.test.ts
@@ -3,11 +3,18 @@ import { merge } from 'lodash';
 import { toDataFrame } from '../dataframe/processDataFrame';
 import { createTheme } from '../themes/createTheme';
 import { ReducerID } from '../transformations/fieldReducer';
+import { FieldType } from '../types/dataFrame';
 import { FieldConfigPropertyItem } from '../types/fieldOverrides';
 import { MappingType, SpecialValueMatch, ValueMapping } from '../types/valueMapping';
 
 import { getDisplayProcessor } from './displayProcessor';
-import { fixCellTemplateExpressions, getFieldDisplayValues, GetFieldDisplayValuesOptions } from './fieldDisplay';
+import {
+  FieldSparkline,
+  fixCellTemplateExpressions,
+  getFieldDisplayValues,
+  GetFieldDisplayValuesOptions,
+  getSparklineHighlight,
+} from './fieldDisplay';
 import { standardFieldConfigEditorRegistry } from './standardFieldConfigEditorRegistry';
 
 describe('FieldDisplay', () => {
@@ -554,5 +561,73 @@ describe('fixCellTemplateExpressions', () => {
     ).toEqual(
       '${__data.fields[10]:date:iso} asd ${__data.fields[15]:date:seconds} asd ${__data.fields[20]:date:YYYY-MM}'
     );
+  });
+});
+
+describe('getSparklineHighlight', () => {
+  const sparkline: FieldSparkline = {
+    y: { name: 'A', type: FieldType.number, values: [null, 2, 3, 4, 10, 8, 8, 8, 9, null], config: {} },
+  };
+
+  it.each([
+    {
+      calc: ReducerID.last,
+      expected: {
+        type: 'point',
+        xIdx: 9,
+      },
+    },
+    {
+      calc: ReducerID.max,
+      expected: {
+        type: 'point',
+        xIdx: 4,
+      },
+    },
+    {
+      calc: ReducerID.min,
+      expected: {
+        type: 'point',
+        xIdx: 1,
+      },
+    },
+    {
+      calc: ReducerID.first,
+      expected: {
+        type: 'point',
+        xIdx: 0,
+      },
+    },
+    {
+      calc: ReducerID.firstNotNull,
+      expected: {
+        type: 'point',
+        xIdx: 1,
+      },
+    },
+    {
+      calc: ReducerID.lastNotNull,
+      expected: {
+        type: 'point',
+        xIdx: 8,
+      },
+    },
+    {
+      calc: ReducerID.mean,
+      expected: {
+        type: 'line',
+        y: 6.5,
+      },
+    },
+    {
+      calc: ReducerID.median,
+      expected: {
+        type: 'line',
+        y: 8,
+      },
+    },
+  ])('it calculates the correct highlight for the $calc', ({ calc, expected }) => {
+    const result = getSparklineHighlight(sparkline, calc);
+    expect(result).toEqual(expected);
   });
 });

--- a/packages/grafana-ui/src/components/RadialGauge/RadialSparkline.tsx
+++ b/packages/grafana-ui/src/components/RadialGauge/RadialSparkline.tsx
@@ -67,7 +67,7 @@ export const RadialSparkline = memo(
 
     return (
       <div style={{ position: 'absolute', top: topPos }}>
-        <Sparkline height={height} width={width} sparkline={sparkline} theme={theme} config={config} />
+        <Sparkline height={height} width={width} sparkline={sparkline} theme={theme} config={config} showHighlights />
       </div>
     );
   }

--- a/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
+++ b/packages/grafana-ui/src/components/Sparkline/Sparkline.tsx
@@ -14,18 +14,18 @@ export interface SparklineProps extends Themeable2 {
   height: number;
   config?: FieldConfig<GraphFieldConfig>;
   sparkline: FieldSparkline;
+  showHighlights?: boolean;
 }
 
-const SparklineFn: React.FC<SparklineProps> = memo((props) => {
-  const { sparkline, config: fieldConfig, theme, width, height } = props;
-
-  const { frame: alignedDataFrame, warning } = prepareSeries(sparkline, fieldConfig);
+export const SparklineFn: React.FC<SparklineProps> = memo((props) => {
+  const { sparkline, config: fieldConfig, theme, width, height, showHighlights } = props;
+  const { frame: alignedDataFrame, warning } = prepareSeries(sparkline, theme, fieldConfig, showHighlights);
   if (warning) {
     return null;
   }
 
   const data = preparePlotData2(alignedDataFrame, getStackingGroups(alignedDataFrame));
-  const configBuilder = prepareConfig(sparkline, alignedDataFrame, theme);
+  const configBuilder = prepareConfig(sparkline, alignedDataFrame, theme, showHighlights);
 
   return <UPlotChart data={data} config={configBuilder} width={width} height={height} />;
 });


### PR DESCRIPTION
Fixes #112977

<img width="1088" height="637" alt="Screenshot 2025-12-18 at 2 45 09 PM" src="https://github.com/user-attachments/assets/ba565962-9749-4d0b-bed4-8763fa9de38c" />

For the new gauge, we will test out highlighting the relevant point which is derived from the calc. If this works well, we could consider adding it to other sparklines.

We also want to add line-based annotations for calcs like mean and median, but those needed more work, so I've split this up.