### PR TITLE
RefreshPicker: Fix icon disappearing when rapidly switching query states

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -8,6 +8,7 @@ import { t } from '@grafana/i18n';
 
 import { ButtonGroup } from '../Button/ButtonGroup';
 import { ButtonSelect } from '../Dropdown/ButtonSelect';
+import { Icon } from '../Icon/Icon';
 import { ToolbarButton, ToolbarButtonVariant } from '../ToolbarButton/ToolbarButton';
 
 // Default intervals used in the refresh picker component
@@ -80,6 +81,7 @@ export class RefreshPicker extends PureComponent<Props> {
     const { onRefresh, intervals, tooltip, value, text, isLoading, noIntervalPicker, width, showAutoInterval } =
       this.props;
 
+    const refreshIcon = isLoading ? 'spinner' : 'sync';
     const currentValue = value || '';
     const variant = this.getVariant();
     const options = intervalsToOptions({ intervals, showAutoInterval });
@@ -114,7 +116,7 @@ export class RefreshPicker extends PureComponent<Props> {
           tooltip={tooltip}
           onClick={onRefresh}
           variant={variant}
-          icon={isLoading ? 'spinner' : 'sync'}
+          icon={<Icon key={refreshIcon} name={refreshIcon} size="lg" />}
           style={width ? { width } : undefined}
           data-testid={selectors.components.RefreshPicker.runButtonV2}
         >


### PR DESCRIPTION
**What is this feature?**

This PR fixes an issue where the Run query button icon (spinner/sync) permanently disappears during rapid state changes, leaving the button with only text and no icon.

**Why do we need this feature?**

As reported in #115552, when users interact with Explore in ways that trigger rapid query state changes (such as repeatedly switching between Search and TraceQL tabs in Tempo, or rapidly clicking the Run query button), the button icon can permanently vanish.

**Root Cause:**

The `Icon` component uses `react-inlinesvg` to render SVG icons. This library:
1. Renders an **empty placeholder** `<svg>` while loading
2. Fetches/parses the SVG content asynchronously  
3. Replaces the placeholder with actual SVG content when loaded

During rapid state toggling (e.g., `Loading` → `Done` → `Loading` in <50ms), the icon prop switches between `spinner` and `sync` faster than the async load completes. React sees the same `<Icon>` component and tries to **reconcile** it by updating props rather than remounting. This leaves `react-inlinesvg`'s internal state machine stuck—it never completes loading and remains showing the empty placeholder permanently.

**How the fix works:**

- icon={isLoading ? 'spinner' : 'sync'}
+ icon={<Icon key={refreshIcon} name={refreshIcon} size="lg" />}Adding `key={refreshIcon}` (where `refreshIcon` is `'spinner'` or `'sync'`) forces React to treat icon changes as **different elements** rather than prop updates to the same element. When the key changes:

1. React **unmounts** the old Icon instance (destroying `react-inlinesvg`'s stuck internal state)
2. React **mounts** a fresh Icon instance with clean state
3. The new `react-inlinesvg` instance loads the correct SVG from scratch

This guarantees the icon always renders correctly regardless of how rapidly the state changes.

**Who is this feature for?**

Grafana users experiencing the disappearing icon issue in Explore, particularly when using datasources like Tempo where rapid tab switching or query state changes are common.

**Which issue(s) does this PR fix?**:

Fixes #115552

> **Note**: Issue #115552 also describes the spinner getting **stuck spinning** after queries complete. This is a separate state management issue where `LoadingState` doesn't transition to `Done` when Tempo returns results. That problem is **not addressed** by this PR and may require separate investigation.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (N/A - bug fix)
- [ ] The docs are updated (N/A - bug fix, no docs needed)