### PR TITLE
V2 Schema + DD: Patch fast with dashboard fixes related to V2 Schema and dynamic dashboards.

### DIFF
--- a/.github/actions/change-detection/action.yml
+++ b/.github/actions/change-detection/action.yml
@@ -95,6 +95,7 @@ runs:
             - 'nx.json'
             - 'tsconfig.json'
             - '.yarn/**'
+            - 'apps/dashboard/pkg/migration/**'
             - '${{ inputs.self }}'
           e2e:
             - 'e2e/**'

--- a/apps/dashboard/pkg/migration/conversion/testdata/input/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.json
@@ -300,15 +300,9 @@
         "y": 0
       },
       "id": 6,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-        "mode": "markdown"
-      },
+      "options": {},
+      "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
+      "mode": "markdown",
       "pluginVersion": "11.0.0-pre",
       "targets": [
         {

--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.panel-target-missing-refid.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v1beta1.panel-target-missing-refid.json
@@ -1,0 +1,156 @@
+{
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "kind": "Dashboard",
+  "metadata": {
+    "name": "ad5vfcn",
+    "namespace": "default",
+    "uid": "dlMZZl6GndU8gJLUQSmgZxXBPCNXyXhNBeQJhHXl0r4X",
+    "resourceVersion": "2",
+    "generation": 2,
+    "creationTimestamp": "2025-11-28T10:14:21Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "288"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedTimestamp": "2025-11-28T10:15:06Z"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 288,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "gdev-testdata"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.0-pre",
+        "targets": [
+          {
+            "datasource": {},
+            "queryType": "randomWalk"
+          },
+          {
+            "datasource": {},
+            "queryType": "randomWalk"
+          }
+        ],
+        "title": "New panel",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 42,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Panel ds inheritance ",
+    "uid": "ad5vfcn",
+    "version": 2
+  },
+  "status": {}
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.value-mapping-and-overrides.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/input/v2beta1.value-mapping-and-overrides.json
@@ -1,0 +1,864 @@
+{
+    "kind": "DashboardWithAccessInfo",
+    "apiVersion": "dashboard.grafana.app/v2beta1",
+    "metadata": {
+      "name": "value-mapping-test",
+      "namespace": "default",
+      "uid": "value-mapping-test",
+      "resourceVersion": "1765384157199094",
+      "generation": 2,
+      "creationTimestamp": "2025-11-19T20:09:28Z",
+      "labels": {
+        "grafana.app/deprecatedInternalID": "646372978987008"
+      }
+    },
+    "spec": {
+      "annotations": [
+        {
+          "kind": "AnnotationQuery",
+          "spec": {
+            "query": {
+              "kind": "DataQuery",
+              "group": "grafana",
+              "version": "v0",
+              "datasource": {
+                "name": "-- Grafana --"
+              },
+              "spec": {}
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations \u0026 Alerts",
+            "builtIn": true,
+            "legacyOptions": {
+              "type": "dashboard"
+            }
+          }
+        }
+      ],
+      "cursorSync": "Off",
+      "description": "Test dashboard for all value mapping types and override matcher types",
+      "editable": true,
+      "elements": {
+        "panel-1": {
+          "kind": "Panel",
+          "spec": {
+            "id": 1,
+            "title": "ValueMap Example",
+            "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "up"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "critical": {
+                            "text": "Critical!",
+                            "color": "red",
+                            "index": 0
+                          },
+                          "ok": {
+                            "text": "OK",
+                            "color": "green",
+                            "index": 2
+                          },
+                          "warning": {
+                            "text": "Warning",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "status"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 100
+                        },
+                        {
+                          "id": "custom.align",
+                          "value": "center"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-2": {
+          "kind": "Panel",
+          "spec": {
+            "id": 2,
+            "title": "RangeMap Example",
+            "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "cpu_usage_percent"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "gauge",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 0,
+                          "to": 50,
+                          "result": {
+                            "text": "Low",
+                            "color": "green",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 50,
+                          "to": 80,
+                          "result": {
+                            "text": "Medium",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 80,
+                          "to": 100,
+                          "result": {
+                            "text": "High",
+                            "color": "red",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": "/^cpu_/"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "percent"
+                        },
+                        {
+                          "id": "decimals",
+                          "value": 2
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-3": {
+          "kind": "Panel",
+          "spec": {
+            "id": 3,
+            "title": "RegexMap Example",
+            "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "log_level"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^error.*/",
+                          "result": {
+                            "text": "Error",
+                            "color": "red",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^warn.*/",
+                          "result": {
+                            "text": "Warning",
+                            "color": "orange",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^info.*/",
+                          "result": {
+                            "text": "Info",
+                            "color": "blue",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byType",
+                        "options": "string"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-text"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-4": {
+          "kind": "Panel",
+          "spec": {
+            "id": 4,
+            "title": "SpecialValueMap Example",
+            "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "some_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "No Data",
+                            "color": "gray",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "nan",
+                          "result": {
+                            "text": "Not a Number",
+                            "color": "gray",
+                            "index": 1
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null+nan",
+                          "result": {
+                            "text": "N/A",
+                            "color": "gray",
+                            "index": 2
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "true",
+                          "result": {
+                            "text": "Yes",
+                            "color": "green",
+                            "index": 3
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "false",
+                          "result": {
+                            "text": "No",
+                            "color": "red",
+                            "index": 4
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "empty",
+                          "result": {
+                            "text": "Empty",
+                            "color": "gray",
+                            "index": 5
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "A"
+                      },
+                      "properties": [
+                        {
+                          "id": "color",
+                          "value": {
+                            "fixedColor": "blue",
+                            "mode": "fixed"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-6": {
+          "kind": "Panel",
+          "spec": {
+            "id": 6,
+            "title": "Empty Properties Override Example",
+            "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "empty_override_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "stat",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {},
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "field_with_empty_override"
+                      },
+                      "properties": []
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        },
+        "panel-5": {
+          "kind": "Panel",
+          "spec": {
+            "id": 5,
+            "title": "Combined Mappings and Overrides Example",
+            "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+            "links": [],
+            "data": {
+              "kind": "QueryGroup",
+              "spec": {
+                "queries": [
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "combined_metric"
+                        }
+                      },
+                      "refId": "A",
+                      "hidden": false
+                    }
+                  },
+                  {
+                    "kind": "PanelQuery",
+                    "spec": {
+                      "query": {
+                        "kind": "DataQuery",
+                        "group": "prometheus",
+                        "version": "v0",
+                        "datasource": {
+                          "name": "prometheus-uid"
+                        },
+                        "spec": {
+                          "expr": "secondary_metric"
+                        }
+                      },
+                      "refId": "B",
+                      "hidden": false
+                    }
+                  }
+                ],
+                "transformations": [],
+                "queryOptions": {}
+              }
+            },
+            "vizConfig": {
+              "kind": "VizConfig",
+              "group": "table",
+              "version": "",
+              "spec": {
+                "options": {},
+                "fieldConfig": {
+                  "defaults": {
+                    "mappings": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "failure": {
+                            "text": "Failure",
+                            "color": "red",
+                            "index": 1
+                          },
+                          "success": {
+                            "text": "Success",
+                            "color": "green",
+                            "index": 0
+                          }
+                        }
+                      },
+                      {
+                        "type": "range",
+                        "options": {
+                          "from": 0,
+                          "to": 100,
+                          "result": {
+                            "text": "In Range",
+                            "color": "blue",
+                            "index": 2
+                          }
+                        }
+                      },
+                      {
+                        "type": "regex",
+                        "options": {
+                          "pattern": "/^[A-Z]{3}-\\d+$/",
+                          "result": {
+                            "text": "ID Format",
+                            "color": "purple",
+                            "index": 3
+                          }
+                        }
+                      },
+                      {
+                        "type": "special",
+                        "options": {
+                          "match": "null",
+                          "result": {
+                            "text": "Missing",
+                            "color": "gray",
+                            "index": 4
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "overrides": [
+                    {
+                      "matcher": {
+                        "id": "byName",
+                        "options": "status"
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.width",
+                          "value": 120
+                        },
+                        {
+                          "id": "custom.cellOptions",
+                          "value": {
+                            "type": "color-background"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byRegexp",
+                        "options": "/^value_/"
+                      },
+                      "properties": [
+                        {
+                          "id": "unit",
+                          "value": "short"
+                        },
+                        {
+                          "id": "min",
+                          "value": 0
+                        },
+                        {
+                          "id": "max",
+                          "value": 100
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byType",
+                        "options": "number"
+                      },
+                      "properties": [
+                        {
+                          "id": "decimals",
+                          "value": 2
+                        },
+                        {
+                          "id": "thresholds",
+                          "value": {
+                            "mode": "absolute",
+                            "steps": [
+                              {
+                                "color": "green",
+                                "value": null
+                              },
+                              {
+                                "color": "yellow",
+                                "value": 50
+                              },
+                              {
+                                "color": "red",
+                                "value": 80
+                              }
+                            ]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byFrameRefID",
+                        "options": "B"
+                      },
+                      "properties": [
+                        {
+                          "id": "displayName",
+                          "value": "Secondary Query"
+                        }
+                      ]
+                    },
+                    {
+                      "matcher": {
+                        "id": "byValue",
+                        "options": {
+                          "op": "gte",
+                          "reducer": "allIsNull",
+                          "value": 0
+                        }
+                      },
+                      "properties": [
+                        {
+                          "id": "custom.hidden",
+                          "value": true
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      },
+      "layout": {
+        "kind": "GridLayout",
+        "spec": {
+          "items": [
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 0,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-1"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 12,
+                "y": 0,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-2"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 8,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-3"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 12,
+                "y": 8,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-4"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 16,
+                "width": 24,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-5"
+                }
+              }
+            },
+            {
+              "kind": "GridLayoutItem",
+              "spec": {
+                "x": 0,
+                "y": 24,
+                "width": 12,
+                "height": 8,
+                "element": {
+                  "kind": "ElementReference",
+                  "name": "panel-6"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "links": [],
+      "liveNow": false,
+      "preload": false,
+      "tags": [
+        "value-mapping",
+        "overrides",
+        "test"
+      ],
+      "timeSettings": {
+        "timezone": "browser",
+        "from": "now-6h",
+        "to": "now",
+        "autoRefresh": "",
+        "autoRefreshIntervals": [
+          "5s",
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "hideTimepicker": false,
+        "fiscalYearStartMonth": 0
+      },
+      "title": "Value Mapping and Overrides Test",
+      "variables": []
+    },
+    "status": {
+      "conversion": {
+        "failed": false,
+        "storedVersion": "v1beta1"
+      }
+    }
+  }

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v0alpha1.json
@@ -743,7 +743,9 @@
             "text": "prod",
             "value": "prod"
           },
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "hide": 0,
           "includeAll": true,
           "label": "cluster",
@@ -764,7 +766,9 @@
             "text": "prod",
             "value": "prod"
           },
-          "datasource": "$datasource",
+          "datasource": {
+            "uid": "$datasource"
+          },
           "hide": 0,
           "includeAll": false,
           "label": "namespace",

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v2alpha1.json
@@ -961,8 +961,12 @@
           "hide": "dontHide",
           "refresh": "onDashboardLoad",
           "skipUrlSync": false,
+          "datasource": {
+            "type": "",
+            "uid": "$datasource"
+          },
           "query": {
-            "kind": "prometheus",
+            "kind": "",
             "spec": {
               "__legacyStringValue": "label_values(up, job)"
             }
@@ -988,8 +992,12 @@
           "hide": "dontHide",
           "refresh": "onDashboardLoad",
           "skipUrlSync": false,
+          "datasource": {
+            "type": "",
+            "uid": "$datasource"
+          },
           "query": {
-            "kind": "prometheus",
+            "kind": "",
             "spec": {
               "__legacyStringValue": "label_values(up{job=~\"$cluster\"}, instance)"
             }

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v15.mimir_rollout_debugging.v42.v2beta1.json
@@ -978,8 +978,11 @@
           "skipUrlSync": false,
           "query": {
             "kind": "DataQuery",
-            "group": "prometheus",
+            "group": "",
             "version": "v0",
+            "datasource": {
+              "name": "$datasource"
+            },
             "spec": {
               "__legacyStringValue": "label_values(up, job)"
             }
@@ -1007,8 +1010,11 @@
           "skipUrlSync": false,
           "query": {
             "kind": "DataQuery",
-            "group": "prometheus",
+            "group": "",
             "version": "v0",
+            "datasource": {
+              "name": "$datasource"
+            },
             "spec": {
               "__legacyStringValue": "label_values(up{job=~\"$cluster\"}, instance)"
             }

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v16.grid_layout_upgrade.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v16.grid_layout_upgrade.v42.v2alpha1.json
@@ -115,7 +115,14 @@
             "kind": "logs",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "logs",
+                  "originalOptions": {
+                    "height": 100
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v16.grid_layout_upgrade.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v16.grid_layout_upgrade.v42.v2beta1.json
@@ -120,7 +120,14 @@
             "group": "logs",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "logs",
+                  "originalOptions": {
+                    "height": 100
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v2.panels-and-services.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v2.panels-and-services.v42.v2alpha1.json
@@ -182,7 +182,20 @@
             "kind": "table",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "table",
+                  "originalOptions": {
+                    "grid": {
+                      "max": 100,
+                      "min": 0
+                    },
+                    "legend": true,
+                    "y2_format": "bytes",
+                    "y_format": "short"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v2.panels-and-services.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v2.panels-and-services.v42.v2beta1.json
@@ -189,7 +189,20 @@
             "group": "table",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "table",
+                  "originalOptions": {
+                    "grid": {
+                      "max": 100,
+                      "min": 0
+                    },
+                    "legend": true,
+                    "y2_format": "bytes",
+                    "y_format": "short"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v24.table-angular.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v24.table-angular.v42.v2alpha1.json
@@ -435,7 +435,29 @@
             "kind": "table",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "table",
+                  "originalOptions": {
+                    "styles": [
+                      {
+                        "colors": [
+                          "red",
+                          "yellow",
+                          "green"
+                        ],
+                        "pattern": "/.*/",
+                        "thresholds": [
+                          "10",
+                          "20"
+                        ],
+                        "unit": "short"
+                      }
+                    ],
+                    "table": "table2"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v24.table-angular.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v24.table-angular.v42.v2beta1.json
@@ -449,7 +449,29 @@
             "group": "table",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "table",
+                  "originalOptions": {
+                    "styles": [
+                      {
+                        "colors": [
+                          "red",
+                          "yellow",
+                          "green"
+                        ],
+                        "pattern": "/.*/",
+                        "thresholds": [
+                          "10",
+                          "20"
+                        ],
+                        "unit": "short"
+                      }
+                    ],
+                    "table": "table2"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v26.text2_to_text.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v26.text2_to_text.v42.v2alpha1.json
@@ -110,7 +110,15 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "# Angular Text Panel\n# $constant\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n## $text\n\n",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v26.text2_to_text.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/migrated_dashboards_output/v1beta1-mig-v26.text2_to_text.v42.v2beta1.json
@@ -115,7 +115,15 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "# Angular Text Panel\n# $constant\n\nFor markdown syntax help: [commonmark.org/help](https://commonmark.org/help/)\n\n## $text\n\n",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-datalinks.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-datalinks.v42.v2alpha1.json
@@ -361,7 +361,15 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data link variables overview\n\nThis dashboard presents variables that one can use when creating *data links*. All links redirect to this dashboard and this panel represents the values that were interpolated in the link that was clicked.\n\n\n#### Series variables\n1. **Name:** \u003cspan style=\"color: orange;\"\u003e$seriesName\u003c/span\u003e\n2. **label.datacenter:** \u003cspan style=\"color: orange;\"\u003e$labelDatacenter\u003c/span\u003e\n3. **label.datacenter.region:** \u003cspan style=\"color: orange;\"\u003e$labelDatacenterRegion\u003c/span\u003e\n\n#### Field variables\n1. **Name:** \u003cspan style=\"color: orange;\"\u003e$fieldName\u003c/span\u003e\n\n#### Value variables\n1. **Time:** \u003cspan style=\"color: orange;\"\u003e$valueTime\u003c/span\u003e\n2. **Numeric:** \u003cspan style=\"color: orange;\"\u003e$valueNumeric\u003c/span\u003e\n3. **Text:** \u003cspan style=\"color: orange;\"\u003e$valueText\u003c/span\u003e\n4. **Calc:** \u003cspan style=\"color: orange;\"\u003e$valueCalc\u003c/span\u003e\n\n",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-datalinks.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-datalinks.v42.v2beta1.json
@@ -372,7 +372,15 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data link variables overview\n\nThis dashboard presents variables that one can use when creating *data links*. All links redirect to this dashboard and this panel represents the values that were interpolated in the link that was clicked.\n\n\n#### Series variables\n1. **Name:** \u003cspan style=\"color: orange;\"\u003e$seriesName\u003c/span\u003e\n2. **label.datacenter:** \u003cspan style=\"color: orange;\"\u003e$labelDatacenter\u003c/span\u003e\n3. **label.datacenter.region:** \u003cspan style=\"color: orange;\"\u003e$labelDatacenterRegion\u003c/span\u003e\n\n#### Field variables\n1. **Name:** \u003cspan style=\"color: orange;\"\u003e$fieldName\u003c/span\u003e\n\n#### Value variables\n1. **Time:** \u003cspan style=\"color: orange;\"\u003e$valueTime\u003c/span\u003e\n2. **Numeric:** \u003cspan style=\"color: orange;\"\u003e$valueNumeric\u003c/span\u003e\n3. **Text:** \u003cspan style=\"color: orange;\"\u003e$valueText\u003c/span\u003e\n4. **Calc:** \u003cspan style=\"color: orange;\"\u003e$valueCalc\u003c/span\u003e\n\n",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables-drilldown.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables-drilldown.v42.v2alpha1.json
@@ -167,7 +167,15 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data center = $datacenter\n\n### server = $server\n\n#### pod = $pod",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables-drilldown.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables-drilldown.v42.v2beta1.json
@@ -174,7 +174,15 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data center = $datacenter\n\n### server = $server\n\n#### pod = $pod",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables.v42.v2alpha1.json
@@ -273,7 +273,15 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data center = $datacenter\n\n### server = $server\n\n#### pod = $pod",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/feature-templating/v0alpha1.testdata-nested-variables.v42.v2beta1.json
@@ -282,7 +282,15 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "## Data center = $datacenter\n\n### server = $server\n\n#### pod = $pod",
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v1beta1.json
@@ -296,6 +296,7 @@
         }
       },
       {
+        "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
         "datasource": {
           "type": "grafana-testdata-datasource"
         },
@@ -306,15 +307,7 @@
           "y": 0
         },
         "id": 6,
-        "options": {
-          "code": {
-            "language": "plaintext",
-            "showLineNumbers": false,
-            "showMiniMap": false
-          },
-          "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-          "mode": "markdown"
-        },
+        "mode": "markdown",
         "pluginVersion": "11.0.0-pre",
         "targets": [
           {

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v2alpha1.json
@@ -1256,13 +1256,13 @@
             "spec": {
               "pluginVersion": "11.0.0-pre",
               "options": {
-                "code": {
-                  "language": "plaintext",
-                  "showLineNumbers": false,
-                  "showMiniMap": false
-                },
-                "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-                "mode": "markdown"
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
+                    "mode": "markdown"
+                  }
+                }
               },
               "fieldConfig": {
                 "defaults": {},

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/migrations/v0alpha1.migrations.v42.v2beta1.json
@@ -1301,13 +1301,13 @@
             "version": "11.0.0-pre",
             "spec": {
               "options": {
-                "code": {
-                  "language": "plaintext",
-                  "showLineNumbers": false,
-                  "showMiniMap": false
-                },
-                "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-                "mode": "markdown"
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
+                    "mode": "markdown"
+                  }
+                }
               },
               "fieldConfig": {
                 "defaults": {},

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-gauge/v0alpha1.gauge_tests.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-gauge/v0alpha1.gauge_tests.v42.v2alpha1.json
@@ -62,6 +62,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -151,6 +157,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -241,6 +253,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -320,6 +338,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -401,6 +425,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -480,6 +510,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -559,6 +595,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -639,6 +681,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -730,6 +778,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -927,6 +981,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -1006,6 +1066,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -1085,6 +1151,12 @@
             "spec": {
               "pluginVersion": "7.4.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-gauge/v0alpha1.gauge_tests.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-gauge/v0alpha1.gauge_tests.v42.v2beta1.json
@@ -67,6 +67,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -159,6 +165,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -252,6 +264,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -334,6 +352,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -418,6 +442,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -500,6 +530,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -582,6 +618,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -665,6 +707,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -759,6 +807,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -961,6 +1015,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -1043,6 +1103,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [
@@ -1125,6 +1191,12 @@
             "version": "7.4.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "gauge",
+                  "originalOptions": {
+                    "nullPointMode": "null"
+                  }
+                },
                 "baseColor": "#299c46",
                 "reduceOptions": {
                   "calcs": [

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-graph/v0alpha1.graph_tests.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-graph/v0alpha1.graph_tests.v42.v2alpha1.json
@@ -412,7 +412,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Should be a long line connecting the null region in the `connected`  mode, and in zero it should just be a line with zero value at the null points. ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -456,7 +466,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Stacking values on top of nulls, should treat the null values as zero. ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -500,7 +520,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Stacking when all values are null should leave a gap in the graph",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -1681,7 +1711,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Left is showing null between values for a normal line graph and staircase graph. Orphaned data points should be rendered as points",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -2061,7 +2101,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Just verify that the tooltip time has millisecond resolution ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -2105,7 +2155,17 @@
             "kind": "text",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Verify that axis labels look ok",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-graph/v0alpha1.graph_tests.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-graph/v0alpha1.graph_tests.v42.v2beta1.json
@@ -429,7 +429,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Should be a long line connecting the null region in the `connected`  mode, and in zero it should just be a line with zero value at the null points. ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -475,7 +485,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Stacking values on top of nulls, should treat the null values as zero. ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -521,7 +541,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Stacking when all values are null should leave a gap in the graph",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -1779,7 +1809,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Left is showing null between values for a normal line graph and staircase graph. Orphaned data points should be rendered as points",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -2172,7 +2212,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Just verify that the tooltip time has millisecond resolution ",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -2218,7 +2268,17 @@
             "group": "text",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "text",
+                  "originalOptions": {
+                    "content": "Verify that axis labels look ok",
+                    "editable": true,
+                    "error": false,
+                    "mode": "markdown"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-heatmap/v0alpha1.heatmap-legacy.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-heatmap/v0alpha1.heatmap-legacy.v42.v2alpha1.json
@@ -74,7 +74,44 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateViridis",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "tooltipDecimals": 4,
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 2,
+                      "format": "areaM2",
+                      "logBase": 1,
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -116,7 +153,46 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {
+                      "cardRound": 50
+                    },
+                    "color": {
+                      "cardColor": "#1F60C4",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "opacity"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 1,
+                      "format": "kwatt",
+                      "logBase": 1,
+                      "show": true,
+                      "width": "100"
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -158,7 +234,44 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#1F60C4",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "opacity"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": true,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 1,
+                      "format": "kwatt",
+                      "logBase": 1,
+                      "show": true,
+                      "width": "100"
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -204,7 +317,46 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateViridis",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "tooltipDecimals": 4,
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 2,
+                      "format": "areaM2",
+                      "logBase": 1,
+                      "max": "50",
+                      "min": "20",
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -246,7 +398,44 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateBuGn",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "xBucketNumber": 10,
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 2,
+                      "show": true,
+                      "splitFactor": 2
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -288,7 +477,44 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateBuGn",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "xBucketNumber": 10,
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 10,
+                      "show": true,
+                      "splitFactor": 5
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-heatmap/v0alpha1.heatmap-legacy.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-heatmap/v0alpha1.heatmap-legacy.v42.v2beta1.json
@@ -78,7 +78,44 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateViridis",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "tooltipDecimals": 4,
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 2,
+                      "format": "areaM2",
+                      "logBase": 1,
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -123,7 +160,46 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {
+                      "cardRound": 50
+                    },
+                    "color": {
+                      "cardColor": "#1F60C4",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "opacity"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 1,
+                      "format": "kwatt",
+                      "logBase": 1,
+                      "show": true,
+                      "width": "100"
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -168,7 +244,44 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#1F60C4",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "opacity"
+                    },
+                    "dataFormat": "tsbuckets",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": true,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 1,
+                      "format": "kwatt",
+                      "logBase": 1,
+                      "show": true,
+                      "width": "100"
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -216,7 +329,46 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateViridis",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "tooltipDecimals": 4,
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "decimals": 2,
+                      "format": "areaM2",
+                      "logBase": 1,
+                      "max": "50",
+                      "min": "20",
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -261,7 +413,44 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateBuGn",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "xBucketNumber": 10,
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 2,
+                      "show": true,
+                      "splitFactor": 2
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -306,7 +495,44 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateBuGn",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": true,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": true
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": true
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "xBucketNumber": 10,
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 10,
+                      "show": true,
+                      "splitFactor": 5
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-polystat/v0alpha1.polystat_test.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-polystat/v0alpha1.polystat_test.v42.v2alpha1.json
@@ -119,7 +119,1073 @@
             "kind": "grafana-polystat-panel",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_2",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": 1,
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": 1,
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "requests/min (rpm)",
+                            "value": "reqpm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-ampere reactive (var)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-ampere reactive (kvar)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -228,7 +1294,1129 @@
             "kind": "grafana-polystat-panel",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_4",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": "",
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": "",
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Milli Bitcoin (mBTC)",
+                            "value": "currencymBTC"
+                          },
+                          {
+                            "text": "Micro Bitcoin (μBTC)",
+                            "value": "currencyμBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Turkish Lira (₺)",
+                            "value": "currencyTRY"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "CFP franc (XPF)",
+                            "value": "currencyXPF"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "counts/sec (cps)",
+                            "value": "cps"
+                          },
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "events/sec (eps)",
+                            "value": "eps"
+                          },
+                          {
+                            "text": "messages/sec (mps)",
+                            "value": "mps"
+                          },
+                          {
+                            "text": "records/sec (rps)",
+                            "value": "recps"
+                          },
+                          {
+                            "text": "rows/sec (rps)",
+                            "value": "rowsps"
+                          },
+                          {
+                            "text": "counts/min (cpm)",
+                            "value": "cpm"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "requests/min (rpm)",
+                            "value": "reqpm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          },
+                          {
+                            "text": "events/min (epm)",
+                            "value": "epm"
+                          },
+                          {
+                            "text": "messages/min (mpm)",
+                            "value": "mpm"
+                          },
+                          {
+                            "text": "records/min (rpm)",
+                            "value": "recpm"
+                          },
+                          {
+                            "text": "rows/min (rpm)",
+                            "value": "rowspm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-Ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-Ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-Ampere reactive (VAr)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-Ampere reactive (kVAr)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -337,7 +2525,1090 @@
             "kind": "grafana-polystat-panel",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_5",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": "",
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": "",
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [
+                      {
+                        "animateMode": "all",
+                        "clickThrough": "",
+                        "compositeName": "comp",
+                        "enabled": true,
+                        "hideMembers": true,
+                        "members": [
+                          {
+                            "seriesName": "A-series"
+                          },
+                          {
+                            "seriesName": "B-series"
+                          }
+                        ],
+                        "sanitizeURLEnabled": true,
+                        "sanitizedURL": "",
+                        "showName": true,
+                        "showValue": true,
+                        "thresholdLevel": 0
+                      }
+                    ],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-ampere reactive (var)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-ampere reactive (kvar)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-polystat/v0alpha1.polystat_test.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/panel-polystat/v0alpha1.polystat_test.v42.v2beta1.json
@@ -130,7 +130,1073 @@
             "group": "grafana-polystat-panel",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_2",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": 1,
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": 1,
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "requests/min (rpm)",
+                            "value": "reqpm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-ampere reactive (var)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-ampere reactive (kvar)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -250,7 +1316,1129 @@
             "group": "grafana-polystat-panel",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_4",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": "",
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": "",
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Milli Bitcoin (mBTC)",
+                            "value": "currencymBTC"
+                          },
+                          {
+                            "text": "Micro Bitcoin (μBTC)",
+                            "value": "currencyμBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Turkish Lira (₺)",
+                            "value": "currencyTRY"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "CFP franc (XPF)",
+                            "value": "currencyXPF"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "counts/sec (cps)",
+                            "value": "cps"
+                          },
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "events/sec (eps)",
+                            "value": "eps"
+                          },
+                          {
+                            "text": "messages/sec (mps)",
+                            "value": "mps"
+                          },
+                          {
+                            "text": "records/sec (rps)",
+                            "value": "recps"
+                          },
+                          {
+                            "text": "rows/sec (rps)",
+                            "value": "rowsps"
+                          },
+                          {
+                            "text": "counts/min (cpm)",
+                            "value": "cpm"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "requests/min (rpm)",
+                            "value": "reqpm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          },
+                          {
+                            "text": "events/min (epm)",
+                            "value": "epm"
+                          },
+                          {
+                            "text": "messages/min (mpm)",
+                            "value": "mpm"
+                          },
+                          {
+                            "text": "records/min (rpm)",
+                            "value": "recpm"
+                          },
+                          {
+                            "text": "rows/min (rpm)",
+                            "value": "rowspm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-Ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-Ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-Ampere reactive (VAr)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-Ampere reactive (kVAr)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []
@@ -370,7 +2558,1090 @@
             "group": "grafana-polystat-panel",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "grafana-polystat-panel",
+                  "originalOptions": {
+                    "animationModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "colors": [
+                      "#299c46",
+                      "rgba(237, 129, 40, 0.89)",
+                      "#d44a3a"
+                    ],
+                    "d3DivId": "d3_svg_5",
+                    "decimals": 2,
+                    "displayModes": [
+                      {
+                        "text": "Show All",
+                        "value": "all"
+                      },
+                      {
+                        "text": "Show Triggered",
+                        "value": "triggered"
+                      }
+                    ],
+                    "fontSizes": [
+                      4,
+                      5,
+                      6,
+                      7,
+                      8,
+                      9,
+                      10,
+                      11,
+                      12,
+                      13,
+                      14,
+                      15,
+                      16,
+                      17,
+                      18,
+                      19,
+                      20,
+                      22,
+                      24,
+                      26,
+                      28,
+                      30,
+                      32,
+                      34,
+                      36,
+                      38,
+                      40,
+                      42,
+                      44,
+                      46,
+                      48,
+                      50,
+                      52,
+                      54,
+                      56,
+                      58,
+                      60,
+                      62,
+                      64,
+                      66,
+                      68,
+                      70
+                    ],
+                    "fontTypes": [
+                      "Open Sans",
+                      "Arial",
+                      "Avant Garde",
+                      "Bookman",
+                      "Consolas",
+                      "Courier",
+                      "Courier New",
+                      "Futura",
+                      "Garamond",
+                      "Helvetica",
+                      "Palatino",
+                      "Times",
+                      "Times New Roman",
+                      "Verdana"
+                    ],
+                    "format": "none",
+                    "notcolors": [
+                      "rgba(245, 54, 54, 0.9)",
+                      "rgba(237, 129, 40, 0.89)",
+                      "rgba(50, 172, 45, 0.97)"
+                    ],
+                    "operatorName": "avg",
+                    "operatorOptions": [
+                      {
+                        "text": "Average",
+                        "value": "avg"
+                      },
+                      {
+                        "text": "Count",
+                        "value": "count"
+                      },
+                      {
+                        "text": "Current",
+                        "value": "current"
+                      },
+                      {
+                        "text": "Delta",
+                        "value": "delta"
+                      },
+                      {
+                        "text": "Difference",
+                        "value": "diff"
+                      },
+                      {
+                        "text": "First",
+                        "value": "first"
+                      },
+                      {
+                        "text": "Log Min",
+                        "value": "logmin"
+                      },
+                      {
+                        "text": "Max",
+                        "value": "max"
+                      },
+                      {
+                        "text": "Min",
+                        "value": "min"
+                      },
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Time of Last Point",
+                        "value": "last_time"
+                      },
+                      {
+                        "text": "Time Step",
+                        "value": "time_step"
+                      },
+                      {
+                        "text": "Total",
+                        "value": "total"
+                      }
+                    ],
+                    "polystat": {
+                      "animationSpeed": 2500,
+                      "columnAutoSize": true,
+                      "columns": "",
+                      "defaultClickThrough": "",
+                      "defaultClickThroughSanitize": true,
+                      "displayLimit": 100,
+                      "fontAutoScale": true,
+                      "fontSize": 12,
+                      "globalDisplayMode": "all",
+                      "globalOperatorName": "avg",
+                      "gradientEnabled": true,
+                      "hexagonSortByDirection": "asc",
+                      "hexagonSortByField": "name",
+                      "maxMetrics": 0,
+                      "polygonBorderColor": "black",
+                      "polygonBorderSize": 2,
+                      "radius": "",
+                      "radiusAutoSize": true,
+                      "rowAutoSize": true,
+                      "rows": "",
+                      "shape": "hexagon_pointed_top",
+                      "tooltipDisplayMode": "all",
+                      "tooltipDisplayTextTriggeredEmpty": "OK",
+                      "tooltipFontSize": 12,
+                      "tooltipFontType": "Open Sans",
+                      "tooltipPrimarySortDirection": "desc",
+                      "tooltipPrimarySortField": "thresholdLevel",
+                      "tooltipSecondarySortDirection": "desc",
+                      "tooltipSecondarySortField": "value",
+                      "tooltipTimestampEnabled": true
+                    },
+                    "savedComposites": [
+                      {
+                        "animateMode": "all",
+                        "clickThrough": "",
+                        "compositeName": "comp",
+                        "enabled": true,
+                        "hideMembers": true,
+                        "members": [
+                          {
+                            "seriesName": "A-series"
+                          },
+                          {
+                            "seriesName": "B-series"
+                          }
+                        ],
+                        "sanitizeURLEnabled": true,
+                        "sanitizedURL": "",
+                        "showName": true,
+                        "showValue": true,
+                        "thresholdLevel": 0
+                      }
+                    ],
+                    "savedOverrides": [],
+                    "shapes": [
+                      {
+                        "text": "Hexagon Pointed Top",
+                        "value": "hexagon_pointed_top"
+                      },
+                      {
+                        "text": "Hexagon Flat Top",
+                        "value": "hexagon_flat_top"
+                      },
+                      {
+                        "text": "Circle",
+                        "value": "circle"
+                      },
+                      {
+                        "text": "Cross",
+                        "value": "cross"
+                      },
+                      {
+                        "text": "Diamond",
+                        "value": "diamond"
+                      },
+                      {
+                        "text": "Square",
+                        "value": "square"
+                      },
+                      {
+                        "text": "Star",
+                        "value": "star"
+                      },
+                      {
+                        "text": "Triangle",
+                        "value": "triangle"
+                      },
+                      {
+                        "text": "Wye",
+                        "value": "wye"
+                      }
+                    ],
+                    "sortDirections": [
+                      {
+                        "text": "Ascending",
+                        "value": "asc"
+                      },
+                      {
+                        "text": "Descending",
+                        "value": "desc"
+                      }
+                    ],
+                    "sortFields": [
+                      {
+                        "text": "Name",
+                        "value": "name"
+                      },
+                      {
+                        "text": "Threshold Level",
+                        "value": "thresholdLevel"
+                      },
+                      {
+                        "text": "Value",
+                        "value": "value"
+                      }
+                    ],
+                    "svgContainer": {},
+                    "thresholdStates": [
+                      {
+                        "text": "ok",
+                        "value": 0
+                      },
+                      {
+                        "text": "warning",
+                        "value": 1
+                      },
+                      {
+                        "text": "critical",
+                        "value": 2
+                      },
+                      {
+                        "text": "custom",
+                        "value": 3
+                      }
+                    ],
+                    "unitFormats": [
+                      {
+                        "submenu": [
+                          {
+                            "text": "none",
+                            "value": "none"
+                          },
+                          {
+                            "text": "short",
+                            "value": "short"
+                          },
+                          {
+                            "text": "percent (0-100)",
+                            "value": "percent"
+                          },
+                          {
+                            "text": "percent (0.0-1.0)",
+                            "value": "percentunit"
+                          },
+                          {
+                            "text": "Humidity (%H)",
+                            "value": "humidity"
+                          },
+                          {
+                            "text": "decibel",
+                            "value": "dB"
+                          },
+                          {
+                            "text": "hexadecimal (0x)",
+                            "value": "hex0x"
+                          },
+                          {
+                            "text": "hexadecimal",
+                            "value": "hex"
+                          },
+                          {
+                            "text": "scientific notation",
+                            "value": "sci"
+                          },
+                          {
+                            "text": "locale format",
+                            "value": "locale"
+                          }
+                        ],
+                        "text": "none"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Dollars ($)",
+                            "value": "currencyUSD"
+                          },
+                          {
+                            "text": "Pounds (£)",
+                            "value": "currencyGBP"
+                          },
+                          {
+                            "text": "Euro (€)",
+                            "value": "currencyEUR"
+                          },
+                          {
+                            "text": "Yen (¥)",
+                            "value": "currencyJPY"
+                          },
+                          {
+                            "text": "Rubles (₽)",
+                            "value": "currencyRUB"
+                          },
+                          {
+                            "text": "Hryvnias (₴)",
+                            "value": "currencyUAH"
+                          },
+                          {
+                            "text": "Real (R$)",
+                            "value": "currencyBRL"
+                          },
+                          {
+                            "text": "Danish Krone (kr)",
+                            "value": "currencyDKK"
+                          },
+                          {
+                            "text": "Icelandic Króna (kr)",
+                            "value": "currencyISK"
+                          },
+                          {
+                            "text": "Norwegian Krone (kr)",
+                            "value": "currencyNOK"
+                          },
+                          {
+                            "text": "Swedish Krona (kr)",
+                            "value": "currencySEK"
+                          },
+                          {
+                            "text": "Czech koruna (czk)",
+                            "value": "currencyCZK"
+                          },
+                          {
+                            "text": "Swiss franc (CHF)",
+                            "value": "currencyCHF"
+                          },
+                          {
+                            "text": "Polish Złoty (PLN)",
+                            "value": "currencyPLN"
+                          },
+                          {
+                            "text": "Bitcoin (฿)",
+                            "value": "currencyBTC"
+                          },
+                          {
+                            "text": "Vietnamese Dong (VND)",
+                            "value": "currencyVND"
+                          },
+                          {
+                            "text": "Malaysian Ringgit (RM)",
+                            "value": "currencyMYR"
+                          },
+                          {
+                            "text": "Bulgarian Lev (BGN)",
+                            "value": "currencyBGN"
+                          }
+                        ],
+                        "text": "currency"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Hertz (1/s)",
+                            "value": "hertz"
+                          },
+                          {
+                            "text": "nanoseconds (ns)",
+                            "value": "ns"
+                          },
+                          {
+                            "text": "microseconds (µs)",
+                            "value": "µs"
+                          },
+                          {
+                            "text": "milliseconds (ms)",
+                            "value": "ms"
+                          },
+                          {
+                            "text": "seconds (s)",
+                            "value": "s"
+                          },
+                          {
+                            "text": "minutes (m)",
+                            "value": "m"
+                          },
+                          {
+                            "text": "hours (h)",
+                            "value": "h"
+                          },
+                          {
+                            "text": "days (d)",
+                            "value": "d"
+                          },
+                          {
+                            "text": "duration (ms)",
+                            "value": "dtdurationms"
+                          },
+                          {
+                            "text": "duration (s)",
+                            "value": "dtdurations"
+                          },
+                          {
+                            "text": "duration (hh:mm:ss)",
+                            "value": "dthms"
+                          },
+                          {
+                            "text": "Timeticks (s/100)",
+                            "value": "timeticks"
+                          }
+                        ],
+                        "text": "time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "YYYY-MM-DD HH:mm:ss",
+                            "value": "dateTimeAsIso"
+                          },
+                          {
+                            "text": "DD/MM/YYYY h:mm:ss a",
+                            "value": "dateTimeAsUS"
+                          },
+                          {
+                            "text": "From Now",
+                            "value": "dateTimeFromNow"
+                          }
+                        ],
+                        "text": "date \u0026 time"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "bits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "bytes"
+                          },
+                          {
+                            "text": "kibibytes",
+                            "value": "kbytes"
+                          },
+                          {
+                            "text": "mebibytes",
+                            "value": "mbytes"
+                          },
+                          {
+                            "text": "gibibytes",
+                            "value": "gbytes"
+                          }
+                        ],
+                        "text": "data (IEC)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "bits",
+                            "value": "decbits"
+                          },
+                          {
+                            "text": "bytes",
+                            "value": "decbytes"
+                          },
+                          {
+                            "text": "kilobytes",
+                            "value": "deckbytes"
+                          },
+                          {
+                            "text": "megabytes",
+                            "value": "decmbytes"
+                          },
+                          {
+                            "text": "gigabytes",
+                            "value": "decgbytes"
+                          }
+                        ],
+                        "text": "data (Metric)"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "packets/sec",
+                            "value": "pps"
+                          },
+                          {
+                            "text": "bits/sec",
+                            "value": "bps"
+                          },
+                          {
+                            "text": "bytes/sec",
+                            "value": "Bps"
+                          },
+                          {
+                            "text": "kilobits/sec",
+                            "value": "Kbits"
+                          },
+                          {
+                            "text": "kilobytes/sec",
+                            "value": "KBs"
+                          },
+                          {
+                            "text": "megabits/sec",
+                            "value": "Mbits"
+                          },
+                          {
+                            "text": "megabytes/sec",
+                            "value": "MBs"
+                          },
+                          {
+                            "text": "gigabytes/sec",
+                            "value": "GBs"
+                          },
+                          {
+                            "text": "gigabits/sec",
+                            "value": "Gbits"
+                          }
+                        ],
+                        "text": "data rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "hashes/sec",
+                            "value": "Hs"
+                          },
+                          {
+                            "text": "kilohashes/sec",
+                            "value": "KHs"
+                          },
+                          {
+                            "text": "megahashes/sec",
+                            "value": "MHs"
+                          },
+                          {
+                            "text": "gigahashes/sec",
+                            "value": "GHs"
+                          },
+                          {
+                            "text": "terahashes/sec",
+                            "value": "THs"
+                          },
+                          {
+                            "text": "petahashes/sec",
+                            "value": "PHs"
+                          },
+                          {
+                            "text": "exahashes/sec",
+                            "value": "EHs"
+                          }
+                        ],
+                        "text": "hash rate"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "ops/sec (ops)",
+                            "value": "ops"
+                          },
+                          {
+                            "text": "requests/sec (rps)",
+                            "value": "reqps"
+                          },
+                          {
+                            "text": "reads/sec (rps)",
+                            "value": "rps"
+                          },
+                          {
+                            "text": "writes/sec (wps)",
+                            "value": "wps"
+                          },
+                          {
+                            "text": "I/O ops/sec (iops)",
+                            "value": "iops"
+                          },
+                          {
+                            "text": "ops/min (opm)",
+                            "value": "opm"
+                          },
+                          {
+                            "text": "reads/min (rpm)",
+                            "value": "rpm"
+                          },
+                          {
+                            "text": "writes/min (wpm)",
+                            "value": "wpm"
+                          }
+                        ],
+                        "text": "throughput"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millimetre (mm)",
+                            "value": "lengthmm"
+                          },
+                          {
+                            "text": "meter (m)",
+                            "value": "lengthm"
+                          },
+                          {
+                            "text": "inch (in)",
+                            "value": "lengthin"
+                          },
+                          {
+                            "text": "feet (ft)",
+                            "value": "lengthft"
+                          },
+                          {
+                            "text": "kilometer (km)",
+                            "value": "lengthkm"
+                          },
+                          {
+                            "text": "mile (mi)",
+                            "value": "lengthmi"
+                          }
+                        ],
+                        "text": "length"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Square Meters (m²)",
+                            "value": "areaM2"
+                          },
+                          {
+                            "text": "Square Feet (ft²)",
+                            "value": "areaF2"
+                          },
+                          {
+                            "text": "Square Miles (mi²)",
+                            "value": "areaMI2"
+                          }
+                        ],
+                        "text": "area"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "milligram (mg)",
+                            "value": "massmg"
+                          },
+                          {
+                            "text": "gram (g)",
+                            "value": "massg"
+                          },
+                          {
+                            "text": "pound (lb)",
+                            "value": "masslb"
+                          },
+                          {
+                            "text": "kilogram (kg)",
+                            "value": "masskg"
+                          },
+                          {
+                            "text": "metric ton (t)",
+                            "value": "masst"
+                          }
+                        ],
+                        "text": "mass"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "metres/second (m/s)",
+                            "value": "velocityms"
+                          },
+                          {
+                            "text": "kilometers/hour (km/h)",
+                            "value": "velocitykmh"
+                          },
+                          {
+                            "text": "miles/hour (mph)",
+                            "value": "velocitymph"
+                          },
+                          {
+                            "text": "knot (kn)",
+                            "value": "velocityknot"
+                          }
+                        ],
+                        "text": "velocity"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "millilitre (mL)",
+                            "value": "mlitre"
+                          },
+                          {
+                            "text": "litre (L)",
+                            "value": "litre"
+                          },
+                          {
+                            "text": "cubic metre",
+                            "value": "m3"
+                          },
+                          {
+                            "text": "Normal cubic metre",
+                            "value": "Nm3"
+                          },
+                          {
+                            "text": "cubic decimetre",
+                            "value": "dm3"
+                          },
+                          {
+                            "text": "gallons",
+                            "value": "gallons"
+                          }
+                        ],
+                        "text": "volume"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Watt (W)",
+                            "value": "watt"
+                          },
+                          {
+                            "text": "Kilowatt (kW)",
+                            "value": "kwatt"
+                          },
+                          {
+                            "text": "Milliwatt (mW)",
+                            "value": "mwatt"
+                          },
+                          {
+                            "text": "Watt per square metre (W/m²)",
+                            "value": "Wm2"
+                          },
+                          {
+                            "text": "Volt-ampere (VA)",
+                            "value": "voltamp"
+                          },
+                          {
+                            "text": "Kilovolt-ampere (kVA)",
+                            "value": "kvoltamp"
+                          },
+                          {
+                            "text": "Volt-ampere reactive (var)",
+                            "value": "voltampreact"
+                          },
+                          {
+                            "text": "Kilovolt-ampere reactive (kvar)",
+                            "value": "kvoltampreact"
+                          },
+                          {
+                            "text": "Watt-hour (Wh)",
+                            "value": "watth"
+                          },
+                          {
+                            "text": "Kilowatt-hour (kWh)",
+                            "value": "kwatth"
+                          },
+                          {
+                            "text": "Kilowatt-min (kWm)",
+                            "value": "kwattm"
+                          },
+                          {
+                            "text": "Joule (J)",
+                            "value": "joule"
+                          },
+                          {
+                            "text": "Electron volt (eV)",
+                            "value": "ev"
+                          },
+                          {
+                            "text": "Ampere (A)",
+                            "value": "amp"
+                          },
+                          {
+                            "text": "Kiloampere (kA)",
+                            "value": "kamp"
+                          },
+                          {
+                            "text": "Milliampere (mA)",
+                            "value": "mamp"
+                          },
+                          {
+                            "text": "Volt (V)",
+                            "value": "volt"
+                          },
+                          {
+                            "text": "Kilovolt (kV)",
+                            "value": "kvolt"
+                          },
+                          {
+                            "text": "Millivolt (mV)",
+                            "value": "mvolt"
+                          },
+                          {
+                            "text": "Decibel-milliwatt (dBm)",
+                            "value": "dBm"
+                          },
+                          {
+                            "text": "Ohm (Ω)",
+                            "value": "ohm"
+                          },
+                          {
+                            "text": "Lumens (Lm)",
+                            "value": "lumens"
+                          }
+                        ],
+                        "text": "energy"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Celsius (°C)",
+                            "value": "celsius"
+                          },
+                          {
+                            "text": "Fahrenheit (°F)",
+                            "value": "fahrenheit"
+                          },
+                          {
+                            "text": "Kelvin (K)",
+                            "value": "kelvin"
+                          }
+                        ],
+                        "text": "temperature"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Millibars",
+                            "value": "pressurembar"
+                          },
+                          {
+                            "text": "Bars",
+                            "value": "pressurebar"
+                          },
+                          {
+                            "text": "Kilobars",
+                            "value": "pressurekbar"
+                          },
+                          {
+                            "text": "Hectopascals",
+                            "value": "pressurehpa"
+                          },
+                          {
+                            "text": "Kilopascals",
+                            "value": "pressurekpa"
+                          },
+                          {
+                            "text": "Inches of mercury",
+                            "value": "pressurehg"
+                          },
+                          {
+                            "text": "PSI",
+                            "value": "pressurepsi"
+                          }
+                        ],
+                        "text": "pressure"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Newton-meters (Nm)",
+                            "value": "forceNm"
+                          },
+                          {
+                            "text": "Kilonewton-meters (kNm)",
+                            "value": "forcekNm"
+                          },
+                          {
+                            "text": "Newtons (N)",
+                            "value": "forceN"
+                          },
+                          {
+                            "text": "Kilonewtons (kN)",
+                            "value": "forcekN"
+                          }
+                        ],
+                        "text": "force"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Gallons/min (gpm)",
+                            "value": "flowgpm"
+                          },
+                          {
+                            "text": "Cubic meters/sec (cms)",
+                            "value": "flowcms"
+                          },
+                          {
+                            "text": "Cubic feet/sec (cfs)",
+                            "value": "flowcfs"
+                          },
+                          {
+                            "text": "Cubic feet/min (cfm)",
+                            "value": "flowcfm"
+                          },
+                          {
+                            "text": "Litre/hour",
+                            "value": "litreh"
+                          },
+                          {
+                            "text": "Litre/min (l/min)",
+                            "value": "flowlpm"
+                          },
+                          {
+                            "text": "milliLitre/min (mL/min)",
+                            "value": "flowmlpm"
+                          }
+                        ],
+                        "text": "flow"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Degrees (°)",
+                            "value": "degree"
+                          },
+                          {
+                            "text": "Radians",
+                            "value": "radian"
+                          },
+                          {
+                            "text": "Gradian",
+                            "value": "grad"
+                          }
+                        ],
+                        "text": "angle"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Meters/sec²",
+                            "value": "accMS2"
+                          },
+                          {
+                            "text": "Feet/sec²",
+                            "value": "accFS2"
+                          },
+                          {
+                            "text": "G unit",
+                            "value": "accG"
+                          }
+                        ],
+                        "text": "acceleration"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "Becquerel (Bq)",
+                            "value": "radbq"
+                          },
+                          {
+                            "text": "curie (Ci)",
+                            "value": "radci"
+                          },
+                          {
+                            "text": "Gray (Gy)",
+                            "value": "radgy"
+                          },
+                          {
+                            "text": "rad",
+                            "value": "radrad"
+                          },
+                          {
+                            "text": "Sievert (Sv)",
+                            "value": "radsv"
+                          },
+                          {
+                            "text": "rem",
+                            "value": "radrem"
+                          },
+                          {
+                            "text": "Exposure (C/kg)",
+                            "value": "radexpckg"
+                          },
+                          {
+                            "text": "roentgen (R)",
+                            "value": "radr"
+                          },
+                          {
+                            "text": "Sievert/hour (Sv/h)",
+                            "value": "radsvh"
+                          }
+                        ],
+                        "text": "radiation"
+                      },
+                      {
+                        "submenu": [
+                          {
+                            "text": "parts-per-million (ppm)",
+                            "value": "ppm"
+                          },
+                          {
+                            "text": "parts-per-billion (ppb)",
+                            "value": "conppb"
+                          },
+                          {
+                            "text": "nanogram per cubic metre (ng/m³)",
+                            "value": "conngm3"
+                          },
+                          {
+                            "text": "nanogram per normal cubic metre (ng/Nm³)",
+                            "value": "conngNm3"
+                          },
+                          {
+                            "text": "microgram per cubic metre (μg/m³)",
+                            "value": "conμgm3"
+                          },
+                          {
+                            "text": "microgram per normal cubic metre (μg/Nm³)",
+                            "value": "conμgNm3"
+                          },
+                          {
+                            "text": "milligram per cubic metre (mg/m³)",
+                            "value": "conmgm3"
+                          },
+                          {
+                            "text": "milligram per normal cubic metre (mg/Nm³)",
+                            "value": "conmgNm3"
+                          },
+                          {
+                            "text": "gram per cubic metre (g/m³)",
+                            "value": "congm3"
+                          },
+                          {
+                            "text": "gram per normal cubic metre (g/Nm³)",
+                            "value": "congNm3"
+                          }
+                        ],
+                        "text": "concentration"
+                      }
+                    ]
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.all-panels.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.all-panels.v42.v2alpha1.json
@@ -665,7 +665,42 @@
             "kind": "heatmap",
             "spec": {
               "pluginVersion": "",
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": false
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 1,
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.all-panels.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.all-panels.v42.v2beta1.json
@@ -691,7 +691,42 @@
             "group": "heatmap",
             "version": "",
             "spec": {
-              "options": {},
+              "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "heatmap",
+                  "originalOptions": {
+                    "cards": {},
+                    "color": {
+                      "cardColor": "#b4ff00",
+                      "colorScale": "sqrt",
+                      "colorScheme": "interpolateOranges",
+                      "exponent": 0.5,
+                      "mode": "spectrum"
+                    },
+                    "dataFormat": "timeseries",
+                    "heatmap": {},
+                    "hideZeroBuckets": false,
+                    "highlightCards": true,
+                    "legend": {
+                      "show": false
+                    },
+                    "reverseYBuckets": false,
+                    "tooltip": {
+                      "show": true,
+                      "showHistogram": false
+                    },
+                    "xAxis": {
+                      "show": true
+                    },
+                    "yAxis": {
+                      "format": "short",
+                      "logBase": 1,
+                      "show": true
+                    },
+                    "yBucketBound": "auto"
+                  }
+                }
+              },
               "fieldConfig": {
                 "defaults": {},
                 "overrides": []

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.home.v42.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.home.v42.v2alpha1.json
@@ -56,6 +56,14 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "panel-tests"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -94,6 +102,15 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "demo"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -133,6 +150,15 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "templating",
+                      "gdev"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -172,6 +198,15 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "datasource-test"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -211,6 +246,12 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": []
+                  }
+                },
                 "maxItems": 100,
                 "query": "",
                 "showHeadings": true,
@@ -247,6 +288,15 @@
             "spec": {
               "pluginVersion": "9.0.0-pre",
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "demo"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.home.v42.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/migrated_dev_dashboards/v0alpha1.v1beta1.v1beta1.home.v42.v2beta1.json
@@ -58,6 +58,14 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "panel-tests"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -97,6 +105,15 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "demo"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -137,6 +154,15 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "templating",
+                      "gdev"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -177,6 +203,15 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "datasource-test"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,
@@ -217,6 +252,12 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": []
+                  }
+                },
                 "maxItems": 100,
                 "query": "",
                 "showHeadings": true,
@@ -254,6 +295,15 @@
             "version": "9.0.0-pre",
             "spec": {
               "options": {
+                "__angularMigration": {
+                  "autoMigrateFrom": "dashlist",
+                  "originalOptions": {
+                    "tags": [
+                      "gdev",
+                      "demo"
+                    ]
+                  }
+                },
                 "maxItems": 1000,
                 "query": "",
                 "showHeadings": false,

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v0alpha1.json
@@ -1,0 +1,161 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "metadata": {
+    "name": "ad5vfcn",
+    "namespace": "default",
+    "uid": "dlMZZl6GndU8gJLUQSmgZxXBPCNXyXhNBeQJhHXl0r4X",
+    "resourceVersion": "2",
+    "generation": 2,
+    "creationTimestamp": "2025-11-28T10:14:21Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "288"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedTimestamp": "2025-11-28T10:15:06Z"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 288,
+    "links": [],
+    "panels": [
+      {
+        "datasource": {
+          "type": "testdata",
+          "uid": "gdev-testdata"
+        },
+        "fieldConfig": {
+          "defaults": {
+            "color": {
+              "mode": "palette-classic"
+            },
+            "custom": {
+              "axisBorderShow": false,
+              "axisCenteredZero": false,
+              "axisColorMode": "text",
+              "axisLabel": "",
+              "axisPlacement": "auto",
+              "barAlignment": 0,
+              "barWidthFactor": 0.6,
+              "drawStyle": "line",
+              "fillOpacity": 0,
+              "gradientMode": "none",
+              "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+              },
+              "insertNulls": false,
+              "lineInterpolation": "linear",
+              "lineWidth": 1,
+              "pointSize": 5,
+              "scaleDistribution": {
+                "type": "linear"
+              },
+              "showPoints": "auto",
+              "showValues": false,
+              "spanNulls": false,
+              "stacking": {
+                "group": "A",
+                "mode": "none"
+              },
+              "thresholdsStyle": {
+                "mode": "off"
+              }
+            },
+            "mappings": [],
+            "thresholds": {
+              "mode": "absolute",
+              "steps": [
+                {
+                  "color": "green",
+                  "value": 0
+                },
+                {
+                  "color": "red",
+                  "value": 80
+                }
+              ]
+            }
+          },
+          "overrides": []
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {
+          "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+          },
+          "tooltip": {
+            "hideZeros": false,
+            "mode": "single",
+            "sort": "none"
+          }
+        },
+        "pluginVersion": "12.4.0-pre",
+        "targets": [
+          {
+            "datasource": {},
+            "queryType": "randomWalk"
+          },
+          {
+            "datasource": {},
+            "queryType": "randomWalk"
+          }
+        ],
+        "title": "New panel",
+        "type": "timeseries"
+      }
+    ],
+    "preload": false,
+    "schemaVersion": 42,
+    "tags": [],
+    "templating": {
+      "list": []
+    },
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {},
+    "timezone": "browser",
+    "title": "Panel ds inheritance ",
+    "uid": "ad5vfcn",
+    "version": 2
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v1beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v2alpha1.json
@@ -1,0 +1,227 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v2alpha1",
+  "metadata": {
+    "name": "ad5vfcn",
+    "namespace": "default",
+    "uid": "dlMZZl6GndU8gJLUQSmgZxXBPCNXyXhNBeQJhHXl0r4X",
+    "resourceVersion": "2",
+    "generation": 2,
+    "creationTimestamp": "2025-11-28T10:14:21Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "288"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedTimestamp": "2025-11-28T10:15:06Z"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "query": {
+            "kind": "grafana",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "New panel",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "testdata",
+                      "spec": {
+                        "queryType": "randomWalk"
+                      }
+                    },
+                    "datasource": {
+                      "type": "testdata",
+                      "uid": "gdev-testdata"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "testdata",
+                      "spec": {
+                        "queryType": "randomWalk"
+                      }
+                    },
+                    "datasource": {
+                      "type": "testdata",
+                      "uid": "gdev-testdata"
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "timeseries",
+            "spec": {
+              "pluginVersion": "12.4.0-pre",
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Panel ds inheritance ",
+    "variables": []
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v1beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v2beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v1beta1.panel-target-missing-refid.v2beta1.json
@@ -1,0 +1,231 @@
+{
+  "kind": "Dashboard",
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "metadata": {
+    "name": "ad5vfcn",
+    "namespace": "default",
+    "uid": "dlMZZl6GndU8gJLUQSmgZxXBPCNXyXhNBeQJhHXl0r4X",
+    "resourceVersion": "2",
+    "generation": 2,
+    "creationTimestamp": "2025-11-28T10:14:21Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "288"
+    },
+    "annotations": {
+      "grafana.app/createdBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedBy": "user:eex2ofwuj0agwd",
+      "grafana.app/updatedTimestamp": "2025-11-28T10:15:06Z"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "query": {
+            "kind": "DataQuery",
+            "group": "grafana",
+            "version": "v0",
+            "datasource": {
+              "name": "-- Grafana --"
+            },
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "New panel",
+          "description": "",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "testdata",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-testdata"
+                      },
+                      "spec": {
+                        "queryType": "randomWalk"
+                      }
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "testdata",
+                      "version": "v0",
+                      "datasource": {
+                        "name": "gdev-testdata"
+                      },
+                      "spec": {
+                        "queryType": "randomWalk"
+                      }
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "VizConfig",
+            "group": "timeseries",
+            "version": "12.4.0-pre",
+            "spec": {
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              },
+              "fieldConfig": {
+                "defaults": {
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "value": 0,
+                        "color": "green"
+                      },
+                      {
+                        "value": 80,
+                        "color": "red"
+                      }
+                    ]
+                  },
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "axisBorderShow": false,
+                    "axisCenteredZero": false,
+                    "axisColorMode": "text",
+                    "axisLabel": "",
+                    "axisPlacement": "auto",
+                    "barAlignment": 0,
+                    "barWidthFactor": 0.6,
+                    "drawStyle": "line",
+                    "fillOpacity": 0,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "insertNulls": false,
+                    "lineInterpolation": "linear",
+                    "lineWidth": 1,
+                    "pointSize": 5,
+                    "scaleDistribution": {
+                      "type": "linear"
+                    },
+                    "showPoints": "auto",
+                    "showValues": false,
+                    "spanNulls": false,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    },
+                    "thresholdsStyle": {
+                      "mode": "off"
+                    }
+                  }
+                },
+                "overrides": []
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Panel ds inheritance ",
+    "variables": []
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v1beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v0alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v0alpha1.json
@@ -1,0 +1,640 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v0alpha1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "liveNow": false,
+    "panels": [
+      {
+        "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "critical": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Critical!"
+                  },
+                  "ok": {
+                    "color": "green",
+                    "index": 2,
+                    "text": "OK"
+                  },
+                  "warning": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 100
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "up",
+            "refId": "A"
+          }
+        ],
+        "title": "ValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Low"
+                  },
+                  "to": 50
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 50,
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Medium"
+                  },
+                  "to": 80
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 80,
+                  "result": {
+                    "color": "red",
+                    "index": 2,
+                    "text": "High"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^cpu_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "percent"
+                },
+                {
+                  "id": "decimals",
+                  "value": 2
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "cpu_usage_percent",
+            "refId": "A"
+          }
+        ],
+        "title": "RangeMap Example",
+        "type": "gauge"
+      },
+      {
+        "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "pattern": "/^error.*/",
+                  "result": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Error"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^warn.*/",
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^info.*/",
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "Info"
+                  }
+                },
+                "type": "regex"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "string"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-text"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "log_level",
+            "refId": "A"
+          }
+        ],
+        "title": "RegexMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 0,
+                    "text": "No Data"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 1,
+                    "text": "Not a Number"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "null+nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 2,
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "true",
+                  "result": {
+                    "color": "green",
+                    "index": 3,
+                    "text": "Yes"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "false",
+                  "result": {
+                    "color": "red",
+                    "index": 4,
+                    "text": "No"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "empty",
+                  "result": {
+                    "color": "gray",
+                    "index": 5,
+                    "text": "Empty"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "A"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 4,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "some_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "SpecialValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "failure": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "Failure"
+                  },
+                  "success": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Success"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "In Range"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "pattern": "/^[A-Z]{3}-\\d+$/",
+                  "result": {
+                    "color": "purple",
+                    "index": 3,
+                    "text": "ID Format"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 4,
+                    "text": "Missing"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 120
+                },
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^value_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "short"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 100
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              },
+              "properties": [
+                {
+                  "id": "decimals",
+                  "value": 2
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "B"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Secondary Query"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byValue",
+                "options": {
+                  "op": "gte",
+                  "reducer": "allIsNull",
+                  "value": 0
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hidden",
+                  "value": true
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 5,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "combined_metric",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "secondary_metric",
+            "refId": "B"
+          }
+        ],
+        "title": "Combined Mappings and Overrides Example",
+        "type": "table"
+      },
+      {
+        "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+        "fieldConfig": {
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "field_with_empty_override"
+              },
+              "properties": []
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "empty_override_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "Empty Properties Override Example",
+        "type": "stat"
+      }
+    ],
+    "preload": false,
+    "refresh": "",
+    "schemaVersion": 42,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Value Mapping and Overrides Test"
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v1beta1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v1beta1.json
@@ -1,0 +1,640 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v1beta1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": {
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "type": "dashboard"
+        }
+      ]
+    },
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "liveNow": false,
+    "panels": [
+      {
+        "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "critical": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Critical!"
+                  },
+                  "ok": {
+                    "color": "green",
+                    "index": 2,
+                    "text": "OK"
+                  },
+                  "warning": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "value"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 100
+                },
+                {
+                  "id": "custom.align",
+                  "value": "center"
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 0
+        },
+        "id": 1,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "up",
+            "refId": "A"
+          }
+        ],
+        "title": "ValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Low"
+                  },
+                  "to": 50
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 50,
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Medium"
+                  },
+                  "to": 80
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "from": 80,
+                  "result": {
+                    "color": "red",
+                    "index": 2,
+                    "text": "High"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^cpu_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "percent"
+                },
+                {
+                  "id": "decimals",
+                  "value": 2
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 0
+        },
+        "id": 2,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "cpu_usage_percent",
+            "refId": "A"
+          }
+        ],
+        "title": "RangeMap Example",
+        "type": "gauge"
+      },
+      {
+        "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "pattern": "/^error.*/",
+                  "result": {
+                    "color": "red",
+                    "index": 0,
+                    "text": "Error"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^warn.*/",
+                  "result": {
+                    "color": "orange",
+                    "index": 1,
+                    "text": "Warning"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "pattern": "/^info.*/",
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "Info"
+                  }
+                },
+                "type": "regex"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "string"
+              },
+              "properties": [
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-text"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 8
+        },
+        "id": 3,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "log_level",
+            "refId": "A"
+          }
+        ],
+        "title": "RegexMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 0,
+                    "text": "No Data"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 1,
+                    "text": "Not a Number"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "null+nan",
+                  "result": {
+                    "color": "gray",
+                    "index": 2,
+                    "text": "N/A"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "true",
+                  "result": {
+                    "color": "green",
+                    "index": 3,
+                    "text": "Yes"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "false",
+                  "result": {
+                    "color": "red",
+                    "index": 4,
+                    "text": "No"
+                  }
+                },
+                "type": "special"
+              },
+              {
+                "options": {
+                  "match": "empty",
+                  "result": {
+                    "color": "gray",
+                    "index": 5,
+                    "text": "Empty"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "A"
+              },
+              "properties": [
+                {
+                  "id": "color",
+                  "value": {
+                    "fixedColor": "blue",
+                    "mode": "fixed"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 12,
+          "y": 8
+        },
+        "id": 4,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "some_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "SpecialValueMap Example",
+        "type": "stat"
+      },
+      {
+        "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+        "fieldConfig": {
+          "defaults": {
+            "mappings": [
+              {
+                "options": {
+                  "failure": {
+                    "color": "red",
+                    "index": 1,
+                    "text": "Failure"
+                  },
+                  "success": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "Success"
+                  }
+                },
+                "type": "value"
+              },
+              {
+                "options": {
+                  "from": 0,
+                  "result": {
+                    "color": "blue",
+                    "index": 2,
+                    "text": "In Range"
+                  },
+                  "to": 100
+                },
+                "type": "range"
+              },
+              {
+                "options": {
+                  "pattern": "/^[A-Z]{3}-\\d+$/",
+                  "result": {
+                    "color": "purple",
+                    "index": 3,
+                    "text": "ID Format"
+                  }
+                },
+                "type": "regex"
+              },
+              {
+                "options": {
+                  "match": "null",
+                  "result": {
+                    "color": "gray",
+                    "index": 4,
+                    "text": "Missing"
+                  }
+                },
+                "type": "special"
+              }
+            ]
+          },
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "status"
+              },
+              "properties": [
+                {
+                  "id": "custom.width",
+                  "value": 120
+                },
+                {
+                  "id": "custom.cellOptions",
+                  "value": {
+                    "type": "color-background"
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byRegexp",
+                "options": "/^value_/"
+              },
+              "properties": [
+                {
+                  "id": "unit",
+                  "value": "short"
+                },
+                {
+                  "id": "min",
+                  "value": 0
+                },
+                {
+                  "id": "max",
+                  "value": 100
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              },
+              "properties": [
+                {
+                  "id": "decimals",
+                  "value": 2
+                },
+                {
+                  "id": "thresholds",
+                  "value": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": null
+                      },
+                      {
+                        "color": "yellow",
+                        "value": 50
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byFrameRefID",
+                "options": "B"
+              },
+              "properties": [
+                {
+                  "id": "displayName",
+                  "value": "Secondary Query"
+                }
+              ]
+            },
+            {
+              "matcher": {
+                "id": "byValue",
+                "options": {
+                  "op": "gte",
+                  "reducer": "allIsNull",
+                  "value": 0
+                }
+              },
+              "properties": [
+                {
+                  "id": "custom.hidden",
+                  "value": true
+                }
+              ]
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 24,
+          "x": 0,
+          "y": 16
+        },
+        "id": 5,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "combined_metric",
+            "refId": "A"
+          },
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "secondary_metric",
+            "refId": "B"
+          }
+        ],
+        "title": "Combined Mappings and Overrides Example",
+        "type": "table"
+      },
+      {
+        "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+        "fieldConfig": {
+          "overrides": [
+            {
+              "matcher": {
+                "id": "byName",
+                "options": "field_with_empty_override"
+              },
+              "properties": []
+            }
+          ]
+        },
+        "gridPos": {
+          "h": 8,
+          "w": 12,
+          "x": 0,
+          "y": 24
+        },
+        "id": 6,
+        "options": {},
+        "pluginVersion": "",
+        "targets": [
+          {
+            "datasource": {
+              "type": "prometheus",
+              "uid": "prometheus-uid"
+            },
+            "expr": "empty_override_metric",
+            "refId": "A"
+          }
+        ],
+        "title": "Empty Properties Override Example",
+        "type": "stat"
+      }
+    ],
+    "preload": false,
+    "refresh": "",
+    "schemaVersion": 42,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "time": {
+      "from": "now-6h",
+      "to": "now"
+    },
+    "timepicker": {
+      "refresh_intervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ]
+    },
+    "timezone": "browser",
+    "title": "Value Mapping and Overrides Test"
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v2alpha1.json
+++ b/apps/dashboard/pkg/migration/conversion/testdata/output/v2beta1.value-mapping-and-overrides.v2alpha1.json
@@ -1,0 +1,850 @@
+{
+  "kind": "DashboardWithAccessInfo",
+  "apiVersion": "dashboard.grafana.app/v2alpha1",
+  "metadata": {
+    "name": "value-mapping-test",
+    "namespace": "default",
+    "uid": "value-mapping-test",
+    "resourceVersion": "1765384157199094",
+    "generation": 2,
+    "creationTimestamp": "2025-11-19T20:09:28Z",
+    "labels": {
+      "grafana.app/deprecatedInternalID": "646372978987008"
+    }
+  },
+  "spec": {
+    "annotations": [
+      {
+        "kind": "AnnotationQuery",
+        "spec": {
+          "datasource": {
+            "type": "grafana",
+            "uid": "-- Grafana --"
+          },
+          "query": {
+            "kind": "grafana",
+            "spec": {}
+          },
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations \u0026 Alerts",
+          "builtIn": true,
+          "legacyOptions": {
+            "type": "dashboard"
+          }
+        }
+      }
+    ],
+    "cursorSync": "Off",
+    "description": "Test dashboard for all value mapping types and override matcher types",
+    "editable": true,
+    "elements": {
+      "panel-1": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "ValueMap Example",
+          "description": "Panel with ValueMap mapping type - maps specific text values to colors and display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "up"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "critical": {
+                          "text": "Critical!",
+                          "color": "red",
+                          "index": 0
+                        },
+                        "ok": {
+                          "text": "OK",
+                          "color": "green",
+                          "index": 2
+                        },
+                        "warning": {
+                          "text": "Warning",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 100
+                      },
+                      {
+                        "id": "custom.align",
+                        "value": "center"
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-2": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "RangeMap Example",
+          "description": "Panel with RangeMap mapping type - maps numerical ranges to colors and display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "cpu_usage_percent"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "gauge",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 0,
+                        "to": 50,
+                        "result": {
+                          "text": "Low",
+                          "color": "green",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 50,
+                        "to": 80,
+                        "result": {
+                          "text": "Medium",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 80,
+                        "to": 100,
+                        "result": {
+                          "text": "High",
+                          "color": "red",
+                          "index": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^cpu_/"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "percent"
+                      },
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "RegexMap Example",
+          "description": "Panel with RegexMap mapping type - maps values matching regex patterns to colors",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "log_level"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^error.*/",
+                        "result": {
+                          "text": "Error",
+                          "color": "red",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^warn.*/",
+                        "result": {
+                          "text": "Warning",
+                          "color": "orange",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^info.*/",
+                        "result": {
+                          "text": "Info",
+                          "color": "blue",
+                          "index": 2
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byType",
+                      "options": "string"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-text"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-4": {
+        "kind": "Panel",
+        "spec": {
+          "id": 4,
+          "title": "SpecialValueMap Example",
+          "description": "Panel with SpecialValueMap mapping type - maps special values like null, NaN, true, false to display text",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "some_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "No Data",
+                          "color": "gray",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "nan",
+                        "result": {
+                          "text": "Not a Number",
+                          "color": "gray",
+                          "index": 1
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null+nan",
+                        "result": {
+                          "text": "N/A",
+                          "color": "gray",
+                          "index": 2
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "true",
+                        "result": {
+                          "text": "Yes",
+                          "color": "green",
+                          "index": 3
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "false",
+                        "result": {
+                          "text": "No",
+                          "color": "red",
+                          "index": 4
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "empty",
+                        "result": {
+                          "text": "Empty",
+                          "color": "gray",
+                          "index": 5
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "A"
+                    },
+                    "properties": [
+                      {
+                        "id": "color",
+                        "value": {
+                          "fixedColor": "blue",
+                          "mode": "fixed"
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-5": {
+        "kind": "Panel",
+        "spec": {
+          "id": 5,
+          "title": "Combined Mappings and Overrides Example",
+          "description": "Panel with all mapping types combined - demonstrates mixing different mapping types and multiple override matchers",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "combined_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                },
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "secondary_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "B",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "table",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {
+                  "mappings": [
+                    {
+                      "type": "value",
+                      "options": {
+                        "failure": {
+                          "text": "Failure",
+                          "color": "red",
+                          "index": 1
+                        },
+                        "success": {
+                          "text": "Success",
+                          "color": "green",
+                          "index": 0
+                        }
+                      }
+                    },
+                    {
+                      "type": "range",
+                      "options": {
+                        "from": 0,
+                        "to": 100,
+                        "result": {
+                          "text": "In Range",
+                          "color": "blue",
+                          "index": 2
+                        }
+                      }
+                    },
+                    {
+                      "type": "regex",
+                      "options": {
+                        "pattern": "/^[A-Z]{3}-\\d+$/",
+                        "result": {
+                          "text": "ID Format",
+                          "color": "purple",
+                          "index": 3
+                        }
+                      }
+                    },
+                    {
+                      "type": "special",
+                      "options": {
+                        "match": "null",
+                        "result": {
+                          "text": "Missing",
+                          "color": "gray",
+                          "index": 4
+                        }
+                      }
+                    }
+                  ]
+                },
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "status"
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.width",
+                        "value": 120
+                      },
+                      {
+                        "id": "custom.cellOptions",
+                        "value": {
+                          "type": "color-background"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byRegexp",
+                      "options": "/^value_/"
+                    },
+                    "properties": [
+                      {
+                        "id": "unit",
+                        "value": "short"
+                      },
+                      {
+                        "id": "min",
+                        "value": 0
+                      },
+                      {
+                        "id": "max",
+                        "value": 100
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byType",
+                      "options": "number"
+                    },
+                    "properties": [
+                      {
+                        "id": "decimals",
+                        "value": 2
+                      },
+                      {
+                        "id": "thresholds",
+                        "value": {
+                          "mode": "absolute",
+                          "steps": [
+                            {
+                              "color": "green",
+                              "value": null
+                            },
+                            {
+                              "color": "yellow",
+                              "value": 50
+                            },
+                            {
+                              "color": "red",
+                              "value": 80
+                            }
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byFrameRefID",
+                      "options": "B"
+                    },
+                    "properties": [
+                      {
+                        "id": "displayName",
+                        "value": "Secondary Query"
+                      }
+                    ]
+                  },
+                  {
+                    "matcher": {
+                      "id": "byValue",
+                      "options": {
+                        "op": "gte",
+                        "reducer": "allIsNull",
+                        "value": 0
+                      }
+                    },
+                    "properties": [
+                      {
+                        "id": "custom.hidden",
+                        "value": true
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "panel-6": {
+        "kind": "Panel",
+        "spec": {
+          "id": 6,
+          "title": "Empty Properties Override Example",
+          "description": "Panel with override that has empty properties array - tests conversion of overrides without any property modifications",
+          "links": [],
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "query": {
+                      "kind": "prometheus",
+                      "spec": {
+                        "expr": "empty_override_metric"
+                      }
+                    },
+                    "datasource": {
+                      "type": "prometheus",
+                      "uid": "prometheus-uid"
+                    },
+                    "refId": "A",
+                    "hidden": false
+                  }
+                }
+              ],
+              "transformations": [],
+              "queryOptions": {}
+            }
+          },
+          "vizConfig": {
+            "kind": "stat",
+            "spec": {
+              "pluginVersion": "",
+              "options": {},
+              "fieldConfig": {
+                "defaults": {},
+                "overrides": [
+                  {
+                    "matcher": {
+                      "id": "byName",
+                      "options": "field_with_empty_override"
+                    },
+                    "properties": []
+                  }
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "layout": {
+      "kind": "GridLayout",
+      "spec": {
+        "items": [
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-1"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 0,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-2"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-3"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 12,
+              "y": 8,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-4"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 16,
+              "width": 24,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-5"
+              }
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "x": 0,
+              "y": 24,
+              "width": 12,
+              "height": 8,
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-6"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "links": [],
+    "liveNow": false,
+    "preload": false,
+    "tags": [
+      "value-mapping",
+      "overrides",
+      "test"
+    ],
+    "timeSettings": {
+      "timezone": "browser",
+      "from": "now-6h",
+      "to": "now",
+      "autoRefresh": "",
+      "autoRefreshIntervals": [
+        "5s",
+        "10s",
+        "30s",
+        "1m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+      ],
+      "hideTimepicker": false,
+      "fiscalYearStartMonth": 0
+    },
+    "title": "Value Mapping and Overrides Test",
+    "variables": []
+  },
+  "status": {
+    "conversion": {
+      "failed": false,
+      "storedVersion": "v2beta1"
+    }
+  }
+}

--- a/apps/dashboard/pkg/migration/conversion/v0alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v0alpha1_to_v1beta1.go
@@ -2,6 +2,7 @@ package conversion
 
 import (
 	"context"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -79,5 +80,57 @@ func ConvertDashboard_V0_to_V1beta1(in *dashv0.Dashboard, out *dashv1.Dashboard,
 		return schemaversion.NewMigrationError(err.Error(), schemaversion.GetSchemaVersion(in.Spec.Object), schemaversion.LATEST_VERSION, "Convert_V0_to_V1")
 	}
 
+	// Normalize template variable datasources from string to object format
+	// This handles legacy dashboards where query variables have datasource: "$datasource" (string)
+	// instead of datasource: { uid: "$datasource" } (object)
+	// our migration pipeline in v36 doesn't address because this was not addressed historically
+	// in DashboardMigrator - see public/app/features/dashboard/state/DashboardMigrator.ts#L607
+	// Which means that we have schemaVersion: 42 dashboards where datasource variable references are still strings
+	normalizeTemplateVariableDatasources(out.Spec.Object)
+
 	return nil
+}
+
+// normalizeTemplateVariableDatasources converts template variable string datasources to object format.
+// Legacy dashboards may have query variables with datasource: "$datasource" (string).
+// This normalizes them to datasource: { uid: "$datasource" } for consistent V1→V2 conversion.
+func normalizeTemplateVariableDatasources(dashboard map[string]interface{}) {
+	templating, ok := dashboard["templating"].(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	list, ok := templating["list"].([]interface{})
+	if !ok {
+		return
+	}
+
+	for _, variable := range list {
+		varMap, ok := variable.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		varType, _ := varMap["type"].(string)
+		if varType != "query" {
+			continue
+		}
+
+		ds := varMap["datasource"]
+		if dsStr, ok := ds.(string); ok && isTemplateVariableRef(dsStr) {
+			// Convert string template variable reference to object format
+			varMap["datasource"] = map[string]interface{}{
+				"uid": dsStr,
+			}
+		}
+	}
+}
+
+// isTemplateVariableRef checks if a string is a Grafana template variable reference.
+// Template variables can be in the form: $varname or ${varname}
+func isTemplateVariableRef(s string) bool {
+	if s == "" {
+		return false
+	}
+	return strings.HasPrefix(s, "$") || strings.HasPrefix(s, "${")
 }

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -2308,20 +2308,24 @@ func buildVizConfig(panelMap map[string]interface{}) dashv2alpha1.DashboardVizCo
 	// We check two cases:
 	// 1. Panel already has autoMigrateFrom set (from v0→v1 migration) - panel type already converted
 	// 2. Panel type is a known Angular panel - need to convert type AND set autoMigrateFrom
+	// 3. Panel has original options - need to set autoMigrateFrom and originalOptions
 	autoMigrateFrom, hasAutoMigrateFrom := panelMap["autoMigrateFrom"].(string)
+	originalOptions := extractAngularOptions(panelMap)
 
 	if !hasAutoMigrateFrom || autoMigrateFrom == "" {
 		// Check if panel type is an Angular type that needs migration
 		if newType := getAngularPanelMigration(panelType, panelMap); newType != "" {
 			autoMigrateFrom = panelType // Original Angular type
 			panelType = newType         // New modern type
+		} else if len(originalOptions) > 0 {
+			autoMigrateFrom = panelType
 		}
 	}
 
 	if autoMigrateFrom != "" {
 		options["__angularMigration"] = map[string]interface{}{
 			"autoMigrateFrom": autoMigrateFrom,
-			"originalOptions": extractAngularOptions(panelMap),
+			"originalOptions": originalOptions,
 		}
 	}
 

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -1185,6 +1185,10 @@ func buildQueryVariable(ctx context.Context, varMap map[string]interface{}, comm
 			// If no UID and no type, use default
 			datasourceType = getDefaultDatasourceType(ctx, dsIndexProvider)
 		}
+	} else if dsStr, ok := datasource.(string); ok && isTemplateVariable(dsStr) {
+		// Handle datasource variable reference (e.g., "$datasource")
+		// Only process template variables - other string values are not supported in V2 format
+		datasourceUID = dsStr
 	} else {
 		datasourceType = getDefaultDatasourceType(ctx, dsIndexProvider)
 	}
@@ -1532,6 +1536,10 @@ func buildAdhocVariable(ctx context.Context, varMap map[string]interface{}, comm
 			// If no UID and no type, use default
 			datasourceType = getDefaultDatasourceType(ctx, dsIndexProvider)
 		}
+	} else if dsStr, ok := datasource.(string); ok && isTemplateVariable(dsStr) {
+		// Handle datasource variable reference (e.g., "$datasource")
+		// Only process template variables - other string values are not supported in V2 format
+		datasourceUID = dsStr
 	} else {
 		datasourceType = getDefaultDatasourceType(ctx, dsIndexProvider)
 	}
@@ -1709,6 +1717,10 @@ func buildGroupByVariable(ctx context.Context, varMap map[string]interface{}, co
 
 		// Resolve Grafana datasource UID when type is "datasource" and UID is empty
 		datasourceUID = resolveGrafanaDatasourceUID(datasourceType, datasourceUID)
+	} else if dsStr, ok := datasource.(string); ok && isTemplateVariable(dsStr) {
+		// Handle datasource variable reference (e.g., "$datasource")
+		// Only process template variables - other string values are not supported in V2 format
+		datasourceUID = dsStr
 	} else {
 		datasourceType = getDefaultDatasourceType(ctx, dsIndexProvider)
 	}

--- a/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
+++ b/apps/dashboard/pkg/migration/conversion/v1beta1_to_v2alpha1.go
@@ -2018,6 +2018,28 @@ func transformPanelQueries(ctx context.Context, panelMap map[string]interface{},
 		}
 	}
 
+	// Ensure each target has a non-empty refId. We only fill missing refIds;
+	existingRefIds := make(map[string]bool)
+	for _, target := range targets {
+		if targetMap, ok := target.(map[string]interface{}); ok {
+			if refId := schemaversion.GetStringValue(targetMap, "refId"); refId != "" {
+				existingRefIds[refId] = true
+			}
+		}
+	}
+	for _, target := range targets {
+		targetMap, ok := target.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		refId := schemaversion.GetStringValue(targetMap, "refId")
+		if refId == "" {
+			refId = nextAvailableRefId(existingRefIds)
+			targetMap["refId"] = refId
+			existingRefIds[refId] = true
+		}
+	}
+
 	queries := make([]dashv2alpha1.DashboardPanelQueryKind, 0, len(targets))
 
 	for _, target := range targets {
@@ -2028,6 +2050,27 @@ func transformPanelQueries(ctx context.Context, panelMap map[string]interface{},
 	}
 
 	return queries
+}
+
+// nextAvailableRefId returns the next unused refId using the same sequence as the
+// frontend helper (A, B, ..., Z, AA, AB, ...).
+func nextAvailableRefId(existing map[string]bool) string {
+	const letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+	var refIdFromIndex func(num int) string
+	refIdFromIndex = func(num int) string {
+		if num < len(letters) {
+			return string(letters[num])
+		}
+		return refIdFromIndex(num/len(letters)-1) + string(letters[num%len(letters)])
+	}
+
+	for i := 0; ; i++ {
+		refId := refIdFromIndex(i)
+		if !existing[refId] {
+			return refId
+		}
+	}
 }
 
 func transformSingleQuery(ctx context.Context, targetMap map[string]interface{}, panelDatasource *dashv2alpha1.DashboardDataSourceRef, dsIndexProvider schemaversion.DataSourceIndexProvider) dashv2alpha1.DashboardPanelQueryKind {

--- a/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
+++ b/apps/dashboard/pkg/migration/conversion/v2alpha1_to_v1beta1.go
@@ -1973,16 +1973,16 @@ func convertFieldConfigOverridesToV1(overrides []dashv2alpha1.DashboardV2alpha1F
 			"options": override.Matcher.Options,
 		}
 
+		properties := make([]map[string]interface{}, 0, len(override.Properties))
 		if len(override.Properties) > 0 {
-			properties := make([]map[string]interface{}, 0, len(override.Properties))
 			for _, prop := range override.Properties {
 				properties = append(properties, map[string]interface{}{
 					"id":    prop.Id,
 					"value": prop.Value,
 				})
 			}
-			overrideMap["properties"] = properties
 		}
+		overrideMap["properties"] = properties
 
 		result = append(result, overrideMap)
 	}
@@ -2074,11 +2074,9 @@ func convertRegexMapToV1(regexMap *dashv2alpha1.DashboardRegexMap) map[string]in
 		return nil
 	}
 
-	options := []map[string]interface{}{
-		{
-			"pattern": regexMap.Options.Pattern,
-			"result":  convertValueMappingResultToV1(regexMap.Options.Result),
-		},
+	options := map[string]interface{}{
+		"pattern": regexMap.Options.Pattern,
+		"result":  convertValueMappingResultToV1(regexMap.Options.Result),
 	}
 
 	return map[string]interface{}{

--- a/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/migrations/migrations.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/dev-dashboards-output/migrations/migrations.v42.json
@@ -290,6 +290,7 @@
       }
     },
     {
+      "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
       "datasource": {
         "type": "grafana-testdata-datasource"
       },
@@ -300,15 +301,7 @@
         "y": 0
       },
       "id": 6,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "# Graph panel \u003e\u003e Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-        "mode": "markdown"
-      },
+      "mode": "markdown",
       "pluginVersion": "11.0.0-pre",
       "targets": [
         {

--- a/apps/dashboard/pkg/migration/testdata/input/v15.mimir_rollout_debugging.json
+++ b/apps/dashboard/pkg/migration/testdata/input/v15.mimir_rollout_debugging.json
@@ -654,7 +654,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": true,
         "label": "cluster",
@@ -677,7 +679,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "namespace",

--- a/apps/dashboard/pkg/migration/testdata/output/latest_version/v15.mimir_rollout_debugging.v42.json
+++ b/apps/dashboard/pkg/migration/testdata/output/latest_version/v15.mimir_rollout_debugging.v42.json
@@ -737,7 +737,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": true,
         "label": "cluster",
@@ -758,7 +760,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "namespace",

--- a/apps/dashboard/pkg/migration/testdata/output/single_version/v15.mimir_rollout_debugging.v15.json
+++ b/apps/dashboard/pkg/migration/testdata/output/single_version/v15.mimir_rollout_debugging.v15.json
@@ -717,7 +717,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": true,
         "label": "cluster",
@@ -739,7 +741,9 @@
           "text": "prod",
           "value": "prod"
         },
-        "datasource": "$datasource",
+        "datasource": {
+          "uid": "$datasource"
+        },
         "hide": 0,
         "includeAll": false,
         "label": "namespace",

--- a/devenv/dev-dashboards/migrations/migrations.json
+++ b/devenv/dev-dashboards/migrations/migrations.json
@@ -299,15 +299,9 @@
         "y": 0
       },
       "id": 6,
-      "options": {
-        "code": {
-          "language": "plaintext",
-          "showLineNumbers": false,
-          "showMiniMap": false
-        },
-        "content": "# Graph panel >> Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
-        "mode": "markdown"
-      },
+      "options": {},
+      "content": "# Graph panel >> Timeseries panel\n\nKnown issues:\n* hiding null/empty series\n* time regions",
+      "mode": "markdown",
       "pluginVersion": "11.0.0-pre",
       "targets": [
         {

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1893,11 +1893,6 @@
       "count": 1
     }
   },
-  "public/app/features/dashboard-scene/serialization/angularMigration.test.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "public/app/features/dashboard-scene/serialization/buildNewDashboardSaveModel.ts": {
     "@typescript-eslint/consistent-type-assertions": {
       "count": 1

--- a/public/app/features/dashboard-scene/edit-pane/DashboardExportButton.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardExportButton.tsx
@@ -18,7 +18,7 @@ const newExportButtonSelector = selectors.pages.Dashboard.DashNav.NewExportButto
 
 export function ShareExportDashboardButton({ dashboard }: Props) {
   return (
-    <Dropdown overlay={<ExportMenu dashboard={dashboard} />} placement="left-end">
+    <Dropdown overlay={<ExportMenu dashboard={dashboard} />} placement="left-start">
       <Sidebar.Button
         icon="download-alt"
         data-testid={newExportButtonSelector.Menu.container}

--- a/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/angularMigration.test.ts
@@ -1,8 +1,21 @@
-import { PanelTypeChangedHandler } from '@grafana/data';
+import { FieldConfigSource, PanelTypeChangedHandler } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 
 import { getV2AngularMigrationHandler, getAngularPanelMigrationHandler } from './angularMigration';
+
+/**
+ * Test type for mutable panel model used in migration handler tests.
+ * Allows arbitrary properties to be added during migration.
+ */
+interface TestPanelModel {
+  id: number;
+  type: string;
+  options: Record<string, unknown>;
+  fieldConfig: FieldConfigSource;
+  targets?: Array<{ refId: string; [key: string]: unknown }>;
+  [key: string]: unknown;
+}
 
 describe('getAngularPanelMigrationHandler', () => {
   describe('Given an old angular panel', () => {
@@ -43,9 +56,11 @@ describe('getAngularPanelMigrationHandler', () => {
         type: 'dashlist',
       });
 
-      const mutatedModel: any = {
+      const mutatedModel: TestPanelModel = {
+        id: 1,
         type: 'dashlist',
         options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
       };
 
       getAngularPanelMigrationHandler(oldModel)(mutatedModel, reactPlugin);
@@ -80,7 +95,7 @@ describe('getV2AngularMigrationHandler', () => {
         },
       };
 
-      const mutatedModel = {
+      const mutatedModel: TestPanelModel = {
         id: 1,
         type: 'stat',
         options: {},
@@ -88,6 +103,11 @@ describe('getV2AngularMigrationHandler', () => {
       };
 
       getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // Verify originalOptions were spread onto the panel (for plugins using setMigrationHandler)
+      expect(mutatedModel['format']).toBe('short');
+      expect(mutatedModel['valueName']).toBe('avg');
+      expect(mutatedModel['orientation']).toBe('horizontal');
 
       // Verify handler received correct arguments
       expect(receivedPrevPluginId).toBe('singlestat');
@@ -123,7 +143,7 @@ describe('getV2AngularMigrationHandler', () => {
         },
       };
 
-      const mutatedModel = {
+      const mutatedModel: TestPanelModel = {
         id: 1,
         type: 'timeseries',
         options: {},
@@ -131,6 +151,10 @@ describe('getV2AngularMigrationHandler', () => {
       };
 
       getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // Verify originalOptions were spread onto the panel (for plugins using setMigrationHandler)
+      expect(mutatedModel['bars']).toBe(true);
+      expect(mutatedModel['lines']).toBe(false);
 
       // Verify handler received correct arguments
       expect(receivedPrevPluginId).toBe('graph');
@@ -163,7 +187,7 @@ describe('getV2AngularMigrationHandler', () => {
         },
       };
 
-      const mutatedModel = {
+      const mutatedModel: TestPanelModel = {
         id: 1,
         type: 'new-panel',
         options: {},
@@ -171,6 +195,9 @@ describe('getV2AngularMigrationHandler', () => {
       };
 
       getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // Verify originalOptions were spread onto the panel (for plugins using setMigrationHandler)
+      expect(mutatedModel['oldOption']).toBe('old');
 
       // Verify handler received correct arguments (options wrapper, not angular)
       expect(receivedPrevPluginId).toBe('some-react-panel');
@@ -220,6 +247,120 @@ describe('getV2AngularMigrationHandler', () => {
       );
 
       warnSpy.mockRestore();
+    });
+  });
+
+  describe('Given v2 migration data for text panel with Angular-style properties', () => {
+    it('Should spread originalOptions onto panel for migration handlers using setMigrationHandler', () => {
+      // Text panel uses setMigrationHandler, not onPanelTypeChanged
+      // The migration handler expects content/mode to be directly on the panel object
+      const reactPlugin = getPanelPlugin({ id: 'text' });
+
+      // This simulates a text panel with Angular-style properties at root level
+      // The backend sets autoMigrateFrom="text" when it detects these properties
+      const migrationData = {
+        autoMigrateFrom: 'text',
+        originalOptions: {
+          content: 'Hello World',
+          mode: 'markdown',
+        },
+      };
+
+      const mutatedModel: TestPanelModel = {
+        id: 1,
+        type: 'text',
+        options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
+      };
+
+      getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // Verify originalOptions were spread onto the panel
+      // This allows textPanelMigrationHandler to see content/mode via panel.hasOwnProperty()
+      expect(mutatedModel['content']).toBe('Hello World');
+      expect(mutatedModel['mode']).toBe('markdown');
+    });
+
+    it('Should not overwrite existing panel properties when spreading originalOptions', () => {
+      const reactPlugin = getPanelPlugin({ id: 'text' });
+
+      const migrationData = {
+        autoMigrateFrom: 'text',
+        originalOptions: {
+          content: 'Old content',
+          mode: 'markdown',
+          id: 999, // Should not overwrite existing id
+        },
+      };
+
+      const mutatedModel: TestPanelModel = {
+        id: 1,
+        type: 'text',
+        options: { existingOption: true },
+        fieldConfig: { defaults: {}, overrides: [] },
+      };
+
+      getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // defaults() only sets properties that don't already exist
+      expect(mutatedModel['content']).toBe('Old content');
+      expect(mutatedModel['mode']).toBe('markdown');
+      expect(mutatedModel.id).toBe(1); // Should keep original id
+      expect(mutatedModel.options).toEqual({ existingOption: true }); // Should keep existing options
+    });
+
+    it('Should work with empty originalOptions', () => {
+      const reactPlugin = getPanelPlugin({ id: 'text' });
+
+      const migrationData = {
+        autoMigrateFrom: 'text',
+        originalOptions: {},
+      };
+
+      const mutatedModel: TestPanelModel = {
+        id: 1,
+        type: 'text',
+        options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
+      };
+
+      // Should not throw
+      expect(() => {
+        getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+      }).not.toThrow();
+    });
+
+    it('Should spread originalOptions AND call onPanelTypeChanged if plugin has both', () => {
+      let handlerCalled = false;
+      const onPanelTypeChanged: PanelTypeChangedHandler = (panel, prevPluginId, prevOptions) => {
+        handlerCalled = true;
+        // Verify originalOptions were already spread onto panel before handler is called
+        expect((panel as TestPanelModel)['customProp']).toBe('custom value');
+        return { migrated: true };
+      };
+
+      const reactPlugin = getPanelPlugin({ id: 'custom-panel' }).setPanelChangeHandler(onPanelTypeChanged);
+
+      const migrationData = {
+        autoMigrateFrom: 'custom-panel',
+        originalOptions: {
+          customProp: 'custom value',
+        },
+      };
+
+      const mutatedModel: TestPanelModel = {
+        id: 1,
+        type: 'custom-panel',
+        options: {},
+        fieldConfig: { defaults: {}, overrides: [] },
+      };
+
+      getV2AngularMigrationHandler(migrationData)(mutatedModel, reactPlugin);
+
+      // Verify both behaviors occurred
+      expect(mutatedModel['customProp']).toBe('custom value'); // originalOptions spread
+      expect(handlerCalled).toBe(true); // onPanelTypeChanged called
+      expect(mutatedModel.options).toEqual({ migrated: true }); // handler result applied
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/sceneVariablesSetToVariables.ts
@@ -554,7 +554,7 @@ export function sceneVariablesSetToSchemaV2Variables(
             ...validateFiltersOrigin(variable.state.originFilters),
             ...validateFiltersOrigin(variable.state.filters),
           ],
-          defaultKeys: variable.state.defaultKeys || [], //FIXME what is the default value?
+          defaultKeys: variable.state.defaultKeys || [],
           allowCustomValue: variable.state.allowCustomValue ?? true,
         },
       };

--- a/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
+++ b/public/app/features/dashboard-scene/serialization/testfiles/nested_dashboard.json
@@ -1137,7 +1137,13 @@
       "datasource": { "name": "esmce00tbim8" },
       "group": "opensearch",
       "spec": {
-        "allowCustomValue": true
+        "name": "adhocVar",
+        "allowCustomValue": true,
+        "filters": [],
+        "baseFilters": [],
+        "defaultKeys": [],
+        "hide": "dontHide",
+        "skipUrlSync": false
       }
     },
     {

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -365,6 +365,35 @@ describe('transformSaveModelSchemaV2ToScene', () => {
     expect(getQueryRunnerFor(vizPanels[0])?.state.datasource?.uid).toBe(MIXED_DATASOURCE_NAME);
   });
 
+  describe('adhoc variables', () => {
+    it('should convert empty defaultKeys array to undefined', () => {
+      const dashboard = cloneDeep(defaultDashboard);
+      const adhocVar = dashboard.spec.variables.find((v) => v.kind === 'AdhocVariable') as AdhocVariableKind;
+      adhocVar.spec.defaultKeys = [];
+
+      const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+      const adhocVariable = scene.state.$variables?.getByName('adhocVar') as AdHocFiltersVariable;
+      expect(adhocVariable).toBeInstanceOf(AdHocFiltersVariable);
+
+      expect(adhocVariable.state.defaultKeys).toBeUndefined();
+    });
+
+    it('should preserve non-empty defaultKeys array', () => {
+      const dashboard = cloneDeep(defaultDashboard);
+
+      const adhocVar = dashboard.spec.variables.find((v) => v.kind === 'AdhocVariable') as AdhocVariableKind;
+      expect(adhocVar.spec.defaultKeys.length).toBeGreaterThan(0);
+
+      const scene = transformSaveModelSchemaV2ToScene(dashboard);
+
+      const adhocVariable = scene.state.$variables?.getByName('adhocVar') as AdHocFiltersVariable;
+      expect(adhocVariable).toBeInstanceOf(AdHocFiltersVariable);
+
+      expect(adhocVariable.state.defaultKeys).toEqual(adhocVar.spec.defaultKeys);
+    });
+  });
+
   describe('When creating a snapshot dashboard scene', () => {
     it('should initialize a dashboard scene with SnapshotVariables', () => {
       const snapshot: DashboardWithAccessInfo<DashboardV2Spec> = {
@@ -400,6 +429,29 @@ describe('transformSaveModelSchemaV2ToScene', () => {
       expect(intervalSnapshot.state.value).toBe('1m');
       expect(intervalSnapshot.state.text).toBe('1m');
       expect(intervalSnapshot.state.isReadOnly).toBe(true);
+    });
+
+    it('should convert empty defaultKeys array to undefined for adhoc variables', () => {
+      const snapshot: DashboardWithAccessInfo<DashboardV2Spec> = cloneDeep({
+        ...defaultDashboard,
+        metadata: {
+          ...defaultDashboard.metadata,
+          annotations: {
+            ...defaultDashboard.metadata.annotations,
+            [AnnoKeyDashboardIsSnapshot]: 'true',
+          },
+        },
+      });
+
+      const adhocVar = snapshot.spec.variables.find((v) => v.kind === 'AdhocVariable') as AdhocVariableKind;
+      adhocVar.spec.defaultKeys = [];
+
+      const scene = transformSaveModelSchemaV2ToScene(snapshot);
+
+      const adhocVariable = scene.state.$variables?.getByName('adhocVar') as AdHocFiltersVariable;
+      expect(adhocVariable).toBeInstanceOf(AdHocFiltersVariable);
+
+      expect(adhocVariable.state.defaultKeys).toBeUndefined();
     });
   });
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -329,7 +329,7 @@ function createSceneVariableFromVariableModel(variable: TypedVariableModelV2): S
       applyMode: 'auto',
       filters: variable.spec.filters ?? [],
       baseFilters: variable.spec.baseFilters ?? [],
-      defaultKeys: variable.spec.defaultKeys,
+      defaultKeys: variable.spec.defaultKeys.length ? variable.spec.defaultKeys : undefined,
       useQueriesAsFilterForOptions: true,
       layout: config.featureToggles.newFiltersUI ? 'combobox' : undefined,
       supportsMultiValueOperators: Boolean(
@@ -536,7 +536,7 @@ export function createVariablesForSnapshot(dashboard: DashboardV2Spec): SceneVar
             applyMode: 'auto',
             filters: v.spec.filters ?? [],
             baseFilters: v.spec.baseFilters ?? [],
-            defaultKeys: v.spec.defaultKeys,
+            defaultKeys: v.spec.defaultKeys?.length ? v.spec.defaultKeys : undefined,
             useQueriesAsFilterForOptions: true,
             layout: config.featureToggles.newFiltersUI ? 'combobox' : undefined,
             supportsMultiValueOperators: Boolean(


### PR DESCRIPTION
  1. 973523f - V2: Fix ad hoc filter defaultKeys incorrectly set to static mode (#115508)
  2. 37c1e3f - Dashboard Schema v1beta1 to v2alpha1: Preserve string template variable datasource references (#115516)
  3. a2a278a - Schema V2: Always set unique refid for queries in conversion V1 -> V2 (#115534)
  4. 7e5eb46 - Dashboards: Fix text panel content loss during v1 to v2 migration (#115496)
  5. f3d4181 - V2 -> V1 conversion: include empty properties array when converting overrides (#115495)
  6. 4bcd31b - Dashboard: change export dropdown placement in sidebar (#115515)