### PR TITLE
Alerting: Disable data source rules APIs based on manageAlerts toggle

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1110,6 +1110,10 @@ export interface FeatureToggles {
   */
   alertingTriage?: boolean;
   /**
+  * When manageAlerts=false, disable data source API for alert rules
+  */
+  alertingDisableDSAPIWithManageAlerts?: boolean;
+  /**
   * Enables the Graphite data source full backend mode
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1834,6 +1834,13 @@ var (
 			Expression:   "false",
 		},
 		{
+			Name:         "alertingDisableDSAPIWithManageAlerts",
+			Description:  "When manageAlerts=false, disable data source API for alert rules",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaAlertingSquad,
+			HideFromDocs: true,
+		},
+		{
 			Name:         "graphiteBackendMode",
 			Description:  "Enables the Graphite data source full backend mode",
 			Stage:        FeatureStagePrivatePreview,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -250,6 +250,7 @@ newClickhouseConfigPageDesign,privatePreview,@grafana/partner-datasources,false,
 teamFolders,experimental,@grafana/grafana-search-navigate-organise,false,false,false
 interactiveLearning,preview,@grafana/pathfinder,false,false,false
 alertingTriage,experimental,@grafana/alerting-squad,false,false,false
+alertingDisableDSAPIWithManageAlerts,experimental,@grafana/alerting-squad,false,false,false
 graphiteBackendMode,privatePreview,@grafana/partner-datasources,false,false,false
 azureResourcePickerUpdates,GA,@grafana/partner-datasources,false,false,true
 prometheusTypeMigration,experimental,@grafana/partner-datasources,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -718,6 +718,10 @@ const (
 	// Enables the alerting triage feature
 	FlagAlertingTriage = "alertingTriage"
 
+	// FlagAlertingDisableDSAPIWithManageAlerts
+	// When manageAlerts=false, disable data source API for alert rules
+	FlagAlertingDisableDSAPIWithManageAlerts = "alertingDisableDSAPIWithManageAlerts"
+
 	// FlagGraphiteBackendMode
 	// Enables the Graphite data source full backend mode
 	FlagGraphiteBackendMode = "graphiteBackendMode"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -197,6 +197,19 @@
     },
     {
       "metadata": {
+        "name": "alertingDisableDSAPIWithManageAlerts",
+        "resourceVersion": "1766143488044",
+        "creationTimestamp": "2025-12-19T11:24:48Z"
+      },
+      "spec": {
+        "description": "When manageAlerts=false, disable data source API for alert rules",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "hideFromDocs": true
+      }
+    },
+    {
+      "metadata": {
         "name": "alertingDisableSendAlertsExternal",
         "resourceVersion": "1764664939750",
         "creationTimestamp": "2024-05-23T12:29:19Z"

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -137,7 +137,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 	// Register endpoints for proxying to Cortex Ruler-compatible backends.
 	api.RegisterRulerApiEndpoints(NewForkingRuler(
 		api.DatasourceCache,
-		NewLotexRuler(proxy, logger),
+		NewLotexRuler(proxy, logger, api.FeatureManager, api.Cfg.DefaultDatasourceManageAlertsUIToggle),
 		&RulerSrv{
 			conditionValidator: api.ConditionValidator,
 			QuotaService:       api.QuotaService,


### PR DESCRIPTION
**What is this feature?**

Add a new feature toggle `alertingDisableDSAPIWithManageAlerts` which when enabled, disables the APIs to manage alerts in data sources with `manageAlerts: false`. In this case the API returns `403` with the error message:

```
GET /api/ruler/my-mimir/api/v1/rules?subtype=mimir

HTTP/1.1 403 Forbidden

{
    "statusCode": 403,
    "messageId": "alerting.manageAlertsDisabled",
    "message": "Alert management is disabled for this datasource"
}

```

**Why do we need this feature?**

Currently, the `manageAlerts` setting only works in the frontend, it hides datasources from the Alerting UI rule picker, but the backend APIs remain accessible. This means users can still create/modify alert rules via direct API calls even when `manageAlerts: false`, if the API is enabled in the data source itself. This PR enforces `manageAlerts` at the API level.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
