### PR TITLE
Variables: Show variable reference instead of interpolated datasource in query variable editor

### DIFF
--- a/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/editors/QueryVariableEditor.tsx
@@ -265,7 +265,7 @@ export function Editor({ variable }: { variable: QueryVariable }) {
         htmlFor="data-source-picker"
         noMargin
       >
-        <DataSourcePicker current={selectedDatasource} onChange={onDataSourceChange} variables={true} width={30} />
+        <DataSourcePicker current={datasourceRef} onChange={onDataSourceChange} variables={true} width={30} />
       </Field>
 
       {selectedDatasource && VariableQueryEditor && (


### PR DESCRIPTION
**What is this feature?**

Updates the `DataSourcePicker` in the query variable modal editor to display the variable reference (e.g., `${datasource}`) instead of the interpolated datasource name.

**Why do we need this feature?**

The query variable editor modal was showing the interpolated datasource value 

**Which issue(s) does this PR fix?:**

Fixes #115621