### PR TITLE
access-control: guard against undefined permission select value

### DIFF
--- a/public/app/core/components/AccessControl/PermissionListItem.tsx
+++ b/public/app/core/components/AccessControl/PermissionListItem.tsx
@@ -31,7 +31,7 @@ export const PermissionListItem = ({ item, permissionLevels, canSet, onRemove, o
       <td>
         <Select
           disabled={!canSet || !item.isManaged}
-          onChange={(p) => onChange(item, p.value!)}
+          onChange={(p) => p?.value && onChange(item, p.value)}
           value={permissionLevels.find((p) => p === item.permission)}
           options={permissionLevels.map((p) => ({ value: p, label: p }))}
         />


### PR DESCRIPTION
What is this change?

Adds a defensive guard in the permission <Select> onChange handler to safely handle undefined values.

Why is this change needed?

This removes a non-null assertion and prevents potential runtime errors if the select emits an undefined value. It improves type safety without altering existing behavior.

Who is this change for?

Grafana developers and users working with access control permission management.

Which issue(s) does this PR fix?

Fixes #

Changelog impact

This is a small internal safety improvement with no user-facing behavior changes.
Suggested label: no-changelog

Special notes for reviewers

This is a non-breaking, defensive change only.

No behavior or UI changes are expected.

Please verify

The permission select continues to work as expected.

No regressions are introduced.

No feature flags or documentation updates are required for this change.
