### PR TITLE
Alerting: Add Cursor frontmatter to CLAUDE.md for auto-loading

### DIFF
--- a/public/app/features/alerting/unified/CLAUDE.md
+++ b/public/app/features/alerting/unified/CLAUDE.md
@@ -1,3 +1,10 @@
+---
+title: Alerting Squad Guidelines
+description: Alerting-specific patterns and conventions for Grafana
+globs:
+  - 'public/app/features/alerting/**'
+---
+
 # Alerting Squad - Claude Code Configuration
 
 This file provides context for Claude Code when working on the Grafana Alerting codebase. It contains alerting-specific patterns and references to Grafana's coding standards.


### PR DESCRIPTION
**What is this feature?**

Adds YAML frontmatter to the `CLAUDE.md` file so that `Cursor IDE `automatically loads the alerting squad guidelines when editing files in `public/app/features/alerting/**.`

### Why this is needed:

Previously, when using Cursor's AI assistant on alerting code, developers had to manually ask the assistant to read the CLAUDE.md file each time to get alerting-specific context (testing patterns, MSW usage, RTK Query conventions, etc.).

With this frontmatter:

```
title: Alerting Squad Guidelines
description: Alerting-specific patterns and conventions for Grafana
globs:
  - "public/app/features/alerting/**"
```
Cursor now automatically includes the alerting guidelines in the AI's context when working on alerting files. This means:

- AI suggestions follow alerting conventions out of the box
- No need to repeatedly ask "read CLAUDE.md"
- More consistent AI-assisted development for the squad

No functional changes - this only affects Cursor IDE behavior.

