### PR TITLE
Dashboard Outline: Differentiate hover styles between edit and view modes

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -94,7 +94,11 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       style={{ '--depth': depth } as React.CSSProperties}
     >
-      <div className={cx(styles.row, { [styles.rowSelected]: isSelected })}>
+      <div
+        className={cx(styles.row, isEditing ? styles.rowEditMode : styles.rowViewMode, {
+          [styles.rowSelected]: isSelected,
+        })}
+      >
         <div className={styles.indentation}></div>
         {isContainer && (
           <button
@@ -191,11 +195,17 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       gap: theme.spacing(0.5),
       borderRadius: theme.shape.radius.default,
-
+    }),
+    rowEditMode: css({
       '&:hover': {
         color: theme.colors.text.primary,
         outline: `1px dashed ${theme.colors.border.strong}`,
         backgroundColor: theme.colors.emphasize(theme.colors.background.primary, 0.05),
+      },
+    }),
+    rowViewMode: css({
+      '&:hover': {
+        textDecoration: 'underline',
       },
     }),
     rowSelected: css({


### PR DESCRIPTION
**What is this feature?**

Adds a distinct hover style for the dashboard outline when not in edit mode. 

before:

Both view and edit modes
<img width="438" height="446" alt="image" src="https://github.com/user-attachments/assets/aad573fb-6ad3-41ef-aa69-d8e9608c5713" />


after:

View mode:
<img width="438" height="446" alt="image" src="https://github.com/user-attachments/assets/6da9ff12-f241-41ad-a58e-5f9e3698d187" />

Edit mode:
<img width="438" height="446" alt="image" src="https://github.com/user-attachments/assets/561ed6e6-f7a4-406b-ad0e-85d36c19d1d8" />


It now mimics hover state in other parts of dashboard like breadcrumbs

<img width="496" height="173" alt="image" src="https://github.com/user-attachments/assets/98e9a4b8-cda5-4256-97a2-576b893c4543" />



**Which issue(s) does this PR fix?**:

Fixes #115644
