### PR TITLE
Auth: Support dynamic JWK set URLs using {{kid}} in JWT authentication

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -967,6 +967,7 @@ email_claim =
 username_claim =
 email_attribute_path =
 username_attribute_path =
+# The URL for the JWK set. Supports {{kid}} as a template variable for dynamic key resolution.
 jwk_set_url =
 jwk_set_bearer_token_file =
 jwk_set_file =

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -920,6 +920,7 @@
 ;username_claim = sub
 ;email_attribute_path = jmespath.email
 ;username_attribute_path = jmespath.username
+# The URL for the JWK set. Supports {{kid}} as a template variable for dynamic key resolution.
 ;jwk_set_url = https://foo.bar/.well-known/jwks.json
 ;jwk_set_bearer_token_file = /path/to/token/file
 ;jwk_set_file = /path/to/jwks.json

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/jwt/index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/jwt/index.md
@@ -178,6 +178,20 @@ cache_ttl = 60m
 If the JWKS endpoint includes cache control headers and the value is less than the configured `cache_ttl`, then the cache control header value is used instead. If the `cache_ttl` is not set, the default of `60m` is used. `no-store` and `no-cache` cache control headers are ignored. To disable JWKS caching, set `cache_ttl = 0s`
 {{< /admonition >}}
 
+#### Dynamic JWKS endpoints
+
+Grafana supports dynamic JWKS endpoints using the `{{kid}}` template variable in the `jwk_set_url`. This is useful for providers like AWS Application Load Balancer (ALB) that expose keys at different URLs.
+
+```ini
+# [auth.jwt]
+jwk_set_url = https://public-keys.auth.elb.eu-west-1.amazonaws.com/{{kid}}/.well-known/jwks.json
+```
+
+When `{{kid}}` is used:
+- The `kid` from the JWT header is URL-escaped and substituted into the template.
+- Each unique URL is cached independently according to `cache_ttl`.
+- For security, Grafana ensures the final URL maintains the same hostname as the configured template.
+
 ### Verify token using a JSON Web Key Set loaded from JSON file
 
 Key set in the same format as in JWKS endpoint but located on disk.


### PR DESCRIPTION
**What is this feature?**

This feature introduces support for dynamic JWK set URLs in Grafana's JWT authentication. By using the new {{kid}} template variable in the jwk_set_url setting, Grafana can now dynamically resolve the public key endpoint based on the Key ID (kid) header present in the incoming JWT.

**Why do we need this feature?**

Certain authentication providers, most notably AWS Application Load Balancer (ALB), do not use a single static JWKS endpoint. Instead, they expose public keys at unique URLs that include the key ID in the path (e.g., https://public-keys.auth.elb.region.amazonaws.com/{{kid}}). This update allows Grafana to integrate seamlessly with these services.

**Who is this feature for?**

This feature is for administrators configuring Grafana to use JWT authentication behind providers that rotate keys using unique endpoints, such as AWS ALB users.


**Which issue(s) does this PR fix?:**
Fixes #109373

**Special notes for your reviewer:**

- **Security:** I've implemented url.PathEscape for the kid substitution to prevent path traversal. Additionally, the implementation validates that the resolved URL maintains the same host as the configured template to prevent SSRF.
- **Caching:** The RemoteCache logic was updated to use the fully resolved URL as the cache key, ensuring that different keys are cached and refreshed independently.
- **Verification:** A new integration test TestIntegrationVerifyUsingDynamicJWKSetURL has been added to pkg/services/auth/jwt/auth_test.go to cover the logic and security checks.
