### PR TITLE
Dashboards: POC/EXPLORATION of dashboard api

### DIFF
--- a/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
+++ b/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
@@ -1,0 +1,57 @@
+export interface DashboardSceneJsonApiV2 {
+  /**
+   * Read the currently open dashboard as v2beta1 Dashboard kind JSON (JSON string).
+   */
+  getCurrentDashboard(space?: number): string;
+
+  /**
+   * Apply a v2beta1 Dashboard kind JSON (JSON string).
+   *
+   * Implementations must enforce **spec-only** updates by rejecting any changes to
+   * `apiVersion`, `kind`, `metadata`, or `status`.
+   */
+  applyCurrentDashboard(resourceJson: string): void;
+}
+
+let singletonInstance: DashboardSceneJsonApiV2 | undefined;
+
+/**
+ * Used during startup by Grafana to register the implementation.
+ *
+ * @internal
+ */
+export function setDashboardSceneJsonApiV2(instance: DashboardSceneJsonApiV2) {
+  singletonInstance = instance;
+}
+
+/**
+ * Returns the registered DashboardScene JSON API.
+ *
+ * @public
+ */
+export function getDashboardSceneJsonApiV2(): DashboardSceneJsonApiV2 {
+  if (!singletonInstance) {
+    throw new Error('DashboardScene JSON API is not available');
+  }
+  return singletonInstance;
+}
+
+/**
+ * Plugin-friendly helper to read the current dashboard as kind JSON (JSON string).
+ *
+ * @public
+ */
+export function getCurrentDashboard(space = 2): string {
+  return getDashboardSceneJsonApiV2().getCurrentDashboard(space);
+}
+
+/**
+ * JSON-string helper to apply a v2 Dashboard kind JSON (spec-only enforcement happens in the implementation).
+ *
+ * @public
+ */
+export function applyCurrentDashboard(resourceJson: string): void {
+  return getDashboardSceneJsonApiV2().applyCurrentDashboard(resourceJson);
+}
+
+

--- a/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
+++ b/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
@@ -13,6 +13,74 @@ export interface DashboardSceneJsonApiV2 {
   getCurrentDashboardErrors(space?: number): string;
 
   /**
+   * Read current dashboard variables (JSON string).
+   *
+   * This returns JSON shaped like:
+   * `{ variables: [{ name, value }] }`
+   * where `value` is `string | string[]`.
+   */
+  getCurrentDashboardVariables(space?: number): string;
+
+  /**
+   * Apply dashboard variable values (JSON string).
+   *
+   * Accepts either:
+   * - `{ variables: [{ name, value }] }`
+   * - or a map `{ [name]: value }`
+   *
+   * where `value` is `string | string[]`.
+   */
+  applyCurrentDashboardVariables(varsJson: string): void;
+
+  /**
+   * Read the current dashboard time range (JSON string).
+   *
+   * This returns JSON shaped like:
+   * `{ from, to, timezone? }`.
+   */
+  getCurrentDashboardTimeRange(space?: number): string;
+
+  /**
+   * Apply the current dashboard time range (JSON string).
+   *
+   * Accepts JSON shaped like:
+   * `{ from, to, timezone? }` where `from/to` are Grafana raw strings (e.g. `now-6h`, `now`).
+   */
+  applyCurrentDashboardTimeRange(timeRangeJson: string): void;
+
+  /**
+   * Select a tab within the current dashboard (JSON string).
+   *
+   * Accepts JSON shaped like:
+   * `{ title?: string, slug?: string }`.
+   */
+  selectCurrentDashboardTab(tabJson: string): void;
+
+  /**
+   * Read current in-dashboard navigation state (JSON string).
+   *
+   * This returns JSON shaped like:
+   * `{ tab: { slug: string, title?: string } | null }`.
+   */
+  getCurrentDashboardNavigation(space?: number): string;
+
+  /**
+   * Scroll/focus a row within the current dashboard (JSON string).
+   *
+   * Accepts JSON shaped like:
+   * `{ title?: string, rowKey?: string }`.
+   */
+  focusCurrentDashboardRow(rowJson: string): void;
+
+  /**
+   * Scroll/focus a panel within the current dashboard (JSON string).
+   *
+   * Accepts JSON shaped like:
+   * `{ panelId: number }`.
+   */
+  focusCurrentDashboardPanel(panelJson: string): void;
+
+  /**
    * Apply a v2beta1 Dashboard kind JSON (JSON string).
    *
    * Implementations must enforce **spec-only** updates by rejecting any changes to
@@ -45,30 +113,98 @@ export function getDashboardSceneJsonApiV2(): DashboardSceneJsonApiV2 {
 }
 
 /**
- * Plugin-friendly helper to read the current dashboard as kind JSON (JSON string).
+ * A grouped, ergonomic API wrapper around the DashboardScene JSON API.
+ *
+ * This is purely a convenience layer: it calls the same underlying registered implementation
+ * as the top-level helper functions, but organizes functionality into namespaces like
+ * `navigation`, `variables`, and `timeRange`.
  *
  * @public
  */
-export function getCurrentDashboard(space = 2): string {
-  return getDashboardSceneJsonApiV2().getCurrentDashboard(space);
-}
+export function getDashboardApi() {
+  const api = getDashboardSceneJsonApiV2();
+  return {
+    /**
+     * Prints/returns a quick reference for the grouped dashboard API, including expected JSON shapes.
+     */
+    help: () => {
+      const text = [
+        'Dashboard API (DashboardScene JSON API, schema v2 kinds)',
+        '',
+        'All inputs/outputs are JSON strings.',
+        'Edits are spec-only: apiVersion/kind/metadata/status must not change.',
+        '',
+        'Read/apply dashboard:',
+        '- dashboard.getCurrent(space?): string',
+        '- dashboard.apply(resourceJson: string): void',
+        '  - resourceJson must be a v2beta1 Dashboard kind object:',
+        '    { apiVersion: "dashboard.grafana.app/v2beta1", kind: "Dashboard", metadata: {...}, spec: {...}, status: {...} }',
+        '',
+        'Errors:',
+        '- errors.getCurrent(space?): string',
+        '  - returns JSON: { errors: [{ panelId, panelTitle, refId?, datasource?, message, severity }] }',
+        '',
+        'Variables:',
+        '- variables.getCurrent(space?): string',
+        '  - returns JSON: { variables: [{ name, value }] } where value is string | string[]',
+        '- variables.apply(varsJson: string): void',
+        '  - accepts JSON: { variables: [{ name, value }] } OR { [name]: value }',
+        '',
+        'Time range:',
+        '- timeRange.getCurrent(space?): string',
+        '  - returns JSON: { from: string, to: string, timezone?: string }',
+        '- timeRange.apply(timeRangeJson: string): void',
+        '  - accepts JSON: { from: "now-6h", to: "now", timezone?: "browser" | "utc" | ... }',
+        '',
+        'Navigation:',
+        '- navigation.getCurrent(space?): string',
+        '  - returns JSON: { tab: { slug: string, title?: string } | null }',
+        '- navigation.selectTab(tabJson: string): void',
+        '  - accepts JSON: { title?: string, slug?: string }',
+        '- navigation.focusRow(rowJson: string): void',
+        '  - accepts JSON: { title?: string, rowKey?: string }',
+        '- navigation.focusPanel(panelJson: string): void',
+        '  - accepts JSON: { panelId: number }',
+        '',
+        'Examples:',
+        '- window.dashboardApi.timeRange.apply(JSON.stringify({ from: "now-6h", to: "now", timezone: "browser" }))',
+        '- window.dashboardApi.navigation.selectTab(JSON.stringify({ title: "Overview" }))',
+        '- window.dashboardApi.navigation.focusPanel(JSON.stringify({ panelId: 12 }))',
+      ].join('\n');
 
-/**
- * Plugin-friendly helper to read aggregated query errors for the current dashboard (JSON string).
- *
- * @public
- */
-export function getCurrentDashboardErrors(space = 2): string {
-  return getDashboardSceneJsonApiV2().getCurrentDashboardErrors(space);
-}
+      // Calling help is an explicit action; logging is useful in the browser console.
+      // Return the text as well so callers can print/store it as they prefer.
+      try {
+        // eslint-disable-next-line no-console
+        console.log(text);
+      } catch {
+        // ignore
+      }
 
-/**
- * JSON-string helper to apply a v2 Dashboard kind JSON (spec-only enforcement happens in the implementation).
- *
- * @public
- */
-export function applyCurrentDashboard(resourceJson: string): void {
-  return getDashboardSceneJsonApiV2().applyCurrentDashboard(resourceJson);
+      return text;
+    },
+    dashboard: {
+      getCurrent: (space = 2) => api.getCurrentDashboard(space),
+      apply: (resourceJson: string) => api.applyCurrentDashboard(resourceJson),
+    },
+    errors: {
+      getCurrent: (space = 2) => JSON.stringify({ errors: JSON.parse(api.getCurrentDashboardErrors(space)) }, null, space),
+    },
+    variables: {
+      getCurrent: (space = 2) => api.getCurrentDashboardVariables(space),
+      apply: (varsJson: string) => api.applyCurrentDashboardVariables(varsJson),
+    },
+    timeRange: {
+      getCurrent: (space = 2) => api.getCurrentDashboardTimeRange(space),
+      apply: (timeRangeJson: string) => api.applyCurrentDashboardTimeRange(timeRangeJson),
+    },
+    navigation: {
+      getCurrent: (space = 2) => api.getCurrentDashboardNavigation(space),
+      selectTab: (tabJson: string) => api.selectCurrentDashboardTab(tabJson),
+      focusRow: (rowJson: string) => api.focusCurrentDashboardRow(rowJson),
+      focusPanel: (panelJson: string) => api.focusCurrentDashboardPanel(panelJson),
+    },
+  };
 }
 
 

--- a/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
+++ b/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
@@ -5,6 +5,14 @@ export interface DashboardSceneJsonApiV2 {
   getCurrentDashboard(space?: number): string;
 
   /**
+   * Read query errors for the currently open dashboard (JSON string).
+   *
+   * This returns a JSON array of objects shaped like:
+   * `{ panelId, panelTitle, refId?, datasource?, message, severity }`.
+   */
+  getCurrentDashboardErrors(space?: number): string;
+
+  /**
    * Apply a v2beta1 Dashboard kind JSON (JSON string).
    *
    * Implementations must enforce **spec-only** updates by rejecting any changes to
@@ -43,6 +51,15 @@ export function getDashboardSceneJsonApiV2(): DashboardSceneJsonApiV2 {
  */
 export function getCurrentDashboard(space = 2): string {
   return getDashboardSceneJsonApiV2().getCurrentDashboard(space);
+}
+
+/**
+ * Plugin-friendly helper to read aggregated query errors for the current dashboard (JSON string).
+ *
+ * @public
+ */
+export function getCurrentDashboardErrors(space = 2): string {
+  return getDashboardSceneJsonApiV2().getCurrentDashboardErrors(space);
 }
 
 /**

--- a/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
+++ b/packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts
@@ -123,6 +123,151 @@ export function getDashboardSceneJsonApiV2(): DashboardSceneJsonApiV2 {
  */
 export function getDashboardApi() {
   const api = getDashboardSceneJsonApiV2();
+  let cachedDashboardSchemaBundle: { bundle: unknown; loadedAt: number } | undefined;
+
+  function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+  }
+
+  function collectRefs(value: unknown, out: Set<string>) {
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        collectRefs(v, out);
+      }
+      return;
+    }
+    if (!isRecord(value)) {
+      return;
+    }
+    for (const [k, v] of Object.entries(value)) {
+      if (k === '$ref' && typeof v === 'string') {
+        out.add(v);
+      } else {
+        collectRefs(v, out);
+      }
+    }
+  }
+
+  function buildOpenApiSchemaBundle(openapi: unknown) {
+    if (!isRecord(openapi)) {
+      throw new Error('OpenAPI document is not an object');
+    }
+    const info = openapi['info'];
+    if (!isRecord(info)) {
+      throw new Error('OpenAPI document is missing info');
+    }
+    const title = info['title'];
+    if (typeof title !== 'string' || title.length === 0) {
+      throw new Error('OpenAPI document is missing info.title');
+    }
+    // This endpoint is expected to return the group/version doc, so validate it explicitly.
+    if (title !== 'dashboard.grafana.app/v2beta1') {
+      throw new Error(`OpenAPI document is not dashboard.grafana.app/v2beta1 (info.title="${title}")`);
+    }
+
+    const components = openapi['components'];
+    if (!isRecord(components)) {
+      throw new Error('OpenAPI document is missing components');
+    }
+    const schemas = components['schemas'];
+    if (!isRecord(schemas)) {
+      throw new Error('OpenAPI document is missing components.schemas');
+    }
+
+    // Find the Dashboard kind schema key by GVK annotation.
+    const dashboardKey = Object.entries(schemas).find(([_, schema]) => {
+      if (!isRecord(schema)) {
+        return false;
+      }
+      const gvk = schema['x-kubernetes-group-version-kind'];
+      if (!Array.isArray(gvk)) {
+        return false;
+      }
+      return gvk.some((x) => {
+        return (
+          isRecord(x) &&
+          x['group'] === 'dashboard.grafana.app' &&
+          x['version'] === 'v2beta1' &&
+          x['kind'] === 'Dashboard'
+        );
+      });
+    })?.[0];
+
+    if (!dashboardKey) {
+      throw new Error('Could not find dashboard.grafana.app/v2beta1 Dashboard schema in OpenAPI document');
+    }
+
+    const rootRef = `#/components/schemas/${dashboardKey}`;
+    const pickedSchemas: Record<string, unknown> = {};
+    const visited = new Set<string>();
+    const queue: string[] = [rootRef];
+
+    while (queue.length) {
+      const ref = queue.shift()!;
+      if (!ref.startsWith('#/components/schemas/')) {
+        continue;
+      }
+      const key = ref.slice('#/components/schemas/'.length);
+      if (visited.has(key)) {
+        continue;
+      }
+      visited.add(key);
+      const schema = schemas[key];
+      if (!schema) {
+        continue;
+      }
+      pickedSchemas[key] = schema;
+
+      const refs = new Set<string>();
+      collectRefs(schema, refs);
+      for (const r of refs) {
+        if (r.startsWith('#/components/schemas/')) {
+          queue.push(r);
+        }
+      }
+    }
+
+    // Sanity-check the root schema shape (helps LLM consumers, and catches wrong schema sources quickly).
+    const rootSchema = pickedSchemas[dashboardKey];
+    if (!isRecord(rootSchema)) {
+      throw new Error('Dashboard schema is not an object');
+    }
+    const required = rootSchema['required'];
+    if (!Array.isArray(required)) {
+      throw new Error('Dashboard schema is missing required fields list');
+    }
+    for (const req of ['apiVersion', 'kind', 'metadata', 'spec']) {
+      if (!required.includes(req)) {
+        throw new Error(`Dashboard schema is missing required field "${req}"`);
+      }
+    }
+
+    return {
+      format: 'openapi3.schemaBundle',
+      source: {
+        url: '/openapi/v3/apis/dashboard.grafana.app/v2beta1',
+      },
+      group: 'dashboard.grafana.app',
+      version: 'v2beta1',
+      kind: 'Dashboard',
+      root: { $ref: rootRef },
+      stats: { schemas: Object.keys(pickedSchemas).length },
+      validation: {
+        ok: true,
+        info: {
+          title,
+        },
+        root: {
+          ref: rootRef,
+          required: ['apiVersion', 'kind', 'metadata', 'spec'],
+        },
+      },
+      components: {
+        schemas: pickedSchemas,
+      },
+    };
+  }
+
   return {
     /**
      * Prints/returns a quick reference for the grouped dashboard API, including expected JSON shapes.
@@ -133,6 +278,13 @@ export function getDashboardApi() {
         '',
         'All inputs/outputs are JSON strings.',
         'Edits are spec-only: apiVersion/kind/metadata/status must not change.',
+        '',
+        'Schema (for LLMs):',
+        '- schema.getSources(space?): string',
+        '- schema.getDashboard(space?): Promise<string>',
+        '- schema.getDashboardSync(space?): string',
+        '  - getDashboard() fetches the OpenAPI v3 document for dashboard.grafana.app/v2beta1 and returns a schema bundle.',
+        '  - getDashboard() validates the document is for dashboard.grafana.app/v2beta1 and that the root schema is the Dashboard kind.',
         '',
         'Read/apply dashboard:',
         '- dashboard.getCurrent(space?): string',
@@ -167,6 +319,7 @@ export function getDashboardApi() {
         '  - accepts JSON: { panelId: number }',
         '',
         'Examples:',
+        '- const schema = JSON.parse(await window.dashboardApi.schema.getDashboard(0))',
         '- window.dashboardApi.timeRange.apply(JSON.stringify({ from: "now-6h", to: "now", timezone: "browser" }))',
         '- window.dashboardApi.navigation.selectTab(JSON.stringify({ title: "Overview" }))',
         '- window.dashboardApi.navigation.focusPanel(JSON.stringify({ panelId: 12 }))',
@@ -183,12 +336,58 @@ export function getDashboardApi() {
 
       return text;
     },
+    schema: {
+      /**
+       * Returns where this API loads schema documents from.
+       */
+      getSources: (space = 2) => {
+        return JSON.stringify(
+          {
+            openapi3: {
+              url: '/openapi/v3/apis/dashboard.grafana.app/v2beta1',
+              note: 'This is the Kubernetes-style OpenAPI document for dashboard.grafana.app/v2beta1. `schema.getDashboard()` extracts the Dashboard schemas into a smaller bundle.',
+            },
+          },
+          null,
+          space
+        );
+      },
+      /**
+       * Fetches and returns an OpenAPI schema bundle for `dashboard.grafana.app/v2beta1` `Dashboard`.
+       *
+       * Returns a JSON string (async) shaped like:
+       * `{ format, source, group, version, kind, root, stats, components: { schemas } }`.
+       */
+      getDashboard: async (space = 2) => {
+        if (!cachedDashboardSchemaBundle) {
+          const rsp = await fetch('/openapi/v3/apis/dashboard.grafana.app/v2beta1', { credentials: 'same-origin' });
+          if (!rsp.ok) {
+            throw new Error(
+              `Failed to fetch OpenAPI document from /openapi/v3/apis/dashboard.grafana.app/v2beta1 (status ${rsp.status})`
+            );
+          }
+          const openapi: unknown = await rsp.json();
+          cachedDashboardSchemaBundle = { bundle: buildOpenApiSchemaBundle(openapi), loadedAt: Date.now() };
+        }
+        return JSON.stringify(cachedDashboardSchemaBundle.bundle, null, space);
+      },
+      /**
+       * Returns the cached schema bundle (sync), if previously loaded by `schema.getDashboard()`.
+       */
+      getDashboardSync: (space = 2) => {
+        if (!cachedDashboardSchemaBundle) {
+          throw new Error('Schema bundle is not loaded. Call `await dashboardApi.schema.getDashboard()` first.');
+        }
+        return JSON.stringify(cachedDashboardSchemaBundle.bundle, null, space);
+      },
+    },
     dashboard: {
       getCurrent: (space = 2) => api.getCurrentDashboard(space),
       apply: (resourceJson: string) => api.applyCurrentDashboard(resourceJson),
     },
     errors: {
-      getCurrent: (space = 2) => JSON.stringify({ errors: JSON.parse(api.getCurrentDashboardErrors(space)) }, null, space),
+      getCurrent: (space = 2) =>
+        JSON.stringify({ errors: JSON.parse(api.getCurrentDashboardErrors(space)) }, null, space),
     },
     variables: {
       getCurrent: (space = 2) => api.getCurrentDashboardVariables(space),
@@ -206,5 +405,3 @@ export function getDashboardApi() {
     },
   };
 }
-
-

--- a/packages/grafana-runtime/src/services/index.ts
+++ b/packages/grafana-runtime/src/services/index.ts
@@ -6,6 +6,7 @@ export * from './templateSrv';
 export * from './live';
 export * from './LocationService';
 export * from './appEvents';
+export * from './dashboardSceneJsonApi';
 
 export {
   setPluginComponentHook,

--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -41,6 +41,7 @@ import {
   setCorrelationsService,
   setPluginFunctionsHook,
   setMegaMenuOpenHook,
+  setDashboardSceneJsonApiV2,
 } from '@grafana/runtime';
 import {
   initOpenFeature,
@@ -85,6 +86,7 @@ import { startMeasure, stopMeasure } from './core/utils/metrics';
 import { initAlerting } from './features/alerting/unified/initAlerting';
 import { initAuthConfig } from './features/auth-config';
 import { getTimeSrv } from './features/dashboard/services/TimeSrv';
+import { dashboardSceneJsonApiV2 } from './features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2';
 import { EmbeddedDashboardLazy } from './features/dashboard-scene/embedding/EmbeddedDashboardLazy';
 import { DashboardLevelTimeMacro } from './features/dashboard-scene/scene/DashboardLevelTimeMacro';
 import { initGrafanaLive } from './features/live';
@@ -251,6 +253,10 @@ export class GrafanaApp {
       const dataSourceSrv = new DatasourceSrv();
       dataSourceSrv.init(config.datasources, config.defaultDatasource);
       setDataSourceSrv(dataSourceSrv);
+
+      // Expose current-dashboard schema-v2 JSON APIs to plugins via @grafana/runtime
+      setDashboardSceneJsonApiV2(dashboardSceneJsonApiV2);
+
       initWindowRuntime();
 
       // Do not pre-load apps if rendererDisableAppPluginsPreload is true and the request comes from the image renderer

--- a/public/app/features/dashboard-scene/api/currentDashboardErrors.test.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardErrors.test.ts
@@ -1,0 +1,73 @@
+import { getCurrentDashboardErrors } from './currentDashboardErrors';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      kubernetesDashboards: true,
+      kubernetesDashboardsV2: true,
+      dashboardNewLayouts: false,
+    },
+  },
+}));
+
+jest.mock('../pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+jest.mock('../utils/dashboardSceneGraph', () => ({
+  dashboardSceneGraph: {
+    getVizPanels: jest.fn(),
+  },
+}));
+
+jest.mock('../utils/utils', () => ({
+  getPanelIdForVizPanel: jest.fn(),
+  getQueryRunnerFor: jest.fn(),
+}));
+
+describe('getCurrentDashboardErrors', () => {
+  const { getDashboardScenePageStateManager } = jest.requireMock('../pages/DashboardScenePageStateManager');
+  const { dashboardSceneGraph } = jest.requireMock('../utils/dashboardSceneGraph');
+  const { getPanelIdForVizPanel, getQueryRunnerFor } = jest.requireMock('../utils/utils');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns an empty list when there are no query errors', () => {
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard: {} } });
+    dashboardSceneGraph.getVizPanels.mockReturnValue([{ state: { title: 'P1' } }]);
+    getPanelIdForVizPanel.mockReturnValue(1);
+    getQueryRunnerFor.mockReturnValue({ state: { data: { errors: [] } } });
+
+    expect(getCurrentDashboardErrors()).toEqual([]);
+  });
+
+  it('returns per-panel error summaries with refId and datasource when available', () => {
+    const panel = { state: { title: 'My panel' } };
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard: {} } });
+    dashboardSceneGraph.getVizPanels.mockReturnValue([panel]);
+    getPanelIdForVizPanel.mockReturnValue(42);
+    getQueryRunnerFor.mockReturnValue({
+      state: {
+        datasource: { uid: 'fallback-ds' },
+        queries: [{ refId: 'A', datasource: { name: 'gdev-mysql' } }],
+        data: { errors: [{ message: 'boom', refId: 'A' }] },
+      },
+    });
+
+    expect(getCurrentDashboardErrors()).toEqual([
+      {
+        panelId: 42,
+        panelTitle: 'My panel',
+        refId: 'A',
+        datasource: 'gdev-mysql',
+        message: 'boom',
+        severity: 'error',
+      },
+    ]);
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/currentDashboardErrors.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardErrors.ts
@@ -2,9 +2,9 @@ import { DataQueryError, DataQueryErrorType } from '@grafana/data';
 import { config } from '@grafana/runtime';
 import type { SceneDataQuery, SceneQueryRunner, VizPanel } from '@grafana/scenes';
 
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
 import { getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
-import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
 
 export type DashboardPanelErrorSeverity = 'error' | 'warning';
 

--- a/public/app/features/dashboard-scene/api/currentDashboardErrors.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardErrors.ts
@@ -1,0 +1,119 @@
+import { DataQueryError, DataQueryErrorType } from '@grafana/data';
+import { config } from '@grafana/runtime';
+import type { SceneDataQuery, SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
+
+export type DashboardPanelErrorSeverity = 'error' | 'warning';
+
+export interface DashboardPanelErrorSummary {
+  panelId: number;
+  panelTitle: string;
+  refId?: string;
+  datasource?: string;
+  message: string;
+  severity: DashboardPanelErrorSeverity;
+}
+
+function assertDashboardV2Enabled() {
+  const isKubernetesDashboardsEnabled = Boolean(config.featureToggles.kubernetesDashboards);
+  const isV2Enabled = Boolean(config.featureToggles.kubernetesDashboardsV2 || config.featureToggles.dashboardNewLayouts);
+
+  if (!isKubernetesDashboardsEnabled || !isV2Enabled) {
+    throw new Error('V2 dashboard kinds API requires kubernetes dashboards v2 to be enabled');
+  }
+}
+
+function getCurrentDashboardScene() {
+  const mgr = getDashboardScenePageStateManager();
+  const dashboard = mgr.state.dashboard;
+  if (!dashboard) {
+    throw new Error('No dashboard is currently open');
+  }
+  return dashboard;
+}
+
+function toMessage(err: DataQueryError): string {
+  return err.message || err.data?.message || err.data?.error || 'Query error';
+}
+
+function toSeverity(err: DataQueryError): DashboardPanelErrorSeverity {
+  // Treat cancellations as warnings; everything else is an error.
+  if (err.type === DataQueryErrorType.Cancelled) {
+    return 'warning';
+  }
+  return 'error';
+}
+
+function formatDatasourceRef(ds: unknown): string | undefined {
+  if (!ds || typeof ds !== 'object') {
+    return undefined;
+  }
+  const obj = ds as Record<string, unknown>;
+  const uid = obj.uid;
+  const name = obj.name;
+  const type = obj.type;
+  if (typeof uid === 'string' && uid.length) {
+    return uid;
+  }
+  if (typeof name === 'string' && name.length) {
+    return name;
+  }
+  if (typeof type === 'string' && type.length) {
+    return type;
+  }
+  return undefined;
+}
+
+function getDatasourceForError(queryRunner: SceneQueryRunner, refId?: string): string | undefined {
+  const queries = (queryRunner.state.queries ?? []) as SceneDataQuery[];
+  const q = refId ? queries.find((qq) => qq.refId === refId) : undefined;
+  const ds = q?.datasource ?? queryRunner.state.datasource;
+  return formatDatasourceRef(ds);
+}
+
+export function getCurrentDashboardErrors(): DashboardPanelErrorSummary[] {
+  assertDashboardV2Enabled();
+
+  const dashboard = getCurrentDashboardScene();
+  const panels = dashboardSceneGraph.getVizPanels(dashboard);
+
+  const out: DashboardPanelErrorSummary[] = [];
+
+  for (const panel of panels) {
+    const queryRunner = getQueryRunnerFor(panel);
+    const errors = queryRunner?.state.data?.errors ?? [];
+    if (!queryRunner || errors.length === 0) {
+      continue;
+    }
+
+    const panelId = getPanelIdForVizPanel(panel);
+    const panelTitle = (panel as VizPanel).state.title ?? '';
+
+    for (const err of errors) {
+      const refId = err.refId;
+      out.push({
+        panelId,
+        panelTitle,
+        refId,
+        datasource: getDatasourceForError(queryRunner, refId),
+        message: toMessage(err),
+        severity: toSeverity(err),
+      });
+    }
+  }
+
+  // Stable ordering for LLM consumption.
+  out.sort((a, b) => {
+    if (a.panelId !== b.panelId) {
+      return a.panelId - b.panelId;
+    }
+    return (a.refId ?? '').localeCompare(b.refId ?? '');
+  });
+
+  return out;
+}
+
+

--- a/public/app/features/dashboard-scene/api/currentDashboardKindV2.test.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardKindV2.test.ts
@@ -1,0 +1,68 @@
+import { defaultSpec as defaultDashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import { getCurrentDashboardKindV2 } from './currentDashboardKindV2';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      kubernetesDashboards: true,
+      kubernetesDashboardsV2: true,
+      dashboardNewLayouts: false,
+    },
+  },
+}));
+
+jest.mock('../pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+describe('getCurrentDashboardKindV2', () => {
+  const { getDashboardScenePageStateManager } = jest.requireMock('../pages/DashboardScenePageStateManager');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns v2beta1 Dashboard kind JSON for the currently open dashboard', () => {
+    const spec = defaultDashboardV2Spec();
+
+    const dashboard = {
+      state: {
+        uid: 'dash-uid',
+        meta: {
+          k8s: {
+            name: 'dash-uid',
+            resourceVersion: '1',
+            creationTimestamp: 'now',
+            annotations: {},
+            labels: {},
+          },
+        },
+      },
+      getSaveResource: () => ({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+        metadata: { name: 'dash-uid' },
+        spec,
+      }),
+    };
+
+    getDashboardScenePageStateManager.mockReturnValue({
+      state: { dashboard },
+    });
+
+    const res = getCurrentDashboardKindV2();
+    expect(res.apiVersion).toBe('dashboard.grafana.app/v2beta1');
+    expect(res.kind).toBe('Dashboard');
+    expect(res.metadata.name).toBe('dash-uid');
+    expect(res.spec).toBe(spec);
+  });
+
+  it('throws if no dashboard is currently open', () => {
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard: undefined } });
+    expect(() => getCurrentDashboardKindV2()).toThrow('No dashboard is currently open');
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/currentDashboardKindV2.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardKindV2.ts
@@ -1,0 +1,70 @@
+import { config } from '@grafana/runtime';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import { Resource } from 'app/features/apiserver/types';
+import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
+
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
+
+function assertDashboardV2Enabled() {
+  const isKubernetesDashboardsEnabled = Boolean(config.featureToggles.kubernetesDashboards);
+  const isV2Enabled = Boolean(config.featureToggles.kubernetesDashboardsV2 || config.featureToggles.dashboardNewLayouts);
+
+  if (!isKubernetesDashboardsEnabled || !isV2Enabled) {
+    throw new Error('V2 dashboard kinds API requires kubernetes dashboards v2 to be enabled');
+  }
+}
+
+function getCurrentDashboardScene() {
+  const mgr = getDashboardScenePageStateManager();
+  const dashboard = mgr.state.dashboard;
+  if (!dashboard) {
+    throw new Error('No dashboard is currently open');
+  }
+  return dashboard;
+}
+
+/**
+ * Returns the currently open dashboard as a v2beta1 Dashboard kind JSON resource.
+ *
+ * Note: This is intentionally scoped to the current `DashboardScene` only (no lookups by UID).
+ */
+export function getCurrentDashboardKindV2(): Resource<DashboardV2Spec, Status, 'Dashboard'> {
+  assertDashboardV2Enabled();
+
+  const scene = getCurrentDashboardScene();
+
+  // Use the scene’s canonical “save resource” representation to avoid hand-assembling fields.
+  const saveResource = scene.getSaveResource({ isNew: !scene.state.uid });
+  if (saveResource.apiVersion !== 'dashboard.grafana.app/v2beta1' || saveResource.kind !== 'Dashboard') {
+    throw new Error('Current dashboard is not a v2beta1 Dashboard resource');
+  }
+
+  const spec = saveResource.spec as unknown;
+  if (!isDashboardV2Spec(spec)) {
+    throw new Error('Current dashboard is not using schema v2 spec');
+  }
+
+  const k8sMeta = scene.state.meta.k8s;
+  if (!k8sMeta) {
+    throw new Error('Current dashboard is missing Kubernetes metadata');
+  }
+
+  return {
+    apiVersion: saveResource.apiVersion,
+    kind: 'Dashboard',
+    metadata: {
+      ...k8sMeta,
+      // Prefer the metadata coming from the save resource for name/generateName if present.
+      name: (saveResource.metadata?.name ?? k8sMeta.name) as string,
+      namespace: saveResource.metadata?.namespace ?? k8sMeta.namespace,
+      labels: saveResource.metadata?.labels ?? k8sMeta.labels,
+      annotations: saveResource.metadata?.annotations ?? k8sMeta.annotations,
+    },
+    spec,
+    // We currently don’t persist/status-sync status in the scene; keep it stable and non-authoritative.
+    status: {} as Status,
+  };
+}
+
+

--- a/public/app/features/dashboard-scene/api/currentDashboardSpecApplyV2.test.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardSpecApplyV2.test.ts
@@ -1,0 +1,141 @@
+import { defaultSpec as defaultDashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import { getCurrentDashboardKindV2 } from './currentDashboardKindV2';
+import { applyCurrentDashboardKindV2, applyCurrentDashboardSpecV2 } from './currentDashboardSpecApplyV2';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  config: {
+    featureToggles: {
+      kubernetesDashboards: true,
+      kubernetesDashboardsV2: true,
+      dashboardNewLayouts: false,
+    },
+  },
+}));
+
+jest.mock('../pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+jest.mock('../serialization/transformSaveModelSchemaV2ToScene', () => ({
+  transformSaveModelSchemaV2ToScene: jest.fn(),
+}));
+
+describe('current dashboard spec apply API', () => {
+  const { getDashboardScenePageStateManager } = jest.requireMock('../pages/DashboardScenePageStateManager');
+  const { transformSaveModelSchemaV2ToScene } = jest.requireMock('../serialization/transformSaveModelSchemaV2ToScene');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applyCurrentDashboardSpecV2 swaps in a new scene immediately and marks it dirty', () => {
+    const currentSpec = defaultDashboardV2Spec();
+    const nextSpec = { ...defaultDashboardV2Spec(), title: 'new title' };
+
+    const currentScene = {
+      state: {
+        uid: 'dash-uid',
+        meta: {
+          url: '/d/dash-uid/slug',
+          slug: 'slug',
+          canSave: true,
+          canEdit: true,
+          canDelete: true,
+          canShare: true,
+          canStar: true,
+          canAdmin: true,
+          publicDashboardEnabled: false,
+          k8s: {
+            name: 'dash-uid',
+            resourceVersion: '1',
+            creationTimestamp: 'now',
+            annotations: {},
+            labels: {},
+          },
+        },
+        isEditing: true,
+      },
+      getSaveModel: () => currentSpec,
+    };
+
+    const nextScene = {
+      onEnterEditMode: jest.fn(),
+      setState: jest.fn(),
+    };
+
+    transformSaveModelSchemaV2ToScene.mockReturnValue(nextScene);
+
+    const mgr = {
+      state: { dashboard: currentScene },
+      setSceneCache: jest.fn(),
+      setState: jest.fn(),
+    };
+
+    getDashboardScenePageStateManager.mockReturnValue(mgr);
+
+    applyCurrentDashboardSpecV2(nextSpec);
+
+    expect(transformSaveModelSchemaV2ToScene).toHaveBeenCalledTimes(1);
+    expect(nextScene.onEnterEditMode).toHaveBeenCalled();
+    expect(nextScene.setState).toHaveBeenCalledWith({ isDirty: true });
+    expect(mgr.setSceneCache).toHaveBeenCalledWith('dash-uid', nextScene);
+    expect(mgr.setState).toHaveBeenCalledWith({ dashboard: nextScene });
+  });
+
+  it('applyCurrentDashboardKindV2 rejects metadata changes and applies only spec when unchanged', () => {
+    const spec = defaultDashboardV2Spec();
+
+    const currentScene = {
+      state: {
+        uid: 'dash-uid',
+        meta: {
+          url: '/d/dash-uid/slug',
+          slug: 'slug',
+          canSave: true,
+          canEdit: true,
+          canDelete: true,
+          canShare: true,
+          canStar: true,
+          canAdmin: true,
+          publicDashboardEnabled: false,
+          k8s: {
+            name: 'dash-uid',
+            resourceVersion: '1',
+            creationTimestamp: 'now',
+            annotations: {},
+            labels: {},
+          },
+        },
+        isEditing: true,
+      },
+      getSaveModel: () => spec,
+      getSaveResource: () => ({
+        apiVersion: 'dashboard.grafana.app/v2beta1',
+        kind: 'Dashboard',
+        metadata: { name: 'dash-uid' },
+        spec,
+      }),
+    };
+
+    const nextScene = { onEnterEditMode: jest.fn(), setState: jest.fn() };
+    transformSaveModelSchemaV2ToScene.mockReturnValue(nextScene);
+
+    const mgr = { state: { dashboard: currentScene }, setSceneCache: jest.fn(), setState: jest.fn() };
+    getDashboardScenePageStateManager.mockReturnValue(mgr);
+
+    const current = getCurrentDashboardKindV2();
+    expect(() =>
+      applyCurrentDashboardKindV2({
+        ...current,
+        metadata: {
+          ...current.metadata,
+          annotations: { ...(current.metadata.annotations ?? {}), 'grafana.app/message': 'changed' },
+        },
+      })
+    ).toThrow('Changing metadata is not allowed');
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/currentDashboardSpecApplyV2.ts
+++ b/public/app/features/dashboard-scene/api/currentDashboardSpecApplyV2.ts
@@ -1,0 +1,126 @@
+import { isEqual } from 'lodash';
+
+import { config } from '@grafana/runtime';
+import { Spec as DashboardV2Spec } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+import { Status } from '@grafana/schema/src/schema/dashboard/v2';
+import { Resource } from 'app/features/apiserver/types';
+import { DashboardWithAccessInfo } from 'app/features/dashboard/api/types';
+import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
+
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
+import { transformSaveModelSchemaV2ToScene } from '../serialization/transformSaveModelSchemaV2ToScene';
+import { validateDashboardSchemaV2 } from '../serialization/transformSceneToSaveModelSchemaV2';
+
+import { getCurrentDashboardKindV2 } from './currentDashboardKindV2';
+
+function assertDashboardV2Enabled() {
+  const isKubernetesDashboardsEnabled = Boolean(config.featureToggles.kubernetesDashboards);
+  const isV2Enabled = Boolean(config.featureToggles.kubernetesDashboardsV2 || config.featureToggles.dashboardNewLayouts);
+
+  if (!isKubernetesDashboardsEnabled || !isV2Enabled) {
+    throw new Error('V2 dashboard kinds API requires kubernetes dashboards v2 to be enabled');
+  }
+}
+
+function getCurrentSceneOrThrow() {
+  const mgr = getDashboardScenePageStateManager();
+  const dashboard = mgr.state.dashboard;
+  if (!dashboard) {
+    throw new Error('No dashboard is currently open');
+  }
+  return { mgr, dashboard };
+}
+
+/**
+ * Immediately applies a schema-v2 dashboard spec to the currently open `DashboardScene`.
+ *
+ * This is a **spec-only** mutation API: it does not allow changing `apiVersion`, `kind`, `metadata`, or `status`.
+ */
+export function applyCurrentDashboardSpecV2(nextSpec: DashboardV2Spec): void {
+  assertDashboardV2Enabled();
+
+  // Validate (throws on error)
+  validateDashboardSchemaV2(nextSpec as unknown);
+
+  const { mgr, dashboard: currentScene } = getCurrentSceneOrThrow();
+
+  // Only operate on v2 scenes
+  const currentModel = currentScene.getSaveModel();
+  if (!isDashboardV2Spec(currentModel)) {
+    throw new Error('Current dashboard is not using schema v2');
+  }
+
+  const k8sMeta = currentScene.state.meta.k8s;
+  if (!k8sMeta) {
+    throw new Error('Current dashboard is missing Kubernetes metadata');
+  }
+
+  // Rebuild a new scene from the current immutable wrapper (metadata/access) + new spec.
+  // This guarantees the UI updates immediately to match the JSON.
+  const dto: DashboardWithAccessInfo<DashboardV2Spec> = {
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    kind: 'DashboardWithAccessInfo',
+    metadata: k8sMeta,
+    spec: nextSpec,
+    status: {} as Status,
+    access: {
+      url: currentScene.state.meta.url,
+      slug: currentScene.state.meta.slug,
+      canSave: currentScene.state.meta.canSave,
+      canEdit: currentScene.state.meta.canEdit,
+      canDelete: currentScene.state.meta.canDelete,
+      canShare: currentScene.state.meta.canShare,
+      canStar: currentScene.state.meta.canStar,
+      canAdmin: currentScene.state.meta.canAdmin,
+      annotationsPermissions: currentScene.state.meta.annotationsPermissions,
+      isPublic: currentScene.state.meta.publicDashboardEnabled,
+    },
+  };
+
+  const nextScene = transformSaveModelSchemaV2ToScene(dto);
+
+  // Keep edit mode semantics consistent with other JSON-apply flows:
+  // - Enter edit mode if needed
+  // - Mark dirty because the spec changed
+  if (currentScene.state.isEditing) {
+    nextScene.onEnterEditMode();
+  } else {
+    nextScene.onEnterEditMode();
+  }
+  nextScene.setState({ isDirty: true });
+
+  // Keep cache coherent for the currently open dashboard
+  if (currentScene.state.uid) {
+    mgr.setSceneCache(currentScene.state.uid, nextScene);
+  }
+
+  mgr.setState({ dashboard: nextScene });
+}
+
+/**
+ * Convenience helper that accepts a full Dashboard kind JSON object, but enforces **spec-only** updates.
+ *
+ * It rejects any attempt to change `apiVersion`, `kind`, `metadata`, or `status` from the currently open dashboard.
+ */
+export function applyCurrentDashboardKindV2(resource: Resource<DashboardV2Spec, Status, 'Dashboard'>): void {
+  assertDashboardV2Enabled();
+
+  const current = getCurrentDashboardKindV2();
+
+  if (!isEqual(resource.apiVersion, current.apiVersion)) {
+    throw new Error('Changing apiVersion is not allowed');
+  }
+  if (!isEqual(resource.kind, current.kind)) {
+    throw new Error('Changing kind is not allowed');
+  }
+  if (!isEqual(resource.metadata, current.metadata)) {
+    throw new Error('Changing metadata is not allowed');
+  }
+  if ('status' in resource && !isEqual(resource.status, current.status)) {
+    throw new Error('Changing status is not allowed');
+  }
+
+  applyCurrentDashboardSpecV2(resource.spec);
+}
+
+

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.navigation.test.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.navigation.test.ts
@@ -115,6 +115,29 @@ describe('dashboardSceneJsonApiV2 (navigation/variables/time)', () => {
     expect(nav).toEqual({ tab: { slug: tabB.getSlug(), title: 'Explore' } });
   });
 
+  it('getCurrentDashboardSelection returns null when not editing', () => {
+    const editPane = { getSelection: jest.fn(() => undefined) };
+    const dashboard = { state: { isEditing: false, editPane }, publishEvent: jest.fn() };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const res = JSON.parse(dashboardSceneJsonApiV2.getCurrentDashboardSelection(0));
+    expect(res).toEqual({ isEditing: false, selection: null });
+  });
+
+  it('getCurrentDashboardSelection returns the selected tab context when editing', () => {
+    const selectedTab = new TabItem({ key: 'tab-a', title: 'Overview' });
+    const editPane = { getSelection: jest.fn(() => selectedTab) };
+    const dashboard = { state: { isEditing: true, editPane }, publishEvent: jest.fn() };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const res = JSON.parse(dashboardSceneJsonApiV2.getCurrentDashboardSelection(0));
+    expect(res.isEditing).toBe(true);
+    expect(res.selection.mode).toBe('single');
+    expect(res.selection.item).toEqual(
+      expect.objectContaining({ type: 'tab', tabSlug: selectedTab.getSlug(), title: 'Overview', key: 'tab-a' })
+    );
+  });
+
   it('focusCurrentDashboardRow expands a collapsed row and calls scrollIntoView', () => {
     const row = new RowItem({ title: 'request duration', collapse: true });
     const scrollSpy = jest.spyOn(row, 'scrollIntoView').mockImplementation(() => {});

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.navigation.test.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.navigation.test.ts
@@ -1,0 +1,134 @@
+import { config, locationService } from '@grafana/runtime';
+import { CustomVariable, SceneTimeRange, TextBoxVariable, sceneGraph } from '@grafana/scenes';
+
+jest.mock('../pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+jest.mock('../utils/dashboardSceneGraph', () => ({
+  dashboardSceneGraph: {
+    getVizPanels: jest.fn(() => []),
+  },
+}));
+
+jest.mock('../utils/utils', () => ({
+  getPanelIdForVizPanel: jest.fn(),
+  getQueryRunnerFor: jest.fn(),
+}));
+
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { TabItem } from '../scene/layout-tabs/TabItem';
+import { TabsLayoutManager } from '../scene/layout-tabs/TabsLayoutManager';
+
+import { dashboardSceneJsonApiV2 } from './runtimeDashboardSceneJsonApiV2';
+
+describe('dashboardSceneJsonApiV2 (navigation/variables/time)', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+
+    // Enable v2 API gate for tests.
+    config.featureToggles.kubernetesDashboards = true;
+    config.featureToggles.kubernetesDashboardsV2 = true;
+
+    jest.spyOn(locationService, 'partial').mockImplementation(() => {});
+  });
+
+  it('getCurrentDashboardVariables returns a stable JSON shape and applyCurrentDashboardVariables updates values', () => {
+    const customVar = new CustomVariable({ name: 'customVar', query: 'a,b,c', value: 'a', text: 'a' });
+    const textVar = new TextBoxVariable({ type: 'textbox', name: 'tb', value: 'x' });
+
+    const dashboard = {
+      state: {
+        $variables: { state: { variables: [customVar, textVar] } },
+      },
+      publishEvent: jest.fn(),
+    };
+
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const before = JSON.parse(dashboardSceneJsonApiV2.getCurrentDashboardVariables(0));
+    expect(before.variables).toEqual(
+      expect.arrayContaining([
+        { name: 'customVar', value: 'a' },
+        { name: 'tb', value: 'x' },
+      ])
+    );
+
+    dashboardSceneJsonApiV2.applyCurrentDashboardVariables(JSON.stringify({ customVar: ['b', 'c'], tb: 'y' }));
+
+    expect(customVar.getValue()).toEqual(['b', 'c']);
+    expect(textVar.getValue()).toBe('y');
+    expect(locationService.partial).toHaveBeenCalledWith({ 'var-customVar': ['b', 'c'] }, true);
+    expect(locationService.partial).toHaveBeenCalledWith({ 'var-tb': 'y' }, true);
+  });
+
+  it('getCurrentDashboardTimeRange returns raw values and applyCurrentDashboardTimeRange calls SceneTimeRange APIs', () => {
+    const tr = new SceneTimeRange({ from: 'now-1h', to: 'now', timeZone: 'browser' });
+    const tzSpy = jest.spyOn(tr, 'onTimeZoneChange');
+    const trSpy = jest.spyOn(tr, 'onTimeRangeChange');
+    const refreshSpy = jest.spyOn(tr, 'onRefresh');
+
+    jest.spyOn(sceneGraph, 'getTimeRange').mockReturnValue(tr);
+
+    const dashboard = { state: {}, publishEvent: jest.fn() };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const current = JSON.parse(dashboardSceneJsonApiV2.getCurrentDashboardTimeRange(0));
+    expect(current).toEqual({ from: 'now-1h', to: 'now', timezone: 'browser' });
+
+    dashboardSceneJsonApiV2.applyCurrentDashboardTimeRange(JSON.stringify({ from: 'now-6h', to: 'now', timezone: 'utc' }));
+    expect(tzSpy).toHaveBeenCalledWith('utc');
+    expect(trSpy).toHaveBeenCalled();
+    expect(refreshSpy).toHaveBeenCalled();
+  });
+
+  it('selectCurrentDashboardTab selects a matching tab by title', () => {
+    const tabA = new TabItem({ key: 'tab-a', title: 'A' });
+    const tabB = new TabItem({ key: 'tab-b', title: 'B' });
+    const tabs = new TabsLayoutManager({ tabs: [tabA, tabB] });
+
+    const dashboard = {
+      state: { body: tabs },
+      publishEvent: jest.fn(),
+    };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const spy = jest.spyOn(tabs, 'switchToTab');
+    dashboardSceneJsonApiV2.selectCurrentDashboardTab(JSON.stringify({ title: 'B' }));
+
+    expect(spy).toHaveBeenCalledWith(tabB);
+  });
+
+  it('getCurrentDashboardNavigation returns the active tab', () => {
+    const tabA = new TabItem({ key: 'tab-a', title: 'Overview' });
+    const tabB = new TabItem({ key: 'tab-b', title: 'Explore' });
+    const tabs = new TabsLayoutManager({ tabs: [tabA, tabB], currentTabSlug: tabB.getSlug() });
+
+    const dashboard = {
+      state: { body: tabs },
+      publishEvent: jest.fn(),
+    };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    const nav = JSON.parse(dashboardSceneJsonApiV2.getCurrentDashboardNavigation(0));
+    expect(nav).toEqual({ tab: { slug: tabB.getSlug(), title: 'Explore' } });
+  });
+
+  it('focusCurrentDashboardRow expands a collapsed row and calls scrollIntoView', () => {
+    const row = new RowItem({ title: 'request duration', collapse: true });
+    const scrollSpy = jest.spyOn(row, 'scrollIntoView').mockImplementation(() => {});
+
+    jest.spyOn(sceneGraph, 'findAllObjects').mockReturnValue([row]);
+
+    const dashboard = { state: {}, publishEvent: jest.fn() };
+    (getDashboardScenePageStateManager as jest.Mock).mockReturnValue({ state: { dashboard } });
+
+    dashboardSceneJsonApiV2.focusCurrentDashboardRow(JSON.stringify({ title: 'request duration' }));
+
+    expect(row.getCollapsedState()).toBe(false);
+    expect(scrollSpy).toHaveBeenCalled();
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ops.test.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ops.test.ts
@@ -1,0 +1,152 @@
+import { config } from '@grafana/runtime';
+import { SceneQueryRunner, VizPanel } from '@grafana/scenes';
+
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
+
+import { dashboardSceneJsonApiV2 } from './runtimeDashboardSceneJsonApiV2';
+
+jest.mock('../utils/utils', () => {
+  const actual = jest.requireActual('../utils/utils');
+  return {
+    ...actual,
+    getDefaultVizPanel: jest.fn(),
+  };
+});
+
+jest.mock('../pages/DashboardScenePageStateManager', () => ({
+  getDashboardScenePageStateManager: jest.fn(),
+}));
+
+jest.mock('../utils/dashboardSceneGraph', () => ({
+  dashboardSceneGraph: {
+    getVizPanels: jest.fn(),
+  },
+}));
+
+describe('dashboardSceneJsonApiV2 (ops)', () => {
+  const { getDashboardScenePageStateManager } = jest.requireMock('../pages/DashboardScenePageStateManager');
+  const { dashboardSceneGraph } = jest.requireMock('../utils/dashboardSceneGraph');
+  const { getDefaultVizPanel } = jest.requireMock('../utils/utils');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    config.featureToggles.kubernetesDashboards = true;
+    config.featureToggles.kubernetesDashboardsV2 = true;
+  });
+
+  it('mergePanelConfig updates fieldConfig defaults in-place (preserves SceneQueryRunner identity)', () => {
+    const runner = new SceneQueryRunner({ queries: [], data: undefined });
+    const panel = new VizPanel({
+      key: 'panel-2',
+      title: 'Time series',
+      fieldConfig: { defaults: { unit: 'short' }, overrides: [] },
+      $data: runner,
+    });
+
+    const dashboard = {
+      state: { isEditing: true },
+      setState: jest.fn(),
+    };
+
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard } });
+    dashboardSceneGraph.getVizPanels.mockReturnValue([panel]);
+
+    const res = JSON.parse(
+      dashboardSceneJsonApiV2.applyCurrentDashboardOps(
+        JSON.stringify([
+          {
+            op: 'mergePanelConfig',
+            panelId: 2,
+            merge: { vizConfig: { fieldConfig: { defaults: { unit: 'ms' } } } },
+          },
+        ])
+      )
+    );
+
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(1);
+    expect(panel.state.fieldConfig.defaults.unit).toBe('ms');
+    expect(panel.state.$data).toBe(runner);
+    expect(dashboard.setState).toHaveBeenCalledWith({ isDirty: true });
+  });
+
+  it('addPanel uses the current layout addPanel (does not rebuild existing panels)', () => {
+    const existingRunner = new SceneQueryRunner({ queries: [], data: undefined });
+    const existingPanel = new VizPanel({
+      key: 'panel-1',
+      title: 'Existing',
+      $data: existingRunner,
+      fieldConfig: { defaults: {}, overrides: [] },
+    });
+
+    const newRunner = new SceneQueryRunner({ queries: [], data: undefined });
+    const newPanel = new VizPanel({
+      // key is assigned by layout.addPanel in real code; the op reads it afterwards.
+      title: 'New panel',
+      $data: newRunner,
+      fieldConfig: { defaults: {}, overrides: [] },
+    });
+
+    getDefaultVizPanel.mockReturnValue(newPanel);
+
+    const layout = {
+      addPanel: jest.fn((p: VizPanel) => {
+        // emulate DefaultGridLayoutManager assigning next panel id/key
+        p.setState({ key: 'panel-2' });
+      }),
+    };
+
+    const dashboard = {
+      state: { isEditing: true, body: layout },
+      setState: jest.fn(),
+      removePanel: jest.fn(),
+    };
+
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard } });
+    dashboardSceneGraph.getVizPanels.mockReturnValue([existingPanel]);
+
+    const res = JSON.parse(dashboardSceneJsonApiV2.applyCurrentDashboardOps(JSON.stringify([{ op: 'addPanel', title: 'Hello' }])));    
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(1);
+    expect(layout.addPanel).toHaveBeenCalledTimes(1);
+    expect(newPanel.state.key).toBe('panel-2');
+
+    // existing panel runner identity preserved
+    expect(existingPanel.state.$data).toBe(existingRunner);
+  });
+
+  it('movePanelToRow supports moving into a GridLayout row (DefaultGridLayoutManager)', () => {
+    const panel = new VizPanel({
+      key: 'panel-6',
+      title: 'Bar chart (steps)',
+      pluginId: 'barchart',
+      fieldConfig: { defaults: {}, overrides: [] },
+      $data: new SceneQueryRunner({ queries: [], data: undefined }),
+    });
+
+    const rowA = new RowItem({ title: 'Charts', layout: DefaultGridLayoutManager.fromVizPanels([panel]) });
+    const rowB = new RowItem({ title: 'Data', layout: DefaultGridLayoutManager.fromVizPanels([]) });
+    const rows = new RowsLayoutManager({ rows: [rowA, rowB] });
+
+    const dashboard = {
+      state: { isEditing: true, body: rows },
+      setState: jest.fn(),
+    };
+
+    getDashboardScenePageStateManager.mockReturnValue({ state: { dashboard } });
+    dashboardSceneGraph.getVizPanels.mockReturnValue([panel]);
+
+    const res = JSON.parse(
+      dashboardSceneJsonApiV2.applyCurrentDashboardOps(JSON.stringify([{ op: 'movePanelToRow', panelId: 6, rowTitle: 'Data' }]))
+    );
+
+    expect(res.ok).toBe(true);
+    expect(res.applied).toBe(1);
+    expect(rowA.state.layout.getVizPanels()).toHaveLength(0);
+    expect(rowB.state.layout.getVizPanels()).toContain(panel);
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.test.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.test.ts
@@ -1,0 +1,92 @@
+import { dashboardSceneJsonApiV2 } from './runtimeDashboardSceneJsonApiV2';
+
+jest.mock('./currentDashboardKindV2', () => ({
+  getCurrentDashboardKindV2: jest.fn(),
+}));
+
+jest.mock('./currentDashboardSpecApplyV2', () => ({
+  applyCurrentDashboardSpecV2: jest.fn(),
+}));
+
+describe('dashboardSceneJsonApiV2 (runtime adapter)', () => {
+  const { getCurrentDashboardKindV2 } = jest.requireMock('./currentDashboardKindV2');
+  const { applyCurrentDashboardSpecV2 } = jest.requireMock('./currentDashboardSpecApplyV2');
+
+  const baseResource = {
+    apiVersion: 'dashboard.grafana.app/v2beta1',
+    kind: 'Dashboard',
+    metadata: { name: 'dash-uid', namespace: 'default' },
+    spec: { title: 'x' },
+    status: {},
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.history.pushState({}, '', '/d/dash-uid/slug');
+  });
+
+  it('getCurrentDashboard returns cached JSON if live serialization fails', () => {
+    getCurrentDashboardKindV2.mockReturnValue(baseResource);
+    const first = dashboardSceneJsonApiV2.getCurrentDashboard(0);
+    expect(JSON.parse(first).metadata.name).toBe('dash-uid');
+
+    getCurrentDashboardKindV2.mockImplementation(() => {
+      throw new Error('Unsupported transformation type');
+    });
+    const second = dashboardSceneJsonApiV2.getCurrentDashboard(0);
+    expect(second).toBe(first);
+  });
+
+  it('applyCurrentDashboard uses cached baseline to enforce immutability if live serialization fails', () => {
+    // Prime cache
+    getCurrentDashboardKindV2.mockReturnValue(baseResource);
+    dashboardSceneJsonApiV2.getCurrentDashboard(0);
+
+    // Now break live serialization
+    getCurrentDashboardKindV2.mockImplementation(() => {
+      throw new Error('Unsupported transformation type');
+    });
+
+    expect(() =>
+      dashboardSceneJsonApiV2.applyCurrentDashboard(
+        JSON.stringify({
+          ...baseResource,
+          apiVersion: 'dashboard.grafana.app/v2alpha1',
+        })
+      )
+    ).toThrow('Changing apiVersion is not allowed');
+  });
+
+  it('applyCurrentDashboard can recover without a baseline by validating against URL UID and applying spec', () => {
+    getCurrentDashboardKindV2.mockImplementation(() => {
+      throw new Error('Unsupported transformation type');
+    });
+
+    const nextSpec = { title: 'recovered' };
+    dashboardSceneJsonApiV2.applyCurrentDashboard(
+      JSON.stringify({
+        ...baseResource,
+        spec: nextSpec,
+      })
+    );
+
+    expect(applyCurrentDashboardSpecV2).toHaveBeenCalledWith(nextSpec);
+  });
+
+  it('applyCurrentDashboard rejects recovery attempts targeting a different dashboard UID', () => {
+    getCurrentDashboardKindV2.mockImplementation(() => {
+      throw new Error('Unsupported transformation type');
+    });
+
+    expect(() =>
+      dashboardSceneJsonApiV2.applyCurrentDashboard(
+        JSON.stringify({
+          ...baseResource,
+          metadata: { ...baseResource.metadata, name: 'other-uid' },
+        })
+      )
+    ).toThrow('Changing metadata is not allowed');
+  });
+});
+
+

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
@@ -2,6 +2,7 @@ import { isEqual } from 'lodash';
 
 import type { DashboardSceneJsonApiV2 } from '@grafana/runtime';
 
+import { getCurrentDashboardErrors } from './currentDashboardErrors';
 import { getCurrentDashboardKindV2 as getCurrentDashboardResourceV2 } from './currentDashboardKindV2';
 import { applyCurrentDashboardSpecV2 } from './currentDashboardSpecApplyV2';
 
@@ -51,6 +52,10 @@ export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
   getCurrentDashboard: (space = 2) => {
     const { resource } = getCurrentDashboardResourceWithFallback();
     return JSON.stringify(resource, null, space);
+  },
+
+  getCurrentDashboardErrors: (space = 2) => {
+    return JSON.stringify(getCurrentDashboardErrors(), null, space);
   },
 
   applyCurrentDashboard: (resourceJson: string) => {

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
@@ -1,6 +1,22 @@
 import { isEqual } from 'lodash';
 
-import type { DashboardSceneJsonApiV2 } from '@grafana/runtime';
+import { RefreshEvent, config, locationService, type DashboardSceneJsonApiV2 } from '@grafana/runtime';
+import {
+  MultiValueVariable,
+  TextBoxVariable,
+  sceneGraph,
+  type SceneObject,
+  type VariableValue,
+} from '@grafana/scenes';
+
+import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
+import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
+import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { RowItem } from '../scene/layout-rows/RowItem';
+import { TabItem } from '../scene/layout-tabs/TabItem';
+import { TabsLayoutManager } from '../scene/layout-tabs/TabsLayoutManager';
+import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
+import { getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
 
 import { getCurrentDashboardErrors } from './currentDashboardErrors';
 import { getCurrentDashboardKindV2 as getCurrentDashboardResourceV2 } from './currentDashboardKindV2';
@@ -19,6 +35,39 @@ type DashboardResourceV2 = ReturnType<typeof getCurrentDashboardResourceV2>;
  * we keep a last-known-good dashboard resource cached as a recovery fallback.
  */
 let lastKnownGoodResource: DashboardResourceV2 | undefined;
+
+function assertDashboardV2Enabled() {
+  const isKubernetesDashboardsEnabled = Boolean(config.featureToggles.kubernetesDashboards);
+  const isV2Enabled = Boolean(config.featureToggles.kubernetesDashboardsV2 || config.featureToggles.dashboardNewLayouts);
+
+  if (!isKubernetesDashboardsEnabled || !isV2Enabled) {
+    throw new Error('V2 dashboard kinds API requires kubernetes dashboards v2 to be enabled');
+  }
+}
+
+function getCurrentDashboardSceneOrThrow() {
+  const mgr = getDashboardScenePageStateManager();
+  const dashboard = mgr.state.dashboard;
+  if (!dashboard) {
+    throw new Error('No dashboard is currently open');
+  }
+  return dashboard;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function findParent<T extends SceneObject>(start: SceneObject, isMatch: (obj: SceneObject) => obj is T): T | null {
+  let cur: SceneObject | undefined = start.parent ?? undefined;
+  while (cur) {
+    if (isMatch(cur)) {
+      return cur;
+    }
+    cur = cur.parent;
+  }
+  return null;
+}
 
 function getDashboardUidFromUrl(): string | undefined {
   const pathname = globalThis.location?.pathname ?? '';
@@ -56,6 +105,223 @@ export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
 
   getCurrentDashboardErrors: (space = 2) => {
     return JSON.stringify(getCurrentDashboardErrors(), null, space);
+  },
+
+  getCurrentDashboardVariables: (space = 2) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const vars = dashboard.state.$variables?.state.variables ?? [];
+
+    const collator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+    const variables = vars.map((v) => ({ name: v.state.name, value: v.getValue() })).sort((a, b) => collator.compare(a.name, b.name));
+
+    return JSON.stringify({ variables }, null, space);
+  },
+
+  applyCurrentDashboardVariables: (varsJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const vars = dashboard.state.$variables?.state.variables ?? [];
+    const parsed: unknown = JSON.parse(varsJson);
+    const parsedObj: Record<string, unknown> = isRecord(parsed) ? parsed : {};
+
+    // Accept either { variables: [{ name, value }] } or { [name]: value }
+    const variablesProp = parsedObj['variables'];
+    const entries: Array<{ name: unknown; value: unknown }> = Array.isArray(variablesProp)
+      ? variablesProp
+      : Object.entries(parsedObj).map(([name, value]) => ({ name, value }));
+
+    for (const entry of entries) {
+      const name = entry.name;
+      const value = entry.value;
+      if (typeof name !== 'string' || name.length === 0) {
+        continue;
+      }
+      if (!(typeof value === 'string' || Array.isArray(value))) {
+        continue;
+      }
+
+      const variable = vars.find((v) => v.state.name === name);
+      if (!variable) {
+        continue;
+      }
+
+      let varValue: VariableValue | undefined;
+      if (typeof value === 'string') {
+        varValue = value;
+      } else if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+        varValue = value;
+      }
+
+      if (!varValue) {
+        continue;
+      }
+
+      if (variable instanceof MultiValueVariable) {
+        variable.changeValueTo(varValue, varValue, true);
+      } else if (variable instanceof TextBoxVariable && typeof varValue === 'string') {
+        variable.setValue(varValue);
+      } else {
+        // Unsupported variable type for programmatic update (for now).
+        continue;
+      }
+
+      locationService.partial({ [`var-${name}`]: varValue }, true);
+    }
+
+    // Force rerun queries and refresh panels.
+    dashboard.publishEvent(new RefreshEvent(), true);
+  },
+
+  getCurrentDashboardTimeRange: (space = 2) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const tr = sceneGraph.getTimeRange(dashboard);
+    const timezone = tr.state.timeZone ?? tr.getTimeZone();
+    return JSON.stringify({ from: tr.state.from, to: tr.state.to, timezone }, null, space);
+  },
+
+  applyCurrentDashboardTimeRange: (timeRangeJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const tr = sceneGraph.getTimeRange(dashboard);
+    const parsed: unknown = JSON.parse(timeRangeJson);
+    const parsedObj: Record<string, unknown> = isRecord(parsed) ? parsed : {};
+
+    const from = parsedObj['from'];
+    const to = parsedObj['to'];
+    const timezone = parsedObj['timezone'];
+
+    if (typeof timezone === 'string' && timezone.length) {
+      tr.onTimeZoneChange(timezone);
+    }
+
+    if (typeof from !== 'string' || typeof to !== 'string') {
+      throw new Error('Invalid time range JSON: expected { from: string, to: string, timezone?: string }');
+    }
+
+    tr.onTimeRangeChange({ ...tr.state.value, raw: { from, to } });
+    tr.onRefresh();
+  },
+
+  selectCurrentDashboardTab: (tabJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const tabReq: unknown = JSON.parse(tabJson);
+    const tabObj: Record<string, unknown> = isRecord(tabReq) ? tabReq : {};
+    const title = typeof tabObj['title'] === 'string' ? tabObj['title'] : undefined;
+    const slug = typeof tabObj['slug'] === 'string' ? tabObj['slug'] : undefined;
+
+    const found = dashboard.state.body instanceof TabsLayoutManager ? dashboard.state.body : sceneGraph.findObject(dashboard, (o) => o instanceof TabsLayoutManager);
+    const tabsManager = found instanceof TabsLayoutManager ? found : null;
+    if (!tabsManager) {
+      throw new Error('No tab layout is active for the current dashboard');
+    }
+
+    const tabs = tabsManager.getTabsIncludingRepeats();
+    const tab = tabs.find((t) => (slug ? t.getSlug() === slug : false) || (title ? t.state.title === title : false));
+    if (!tab?.state.key) {
+      throw new Error('Tab not found');
+    }
+
+    // NOTE: `forceSelectTab` also selects the tab in the edit pane (opens the edit UI).
+    // The API must not trigger edit selection when navigating.
+    tabsManager.switchToTab(tab);
+    locationService.partial({ [tabsManager.getUrlKey()]: tab.getSlug() }, true);
+  },
+
+  getCurrentDashboardNavigation: (space = 2) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+
+    const found = dashboard.state.body instanceof TabsLayoutManager ? dashboard.state.body : sceneGraph.findObject(dashboard, (o) => o instanceof TabsLayoutManager);
+    const tabsManager = found instanceof TabsLayoutManager ? found : null;
+
+    if (!tabsManager) {
+      return JSON.stringify({ tab: null }, null, space);
+    }
+
+    const currentTab = tabsManager.getCurrentTab();
+    if (!currentTab) {
+      return JSON.stringify({ tab: null }, null, space);
+    }
+
+    return JSON.stringify(
+      {
+        tab: {
+          slug: currentTab.getSlug(),
+          title: currentTab.state.title,
+        },
+      },
+      null,
+      space
+    );
+  },
+
+  focusCurrentDashboardRow: (rowJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const req: unknown = JSON.parse(rowJson);
+    const reqObj: Record<string, unknown> = isRecord(req) ? req : {};
+    const title = typeof reqObj['title'] === 'string' ? reqObj['title'] : undefined;
+    const rowKey = typeof reqObj['rowKey'] === 'string' ? reqObj['rowKey'] : undefined;
+
+    const rows = sceneGraph.findAllObjects(dashboard, (o) => o instanceof RowItem).filter((o): o is RowItem => o instanceof RowItem);
+    const row = rows.find((r) => (rowKey ? r.state.key === rowKey : false) || (title ? r.state.title === title : false));
+    if (!row) {
+      throw new Error('Row not found');
+    }
+
+    const tab = findParent(row, (o): o is TabItem => o instanceof TabItem);
+    const tabsManager = tab ? findParent(tab, (o): o is TabsLayoutManager => o instanceof TabsLayoutManager) : null;
+    if (tab?.state.key && tabsManager) {
+      tabsManager.switchToTab(tab);
+      locationService.partial({ [tabsManager.getUrlKey()]: tab.getSlug() }, true);
+    }
+
+    if (row.state.collapse) {
+      row.setCollapsedState(false);
+    }
+    row.scrollIntoView();
+  },
+
+  focusCurrentDashboardPanel: (panelJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const req: unknown = JSON.parse(panelJson);
+    const reqObj: Record<string, unknown> = isRecord(req) ? req : {};
+    const panelId = reqObj['panelId'];
+    if (typeof panelId !== 'number') {
+      throw new Error('Invalid panel JSON: expected { panelId: number }');
+    }
+
+    const vizPanel = dashboardSceneGraph.getVizPanels(dashboard).find((p) => getPanelIdForVizPanel(p) === panelId);
+    if (!vizPanel) {
+      throw new Error('Panel not found');
+    }
+
+    // Ensure containing tab is active, if any.
+    const tab = findParent(vizPanel, (o): o is TabItem => o instanceof TabItem);
+    const tabsManager = tab ? findParent(tab, (o): o is TabsLayoutManager => o instanceof TabsLayoutManager) : null;
+    if (tab?.state.key && tabsManager) {
+      tabsManager.switchToTab(tab);
+      locationService.partial({ [tabsManager.getUrlKey()]: tab.getSlug() }, true);
+    }
+
+    // Ensure containing row is expanded, if any.
+    const row = findParent(vizPanel, (o): o is RowItem => o instanceof RowItem);
+    if (row?.state.collapse) {
+      row.setCollapsedState(false);
+    }
+
+    // Scroll nearest known layout item that supports scrollIntoView.
+    const gridItem = findParent(vizPanel, (o): o is DashboardGridItem => o instanceof DashboardGridItem);
+    const autoGridItem = findParent(vizPanel, (o): o is AutoGridItem => o instanceof AutoGridItem);
+    (gridItem ?? autoGridItem)?.scrollIntoView();
+
+    // Best-effort rerun queries for this panel if it has a runner.
+    const runner = getQueryRunnerFor(vizPanel);
+    runner?.runQueries?.();
   },
 
   applyCurrentDashboard: (resourceJson: string) => {

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
@@ -1,0 +1,122 @@
+import { isEqual } from 'lodash';
+
+import type { DashboardSceneJsonApiV2 } from '@grafana/runtime';
+
+import { getCurrentDashboardKindV2 as getCurrentDashboardResourceV2 } from './currentDashboardKindV2';
+import { applyCurrentDashboardSpecV2 } from './currentDashboardSpecApplyV2';
+
+type DashboardResourceV2 = ReturnType<typeof getCurrentDashboardResourceV2>;
+
+/**
+ * The dashboard JSON API is required to be resilient for automation.
+ *
+ * In practice, the currently loaded `DashboardScene` might temporarily be in a state that cannot be
+ * serialized back to a v2 resource (for example, if the scene contains unsupported transformation types).
+ *
+ * To avoid “bricking” the API in that situation (where both `getCurrentDashboard()` and
+ * `applyCurrentDashboard()` would fail because they need to read the current resource),
+ * we keep a last-known-good dashboard resource cached as a recovery fallback.
+ */
+let lastKnownGoodResource: DashboardResourceV2 | undefined;
+
+function getDashboardUidFromUrl(): string | undefined {
+  const pathname = globalThis.location?.pathname ?? '';
+  // Expected: /d/<uid>/<slug>
+  const match = pathname.match(/\/d\/([^/]+)/);
+  return match?.[1];
+}
+
+function getCurrentDashboardResourceWithFallback(): { resource: DashboardResourceV2; source: 'live' | 'cache' } {
+  try {
+    const resource = getCurrentDashboardResourceV2();
+    lastKnownGoodResource = resource;
+    return { resource, source: 'live' };
+  } catch (err) {
+    if (lastKnownGoodResource) {
+      return { resource: lastKnownGoodResource, source: 'cache' };
+    }
+
+    const details = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      'DashboardScene JSON API could not read the current dashboard resource. ' +
+        'This can happen if the loaded DashboardScene cannot be serialized to schema v2. ' +
+        'To recover, call applyCurrentDashboard() with a valid v2beta1 Dashboard JSON (spec-only changes) ' +
+        'whose metadata.name matches the dashboard UID in the URL.\n\n' +
+        `Underlying error: ${details}`
+    );
+  }
+}
+
+export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
+  getCurrentDashboard: (space = 2) => {
+    const { resource } = getCurrentDashboardResourceWithFallback();
+    return JSON.stringify(resource, null, space);
+  },
+
+  applyCurrentDashboard: (resourceJson: string) => {
+    const resource = JSON.parse(resourceJson);
+    let current: DashboardResourceV2 | undefined;
+    try {
+      // Prefer live for strict immutability checks, but fall back to cached baseline.
+      current = getCurrentDashboardResourceV2();
+      lastKnownGoodResource = current;
+    } catch {
+      current = lastKnownGoodResource;
+    }
+
+    // If we can’t read the current resource at all (no cache), we still allow recovery by validating
+    // that the caller targets the currently open dashboard, and that the payload is a v2beta1 Dashboard.
+    if (!current) {
+      const uidFromUrl = getDashboardUidFromUrl();
+
+      if (resource.apiVersion !== 'dashboard.grafana.app/v2beta1') {
+        throw new Error('Changing apiVersion is not allowed');
+      }
+      if (resource.kind !== 'Dashboard') {
+        throw new Error('Changing kind is not allowed');
+      }
+      if (!resource.metadata || typeof resource.metadata !== 'object') {
+        throw new Error('Changing metadata is not allowed');
+      }
+      if (uidFromUrl && resource.metadata.name !== uidFromUrl) {
+        throw new Error('Changing metadata is not allowed');
+      }
+      if (!('status' in resource)) {
+        // Keep error message consistent; callers should include status even if empty.
+        throw new Error('Changing status is not allowed');
+      }
+
+      applyCurrentDashboardSpecV2(resource.spec);
+      // Best-effort refresh cache after recovery.
+      try {
+        lastKnownGoodResource = getCurrentDashboardResourceV2();
+      } catch {
+        // ignore
+      }
+      return;
+    }
+
+    if (!isEqual(resource.apiVersion, current.apiVersion)) {
+      throw new Error('Changing apiVersion is not allowed');
+    }
+    if (!isEqual(resource.kind, current.kind)) {
+      throw new Error('Changing kind is not allowed');
+    }
+    if (!isEqual(resource.metadata, current.metadata)) {
+      throw new Error('Changing metadata is not allowed');
+    }
+    if (!isEqual(resource.status, current.status)) {
+      throw new Error('Changing status is not allowed');
+    }
+
+    applyCurrentDashboardSpecV2(resource.spec);
+    // Best-effort cache refresh after apply.
+    try {
+      lastKnownGoodResource = getCurrentDashboardResourceV2();
+    } catch {
+      // ignore
+    }
+  },
+};
+
+

--- a/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
+++ b/public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts
@@ -3,20 +3,33 @@ import { isEqual } from 'lodash';
 import { RefreshEvent, config, locationService, type DashboardSceneJsonApiV2 } from '@grafana/runtime';
 import {
   MultiValueVariable,
+  SceneGridRow,
+  SceneVariableSet,
   TextBoxVariable,
   sceneGraph,
+  VizPanel,
   type SceneObject,
   type VariableValue,
 } from '@grafana/scenes';
 
 import { getDashboardScenePageStateManager } from '../pages/DashboardScenePageStateManager';
 import { AutoGridItem } from '../scene/layout-auto-grid/AutoGridItem';
+import { AutoGridLayoutManager } from '../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 import { RowItem } from '../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../scene/layout-rows/RowsLayoutManager';
 import { TabItem } from '../scene/layout-tabs/TabItem';
 import { TabsLayoutManager } from '../scene/layout-tabs/TabsLayoutManager';
+import { addNewRowTo } from '../scene/layouts-shared/addNew';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
-import { getPanelIdForVizPanel, getQueryRunnerFor } from '../utils/utils';
+import {
+  getDefaultVizPanel,
+  getGridItemKeyForPanelId,
+  getLayoutManagerFor,
+  getPanelIdForVizPanel,
+  getQueryRunnerFor,
+} from '../utils/utils';
 
 import { getCurrentDashboardErrors } from './currentDashboardErrors';
 import { getCurrentDashboardKindV2 as getCurrentDashboardResourceV2 } from './currentDashboardKindV2';
@@ -69,6 +82,37 @@ function findParent<T extends SceneObject>(start: SceneObject, isMatch: (obj: Sc
   return null;
 }
 
+function removeVizPanelFromCurrentLayoutInPlace(panel: VizPanel) {
+  const parent = panel.parent;
+  if (!parent) {
+    return;
+  }
+
+  if (parent instanceof AutoGridItem) {
+    const mgr = findParent(parent, (o): o is AutoGridLayoutManager => o instanceof AutoGridLayoutManager);
+    if (mgr) {
+      mgr.state.layout.setState({ children: mgr.state.layout.state.children.filter((c) => c !== parent) });
+      return;
+    }
+  }
+
+  if (parent instanceof DashboardGridItem) {
+    const mgr = findParent(parent, (o): o is DefaultGridLayoutManager => o instanceof DefaultGridLayoutManager);
+    if (mgr) {
+      mgr.state.grid.setState({ children: mgr.state.grid.state.children.filter((c) => c !== parent) });
+      return;
+    }
+  }
+
+  // Last resort: ask the layout manager abstraction (may require edit-pane plumbing).
+  try {
+    const mgr = getLayoutManagerFor(panel);
+    mgr.removePanel?.(panel);
+  } catch {
+    // ignore
+  }
+}
+
 function getDashboardUidFromUrl(): string | undefined {
   const pathname = globalThis.location?.pathname ?? '';
   // Expected: /d/<uid>/<slug>
@@ -95,6 +139,116 @@ function getCurrentDashboardResourceWithFallback(): { resource: DashboardResourc
         `Underlying error: ${details}`
     );
   }
+}
+
+function addVizPanelToLayoutInPlace(layout: unknown, panel: VizPanel, sourceGridItem?: DashboardGridItem) {
+  if (layout instanceof AutoGridLayoutManager) {
+    layout.state.layout.setState({
+      children: [...layout.state.layout.state.children, new AutoGridItem({ body: panel })],
+    });
+    return;
+  }
+
+  if (layout instanceof DefaultGridLayoutManager) {
+    const children = layout.state.grid.state.children;
+
+    // Put it at the bottom.
+    let nextY = 0;
+    for (const child of children) {
+      const childState = isRecord(child) ? child['state'] : undefined;
+      const y = isRecord(childState) && typeof childState['y'] === 'number' ? childState['y'] : 0;
+      const h = isRecord(childState) && typeof childState['height'] === 'number' ? childState['height'] : 0;
+      nextY = Math.max(nextY, y + h);
+    }
+
+    const panelId = getPanelIdForVizPanel(panel);
+    const width = sourceGridItem?.state.width ?? 24;
+    const height = sourceGridItem?.state.height ?? 8;
+    const x = 0;
+
+    const key = sourceGridItem?.state.key ?? getGridItemKeyForPanelId(panelId);
+
+    const newGridItem = new DashboardGridItem({
+      x,
+      y: nextY,
+      width,
+      height,
+      body: panel,
+      key,
+    });
+
+    layout.state.grid.setState({ children: [...children, newGridItem] });
+    return;
+  }
+
+  throw new Error(`Unsupported layout type: ${layout instanceof Object ? layout.constructor?.name : typeof layout}`);
+}
+
+function toSelectedItem(obj: SceneObject, dashboard: ReturnType<typeof getCurrentDashboardSceneOrThrow>): Record<string, unknown> {
+  // Dashboard selection is represented as the dashboard instance itself.
+  if (obj === dashboard) {
+    return {
+      type: 'dashboard',
+      title: dashboard.state.title,
+      key: dashboard.state.key,
+    };
+  }
+
+  if (obj instanceof VizPanel) {
+    return {
+      type: 'panel',
+      panelId: getPanelIdForVizPanel(obj),
+      title: obj.state.title,
+      pluginId: obj.state.pluginId,
+      key: obj.state.key,
+    };
+  }
+
+  if (obj instanceof RowItem) {
+    return {
+      type: 'row',
+      rowKey: obj.state.key,
+      title: obj.state.title,
+    };
+  }
+
+  if (obj instanceof SceneGridRow) {
+    return {
+      type: 'row',
+      rowKey: obj.state.key,
+    };
+  }
+
+  if (obj instanceof TabItem) {
+    return {
+      type: 'tab',
+      tabSlug: obj.getSlug(),
+      title: obj.state.title,
+      key: obj.state.key,
+    };
+  }
+
+  if (obj instanceof SceneVariableSet) {
+    return {
+      type: 'variables',
+      key: obj.state.key,
+    };
+  }
+
+  if (obj instanceof MultiValueVariable || obj instanceof TextBoxVariable) {
+    return {
+      type: 'variable',
+      name: obj.state.name,
+      value: obj.getValue(),
+      key: obj.state.key,
+    };
+  }
+
+  return {
+    type: 'unknown',
+    key: obj.state.key,
+    class: obj.constructor?.name,
+  };
 }
 
 export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
@@ -258,6 +412,48 @@ export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
     );
   },
 
+  getCurrentDashboardSelection: (space = 2) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    const isEditing = Boolean(dashboard.state.isEditing);
+
+    // Selection is only meaningful when editing; in view mode we keep this explicitly null.
+    if (!isEditing) {
+      return JSON.stringify({ isEditing, selection: null }, null, space);
+    }
+
+    const selection = dashboard.state.editPane.getSelection();
+    if (!selection) {
+      return JSON.stringify({ isEditing, selection: null }, null, space);
+    }
+
+    if (Array.isArray(selection)) {
+      return JSON.stringify(
+        {
+          isEditing,
+          selection: {
+            mode: 'multi',
+            items: selection.map((o) => toSelectedItem(o, dashboard)),
+          },
+        },
+        null,
+        space
+      );
+    }
+
+    return JSON.stringify(
+      {
+        isEditing,
+        selection: {
+          mode: 'single',
+          item: toSelectedItem(selection, dashboard),
+        },
+      },
+      null,
+      space
+    );
+  },
+
   focusCurrentDashboardRow: (rowJson: string) => {
     assertDashboardV2Enabled();
     const dashboard = getCurrentDashboardSceneOrThrow();
@@ -387,6 +583,556 @@ export const dashboardSceneJsonApiV2: DashboardSceneJsonApiV2 = {
     } catch {
       // ignore
     }
+  },
+
+  previewCurrentDashboardOps: (opsJson: string) => {
+    assertDashboardV2Enabled();
+    const parsed: unknown = JSON.parse(opsJson);
+    let ops: unknown[] = [];
+    if (Array.isArray(parsed)) {
+      ops = parsed;
+    } else if (isRecord(parsed)) {
+      const v = parsed['ops'];
+      if (Array.isArray(v)) {
+        ops = v;
+      }
+    }
+
+    if (!Array.isArray(ops)) {
+      return JSON.stringify({ ok: false, errors: ['Invalid ops JSON: expected an array or { ops: [] }'] }, null, 2);
+    }
+
+    const errors: string[] = [];
+    let supported = 0;
+    let unsupported = 0;
+
+    for (const op of ops) {
+      if (!isRecord(op) || typeof op['op'] !== 'string') {
+        errors.push('Invalid op: expected an object with "op" string');
+        continue;
+      }
+      const opName = op['op'];
+      if (
+        opName === 'setPanelTitle' ||
+        opName === 'setGridPos' ||
+        opName === 'mergePanelConfig' ||
+        opName === 'addPanel' ||
+        opName === 'removePanel' ||
+        opName === 'addRow' ||
+        opName === 'removeRow' ||
+        opName === 'addTab' ||
+        opName === 'removeTab' ||
+        opName === 'movePanelToRow' ||
+        opName === 'movePanelToTab'
+      ) {
+        supported++;
+      } else {
+        unsupported++;
+      }
+    }
+
+    // Best-effort: we do not validate existence here beyond parsing; apply will.
+    return JSON.stringify({ ok: errors.length === 0, supported, unsupported, errors: errors.length ? errors : undefined }, null, 2);
+  },
+
+  applyCurrentDashboardOps: (opsJson: string) => {
+    assertDashboardV2Enabled();
+    const dashboard = getCurrentDashboardSceneOrThrow();
+    if (!dashboard.state.isEditing) {
+      dashboard.onEnterEditMode?.();
+    }
+
+    const parsed: unknown = JSON.parse(opsJson);
+    let ops: unknown[] = [];
+    if (Array.isArray(parsed)) {
+      ops = parsed;
+    } else if (isRecord(parsed)) {
+      const v = parsed['ops'];
+      if (Array.isArray(v)) {
+        ops = v;
+      }
+    }
+
+    if (!Array.isArray(ops)) {
+      return JSON.stringify({ ok: false, errors: ['Invalid ops JSON: expected an array or { ops: [] }'] }, null, 2);
+    }
+
+    const errors: string[] = [];
+    let applied = 0;
+    const results: unknown[] = [];
+
+    const getPanelsById = (panelId: number) => {
+      // Note: dashboards can contain repeated panels (and some layouts can temporarily produce multiple
+      // VizPanel instances for the same legacy id). To keep the live view and the serialized save model
+      // consistent, apply config changes to all matching panels.
+      return dashboardSceneGraph.getVizPanels(dashboard).filter((p) => getPanelIdForVizPanel(p) === panelId);
+    };
+
+    function getRootTabsManager(): TabsLayoutManager | null {
+      const found = dashboard.state.body instanceof TabsLayoutManager ? dashboard.state.body : sceneGraph.findObject(dashboard, (o) => o instanceof TabsLayoutManager);
+      return found instanceof TabsLayoutManager ? found : null;
+    }
+
+    function getCurrentLayoutManager() {
+      const tabs = getRootTabsManager();
+      if (tabs) {
+        const currentTab = tabs.getCurrentTab();
+        if (!currentTab) {
+          throw new Error('Could not find currently active tab');
+        }
+        return currentTab.state.layout;
+      }
+      return dashboard.state.body;
+    }
+
+    function getCurrentRowsManagerOrThrow(): RowsLayoutManager {
+      const layout = getCurrentLayoutManager();
+      if (layout instanceof RowsLayoutManager) {
+        return layout;
+      }
+      throw new Error('Current layout is not RowsLayout (addRow/removeRow require RowsLayout)');
+    }
+
+    for (const op of ops) {
+      if (!isRecord(op) || typeof op['op'] !== 'string') {
+        errors.push('Invalid op: expected an object with "op" string');
+        continue;
+      }
+
+      const opName = op['op'];
+
+      try {
+        if (opName === 'addPanel') {
+          const title = op['title'];
+          const pluginId = op['pluginId'];
+          const rowTitle = op['rowTitle'];
+          const rowKey = op['rowKey'];
+
+          if (title !== undefined && typeof title !== 'string') {
+            throw new Error('addPanel: title must be a string when provided');
+          }
+          if (pluginId !== undefined && typeof pluginId !== 'string') {
+            throw new Error('addPanel: pluginId must be a string when provided');
+          }
+          if (rowTitle !== undefined && typeof rowTitle !== 'string') {
+            throw new Error('addPanel: rowTitle must be a string when provided');
+          }
+          if (rowKey !== undefined && typeof rowKey !== 'string') {
+            throw new Error('addPanel: rowKey must be a string when provided');
+          }
+
+          const vizPanel: VizPanel = getDefaultVizPanel();
+          if (typeof title === 'string') {
+            vizPanel.setState({ title });
+          }
+          if (typeof pluginId === 'string') {
+            vizPanel.setState({ pluginId });
+          }
+
+          const layout = getCurrentLayoutManager();
+
+          // If we're in a RowsLayout, optionally target a specific row; otherwise use last row.
+          if (layout instanceof RowsLayoutManager) {
+            const rows = layout.state.rows;
+            const row =
+              rows.find((r) => (rowKey ? r.state.key === rowKey : false) || (rowTitle ? r.state.title === rowTitle : false)) ??
+              rows[rows.length - 1];
+            if (!row) {
+              throw new Error('addPanel: no row available to add to');
+            }
+            row.state.layout.addPanel(vizPanel);
+          } else if ('addPanel' in layout && typeof layout.addPanel === 'function') {
+            layout.addPanel(vizPanel);
+          } else {
+            throw new Error('addPanel: current layout does not support adding panels');
+          }
+
+          const newPanelId = getPanelIdForVizPanel(vizPanel);
+          results.push({ op: 'addPanel', panelId: newPanelId, title: vizPanel.state.title });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'removePanel') {
+          const panelId = op['panelId'];
+          if (typeof panelId !== 'number') {
+            throw new Error('removePanel expects { panelId: number }');
+          }
+
+          const panels = getPanelsById(panelId);
+          if (panels.length === 0) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+
+          for (const panel of panels) {
+            dashboard.removePanel?.(panel);
+          }
+
+          results.push({ op: 'removePanel', panelId, removed: panels.length });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'addRow') {
+          const title = op['title'];
+          if (title !== undefined && typeof title !== 'string') {
+            throw new Error('addRow: title must be a string when provided');
+          }
+
+          // Mimic UI behavior: if the current tab is not a RowsLayout, migrate it to RowsLayout,
+          // then add a new empty row (so existing panels remain in the first row).
+          const tabsManager = getRootTabsManager();
+          const currentTab = tabsManager?.getCurrentTab();
+          const currentLayout = getCurrentLayoutManager();
+
+          if (!(currentLayout instanceof RowsLayoutManager)) {
+            addNewRowTo(currentLayout);
+          }
+
+          const nextLayout = currentTab ? currentTab.state.layout : dashboard.state.body;
+          if (!(nextLayout instanceof RowsLayoutManager)) {
+            throw new Error('Failed to switch to RowsLayout');
+          }
+
+          const existingTitles = new Set(
+            nextLayout.state.rows.map((r) => r.state.title).filter((t): t is string => typeof t === 'string' && t.length > 0)
+          );
+          const baseTitle = typeof title === 'string' && title.length ? title : 'New row';
+          let nextTitle = baseTitle;
+          if (existingTitles.has(nextTitle)) {
+            let i = 2;
+            while (existingTitles.has(`${baseTitle} ${i}`)) {
+              i++;
+            }
+            nextTitle = `${baseTitle} ${i}`;
+          }
+
+          const row = new RowItem({ title: nextTitle });
+          nextLayout.setState({ rows: [...nextLayout.state.rows, row] });
+
+          results.push({ op: 'addRow', rowKey: row.state.key, title: row.state.title });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'removeRow') {
+          const title = op['title'];
+          const rowKey = op['rowKey'];
+          if (title !== undefined && typeof title !== 'string') {
+            throw new Error('removeRow: title must be a string when provided');
+          }
+          if (rowKey !== undefined && typeof rowKey !== 'string') {
+            throw new Error('removeRow: rowKey must be a string when provided');
+          }
+
+          const rowsManager = getCurrentRowsManagerOrThrow();
+          const row =
+            rowsManager.state.rows.find((r) => (rowKey ? r.state.key === rowKey : false) || (title ? r.state.title === title : false));
+          if (!row) {
+            throw new Error('Row not found');
+          }
+          rowsManager.removeRow(row, true);
+          results.push({ op: 'removeRow', rowKey: row.state.key, title: row.state.title });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'movePanelToRow') {
+          const panelId = op['panelId'];
+          const rowKey = op['rowKey'];
+          const rowTitle = op['rowTitle'];
+
+          if (typeof panelId !== 'number') {
+            throw new Error('movePanelToRow expects { panelId: number, rowKey?: string, rowTitle?: string }');
+          }
+          if (rowKey !== undefined && typeof rowKey !== 'string') {
+            throw new Error('movePanelToRow: rowKey must be a string when provided');
+          }
+          if (rowTitle !== undefined && typeof rowTitle !== 'string') {
+            throw new Error('movePanelToRow: rowTitle must be a string when provided');
+          }
+
+          const rowsManager = getCurrentRowsManagerOrThrow();
+          const targetRow =
+            rowsManager.state.rows.find((r) => (rowKey ? r.state.key === rowKey : false) || (rowTitle ? r.state.title === rowTitle : false)) ??
+            rowsManager.state.rows[rowsManager.state.rows.length - 1];
+
+          if (!targetRow) {
+            throw new Error('movePanelToRow: target row not found');
+          }
+
+          const targetLayout = targetRow.state.layout;
+          if (!(targetLayout instanceof AutoGridLayoutManager || targetLayout instanceof DefaultGridLayoutManager)) {
+            throw new Error(
+              `movePanelToRow currently supports only AutoGrid and Grid row layouts (got ${targetLayout.constructor?.name ?? 'unknown'})`
+            );
+          }
+
+          const panels = getPanelsById(panelId);
+          if (panels.length === 0) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+
+          for (const p of panels) {
+            const sourceGridItem = p.parent instanceof DashboardGridItem ? p.parent : undefined;
+            removeVizPanelFromCurrentLayoutInPlace(p);
+            p.clearParent();
+            addVizPanelToLayoutInPlace(targetLayout, p, sourceGridItem);
+          }
+
+          results.push({
+            op: 'movePanelToRow',
+            panelId,
+            rowKey: targetRow.state.key,
+            rowTitle: targetRow.state.title,
+            moved: panels.length,
+          });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'movePanelToTab') {
+          const panelId = op['panelId'];
+          const tabTitle = op['tabTitle'];
+          const tabSlug = op['tabSlug'];
+
+          if (typeof panelId !== 'number') {
+            throw new Error('movePanelToTab expects { panelId: number, tabTitle?: string, tabSlug?: string }');
+          }
+          if (tabTitle !== undefined && typeof tabTitle !== 'string') {
+            throw new Error('movePanelToTab: tabTitle must be a string when provided');
+          }
+          if (tabSlug !== undefined && typeof tabSlug !== 'string') {
+            throw new Error('movePanelToTab: tabSlug must be a string when provided');
+          }
+
+          const tabsManager = getRootTabsManager();
+          if (!tabsManager) {
+            throw new Error('movePanelToTab requires TabsLayout');
+          }
+
+          const tab = tabsManager.state.tabs.find(
+            (t) => (tabSlug ? t.getSlug() === tabSlug : false) || (tabTitle ? t.state.title === tabTitle : false)
+          );
+          if (!tab) {
+            throw new Error('Tab not found');
+          }
+
+          const panels = getPanelsById(panelId);
+          if (panels.length === 0) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+          if (panels.length > 1) {
+            throw new Error('movePanelToTab does not support repeated panels (multiple instances share the same panelId)');
+          }
+
+          const panel = panels[0];
+          const sourceGridItem = panel.parent instanceof DashboardGridItem ? panel.parent : undefined;
+          removeVizPanelFromCurrentLayoutInPlace(panel);
+          panel.clearParent();
+          const targetLayout = tab.getLayout();
+          if (targetLayout instanceof RowsLayoutManager) {
+            // Keep behavior aligned with RowsLayoutManager.addPanel (adds to first row), but support both grid types.
+            const firstRow = targetLayout.state.rows[0];
+            if (!firstRow) {
+              throw new Error('movePanelToTab: target tab has no rows');
+            }
+            addVizPanelToLayoutInPlace(firstRow.state.layout, panel, sourceGridItem);
+          } else {
+            addVizPanelToLayoutInPlace(targetLayout, panel, sourceGridItem);
+          }
+
+          results.push({ op: 'movePanelToTab', panelId, tabTitle: tab.state.title, tabSlug: tab.getSlug() });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'addTab') {
+          const title = op['title'];
+          if (title !== undefined && typeof title !== 'string') {
+            throw new Error('addTab: title must be a string when provided');
+          }
+
+          const tabsManager = getRootTabsManager();
+          if (!tabsManager) {
+            throw new Error('addTab/removeTab require TabsLayout');
+          }
+
+          // Important: tab slug is derived from title. Set title before adding so currentTabSlug points at the final slug.
+          const newTab = typeof title === 'string' && title.length ? new TabItem({ title }) : new TabItem({});
+          const tab = tabsManager.addNewTab(newTab);
+          // Defensive: make sure we end up on the final slug (slug can change if title is later edited / uniquified).
+          tabsManager.switchToTab(tab);
+          // keep URL in sync with the new tab selection
+          locationService.partial({ [tabsManager.getUrlKey()]: tab.getSlug() }, true);
+
+          results.push({ op: 'addTab', slug: tab.getSlug(), title: tab.state.title });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'removeTab') {
+          const title = op['title'];
+          const slug = op['slug'];
+          if (title !== undefined && typeof title !== 'string') {
+            throw new Error('removeTab: title must be a string when provided');
+          }
+          if (slug !== undefined && typeof slug !== 'string') {
+            throw new Error('removeTab: slug must be a string when provided');
+          }
+
+          const tabsManager = getRootTabsManager();
+          if (!tabsManager) {
+            throw new Error('addTab/removeTab require TabsLayout');
+          }
+
+          const tab = tabsManager.getTabsIncludingRepeats().find((t) => (slug ? t.getSlug() === slug : false) || (title ? t.state.title === title : false));
+          if (!tab) {
+            throw new Error('Tab not found');
+          }
+
+          tabsManager.removeTab(tab, true);
+          // keep URL in sync with the new current tab
+          const current = tabsManager.getCurrentTab();
+          if (current) {
+            locationService.partial({ [tabsManager.getUrlKey()]: current.getSlug() }, true);
+          }
+
+          results.push({ op: 'removeTab', slug: tab.getSlug(), title: tab.state.title });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'setPanelTitle') {
+          const panelId = op['panelId'];
+          const title = op['title'];
+          if (typeof panelId !== 'number' || typeof title !== 'string') {
+            throw new Error('setPanelTitle expects { panelId: number, title: string }');
+          }
+          const panels = getPanelsById(panelId);
+          if (panels.length === 0) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+          for (const panel of panels) {
+            panel.onTitleChange?.(title);
+          }
+          applied++;
+          continue;
+        }
+
+        if (opName === 'setGridPos') {
+          const panelIdRaw = op['panelId'];
+          const xRaw = op['x'];
+          const yRaw = op['y'];
+          const wRaw = op['w'];
+          const hRaw = op['h'];
+          if (
+            typeof panelIdRaw !== 'number' ||
+            typeof xRaw !== 'number' ||
+            typeof yRaw !== 'number' ||
+            typeof wRaw !== 'number' ||
+            typeof hRaw !== 'number'
+          ) {
+            throw new Error('setGridPos expects { panelId: number, x: number, y: number, w: number, h: number }');
+          }
+          const panelId = panelIdRaw;
+          const x = xRaw;
+          const y = yRaw;
+          const w = wRaw;
+          const h = hRaw;
+
+          const panels = getPanelsById(panelId);
+          const panel = panels[0];
+          if (!panel) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+          const gridItem = findParent(panel, (o): o is DashboardGridItem => o instanceof DashboardGridItem);
+          if (!gridItem) {
+            // AutoGrid does not support explicit positions; require full apply for now.
+            throw new Error('setGridPos is only supported for GridLayout panels');
+          }
+          gridItem.setState({ x, y, width: w, height: h });
+          applied++;
+          continue;
+        }
+
+        if (opName === 'mergePanelConfig') {
+          const panelId = op['panelId'];
+          const mergeObj = op['merge'];
+          if (typeof panelId !== 'number' || !isRecord(mergeObj)) {
+            throw new Error('mergePanelConfig expects { panelId: number, merge: object }');
+          }
+          const panels = getPanelsById(panelId);
+          if (panels.length === 0) {
+            throw new Error(`Panel not found: ${panelId}`);
+          }
+
+          // Accept either { vizConfig: { fieldConfig?, options? } } or { fieldConfig?, options? }.
+          const vizConfigAny = mergeObj['vizConfig'];
+          const vizConfig = isRecord(vizConfigAny) ? vizConfigAny : undefined;
+          const fieldConfigAny = (vizConfig && vizConfig['fieldConfig']) ?? mergeObj['fieldConfig'];
+          const optionsAny = (vizConfig && vizConfig['options']) ?? mergeObj['options'];
+
+          for (const panel of panels) {
+            // Field config: support defaults merge (units, decimals, thresholds, mappings, etc).
+            if (isRecord(fieldConfigAny)) {
+              const defaultsAny = fieldConfigAny['defaults'];
+              if (isRecord(defaultsAny)) {
+                const prevDefaults = panel.state.fieldConfig?.defaults ?? {};
+                const prevOverrides = panel.state.fieldConfig?.overrides ?? [];
+                const nextDefaults = { ...prevDefaults, ...defaultsAny };
+                const nextFieldConfig = { defaults: nextDefaults, overrides: prevOverrides };
+                // Prefer `onFieldConfigChange` so the panel clears its internal field-config cache and
+                // applies plugin defaults consistently (needed for correct rendering, e.g. stat thresholds).
+                try {
+                  panel.onFieldConfigChange?.(nextFieldConfig, true);
+                } catch {
+                  // Fallback to a plain state update if plugin defaults application fails.
+                  panel.setState({ fieldConfig: nextFieldConfig });
+                }
+              }
+            }
+
+            // Options: allow passing arbitrary plugin options object (DeepPartial<{}> is permissive).
+            if (isRecord(optionsAny)) {
+              panel.onOptionsChange?.(optionsAny, false);
+            }
+
+            // If merge included unknown keys, attempt a safe best-effort by merging state keys we recognize.
+            // (This intentionally stays conservative; prefer fieldConfig/options.)
+            const title = mergeObj['title'];
+            if (typeof title === 'string') {
+              panel.onTitleChange?.(title);
+            }
+          }
+
+          applied++;
+          continue;
+        }
+
+        errors.push(`Unsupported op: ${opName}`);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        errors.push(`${String(opName)}: ${msg}`);
+      }
+    }
+
+    // Mark dirty explicitly if currently editing and we applied changes. This helps keep Save enabled even if
+    // we applied changes before the change tracker picks them up.
+    if (applied > 0 && dashboard.state.isEditing) {
+      dashboard.setState({ isDirty: true });
+    }
+
+    return JSON.stringify(
+      {
+        ok: errors.length === 0,
+        applied,
+        results: results.length ? results : undefined,
+        errors: errors.length ? errors : undefined,
+      },
+      null,
+      2
+    );
   },
 };
 

--- a/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSceneToSaveModelSchemaV2.ts
@@ -140,9 +140,13 @@ export function transformSceneToSaveModelSchemaV2(scene: DashboardScene, isSnaps
   };
 
   try {
+    // Remove nulls before validation since schema v2 does not support null for many fields,
+    // but the live scene state can still contain nulls (for example, in thresholds step values).
+    const cleaned = sortedDeepCloneWithoutNulls(dashboardSchemaV2, true);
+
     // validateDashboardSchemaV2 will throw an error if the dashboard is not valid
-    if (validateDashboardSchemaV2(dashboardSchemaV2)) {
-      return sortedDeepCloneWithoutNulls(dashboardSchemaV2, true);
+    if (validateDashboardSchemaV2(cleaned)) {
+      return cleaned;
     }
     // should never reach this point, validation should throw an error
     throw new Error('Error we could transform the dashboard to schema v2: ' + dashboardSchemaV2);

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -1,9 +1,5 @@
 import { PanelData, RawTimeRange } from '@grafana/data';
-import {
-  applyCurrentDashboard,
-  getCurrentDashboard,
-  getCurrentDashboardErrors,
-} from '@grafana/runtime';
+import { getDashboardApi } from '@grafana/runtime';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
@@ -21,9 +17,28 @@ declare global {
      * Intended for browser console usage.
      */
     dashboardApi?: {
-      getCurrentDashboard: (space?: number) => string;
-      getCurrentDashboardErrors: (space?: number) => string;
-      applyCurrentDashboard: (resourceJson: string) => void;
+      help: () => string;
+      navigation: {
+        getCurrent: (space?: number) => string;
+        selectTab: (tabJson: string) => void;
+        focusRow: (rowJson: string) => void;
+        focusPanel: (panelJson: string) => void;
+      };
+      variables: {
+        getCurrent: (space?: number) => string;
+        apply: (varsJson: string) => void;
+      };
+      timeRange: {
+        getCurrent: (space?: number) => string;
+        apply: (timeRangeJson: string) => void;
+      };
+      errors: {
+        getCurrent: (space?: number) => string;
+      };
+      dashboard: {
+        getCurrent: (space?: number) => string;
+        apply: (resourceJson: string) => void;
+      };
     };
   }
 }
@@ -70,9 +85,6 @@ export function initWindowRuntime() {
   };
 
   // Expose the same API that plugins use via @grafana/runtime, but on `window` for easy console access.
-  window.dashboardApi = {
-    getCurrentDashboard,
-    getCurrentDashboardErrors,
-    applyCurrentDashboard,
-  };
+  // Only the grouped API surface is exposed.
+  window.dashboardApi = getDashboardApi();
 }

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -25,6 +25,7 @@ declare global {
       };
       navigation: {
         getCurrent: (space?: number) => string;
+        getSelection: (space?: number) => string;
         selectTab: (tabJson: string) => void;
         focusRow: (rowJson: string) => void;
         focusPanel: (panelJson: string) => void;
@@ -43,6 +44,8 @@ declare global {
       dashboard: {
         getCurrent: (space?: number) => string;
         apply: (resourceJson: string) => void;
+        previewOps: (opsJson: string) => string;
+        applyOps: (opsJson: string) => string;
       };
     };
   }

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -1,4 +1,8 @@
 import { PanelData, RawTimeRange } from '@grafana/data';
+import {
+  applyCurrentDashboard,
+  getCurrentDashboard,
+} from '@grafana/runtime';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
 
@@ -10,6 +14,14 @@ declare global {
       getDashboardSaveModel: () => DashboardModel | undefined;
       getDashboardTimeRange: () => { from: number; to: number; raw: RawTimeRange };
       getPanelData: () => Record<number, PanelData | undefined> | undefined;
+    };
+    /**
+     * Exposes the current-dashboard schema v2 JSON API for debugging / automation.
+     * Intended for browser console usage.
+     */
+    dashboardApi?: {
+      getCurrentDashboard: (space?: number) => string;
+      applyCurrentDashboard: (resourceJson: string) => void;
     };
   }
 }
@@ -53,5 +65,11 @@ export function initWindowRuntime() {
         return acc;
       }, {});
     },
+  };
+
+  // Expose the same API that plugins use via @grafana/runtime, but on `window` for easy console access.
+  window.dashboardApi = {
+    getCurrentDashboard,
+    applyCurrentDashboard,
   };
 }

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -18,6 +18,11 @@ declare global {
      */
     dashboardApi?: {
       help: () => string;
+      schema: {
+        getSources: (space?: number) => string;
+        getDashboard: (space?: number) => Promise<string>;
+        getDashboardSync: (space?: number) => string;
+      };
       navigation: {
         getCurrent: (space?: number) => string;
         selectTab: (tabJson: string) => void;

--- a/public/app/features/runtime/init.ts
+++ b/public/app/features/runtime/init.ts
@@ -2,6 +2,7 @@ import { PanelData, RawTimeRange } from '@grafana/data';
 import {
   applyCurrentDashboard,
   getCurrentDashboard,
+  getCurrentDashboardErrors,
 } from '@grafana/runtime';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { getTimeSrv } from 'app/features/dashboard/services/TimeSrv';
@@ -21,6 +22,7 @@ declare global {
      */
     dashboardApi?: {
       getCurrentDashboard: (space?: number) => string;
+      getCurrentDashboardErrors: (space?: number) => string;
       applyCurrentDashboard: (resourceJson: string) => void;
     };
   }
@@ -70,6 +72,7 @@ export function initWindowRuntime() {
   // Expose the same API that plugins use via @grafana/runtime, but on `window` for easy console access.
   window.dashboardApi = {
     getCurrentDashboard,
+    getCurrentDashboardErrors,
     applyCurrentDashboard,
   };
 }


### PR DESCRIPTION
## Summary

This PR is an **exploration / proof-of-concept** that introduces a **frontend-only DashboardScene JSON API** intended for LLM-driven dashboard editing (for example via `grafana-assistant`) and for debugging/automation in the browser.

It focuses on making the “edit dashboard as JSON” workflow reliable, safe, and usable from plugins and the console, while also exploring a pragmatic path to **partial updates** that avoid full scene rebuilds.

## What’s included (by area)

### Frontend DashboardScene JSON API (schema v2)

Adds a registered API surface (via `@grafana/runtime`) for operating on the **currently open** `DashboardScene`:

- **Read current dashboard** as a **`dashboard.grafana.app/v2beta1` `Dashboard` kind** JSON (string).
- **Apply dashboard updates** from JSON (string), with **spec-only mutation enforcement**:
  - Reject changes to `apiVersion`, `kind`, `metadata`, `status`
  - Only `spec` is allowed to change
- **V2 gating**: throws a clear error when schema v2 dashboards are not enabled.

Core files:
- `packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts`
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`
- `public/app/app.ts`

### Resilience / recovery when serialization fails

Makes the API resilient to cases where the live `DashboardScene` cannot be serialized back into schema v2 (for example unsupported transformations).

- `getCurrentDashboard()` falls back to a **last-known-good cached resource**
- `applyCurrentDashboard()` can still function in recovery scenarios while maintaining immutability rules

Key implementation:
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`

### Schema for LLMs (OpenAPI bundle)

Adds a way for an LLM to fetch a machine-readable **v2 dashboard schema**:

- `dashboardApi.schema.getDashboard()` returns a compact **OpenAPI schema bundle** for `dashboard.grafana.app/v2beta1 Dashboard`

Key implementation:
- `packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts`
- Adapter wiring in `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`

### Errors API (query errors aggregation)

Adds a method to collect current panel query errors from the open dashboard and expose them as JSON:

- `dashboardApi.errors.getCurrent()`

Key implementation:
- `public/app/features/dashboard-scene/api/currentDashboardErrors.ts`

### Navigation + variables + time range

Adds programmatic control of:
- **tab selection / focus navigation**
- **variable values**
- **time range**

Key implementation + tests:
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.navigation.test.ts`

### Partial updates (“ops”)

Introduces an experimental **ops-based** API for in-place mutations of the live scene graph to avoid unnecessary reloads:

- `dashboardApi.dashboard.previewOps()`
- `dashboardApi.dashboard.applyOps()`

Includes ops for:
- add/remove panels/rows/tabs
- move panel to row / move panel to tab (supports **AutoGrid + GridLayout** destinations)
- merge panel config (field config + options)
- set panel title / set grid position

Key implementation + tests:
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ops.test.ts`

### “Selection context” for LLM targeting

Adds `dashboardApi.navigation.getSelection()` to expose the current edit-pane selection as JSON so an LLM can interpret instructions like “update this panel”.

Key implementation:
- `public/app/features/dashboard-scene/api/runtimeDashboardSceneJsonApiV2.ts`
- `packages/grafana-runtime/src/services/dashboardSceneJsonApi.ts`

### Console access (window API)

Exposes the grouped API for debugging/automation:

- `window.dashboardApi = getDashboardApi()`

Key file:
- `public/app/features/runtime/init.ts`

## Tests / coverage

Adds unit tests around:
- kind read/apply behavior
- schema extraction/bundling
- errors aggregation
- navigation/time/variables
- ops behavior

Files include:
- `public/app/features/dashboard-scene/api/*test.ts`

## Notes / limitations (POC)

- This PR is **experimental** and intended for iteration as we learn what the LLM workflow needs.
- The ops API is intentionally scoped: it targets only the **currently loaded dashboard** and only supports a defined set of operations.


