### PR TITLE
RecentlyViewedDashboards: Retry when error

### DIFF
--- a/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyViewedDashboards.tsx
@@ -25,6 +25,7 @@ export function RecentlyViewedDashboards() {
     value: recentDashboards = [],
     loading,
     retry,
+    error,
   } = useAsyncRetry(async () => {
     if (!evaluateBooleanFlag('recentlyViewedDashboards', false)) {
       return [];
@@ -62,7 +63,18 @@ export function RecentlyViewedDashboards() {
       className={styles.title}
       contentClassName={styles.content}
     >
-      {/* placeholder */}
+      {error && (
+        <>
+          <Text color="secondary">
+            <Trans i18nKey="browse-dashboards.recently-viewed.error">
+              Recently viewed dashboards couldn’t be loaded.
+            </Trans>
+          </Text>
+          <Button onClick={retry} size="xs" fill="text">
+            {t('browse-dashboards.recently-viewed.retry', 'Retry')}
+          </Button>
+        </>
+      )}
       {loading && <Spinner />}
       {/* TODO: Better empty state https://github.com/grafana/grafana/issues/114804 */}
       {!loading && recentDashboards.length === 0 && (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3748,6 +3748,8 @@
     "recently-viewed": {
       "clear": "Clear history",
       "empty": "Nothing viewed yet",
+      "error": "Recently viewed dashboards couldn’t be loaded.",
+      "retry": "Retry",
       "title": "Recently viewed"
     },
     "restore": {


### PR DESCRIPTION
**What is this feature?**

`RecentlyViewedDashboards`: When there's error, add retry button 

**Why do we need this feature?**

Provide user ability to auto recover

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/115241

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
