### PR TITLE
Redesign Empty Transformation Panel

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/EmptyTransformationsMessage.tsx
@@ -4,7 +4,7 @@ import { DataFrame, DataTransformerID, standardTransformersRegistry, Transformer
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Box, Button, Grid, Stack, Text } from '@grafana/ui';
+import { Box, Button, Stack, Text } from '@grafana/ui';
 import config from 'app/core/config';
 
 import { SqlExpressionCard } from '../../../dashboard/components/TransformationsEditor/SqlExpressionCard';
@@ -25,9 +25,6 @@ const TRANSFORMATION_IDS = [
   DataTransformerID.extractFields,
   DataTransformerID.filterByValue,
 ];
-
-const GRID_COLUMNS_WITH_SQL = 5;
-const GRID_COLUMNS_WITHOUT_SQL = 4;
 
 export function LegacyEmptyTransformationsMessage({ onShowPicker }: { onShowPicker: () => void }) {
   return (
@@ -94,13 +91,25 @@ export function NewEmptyTransformationsMessage(props: EmptyTransformationsProps)
   };
 
   const showSqlCard = hasGoToQueries && config.featureToggles.sqlExpressions;
-  const gridColumns = showSqlCard ? GRID_COLUMNS_WITH_SQL : GRID_COLUMNS_WITHOUT_SQL;
 
   return (
-    <Box alignItems="center" padding={4}>
-      <Stack direction="column" alignItems="center" gap={4}>
+    <Box padding={2}>
+      <Stack direction="column" alignItems="start" gap={2}>
+        <Stack direction="column" alignItems="start" gap={1}>
+          <Text element="h3" textAlignment="start">
+            <Trans i18nKey="transformations.empty.add-transformation-header">Add a Transformation</Trans>
+          </Text>
+          <Text element="p" textAlignment="start" color="secondary">
+            <Trans i18nKey="transformations.empty.add-transformation-body">
+              Transformations allow data to be changed in various ways before your visualization is shown.
+              <br />
+              This includes joining data together, renaming fields, making calculations, formatting data for display,
+              and more.
+            </Trans>
+          </Text>
+        </Stack>
         {(hasAddTransformation || hasGoToQueries) && (
-          <Grid columns={gridColumns} gap={1}>
+          <Stack direction="row" gap={1} wrap>
             {showSqlCard && (
               <SqlExpressionCard
                 name={t('dashboard-scene.empty-transformations-message.sql-name', 'Transform with SQL')}
@@ -125,19 +134,17 @@ export function NewEmptyTransformationsMessage(props: EmptyTransformationsProps)
                   data={props.data}
                 />
               ))}
-          </Grid>
+          </Stack>
         )}
-        <Stack direction="row" gap={2}>
-          <Button
-            icon="plus"
-            variant="primary"
-            size="md"
-            onClick={handleShowMoreClick}
-            data-testid={selectors.components.Transforms.addTransformationButton}
-          >
-            <Trans i18nKey="dashboard-scene.empty-transformations-message.show-more">Show more</Trans>
-          </Button>
-        </Stack>
+        <Button
+          icon="plus"
+          variant="primary"
+          size="md"
+          onClick={handleShowMoreClick}
+          data-testid={selectors.components.Transforms.addTransformationButton}
+        >
+          <Trans i18nKey="dashboard-scene.empty-transformations-message.show-more">Show more</Trans>
+        </Button>
       </Stack>
     </Box>
   );

--- a/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
@@ -36,6 +36,7 @@ export function SqlExpressionCard({ name, description, imageUrl, onClick, testId
 function getSqlExpressionCardStyles(theme: GrafanaTheme2) {
   return {
     card: css({
+      maxWidth: '200px',
       gridTemplateRows: 'min-content 0 1fr 0',
       marginBottom: 0,
     }),

--- a/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
@@ -1,4 +1,4 @@
-import { Card, useStyles2 } from '@grafana/ui';
+import { Card, Text, useStyles2 } from '@grafana/ui';
 
 import { getCardStyles } from './getCardStyles';
 
@@ -14,19 +14,11 @@ export function SqlExpressionCard({ name, description, imageUrl, onClick, testId
   const styles = useStyles2(getCardStyles);
 
   return (
-    <Card className={styles.newCard} data-testid={testId} onClick={onClick} noMargin>
-      <Card.Heading className={styles.heading}>
-        <div className={styles.titleRow}>
-          <span>{name}</span>
-        </div>
-      </Card.Heading>
-      <Card.Description className={styles.description}>
-        <span>{description}</span>
-        {imageUrl && (
-          <span>
-            <img className={styles.image} src={imageUrl} alt={name} />
-          </span>
-        )}
+    <Card className={styles.baseCard} data-testid={testId} onClick={onClick} noMargin>
+      <Card.Heading>{name}</Card.Heading>
+      <Card.Description>
+        <Text variant="bodySmall">{description}</Text>
+        {imageUrl && <img className={styles.image} src={imageUrl} alt={name} />}
       </Card.Description>
     </Card>
   );

--- a/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/SqlExpressionCard.tsx
@@ -1,7 +1,6 @@
-import { css } from '@emotion/css';
-
-import { GrafanaTheme2 } from '@grafana/data';
 import { Card, useStyles2 } from '@grafana/ui';
+
+import { getCardStyles } from './getCardStyles';
 
 export interface SqlExpressionCardProps {
   name: string;
@@ -12,10 +11,10 @@ export interface SqlExpressionCardProps {
 }
 
 export function SqlExpressionCard({ name, description, imageUrl, onClick, testId }: SqlExpressionCardProps) {
-  const styles = useStyles2(getSqlExpressionCardStyles);
+  const styles = useStyles2(getCardStyles);
 
   return (
-    <Card className={styles.card} data-testid={testId} onClick={onClick} noMargin>
+    <Card className={styles.newCard} data-testid={testId} onClick={onClick} noMargin>
       <Card.Heading className={styles.heading}>
         <div className={styles.titleRow}>
           <span>{name}</span>
@@ -31,42 +30,4 @@ export function SqlExpressionCard({ name, description, imageUrl, onClick, testId
       </Card.Description>
     </Card>
   );
-}
-
-function getSqlExpressionCardStyles(theme: GrafanaTheme2) {
-  return {
-    card: css({
-      maxWidth: '200px',
-      gridTemplateRows: 'min-content 0 1fr 0',
-      marginBottom: 0,
-    }),
-    heading: css({
-      fontWeight: 400,
-      '> button': {
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        gap: theme.spacing(1),
-      },
-    }),
-    titleRow: css({
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      flexWrap: 'nowrap',
-      width: '100%',
-    }),
-    description: css({
-      fontSize: theme.typography.bodySmall.fontSize,
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-    }),
-    image: css({
-      display: 'block',
-      maxWidth: '100%',
-      marginTop: theme.spacing(2),
-    }),
-  };
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -133,6 +133,7 @@ function getTransformationCardStyles(theme: GrafanaTheme2) {
       right: theme.spacing(1),
     }),
     newCard: css({
+      maxWidth: '200px',
       gridTemplateRows: 'min-content 0 1fr 0',
       marginBottom: 0,
     }),

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -1,8 +1,7 @@
-import { cx, css } from '@emotion/css';
+import { cx } from '@emotion/css';
 
 import {
   DataFrame,
-  GrafanaTheme2,
   TransformerRegistryItem,
   TransformationApplicabilityLevels,
   standardTransformersRegistry,
@@ -10,6 +9,8 @@ import {
 import { selectors } from '@grafana/e2e-selectors';
 import { Badge, Card, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
 import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo';
+
+import { getCardStyles } from './getCardStyles';
 
 export interface TransformationCardProps {
   transform: TransformerRegistryItem;
@@ -29,7 +30,7 @@ export function TransformationCard({
   showTags = true,
 }: TransformationCardProps) {
   const theme = useTheme2();
-  const styles = useStyles2(getTransformationCardStyles);
+  const styles = useStyles2(getCardStyles);
 
   // Check to see if the transform is applicable to the given data
   let applicabilityScore = TransformationApplicabilityLevels.Applicable;
@@ -88,62 +89,4 @@ export function TransformationCard({
       </Card.Description>
     </Card>
   );
-}
-
-function getTransformationCardStyles(theme: GrafanaTheme2) {
-  return {
-    heading: css({
-      fontWeight: 400,
-      '> button': {
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        gap: theme.spacing(1),
-      },
-    }),
-    titleRow: css({
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      flexWrap: 'nowrap',
-      width: '100%',
-    }),
-    description: css({
-      fontSize: theme.typography.bodySmall.fontSize,
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
-    }),
-    image: css({
-      display: 'block',
-      maxWidth: '100%',
-      marginTop: theme.spacing(2),
-    }),
-    cardDisabled: css({
-      backgroundColor: theme.colors.action.disabledBackground,
-      img: {
-        filter: 'grayscale(100%)',
-        opacity: 0.33,
-      },
-    }),
-    cardApplicableInfo: css({
-      position: 'absolute',
-      bottom: theme.spacing(1),
-      right: theme.spacing(1),
-    }),
-    newCard: css({
-      maxWidth: '200px',
-      gridTemplateRows: 'min-content 0 1fr 0',
-      marginBottom: 0,
-    }),
-    pluginStateInfoWrapper: css({
-      marginLeft: theme.spacing(0.5),
-    }),
-    tagsWrapper: css({
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: theme.spacing(0.5),
-    }),
-  };
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -13,24 +13,26 @@ import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo
 import { getCardStyles } from './getCardStyles';
 
 export interface TransformationCardProps {
-  transform: TransformerRegistryItem;
+  data?: DataFrame[];
+  fullWidth?: boolean;
   onClick: (id: string) => void;
   showIllustrations?: boolean;
-  data?: DataFrame[];
   showPluginState?: boolean;
   showTags?: boolean;
+  transform: TransformerRegistryItem;
 }
 
 export function TransformationCard({
-  transform,
-  showIllustrations,
-  onClick,
   data = [],
+  fullWidth = false,
+  onClick,
+  showIllustrations,
   showPluginState = true,
   showTags = true,
+  transform,
 }: TransformationCardProps) {
   const theme = useTheme2();
-  const styles = useStyles2(getCardStyles);
+  const styles = useStyles2(getCardStyles, fullWidth);
 
   // Check to see if the transform is applicable to the given data
   let applicabilityScore = TransformationApplicabilityLevels.Applicable;

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -7,7 +7,7 @@ import {
   standardTransformersRegistry,
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
-import { Badge, Card, IconButton, useStyles2, useTheme2 } from '@grafana/ui';
+import { Badge, Card, IconButton, Stack, Text, useStyles2, useTheme2 } from '@grafana/ui';
 import { PluginStateInfo } from 'app/features/plugins/components/PluginStateInfo';
 
 import { getCardStyles } from './getCardStyles';
@@ -48,7 +48,7 @@ export function TransformationCard({
     }
   }
 
-  const cardClasses = !isApplicable && data.length > 0 ? cx(styles.newCard, styles.cardDisabled) : styles.newCard;
+  const cardClasses = cx(styles.baseCard, { [styles.cardDisabled]: !isApplicable });
   const imageUrl = theme.isDark ? transform.imageDark : transform.imageLight;
   const description = standardTransformersRegistry.getIfExists(transform.id)?.description;
 
@@ -59,15 +59,11 @@ export function TransformationCard({
       onClick={() => onClick(transform.id)}
       noMargin
     >
-      <Card.Heading className={styles.heading}>
-        <div className={styles.titleRow}>
-          <span>{transform.name}</span>
-          {showPluginState && (
-            <span className={styles.pluginStateInfoWrapper}>
-              <PluginStateInfo state={transform.state} />
-            </span>
-          )}
-        </div>
+      <Card.Heading>
+        <Stack alignItems="center" justifyContent="space-between">
+          {transform.name}
+          {showPluginState && <PluginStateInfo state={transform.state} />}
+        </Stack>
         {showTags && transform.tags && transform.tags.size > 0 && (
           <div className={styles.tagsWrapper}>
             {Array.from(transform.tags).map((tag) => (
@@ -76,15 +72,11 @@ export function TransformationCard({
           </div>
         )}
       </Card.Heading>
-      <Card.Description className={styles.description}>
-        <span>{description}</span>
-        {showIllustrations && imageUrl && (
-          <span>
-            <img className={styles.image} src={imageUrl} alt={transform.name} />
-          </span>
-        )}
+      <Card.Description>
+        <Text variant="bodySmall">{description || ''}</Text>
+        {showIllustrations && imageUrl && <img className={styles.image} src={imageUrl} alt={transform.name} />}
         {!isApplicable && applicabilityDescription !== null && (
-          <IconButton className={styles.cardApplicableInfo} name="info-circle" tooltip={applicabilityDescription} />
+          <IconButton className={styles.applicableInfoButton} name="info-circle" tooltip={applicabilityDescription} />
         )}
       </Card.Description>
     </Card>

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -5,7 +5,7 @@ import { DataFrame, GrafanaTheme2, TransformerRegistryItem, SelectableValue } fr
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Drawer, FilterPill, Grid, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
+import { Drawer, FilterPill, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { getCategoriesLabels } from 'app/features/transformers/utils';
 
@@ -162,7 +162,7 @@ interface TransformationsGridProps {
 
 function TransformationsGrid({ showIllustrations, transformations, onClick, data }: TransformationsGridProps) {
   return (
-    <Grid columns={3} gap={1}>
+    <Stack direction="row" gap={1} wrap>
       {transformations.map((transform) => (
         <TransformationCard
           key={transform.id}
@@ -172,6 +172,6 @@ function TransformationsGrid({ showIllustrations, transformations, onClick, data
           data={data}
         />
       ))}
-    </Grid>
+    </Stack>
   );
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationPickerNg.tsx
@@ -5,7 +5,7 @@ import { DataFrame, GrafanaTheme2, TransformerRegistryItem, SelectableValue } fr
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Drawer, FilterPill, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
+import { Drawer, FilterPill, Grid, Input, Stack, Switch, useStyles2 } from '@grafana/ui';
 import config from 'app/core/config';
 import { getCategoriesLabels } from 'app/features/transformers/utils';
 
@@ -162,16 +162,17 @@ interface TransformationsGridProps {
 
 function TransformationsGrid({ showIllustrations, transformations, onClick, data }: TransformationsGridProps) {
   return (
-    <Stack direction="row" gap={1} wrap>
+    <Grid columns={3} gap={1}>
       {transformations.map((transform) => (
         <TransformationCard
-          key={transform.id}
-          transform={transform}
-          showIllustrations={showIllustrations}
-          onClick={onClick}
           data={data}
+          fullWidth
+          key={transform.id}
+          onClick={onClick}
+          showIllustrations={showIllustrations}
+          transform={transform}
         />
       ))}
-    </Stack>
+    </Grid>
   );
 }

--- a/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
+++ b/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-export const getCardStyles = (theme: GrafanaTheme2, fullWidth = false) => ({
+export const getCardStyles = (theme: GrafanaTheme2, fullWidth?: boolean) => ({
   baseCard: css({
     maxWidth: fullWidth ? 'none' : '200px',
     width: fullWidth ? '100%' : 'auto',

--- a/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
+++ b/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
@@ -46,7 +46,6 @@ export const getCardStyles = (theme: GrafanaTheme2) => {
     }),
     newCard: css({
       maxWidth: '200px',
-      gridTemplateRows: 'min-content 0 1fr 0',
       marginBottom: 0,
     }),
     pluginStateInfoWrapper: css({

--- a/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
+++ b/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
@@ -2,34 +2,33 @@ import { css } from '@emotion/css';
 
 import { GrafanaTheme2 } from '@grafana/data';
 
-export const getCardStyles = (theme: GrafanaTheme2) => {
-  return {
-    baseCard: css({
-      maxWidth: '200px',
-      marginBottom: 0,
-    }),
-    image: css({
-      display: 'block',
-      maxWidth: '100%',
-      marginTop: theme.spacing(2),
-    }),
-    cardDisabled: css({
-      backgroundColor: theme.colors.action.disabledBackground,
-      img: {
-        filter: 'grayscale(100%)',
-        opacity: 0.33,
-      },
-    }),
-    applicableInfoButton: css({
-      position: 'absolute',
-      bottom: theme.spacing(1),
-      right: theme.spacing(1),
-    }),
-    tagsWrapper: css({
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: theme.spacing(0.5),
-      marginTop: theme.spacing(0.5),
-    }),
-  };
-};
+export const getCardStyles = (theme: GrafanaTheme2, fullWidth = false) => ({
+  baseCard: css({
+    maxWidth: fullWidth ? 'none' : '200px',
+    width: fullWidth ? '100%' : 'auto',
+    marginBottom: 0,
+  }),
+  image: css({
+    display: 'block',
+    maxWidth: '100%',
+    marginTop: theme.spacing(2),
+  }),
+  cardDisabled: css({
+    backgroundColor: theme.colors.action.disabledBackground,
+    img: {
+      filter: 'grayscale(100%)',
+      opacity: 0.33,
+    },
+  }),
+  applicableInfoButton: css({
+    position: 'absolute',
+    bottom: theme.spacing(1),
+    right: theme.spacing(1),
+  }),
+  tagsWrapper: css({
+    display: 'flex',
+    flexWrap: 'wrap',
+    gap: theme.spacing(0.5),
+    marginTop: theme.spacing(0.5),
+  }),
+});

--- a/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
+++ b/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
@@ -1,0 +1,61 @@
+import { css } from '@emotion/css';
+
+import { GrafanaTheme2 } from '@grafana/data';
+
+export const getCardStyles = (theme: GrafanaTheme2) => {
+  return {
+    heading: css({
+      fontWeight: 400,
+      '> button': {
+        width: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'flex-start',
+        gap: theme.spacing(1),
+      },
+    }),
+    titleRow: css({
+      display: 'flex',
+      justifyContent: 'space-between',
+      alignItems: 'center',
+      flexWrap: 'nowrap',
+      width: '100%',
+    }),
+    description: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+      display: 'flex',
+      flexDirection: 'column',
+      justifyContent: 'space-between',
+    }),
+    image: css({
+      display: 'block',
+      maxWidth: '100%',
+      marginTop: theme.spacing(2),
+    }),
+    cardDisabled: css({
+      backgroundColor: theme.colors.action.disabledBackground,
+      img: {
+        filter: 'grayscale(100%)',
+        opacity: 0.33,
+      },
+    }),
+    cardApplicableInfo: css({
+      position: 'absolute',
+      bottom: theme.spacing(1),
+      right: theme.spacing(1),
+    }),
+    newCard: css({
+      maxWidth: '200px',
+      gridTemplateRows: 'min-content 0 1fr 0',
+      marginBottom: 0,
+    }),
+    pluginStateInfoWrapper: css({
+      marginLeft: theme.spacing(0.5),
+    }),
+    tagsWrapper: css({
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: theme.spacing(0.5),
+    }),
+  };
+};

--- a/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
+++ b/public/app/features/dashboard/components/TransformationsEditor/getCardStyles.ts
@@ -4,28 +4,9 @@ import { GrafanaTheme2 } from '@grafana/data';
 
 export const getCardStyles = (theme: GrafanaTheme2) => {
   return {
-    heading: css({
-      fontWeight: 400,
-      '> button': {
-        width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'flex-start',
-        gap: theme.spacing(1),
-      },
-    }),
-    titleRow: css({
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-      flexWrap: 'nowrap',
-      width: '100%',
-    }),
-    description: css({
-      fontSize: theme.typography.bodySmall.fontSize,
-      display: 'flex',
-      flexDirection: 'column',
-      justifyContent: 'space-between',
+    baseCard: css({
+      maxWidth: '200px',
+      marginBottom: 0,
     }),
     image: css({
       display: 'block',
@@ -39,22 +20,16 @@ export const getCardStyles = (theme: GrafanaTheme2) => {
         opacity: 0.33,
       },
     }),
-    cardApplicableInfo: css({
+    applicableInfoButton: css({
       position: 'absolute',
       bottom: theme.spacing(1),
       right: theme.spacing(1),
-    }),
-    newCard: css({
-      maxWidth: '200px',
-      marginBottom: 0,
-    }),
-    pluginStateInfoWrapper: css({
-      marginLeft: theme.spacing(0.5),
     }),
     tagsWrapper: css({
       display: 'flex',
       flexWrap: 'wrap',
       gap: theme.spacing(0.5),
+      marginTop: theme.spacing(0.5),
     }),
   };
 };


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR changes some css around the Empty Transformation Panel to make it a more responsive and user friendly experience.

## Changes
<!--- Describe your changes in detail -->

* Changes the layout of the cards from a grid to flexbox (both in the Empty Transformation Panel and the Transformation Picker panel)
* Moves and cleaned up the card styles that were copied across `SqlExpressionCard` and `TransformationCard` into its own file so both cards can use the same unified styles

## Risks
No significant risks, potentially some small display issues with the CSS that was changed

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->
https://github.com/user-attachments/assets/8c5dd286-091f-4a3d-9390-988d625b2140

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Edit a panel in a dashboard
* Go to the transformations tab
* Ensure the empty transformations component renders properly
* Click the Show more button and make sure the full page of the transformations still renders properly

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->

- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable
