### PR TITLE
Inspector: Fix Apply button alignment in JSON tab toolbar

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2657,11 +2657,6 @@
       "count": 1
     }
   },
-  "public/app/features/inspector/InspectJSONTab.tsx": {
-    "no-restricted-syntax": {
-      "count": 1
-    }
-  },
   "public/app/features/inspector/InspectStatsTab.tsx": {
     "@grafana/no-aria-label-selectors": {
       "count": 1

--- a/public/app/features/inspector/InspectJSONTab.tsx
+++ b/public/app/features/inspector/InspectJSONTab.tsx
@@ -125,7 +125,7 @@ export function InspectJSONTab({ panel, dashboard, data, onClose }: Props) {
   return (
     <div className={styles.wrap}>
       <div className={styles.toolbar} data-testid={selectors.components.PanelInspector.Json.content}>
-        <Field label={t('dashboard.inspect-json.select-source', 'Select source')} className="flex-grow-1">
+        <Field label={t('dashboard.inspect-json.select-source', 'Select source')} className="flex-grow-1" noMargin>
           <Select
             inputId="select-source-dropdown"
             options={jsonOptions}

--- a/public/app/features/inspector/styles.ts
+++ b/public/app/features/inspector/styles.ts
@@ -27,7 +27,7 @@ export const getPanelInspectorStyles2 = (theme: GrafanaTheme2) => {
       display: 'flex',
       width: '100%',
       flexGrow: 0,
-      alignItems: 'center',
+      alignItems: 'flex-end',
       justifyContent: 'flex-end',
       marginBottom: theme.v1.spacing.sm,
     }),


### PR DESCRIPTION
**What is this feature?**

This PR fixes the vertical alignment of the "Apply" button in the Panel Inspector's JSON tab toolbar. The button is now properly aligned with the "Select source" dropdown field.

before:
<img width="822" height="175" alt="image" src="https://github.com/user-attachments/assets/e0dffb70-6e4a-46e1-9539-1ce56c9e2385" />

after:

scenes:
<img width="831" height="195" alt="image" src="https://github.com/user-attachments/assets/66deb09f-172f-4723-b263-4d0ab36ceee9" />

non-scenes
<img width="808" height="216" alt="image" src="https://github.com/user-attachments/assets/139be0a8-f255-45ad-8d43-cd9fd8798192" />

