### PR TITLE
Plugins: Change pageId parameter type in usePluginDetailsTabs

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2868,11 +2868,6 @@
       "count": 1
     }
   },
-  "public/app/features/plugins/admin/components/PluginDetailsPage.tsx": {
-    "@typescript-eslint/consistent-type-assertions": {
-      "count": 1
-    }
-  },
   "public/app/features/plugins/admin/helpers.ts": {
     "no-restricted-syntax": {
       "count": 2

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -17,7 +17,6 @@ import { PluginDetailsSignature } from '../components/PluginDetailsSignature';
 import { usePluginDetailsTabs } from '../hooks/usePluginDetailsTabs';
 import { usePluginPageExtensions } from '../hooks/usePluginPageExtensions';
 import { useGetSingle, useFetchStatus, useFetchDetailsStatus } from '../state/hooks';
-import { PluginTabIds } from '../types';
 
 import { PluginDetailsDeprecatedWarning } from './PluginDetailsDeprecatedWarning';
 
@@ -50,11 +49,7 @@ export function PluginDetailsPage({
   const queryParams = new URLSearchParams(location.search);
   const plugin = useGetSingle(pluginId); // fetches the plugin settings for this Grafana instance
   const isNarrowScreen = useMedia('(max-width: 600px)');
-  const { navModel, activePageId } = usePluginDetailsTabs(
-    plugin,
-    queryParams.get('page') as PluginTabIds,
-    isNarrowScreen
-  );
+  const { navModel, activePageId } = usePluginDetailsTabs(plugin, queryParams.get('page'), isNarrowScreen);
   const { actions, info, subtitle } = usePluginPageExtensions(plugin);
   const { isLoading: isFetchLoading } = useFetchStatus();
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();

--- a/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
+++ b/public/app/features/plugins/admin/hooks/usePluginDetailsTabs.tsx
@@ -18,9 +18,9 @@ type ReturnType = {
 };
 
 function getCurrentPageId(
-  pageId: PluginTabIds | undefined,
   isNarrowScreen: boolean | undefined,
-  defaultTab: string
+  defaultTab: string,
+  pageId?: PluginTabIds | string | null
 ): PluginTabIds | string {
   if (!isNarrowScreen && pageId === PluginTabIds.PLUGINDETAILS) {
     return defaultTab;
@@ -30,7 +30,7 @@ function getCurrentPageId(
 
 export const usePluginDetailsTabs = (
   plugin?: CatalogPlugin,
-  pageId?: PluginTabIds,
+  pageId?: PluginTabIds | string | null,
   isNarrowScreen?: boolean
 ): ReturnType => {
   const { loading, error, value: pluginConfig } = usePluginConfig(plugin);
@@ -38,7 +38,7 @@ export const usePluginDetailsTabs = (
   const defaultTab = useDefaultPage(plugin, pluginConfig);
   const isPublished = Boolean(plugin?.isPublished);
 
-  const currentPageId = getCurrentPageId(pageId, isNarrowScreen, defaultTab);
+  const currentPageId = getCurrentPageId(isNarrowScreen, defaultTab, pageId);
 
   const navModelChildren = useMemo(() => {
     const canConfigurePlugins = plugin && contextSrv.hasPermissionInMetadata(AccessControlAction.PluginsWrite, plugin);


### PR DESCRIPTION
**What is this feature?**
This is a fix for eslint error:
65:5  error  Do not use any type assertions  @typescript-eslint/consistent-type-assertions

**Why do we need this feature?**
We used type assertions, but we can add string | type into usePluginDetailsTabs hook to get queryParam as it is