### PR TITLE
Alerting: Fix a race condition panic in ResetStateByRuleUID

### DIFF
--- a/pkg/services/ngalert/schedule/registry.go
+++ b/pkg/services/ngalert/schedule/registry.go
@@ -101,13 +101,13 @@ func (e *Evaluation) Fingerprint() fingerprint {
 type alertRulesRegistry struct {
 	rules        map[models.AlertRuleKey]*models.AlertRule
 	folderTitles map[models.FolderKey]string
-	mu           sync.Mutex
+	mu           sync.RWMutex
 }
 
 // all returns all rules in the registry.
 func (r *alertRulesRegistry) all() ([]*models.AlertRule, map[models.FolderKey]string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	result := make([]*models.AlertRule, 0, len(r.rules))
 	for _, rule := range r.rules {
 		result = append(result, rule)
@@ -116,8 +116,8 @@ func (r *alertRulesRegistry) all() ([]*models.AlertRule, map[models.FolderKey]st
 }
 
 func (r *alertRulesRegistry) get(k models.AlertRuleKey) *models.AlertRule {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return r.rules[k]
 }
 
@@ -157,12 +157,14 @@ func (r *alertRulesRegistry) del(k models.AlertRuleKey) (*models.AlertRule, bool
 }
 
 func (r *alertRulesRegistry) isEmpty() bool {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return len(r.rules) == 0
 }
 
 func (r *alertRulesRegistry) needsUpdate(keys []models.AlertRuleKeyWithVersion) bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	if len(r.rules) != len(keys) {
 		return true
 	}

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -232,9 +232,7 @@ func (st *Manager) Get(orgID int64, alertRuleUID string, stateId data.Fingerprin
 	return st.cache.get(orgID, alertRuleUID, stateId)
 }
 
-// DeleteStateByRuleUID removes the rule instances from cache and instanceStore. A closed channel is returned to be able
-// to gracefully handle the clear state step in scheduler in case we do not need to use the historian to save state
-// history.
+// DeleteStateByRuleUID removes the rule instances from cache and instanceStore.
 func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.AlertRuleKeyWithGroup, reason string) []StateTransition {
 	logger := st.log.FromContext(ctx)
 	logger.Debug("Resetting state of the rule")
@@ -292,10 +290,14 @@ func (st *Manager) ForgetStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 // ResetStateByRuleUID removes the rule instances from cache and instanceStore and saves state history. If the state
 // history has to be saved, rule must not be nil.
 func (st *Manager) ResetStateByRuleUID(ctx context.Context, rule *ngModels.AlertRule, reason string) []StateTransition {
+	if rule == nil {
+		return nil
+	}
+
 	ruleKey := rule.GetKeyWithGroup()
 	transitions := st.DeleteStateByRuleUID(ctx, ruleKey, reason)
 
-	if rule == nil || st.historian == nil || len(transitions) == 0 {
+	if st.historian == nil || len(transitions) == 0 {
 		return transitions
 	}
 

--- a/pkg/services/ngalert/state/manager_test.go
+++ b/pkg/services/ngalert/state/manager_test.go
@@ -2051,6 +2051,39 @@ func TestIntegrationResetStateByRuleUID(t *testing.T) {
 	}
 }
 
+func TestResetStateByRuleUID(t *testing.T) {
+	ctx := context.Background()
+
+	setupManager := func(historian state.Historian) *state.Manager {
+		cfg := state.ManagerCfg{
+			Metrics:       metrics.NewNGAlert(prometheus.NewPedanticRegistry()).GetStateMetrics(),
+			ExternalURL:   nil,
+			InstanceStore: &state.FakeInstanceStore{},
+			Images:        &state.NoopImageService{},
+			Clock:         clock.NewMock(),
+			Historian:     historian,
+			Tracer:        tracing.InitializeTracerForTest(),
+			Log:           log.New("ngalert.state.manager"),
+		}
+
+		return state.NewManager(cfg, state.NewNoopPersister())
+	}
+
+	t.Run("with nil historian", func(t *testing.T) {
+		manager := setupManager(nil)
+
+		transitions := manager.ResetStateByRuleUID(ctx, nil, "test reason")
+		require.Empty(t, transitions)
+	})
+
+	t.Run("with historian", func(t *testing.T) {
+		manager := setupManager(&state.FakeHistorian{})
+
+		transitions := manager.ResetStateByRuleUID(ctx, nil, "test reason")
+		require.Empty(t, transitions)
+	})
+}
+
 func setCacheID(s *state.State) *state.State {
 	if s.CacheID != 0 {
 		return s


### PR DESCRIPTION
**What is this feature?**

This PR fixes a data race in the alert rule scheduler's registry that could cause nil pointer panics when updating alert rules:
* The `alertRulesRegistry.needsUpdate()` method reads `r.rules` map without holding a lock, while `set`, `update`, and `del` methods write to it with a lock. 
* `ResetStateByRuleUID` has a check for a `nil` rule, but the check was happening too late, the function called `rule.GetKeyWithGroup()` before checking if rule was nil

**Which issue(s) does this PR fix?**:

Fixes #114255

**Special notes for your reviewer:**

<details>
<summary>Race detection test</summary>


```go
func TestAlertRulesRegistry_NeedsUpdateRace(t *testing.T) {
	r := alertRulesRegistry{rules: make(map[models.AlertRuleKey]*models.AlertRule)}
	r.set([]*models.AlertRule{{OrgID: 1, UID: "rule1", Version: 1}}, nil)

	done := make(chan bool, 2)
	keys := []models.AlertRuleKeyWithVersion{{AlertRuleKey: models.AlertRuleKey{OrgID: 1, UID: "rule1"}, Version: 1}}

	// Read: needsUpdate()
	go func() {
		for range 50 {
			r.needsUpdate(keys)
		}
		done <- true
	}()

	// Write: set()
	go func() {
		for i := range 50 {
			r.set([]*models.AlertRule{{OrgID: 1, UID: "rule1", Version: int64(i + 2)}}, nil)
		}
		done <- true
	}()

	<-done
	<-done
}
```

On `main` branch:

```
=== RUN   TestAlertRulesRegistry_NeedsUpdateRace
==================
WARNING: DATA RACE

Write at 0x00c000a4c120 by goroutine 56:
  github.com/grafana/grafana/pkg/services/ngalert/schedule.(*alertRulesRegistry).set()
      /Users/alexander/projects/grafana/pkg/services/ngalert/schedule/registry.go:133 +0x2fc
  github.com/grafana/grafana/pkg/services/ngalert/schedule.TestAlertRulesRegistry_NeedsUpdateRace.func2()
      /Users/alexander/projects/grafana/pkg/services/ngalert/schedule/registry_test.go:329 +0x7c

Previous read at 0x00c000a4c120 by goroutine 55:
  github.com/grafana/grafana/pkg/services/ngalert/schedule.(*alertRulesRegistry).needsUpdate()
      /Users/alexander/projects/grafana/pkg/services/ngalert/schedule/registry.go:166 +0x68
  github.com/grafana/grafana/pkg/services/ngalert/schedule.TestAlertRulesRegistry_NeedsUpdateRace.func1()
      /Users/alexander/projects/grafana/pkg/services/ngalert/schedule/registry_test.go:321 +0xac

...
==================
    testing.go:1617: race detected during execution of test
--- FAIL: TestAlertRulesRegistry_NeedsUpdateRace (0.00s)
...
```

With the fix:

```
=== RUN   TestAlertRulesRegistry_NeedsUpdateRace
--- PASS: TestAlertRulesRegistry_NeedsUpdateRace (0.00s)
PASS
ok  	github.com/grafana/grafana/pkg/services/ngalert/schedule	2.280s
```

</details>

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
