### PR TITLE
Dashboards: Clear edit pane selection when entering panel edit

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts
@@ -112,6 +112,37 @@ describe('PanelEditor', () => {
     });
   });
 
+  describe('Entering panel edit', () => {
+    it('should clear edit pane selection', () => {
+      pluginPromise = Promise.resolve(getPanelPlugin({ id: 'text', skipDataQuery: true }));
+
+      const panel = new VizPanel({
+        key: 'panel-1',
+        pluginId: 'text',
+        title: 'original title',
+      });
+      const gridItem = new DashboardGridItem({ body: panel });
+      const panelEditor = buildPanelEditScene(panel);
+      const dashboard = new DashboardScene({
+        editPanel: panelEditor,
+        isEditing: true,
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        body: new DefaultGridLayoutManager({
+          grid: new SceneGridLayout({
+            children: [gridItem],
+          }),
+        }),
+      });
+
+      dashboard.state.editPane.selectObject(panel, panel.state.key!, { force: true });
+      expect(dashboard.state.editPane.getSelection()).toBe(panel);
+
+      deactivate = activateFullSceneTree(dashboard);
+
+      expect(dashboard.state.editPane.getSelection()).toBeUndefined();
+    });
+  });
+
   describe('When discarding', () => {
     it('should discard changes revert all changes', async () => {
       const { panelEditor, panel, dashboard } = await setup();

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -87,7 +87,7 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
     const dashboard = getDashboardSceneFor(this);
 
     // Clear any panel selection when entering panel edit mode.
-    // This fixes a UX issue where clicking the panel menu (⋮) and then "Edit" causes the panel to become selected
+    // Need to clear selection here since selection is activated when panel edit mode is entered through the panel actions menu. This causes sidebar panel editor to be open when exiting panel edit mode
     dashboard.state.editPane.clearSelection();
 
     if (panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID) {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditor.tsx
@@ -84,6 +84,11 @@ export class PanelEditor extends SceneObjectBase<PanelEditorState> {
 
   private _activationHandler() {
     const panel = this.state.panelRef.resolve();
+    const dashboard = getDashboardSceneFor(this);
+
+    // Clear any panel selection when entering panel edit mode.
+    // This fixes a UX issue where clicking the panel menu (⋮) and then "Edit" causes the panel to become selected
+    dashboard.state.editPane.clearSelection();
 
     if (panel.state.pluginId === UNCONFIGURED_PANEL_PLUGIN_ID) {
       if (config.featureToggles.newVizSuggestions) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->
**What is this feature?**

Clears dashboard edit-pane selection when entering panel edit so the element edit sidebar doesn’t remain open after exiting panel edit.

**Why do we need this feature?**

In Dynamic Dashboards, opening panel edit via the panel menu (⋮) → **Edit** can also select the panel (pointer events on the panel header). That selection persists when returning from panel edit, leaving the right sidebar (“Panel” pane) open. Entering panel edit via the `e` shortcut doesn’t select the panel, so the behavior is inconsistent.

**Which issue(s) does this PR fix?**

Fixes #115561

**How is this tested?**

- `yarn jest public/app/features/dashboard-scene/panel-edit/PanelEditor.test.ts`
- `yarn jest public/app/features/dashboard-scene/panel-edit`

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->