### PR TITLE
Playlists: Support get with None role

### DIFF
--- a/pkg/services/apiserver/auth/authorizer/role.go
+++ b/pkg/services/apiserver/auth/authorizer/role.go
@@ -15,6 +15,8 @@ var _ authorizer.Authorizer = &roleAuthorizer{}
 
 var orgRoleNoneAsViewerAPIGroups = []string{
 	"productactivation.ext.grafana.com",
+	// playlist can be removed after this issue is resolved: https://github.com/grafana/grafana/issues/115712
+	"playlist.grafana.app",
 }
 
 type roleAuthorizer struct{}

--- a/pkg/tests/apis/playlist/playlist_test.go
+++ b/pkg/tests/apis/playlist/playlist_test.go
@@ -447,7 +447,7 @@ func doPlaylistTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelp
 		_, err = clientNone.Resource.Get(context.Background(), created.GetName(), metav1.GetOptions{})
 		require.NoError(t, err)
 
-		// Mone role can get but can not create edit or delete a playlist
+		// None role can get but can not create edit or delete a playlist
 		_, err = clientNone.Resource.Create(context.Background(),
 			helper.LoadYAMLOrJSONFile("testdata/playlist-generate.yaml"),
 			metav1.CreateOptions{},


### PR DESCRIPTION
**What is this feature?**

Support get playlist with `None` role.


Fixes https://github.com/grafana/support-escalations/issues/19886

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
