### PR TITLE
Alerting: Fix export of imported Prometheus-style recording rules to terraform

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -493,6 +493,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 				r.GrafanaManagedAlert.NoDataState = apimodels.OK
 				r.GrafanaManagedAlert.ExecErrState = apimodels.AlertingErrState
 				r.GrafanaManagedAlert.NotificationSettings = &apimodels.AlertRuleNotificationSettings{}
+				r.GrafanaManagedAlert.MissingSeriesEvalsToResolve = util.Pointer[int64](1)
 				r.For = func() *model.Duration { five := model.Duration(time.Second * 5); return &five }()
 				r.KeepFiringFor = func() *model.Duration { five := model.Duration(time.Second * 5); return &five }()
 				return &r
@@ -502,6 +503,7 @@ func TestValidateRuleNode_NoUID(t *testing.T) {
 				require.Empty(t, alert.NoDataState)
 				require.Empty(t, alert.ExecErrState)
 				require.Nil(t, alert.NotificationSettings)
+				require.Nil(t, alert.MissingSeriesEvalsToResolve)
 				require.Zero(t, alert.For)
 				require.Zero(t, alert.KeepFiringFor)
 			},

--- a/pkg/services/ngalert/api/validation/api_ruler_validation.go
+++ b/pkg/services/ngalert/api/validation/api_ruler_validation.go
@@ -193,6 +193,7 @@ func validateRecordingRuleFields(in *apimodels.PostableExtendedRuleNode, newRule
 	newRule.For = 0
 	newRule.KeepFiringFor = 0
 	newRule.NotificationSettings = nil
+	newRule.MissingSeriesEvalsToResolve = nil
 
 	return newRule, nil
 }

--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -272,16 +272,16 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 		RuleGroup:     promGroup.Name,
 		IsPaused:      isPaused,
 		Record:        record,
+	}
+
+	if !isRecordingRule {
+		result.NotificationSettings = p.cfg.NotificationSettings
 
 		// MissingSeriesEvalsToResolve is set to 1 to match the Prometheus behaviour.
 		// Prometheus resolves alerts as soon as the series disappears.
 		// By setting this value to 1 we ensure that the alert is resolved on the first evaluation
 		// that doesn't have the series.
-		MissingSeriesEvalsToResolve: util.Pointer[int64](1),
-	}
-
-	if !isRecordingRule {
-		result.NotificationSettings = p.cfg.NotificationSettings
+		result.MissingSeriesEvalsToResolve = util.Pointer[int64](1)
 	}
 
 	if p.cfg.KeepOriginalRuleDefinition != nil && *p.cfg.KeepOriginalRuleDefinition {

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -358,7 +358,12 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 
 				require.Equal(t, models.Duration(evalOffset), grafanaRule.Data[0].RelativeTimeRange.To)
 				require.Equal(t, models.Duration(10*time.Minute+evalOffset), grafanaRule.Data[0].RelativeTimeRange.From)
-				require.Equal(t, util.Pointer(int64(1)), grafanaRule.MissingSeriesEvalsToResolve)
+
+				if promRule.Record != "" {
+					require.Nil(t, grafanaRule.MissingSeriesEvalsToResolve)
+				} else {
+					require.Equal(t, util.Pointer(int64(1)), grafanaRule.MissingSeriesEvalsToResolve)
+				}
 
 				require.Equal(t, models.OkErrState, grafanaRule.ExecErrState)
 				require.Equal(t, models.OK, grafanaRule.NoDataState)


### PR DESCRIPTION
**What is this feature?**

Do not export `missing_series_evals_to_resolve` field for recording rules.

**Why do we need this feature?**

Currently the "Export alert rule" feature exports this field too, and it's impossible to upload it back via Terraform because it's mutually exclusive with `record` field in the provider and we set it during the import of Prometheus-style rules. This PR removes it from both places: Grafana does not set it anymore for recording rules during the import, and does not populate the field for recording rules during the export.

**Who is this feature for?**

Users of "Export alert rule to Terraform" feature

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/terraform-provider-grafana/issues/2442

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
