### PR TITLE
[release-12.0.9] chore(deps): update dependency node-forge to v1.3.3

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -22822,9 +22822,9 @@ __metadata:
   linkType: hard
 
 "node-forge@npm:^1, node-forge@npm:^1.3.1":
-  version: 1.3.1
-  resolution: "node-forge@npm:1.3.1"
-  checksum: 10/05bab6868633bf9ad4c3b1dd50ec501c22ffd69f556cdf169a00998ca1d03e8107a6032ba013852f202035372021b845603aeccd7dfcb58cdb7430013b3daa8d
+  version: 1.3.3
+  resolution: "node-forge@npm:1.3.3"
+  checksum: 10/f41c31b9296771a4b8c955d58417471712f54f324603a35f8e6cbac19d5e6eaaf5fd5fd14584dfedecbf46a05438ded6eee60a5f2f0822fc5061aaa073cfc75d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/114522 to release-12.0.9 to bump node-forge to v1.3.3

Cherry-pick was discarded and yarn up -R node-forge ran manually