### PR TITLE
Alerting: Auto-format numeric values in Alert Rule History

### DIFF
--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
@@ -82,22 +82,17 @@ describe('LogRecordViewerByTimestamp', () => {
 
       render(<LogRecordViewerByTimestamp records={records} commonLabels={[]} />);
 
-      // Check that values are formatted correctly
       expect(screen.getByText(/cpu_usage/)).toBeInTheDocument();
-      // 42.987654321 has > 4 decimals, so should use scientific notation
       expect(screen.getByText(/4\.299e\+1/i)).toBeInTheDocument();
 
-      // Large number should use scientific notation
       expect(screen.getByText(/memory_mb/)).toBeInTheDocument();
-      expect(screen.getByText(/1\.235e\+6/i)).toBeInTheDocument(); // 1234567.89 → scientific notation
+      expect(screen.getByText(/1\.235e\+6/i)).toBeInTheDocument();
 
-      // Small number should use scientific notation
       expect(screen.getByText(/disk_io/)).toBeInTheDocument();
-      expect(screen.getByText(/1\.234e-3/i)).toBeInTheDocument(); // 0.001234 → scientific notation
+      expect(screen.getByText(/1\.234e-3/i)).toBeInTheDocument();
 
-      // Boundary value should use standard notation
       expect(screen.getByText(/request_count/)).toBeInTheDocument();
-      expect(screen.getByText(/10000/)).toBeInTheDocument(); // 10000 → 10000
+      expect(screen.getByText(/10000/)).toBeInTheDocument();
     });
 
     it('should format various numeric ranges correctly', () => {
@@ -121,21 +116,20 @@ describe('LogRecordViewerByTimestamp', () => {
 
       render(<LogRecordViewerByTimestamp records={records} commonLabels={[]} />);
 
-      // Verify all values are present and formatted
       expect(screen.getByText(/small/)).toBeInTheDocument();
-      expect(screen.getByText(/1\.000e-3/i)).toBeInTheDocument(); // 0.001 → scientific notation
+      expect(screen.getByText(/1\.000e-3/i)).toBeInTheDocument();
 
       expect(screen.getByText(/normal/)).toBeInTheDocument();
-      expect(screen.getByText(/42\.5/)).toBeInTheDocument(); // 42.5 → standard notation
+      expect(screen.getByText(/42\.5/)).toBeInTheDocument();
 
       expect(screen.getByText(/large/)).toBeInTheDocument();
-      expect(screen.getByText(/1\.235e\+5/i)).toBeInTheDocument(); // 123456 → scientific notation
+      expect(screen.getByText(/1\.235e\+5/i)).toBeInTheDocument();
 
       expect(screen.getByText(/boundary_low/)).toBeInTheDocument();
-      expect(screen.getByText(/0\.01/)).toBeInTheDocument(); // 0.01 → standard notation (boundary)
+      expect(screen.getByText(/0\.01/)).toBeInTheDocument();
 
       expect(screen.getByText(/boundary_high/)).toBeInTheDocument();
-      expect(screen.getByText(/10000/)).toBeInTheDocument(); // 10000 → standard notation (boundary)
+      expect(screen.getByText(/10000/)).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.test.tsx
@@ -84,7 +84,8 @@ describe('LogRecordViewerByTimestamp', () => {
 
       // Check that values are formatted correctly
       expect(screen.getByText(/cpu_usage/)).toBeInTheDocument();
-      expect(screen.getByText(/42\.9877/)).toBeInTheDocument(); // 42.987654321 → 42.9877 (4 decimals)
+      // 42.987654321 has > 4 decimals, so should use scientific notation
+      expect(screen.getByText(/4\.299e\+1/i)).toBeInTheDocument();
 
       // Large number should use scientific notation
       expect(screen.getByText(/memory_mb/)).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
+++ b/public/app/features/alerting/unified/components/rules/state-history/LogRecordViewer.tsx
@@ -13,6 +13,7 @@ import { AlertStateTag } from '../AlertStateTag';
 
 import { ErrorMessageRow } from './ErrorMessageRow';
 import { LogRecord, omitLabels } from './common';
+import { formatNumericValue } from './numberFormatter';
 
 type LogRecordViewerProps = {
   records: LogRecord[];
@@ -182,7 +183,7 @@ const AlertInstanceValues = memo(({ record }: { record: Record<string, number> }
   return (
     <>
       {values.map(([key, value]) => (
-        <AlertLabel key={key} labelKey={key} value={String(value)} />
+        <AlertLabel key={key} labelKey={key} value={formatNumericValue(value)} />
       ))}
     </>
   );

--- a/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
@@ -64,7 +64,7 @@ describe('formatNumericValue', () => {
     it('should limit to 4 decimal places without rounding integer parts', () => {
       expect(formatNumericValue(123.456)).toBe('123.456');
       expect(formatNumericValue(1234.567)).toBe('1234.567');
-      expect(formatNumericValue(9999.9)).toBe('9999.9'); // Preserves integer part, doesn't round to 10000
+      expect(formatNumericValue(9999.9)).toBe('9999.9');
       expect(formatNumericValue(9999.1234)).toBe('9999.1234');
     });
 
@@ -116,23 +116,18 @@ describe('formatNumericValue', () => {
 
   describe('Edge cases', () => {
     it('should handle numbers exactly at boundaries', () => {
-      // Lower boundary: exactly 1e-2 should use standard notation
       expect(formatNumericValue(0.01)).toBe('0.01');
 
-      // Just below boundary should use scientific notation
       const justBelow = formatNumericValue(0.009999);
       expect(justBelow).toMatch(/^9\.999e-3$/i);
 
-      // Upper boundary: exactly 1e4 should use standard notation
       expect(formatNumericValue(10000)).toBe('10000');
 
-      // Just above boundary should use scientific notation
       const justAbove = formatNumericValue(10001);
       expect(justAbove).toMatch(/^1\.000e\+4$/i);
     });
 
     it('should use scientific notation for very precise decimals with > 4 decimal places', () => {
-      // Numbers with > 4 decimals use scientific notation
       expect(formatNumericValue(1.23456789)).toMatch(/^1\.235e\+0$/i);
       expect(formatNumericValue(123.456789)).toMatch(/^1\.235e\+2$/i);
       expect(formatNumericValue(0.123456789)).toMatch(/^1\.235e-1$/i);
@@ -147,36 +142,29 @@ describe('formatNumericValue', () => {
 
   describe('countDecimalPlaces edge cases', () => {
     it('should handle numbers that toString() would convert to scientific notation', () => {
-      // Very small number - magnitude check handles it, countDecimalPlaces should return 0
-      // This tests that we don't try to count decimals for numbers outside readable range
       const result = formatNumericValue(1e-10);
-      expect(result).toMatch(/^1\.000e-10$/i); // Uses scientific notation based on magnitude
+      expect(result).toMatch(/^1\.000e-10$/i);
 
-      // Very large number
       const result2 = formatNumericValue(1e10);
-      expect(result2).toMatch(/^1\.000e\+10$/i); // Uses scientific notation based on magnitude
+      expect(result2).toMatch(/^1\.000e\+10$/i);
     });
 
     it('should correctly count decimals for numbers with trailing zeros', () => {
-      // These should use standard notation (≤ 4 decimals)
-      expect(formatNumericValue(1.234)).toBe('1.234'); // Trailing zero removed, 3 decimals
-      expect(formatNumericValue(1.2)).toBe('1.2'); // Trailing zeros removed, 1 decimal
-      expect(formatNumericValue(1.0)).toBe('1'); // All zeros removed, treated as integer
+      expect(formatNumericValue(1.234)).toBe('1.234');
+      expect(formatNumericValue(1.2)).toBe('1.2');
+      expect(formatNumericValue(1.0)).toBe('1');
     });
 
     it('should handle boundary values correctly', () => {
-      // Exactly at boundaries
-      expect(formatNumericValue(0.01)).toBe('0.01'); // 2 decimals, standard notation
-      expect(formatNumericValue(10000)).toBe('10000'); // Integer, standard notation
+      expect(formatNumericValue(0.01)).toBe('0.01');
+      expect(formatNumericValue(10000)).toBe('10000');
 
-      // Just inside boundaries with many decimals
-      expect(formatNumericValue(0.01001)).toMatch(/^1\.001e-2$/i); // 5 decimals, scientific notation
-      expect(formatNumericValue(9999.1234)).toBe('9999.1234'); // 4 decimals, standard notation
-      expect(formatNumericValue(9999.12345)).toMatch(/^9\.999e\+3$/i); // 5 decimals, scientific notation
+      expect(formatNumericValue(0.01001)).toMatch(/^1\.001e-2$/i);
+      expect(formatNumericValue(9999.1234)).toBe('9999.1234');
+      expect(formatNumericValue(9999.12345)).toMatch(/^9\.999e\+3$/i);
     });
 
     it('should handle numbers in readable range that have many decimals', () => {
-      // These should use scientific notation due to > 4 decimal places
       expect(formatNumericValue(1.4153928131348452)).toMatch(/^1\.415e\+0$/i);
       expect(formatNumericValue(42.987654321)).toMatch(/^4\.299e\+1$/i);
       expect(formatNumericValue(123.456789)).toMatch(/^1\.235e\+2$/i);

--- a/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
@@ -1,0 +1,130 @@
+import { formatNumericValue } from './numberFormatter';
+
+describe('formatNumericValue', () => {
+  describe('Zero and special values', () => {
+    it('should format zero correctly', () => {
+      expect(formatNumericValue(0)).toBe('0');
+      expect(formatNumericValue(-0)).toBe('0');
+    });
+
+    it('should handle NaN', () => {
+      expect(formatNumericValue(NaN)).toBe('NaN');
+    });
+
+    it('should handle Infinity', () => {
+      expect(formatNumericValue(Infinity)).toBe('Infinity');
+      expect(formatNumericValue(-Infinity)).toBe('-Infinity');
+    });
+  });
+
+  describe('Very small numbers (scientific notation)', () => {
+    it('should use scientific notation for values less than 1e-2', () => {
+      const result1 = formatNumericValue(1e-3);
+      expect(result1).toMatch(/^1\.000e-3$/i);
+
+      const result2 = formatNumericValue(0.001);
+      expect(result2).toMatch(/^1\.000e-3$/i);
+
+      const result3 = formatNumericValue(0.009);
+      expect(result3).toMatch(/^9\.000e-3$/i);
+    });
+
+    it('should use scientific notation for values just below 1e-2', () => {
+      const result = formatNumericValue(0.00999);
+      expect(result).toMatch(/^9\.990e-3$/i);
+    });
+
+    it('should format the example from requirements correctly', () => {
+      // 1.4153928131348452 is in readable range (> 1e-2), so should use standard notation with 4 decimals
+      const result = formatNumericValue(1.4153928131348452);
+      expect(result).toBe('1.4154');
+    });
+
+    it('should handle negative very small numbers', () => {
+      const result = formatNumericValue(-1e-3);
+      expect(result).toMatch(/^-1\.000e-3$/i);
+
+      const result2 = formatNumericValue(-0.001);
+      expect(result2).toMatch(/^-1\.000e-3$/i);
+    });
+  });
+
+  describe('Human-readable range (standard notation)', () => {
+    it('should use standard notation for boundary value 1e-2', () => {
+      expect(formatNumericValue(0.01)).toBe('0.01');
+    });
+
+    it('should use standard notation for values in readable range', () => {
+      expect(formatNumericValue(0.1)).toBe('0.1');
+      expect(formatNumericValue(1)).toBe('1');
+      expect(formatNumericValue(1.234)).toBe('1.234');
+      expect(formatNumericValue(42.5)).toBe('42.5');
+    });
+
+    it('should limit to 4 decimal places without rounding integer parts', () => {
+      expect(formatNumericValue(123.456)).toBe('123.456');
+      expect(formatNumericValue(123.456789)).toBe('123.4568');
+      expect(formatNumericValue(1234.567)).toBe('1234.567');
+      expect(formatNumericValue(9999.9)).toBe('9999.9');
+      expect(formatNumericValue(9999.1234)).toBe('9999.1234');
+    });
+
+    it('should use standard notation for boundary value 1e4', () => {
+      expect(formatNumericValue(10000)).toBe('10000');
+    });
+
+    it('should handle negative numbers in readable range', () => {
+      expect(formatNumericValue(-0.1)).toBe('-0.1');
+      expect(formatNumericValue(-42.98765)).toBe('-42.9877');
+      expect(formatNumericValue(-123.456)).toBe('-123.456');
+      expect(formatNumericValue(-9999.9)).toBe('-9999.9');
+    });
+  });
+
+  describe('Very large numbers (scientific notation)', () => {
+    it('should use scientific notation for values greater than 1e4', () => {
+      const result1 = formatNumericValue(10001);
+      expect(result1).toMatch(/^1\.000e\+4$/i);
+
+      const result2 = formatNumericValue(123456);
+      expect(result2).toMatch(/^1\.235e\+5$/i);
+    });
+
+    it('should handle negative very large numbers', () => {
+      const result = formatNumericValue(-1e5);
+      expect(result).toMatch(/^-1\.000e\+5$/i);
+
+      const result2 = formatNumericValue(-123456);
+      expect(result2).toMatch(/^-1\.235e\+5$/i);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('should handle numbers exactly at boundaries', () => {
+      // Lower boundary: exactly 1e-2 should use standard notation
+      expect(formatNumericValue(0.01)).toBe('0.01');
+
+      // Just below boundary should use scientific notation
+      const justBelow = formatNumericValue(0.009999);
+      expect(justBelow).toMatch(/^9\.999e-3$/i);
+
+      // Upper boundary: exactly 1e4 should use standard notation
+      expect(formatNumericValue(10000)).toBe('10000');
+
+      // Just above boundary should use scientific notation
+      const justAbove = formatNumericValue(10001);
+      expect(justAbove).toMatch(/^1\.000e\+4$/i);
+    });
+
+    it('should limit decimal places for very precise decimals', () => {
+      expect(formatNumericValue(1.23456789)).toBe('1.2346');
+      expect(formatNumericValue(123.456789)).toBe('123.4568');
+      expect(formatNumericValue(0.123456789)).toBe('0.1235');
+    });
+
+    it('should handle floating-point precision artifacts', () => {
+      const result = formatNumericValue(0.1 + 0.2);
+      expect(result).toMatch(/^0\.3/);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.test.ts
@@ -144,4 +144,42 @@ describe('formatNumericValue', () => {
       expect(formatNumericValue(123.4567)).toBe('123.4567');
     });
   });
+
+  describe('countDecimalPlaces edge cases', () => {
+    it('should handle numbers that toString() would convert to scientific notation', () => {
+      // Very small number - magnitude check handles it, countDecimalPlaces should return 0
+      // This tests that we don't try to count decimals for numbers outside readable range
+      const result = formatNumericValue(1e-10);
+      expect(result).toMatch(/^1\.000e-10$/i); // Uses scientific notation based on magnitude
+
+      // Very large number
+      const result2 = formatNumericValue(1e10);
+      expect(result2).toMatch(/^1\.000e\+10$/i); // Uses scientific notation based on magnitude
+    });
+
+    it('should correctly count decimals for numbers with trailing zeros', () => {
+      // These should use standard notation (≤ 4 decimals)
+      expect(formatNumericValue(1.234)).toBe('1.234'); // Trailing zero removed, 3 decimals
+      expect(formatNumericValue(1.2)).toBe('1.2'); // Trailing zeros removed, 1 decimal
+      expect(formatNumericValue(1.0)).toBe('1'); // All zeros removed, treated as integer
+    });
+
+    it('should handle boundary values correctly', () => {
+      // Exactly at boundaries
+      expect(formatNumericValue(0.01)).toBe('0.01'); // 2 decimals, standard notation
+      expect(formatNumericValue(10000)).toBe('10000'); // Integer, standard notation
+
+      // Just inside boundaries with many decimals
+      expect(formatNumericValue(0.01001)).toMatch(/^1\.001e-2$/i); // 5 decimals, scientific notation
+      expect(formatNumericValue(9999.1234)).toBe('9999.1234'); // 4 decimals, standard notation
+      expect(formatNumericValue(9999.12345)).toMatch(/^9\.999e\+3$/i); // 5 decimals, scientific notation
+    });
+
+    it('should handle numbers in readable range that have many decimals', () => {
+      // These should use scientific notation due to > 4 decimal places
+      expect(formatNumericValue(1.4153928131348452)).toMatch(/^1\.415e\+0$/i);
+      expect(formatNumericValue(42.987654321)).toMatch(/^4\.299e\+1$/i);
+      expect(formatNumericValue(123.456789)).toMatch(/^1\.235e\+2$/i);
+    });
+  });
 });

--- a/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.ts
@@ -1,0 +1,39 @@
+const NOTATION_THRESHOLD_SMALL = 1e-2;
+const NOTATION_THRESHOLD_LARGE = 1e4;
+const MAX_DECIMAL_PLACES = 4;
+const EXPONENTIAL_DECIMALS = 3;
+
+// Create formatter once at module level (reused for all calls)
+const readableRangeFormatter = new Intl.NumberFormat(undefined, {
+  maximumFractionDigits: MAX_DECIMAL_PLACES,
+  useGrouping: false,
+});
+
+/**
+ * Formats a numeric value for display in alert rule history.
+ * - For values in human-readable range (1e-2 to 1e4): shows up to 4 decimal places
+ * - For very small values (< 1e-2): uses scientific notation with 4 significant digits
+ * - For very large values (> 1e4): uses scientific notation with 4 significant digits
+ *
+ * @param value - The number to format
+ * @returns A formatted string representation of the number
+ */
+export function formatNumericValue(value: number): string {
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+
+  if (value === 0) {
+    return '0';
+  }
+
+  const absValue = Math.abs(value);
+
+  // Use scientific notation for very small or very large numbers
+  if (absValue < NOTATION_THRESHOLD_SMALL || absValue > NOTATION_THRESHOLD_LARGE) {
+    return value.toExponential(EXPONENTIAL_DECIMALS);
+  }
+
+  // For human-readable range, reuse the module-level formatter
+  return readableRangeFormatter.format(value);
+}

--- a/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.ts
+++ b/public/app/features/alerting/unified/components/rules/state-history/numberFormatter.ts
@@ -1,7 +1,7 @@
 const NOTATION_THRESHOLD_SMALL = 1e-2;
 const NOTATION_THRESHOLD_LARGE = 1e4;
 const MAX_DECIMAL_PLACES = 4;
-const EXPONENTIAL_DECIMALS = 3;
+const EXPONENTIAL_DECIMALS = 3; // 4 significant digits = 1 digit + 3 decimals
 
 // Create formatter once at module level (reused for all calls)
 const readableRangeFormatter = new Intl.NumberFormat(undefined, {
@@ -10,17 +10,39 @@ const readableRangeFormatter = new Intl.NumberFormat(undefined, {
 });
 
 /**
+ * Counts the number of decimal places in a number.
+ */
+function countDecimalPlaces(value: number): number {
+  if (Number.isInteger(value)) {
+    return 0;
+  }
+
+  // Convert to string and find decimal point
+  const str = value.toString();
+  const decimalIndex = str.indexOf('.');
+
+  if (decimalIndex === -1) {
+    return 0;
+  }
+
+  // Return count of digits after decimal point
+  return str.length - decimalIndex - 1;
+}
+
+/**
  * Formats a numeric value for display in alert rule history.
- * - For values in human-readable range (1e-2 to 1e4): shows up to 4 decimal places
+ * - For values in human-readable range (1e-2 to 1e4) with ≤ 4 decimal places: shows up to 4 decimal places
  * - For very small values (< 1e-2): uses scientific notation with 4 significant digits
  * - For very large values (> 1e4): uses scientific notation with 4 significant digits
+ * - For numbers with > 4 decimal places: uses scientific notation with 4 significant digits
  *
  * @param value - The number to format
  * @returns A formatted string representation of the number
  */
 export function formatNumericValue(value: number): string {
+  // Handle special cases
   if (!Number.isFinite(value)) {
-    return String(value);
+    return String(value); // NaN, Infinity
   }
 
   if (value === 0) {
@@ -28,12 +50,19 @@ export function formatNumericValue(value: number): string {
   }
 
   const absValue = Math.abs(value);
+  const decimalPlaces = countDecimalPlaces(value);
 
-  // Use scientific notation for very small or very large numbers
-  if (absValue < NOTATION_THRESHOLD_SMALL || absValue > NOTATION_THRESHOLD_LARGE) {
+  // Use scientific notation for:
+  // 1. Very small or very large numbers (magnitude-based)
+  // 2. OR numbers with excessive decimal precision (> 4 decimals)
+  if (
+    absValue < NOTATION_THRESHOLD_SMALL ||
+    absValue > NOTATION_THRESHOLD_LARGE ||
+    decimalPlaces > MAX_DECIMAL_PLACES
+  ) {
     return value.toExponential(EXPONENTIAL_DECIMALS);
   }
 
-  // For human-readable range, reuse the module-level formatter
+  // For human-readable range with ≤ 4 decimal places, use standard notation
   return readableRangeFormatter.format(value);
 }


### PR DESCRIPTION
**What is this feature?**

Implements auto-formatting for numeric query results displayed in the Alert Rule Detail → History page. Numbers are formatted using a hybrid approach:
- **Standard notation** (up to 4 decimal places) for values in the human-readable range (1e-2 to 1e4) with ≤ 4 decimal places
- **Scientific notation** (4 significant digits) for very small values (< 1e-2), very large values (> 1e4), or numbers with excessive decimal precision (> 4 decimal places)

### Example Output

**Before:**
<img width="1840" height="1196" alt="before" src="https://github.com/user-attachments/assets/0d9267dc-8224-42be-a5f6-423876ed9ebc" />

**After:**
<img width="1840" height="1196" alt="after" src="https://github.com/user-attachments/assets/5b474f6b-2fbb-4759-be5f-18204f647142" />

**Why do we need this feature?**

The Alert Rule History page currently displays numeric query results with very high precision (e.g., `42.987654321`, `1.4153928131348452`), which clutters the UI and makes it difficult to quickly scan values.

**Who is this feature for?**

All users viewing Alert Rule History, particularly those monitoring alert rules with numeric query results that have high precision or extreme values.

**Which issue(s) does this PR fix?**:

Fixes #115697

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
