### PR TITLE
fix: bump default facet search limit for unified search

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/dashboard/v0alpha1/endpoints.gen.ts
@@ -243,6 +243,7 @@ const injectedRtkApi = api
             type: queryArg['type'],
             folder: queryArg.folder,
             facet: queryArg.facet,
+            facetLimit: queryArg.facetLimit,
             tags: queryArg.tags,
             libraryPanel: queryArg.libraryPanel,
             permission: queryArg.permission,
@@ -663,6 +664,8 @@ export type SearchDashboardsAndFoldersApiArg = {
   folder?: string;
   /** count distinct terms for selected fields */
   facet?: string[];
+  /** maximum number of terms to return per facet (default 50, max 1000) */
+  facetLimit?: number;
   /** tag query filter */
   tags?: string[];
   /** find dashboards that reference a given libraryPanel */

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -349,6 +349,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, user identity.Requester, getDashboardsUIDsSharedWithUser func() ([]string, error)) (*resourcepb.ResourceSearchRequest, error) {
 	// get limit and offset from query params
 	limit := 50
+	facetLimit := 500
 	offset := 0
 	page := 1
 	if queryParams.Has("limit") {
@@ -431,12 +432,11 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 	// The facet term fields
 	if facets, ok := queryParams["facet"]; ok {
-		facetLimit := int64(50) // default limit
 		if queryParams.Has("facetLimit") {
-			if parsed, err := strconv.ParseInt(queryParams.Get("facetLimit"), 10, 64); err == nil && parsed > 0 {
+			if parsed, err := strconv.Atoi(queryParams.Get("facetLimit")); err == nil && parsed > 0 {
 				facetLimit = parsed
 				if facetLimit > 1000 {
-					facetLimit = 1000 // cap at 1000 for performance
+					facetLimit = 1000
 				}
 			}
 		}
@@ -444,7 +444,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		for _, v := range facets {
 			searchRequest.Facet[v] = &resourcepb.ResourceSearchRequest_Facet{
 				Field: v,
-				Limit: facetLimit,
+				Limit: int64(facetLimit),
 			}
 		}
 	}

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -426,7 +426,7 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 		for _, v := range facets {
 			searchRequest.Facet[v] = &resourcepb.ResourceSearchRequest_Facet{
 				Field: v,
-				Limit: 50,
+				Limit: 10000,
 			}
 		}
 	}

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -117,6 +117,15 @@ func (s *SearchHandler) GetAPIRoutes(defs map[string]common.OpenAPIDefinition) *
 								},
 								{
 									ParameterProps: spec3.ParameterProps{
+										Name:        "facetLimit",
+										In:          "query",
+										Description: "maximum number of terms to return per facet (default 50, max 1000)",
+										Required:    false,
+										Schema:      spec.Int64Property(),
+									},
+								},
+								{
+									ParameterProps: spec3.ParameterProps{
 										Name:        "tags",
 										In:          "query",
 										Description: "tag query filter",
@@ -422,11 +431,20 @@ func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, use
 
 	// The facet term fields
 	if facets, ok := queryParams["facet"]; ok {
+		facetLimit := int64(50) // default limit
+		if queryParams.Has("facetLimit") {
+			if parsed, err := strconv.ParseInt(queryParams.Get("facetLimit"), 10, 64); err == nil && parsed > 0 {
+				facetLimit = parsed
+				if facetLimit > 1000 {
+					facetLimit = 1000 // cap at 1000 for performance
+				}
+			}
+		}
 		searchRequest.Facet = make(map[string]*resourcepb.ResourceSearchRequest_Facet)
 		for _, v := range facets {
 			searchRequest.Facet[v] = &resourcepb.ResourceSearchRequest_Facet{
 				Field: v,
-				Limit: 10000,
+				Limit: facetLimit,
 			}
 		}
 	}

--- a/pkg/registry/apis/dashboard/search.go
+++ b/pkg/registry/apis/dashboard/search.go
@@ -349,7 +349,7 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 func convertHttpSearchRequestToResourceSearchRequest(queryParams url.Values, user identity.Requester, getDashboardsUIDsSharedWithUser func() ([]string, error)) (*resourcepb.ResourceSearchRequest, error) {
 	// get limit and offset from query params
 	limit := 50
-	facetLimit := 500
+	facetLimit := 50
 	offset := 0
 	page := 1
 	if queryParams.Has("limit") {

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -812,8 +812,40 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Explain: false,
 				Fields:  defaultFields,
 				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
-					"tags":   {Field: "tags", Limit: 10000},
-					"folder": {Field: "folder", Limit: 10000},
+					"tags":   {Field: "tags", Limit: 50},
+					"folder": {Field: "folder", Limit: 50},
+				},
+				Federated: []*resourcepb.ResourceKey{folderKey},
+			},
+		},
+		"facet fields with custom limit": {
+			queryString: "facet=tags&facetLimit=500",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{Key: dashboardKey},
+				Query:   "",
+				Limit:   50,
+				Offset:  0,
+				Page:    1,
+				Explain: false,
+				Fields:  defaultFields,
+				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
+					"tags": {Field: "tags", Limit: 500},
+				},
+				Federated: []*resourcepb.ResourceKey{folderKey},
+			},
+		},
+		"facet fields with limit exceeding max": {
+			queryString: "facet=tags&facetLimit=5000",
+			expected: &resourcepb.ResourceSearchRequest{
+				Options: &resourcepb.ListOptions{Key: dashboardKey},
+				Query:   "",
+				Limit:   50,
+				Offset:  0,
+				Page:    1,
+				Explain: false,
+				Fields:  defaultFields,
+				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
+					"tags": {Field: "tags", Limit: 1000},
 				},
 				Federated: []*resourcepb.ResourceKey{folderKey},
 			},

--- a/pkg/registry/apis/dashboard/search_test.go
+++ b/pkg/registry/apis/dashboard/search_test.go
@@ -812,8 +812,8 @@ func TestConvertHttpSearchRequestToResourceSearchRequest(t *testing.T) {
 				Explain: false,
 				Fields:  defaultFields,
 				Facet: map[string]*resourcepb.ResourceSearchRequest_Facet{
-					"tags":   {Field: "tags", Limit: 50},
-					"folder": {Field: "folder", Limit: 50},
+					"tags":   {Field: "tags", Limit: 10000},
+					"folder": {Field: "folder", Limit: 10000},
 				},
 				Federated: []*resourcepb.ResourceKey{folderKey},
 			},

--- a/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/dashboard.grafana.app-v0alpha1.json
@@ -1803,6 +1803,15 @@
             }
           },
           {
+            "name": "facetLimit",
+            "in": "query",
+            "description": "maximum number of terms to return per facet (default 50, max 1000)",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
             "name": "tags",
             "in": "query",
             "description": "tag query filter",

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -106,7 +106,7 @@ export class UnifiedSearcher implements GrafanaSearcher {
 
   async tags(query: SearchQuery): Promise<TermCount[]> {
     const qry = query.query ?? '*';
-    let uri = `${searchURI}?facet=tags&query=${qry}&limit=1`;
+    let uri = `${searchURI}?facet=tags&facetLimit=1000&query=${qry}&limit=1`;
     const resp = await getBackendSrv().get<SearchAPIResponse>(uri);
     return resp.facets?.tags?.terms || [];
   }


### PR DESCRIPTION
**Escalation:** https://github.com/grafana/support-escalations/issues/20049

Previously the facet limit has been hardcoded as 50. In this PR, we are introducing a new query parameter (`facetLimit`) through which the facet limit value can be passed onto the dashboard search request.

```
➜  ~ curl 'http://localhost:3000/apis/dashboard.grafana.app/v0alpha1/namespaces/default/search?facet=tags&facetLimit=1000&query=*&limit=1'
{
  "totalHits": 10,
  "hits": [
    {
      "resource": "dashboards",
      "name": "dash-1",
      "title": "Dashboard 1"
    }
  ],
  "queryCost": 207,
  "maxScore": 1,
  "facets": {
    "tags": {
      "field": "tags",
      "total": 57,  <--------- exceeding 50 with the new support!
      "missing": 9,
...
```

<img width="1452" height="950" alt="Screenshot 2025-12-23 at 15 42 32" src="https://github.com/user-attachments/assets/4900b5d5-9d69-452d-8f6e-229c3814dde6" />

